### PR TITLE
Added useful tip with local addresses

### DIFF
--- a/bin/vite.js
+++ b/bin/vite.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const argv = require('minimist')(process.argv.slice(2))
 const server = require('../dist/server').createServer(argv)
+const getIPv4AddressList = require('../dist/server/utils').getIPv4AddressList
 
 let port = argv.port || 3000
 
@@ -17,7 +18,11 @@ server.on('error', (e) => {
 })
 
 server.on('listening', () => {
-  console.log(`Running at http://localhost:${port}`)
+  console.log(`Running at:`)
+  getIPv4AddressList().forEach((ip) => {
+    console.log(`  > http://${ip}:${port}`)
+  })
+  console.log(' ')
 })
 
 server.listen(port)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     ]
   },
   "dependencies": {
-    "@types/koa": "^2.11.3",
     "@vue/compiler-sfc": "^3.0.0-beta.3",
     "chokidar": "^3.3.1",
     "es-module-lexer": "^0.3.18",
@@ -55,6 +54,7 @@
     "ws": "^7.2.3"
   },
   "devDependencies": {
+    "@types/koa": "^2.11.3",
     "@types/es-module-lexer": "^0.3.0",
     "@types/hash-sum": "^1.0.0",
     "@types/lru-cache": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "@types/koa": "^2.11.3",
     "@vue/compiler-sfc": "^3.0.0-beta.3",
     "chokidar": "^3.3.1",
     "es-module-lexer": "^0.3.18",
@@ -54,7 +55,6 @@
     "ws": "^7.2.3"
   },
   "devDependencies": {
-    "@types/koa": "^2.11.3",
     "@types/es-module-lexer": "^0.3.0",
     "@types/hash-sum": "^1.0.0",
     "@types/lru-cache": "^5.1.0",

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import LRUCache from 'lru-cache'
+import os from 'os'
 
 interface CacheEntry {
   lastModified: number
@@ -24,4 +25,19 @@ export async function cachedRead(path: string, encoding?: string) {
     lastModified
   })
   return content
+}
+
+export function getIPv4AddressList(): string[] {
+  const networkInterfaces = os.networkInterfaces()
+  let result: string[] = []
+
+  Object.keys(networkInterfaces).forEach((key) => {
+    const ips = (networkInterfaces[key] || [])
+      .filter((details) => details.family === 'IPv4')
+      .map((detail) => detail.address)
+
+    result = result.concat(ips)
+  })
+
+  return result
 }


### PR DESCRIPTION
You don't have to check my local IP when I want to access it on a device in the same LAN

For example: 
```
npx vite

Running at:
  > http://127.0.0.1:3000
  > http://192.168.1.35:3000
```



----

And, `fs.promises` in `src/server/utils.ts` does not support some lower versions of node.

Use `util.promisify` to support `> node 8`
