### PR TITLE
Added useful tip with local addresses

### DIFF
--- a/bin/vite.js
+++ b/bin/vite.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 const argv = require('minimist')(process.argv.slice(2))
+const getIPv4AddressList = require('../dist/utils').getIPv4AddressList
 
 if (argv._[0] === 'build') {
   require('../dist').build(argv)
@@ -21,7 +22,11 @@ if (argv._[0] === 'build') {
   })
 
   server.on('listening', () => {
-    console.log(`Running at http://localhost:${port}`)
+    console.log(`Running at:`)
+    getIPv4AddressList().forEach((ip) => {
+      console.log(`  > http://${ip}:${port}`)
+    })
+    console.log(' ')
   })
 
   server.listen(port)

--- a/src/node/utils.ts
+++ b/src/node/utils.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs'
 import LRUCache from 'lru-cache'
+import os from 'os'
 
 interface CacheEntry {
   lastModified: number
@@ -24,4 +25,19 @@ export async function cachedRead(path: string, encoding?: string) {
     lastModified
   })
   return content
+}
+
+export function getIPv4AddressList(): string[] {
+  const networkInterfaces = os.networkInterfaces()
+  let result: string[] = []
+
+  Object.keys(networkInterfaces).forEach((key) => {
+    const ips = (networkInterfaces[key] || [])
+      .filter((details) => details.family === 'IPv4')
+      .map((detail) => detail.address)
+
+    result = result.concat(ips)
+  })
+
+  return result
 }


### PR DESCRIPTION
You don't have to check my local IP when I want to access it on a device in the same LAN

For example:

```
npx vite

Running at:
  > http://127.0.0.1:3000
  > http://192.168.1.35:3000
```

----

And, `fs.promises` in `src/server/utils.ts` does not support some lower versions of node.

Use `util.promisify` to support `> node 8`