### PR TITLE
fix: check `fs.promise` before using it

### DIFF
--- a/create-vite-app/index.js
+++ b/create-vite-app/index.js
@@ -3,6 +3,12 @@ const path = require('path')
 const { promises: fs } = require('fs')
 
 async function init() {
+
+  if (!fs) {
+    console.info(`Error: Current node version doesn't support \`require('fs').promises\` API.`)
+    return
+  }
+
   const targetDir = process.argv[2]
 
   if (!targetDir) {


### PR DESCRIPTION
Add a simple check for `fs.promise` API otherwise the user will always get `"Error: target directory alreay exists."` error if his/her node version is below v10.0.