### PR TITLE
fix: crash when importing component with no script tag

### DIFF
--- a/src/node/serverPluginVue.ts
+++ b/src/node/serverPluginVue.ts
@@ -163,7 +163,7 @@ function compileSFCMain(
   let hasScoped = false
   let hasCSSModules = false
   if (descriptor.styles) {
-    code += `import { updateStyle } from "${hmrClientId}"\n`
+    code += `\nimport { updateStyle } from "${hmrClientId}"\n`
     descriptor.styles.forEach((s, i) => {
       const styleRequest = publicPath + `?type=style&index=${i}`
       if (s.scoped) hasScoped = true


### PR DESCRIPTION
Fix a crash when importing a vue component with no script tag. It also fixes the tests.

This was caused by a parsing error:
```js
const __script = {}import { updateStyle } from "/@hmr"
```
which is not JS valid. So I add the following to be
```js
const __script = {}
import { updateStyle } from "/@hmr"
```