### PR TITLE
fix(cli): Fix vue/valid-template-root error.

### DIFF
--- a/create-vite-app/template/_App.vue
+++ b/create-vite-app/template/_App.vue
@@ -1,10 +1,12 @@
 <template>
-  <h1>Hello Vite + Vue 3!</h1>
-  <p>Edit ./App.vue to test hot module replacement (HMR).</p>
-  <p>
-    <span>Count is: {{ count }}</span>
-    <button @click="count++">increment</button>
-  </p>
+  <div>
+    <h1>Hello Vite + Vue 3!</h1>
+    <p>Edit ./App.vue to test hot module replacement (HMR).</p>
+    <p>
+      <span>Count is: {{ count }}</span>
+      <button @click="count++">increment</button>
+    </p>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
The template root requires exactly one element.

```vue
<template>
  <h1></h1>
  <p></p>
</template>
```

=>

```vue
<template>
  <div>
    <h1></h1>
    <p></p>
  </div>
</template>
```