### PR TITLE
fix: fix resolve path on windows

### DIFF
--- a/src/node/server/serverPluginModuleRewrite.ts
+++ b/src/node/server/serverPluginModuleRewrite.ts
@@ -167,7 +167,7 @@ function rewriteImports(
             }
           } else {
             let pathname = cleanUrl(
-              slash(path.join(path.dirname(importer), id))
+              slash(path.posix.resolve(path.dirname(importer), id))
             )
             const queryMatch = id.match(queryRE)
             let query = queryMatch ? queryMatch[0] : ''

--- a/src/node/server/serverPluginModuleRewrite.ts
+++ b/src/node/server/serverPluginModuleRewrite.ts
@@ -167,7 +167,7 @@ function rewriteImports(
             }
           } else {
             let pathname = cleanUrl(
-              slash(path.resolve(path.dirname(importer), id))
+              slash(path.join(path.dirname(importer), id))
             )
             const queryMatch = id.match(queryRE)
             let query = queryMatch ? queryMatch[0] : ''


### PR DESCRIPTION
On windows using `path.resolve` will resolve the path relative to the current location, because the `importer` would be `/index.html`, the dirname is `/` making the `path.resolve` to be resolved drivers root eg: `C:/` 


fixes #70  #69 