### PR TITLE
fix: rewrite `@vue/runtime*` imports to `vue`

### DIFF
--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -22,6 +22,10 @@ const defaultFileToRequest = (filePath: string, root: string) =>
   `/${slash(path.relative(root, filePath))}`
 
 const defaultIdToRequest = (id: string) => {
+  // If requires `@vue/runtime-*` default to the runtime vue
+  if (id.startsWith('@vue/runtime-')) {
+    return '/@modules/vue'
+  }
   if (id.startsWith('@') && id.indexOf('/') < 0) {
     return `/${id}`
   }

--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -23,11 +23,26 @@ const defaultFileToRequest = (filePath: string, root: string) =>
 
 const defaultIdToRequest = (id: string) => {
   if (id.startsWith('@') && id.indexOf('/') < 0) {
+    return `/${id}`
+  }
+}
+
+/**
+ * Vue runtime resolver, resolves `@vue/runtime-*` dependencies
+ * to `vue`
+ */
+export const VueRuntimeResolver: Resolver = {
+  fileToRequest(fp, root) {
+    return undefined
+  },
+  requestToFile(fp, root) {
+    return undefined
+  },
+  idToRequest(id) {
     // If requires `@vue/runtime-*` default to the runtime vue
     if (id.startsWith('@vue/runtime-')) {
       return '/@modules/vue'
     }
-    return `/${id}`
   }
 }
 

--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -22,11 +22,11 @@ const defaultFileToRequest = (filePath: string, root: string) =>
   `/${slash(path.relative(root, filePath))}`
 
 const defaultIdToRequest = (id: string) => {
-  // If requires `@vue/runtime-*` default to the runtime vue
-  if (id.startsWith('@vue/runtime-')) {
-    return '/@modules/vue'
-  }
   if (id.startsWith('@') && id.indexOf('/') < 0) {
+    // If requires `@vue/runtime-*` default to the runtime vue
+    if (id.startsWith('@vue/runtime-')) {
+      return '/@modules/vue'
+    }
     return `/${id}`
   }
 }

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -1,7 +1,12 @@
 import http, { Server } from 'http'
 import Koa from 'koa'
 import chokidar from 'chokidar'
-import { Resolver, createResolver, InternalResolver } from '../resolver'
+import {
+  Resolver,
+  createResolver,
+  InternalResolver,
+  VueRuntimeResolver
+} from '../resolver'
 import { moduleRewritePlugin } from './serverPluginModuleRewrite'
 import { moduleResolvePlugin } from './serverPluginModuleResolve'
 import { vuePlugin } from './serverPluginVue'
@@ -55,6 +60,9 @@ export function createServer(config: ServerConfig = {}): Server {
     resolvers = [],
     jsx = {}
   } = config
+
+  resolvers.push(VueRuntimeResolver)
+
   const app = new Koa()
   const server = http.createServer(app.callback())
   const watcher = chokidar.watch(root, {


### PR DESCRIPTION
Fixes #71

If `@vue/runtime*` requested defaults to `/@modules/vue`, this is to keep reactivity.