### PR TITLE
feat(create-vite-app): use valid html file

### DIFF
--- a/create-vite-app/template/_index.html
+++ b/create-vite-app/template/_index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">

--- a/create-vite-app/template/_index.html
+++ b/create-vite-app/template/_index.html
@@ -1,7 +1,16 @@
-<div id="app"></div>
-<script type="module">
-import { createApp } from 'vue'
-import App from './App.vue'
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vite App</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module">
+    import { createApp } from 'vue'
+    import App from './App.vue'
 
-createApp(App).mount('#app')
-</script>
+    createApp(App).mount('#app')
+  </script>
+</body>
+</html>


### PR DESCRIPTION
When creating an app with `create-vite-app`, the generated index.html is not really valid. I add basic html5 content around the existing one.