### PR TITLE
fixed template root warning in create-vite-app

### DIFF
--- a/create-vite-app/template/_App.vue
+++ b/create-vite-app/template/_App.vue
@@ -1,10 +1,12 @@
 <template>
-  <h1>Hello Vite + Vue 3!</h1>
-  <p>Edit ./App.vue to test hot module replacement (HMR).</p>
-  <p>
-    <span>Count is: {{ count }}</span>
-    <button @click="count++">increment</button>
-  </p>
+  <div>
+    <h1>Hello Vite + Vue 3!</h1>
+    <p>Edit ./App.vue to test hot module replacement (HMR).</p>
+    <p>
+      <span>Count is: {{ count }}</span>
+      <button @click="count++">increment</button>
+    </p>
+  </div>
 </template>
 
 <script>
@@ -18,7 +20,8 @@ h1 {
   color: #4fc08d;
 }
 
-h1, p {
+h1,
+p {
   font-family: Arial, Helvetica, sans-serif;
 }
 </style>


### PR DESCRIPTION
Received the following warning when opening `App.vue` in `create-vite-app`.

<img width="734" alt="Screen Shot 2020-05-07 at 9 40 14 AM" src="https://user-images.githubusercontent.com/43385166/81308411-5b79ad00-9047-11ea-9a00-5a38b1ce66b0.png">

Fixed by wrapping elements in div.