### PR TITLE
Log brotli-compressed size of output files

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@types/koa": "^2.11.3",
     "@vue/compiler-sfc": "^3.0.0-beta.10",
+    "brotli-size": "^4.0.0",
     "chalk": "^4.0.0",
     "chokidar": "^3.3.1",
     "cssnano": "^4.1.10",

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -259,7 +259,9 @@ export async function build(options: BuildOptions = {}): Promise<BuildResult> {
         console.log(
           `${chalk.gray(`[write]`)} ${writeColors[type](
             path.relative(cwd, filepath)
-          )} ${(content.length / 1024).toFixed(2)}kb`
+          )} ${(content.length / 1024).toFixed(2)}kb, brotli: ${(
+            require('brotli-size').sync(content) / 1024
+          ).toFixed(2)}kb`
         )
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,6 +1324,13 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+brotli-size@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/brotli-size/-/brotli-size-4.0.0.tgz#a05ee3faad3c0e700a2f2da826ba6b4d76e69e5e"
+  integrity sha512-uA9fOtlTRC0iqKfzff1W34DXUA3GyVqbUaeo3Rw3d4gd1eavKVCETXrn3NzO74W+UVkG3UHu8WxUi+XvKI/huA==
+  dependencies:
+    duplexer "0.1.1"
+
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
@@ -2396,6 +2403,11 @@ dot-prop@^5.2.0:
   integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
   dependencies:
     is-obj "^2.0.0"
+
+duplexer@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+  integrity sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Most sites will serve with brotli compression to browsers which support it (i.e. all modern ones). Logging just the uncompressed size is somewhat disingenuous; [pika.dev](https://pika.dev/search) and friends show compressed sizes by default as it is true what most users will actually download.

Example output:

```
$ vite build
vite v0.13.0
\ Building for production...
[write] dist\assets\index.js 8.41kb, brotli: 3.15kb
[write] dist\assets\style.css 0.00kb, brotli: 0.00kb
[write] dist\index.html 0.22kb, brotli: 0.10kb
Build completed in 1.10s.
```

On the very small app I tested this on, calculating brotli sizes added ~3% to the build time.