### PR TITLE
fix: single quote 'src' attribute for <script>

### DIFF
--- a/src/node/server/serverPluginModuleRewrite.ts
+++ b/src/node/server/serverPluginModuleRewrite.ts
@@ -81,7 +81,9 @@ export const moduleRewritePlugin: Plugin = ({ app, watcher, resolver }) => {
             const srcAttr = openTag.match(srcRE)
             if (srcAttr) {
               // register script as a import dep for hmr
-              const importee = cleanUrl(slash(path.resolve('/', srcAttr[1])))
+              const importee = cleanUrl(
+                slash(path.resolve('/', srcAttr[1] || srcAttr[2]))
+              )
               debugHmr(`        ${importer} imports ${importee}`)
               ensureMapEntry(importerMap, importee).add(importer)
             }


### PR DESCRIPTION
This fixes an issue with using single quotes rather than double quotes for the `src` attribute of script tags in `index.html`.

```diff
<!doctype html>
<html lang='en'>
-	<script type='module' src='./app/App.tsx'></script>
</html>
```

`TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined`