### PR TITLE
fix: run all transforms that pass particular `test` during build process

### DIFF
--- a/src/node/transform.ts
+++ b/src/node/transform.ts
@@ -47,11 +47,13 @@ export function createBuildJsTransformPlugin(
     name: 'vite:transforms',
     async transform(code, id) {
       const { path, query } = parseWithQuery(id)
+      let result: string | Promise<string> = code
       for (const t of transforms) {
         if (t.test(path, query)) {
-          return t.transform(code, true)
+          result = await t.transform(result, true)
         }
       }
+      return result
     }
   }
 }


### PR DESCRIPTION
Great work on the plugin system and kudos for introducing the config file so quickly!

Currently, all transforms that pass particular `test` are executed one after the other and each one takes the result of the previous transform. This is only the case for the dev server, for the build process only the first passing transform is executed, this PR makes it consistent.