### PR TITLE
fix: prioritize .mjs files over .js files

### DIFF
--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -38,7 +38,7 @@ const defaultFileToRequest = (filePath: string, root: string): string => {
   return `/${slash(path.relative(root, filePath))}`
 }
 
-export const supportedExts = ['.js', '.ts', '.jsx', '.tsx', '.json']
+export const supportedExts = ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json']
 
 const debug = require('debug')('vite:resolve')
 

--- a/src/node/server/serverPluginModuleResolve.ts
+++ b/src/node/server/serverPluginModuleResolve.ts
@@ -71,6 +71,18 @@ export const moduleResolvePlugin: ServerPlugin = ({ root, app, watcher }) => {
     try {
       // we land here after a module entry redirect
       // or a direct deep import like 'foo/bar/baz.js'.
+
+      // some packages (i.e. graphql) ship .mjs files with ES exports
+      // when a file without an extension was requested, we will try an mjs file first
+      // as resolve defaults to the .js extension
+      if (path.extname(id) === '') {
+        try {
+          return serve(id, resolve(root, `${id}.mjs`), 'node_modules')
+        } catch (e) {
+          // ignore module not found (and all other) errors
+        }
+      }
+
       const file = resolve(root, id)
       return serve(id, file, 'node_modules')
     } catch (e) {


### PR DESCRIPTION
Prioritize `.mjs` files over `.js` files. This does not really follow spec but will make vite a lot more compatible with existing modules out there.

One example is the `graphql` package mentioned in #127 

Fixes #127 