### PR TITLE
Introduce shouldPreload

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -151,7 +151,8 @@ export async function build(options: BuildConfig = {}): Promise<BuildResult> {
     write = true,
     minify = true,
     silent = false,
-    sourcemap = false
+    sourcemap = false,
+    shouldPreload = null
   } = options
 
   let spinner: Ora | undefined
@@ -177,7 +178,8 @@ export async function build(options: BuildConfig = {}): Promise<BuildResult> {
     publicBasePath,
     assetsDir,
     assetsInlineLimit,
-    resolver
+    resolver,
+    shouldPreload
   )
 
   const basePlugins = await createBaseRollupPlugins(root, resolver, options)

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -8,7 +8,8 @@ import { Options as RollupPluginVueOptions } from 'rollup-plugin-vue'
 import { CompilerOptions } from '@vue/compiler-sfc'
 import Rollup, {
   InputOptions as RollupInputOptions,
-  OutputOptions as RollupOutputOptions
+  OutputOptions as RollupOutputOptions,
+  OutputChunk
 } from 'rollup'
 import { Transform } from './transform'
 import { DepOptimizationOptions } from './depOptimizer'
@@ -153,6 +154,11 @@ export interface BuildConfig extends SharedConfig {
    * @default true
    */
   emitAssets?: boolean
+  /**
+   * Predicate function that determines wheter a link rel=modulepreload shall be
+   * added to the index.html for the chunk passed in
+   */
+  shouldPreload?: (chunk: OutputChunk) => boolean
 }
 
 export interface UserConfig

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -155,7 +155,7 @@ export interface BuildConfig extends SharedConfig {
    */
   emitAssets?: boolean
   /**
-   * Predicate function that determines wheter a link rel=modulepreload shall be
+   * Predicate function that determines whether a link rel=modulepreload shall be
    * added to the index.html for the chunk passed in
    */
   shouldPreload?: (chunk: OutputChunk) => boolean


### PR DESCRIPTION
This PR adds an optional config option named `shouldPreload` that accepts a predicate function receiving a rollup `OutputChunk` and returns a boolean indicating whether to add a `<link rel="modulerepload" href="..." />` to the index.html or not.

Open for feedback. Maybe a more generic solution would be to offer the ability of adding html processing plugins.