### PR TITLE
fix: remove unreachable condition

### DIFF
--- a/src/node/server/serverPluginServeStatic.ts
+++ b/src/node/server/serverPluginServeStatic.ts
@@ -44,7 +44,7 @@ export const serveStaticPlugin: ServerPlugin = ({
     }
 
     const ext = path.extname(ctx.path)
-    if (ext && !accept.includes('text/html')) {
+    if (ext) {
       debug(`not redirecting ${ctx.url} (has file extension)`)
       return next()
     }


### PR DESCRIPTION
useless condition
```js
    if (**!(accept.includes('text/html')** || accept.includes('*/*'))) {
      debug(`not redirecting ${ctx.url} (not accepting html)`)
      return next()
    }

    const ext = path.extname(ctx.path)
    if (ext && **!accept.includes('text/html')**) {
      debug(`not redirecting ${ctx.url} (has file extension)`)
      return next()
    }
```