### PR TITLE
Force esbuild to output ES2019

### DIFF
--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -62,7 +62,8 @@ export const transform = async (
     ...options,
     loader: options.loader || (path.extname(file).slice(1) as any),
     sourcemap: true,
-    sourcefile: file
+    sourcefile: file,
+    target: 'es2019'
   }
   try {
     const result = await service.transform(src, options)


### PR DESCRIPTION
Rollup does not appear to support optional chaining (`foo?.bar`). Work around this by lowering the esbuild target to ES2019.

This is purely a proposal, I understand there might be unintended consequences. I can also imagine you might only want to do this for builds, where rollup is involved.

Related: https://github.com/rollup/plugins/issues/205

Typescript:
```ts
       if (queryContext?.running) {
```

Current `npx vite build` output
```
vite v0.15.3
| Building for production...
[vite] Build errored out.
Error: Unexpected token (Note that you need plugins to import files that are not JavaScript)
    at error (<snip>\node_modules\rollup\dist\shared\rollup.js:161:30)
    at Module.error (<snip>\node_modules\rollup\dist\shared\rollup.js:15097:16)
    at tryParse (<snip>\node_modules\rollup\dist\shared\rollup.js:14986:23)
    at Module.setSource (<snip>\node_modules\rollup\dist\shared\rollup.js:15385:30)
    at ModuleLoader.addModuleSource (<snip>\node_modules\rollup\dist\shared\rollup.js:17418:20)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async ModuleLoader.fetchModule (<snip>\node_modules\rollup\dist\shared\rollup.js:17479:9)
    at async <snip>\node_modules\rollup\dist\shared\rollup.js:17449:36
    at async Promise.all (index 0)
    at async ModuleLoader.fetchModule (<snip>\node_modules\rollup\dist\shared\rollup.js:17480:9) {
  code: 'PARSE_ERROR',
  parserError: SyntaxError: Unexpected token (478:23)
      at Object.pp$4.raise (<snip>\node_modules\rollup\dist\shared\rollup.js:3454:13)
      at Object.pp.unexpected (<snip>\node_modules\rollup\dist\shared\rollup.js:1258:8)
      at Object.pp$3.parseExprAtom (<snip>\node_modules\rollup\dist\shared\rollup.js:2853:10)
      at Object.parseExprAtom (<snip>\node_modules\rollup\dist\shared\rollup.js:5888:75)
      at Object.pp$3.parseExprSubscripts (<snip>\node_modules\rollup\dist\shared\rollup.js:2681:19)
      at Object.pp$3.parseMaybeUnary (<snip>\node_modules\rollup\dist\shared\rollup.js:2658:17)
      at Object.parseMaybeUnary (<snip>\node_modules\rollup\dist\shared\rollup.js:5802:29)
      at Object.pp$3.parseExprOps (<snip>\node_modules\rollup\dist\shared\rollup.js:2593:19)
      at Object.pp$3.parseMaybeConditional (<snip>\node_modules\rollup\dist\shared\rollup.js:2576:19)
      at Object.pp$3.parseMaybeAssign (<snip>\node_modules\rollup\dist\shared\rollup.js:2549:19) {
    pos: 17952,
    loc: Position { line: 478, column: 23 },
    raisedAt: 17953
  },
  pos: <snip>,
  loc: <snip>,
  frame: '<snip>' +
    '583:       if (queryContext?.running) {\n' +
    '                             ^\n' +
    '<snip>',
  watchFiles: <snip>
}
<snip>
```