### PR TITLE
fix: just return content with `devFlag` + html content

### DIFF
--- a/playground/test.html
+++ b/playground/test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vite App</title>
+  <link rel="icon" href="/public/icon.png" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -6,6 +6,9 @@ const config: UserConfig = {
   alias: {
     alias: '/aliased'
   },
+  entry: {
+    test: './test.html'
+  },
   jsx: 'preact',
   minify: false,
   serviceWorker: !!process.env.USE_SW,

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -27,6 +27,11 @@ export interface SharedConfig {
    */
   root?: string
   /**
+   * todo work for build
+   * Project entry. The `index.html` is default included.
+   * */
+  entry?: Record<string, string>
+  /**
    * Import alias. Can only be exact mapping, does not support wildcard syntax.
    */
   alias?: Record<string, string>

--- a/src/node/server/serverPluginModuleRewrite.ts
+++ b/src/node/server/serverPluginModuleRewrite.ts
@@ -62,29 +62,34 @@ export const moduleRewritePlugin: ServerPlugin = ({
     await initLexer
     let hasInjectedDevFlag = false
     const importer = '/index.html'
-    return html!.replace(scriptRE, (matched, openTag, script) => {
-      const devFlag = hasInjectedDevFlag ? `` : devInjectionCode
-      hasInjectedDevFlag = true
-      if (script) {
-        return `${devFlag}${openTag}${rewriteImports(
-          root,
-          script,
-          importer,
-          resolver
-        )}</script>`
-      } else {
-        const srcAttr = openTag.match(srcRE)
-        if (srcAttr) {
-          // register script as a import dep for hmr
-          const importee = cleanUrl(
-            slash(path.resolve('/', srcAttr[1] || srcAttr[2]))
-          )
-          debugHmr(`        ${importer} imports ${importee}`)
-          ensureMapEntry(importerMap, importee).add(importer)
+    const devFlag = hasInjectedDevFlag ? `` : devInjectionCode
+    return (
+      devFlag +
+      html!.replace(scriptRE, (matched, openTag, script) => {
+        debugHmr(matched, openTag, script)
+
+        hasInjectedDevFlag = true
+        if (script) {
+          return `${openTag}${rewriteImports(
+            root,
+            script,
+            importer,
+            resolver
+          )}</script>`
+        } else {
+          const srcAttr = openTag.match(srcRE)
+          if (srcAttr) {
+            // register script as a import dep for hmr
+            const importee = cleanUrl(
+              slash(path.resolve('/', srcAttr[1] || srcAttr[2]))
+            )
+            debugHmr(`        ${importer} imports ${importee}`)
+            ensureMapEntry(importerMap, importee).add(importer)
+          }
+          return `${matched}`
         }
-        return `${devFlag}${matched}`
-      }
-    })
+      })
+    )
   }
 
   app.use(async (ctx, next) => {

--- a/test/test.js
+++ b/test/test.js
@@ -372,6 +372,11 @@ describe('vite', () => {
 
     declareTests(false)
 
+    test('multi entry', async () => {
+      await page.goto('http://localhost:3000/test.html')
+      expect(await getText('h1')).toMatch('Vite Playground')
+    })
+
     // Assert that all edited files are reflected on page reload
     // i.e. service-worker cache is correctly busted
     test('sw cache busting', async () => {


### PR DESCRIPTION
fix #161.#160