### PR TITLE
chore : Fix typo on resolveJsxOptions

### DIFF
--- a/src/node/build/buildPluginEsbuild.ts
+++ b/src/node/build/buildPluginEsbuild.ts
@@ -1,12 +1,12 @@
 import { Plugin } from 'rollup'
-import { tjsxRE, transform, reoslveJsxOptions } from '../esbuildService'
+import { tjsxRE, transform, resolveJsxOptions } from '../esbuildService'
 import { SharedConfig } from '../config'
 
 export const createEsbuildPlugin = async (
   minify: boolean,
   jsx: SharedConfig['jsx']
 ): Promise<Plugin> => {
-  const jsxConfig = reoslveJsxOptions(jsx)
+  const jsxConfig = resolveJsxOptions(jsx)
 
   return {
     name: 'vite:esbuild',

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -20,7 +20,7 @@ const JsxPresets: Record<
   react: {} // use esbuild default
 }
 
-export function reoslveJsxOptions(options: SharedConfig['jsx'] = 'vue') {
+export function resolveJsxOptions(options: SharedConfig['jsx'] = 'vue') {
   if (typeof options === 'string') {
     if (!(options in JsxPresets)) {
       console.error(`[vite] unknown jsx preset: '${options}'.`)

--- a/src/node/server/serverPluginEsbuild.ts
+++ b/src/node/server/serverPluginEsbuild.ts
@@ -2,14 +2,14 @@ import { ServerPlugin } from '.'
 import {
   tjsxRE,
   transform,
-  reoslveJsxOptions,
+  resolveJsxOptions,
   vueJsxPublicPath,
   vueJsxFilePath
 } from '../esbuildService'
 import { readBody, genSourceMapString, cachedRead } from '../utils'
 
 export const esbuildPlugin: ServerPlugin = ({ app, config }) => {
-  const jsxConfig = reoslveJsxOptions(config.jsx)
+  const jsxConfig = resolveJsxOptions(config.jsx)
 
   app.use(async (ctx, next) => {
     // intercept and return vue jsx helper import


### PR DESCRIPTION
I found a typo on the method `resolveJsxOptions` (was `reoslveJsxOptions` before).