### PR TITLE
fix: static assets changes with full-reload - images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ TODOs.md
 *.log
 test/temp
 explorations
+.idea

--- a/src/node/server/serverPluginHmr.ts
+++ b/src/node/server/serverPluginHmr.ts
@@ -343,6 +343,14 @@ export const hmrPlugin: ServerPlugin = ({
       }
     } else {
       debugHmr(`no importers for ${publicPath}.`)
+      //TODO: Check for static assets from a certain folder like /public.
+      if (publicPath.startsWith('/public')) {
+        send({
+          type: 'full-reload',
+          timestamp,
+          path: publicPath
+        })
+      }
     }
   }
 }


### PR DESCRIPTION
static assets like images when replaced should get updated via full reload since images might have been placed in more than 1 components without any imports.

have considered 'public/' as the static path root.