### PR TITLE
fix process not defined

### DIFF
--- a/src/node/server/serverPluginHtml.ts
+++ b/src/node/server/serverPluginHtml.ts
@@ -20,13 +20,13 @@ export const htmlPlugin: ServerPlugin = ({ root, app, watcher, resolver }) => {
   // inject __DEV__ and process.env.NODE_ENV flags
   // since some ESM builds expect these to be replaced by the bundler
   const devInjectionCode =
-    `\n<script type="module">\n` +
-    `import "${hmrClientPublicPath}"\n` +
+    `\n<script>\n` +
     `window.__DEV__ = true\n` +
     `window.__BASE__ = '/'\n` +
     `window.process = { env: { NODE_ENV: 'development' }}\n` +
-    `</script>\n`
-
+    `</script>` +
+    `\n<script type="module" src="${hmrClientPublicPath}"></script>\n`
+    
   const scriptRE = /(<script\b[^>]*>)([\s\S]*?)<\/script>/gm
   const srcRE = /\bsrc=(?:"([^"]+)"|'([^']+)'|([^'"\s]+)\b)/
 


### PR DESCRIPTION
Hey, thanks for this amazing project! :)

I get the following error that apparently was introduced in v0.16.2

<img width="769" alt="Screenshot 2020-05-21 at 07 56 55" src="https://user-images.githubusercontent.com/5595092/82529485-6a7a5800-9b3b-11ea-8896-041b70c223e6.png">

I think this is due to the following change ba614ef59b576c2ea34baa580adb59d6d16625e8

I basically just reverted this change so that the `window.process` is defined before the `import`.