### PR TITLE
feat(cli): let `port` and `open` configurable in vite config file

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -108,12 +108,7 @@ async function resolveOptions() {
   return argv
 }
 
-async function runServe(
-  options: UserConfig & {
-    port?: number
-    open?: boolean
-  }
-) {
+async function runServe(options: UserConfig) {
   const server = require('../dist').createServer(options)
 
   let port = options.port || 3000

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -85,6 +85,16 @@ export interface SharedConfig {
 
 export interface ServerConfig extends SharedConfig {
   /**
+   * Vite server port to listen on
+   * @default 3000
+   */
+  port?: number
+  /**
+   * Auto open browser
+   * @default true
+   */
+  open?: boolean
+  /**
    * Configure custom proxy rules for the dev server. Uses
    * [`koa-proxies`](https://github.com/vagusX/koa-proxies) which in turn uses
    * [`http-proxy`](https://github.com/http-party/node-http-proxy). Each key can


### PR DESCRIPTION
For example

``` ts
import type { UserConfig } from 'vite'
import { sassPlugin } from './plugins/sassPlugin'
import { jsPlugin } from './plugins/jsPlugin'

const config: UserConfig = {
  alias: {
    alias: '/aliased'
  },
  port: 8080,
  open: false,
  jsx: 'preact',
  minify: false,
  serviceWorker: !!process.env.USE_SW,
  plugins: [sassPlugin, jsPlugin]
}

export default config
```

Build and test has succeeds pass in local, i don't know why is fail in the ci ...

UPDATE: The reason is that I fork the code of the last few days