### PR TITLE
fix for antd@4

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -143,6 +143,7 @@ export async function build(options: BuildConfig = {}): Promise<BuildResult> {
 
   const {
     root = process.cwd(),
+    noDevFlag = false,
     base = '/',
     outDir = path.resolve(root, 'dist'),
     assetsDir = '_assets',
@@ -215,7 +216,7 @@ export async function build(options: BuildConfig = {}): Promise<BuildResult> {
         {
           'process.env.NODE_ENV': '"production"',
           'process.env.': `({}).`,
-          __DEV__: 'false',
+          ...(noDevFlag ? {} : { __DEV__: 'false' }),
           __BASE__: JSON.stringify(publicBasePath)
         },
         sourcemap

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -30,6 +30,7 @@ Options:
   --serviceWorker, -sw       [boolean] configure service worker caching (default: false)
   --port                     [number]  port to use for serve
   --open                     [boolean] open browser on server start
+  --noDevFlag                [boolean] build without __DEV__ flag variable injection (default: false)
   --base                     [string]  public base path for build (default: /)
   --outDir                   [string]  output directory for build (default: dist)
   --assetsDir                [string]  directory under outDir to place assets in (default: assets)

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -229,6 +229,11 @@ export interface BuildConfig extends SharedConfig {
    * added to the index.html for the chunk passed in
    */
   shouldPreload?: (chunk: OutputChunk) => boolean
+  /**
+   * Turn of `__DEV__` variable flag injection when build
+   * user can define there own variable using process.env.NODE_ENV
+   */
+  noDevFlag?: boolean
 }
 
 export interface UserConfig extends BuildConfig, ServerConfig {

--- a/src/node/utils/cssUtils.ts
+++ b/src/node/utils/cssUtils.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { asyncReplace } from './transformUtils'
 import { isExternalUrl } from './pathUtils'
 
-const urlRE = /(url\(\s*['"]?)([^"')]+)(["']?\s*\))/
+const urlRE = /(?<!(?:fill:\s*|\w))(url\(\s*['"]?)([^"')]+)(["']?\s*\))/
 
 type Replacer = (url: string) => string | Promise<string>
 


### PR DESCRIPTION
there are two problems blocks app to build with antd@4

1. there is a line in antd's css `fill: url(#linearGradient-1);`, vite will try to pack this "file" from url which throws us an `Error ENOENT: no such file or directory, open '.../node_modules/antd/dist/#linearGradient-1'`, I added a Lookbehind assertion in cssUtils to fix it

2. createReplacePlugin() replaced all `__DEV__` occurrence in source file, there is a dependency file in antd runs like `const __DEV__ = ...` which throws error after that replacement applied:

```
parserError: SyntaxError: Unexpected keyword 'false' (17:4)
"17: var __DEV__ = process.env.NODE_ENV !== 'production';\n" +
         ^
```
So I added a build option `noDevFlag` to let user turn off this variable injection feature.

example: https://github.com/undoZen/vite/tree/antd4-example/examples/antd4
build fine with this pr