### PR TITLE
fix: defaultRequestToFile should handle uncached node_modules request

### DIFF
--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -24,10 +24,15 @@ export interface InternalResolver {
 
 const defaultRequestToFile = (publicPath: string, root: string): string => {
   if (moduleRE.test(publicPath)) {
-    const moduleFilePath = idToFileMap.get(publicPath.replace(moduleRE, ''))
-    if (moduleFilePath) {
-      return moduleFilePath
+    const id = publicPath.replace(moduleRE, '')
+    const cachedModuleFilePath = idToFileMap.get(id)
+    if (cachedModuleFilePath) {
+      return cachedModuleFilePath
     }
+    const resolved = resolveNodeModuleFile(root, id)
+    if (!resolved) throw new Error(`Can't resolve "${id}"`)
+    idToFileMap.set(id, resolved)
+    return resolved
   }
   return path.join(root, publicPath.slice(1))
 }

--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -30,9 +30,10 @@ const defaultRequestToFile = (publicPath: string, root: string): string => {
       return cachedModuleFilePath
     }
     const resolved = resolveNodeModuleFile(root, id)
-    if (!resolved) throw new Error(`Can't resolve "${id}"`)
-    idToFileMap.set(id, resolved)
-    return resolved
+    if (resolved) {
+      idToFileMap.set(id, resolved)
+      return resolved
+    }
   }
   return path.join(root, publicPath.slice(1))
 }


### PR DESCRIPTION
Fix: https://github.com/vitejs/vite/issues/228

Let me explain with this reproduce repo: https://github.com/csr632/test-vite/tree/wrong-resolve
When dev server is re-writing this module: [test-package/es/index.js](https://github.com/csr632/test-vite/blob/wrong-resolve/test-package/es/index.js) 
vite go to this line:
https://github.com/csr632/vite/blob/ada8886e36578c7f43b7cd12bacd65e5a7c4c6e4/src/node/server/serverPluginModuleRewrite.ts#L243
with pathname being "/@modules/test-package/es/nested", which is not cached by idToFileMap:https://github.com/csr632/vite/blob/e786897134cb35ca19f4358c2829a82a1b3269e7/src/node/resolver.ts#L28
Previously defaultRequestToFile do nothing when this happen, and return `path.join(root, publicPath.slice(1))`, which doesn't make sense because publicPath is something like `/@modules/test-package/es/nested`.