### PR TITLE
fix: rollup should respect package.json#browser

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -130,7 +130,8 @@ export async function createBaseRollupPlugins(
     require('@rollup/plugin-node-resolve')({
       rootDir: root,
       extensions: supportedExts,
-      preferBuiltins: false
+      preferBuiltins: false,
+      browser: true
     }),
     require('@rollup/plugin-commonjs')({
       extensions: ['.js', '.cjs'],


### PR DESCRIPTION
We can assume vite is building for browser envirenment.