### PR TITLE
fix: defaultRequestToFile should consider optimized modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ dist
 dist-ssr
 TODOs.md
 *.log
-test/temp
+temp
 explorations
 .idea

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "jest": "^25.4.0",
     "lint-staged": "^10.1.6",
     "lodash-es": "^4.17.15",
+    "moment": "^2.26.0",
     "npm-run-all": "^4.1.5",
     "postcss-nesting": "^7.0.1",
     "preact": "^10.4.1",

--- a/playground/App.vue
+++ b/playground/App.vue
@@ -22,6 +22,7 @@
   <TestJsx />
   <TestAlias />
   <TestTransform />
+  <TestRewriteOptimized />
 </template>
 
 <script>
@@ -40,6 +41,7 @@ import TestTs from './ts/TestTs.vue'
 import TestJsx from './TestJsx.vue'
 import TestAlias from './TestAlias.vue'
 import TestTransform from './TestTransform.vue'
+import TestRewriteOptimized from "./rewrite-optimized/TestRewriteOptimized.vue";
 
 export default {
   data: () => ({
@@ -61,7 +63,8 @@ export default {
     TestJsx,
     TestAlias,
     TestTransform,
-    TestAsync: defineAsyncComponent(() => import('./TestAsync.vue'))
+    TestAsync: defineAsyncComponent(() => import('./TestAsync.vue')),
+    TestRewriteOptimized
   }
 }
 </script>

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,8 +5,8 @@
     "serve": "serve dist"
   },
   "dependencies": {
-    "lodash-es": "^4.17.15",
-    "moment": "^2.26.0",
+    "lodash-es": "link:../node_modules/lodash-es",
+    "moment": "link:../node_modules/moment",
     "rewrite-optimized-test-package": "link:./rewrite-optimized/test-package"
   }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -5,6 +5,8 @@
     "serve": "serve dist"
   },
   "dependencies": {
-    "lodash-es": "^4.17.15"
+    "lodash-es": "^4.17.15",
+    "moment": "^2.26.0",
+    "rewrite-optimized-test-package": "link:./rewrite-optimized/test-package"
   }
 }

--- a/playground/rewrite-optimized/TestRewriteOptimized.vue
+++ b/playground/rewrite-optimized/TestRewriteOptimized.vue
@@ -1,0 +1,12 @@
+<template>
+  <h2>Test rewrite in optimized module</h2>
+  <p class="test-rewrite-in-optimized">{{ msg }}</p>
+</template>
+
+<script>
+import moment from 'rewrite-optimized-test-package'
+
+export default {
+  data: () => ({ msg: moment(1590231082886).format('MMMM Do YYYY, h:mm:ss a') })
+}
+</script>

--- a/playground/rewrite-optimized/test-package/index.js
+++ b/playground/rewrite-optimized/test-package/index.js
@@ -1,0 +1,3 @@
+import { util } from './util'
+
+export default util

--- a/playground/rewrite-optimized/test-package/package.json
+++ b/playground/rewrite-optimized/test-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "rewrite-optimized-test-package",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/playground/rewrite-optimized/test-package/util.js
+++ b/playground/rewrite-optimized/test-package/util.js
@@ -1,0 +1,3 @@
+import moment from 'moment'
+
+export const util = moment

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -8,7 +8,10 @@ const config: UserConfig = {
   jsx: 'preact',
   minify: false,
   serviceWorker: !!process.env.USE_SW,
-  plugins: [jsPlugin]
+  plugins: [jsPlugin],
+  optimizeDeps: {
+    commonJSWhitelist: ['moment']
+  }
 }
 
 export default config

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -2,15 +2,13 @@
 # yarn lockfile v1
 
 
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+"lodash-es@link:../node_modules/lodash-es":
+  version "0.0.0"
+  uid ""
 
-moment@^2.26.0:
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
-  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
+"moment@link:../node_modules/moment":
+  version "0.0.0"
+  uid ""
 
 "rewrite-optimized-test-package@link:./rewrite-optimized/test-package":
   version "0.0.0"

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -6,3 +6,12 @@ lodash-es@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
+moment@^2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
+  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
+
+"rewrite-optimized-test-package@link:./rewrite-optimized/test-package":
+  version "0.0.0"
+  uid ""

--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -25,14 +25,20 @@ export interface InternalResolver {
 const defaultRequestToFile = (publicPath: string, root: string): string => {
   if (moduleRE.test(publicPath)) {
     const id = publicPath.replace(moduleRE, '')
-    const cachedModuleFilePath = idToFileMap.get(id)
-    if (cachedModuleFilePath) {
-      return cachedModuleFilePath
+    // try to resolve from optimized modules
+    const optimizedModule = resolveOptimizedModule(root, id)
+    if (optimizedModule) {
+      return optimizedModule
     }
-    const resolved = resolveNodeModuleFile(root, id)
-    if (resolved) {
-      idToFileMap.set(id, resolved)
-      return resolved
+    // try to resolve from normal node_modules
+    const cachedNodeModule = idToFileMap.get(id)
+    if (cachedNodeModule) {
+      return cachedNodeModule
+    }
+    const nodeModule = resolveNodeModuleFile(root, id)
+    if (nodeModule) {
+      idToFileMap.set(id, nodeModule)
+      return nodeModule
     }
   }
   return path.join(root, publicPath.slice(1))

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra')
 const path = require('path')
 const execa = require('execa')
 const puppeteer = require('puppeteer')
+const moment = require('moment')
 
 jest.setTimeout(100000)
 
@@ -9,7 +10,7 @@ const timeout = (n) => new Promise((r) => setTimeout(r, n))
 
 const binPath = path.resolve(__dirname, '../bin/vite.js')
 const fixtureDir = path.join(__dirname, '../playground')
-const tempDir = path.join(__dirname, 'temp')
+const tempDir = path.join(__dirname, '../temp')
 let devServer
 let browser
 let page
@@ -46,6 +47,7 @@ beforeAll(async () => {
   await fs.copy(fixtureDir, tempDir, {
     filter: (file) => !/dist|node_modules/.test(file)
   })
+  await execa('yarn', { cwd: tempDir })
 })
 
 afterAll(async () => {
@@ -355,7 +357,7 @@ describe('vite', () => {
 
     test('rewrite import in optimized deps', async () => {
       expect(await getText('.test-rewrite-in-optimized')).toMatch(
-        'May 23rd 2020, 6:51:22 pm'
+        moment(1590231082886).format('MMMM Do YYYY, h:mm:ss a')
       )
     })
   }

--- a/test/test.js
+++ b/test/test.js
@@ -352,6 +352,12 @@ describe('vite', () => {
       await expectByPolling(() => getText('.async'), 'should show up')
       expect(await getComputedColor('.async')).toBe('rgb(139, 69, 19)')
     })
+
+    test('rewrite import in optimized deps', async () => {
+      expect(await getText('.test-rewrite-in-optimized')).toMatch(
+        'May 23rd 2020, 6:51:22 pm'
+      )
+    })
   }
 
   // test build first since we are going to edit the fixtures when testing dev

--- a/yarn.lock
+++ b/yarn.lock
@@ -4802,6 +4802,11 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
+moment@^2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
+  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
I forgot to consider optimized modules in this pr: https://github.com/vitejs/vite/pull/230
which leads to a issue when rewriting cross import between optimized modules.
Here is a reproduction:
https://github.com/csr632/test-vite/tree/rewrite-extension-issue
You can also cherry-pick the second commit onto current master branch to see the issue.