### PR TITLE
refactor: vue update by hmr api

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -180,9 +180,9 @@ async function updateModule(
   } else {
     // dep update
     for (const { deps } of mod.callbacks) {
-      if (Array.isArray(deps)) {
+      if (Array.isArray(deps) && deps.includes(changedPath)) {
         deps.forEach((dep) => modulesToUpdate.add(dep))
-      } else {
+      } else if (deps === changedPath) {
         modulesToUpdate.add(deps)
       }
     }
@@ -195,7 +195,7 @@ async function updateModule(
       : modulesToUpdate.has(deps)
   })
   // reset callbacks on self update since they are going to be registered again
-  if (isSelfUpdate) {
+  if (modulesToUpdate.has(id)) {
     mod.callbacks = []
   }
 
@@ -222,7 +222,7 @@ async function updateModule(
     }
   }
 
-  console.log(`[vite]: js module hot updated: `, id)
+  console.log(`[vite]: js module hot updated: `, changedPath)
 }
 
 interface HotModule {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -87,8 +87,7 @@ socket.addEventListener('message', async ({ data }) => {
     case 'vue-style-update':
       const stylePath = `${path}?type=style&index=${index}`
       await bustSwCache(stylePath)
-      const content = await import(stylePath + `&t=${timestamp}`)
-      updateStyle(id, content.default)
+      await import(stylePath + `&t=${timestamp}`)
       console.log(
         `[vite] ${path} style${index > 0 ? `#${index}` : ``} updated.`
       )

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -63,15 +63,9 @@ function warnFailedFetch(err: Error, path: string | string[]) {
 
 // Listen for messages
 socket.addEventListener('message', async ({ data }) => {
-  const {
-    type,
-    path,
-    changeSrcPath,
-    id,
-    index,
-    timestamp,
-    customData
-  } = JSON.parse(data)
+  const { type, path, changeSrcPath, id, timestamp, customData } = JSON.parse(
+    data
+  )
 
   if (changeSrcPath) {
     await bustSwCache(changeSrcPath)
@@ -84,18 +78,10 @@ socket.addEventListener('message', async ({ data }) => {
     case 'connected':
       console.log(`[vite] connected.`)
       break
-    case 'vue-style-update':
-      const stylePath = `${path}?type=style&index=${index}`
-      await bustSwCache(stylePath)
-      await import(stylePath + `&t=${timestamp}`)
-      console.log(
-        `[vite] ${path} style${index > 0 ? `#${index}` : ``} updated.`
-      )
-      break
     case 'style-update':
-      await bustSwCache(`${path}?import`)
-      const style = await import(`${path}?t=${timestamp}`)
-      updateStyle(id, style.default)
+      const hasQuery = path.includes('?') ? '&' : '?'
+      await bustSwCache(`${path}${hasQuery}import`)
+      await import(`${path}${hasQuery}t=${timestamp}`)
       console.log(`[vite] ${path} updated.`)
       break
     case 'style-remove':

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -166,9 +166,9 @@ async function updateModule(
   } else {
     // dep update
     for (const { deps } of mod.callbacks) {
-      if (Array.isArray(deps) && deps.includes(changedPath)) {
+      if (Array.isArray(deps)) {
         deps.forEach((dep) => modulesToUpdate.add(dep))
-      } else if (deps === changedPath) {
+      } else {
         modulesToUpdate.add(deps)
       }
     }
@@ -181,7 +181,7 @@ async function updateModule(
       : modulesToUpdate.has(deps)
   })
   // reset callbacks on self update since they are going to be registered again
-  if (modulesToUpdate.has(id)) {
+  if (isSelfUpdate) {
     mod.callbacks = []
   }
 
@@ -208,7 +208,7 @@ async function updateModule(
     }
   }
 
-  console.log(`[vite]: js module hot updated: `, changedPath)
+  console.log(`[vite]: js module hot updated: `, id)
 }
 
 interface HotModule {

--- a/src/node/server/serverPluginCss.ts
+++ b/src/node/server/serverPluginCss.ts
@@ -1,10 +1,10 @@
 import { ServerPlugin } from '.'
-import { hmrClientId } from './serverPluginHmr'
 import hash_sum from 'hash-sum'
 import { Context } from 'koa'
 import { cleanUrl, isImportRequest, readBody } from '../utils'
 import { srcImportMap, vueCache } from './serverPluginVue'
 import {
+  codegenCss,
   compileCss,
   cssPreprocessLangRE,
   rewriteCssUrls
@@ -34,33 +34,21 @@ export const cssPlugin: ServerPlugin = ({
       // note ctx.body could be null if upstream set status to 304
       ctx.body
     ) {
+      const id = JSON.stringify(hash_sum(ctx.path))
       if (isImportRequest(ctx)) {
         await processCss(root, ctx)
         // we rewrite css with `?import` to a js module that inserts a style
         // tag linking to the actual raw url
         ctx.type = 'js'
-        const id = JSON.stringify(hash_sum(ctx.path))
-        let code =
-          `import { updateStyle } from "${hmrClientId}"\n` +
-          `const css = ${JSON.stringify(processedCSS.get(ctx.path)!.css)}\n` +
-          `updateStyle(${id}, css)\n`
-        if (ctx.path.endsWith('.module.css')) {
-          code += `export default ${JSON.stringify(
-            processedCSS.get(ctx.path)!.modules
-          )}`
-        } else {
-          code += `export default css`
-        }
-        ctx.body = code.trim()
+        const { css, modules } = processedCSS.get(ctx.path)!
+        ctx.body = codegenCss(id, css, modules)
       } else {
         // raw request, return compiled css
         if (!processedCSS.has(ctx.path)) {
           await processCss(root, ctx)
         }
         ctx.type = 'js'
-        ctx.body = `export default ${JSON.stringify(
-          processedCSS.get(ctx.path)!.css
-        )}`
+        ctx.body = codegenCss(id, processedCSS.get(ctx.path)!.css)
       }
     }
   })
@@ -78,10 +66,8 @@ export const cssPlugin: ServerPlugin = ({
           chalk.green(`[vite:hmr] `) + `${publicPath} updated. (style)`
         )
         watcher.send({
-          type: 'vue-style-update',
-          path: publicPath,
-          index: Number(index),
-          id: `${hash_sum(publicPath)}-${index}`,
+          type: 'style-update',
+          path: `${publicPath}?type=style&index=${index}`,
           timestamp: Date.now()
         })
         return
@@ -94,14 +80,12 @@ export const cssPlugin: ServerPlugin = ({
       }
 
       const publicPath = resolver.fileToRequest(file)
-      const id = hash_sum(publicPath)
 
       // bust process cache
       processedCSS.delete(publicPath)
 
       watcher.send({
         type: 'style-update',
-        id,
         path: publicPath,
         timestamp: Date.now()
       })

--- a/src/node/server/serverPluginHmr.ts
+++ b/src/node/server/serverPluginHmr.ts
@@ -309,7 +309,7 @@ export const hmrPlugin: ServerPlugin = ({
           send({
             type: 'js-update',
             path: vueBoundary,
-            changeSrcPath: vueBoundary,
+            changeSrcPath: publicPath,
             timestamp
           })
         })

--- a/src/node/server/serverPluginHmr.ts
+++ b/src/node/server/serverPluginHmr.ts
@@ -73,7 +73,6 @@ export const hmrClientPublicPath = `/${hmrClientId}`
 
 interface HMRPayload {
   type:
-    | 'vue-style-update'
     | 'js-update'
     | 'style-update'
     | 'style-remove'
@@ -178,8 +177,7 @@ export const hmrPlugin: ServerPlugin = ({
     // check which part of the file changed
     let needRerender = false
 
-    if (!isEqual(descriptor.script, prevDescriptor.script)) {
-      // reload
+    const vueReload = () => {
       send({
         type: 'js-update',
         path: publicPath,
@@ -190,6 +188,10 @@ export const hmrPlugin: ServerPlugin = ({
         chalk.green(`[vite:hmr] `) +
           `${path.relative(root, file)} updated. (reload)`
       )
+    }
+
+    if (!isEqual(descriptor.script, prevDescriptor.script)) {
+      vueReload()
       return
     }
 
@@ -209,16 +211,7 @@ export const hmrPlugin: ServerPlugin = ({
       prevStyles.some((s) => s.module != null) ||
       nextStyles.some((s) => s.module != null)
     ) {
-      send({
-        type: 'js-update',
-        path: publicPath,
-        changeSrcPath: publicPath,
-        timestamp
-      })
-      console.log(
-        chalk.green(`[vite:hmr] `) +
-          `${path.relative(root, file)} updated. (reload)`
-      )
+      vueReload()
       return
     }
 
@@ -232,10 +225,8 @@ export const hmrPlugin: ServerPlugin = ({
       if (!prevStyles[i] || !isEqual(prevStyles[i], nextStyles[i])) {
         didUpdateStyle = true
         send({
-          type: 'vue-style-update',
-          path: publicPath,
-          index: i,
-          id: `${styleId}-${i}`,
+          type: 'style-update',
+          path: `${publicPath}?type=style&index=${i}`,
           timestamp
         })
       }

--- a/src/node/server/serverPluginHmr.ts
+++ b/src/node/server/serverPluginHmr.ts
@@ -234,9 +234,6 @@ export const hmrPlugin: ServerPlugin = ({
         send({
           type: 'vue-style-update',
           path: publicPath,
-          changeSrcPath:
-            `${publicPath}?type=style&index=${i}` +
-            (nextStyles[i].module ? '&module' : ''),
           index: i,
           id: `${styleId}-${i}`,
           timestamp

--- a/src/node/server/serverPluginModuleRewrite.ts
+++ b/src/node/server/serverPluginModuleRewrite.ts
@@ -150,10 +150,7 @@ export function rewriteImports(
           let resolved
           if (id === hmrClientId) {
             resolved = hmrClientPublicPath
-            if (
-              /\bhot\b/.test(source.substring(ss, se)) &&
-              !/.vue$|.vue\?type=/.test(importer)
-            ) {
+            if (/\bhot\b/.test(source.substring(ss, se))) {
               // the user explicit imports the HMR API in a js file
               // making the module hot.
               rewriteFileWithHMR(root, source, importer, resolver, s)

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -247,15 +247,10 @@ async function compileSFCMain(
         }
         const styleVar = `__style${i}`
         const moduleName = typeof s.module === 'string' ? s.module : '$style'
-        const moduleRequest = styleRequest + '&module'
-        code += `\nimport ${styleVar} from ${JSON.stringify(moduleRequest)}`
+        code += `\nimport ${styleVar} from ${JSON.stringify(
+          styleRequest + '&module'
+        )}`
         code += `\n__cssModules[${JSON.stringify(moduleName)}] = ${styleVar}`
-        code += `\n if (__DEV__) {
-  hot.accept(${JSON.stringify(moduleRequest)}, (a) => {
-    __cssModules[${JSON.stringify(moduleName)}] = ${styleVar}
-    __VUE_HMR_RUNTIME__.rerender("${id}")
-  })
-}`
       } else {
         code += `\nimport ${JSON.stringify(styleRequest)}`
       }

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -257,8 +257,7 @@ async function compileSFCMain(
   })
 }`
       } else {
-        code += `\nimport css_${i} from ${JSON.stringify(styleRequest)}`
-        code += `\nupdateStyle("${id}-${i}", css_${i})`
+        code += `\nimport ${JSON.stringify(styleRequest)}`
       }
     })
     if (hasScoped) {

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -228,9 +228,8 @@ async function compileSFCMain(
     code += `const __script = {}`
   }
 
-  code += `\n if (hot) {
+  code += `\n if (__DEV__) {
   hot.accept((m) => {
-    console.log(m)
     __VUE_HMR_RUNTIME__.reload("${id}", m.default)
   })
 }`
@@ -251,7 +250,7 @@ async function compileSFCMain(
         const moduleRequest = styleRequest + '&module'
         code += `\nimport ${styleVar} from ${JSON.stringify(moduleRequest)}`
         code += `\n__cssModules[${JSON.stringify(moduleName)}] = ${styleVar}`
-        code += `\n if (hot) {
+        code += `\n if (__DEV__) {
   hot.accept(${JSON.stringify(moduleRequest)}, (a) => {
     __cssModules[${JSON.stringify(moduleName)}] = ${styleVar}
     __VUE_HMR_RUNTIME__.rerender("${id}")
@@ -273,7 +272,7 @@ async function compileSFCMain(
       templateRequest
     )}`
     code += `\n__script.render = __render`
-    code += `\n if (hot) {
+    code += `\n if (__DEV__) {
   hot.accept(${JSON.stringify(templateRequest)}, (m) => {
     __VUE_HMR_RUNTIME__.rerender("${id}", m.render)
   })

--- a/src/node/utils/cssUtils.ts
+++ b/src/node/utils/cssUtils.ts
@@ -88,9 +88,9 @@ export function codegenCss(
   modules?: Record<string, string>
 ): string {
   let code =
-    `import { hot, updateStyle } from "${hmrClientPublicPath}"\n` +
+    `import { updateStyle } from "${hmrClientPublicPath}"\n` +
     `const css = ${JSON.stringify(css)}\n` +
-    `updateStyle("${id}", css)\n`
+    `updateStyle(${JSON.stringify(id)}, css)\n`
   if (modules) {
     code += `export default ${JSON.stringify(modules)}`
   } else {

--- a/src/node/utils/cssUtils.ts
+++ b/src/node/utils/cssUtils.ts
@@ -9,6 +9,7 @@ import {
   SFCAsyncStyleCompileOptions,
   SFCStyleCompileResults
 } from '@vue/compiler-sfc'
+import { hmrClientPublicPath } from '../server/serverPluginHmr'
 
 export const urlRE = /(url\(\s*['"]?)([^"')]+)(["']?\s*\))/
 export const cssPreprocessLangRE = /(.+).(less|sass|scss|styl|stylus)$/
@@ -79,6 +80,23 @@ export async function compileCss(
         }
       : {})
   })
+}
+
+export function codegenCss(
+  id: string,
+  css: string,
+  modules?: Record<string, string>
+): string {
+  let code =
+    `import { hot, updateStyle } from "${hmrClientPublicPath}"\n` +
+    `const css = ${JSON.stringify(css)}\n` +
+    `updateStyle("${id}", css)\n`
+  if (modules) {
+    code += `export default ${JSON.stringify(modules)}`
+  } else {
+    code += `export default css`
+  }
+  return code
 }
 
 // postcss-load-config doesn't expose Result type

--- a/test/test.js
+++ b/test/test.js
@@ -164,17 +164,17 @@ describe('vite', () => {
         )
         await expectByPolling(
           () => browserLogs[browserLogs.length - 1],
-          'js module hot updated:  /testHmrManualDep.js'
+          'js module hot updated:  /testHmrManual.js'
         )
         expect(
-          browserLogs.slice(browserLogs.length - 4, browserLogs.length - 1)
+          browserLogs.slice(browserLogs.length - 7, browserLogs.length - 1)
         ).toEqual([
           // dispose for both dep and self
-          // `foo was: 2`,
+          `foo was: 2`,
           `(dep) foo was: 1`,
           // self callbacks
-          // `(self-accepting)1.foo is now: 2`,
-          // `(self-accepting)2.foo is now: 2`,
+          `(self-accepting)1.foo is now: 2`,
+          `(self-accepting)2.foo is now: 2`,
           // dep callbacks
           `(single dep) foo is now: 2`,
           `(multiple deps) foo is now: 2`

--- a/test/test.js
+++ b/test/test.js
@@ -164,17 +164,17 @@ describe('vite', () => {
         )
         await expectByPolling(
           () => browserLogs[browserLogs.length - 1],
-          'js module hot updated:  /testHmrManual.js'
+          'js module hot updated:  /testHmrManualDep.js'
         )
         expect(
-          browserLogs.slice(browserLogs.length - 7, browserLogs.length - 1)
+          browserLogs.slice(browserLogs.length - 4, browserLogs.length - 1)
         ).toEqual([
           // dispose for both dep and self
-          `foo was: 2`,
+          // `foo was: 2`,
           `(dep) foo was: 1`,
           // self callbacks
-          `(self-accepting)1.foo is now: 2`,
-          `(self-accepting)2.foo is now: 2`,
+          // `(self-accepting)1.foo is now: 2`,
+          // `(self-accepting)2.foo is now: 2`,
           // dep callbacks
           `(single dep) foo is now: 2`,
           `(multiple deps) foo is now: 2`


### PR DESCRIPTION
I do it because i think it is useful for let the logics with built-in `vue` process  can be as an plugin.Well I think the hmr with vue module should be implement by hmr api, instead of use internal logic
## Other

I find top boundary will update self when deps is changed.eg blew case.
```
hot.accpet('A',  'B', () => {} )
```
I think this bevaior should be handle by user self.`vite` don't do it because sometimes user don't hope `A` full-reload when `B` change.
If the user want to do this bevaior.they can do like this blew.
```
hot.accpet('A',  'B', () => {
   import('A') // re-import A
} )
```
Or better way. we can add hmr bubble for not accpet deps.And accpet deps should not bubble.Like this blew.
``` ts
// A
import 'B'
import 'C'
hot.accpet('A',  'B', () => {} )
```
A should not update when B changed.A should update when C change.