### PR TITLE
fix: dotenv debug option

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -429,7 +429,7 @@ function loadEnv(mode: string, root: string): Record<string, string> {
     const path = lookupFile(root, [file], true)
     if (path) {
       const result = dotenv.config({
-        debug: !!process.env.DEBUG,
+        debug: !!process.env.DEBUG || undefined,
         path
       })
       if (result.error) {


### PR DESCRIPTION
The debug option of dotenv is very unfriendly, the type check makes it can only be set to boolean or undefined, but when its value is not equal to null, the debug information is always printed by default.