### PR TITLE
fix: rollup resolve alias

### DIFF
--- a/src/node/build/buildPluginResolve.ts
+++ b/src/node/build/buildPluginResolve.ts
@@ -29,7 +29,7 @@ export const createBuildResolvePlugin = (
       }
       // fallback to node-resolve because alias
       if (id !== original) {
-        const resolved = this.resolve(id, importer, { skipSelf: true })
+        const resolved = await this.resolve(id, importer, { skipSelf: true })
         return resolved || { id }
       }
     }


### PR DESCRIPTION
`this.resolve` return a promise. This promise may resolve to null.
Without awaiting this promise, the next line `resolved || { id }` does not make sense.