### PR TITLE
fix: fix rollup not respecting 'browser' field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ TODOs.md
 temp
 explorations
 .idea
+.vscode
 *.local

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@babel/parser": "^7.9.4",
-    "@rollup/plugin-commonjs": "~11.0.0",
+    "@rollup/plugin-commonjs": "^12.0.0",
     "@rollup/plugin-json": "^4.0.3",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@types/koa": "^2.11.3",

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -140,13 +140,13 @@ export async function createBaseRollupPlugins(
     // user transforms
     ...(transforms.length ? [createBuildJsTransformPlugin(transforms)] : []),
     require('@rollup/plugin-node-resolve')({
+      browser: true,
       rootDir: root,
       extensions: supportedExts,
       preferBuiltins: false
     }),
     require('@rollup/plugin-commonjs')({
-      extensions: ['.js', '.cjs'],
-      namedExports: knownNamedExports
+      extensions: ['.js', '.cjs']
     })
   ].filter(Boolean)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,13 +465,15 @@
   resolved "https://registry.yarnpkg.com/@pika/react/-/react-16.13.1.tgz#20e47997d2a2f1e5da39a8e28b75db2ec77d99c6"
   integrity sha512-v33Ub2QxntNpDFRnkj3tCbT6jMb7Etu7LOMQO/YAulLRIDtDvJdMwuOVJDdPYUmDtWjfWOB5xSP7nl7k0BApbQ==
 
-"@rollup/plugin-commonjs@~11.0.0":
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-11.0.2.tgz#837cc6950752327cb90177b608f0928a4e60b582"
-  integrity sha512-MPYGZr0qdbV5zZj8/2AuomVpnRVXRU5XKXb3HVniwRoRCreGlf5kOE081isNWeiLIi6IYkwTX9zE0/c7V8g81g==
+"@rollup/plugin-commonjs@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.npm.taobao.org/@rollup/plugin-commonjs/download/@rollup/plugin-commonjs-12.0.0.tgz#e2f308ae6057499e0f413f878fff7c3a0fdc02a1"
+  integrity sha1-4vMIrmBXSZ4PQT+Hj/98Og/cAqE=
   dependencies:
-    "@rollup/pluginutils" "^3.0.0"
+    "@rollup/pluginutils" "^3.0.8"
+    commondir "^1.0.1"
     estree-walker "^1.0.1"
+    glob "^7.1.2"
     is-reference "^1.1.2"
     magic-string "^0.25.2"
     resolve "^1.11.0"
@@ -494,7 +496,7 @@
     is-module "^1.0.0"
     resolve "^1.14.2"
 
-"@rollup/pluginutils@^3.0.0", "@rollup/pluginutils@^3.0.8":
+"@rollup/pluginutils@^3.0.8":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.0.10.tgz#a659b9025920378494cd8f8c59fbf9b3a50d5f12"
   integrity sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==
@@ -1744,6 +1746,11 @@ commander@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npm.taobao.org/commondir/download/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 compare-func@^1.3.1:
   version "1.3.2"


### PR DESCRIPTION
Some libs are using  `package.json#browser` field to differentiate server/browser implementation (e.g. axios).  Without setting `browser: true`, `@rollup/plugin-node-resolve` will resolve with default files and results in code like `import 'http'` in browser.

This PR also upgrades `@rollup/plugin-commonjs` because it handles some commonjs package better in my case.