### PR TITLE
fix: some package's `module` entry doesn't have extension

### DIFF
--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -268,6 +268,9 @@ export function resolveNodeModule(
     let entryFilePath: string | null = null
     if (entryPoint) {
       entryFilePath = path.join(path.dirname(pkgPath), entryPoint!)
+      if (!entryFilePath.endsWith('.js')) {
+        entryFilePath = entryFilePath + '.js'
+      }
       entryPoint = path.posix.join(id, entryPoint!)
       // save the resolved file path now so we don't need to do it again in
       // resolveNodeModuleFile()


### PR DESCRIPTION
Some popular libs(e.g. [rc-tooltip](https://github.com/react-component/tooltip/blob/master/package.json#L28)) are setting 'package.json#module' field WITHOUT file extension (`.js`). For better compatibility, we should add for them?