### PR TITLE
fix: import.meta.hot should be injected before first `if (import.meta…

### DIFF
--- a/src/node/server/serverPluginHmr.ts
+++ b/src/node/server/serverPluginHmr.ts
@@ -399,7 +399,8 @@ export function rewriteFileWithHMR(
     // if (import.meta.hot) ...
     if (node.type === 'IfStatement') {
       const isDevBlock = isMetaHot(node.test)
-      if (isDevBlock) {
+      if (isDevBlock && !importMetaConditional) {
+        // remember the first occurence of `if (import.meta.hot)`
         importMetaConditional = node
       }
       if (node.consequent.type === 'BlockStatement') {


### PR DESCRIPTION
….hot)`

There may be multi `if (import.meta.hot)` in one module, we should inject  `import.meta.hot` value before the first one.

Fix: https://github.com/vitejs/vite/issues/282