### PR TITLE
refactor: regex for cleanUrl hash

### DIFF
--- a/src/node/utils/pathUtils.ts
+++ b/src/node/utils/pathUtils.ts
@@ -9,7 +9,7 @@ export const resolveFrom = (root: string, id: string) =>
   resolve.sync(id, { basedir: root, extensions: supportedExts })
 
 export const queryRE = /\?.*$/
-export const hashRE = /\#.*$/
+export const hashRE = /#.*$/
 
 export const cleanUrl = (url: string) =>
   url.replace(hashRE, '').replace(queryRE, '')


### PR DESCRIPTION
removed redundant escape before # as it's not a special char in regex.