### PR TITLE
fix: add vite to ignore list of optimization

### DIFF
--- a/src/node/depOptimizer.ts
+++ b/src/node/depOptimizer.ts
@@ -12,6 +12,7 @@ import { Ora } from 'ora'
 import { createBuildCssPlugin } from './build/buildPluginCss'
 
 const KNOWN_IGNORE_LIST = new Set([
+  'vite',
   'tailwindcss',
   '@tailwindcss/ui',
   '@pika/react',


### PR DESCRIPTION
When vite is mistakenly put into dependency instead of devDependency, it tries to optimize itself and fails. This happens since vite 0.18.0.
Simply adding vite to ignore list can ease this problem.

Here's the part of error log when vite fails to optimize.
```
[vite] Dep optimization failed with error:
Error: Unexpected character '�' (Note that you need plugins to import files that are not JavaScript)
    at error (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:217:30)
    at Module.error (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:15145:16)
    at tryParse (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:15034:23)
    at Module.setSource (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:15436:30)
    at ModuleLoader.addModuleSource (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:17430:20)
    at async ModuleLoader.fetchModule (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:17491:9)
    at async /Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:17461:36
    at async Promise.all (index 0)
    at async ModuleLoader.fetchModule (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:17492:9)
    at async /Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:17475:68 {
  code: 'PARSE_ERROR',
  parserError: SyntaxError: Unexpected character '�' (1:0)
      at Object.pp$4.raise (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:3922:13)
      at Object.pp$9.getTokenFromCode (/Users/mythosil/git/github.com/vuejs/vite/node_modules/rollup/dist/shared/rollup.js:5690:8)
...
```