### PR TITLE
hint more clear at builtin bail

### DIFF
--- a/src/node/depOptimizer.ts
+++ b/src/node/depOptimizer.ts
@@ -198,7 +198,9 @@ export async function optimizeDeps(
         if (isbuiltin(id)) {
           let importingDep
           if (importer) {
-            const match = slash(importer).match(/\/node_modules\/(\w+)\//)
+            const match = slash(importer).match(
+              /\/node_modules\/([^@\/][^\/]*|@[^\/]+\/[^\/]+)\//
+            )
             if (match) {
               importingDep = match[1]
             }


### PR DESCRIPTION
to match package name not only `\w+` but with dash or under namespace
```
> '/node_modules/test/abc/def'.match(/\/node_modules\/([^@\/][^\/]*|@[^\/]+\/[^\/]+)\//)
[
  '/node_modules/test/',
  'test',
  index: 0,
  input: '/node_modules/test/abc/def',
  groups: undefined
]
> '/node_modules/te-st/abc/def'.match(/\/node_modules\/([^@\/][^\/]*|@[^\/]+\/[^\/]+)\//)
[
  '/node_modules/te-st/',
  'te-st',
  index: 0,
  input: '/node_modules/te-st/abc/def',
  groups: undefined
]
> '/node_modules/@te/st/abc/def'.match(/\/node_modules\/([^@\/][^\/]*|@[^\/]+\/[^\/]+)\//)
[
  '/node_modules/@te/st/',
  '@te/st',
  index: 0,
  input: '/node_modules/@te/st/abc/def',
  groups: undefined
]
```