### PR TITLE
fix: add .html into supportedExts

### DIFF
--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -25,7 +25,15 @@ export interface InternalResolver {
   resolveExt(publicPath: string): string | undefined
 }
 
-export const supportedExts = ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json']
+export const supportedExts = [
+  '.html',
+  '.mjs',
+  '.js',
+  '.ts',
+  '.jsx',
+  '.tsx',
+  '.json'
+]
 export const mainFields = ['module', 'jsnext', 'jsnext:main', 'browser', 'main']
 
 const defaultRequestToFile = (publicPath: string, root: string): string => {


### PR DESCRIPTION
When there are multiple files starting with` index.`, `serverStaticServePlugin` cannot resolve the extension of the index.html file correctly.  