### PR TITLE
fix: root path resolve (#323)

### DIFF
--- a/src/node/server/serverPluginServeStatic.ts
+++ b/src/node/server/serverPluginServeStatic.ts
@@ -17,6 +17,8 @@ export const serveStaticPlugin: ServerPlugin = ({
   watcher
 }) => {
   app.use(async (ctx, next) => {
+    if (ctx.path === '/') return next()
+
     // short circuit requests that have already been explicitly handled
     if (ctx.body || ctx.status !== 404) {
       return


### PR DESCRIPTION
When multiple files starting with `index.` exist on the root directory of the project(eg. `index.jsx` `index.jsx` ...), `serverPluginServeStatic` will assign other file type to `index.html`