### PR TITLE
fix(transform): fix regression of transforms functionality

### DIFF
--- a/src/node/transform.ts
+++ b/src/node/transform.ts
@@ -48,6 +48,7 @@ export function createServerTransformPlugin(
                 path,
                 query
               )
+              code = ctx.body
             }
           }
         }


### PR DESCRIPTION
Fix regression when multiple transforms are handling the same file in a chain.

It was introduced in the following commit:
https://github.com/vitejs/vite/commit/8d6ca7528b13ae5a0f929c363421696d6070542d#diff-bd94f64f43c4443242b281bf5457c155L32