### PR TITLE
fix: consist url to open in browser with https option

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -163,7 +163,7 @@ async function runServe(options: UserConfig) {
     require('debug')('vite:server')(`server ready in ${Date.now() - start}ms.`)
 
     if (options.open) {
-      require('./utils/openBrowser').openBrowser(`http://localhost:${port}`)
+      require('./utils/openBrowser').openBrowser(`${protocol}://localhost:${port}`)
     }
   })
 }


### PR DESCRIPTION
Currently, with `https: true` and `open: true` set in vite.config.js, the program would still open a http url `http://localhost:PORT`. This can get developers confused.

![image](https://user-images.githubusercontent.com/8180186/83612994-bbfff980-a5b5-11ea-914c-801f7f6fcdb2.png)
