### PR TITLE
Allow for custom hostname instead of using localhost

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -141,7 +141,7 @@ async function runServe(options: UserConfig) {
     }
   })
 
-  server.listen(port, () => {
+  server.listen(port, hostname, () => {
     console.log()
     console.log(`  Dev server running at:`)
     const interfaces = os.networkInterfaces()

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -125,7 +125,9 @@ async function runServe(options: UserConfig) {
   const server = require('./server').createServer(options)
 
   let port = options.port || 3000
+  let hostname = options.hostname || 'localhost'
   const protocol = options.https ? 'https' : 'http'
+  
   server.on('error', (e: Error & { code?: string }) => {
     if (e.code === 'EADDRINUSE') {
       console.log(`Port ${port} is in use, trying another one...`)
@@ -151,7 +153,7 @@ async function runServe(options: UserConfig) {
             type: detail.address.includes('127.0.0.1')
               ? 'Local:   '
               : 'Network: ',
-            host: detail.address.replace('127.0.0.1', 'localhost')
+            host: detail.address.replace('127.0.0.1', hostname)
           }
         })
         .forEach(({ type, host }) => {
@@ -164,7 +166,7 @@ async function runServe(options: UserConfig) {
 
     if (options.open) {
       require('./utils/openBrowser').openBrowser(
-        `${protocol}://localhost:${port}`
+        `${protocol}://${hostname}:${port}`
       )
     }
   })

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -119,6 +119,7 @@ export interface SharedConfig {
 }
 
 export interface ServerConfig extends SharedConfig {
+  hostname?: string
   port?: number
   open?: boolean
   /**


### PR DESCRIPTION
This allows you to specify a different hostname when starting up the dev server instead of using the default localhost. This is useful where we have valid ssl certificates for our local dev environments and want the hostname to match.