### PR TITLE
fix: serve map file inside linked pkg

### DIFF
--- a/src/node/server/serverPluginModuleResolve.ts
+++ b/src/node/server/serverPluginModuleResolve.ts
@@ -74,8 +74,8 @@ export const moduleResolvePlugin: ServerPlugin = ({ root, app, resolver }) => {
     }
 
     if (isMapFile && importer) {
-      // the `resolveNodeModuleFile` doesn't works with linked pkg
-      // our last try: infer from same dir of the importer
+      // the resolveNodeModuleFile doesn't work with linked pkg
+      // our last try: infer from the dir of importer
       const inferMapPath = path.join(
         path.dirname(importerFilePath),
         path.basename(ctx.path)

--- a/src/node/server/serverPluginModuleResolve.ts
+++ b/src/node/server/serverPluginModuleResolve.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import chalk from 'chalk'
+import fs from 'fs-extra'
 import { ServerPlugin } from '.'
 import { resolveVue, cachedRead } from '../utils'
 import { URL } from 'url'
@@ -56,9 +57,11 @@ export const moduleResolvePlugin: ServerPlugin = ({ root, app, resolver }) => {
 
     const referer = ctx.get('referer')
     let importer: string | undefined
+    // this is a map file request from browser dev tool
+    const isMapFile = ctx.path.endsWith('.map')
     if (referer) {
       importer = new URL(referer).pathname
-    } else if (ctx.path.endsWith('.map')) {
+    } else if (isMapFile) {
       // for some reason Chrome doesn't provide referer for source map requests.
       // do our best to reverse-infer the importer.
       importer = ctx.path.replace(/\.map$/, '')
@@ -68,6 +71,18 @@ export const moduleResolvePlugin: ServerPlugin = ({ root, app, resolver }) => {
     const nodeModulePath = resolveNodeModuleFile(importerFilePath, id)
     if (nodeModulePath) {
       return serve(id, nodeModulePath, 'node_modules')
+    }
+
+    if (isMapFile && importer) {
+      // the `resolveNodeModuleFile` doesn't works with linked pkg
+      // our last try: infer from same dir of the importer
+      const inferMapPath = path.join(
+        path.dirname(importerFilePath),
+        path.basename(ctx.path)
+      )
+      if (fs.existsSync(inferMapPath)) {
+        return serve(id, inferMapPath, 'map file in linked pkg')
+      }
     }
 
     console.error(


### PR DESCRIPTION
reproduce:
https://github.com/vitejs/vite-plugin-react-pages/tree/b6515ff709e2239985e918dbde07e232e0c834ec

steps:
```
pnpm i
cd fixtures/use-theme
npm run dev
```
Open your browser dev tool. You will see this if your browser request a map file:
![image](https://user-images.githubusercontent.com/18747423/84250383-8f605a80-ab3e-11ea-960e-db2071f73b8c.png)
