### PR TITLE
fix: include importMeta.d.ts in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bin",
     "dist/**/*.js",
     "dist/**/*.d.ts",
-    "hmr.d.ts"
+    "importMeta.d.ts"
   ],
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
`hmr.d.ts` was renamed to `importMeta.d.ts`, however, the `package.json` does not reflect on that yet. Therefore it's still missing from the npm package.