### PR TITLE
feat: added onBuild() hook

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -192,7 +192,8 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
     shouldPreload = null,
     env = {},
     mode = 'production',
-    cssPreprocessOptions = {}
+    cssPreprocessOptions = {},
+    onBuild = null
   } = options
 
   const isTest = process.env.NODE_ENV === 'test'
@@ -404,6 +405,10 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
 
   // stop the esbuild service after each build
   stopService()
+
+  if (onBuild) {
+    await onBuild(output)
+  }
 
   return {
     assets: output,

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -8,6 +8,7 @@ import { CompilerOptions, SFCStyleCompileOptions } from '@vue/compiler-sfc'
 import Rollup, {
   InputOptions as RollupInputOptions,
   OutputOptions as RollupOutputOptions,
+  RollupOutput,
   OutputChunk
 } from 'rollup'
 import { createEsbuildPlugin } from './build/buildPluginEsbuild'
@@ -257,6 +258,10 @@ export interface BuildConfig extends SharedConfig {
    * @default true
    */
   emitAssets?: boolean
+  /**
+   * Callback when build is complete
+   */
+  onBuild?: (assets: RollupOutput['output']) => Promise<void>
   /**
    * Predicate function that determines whether a link rel=modulepreload shall be
    * added to the index.html for the chunk passed in


### PR DESCRIPTION
## Why this new option ?

I plan on using vite with ruby on rails, symfony and Laravel so I need a way to generate a json containing something that looks like this :

```json
{
   "entrypoint": "output",
   "entrypoint2": "output"
}
```

Unfortunately, vite loads rollup plugins too early so I created a new option that is called when a build occurs. With this hook we can call something when build finishes. 