### PR TITLE
fix: fallback to https when using secure and proxies (closes #484)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@rollup/plugin-node-resolve": "^8.0.0",
     "@types/koa": "^2.11.3",
     "@types/lru-cache": "^5.1.0",
+    "@types/mime-types": "^2.1.0",
     "@vue/compiler-dom": "^3.0.0-beta.14",
     "@vue/compiler-sfc": "^3.0.0-beta.14",
     "brotli-size": "^4.0.0",

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -120,10 +120,16 @@ export function createServer(config: ServerConfig): Server {
 }
 
 function resolveServer(
-  { https = false, httpsOptions = {} }: ServerConfig,
+  { https = false, httpsOptions = {}, proxy }: ServerConfig,
   requestListener: RequestListener
 ) {
   if (https) {
+    if (proxy && Object.keys(proxy).length > 0) {
+      return require('https').createServer(
+        resolveHttpsConfig(httpsOptions),
+        requestListener
+      )
+    }
     return require('http2').createSecureServer(
       {
         ...resolveHttpsConfig(httpsOptions),

--- a/src/node/server/serverPluginHmr.ts
+++ b/src/node/server/serverPluginHmr.ts
@@ -307,7 +307,7 @@ export function rewriteFileWithHMR(
         )
       }
 
-      const method = node.callee.property.name
+      const method = (node.callee.property as { name: string }).name
       if (method === 'accept' || method === 'acceptDeps') {
         if (!isDevBlock) {
           console.error(


### PR DESCRIPTION
fallback to using `https.createServer` if the `proxy` config is used along with using `https`