### PR TITLE
deps: bump esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
     "es-module-lexer": "^0.3.18",
-    "esbuild": "^0.5.11",
+    "esbuild": "^0.5.19",
     "etag": "^1.8.1",
     "execa": "^4.0.1",
     "fs-extra": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,10 +2398,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.5.11:
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.5.11.tgz#9872ad552db1958d37a6ad7160294bf4320c0531"
-  integrity sha512-E/SBK3tHIcj3iCZh0bUf8/pmEAcM10W7SH2feuHZSzTpLZmtxlWl9j5tesY6OLkv2oDgfX0r9mbOeltXUbJe4Q==
+esbuild@^0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.5.19.tgz#00daed3290407e87347266ed285ef4ce86040f13"
+  integrity sha512-QiK0BCLPemNO9zziNOFudQbtNnEax/x8faBfbtEtfhb53gNk0H5J10uFrzmJef1P379VrP66BZpc02iqBuM/+g==
 
 escape-html@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Fixes esbuild bug ([#213](https://github.com/evanw/esbuild/issues/213)) where `readonly` function from Vue wasn't recognized as a type.