### PR TITLE
refactor: simplify ssrBuild call

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -209,13 +209,6 @@ export async function createBaseRollupPlugins(
  * Returns a Promise containing the build result.
  */
 export async function build(options: BuildConfig): Promise<BuildResult> {
-  if (options.ssr) {
-    return ssrBuild({
-      ...options,
-      ssr: false // since ssrBuild calls build, this avoids an infinite loop.
-    })
-  }
-
   const {
     root = process.cwd(),
     base = '/',

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -174,7 +174,7 @@ async function runServe(options: UserConfig) {
 
 async function runBuild(options: UserConfig) {
   try {
-    await require('./build').build(options)
+    await require('./build')[options.ssr ? 'ssrBuild' : 'build'](options)
     process.exit(0)
   } catch (err) {
     console.error(chalk.red(`[vite] Build errored out.`))


### PR DESCRIPTION
A tiny refactor that simplifies `build -> buildSsr -> build` into just `ssrBuild -> build`.