### PR TITLE
fix(dev): disable hoisted for `dev`

### DIFF
--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -523,6 +523,8 @@ function compileSFCTemplate(
     },
     compilerOptions: {
       ...userOptions,
+      // #514 hoist node not support hmr.
+      hoistStatic: false,
       scopeId: scoped ? `data-v-${hash_sum(publicPath)}` : null,
       runtimeModuleName: resolveVue(root).isLocal
         ? // in local mode, vue would have been optimized so must be referenced


### PR DESCRIPTION
close #514

## Bug Reason

Because hoisted vnode only have one copy, the `el` will caused conflict with multi used.But it is a design, the static vnode will not update forever on production.So we need diasbled hoisted in dev.