### PR TITLE
fix: remove deep import warning for assets

### DIFF
--- a/src/node/optimizer/pluginAssets.ts
+++ b/src/node/optimizer/pluginAssets.ts
@@ -6,7 +6,7 @@ import { isStaticAsset, bareImportRE, resolveFrom } from '../utils'
 import path from 'path'
 import { InternalResolver } from '../resolver'
 
-const isAsset = (id: string) => isCSSRequest(id) || isStaticAsset(id)
+export const isAsset = (id: string) => isCSSRequest(id) || isStaticAsset(id)
 
 export const depAssetExternalPlugin: Plugin = {
   name: 'vite:optimize-dep-assets-external',

--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -16,6 +16,7 @@ import {
 import { resolveOptimizedCacheDir } from './optimizer'
 import { hmrClientPublicPath } from './server/serverPluginHmr'
 import chalk from 'chalk'
+import { isAsset } from './optimizer/pluginAssets'
 
 const debug = require('debug')('vite:resolve')
 const isWin = require('os').platform() === 'win32'
@@ -383,19 +384,21 @@ export function resolveBareModuleRequest(
           // redirect it the optimized copy.
           return resolveBareModuleRequest(root, depId, importer, resolver)
         }
-        // warn against deep imports to optimized dep
-        console.error(
-          chalk.yellow(
-            `\n[vite] Avoid deep import "${id}" (imported by ${importer})\n` +
-              `because "${depId}" has been pre-optimized by vite into a single file.\n` +
-              `Prefer importing directly from the module entry:\n` +
-              chalk.cyan(`\n  import { ... } from "${depId}" \n\n`) +
-              `If the dependency requires deep import to function properly, \n` +
-              `add the deep path to ${chalk.cyan(
-                `optimizeDeps.include`
-              )} in vite.config.js.\n`
+        if (!isAsset(id)) {
+          // warn against deep imports to optimized dep
+          console.error(
+            chalk.yellow(
+              `\n[vite] Avoid deep import "${id}" (imported by ${importer})\n` +
+                `because "${depId}" has been pre-optimized by vite into a single file.\n` +
+                `Prefer importing directly from the module entry:\n` +
+                chalk.cyan(`\n  import { ... } from "${depId}" \n\n`) +
+                `If the dependency requires deep import to function properly, \n` +
+                `add the deep path to ${chalk.cyan(
+                  `optimizeDeps.include`
+                )} in vite.config.js.\n`
+            )
           )
-        )
+        }
       }
 
       // resolve ext for deepImport


### PR DESCRIPTION
We often need to import css from component libraries. But vite gives warning about it: 

![image](https://user-images.githubusercontent.com/18747423/87672202-2a36ff00-c7a5-11ea-8d43-77ca35e5ea79.png)

We should remove this warning for assets(css, image .etc). 