### PR TITLE
feat(dev):  hmr websocket use the port of location.port

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,6 +1,5 @@
 // replaced by serverPluginHmr when served
 declare const __SW_ENABLED__: boolean
-declare const __PORT__: number
 
 // This file runs in the browser.
 import { HMRRuntime } from 'vue'
@@ -53,7 +52,8 @@ console.log('[vite] connecting...')
 declare var __VUE_HMR_RUNTIME__: HMRRuntime
 
 const socketProtocol = location.protocol === 'https:' ? 'wss' : 'ws'
-const socketUrl = `${socketProtocol}://${location.hostname}:${__PORT__}`
+const port = location.port
+const socketUrl = `${socketProtocol}://${location.hostname}${port ? `:${port}`: ''}`
 const socket = new WebSocket(socketUrl, 'vite-hmr')
 
 function warnFailedFetch(err: Error, path: string | string[]) {


### PR DESCRIPTION
Use the port of location.port which support the develop mode with nginx proxy.

Due to the cookie policy, if you want to request to the online service in local development, you must use the same domain of online service. 
So there comes an idea of proxy the  `https://3000.onlinedomain.com` to local `https://localhost:3000` 

In webpack this works fine, the hot reload websocket url  will be `wss://3000.onlinedomain.com`. However in vite, it uses the PORT in config now, which will be `https://3000.onlinedomain.com:3000`, which will cause an ssl error. And this pull request is aim to use the `location.port` instead of config.

 
![image](https://user-images.githubusercontent.com/7057473/87761636-60778b80-c844-11ea-8d88-aefb22d85d48.png)
