### PR TITLE
fix(node): Support passing "0" as port

### DIFF
--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -123,8 +123,8 @@ export function createServer(config: ServerConfig): Server {
     if (optimizeDeps.auto !== false) {
       await require('../optimizer').optimizeDeps(config)
     }
-    context.port = port
-    return listen(port, ...args)
+    listen(port, ...args)
+    context.port = server.address().port
   }) as any
 
   return server

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -123,9 +123,9 @@ export function createServer(config: ServerConfig): Server {
     if (optimizeDeps.auto !== false) {
       await require('../optimizer').optimizeDeps(config)
     }
-    const listenResult = listen(port, ...args)
+    const listener = listen(port, ...args)
     context.port = server.address().port
-    return listenResult
+    return listener
   }) as any
 
   return server

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -123,8 +123,9 @@ export function createServer(config: ServerConfig): Server {
     if (optimizeDeps.auto !== false) {
       await require('../optimizer').optimizeDeps(config)
     }
-    listen(port, ...args)
+    const listenResult = listen(port, ...args)
     context.port = server.address().port
+    return listenResult
   }) as any
 
   return server


### PR DESCRIPTION
Hello,

First of all, thank you very much for creating and maintaining this library, very exciting.

I have been playing with it today and I find the Node API to be great. Looking forward to some more extensive docs, but the source is pretty clear and I was able to figure out the usage.

The change I am proposing here is to support passing a zero (`0`) as a port to the server `listen` method. Since I will be instantiating multiple vite processes, I don't really care about the port, which is why I want Node to choose one at will. Usually, you can just pass a zero, and Node will select a random available port. However, since vite stores the exact port that was passed through options, it later fails because it tries to use `0` instead of an actual port resolved by Node.

This simple change should fix that, and from what I can tell, it should not be a breaking change.

Open to the feedback, of course, thanks!