### PR TITLE
fix(node): fix type of cssPreprocessOptions

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -30,7 +30,7 @@ export type PreprocessLang = NonNullable<
 
 export type PreprocessOptions = SFCStyleCompileOptions['preprocessOptions']
 
-export type CssPreprocessOptions = Record<PreprocessLang, PreprocessOptions>
+export type CssPreprocessOptions = Partial<Record<PreprocessLang, PreprocessOptions>>
 
 export { Resolver, Transform }
 


### PR DESCRIPTION
We don't really need all keys for `cssPreprocessOptions`.
Added `Partial` to make them optional.