### PR TITLE
fix(client): Avoid overwriting the process global

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -5,11 +5,9 @@ declare const __SW_ENABLED__: boolean
 declare const __PORT__: number
 declare const __MODE__: string
 declare const __DEFINES__: Record<string, any>
-;(window as any).process = {
-  env: {
-    NODE_ENV: __MODE__
-  }
-}
+;(window as any).process = (window as any).process || {}
+;(window as any).process.env = (window as any).process.env || {}
+;(window as any).process.env.NODE_ENV = __MODE__
 
 const defines = __DEFINES__
 Object.keys(defines).forEach((key) => {


### PR DESCRIPTION
Hi,

I found the process assignment to be too aggressive. I am using vite inside Electron, and so the `process` global is already defined (when nodeIntegration is enabled) and contains useful info that I would prefer to keep.

The approach I am proposing is a bit more verbose, but should keep the already defined `process` intact, if it exists.