### PR TITLE
fix(dev): replace config.define instead of inserting object

### DIFF
--- a/playground/App.vue
+++ b/playground/App.vue
@@ -1,6 +1,7 @@
 <template>
   <h1>Vite Playground</h1>
   <TestEnv />
+  <TestDefine />
   <h2>Async Component</h2>
   <TestAsync />
   <TestModuleResolve />
@@ -35,6 +36,7 @@
 <script>
 import { defineAsyncComponent } from 'vue'
 import TestEnv from './TestEnv.vue'
+import TestDefine from './define/TestDefine.vue'
 import TestHmr from './hmr/TestHmr.vue'
 import TestPostCss from './css/TestPostCss.vue'
 import TestScopedCss from './css/TestScopedCss.vue'
@@ -64,6 +66,7 @@ import TestSyntax from './TestSyntax.vue'
 const App = {
   components: {
     TestEnv,
+    TestDefine,
     TestModuleResolve,
     TestHmr,
     TestPostCss,

--- a/playground/define/TestDefine.vue
+++ b/playground/define/TestDefine.vue
@@ -1,0 +1,22 @@
+<template>
+  <h2>Config define</h2>
+  <p class="config-define-value">
+    <pre>config.define.value: {{ value }}</pre>
+  </p>
+  <p class="config-define-value-from-js">
+    <pre>config.define.value from js: {{ valueFromJS }}</pre>
+  </p>
+</template>
+
+<script>
+import { value } from './test'
+
+export default {
+  data() {
+    return {
+      value: __VALUE__,
+      valueFromJS: value
+    }
+  }
+}
+</script>

--- a/playground/define/test.js
+++ b/playground/define/test.js
@@ -1,0 +1,1 @@
+export const value = __VALUE__

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -7,6 +7,9 @@ const config: UserConfig = {
     alias: '/alias/aliased',
     '/@alias/': require('path').resolve(__dirname, 'alias/aliased-dir')
   },
+  define: {
+    __VALUE__: 'value'
+  },
   jsx: 'preact',
   plugins: [jsPlugin],
   vueCustomBlockTransforms: { i18n: i18nTransform },

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -261,7 +261,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
     shouldPreload = null,
     env = {},
     mode: configMode = 'production',
-    define: userDefineReplacements,
+    define: userDefineReplacements = {},
     cssPreprocessOptions,
     cssModuleOptions = {}
   } = options
@@ -336,6 +336,9 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
     builtInEnvReplacements[`import.meta.env.${key}`] = JSON.stringify(
       builtInClientEnv[key as keyof typeof builtInClientEnv]
     )
+  })
+  Object.keys(userDefineReplacements).forEach((key) => {
+    userDefineReplacements[key] = JSON.stringify(userDefineReplacements[key])
   })
 
   // lazy require rollup so that we don't load it when only using the dev server

--- a/test/test.js
+++ b/test/test.js
@@ -137,6 +137,15 @@ describe('vite', () => {
       )
     })
 
+    test('config.define', async () => {
+      expect(await getText('.config-define-value')).toMatch(
+        `config.define.value: value`
+      )
+      expect(await getText('.config-define-value-from-js')).toMatch(
+        `config.define.value from js: value`
+      )
+    })
+
     test('module resolving', async () => {
       expect(await getText('.module-resolve-router')).toMatch('ok')
       expect(await getText('.module-resolve-store')).toMatch('ok')


### PR DESCRIPTION
When `config.define` is set like below (`vite.config.js`)
```js
module.exports = {
  define: {
    __VAR__: 'string'
  }
}
```
and `main.js` is like below.
```js
console.log(__VAR__)
```

On dev server it becomes like
```js
console.log('string')
```
though built script becomes like
```js
console.log(string)
```

This PR will fix the build to be same as dev server.
