### PR TITLE
fix: make vite.config support es2020 syntax

### DIFF
--- a/playground/plugins/jsPlugin.ts
+++ b/playground/plugins/jsPlugin.ts
@@ -15,6 +15,8 @@ export const jsPlugin: Plugin = {
         s.overwrite(i + 2, i + 3, String(Number(cur) + 1))
         // test source map by appending lines
         s.prepend(`\n\n\n`)
+        // test if es2020 stntax works in vite.config.ts
+        s?.append('') ?? null
 
         return {
           code: s.toString(),

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -15,7 +15,10 @@ import Rollup, {
   OutputOptions as RollupOutputOptions,
   OutputChunk
 } from 'rollup'
-import { createEsbuildPlugin } from './build/buildPluginEsbuild'
+import {
+  createEsbuildPlugin,
+  createEsbuildRenderChunkPlugin
+} from './build/buildPluginEsbuild'
 import { ServerPlugin } from './server'
 import { Resolver, supportedExts } from './resolver'
 import { Transform, CustomBlockTransform } from './transform'
@@ -396,6 +399,10 @@ export async function resolveConfig(
       // transpile es import syntax to require syntax using rollup.
       const rollup = require('rollup') as typeof Rollup
       const esbuildPlugin = await createEsbuildPlugin({})
+      const esbuildRenderChunkPlugin = createEsbuildRenderChunkPlugin(
+        'es2019',
+        false
+      )
       // use node-resolve to support .ts files
       const nodeResolve = require('@rollup/plugin-node-resolve').nodeResolve({
         extensions: supportedExts
@@ -406,7 +413,7 @@ export async function resolveConfig(
           id.slice(-5, id.length) === '.json',
         input: resolvedPath,
         treeshake: false,
-        plugins: [esbuildPlugin, nodeResolve]
+        plugins: [esbuildPlugin, nodeResolve, esbuildRenderChunkPlugin]
       })
 
       const {


### PR DESCRIPTION
Optional chaining and nullish coalescing

I added a test case. You can watch it fail by comment out the fix lines.