### PR TITLE
feat(dev): support css sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "chalk": "^4.0.0",
     "chokidar": "^3.3.1",
     "clean-css": "^4.2.3",
+    "concat-with-sourcemaps": "^1.1.0",
     "debug": "^4.1.1",
     "dotenv": "^8.2.0",
     "dotenv-expand": "^5.1.0",
@@ -96,6 +97,7 @@
     "rollup-pluginutils": "^2.8.2",
     "selfsigned": "^1.10.7",
     "slash": "^3.0.0",
+    "source-map": "^0.7.3",
     "vue": "^3.0.0-rc.5",
     "ws": "^7.2.3"
   },

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -157,10 +157,12 @@ export const vuePlugin: ServerPlugin = ({
         index,
         filePath,
         publicPath,
+        ctx,
         config
       )
       ctx.type = 'js'
       ctx.body = codegenCss(`${id}-${index}`, result.code, result.modules)
+      ctx.map = result.map as any
       return etagCacheCheck(ctx)
     }
 
@@ -589,7 +591,7 @@ function compileSFCTemplate(
 
   const result = {
     code,
-    map: map as SourceMap
+    map: map as any
   }
 
   cached = cached || { styles: [], customs: [] }
@@ -606,6 +608,7 @@ async function compileSFCStyle(
   index: number,
   filePath: string,
   publicPath: string,
+  ctx: Context,
   { cssPreprocessOptions, cssModuleOptions }: ServerPluginContext['config']
 ): Promise<SFCStyleCompileResults> {
   let cached = vueCache.get(filePath)
@@ -619,7 +622,7 @@ async function compileSFCStyle(
 
   const { generateCodeFrame } = resolveCompiler(root)
   const resource = filePath + `?type=style&index=${index}`
-  const result = (await compileCss(root, publicPath, {
+  const result = (await compileCss(root, publicPath, ctx.read, {
     source: style.content,
     filename: resource,
     id: ``, // will be computed in compileCss

--- a/src/node/utils/sourcemap.ts
+++ b/src/node/utils/sourcemap.ts
@@ -1,0 +1,38 @@
+import { SourceNode, RawSourceMap } from 'source-map'
+
+const SPLIT_REGEX = /(?!$)[^\n\r;{}]*[\n\r;{}]*/g
+
+function splitCode(code: string) {
+  return code.match(SPLIT_REGEX) || []
+}
+
+export function getOriginalSourceMap(
+  code: string,
+  filePath: string
+): RawSourceMap {
+  const lines = code.split('\n')
+
+  const linesSourceNode = lines.map((row, index) => {
+    let column = 0
+    const columnsSourceNode = splitCode(
+      row + (index !== lines.length - 1 ? '\n' : '')
+    ).map((item) => {
+      if (/^\s*$/.test(item)) {
+        column += item.length
+        return item
+      }
+      const res = new SourceNode(index + 1, column, filePath, item)
+      column += item.length
+      return res
+    })
+    return new SourceNode(null, null, null, columnsSourceNode)
+  })
+
+  const sourceNode = new SourceNode(null, null, null, linesSourceNode)
+
+  const sourceMapGenerator = sourceNode.toStringWithSourceMap({
+    file: filePath
+  }).map
+  sourceMapGenerator.setSourceContent(filePath, code)
+  return sourceMapGenerator.toJSON()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,6 +1764,13 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+concat-with-sourcemaps@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz#d4ea93f05ae25790951b99e7b3b09e3908a4082e"
+  integrity sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==
+  dependencies:
+    source-map "^0.6.1"
+
 consolidate@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/consolidate/-/consolidate-0.15.1.tgz#21ab043235c71a07d45d9aad98593b0dba56bab7"


### PR DESCRIPTION
close #649

For build css courcemap, the code will be transformed by `rollup-plugin-vue` first and lost dependencies info, that caused lost some css sourcemap imported by vue style block imported.
I have a try with disable  `rollup-plugin-vue` css handle and move logic into vite-css-build plugin, but will not get correct preprocessor lang(it need parse sfc block to get this).That means that we need do more something in vite, not `rollup-plugin-vue`.
I think I  used the error way and want to get advice for support build css sourcemap, thanks a lot =.=