### PR TITLE
fix: stop prepending "/public" to asset paths

### DIFF
--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -62,10 +62,6 @@ const defaultRequestToFile = (publicPath: string, root: string): string => {
       return nodeModule
     }
   }
-  const publicDirPath = path.join(root, 'public', publicPath.slice(1))
-  if (fs.existsSync(publicDirPath)) {
-    return publicDirPath
-  }
   return path.join(root, publicPath.slice(1))
 }
 


### PR DESCRIPTION
This prevents `[vite] files in the public directory are served at the root path.` warnings when assets are stored in the `./public` directory.