### PR TITLE
feat: support css alias

### DIFF
--- a/playground/alias/TestAlias.vue
+++ b/playground/alias/TestAlias.vue
@@ -1,7 +1,7 @@
 <template>
   <h2>Alias</h2>
-  <p class="alias">{{ msg }}</p>
-  <p class="dir-alias">{{ dirMsg }}</p>
+  <p class="alias alias-css">{{ msg }}</p>
+  <p class="dir-alias alias-scss">{{ dirMsg }}</p>
   <p class="dir-alias-index">{{ dirIndexMsg }}</p>
   <p class="dir-alias-import-outside">{{ importOutsideMsg }}</p>
 </template>
@@ -21,3 +21,8 @@ export default {
   })
 }
 </script>
+
+<style lang="scss">
+  @import "/@alias/aliased.css";
+  @import "/@alias/aliasedScss.scss";
+</style>

--- a/playground/alias/aliased-dir/aliased.css
+++ b/playground/alias/aliased-dir/aliased.css
@@ -1,0 +1,3 @@
+.alias-css {
+    color: red;
+}

--- a/src/node/build/buildPluginCss.ts
+++ b/src/node/build/buildPluginCss.ts
@@ -17,6 +17,7 @@ import {
 } from '@vue/compiler-sfc'
 import chalk from 'chalk'
 import { CssPreprocessOptions } from '../config'
+import { InternalResolver } from '../resolver'
 
 const debug = require('debug')('vite:build:css')
 
@@ -34,16 +35,19 @@ interface BuildCssOption {
   modulesOptions?: SFCAsyncStyleCompileOptions['modulesOptions']
 }
 
-export const createBuildCssPlugin = ({
-  root,
-  publicBase,
-  assetsDir,
-  minify = false,
-  inlineLimit = 0,
-  cssCodeSplit = true,
-  preprocessOptions,
-  modulesOptions = {}
-}: BuildCssOption): Plugin => {
+export const createBuildCssPlugin = (
+  resolver: InternalResolver,
+  {
+    root,
+    publicBase,
+    assetsDir,
+    minify = false,
+    inlineLimit = 0,
+    cssCodeSplit = true,
+    preprocessOptions,
+    modulesOptions = {}
+  }: BuildCssOption
+): Plugin => {
   const styles: Map<string, string> = new Map()
   const assets = new Map<string, Buffer>()
   let staticCss = ''
@@ -63,6 +67,7 @@ export const createBuildCssPlugin = ({
         const result = isVueStyle
           ? css
           : await compileCss(
+              resolver,
               root,
               id,
               {

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -151,7 +151,9 @@ export async function createBaseRollupPlugins(
     // vite:esbuild
     enableEsbuild ? await createEsbuildPlugin(options.jsx) : null,
     // vue
-    enableRollupPluginVue ? await createVuePlugin(root, options) : null,
+    enableRollupPluginVue
+      ? await createVuePlugin(resolver, root, options)
+      : null,
     require('@rollup/plugin-json')({
       preferConst: true,
       indent: '  ',
@@ -181,6 +183,7 @@ export async function createBaseRollupPlugins(
 }
 
 async function createVuePlugin(
+  resolver: InternalResolver,
   root: string,
   {
     vueCustomBlockTransforms = {},
@@ -195,7 +198,7 @@ async function createVuePlugin(
   const {
     options: postcssOptions,
     plugins: postcssPlugins
-  } = await resolvePostcssOptions(root, true)
+  } = await resolvePostcssOptions(resolver, root, true)
 
   if (typeof vueTransformAssetUrls === 'object') {
     vueTransformAssetUrls = {
@@ -378,7 +381,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
         sourcemap
       ),
       // vite:css
-      createBuildCssPlugin({
+      createBuildCssPlugin(resolver, {
         root,
         publicBase: publicBasePath,
         assetsDir,

--- a/src/node/server/serverPluginCss.ts
+++ b/src/node/server/serverPluginCss.ts
@@ -139,7 +139,7 @@ export const cssPlugin: ServerPlugin = ({ root, app, watcher, resolver }) => {
     const filePath = resolver.requestToFile(ctx.path)
     const preprocessLang = ctx.path.replace(cssPreprocessLangRE, '$2')
 
-    const result = await compileCss(root, ctx.path, {
+    const result = await compileCss(resolver, root, ctx.path, {
       id: '',
       source: css,
       filename: filePath,

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -152,6 +152,7 @@ export const vuePlugin: ServerPlugin = ({
       }
       const id = hash_sum(publicPath)
       const result = await compileSFCStyle(
+        resolver,
         root,
         styleBlock,
         index,
@@ -601,6 +602,7 @@ function compileSFCTemplate(
 }
 
 async function compileSFCStyle(
+  resolver: InternalResolver,
   root: string,
   style: SFCStyleBlock,
   index: number,
@@ -619,7 +621,7 @@ async function compileSFCStyle(
 
   const { generateCodeFrame } = resolveCompiler(root)
   const resource = filePath + `?type=style&index=${index}`
-  const result = (await compileCss(root, publicPath, {
+  const result = (await compileCss(resolver, root, publicPath, {
     source: style.content,
     filename: resource,
     id: ``, // will be computed in compileCss

--- a/test/test.js
+++ b/test/test.js
@@ -613,6 +613,9 @@ describe('vite', () => {
           'directory aliased internal import outside hmr works'
         )
       }
+      // css alias
+      expect(await getComputedColor('.alias-css')).toBe('rgb(255, 0, 0)')
+      expect(await getComputedColor('.alias-scss')).toBe('rgb(255, 0, 0)')
     })
 
     test('transforms', async () => {


### PR DESCRIPTION
close #650

This pr is supported css and scss for now, but it will break build(`rollup-plugin-vue` will error with css alias).And resolve with #659 css sourcemap, maybe we should disable `rollup-plugin-vue` transform css.I'm not sure for this, hope get your suggestion.