### PR TITLE
fix(build): create at most one `esbuildService`

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -506,7 +506,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
   }
 
   // stop the esbuild service after each build
-  stopService()
+  await stopService()
 
   return {
     assets: output,

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -39,18 +39,21 @@ export function resolveJsxOptions(options: SharedConfig['jsx'] = 'vue') {
 }
 
 // lazy start the service
-let _service: Service | undefined
+let _servicePromise: Promise<Service> | undefined
 
 const ensureService = async () => {
-  if (!_service) {
-    _service = await startService()
+  if (!_servicePromise) {
+    _servicePromise = startService()
   }
-  return _service
+  return _servicePromise
 }
 
-export const stopService = () => {
-  _service && _service.stop()
-  _service = undefined
+export const stopService = async () => {
+  if (_servicePromise) {
+    const service = await _servicePromise
+    service.stop()
+    _servicePromise = undefined
+  }
 }
 
 // transform used in server plugins with a more friendly API


### PR DESCRIPTION
fix #693

Also ensures that `stopService` will always wait for the service to actually have been created.
Otherwise, I think there might be edge cases where `stopService` is called _before_ the service has actually been _started,_ preventing proper cleanup.