### PR TITLE
feat(build): add option for renaming output css filename

### DIFF
--- a/src/node/build/buildPluginCss.ts
+++ b/src/node/build/buildPluginCss.ts
@@ -23,6 +23,17 @@ const debug = require('debug')('vite:build:css')
 const cssInjectionMarker = `__VITE_CSS__`
 const cssInjectionRE = /__VITE_CSS__\(\)/g
 
+interface ModulesOptions {
+  scopeBehaviour?: 'global' | 'local'
+  globalModulePaths?: string[]
+  generateScopedName?:
+    | string
+    | ((name: string, filename: string, css: string) => string)
+  hashPrefix?: string
+  localsConvention?: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'
+  cssFileName?: string | ((staticCss: string) => string)
+}
+
 interface BuildCssOption {
   root: string
   publicBase: string
@@ -31,7 +42,7 @@ interface BuildCssOption {
   inlineLimit?: number
   cssCodeSplit?: boolean
   preprocessOptions?: CssPreprocessOptions
-  modulesOptions?: SFCAsyncStyleCompileOptions['modulesOptions']
+  modulesOptions?: ModulesOptions
 }
 
 export const createBuildCssPlugin = ({
@@ -171,7 +182,15 @@ export const createBuildCssPlugin = ({
         staticCss = minifyCSS(staticCss)
       }
 
-      const cssFileName = `style.${hash_sum(staticCss)}.css`
+      let cssFileName = `style.${hash_sum(staticCss)}.css`
+
+      if (modulesOptions!.cssFileName) {
+        if (typeof modulesOptions!.cssFileName === 'string') {
+          cssFileName = modulesOptions!.cssFileName
+        } else {
+          cssFileName = modulesOptions!.cssFileName(staticCss)
+        }
+      }
 
       bundle[cssFileName] = {
         name: cssFileName,


### PR DESCRIPTION
Following this issue : https://github.com/vitejs/vite/issues/378 and my response. 
I have added an option for renaming css output filename with two way : string or callback with return text. 
Currently the css filename format is hardcoded in `buildPluginCss.ts`.
It allow user handle and format the filename as it want.

It's my first PR for an open-source project tell if I'have done something wrong in the workflow of developing vite and contribute to the project. I tried to follow the git commit formatting rule and the contributing guide.
The only thing I not make it's a Jest test case. It's a small option but if you want I can make one.