### PR TITLE
fix esbuildService error handling

### DIFF
--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -102,7 +102,6 @@ export const transform = async (
     if (e.errors) {
       e.errors.forEach((m: Message) => printMessage(m, src))
     } else {
-      console.error(e)
       throw e
     }
     debug(`options used: `, options)
@@ -127,7 +126,6 @@ function printMessage(m: Message, code: string) {
     try {
       require('@vue/compiler-dom').generateCodeFrame(code, offset, offset + 1)
     } catch (e) {
-      console.error(e)
       throw e
     }
   }

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -123,8 +123,11 @@ function printMessage(m: Message, code: string) {
         .slice(0, line - 1)
         .map((l) => l.length)
         .reduce((total, l) => total + l + 1, 0) + column
-    console.error(
-      require('@vue/compiler-dom').generateCodeFrame(code, offset, offset + 1)
-    )
+    try {
+      require('@vue/compiler-dom').generateCodeFrame(code, offset, offset + 1);
+    } catch (error) {
+      console.error(error);
+      process.exit(1);
+    }
   }
 }

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -103,6 +103,7 @@ export const transform = async (
       e.errors.forEach((m: Message) => printMessage(m, src))
     } else {
       console.error(e)
+      throw e
     }
     debug(`options used: `, options)
     return {
@@ -124,10 +125,10 @@ function printMessage(m: Message, code: string) {
         .map((l) => l.length)
         .reduce((total, l) => total + l + 1, 0) + column
     try {
-      require('@vue/compiler-dom').generateCodeFrame(code, offset, offset + 1);
-    } catch (error) {
-      console.error(error);
-      process.exit(1);
+      require('@vue/compiler-dom').generateCodeFrame(code, offset, offset + 1)
+    } catch (e) {
+      console.error(e)
+      throw e
     }
   }
 }

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -102,7 +102,7 @@ export const transform = async (
     if (e.errors) {
       e.errors.forEach((m: Message) => printMessage(m, src))
     } else {
-      throw e
+      throw new Error(e);
     }
     debug(`options used: `, options)
     return {
@@ -126,7 +126,7 @@ function printMessage(m: Message, code: string) {
     try {
       require('@vue/compiler-dom').generateCodeFrame(code, offset, offset + 1)
     } catch (e) {
-      throw e
+      throw new Error(e);
     }
   }
 }


### PR DESCRIPTION
This PR fixes error handling in esbuildService.js.

Motivation:
I'm using vite to build my React app. When I attempted to build my app on Github Actions, vite occurred some error, but an action workflow didn't stop properly. I expect actions are stopped and print an error if some errors occur, but tests seem to succeed. This is a problem. I think vite has to stop with an error. So I created this pull request.

Before:
When the transform fails, the error object is not thrown(error object is suppressed). 

After
Transform function comes to be able to throw an error.