### PR TITLE
add support for lib that expose a `browser.esm` field for browser es module

### DIFF
--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -41,7 +41,7 @@ export interface InternalResolver {
 }
 
 export const supportedExts = ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json']
-export const mainFields = ['module', 'jsnext', 'jsnext:main', 'browser', 'main']
+export const mainFields = ['browser.esm', 'module', 'jsnext', 'jsnext:main', 'browser', 'main']
 
 const defaultRequestToFile = (publicPath: string, root: string): string => {
   if (moduleRE.test(publicPath)) {


### PR DESCRIPTION
The library https://github.com/ethers-io/ethers.js supports as many environment as possible and for that it has setup various field in each of its package.json

For exanple `@ethersproject/random` has a `browser.esm` field in its [package.json](https://github.com/ethers-io/ethers.js/blob/5b5904ea9977ecf8c079a57593b627553f0126a0/packages/random/package.json#L4)

This field is not read by vite and instead vite will read the module field which @ethersproject/random use for es module targeting node (which include dependencies on builtins package that won't work in a browser environment).

This PR had `browser.esm` at the beginning of the mainfFields array.

If you think, this is not the way forward, an alternative would be to allow user to define what the mainFields array should be in the vite.config.js options

