### PR TITLE
feat: set NODE_ENV if not present

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -61,6 +61,7 @@ console.log(chalk.cyan(`vite v${require('../../package.json').version}`))
 
   const envMode = mode || m || defaultMode
   const options = await resolveOptions(envMode)
+  process.env.NODE_ENV = process.env.NODE_ENV || envMode
   if (!options.command || options.command === 'serve') {
     runServe(options)
   } else if (options.command === 'build') {


### PR DESCRIPTION
fix #696

Set `NODE_ENV` if it's not present for toolchains like PostCSS to detect the build env.