### PR TITLE
chore: rename internal terser options type name

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -23,7 +23,7 @@ import { DepOptimizationOptions } from './optimizer'
 import { IKoaProxiesOptions } from 'koa-proxies'
 import { ServerOptions } from 'https'
 import { lookupFile } from './utils'
-import { Options } from 'rollup-plugin-terser'
+import { Options as RollupTerserOptions } from 'rollup-plugin-terser'
 
 export type PreprocessLang = NonNullable<
   SFCStyleCompileOptions['preprocessLang']
@@ -249,7 +249,7 @@ export interface BuildConfig extends SharedConfig {
   /**
    * The option for `terser`
    */
-  terserOption?: Options
+  terserOption?: RollupTerserOptions
   /**
    * Transpile target for esbuild.
    * Defaults to 'es2019' which transpiles optional chaining so it works with


### PR DESCRIPTION
Renamed `Options` to`RollupTerserOptions` for better context reading.