### PR TITLE
fix: prepend "file://" protocol to sourcemap source paths

### DIFF
--- a/src/node/server/serverPluginSourceMap.ts
+++ b/src/node/server/serverPluginSourceMap.ts
@@ -18,12 +18,12 @@ export function mergeSourceMap(
   return merge(oldMap, newMap) as SourceMap
 }
 
-function genSourceMapString(map: SourceMap | string | undefined) {
-  if (typeof map !== 'string') {
-    map = JSON.stringify(map)
-  }
+function genSourceMapString(map: SourceMap) {
+  // Ensure devtools can fetch the mapped sources.
+  const sources = map.sources.map((path) => 'file://' + path)
+
   return `\n//# sourceMappingURL=data:application/json;base64,${Buffer.from(
-    map
+    JSON.stringify({ ...map, sources })
   ).toString('base64')}`
 }
 


### PR DESCRIPTION
This PR prepends the `file://` protocol to paths in the `sources` array of sourcemaps generated by the `genSourceMapString` function. Before this change, devtools would try loading sources from `http://localhost:{port}/{absolutePath}` (which is a 404).

I also updated the type signature of `genSourceMapString` since `ctx.map` is always an object.

I tested it manually, and it's now working as expected (as in, source files are now loaded by devtools, instead of a 404).