### PR TITLE
fix: omit "?t=" query from esbuild sourcemap source path

### DIFF
--- a/src/node/server/serverPluginEsbuild.ts
+++ b/src/node/server/serverPluginEsbuild.ts
@@ -6,7 +6,7 @@ import {
   vueJsxPublicPath,
   vueJsxFilePath
 } from '../esbuildService'
-import { readBody } from '../utils'
+import { readBody, cleanUrl } from '../utils'
 
 export const esbuildPlugin: ServerPlugin = ({ app, config, resolver }) => {
   const jsxConfig = resolveJsxOptions(config.jsx)
@@ -32,7 +32,7 @@ export const esbuildPlugin: ServerPlugin = ({ app, config, resolver }) => {
     const src = await readBody(ctx.body)
     const { code, map } = await transform(
       src!,
-      resolver.requestToFile(ctx.url),
+      resolver.requestToFile(cleanUrl(ctx.url)),
       jsxConfig,
       config.jsx
     )


### PR DESCRIPTION
This prevents duplication of source paths in the sourcemap emitted by esbuild.

Before this change, the `sources` array of the final sourcemap would contain duplicate paths, one with `?t=` and one without.