### PR TITLE
fix: don't mutate plugins array in postcss config

### DIFF
--- a/src/node/utils/cssUtils.ts
+++ b/src/node/utils/cssUtils.ts
@@ -156,7 +156,7 @@ async function loadPostcssConfig(
 export async function resolvePostcssOptions(root: string, isBuild: boolean) {
   const config = await loadPostcssConfig(root)
   const options = config && config.options
-  const plugins = config ? config.plugins : []
+  const plugins = config && config.plugins ? config.plugins.slice() : []
   plugins.unshift(require('postcss-import')())
   if (isBuild) {
     plugins.push(require('postcss-discard-comments')({ removeAll: true }))


### PR DESCRIPTION
Right now if you have a postcss.config.js file, the plugins array grows bigger and bigger over time.

related https://github.com/vitejs/vite/issues/331

![image](https://user-images.githubusercontent.com/905328/92595557-db897b00-f2a4-11ea-9427-f822f8a6f4a6.png)
