### PR TITLE
feat(config): transforms for index.html

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -30,11 +30,7 @@ const config: UserConfig = {
   indexHtmlTransforms: [
     {
       flush: 'pre',
-      transform: (ctx) =>
-        ctx.code.replace(
-          /<title>.*?<\/title>/,
-          '<title>Vite Playground</title>'
-        )
+      transform: (ctx) => ctx.code.replace(/Vite App/, 'Vite Playground')
     }
   ],
   emitManifest: true

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -27,6 +27,16 @@ const config: UserConfig = {
   vueTransformAssetUrls: {
     img: ['src', 'data-src']
   },
+  indexHtmlTransforms: [
+    {
+      flush: 'pre',
+      transform: (ctx) =>
+        ctx.code.replace(
+          /<title>.*?<\/title>/,
+          '<title>Vite Playground</title>'
+        )
+    }
+  ],
   emitManifest: true
 }
 

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -28,10 +28,7 @@ const config: UserConfig = {
     img: ['src', 'data-src']
   },
   indexHtmlTransforms: [
-    {
-      flush: 'pre',
-      transform: (ctx) => ctx.code.replace(/Vite App/, 'Vite Playground')
-    }
+    ({ code }) => code.replace(/Vite App/, 'Vite Playground')
   ],
   emitManifest: true
 }

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -296,7 +296,8 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
     assetsDir,
     assetsInlineLimit,
     resolver,
-    shouldPreload
+    shouldPreload,
+    options
   )
 
   const basePlugins = await createBaseRollupPlugins(root, resolver, options)
@@ -443,7 +444,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
 
   spinner && spinner.stop()
 
-  const indexHtml = emitIndex ? renderIndex(output) : ''
+  const indexHtml = emitIndex ? await renderIndex(output) : ''
 
   if (write) {
     const printFilesInfo = async (

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -22,7 +22,11 @@ import {
 } from './build/buildPluginEsbuild'
 import { Context, ServerPlugin } from './server'
 import { Resolver, supportedExts } from './resolver'
-import { Transform, CustomBlockTransform } from './transform'
+import {
+  Transform,
+  CustomBlockTransform,
+  IndexHtmlTransform
+} from './transform'
 import { DepOptimizationOptions } from './optimizer'
 import { ServerOptions } from 'https'
 import { lookupFile } from './utils'
@@ -114,6 +118,10 @@ export interface SharedConfig {
    * Custom file transforms.
    */
   transforms?: Transform[]
+  /**
+   * Custom index.html transforms.
+   */
+  indexHtmlTransforms?: IndexHtmlTransform[]
   /**
    * Define global variable replacements.
    * Entries will be defined on `window` during dev and replaced during build.
@@ -431,6 +439,7 @@ export interface Plugin
     UserConfig,
     | 'alias'
     | 'transforms'
+    | 'indexHtmlTransforms'
     | 'define'
     | 'resolvers'
     | 'configureServer'
@@ -607,6 +616,10 @@ function resolvePlugin(config: UserConfig, plugin: Plugin): UserConfig {
       ...config.define
     },
     transforms: [...(config.transforms || []), ...(plugin.transforms || [])],
+    indexHtmlTransforms: [
+      ...(config.indexHtmlTransforms || []),
+      ...(plugin.indexHtmlTransforms || [])
+    ],
     resolvers: [...(config.resolvers || []), ...(plugin.resolvers || [])],
     configureServer: ([] as ServerPlugin[]).concat(
       config.configureServer || [],

--- a/src/node/transform.ts
+++ b/src/node/transform.ts
@@ -35,11 +35,6 @@ export interface TransformContext extends TransformTestContext {
   code: string
 }
 
-export interface IndexHtmlTransformContext {
-  code: string
-  isBuild: boolean
-}
-
 export interface TransformResult {
   code: string
   map?: SourceMap
@@ -54,13 +49,25 @@ export interface Transform {
   transform: TransformFn
 }
 
-export interface IndexHtmlTransform {
-  /**
-   * Timing for applying the transform.
-   */
-  flush: 'pre' | 'post'
-  transform: (ctx: IndexHtmlTransformContext) => string | Promise<string>
+export interface IndexHtmlTransformContext {
+  code: string
+  isBuild: boolean
 }
+
+export type IndexHtmlTransformFn = (
+  ctx: IndexHtmlTransformContext
+) => string | Promise<string>
+
+export type IndexHtmlTransform =
+  | IndexHtmlTransformFn
+  | {
+      /**
+       * Timing for applying the transform.
+       * @default: 'post'
+       */
+      apply?: 'pre' | 'post'
+      transform: IndexHtmlTransformFn
+    }
 
 export type CustomBlockTransform = TransformFn
 

--- a/src/node/transform.ts
+++ b/src/node/transform.ts
@@ -35,6 +35,11 @@ export interface TransformContext extends TransformTestContext {
   code: string
 }
 
+export interface IndexHtmlTransformContext {
+  code: string
+  isBuild: boolean
+}
+
 export interface TransformResult {
   code: string
   map?: SourceMap
@@ -47,6 +52,14 @@ export type TransformFn = (
 export interface Transform {
   test: (ctx: TransformTestContext) => boolean
   transform: TransformFn
+}
+
+export interface IndexHtmlTransform {
+  /**
+   * Timing for applying the transform.
+   */
+  flush: 'pre' | 'post'
+  transform: (ctx: IndexHtmlTransformContext) => string | Promise<string>
 }
 
 export type CustomBlockTransform = TransformFn

--- a/src/node/utils/transformUtils.ts
+++ b/src/node/utils/transformUtils.ts
@@ -33,13 +33,21 @@ export function injectScriptToHtml(html: string, script: string) {
 export async function transformIndexHtml(
   html: string,
   transforms: IndexHtmlTransform[] = [],
-  flush: 'pre' | 'post',
+  apply: 'pre' | 'post',
   isBuild = false
 ) {
-  const trans = transforms.filter((t) => t.flush === flush)
+  const trans = transforms
+    .map((t) => {
+      return typeof t === 'function' && apply === 'post'
+        ? t
+        : t.apply === apply
+        ? t.transform
+        : undefined
+    })
+    .filter(Boolean)
   let code = html
-  for (const tranform of trans) {
-    code = await tranform.transform({ isBuild, code })
+  for (const transform of trans) {
+    code = await transform!({ isBuild, code })
   }
   return code
 }

--- a/src/node/utils/transformUtils.ts
+++ b/src/node/utils/transformUtils.ts
@@ -1,3 +1,5 @@
+import { IndexHtmlTransform } from '../transform'
+
 export async function asyncReplace(
   input: string,
   re: RegExp,
@@ -26,4 +28,18 @@ export function injectScriptToHtml(html: string, script: string) {
   }
   // if no <head> tag or doctype is present, just prepend
   return script + html
+}
+
+export async function transformIndexHtml(
+  html: string,
+  transforms: IndexHtmlTransform[] = [],
+  flush: 'pre' | 'post',
+  isBuild = false
+) {
+  const trans = transforms.filter((t) => t.flush === flush)
+  let code = html
+  for (const tranform of trans) {
+    code = await tranform.transform({ isBuild, code })
+  }
+  return code
 }

--- a/test/test.js
+++ b/test/test.js
@@ -832,7 +832,7 @@ describe('vite', () => {
     declareTests(false)
 
     test('hmr (index.html full-reload)', async () => {
-      expect(await getText('title')).toMatch('Vite App')
+      expect(await getText('title')).toMatch('Vite Playground')
       // hmr
       const reload = page.waitForNavigation({
         waitUntil: 'domcontentloaded'
@@ -841,12 +841,12 @@ describe('vite', () => {
         content.replace('Vite App', 'Vite App Test')
       )
       await reload
-      await expectByPolling(() => getText('title'), 'Vite App Test')
+      await expectByPolling(() => getText('title'), 'Vite Playground Test')
     })
 
     test('hmr (html full-reload)', async () => {
       await page.goto('http://localhost:3000/test.html')
-      expect(await getText('title')).toMatch('Vite App')
+      expect(await getText('title')).toMatch('Vite Playground')
       // hmr
       const reload = page.waitForNavigation({
         waitUntil: 'domcontentloaded'
@@ -855,7 +855,7 @@ describe('vite', () => {
         content.replace('Vite App', 'Vite App Test')
       )
       await reload
-      await expectByPolling(() => getText('title'), 'Vite App Test')
+      await expectByPolling(() => getText('title'), 'Vite Playground Test')
     })
 
     // Assert that all edited files are reflected on page reload


### PR DESCRIPTION
This PR introduced a new config `indexHtmlTransforms` which allows plugins and `vite.config.js` to transform the index.html for various needs. (not sure about the naming though, feel free to leave comments)

For example, it would be useful for these plugins(probably not exist yet, just giving the context
- `vite-plugin-meta`
- `vite-plugin-sitemap`
- `vite-plugin-pwa`
- `vite-plugin-minify`
- etc.

the following config replaces page's title to `Vite Playground`

```js
// vite.config.js

export default {
  indexHtmlTransforms: [
    {
      flush: 'pre', // or 'post'
      transform({ code, isBuild }) {
        return code.replace(/<title>.*?<\/title>/, '<title>Vite Playground</title>')
      }
    }
  ]
}
```

`flush` also provides the ability to control when should the transforms apply (before Vite's processing or after)


Resolves #528, #739 

Related https://github.com/vitejs/vite/issues/639, https://github.com/vuejs/vitepress/pull/77#issuecomment-687076258

