### PR TITLE
fix: Add support for GitHub Codespaces (close #797)

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -29,8 +29,9 @@ console.log('[vite] connecting...')
 
 declare var __VUE_HMR_RUNTIME__: HMRRuntime
 
+const socketPort = __PORT__ || location.port
 const socketProtocol = location.protocol === 'https:' ? 'wss' : 'ws'
-const socketUrl = `${socketProtocol}://${location.hostname}:${__PORT__}`
+const socketUrl = `${socketProtocol}://${location.hostname}:${socketPort}`
 const socket = new WebSocket(socketUrl, 'vite-hmr')
 
 function warnFailedFetch(err: Error, path: string | string[]) {

--- a/src/node/server/serverPluginClient.ts
+++ b/src/node/server/serverPluginClient.ts
@@ -1,14 +1,26 @@
 import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
-import { ServerPlugin } from '.'
+import { Context, ServerPlugin, State } from '.'
 import { defaultDefines } from '../config'
+import Application from 'koa'
 
 export const clientFilePath = path.resolve(__dirname, '../../client/client.js')
 
 export const clientPublicPath = `/vite/client`
 
 const legacyPublicPath = '/vite/hmr'
+
+function updatePort(
+  clientCode: string,
+  ctx: Application.ParameterizedContext<State, Context>
+) {
+  // If the end-user is running the CLI within a GitHub Codespace,
+  // then set the port to 0, which indicates that we should use
+  // whichever port the client application is running on (e.g. 443).
+  const port = !!process.env['CODESPACES'] ? 0 : ctx.port
+  return clientCode.replace(`__PORT__`, port.toString())
+}
 
 export const clientPlugin: ServerPlugin = ({ app, config }) => {
   const clientCode = fs
@@ -26,7 +38,7 @@ export const clientPlugin: ServerPlugin = ({ app, config }) => {
     if (ctx.path === clientPublicPath) {
       ctx.type = 'js'
       ctx.status = 200
-      ctx.body = clientCode.replace(`__PORT__`, ctx.port.toString())
+      ctx.body = updatePort(clientCode, ctx)
     } else {
       if (ctx.path === legacyPublicPath) {
         console.error(


### PR DESCRIPTION
This PR fixes #797, by detecting that the end-user is running within [GitHub Codespaces](https://github.com/features/codespaces). In this context, the server is being "forwarded" outside of the Codespace via a non-localhost URL, and so we want the Websocket/HMR client to connect to the port of the **forwarded URL** (e.g. 443), not the port of the server running inside the container (e.g. 3000).

> Note: This change is generally useful for any virtualized cloud environment that supports secure port forwarding. However, to keep things simple, I simply made the check GitHub Codespaces specific for now.