### PR TITLE
feat: Configurable asset inclusion (fix: #810)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Both CSS and JSON imports also support Hot Module Replacement.
 
 You can reference static assets in your `*.vue` templates, styles and plain `.css` files either using absolute public paths (based on project root) or relative paths (based on your file system). The latter is similar to the behavior you are used to if you have used `vue-cli` or webpack's `file-loader`.
 
+Common image, media, and font filetypes are detected and included as assets automatically. You can override this using the `assetsInclude` configuration option.
+
 All referenced assets, including those using absolute paths, will be copied to the dist folder with a hashed file name in the production build. Never-referenced assets will not be copied. Similar to `vue-cli`, image assets smaller than 4kb will be base64 inlined.
 
 All **static** path references, including absolute paths, should be based on your working directory structure.

--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -92,21 +92,13 @@ export const registerAssets = (
   }
 }
 
-interface BuildAssetPluginOptions {
-  root: string
-  resolver: InternalResolver
-  publicBase: string
-  assetsDir: string
+export const createBuildAssetPlugin = (
+  root: string,
+  resolver: InternalResolver,
+  publicBase: string,
+  assetsDir: string,
   inlineLimit: number
-}
-
-export const createBuildAssetPlugin = ({
-  root,
-  resolver,
-  publicBase,
-  assetsDir,
-  inlineLimit
-}: BuildAssetPluginOptions): Plugin => {
+): Plugin => {
   const assets = new Map<string, Buffer>()
 
   return {

--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -5,6 +5,7 @@ import { cleanUrl } from '../utils'
 import hash_sum from 'hash-sum'
 import slash from 'slash'
 import mime from 'mime-types'
+import { InternalResolver } from '../resolver'
 
 const debug = require('debug')('vite:build:asset')
 
@@ -93,25 +94,25 @@ export const registerAssets = (
 
 interface BuildAssetPluginOptions {
   root: string
+  resolver: InternalResolver
   publicBase: string
   assetsDir: string
   inlineLimit: number
-  include: (file: string) => boolean
 }
 
 export const createBuildAssetPlugin = ({
   root,
+  resolver,
   publicBase,
   assetsDir,
-  inlineLimit,
-  include
+  inlineLimit
 }: BuildAssetPluginOptions): Plugin => {
   const assets = new Map<string, Buffer>()
 
   return {
     name: 'vite:asset',
     async load(id) {
-      if (include(id)) {
+      if (resolver.isAssetRequest(id)) {
         const { fileName, content, url } = await resolveAsset(
           id,
           root,

--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -91,18 +91,27 @@ export const registerAssets = (
   }
 }
 
-export const createBuildAssetPlugin = (
-  root: string,
-  publicBase: string,
-  assetsDir: string,
+interface BuildAssetPluginOptions {
+  root: string
+  publicBase: string
+  assetsDir: string
   inlineLimit: number
-): Plugin => {
+  include?: (file: string) => boolean
+}
+
+export const createBuildAssetPlugin = ({
+  root,
+  publicBase,
+  assetsDir,
+  inlineLimit,
+  include = isStaticAsset
+}: BuildAssetPluginOptions): Plugin => {
   const assets = new Map<string, Buffer>()
 
   return {
     name: 'vite:asset',
     async load(id) {
-      if (isStaticAsset(id)) {
+      if (include(id)) {
         const { fileName, content, url } = await resolveAsset(
           id,
           root,

--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import fs from 'fs-extra'
 import { Plugin, OutputBundle } from 'rollup'
-import { cleanUrl, isStaticAsset } from '../utils'
+import { cleanUrl } from '../utils'
 import hash_sum from 'hash-sum'
 import slash from 'slash'
 import mime from 'mime-types'
@@ -96,7 +96,7 @@ interface BuildAssetPluginOptions {
   publicBase: string
   assetsDir: string
   inlineLimit: number
-  include?: (file: string) => boolean
+  include: (file: string) => boolean
 }
 
 export const createBuildAssetPlugin = ({
@@ -104,7 +104,7 @@ export const createBuildAssetPlugin = ({
   publicBase,
   assetsDir,
   inlineLimit,
-  include = isStaticAsset
+  include
 }: BuildAssetPluginOptions): Plugin => {
   const assets = new Map<string, Buffer>()
 

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -391,12 +391,12 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
         modulesOptions: cssModuleOptions
       }),
       // vite:asset
-      createBuildAssetPlugin(
+      createBuildAssetPlugin({
         root,
-        publicBasePath,
+        publicBase: publicBasePath,
         assetsDir,
-        assetsInlineLimit
-      ),
+        inlineLimit: assetsInlineLimit
+      }),
       createBuildWasmPlugin(root, publicBasePath, assetsDir, assetsInlineLimit),
       enableEsbuild
         ? createEsbuildRenderChunkPlugin(esbuildTarget, minify === 'esbuild')

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -392,13 +392,13 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
         modulesOptions: cssModuleOptions
       }),
       // vite:asset
-      createBuildAssetPlugin({
+      createBuildAssetPlugin(
         root,
         resolver,
-        publicBase: publicBasePath,
+        publicBasePath,
         assetsDir,
-        inlineLimit: assetsInlineLimit
-      }),
+        assetsInlineLimit
+      ),
       createBuildWasmPlugin(root, publicBasePath, assetsDir, assetsInlineLimit),
       enableEsbuild
         ? createEsbuildRenderChunkPlugin(esbuildTarget, minify === 'esbuild')

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -394,10 +394,10 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
       // vite:asset
       createBuildAssetPlugin({
         root,
+        resolver,
         publicBase: publicBasePath,
         assetsDir,
-        inlineLimit: assetsInlineLimit,
-        include: (file) => resolver.isAssetRequest(file)
+        inlineLimit: assetsInlineLimit
       }),
       createBuildWasmPlugin(root, publicBasePath, assetsDir, assetsInlineLimit),
       enableEsbuild

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import chalk from 'chalk'
 import { Ora } from 'ora'
-import { resolveFrom, lookupFile, isStaticAsset } from '../utils'
+import { resolveFrom, lookupFile } from '../utils'
 import {
   rollup as Rollup,
   RollupOutput,
@@ -242,7 +242,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
     outDir = path.resolve(root, 'dist'),
     assetsDir = '_assets',
     assetsInlineLimit = 4096,
-    assetsInclude = isStaticAsset,
+    assetsInclude,
     cssCodeSplit = true,
     alias = {},
     resolvers = [],
@@ -362,7 +362,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
           !/\?vue&type=template/.test(id) &&
           // also exclude css and static assets for performance
           !isCSSRequest(id) &&
-          !assetsInclude(id),
+          !resolver.isAssetRequest(id),
         {
           ...defaultDefines,
           ...userDefineReplacements,
@@ -397,7 +397,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
         publicBase: publicBasePath,
         assetsDir,
         inlineLimit: assetsInlineLimit,
-        include: assetsInclude
+        include: (file) => resolver.isAssetRequest(file)
       }),
       createBuildWasmPlugin(root, publicBasePath, assetsDir, assetsInlineLimit),
       enableEsbuild

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -284,7 +284,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
   const publicBasePath = base.replace(/([^/])$/, '$1/') // ensure ending slash
   const resolvedAssetsPath = path.join(outDir, assetsDir)
 
-  const resolver = createResolver(root, resolvers, alias)
+  const resolver = createResolver(root, resolvers, alias, assetsInclude)
 
   const { htmlPlugin, renderIndex } = await createBuildHtmlPlugin(
     root,

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -242,6 +242,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
     outDir = path.resolve(root, 'dist'),
     assetsDir = '_assets',
     assetsInlineLimit = 4096,
+    assetsInclude = isStaticAsset,
     cssCodeSplit = true,
     alias = {},
     resolvers = [],
@@ -361,7 +362,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
           !/\?vue&type=template/.test(id) &&
           // also exclude css and static assets for performance
           !isCSSRequest(id) &&
-          !isStaticAsset(id),
+          !assetsInclude(id),
         {
           ...defaultDefines,
           ...userDefineReplacements,
@@ -395,7 +396,8 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
         root,
         publicBase: publicBasePath,
         assetsDir,
-        inlineLimit: assetsInlineLimit
+        inlineLimit: assetsInlineLimit,
+        include: assetsInclude
       }),
       createBuildWasmPlugin(root, publicBasePath, assetsDir, assetsInlineLimit),
       enableEsbuild

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -72,6 +72,10 @@ export interface SharedConfig {
    */
   alias?: Record<string, string>
   /**
+   * Function that tests a file path for inclusion as a static asset.
+   */
+  assetsInclude?: (file: string) => boolean
+  /**
    * Custom file transforms.
    */
   transforms?: Transform[]

--- a/src/node/optimizer/index.ts
+++ b/src/node/optimizer/index.ts
@@ -15,7 +15,10 @@ import { lookupFile, resolveFrom } from '../utils'
 import { init, parse } from 'es-module-lexer'
 import chalk from 'chalk'
 import { Ora } from 'ora'
-import { createDepAssetPlugin, depAssetExternalPlugin } from './pluginAssets'
+import {
+  createDepAssetPlugin,
+  createDepAssetExternalPlugin
+} from './pluginAssets'
 
 const debug = require('debug')('vite:optimize')
 
@@ -186,7 +189,7 @@ export async function optimizeDeps(
       onwarn: onRollupWarning(spinner, options),
       ...config.rollupInputOptions,
       plugins: [
-        depAssetExternalPlugin,
+        createDepAssetExternalPlugin(),
         ...(await createBaseRollupPlugins(root, resolver, config)),
         createDepAssetPlugin({ resolver, root })
       ]

--- a/src/node/optimizer/index.ts
+++ b/src/node/optimizer/index.ts
@@ -194,9 +194,9 @@ export async function optimizeDeps(
       onwarn: onRollupWarning(spinner, options),
       ...config.rollupInputOptions,
       plugins: [
-        createDepAssetExternalPlugin({ resolver }),
+        createDepAssetExternalPlugin(resolver),
         ...(await createBaseRollupPlugins(root, resolver, config)),
-        createDepAssetPlugin({ resolver, root })
+        createDepAssetPlugin(resolver, root)
       ]
     })
 

--- a/src/node/optimizer/index.ts
+++ b/src/node/optimizer/index.ts
@@ -188,7 +188,7 @@ export async function optimizeDeps(
       plugins: [
         depAssetExternalPlugin,
         ...(await createBaseRollupPlugins(root, resolver, config)),
-        createDepAssetPlugin(resolver, root)
+        createDepAssetPlugin({ resolver, root })
       ]
     })
 

--- a/src/node/optimizer/index.ts
+++ b/src/node/optimizer/index.ts
@@ -186,7 +186,6 @@ export async function optimizeDeps(
 
   try {
     const rollup = require('rollup') as typeof Rollup
-    const { assetsInclude } = config
 
     const bundle = await rollup.rollup({
       input: qualified,
@@ -195,15 +194,9 @@ export async function optimizeDeps(
       onwarn: onRollupWarning(spinner, options),
       ...config.rollupInputOptions,
       plugins: [
-        createDepAssetExternalPlugin({
-          include: assetsInclude
-        }),
+        createDepAssetExternalPlugin({ resolver }),
         ...(await createBaseRollupPlugins(root, resolver, config)),
-        createDepAssetPlugin({
-          resolver,
-          root,
-          include: assetsInclude
-        })
+        createDepAssetPlugin({ resolver, root })
       ]
     })
 

--- a/src/node/optimizer/index.ts
+++ b/src/node/optimizer/index.ts
@@ -181,6 +181,7 @@ export async function optimizeDeps(
 
   try {
     const rollup = require('rollup') as typeof Rollup
+    const { assetsInclude } = config
 
     const bundle = await rollup.rollup({
       input: qualified,
@@ -189,9 +190,15 @@ export async function optimizeDeps(
       onwarn: onRollupWarning(spinner, options),
       ...config.rollupInputOptions,
       plugins: [
-        createDepAssetExternalPlugin(),
+        createDepAssetExternalPlugin({
+          include: assetsInclude
+        }),
         ...(await createBaseRollupPlugins(root, resolver, config)),
-        createDepAssetPlugin({ resolver, root })
+        createDepAssetPlugin({
+          resolver,
+          root,
+          include: assetsInclude
+        })
       ]
     })
 

--- a/src/node/optimizer/index.ts
+++ b/src/node/optimizer/index.ts
@@ -102,7 +102,12 @@ export async function optimizeDeps(
   await fs.ensureDir(cacheDir)
 
   const options = config.optimizeDeps || {}
-  const resolver = createResolver(root, config.resolvers, config.alias)
+  const resolver = createResolver(
+    root,
+    config.resolvers,
+    config.alias,
+    config.assetsInclude
+  )
 
   // Determine deps to optimize. The goal is to only pre-bundle deps that falls
   // under one of the following categories:

--- a/src/node/optimizer/pluginAssets.ts
+++ b/src/node/optimizer/pluginAssets.ts
@@ -8,7 +8,7 @@ import { InternalResolver } from '../resolver'
 
 export const isAsset = (id: string) => isCSSRequest(id) || isStaticAsset(id)
 
-export const depAssetExternalPlugin: Plugin = {
+export const createDepAssetExternalPlugin = (): Plugin => ({
   name: 'vite:optimize-dep-assets-external',
   resolveId(id) {
     if (isAsset(id)) {
@@ -18,7 +18,7 @@ export const depAssetExternalPlugin: Plugin = {
       }
     }
   }
-}
+})
 
 interface DepAssetPluginOptions {
   resolver: InternalResolver

--- a/src/node/optimizer/pluginAssets.ts
+++ b/src/node/optimizer/pluginAssets.ts
@@ -6,8 +6,6 @@ import { isStaticAsset, bareImportRE, resolveFrom } from '../utils'
 import path from 'path'
 import { InternalResolver } from '../resolver'
 
-export const isAsset = (id: string) => isCSSRequest(id) || isStaticAsset(id)
-
 interface DepAssetExternalPluginOptions {
   include?: (file: string) => boolean
 }

--- a/src/node/optimizer/pluginAssets.ts
+++ b/src/node/optimizer/pluginAssets.ts
@@ -8,10 +8,16 @@ import { InternalResolver } from '../resolver'
 
 export const isAsset = (id: string) => isCSSRequest(id) || isStaticAsset(id)
 
-export const createDepAssetExternalPlugin = (): Plugin => ({
+interface DepAssetExternalPluginOptions {
+  include?: (file: string) => boolean
+}
+
+export const createDepAssetExternalPlugin = ({
+  include = isStaticAsset
+}: DepAssetExternalPluginOptions = {}): Plugin => ({
   name: 'vite:optimize-dep-assets-external',
   resolveId(id) {
-    if (isAsset(id)) {
+    if (isCSSRequest(id) || include(id)) {
       return {
         id,
         external: true

--- a/src/node/optimizer/pluginAssets.ts
+++ b/src/node/optimizer/pluginAssets.ts
@@ -6,13 +6,9 @@ import { bareImportRE, resolveFrom } from '../utils'
 import path from 'path'
 import { InternalResolver } from '../resolver'
 
-interface DepAssetExternalPluginOptions {
+export const createDepAssetExternalPlugin = (
   resolver: InternalResolver
-}
-
-export const createDepAssetExternalPlugin = ({
-  resolver
-}: DepAssetExternalPluginOptions): Plugin => ({
+): Plugin => ({
   name: 'vite:optimize-dep-assets-external',
   resolveId(id) {
     if (isCSSRequest(id) || resolver.isAssetRequest(id)) {
@@ -24,15 +20,10 @@ export const createDepAssetExternalPlugin = ({
   }
 })
 
-interface DepAssetPluginOptions {
-  resolver: InternalResolver
+export const createDepAssetPlugin = (
+  resolver: InternalResolver,
   root: string
-}
-
-export const createDepAssetPlugin = ({
-  resolver,
-  root
-}: DepAssetPluginOptions): Plugin => {
+): Plugin => {
   return {
     name: 'vite:optimize-dep-assets',
     async transform(code, id) {

--- a/src/node/optimizer/pluginAssets.ts
+++ b/src/node/optimizer/pluginAssets.ts
@@ -20,10 +20,17 @@ export const depAssetExternalPlugin: Plugin = {
   }
 }
 
-export const createDepAssetPlugin = (
-  resolver: InternalResolver,
+interface DepAssetPluginOptions {
+  resolver: InternalResolver
   root: string
-): Plugin => {
+  include?: (file: string) => boolean
+}
+
+export const createDepAssetPlugin = ({
+  resolver,
+  root,
+  include = isStaticAsset
+}: DepAssetPluginOptions): Plugin => {
   return {
     name: 'vite:optimize-dep-assets',
     async transform(code, id) {
@@ -36,7 +43,7 @@ export const createDepAssetPlugin = (
             const { s: start, e: end, d: dynamicIndex } = imports[i]
             if (dynamicIndex === -1) {
               const importee = code.slice(start, end)
-              if (isAsset(importee)) {
+              if (isCSSRequest(importee) || include(importee)) {
                 // replace css/asset imports to deep imports to their original
                 // location
                 s = s || new MagicString(code)

--- a/src/node/resolver.ts
+++ b/src/node/resolver.ts
@@ -16,7 +16,6 @@ import {
 import { resolveOptimizedCacheDir } from './optimizer'
 import { clientPublicPath } from './server/serverPluginClient'
 import chalk from 'chalk'
-import { isAsset } from './optimizer/pluginAssets'
 
 const debug = require('debug')('vite:resolve')
 const isWin = require('os').platform() === 'win32'
@@ -387,7 +386,7 @@ export function resolveBareModuleRequest(
           // redirect it the optimized copy.
           return resolveBareModuleRequest(root, depId, importer, resolver)
         }
-        if (!isAsset(id)) {
+        if (jsSrcRE.test(id)) {
           // warn against deep imports to optimized dep
           console.error(
             chalk.yellow(

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -56,7 +56,8 @@ export function createServer(config: ServerConfig): Server {
     transforms = [],
     vueCustomBlockTransforms = {},
     optimizeDeps = {},
-    enableEsbuild = true
+    enableEsbuild = true,
+    assetsInclude
   } = config
 
   const app = new Koa<State, Context>()
@@ -116,7 +117,9 @@ export function createServer(config: ServerConfig): Server {
     cssPlugin,
     enableEsbuild ? esbuildPlugin : null,
     jsonPlugin,
-    createAssetPathPlugin(),
+    createAssetPathPlugin({
+      include: assetsInclude
+    }),
     webWorkerPlugin,
     wasmPlugin,
     serveStaticPlugin

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -12,7 +12,7 @@ import { hmrPlugin, HMRWatcher } from './serverPluginHmr'
 import { serveStaticPlugin } from './serverPluginServeStatic'
 import { jsonPlugin } from './serverPluginJson'
 import { cssPlugin } from './serverPluginCss'
-import { assetPathPlugin } from './serverPluginAssets'
+import { createAssetPathPlugin } from './serverPluginAssets'
 import { esbuildPlugin } from './serverPluginEsbuild'
 import { ServerConfig } from '../config'
 import { createServerTransformPlugin } from '../transform'
@@ -116,7 +116,7 @@ export function createServer(config: ServerConfig): Server {
     cssPlugin,
     enableEsbuild ? esbuildPlugin : null,
     jsonPlugin,
-    assetPathPlugin,
+    createAssetPathPlugin(),
     webWorkerPlugin,
     wasmPlugin,
     serveStaticPlugin

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -12,7 +12,7 @@ import { hmrPlugin, HMRWatcher } from './serverPluginHmr'
 import { serveStaticPlugin } from './serverPluginServeStatic'
 import { jsonPlugin } from './serverPluginJson'
 import { cssPlugin } from './serverPluginCss'
-import { createAssetPathPlugin } from './serverPluginAssets'
+import { assetPathPlugin } from './serverPluginAssets'
 import { esbuildPlugin } from './serverPluginEsbuild'
 import { ServerConfig } from '../config'
 import { createServerTransformPlugin } from '../transform'
@@ -56,8 +56,7 @@ export function createServer(config: ServerConfig): Server {
     transforms = [],
     vueCustomBlockTransforms = {},
     optimizeDeps = {},
-    enableEsbuild = true,
-    assetsInclude
+    enableEsbuild = true
   } = config
 
   const app = new Koa<State, Context>()
@@ -117,9 +116,7 @@ export function createServer(config: ServerConfig): Server {
     cssPlugin,
     enableEsbuild ? esbuildPlugin : null,
     jsonPlugin,
-    createAssetPathPlugin({
-      include: assetsInclude
-    }),
+    assetPathPlugin,
     webWorkerPlugin,
     wasmPlugin,
     serveStaticPlugin

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -56,7 +56,8 @@ export function createServer(config: ServerConfig): Server {
     transforms = [],
     vueCustomBlockTransforms = {},
     optimizeDeps = {},
-    enableEsbuild = true
+    enableEsbuild = true,
+    assetsInclude
   } = config
 
   const app = new Koa<State, Context>()
@@ -69,7 +70,7 @@ export function createServer(config: ServerConfig): Server {
       pollInterval: 10
     }
   }) as HMRWatcher
-  const resolver = createResolver(root, resolvers, alias)
+  const resolver = createResolver(root, resolvers, alias, assetsInclude)
 
   const context: ServerPluginContext = {
     root,

--- a/src/node/server/serverPluginAssets.ts
+++ b/src/node/server/serverPluginAssets.ts
@@ -1,10 +1,9 @@
 import { ServerPlugin } from '.'
-import { isImportRequest, isStaticAsset } from '../utils'
+import { isImportRequest } from '../utils'
 
 export const assetPathPlugin: ServerPlugin = ({ app }) => {
   app.use(async (ctx, next) => {
-    const include = ctx.config.assetsInclude || isStaticAsset
-    if (include(ctx.path) && isImportRequest(ctx)) {
+    if (ctx.resolver.isAssetRequest(ctx.path) && isImportRequest(ctx)) {
       ctx.type = 'js'
       ctx.body = `export default ${JSON.stringify(ctx.path)}`
       return

--- a/src/node/server/serverPluginAssets.ts
+++ b/src/node/server/serverPluginAssets.ts
@@ -1,9 +1,9 @@
 import { ServerPlugin } from '.'
 import { isImportRequest } from '../utils'
 
-export const assetPathPlugin: ServerPlugin = ({ app }) => {
+export const assetPathPlugin: ServerPlugin = ({ app, resolver }) => {
   app.use(async (ctx, next) => {
-    if (ctx.resolver.isAssetRequest(ctx.path) && isImportRequest(ctx)) {
+    if (resolver.isAssetRequest(ctx.path) && isImportRequest(ctx)) {
       ctx.type = 'js'
       ctx.body = `export default ${JSON.stringify(ctx.path)}`
       return

--- a/src/node/server/serverPluginAssets.ts
+++ b/src/node/server/serverPluginAssets.ts
@@ -1,21 +1,14 @@
 import { ServerPlugin } from '.'
 import { isImportRequest, isStaticAsset } from '../utils'
 
-interface AssetPathPluginOptions {
-  include?: (file: string) => boolean
-}
-
-export const createAssetPathPlugin = ({
-  include = isStaticAsset
-}: AssetPathPluginOptions = {}): ServerPlugin => {
-  return ({ app }) => {
-    app.use(async (ctx, next) => {
-      if (include(ctx.path) && isImportRequest(ctx)) {
-        ctx.type = 'js'
-        ctx.body = `export default ${JSON.stringify(ctx.path)}`
-        return
-      }
-      return next()
-    })
-  }
+export const assetPathPlugin: ServerPlugin = ({ app }) => {
+  app.use(async (ctx, next) => {
+    const include = ctx.config.assetsInclude || isStaticAsset
+    if (include(ctx.path) && isImportRequest(ctx)) {
+      ctx.type = 'js'
+      ctx.body = `export default ${JSON.stringify(ctx.path)}`
+      return
+    }
+    return next()
+  })
 }

--- a/src/node/server/serverPluginAssets.ts
+++ b/src/node/server/serverPluginAssets.ts
@@ -1,10 +1,16 @@
 import { ServerPlugin } from '.'
 import { isImportRequest, isStaticAsset } from '../utils'
 
-export const createAssetPathPlugin = (): ServerPlugin => {
+interface AssetPathPluginOptions {
+  include?: (file: string) => boolean
+}
+
+export const createAssetPathPlugin = ({
+  include = isStaticAsset
+}: AssetPathPluginOptions = {}): ServerPlugin => {
   return ({ app }) => {
     app.use(async (ctx, next) => {
-      if (isStaticAsset(ctx.path) && isImportRequest(ctx)) {
+      if (include(ctx.path) && isImportRequest(ctx)) {
         ctx.type = 'js'
         ctx.body = `export default ${JSON.stringify(ctx.path)}`
         return

--- a/src/node/server/serverPluginAssets.ts
+++ b/src/node/server/serverPluginAssets.ts
@@ -1,13 +1,15 @@
 import { ServerPlugin } from '.'
 import { isImportRequest, isStaticAsset } from '../utils'
 
-export const assetPathPlugin: ServerPlugin = ({ app }) => {
-  app.use(async (ctx, next) => {
-    if (isStaticAsset(ctx.path) && isImportRequest(ctx)) {
-      ctx.type = 'js'
-      ctx.body = `export default ${JSON.stringify(ctx.path)}`
-      return
-    }
-    return next()
-  })
+export const createAssetPathPlugin = (): ServerPlugin => {
+  return ({ app }) => {
+    app.use(async (ctx, next) => {
+      if (isStaticAsset(ctx.path) && isImportRequest(ctx)) {
+        ctx.type = 'js'
+        ctx.body = `export default ${JSON.stringify(ctx.path)}`
+        return
+      }
+      return next()
+    })
+  }
 }

--- a/src/node/server/serverPluginServeStatic.ts
+++ b/src/node/server/serverPluginServeStatic.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import { ServerPlugin } from '.'
-import { isStaticAsset } from '../utils'
 import chalk from 'chalk'
 
 const send = require('koa-send')
@@ -22,7 +21,7 @@ export const serveStaticPlugin: ServerPlugin = ({
     }
 
     // warn non-root references to assets under /public/
-    if (ctx.path.startsWith('/public/') && isStaticAsset(ctx.path)) {
+    if (ctx.path.startsWith('/public/') && resolver.isAssetRequest(ctx.path)) {
       console.error(
         chalk.yellow(
           `[vite] files in the public directory are served at the root path.\n` +


### PR DESCRIPTION
Adds a new configuration option `assetsInclude` which overrides the default regex matching here:

https://github.com/vitejs/vite/blob/12c7c5dabda62bf5745cf0e3c25f609d2cc1438f/src/node/utils/pathUtils.ts#L52-L61

You can use the feature like this:

```js
// vite.config.js
export default {
  assetsInclude(file) {
    return /\.(hdr|glb|usdz|png)$/.test(file)
  }
}

```