### PR TITLE
fix(build): stop spinner on rollup error

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -98,6 +98,9 @@ export function onRollupWarning(
           `If you do want to externalize this module explicitly add it to\n` +
           `\`rollupInputOptions.external\``
       }
+      if (spinner) {
+        spinner.stop()
+      }
       throw new Error(message)
     }
     if (


### PR DESCRIPTION
This stops the spinner before throwing, when handling rollup warning.

Before this change when using Vite build programatically from another module even when the error is captured the spinner would keep on spinning.