### PR TITLE
feat: let user config be a function

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -357,7 +357,7 @@ export async function resolveConfig(
 ): Promise<ResolvedConfig | undefined> {
   const start = Date.now()
   const cwd = process.cwd()
-  let config: ResolvedConfig | undefined
+  let config: ResolvedConfig | ((mode: string) => ResolvedConfig) | undefined
   let resolvedPath: string | undefined
   let isTS = false
   if (configPath) {
@@ -427,6 +427,10 @@ export async function resolveConfig(
       })
 
       config = await loadConfigFromBundledFile(resolvedPath, code)
+    }
+
+    if (typeof config === 'function') {
+      config = config(mode)
     }
 
     // normalize config root to absolute


### PR DESCRIPTION
The `vite.config` module can export a function that receives a `mode: string` argument, useful for different configuration between production and development.

```ts
export default (mode: string) => ({
  alias: {
    foo: mode === 'production' ? 'foo/dist' : 'foo/src',
  }
})
```