### PR TITLE
fix: check root node_modules for missing aliased import

### DIFF
--- a/src/node/build/buildPluginResolve.ts
+++ b/src/node/build/buildPluginResolve.ts
@@ -1,5 +1,6 @@
 import { Plugin } from 'rollup'
 import fs from 'fs-extra'
+import path from 'path'
 import { resolveVue } from '../utils/resolveVue'
 import { InternalResolver } from '../resolver'
 import { isExternalUrl } from '../utils'
@@ -33,7 +34,14 @@ export const createBuildResolvePlugin = (
       }
       // fallback to node-resolve because alias
       if (id !== original) {
-        const resolved = await this.resolve(id, importer, { skipSelf: true })
+        const resolve = (id: string) =>
+          this.resolve(id, importer, { skipSelf: true })
+
+        const resolved =
+          (await resolve(id)) ||
+          // aliased import might be provided by root
+          (await resolve(path.join(root, 'node_modules', id)))
+
         return resolved || { id }
       }
     }


### PR DESCRIPTION
If a local dependency added with `yarn link` exists outside the root directory, Rollup can't resolve aliased imports 
(eg: `react` ➤ `@pika/react`) so we need to check the root node_modules in that case.