### PR TITLE
feat: add `configureBuild` hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "fs-extra": "^9.0.1",
     "hash-sum": "^2.0.0",
     "isbuiltin": "^1.0.0",
+    "klona": "^2.0.4",
     "koa": "^2.13.0",
     "koa-conditional-get": "^3.0.0",
     "koa-etag": "^4.0.0",

--- a/src/node/build/buildPluginEsbuild.ts
+++ b/src/node/build/buildPluginEsbuild.ts
@@ -10,7 +10,7 @@ import {
 import { SharedConfig } from '../config'
 
 export const createEsbuildPlugin = async (
-  jsx: SharedConfig['jsx']
+  jsx: SharedConfig['jsx'] = 'vue'
 ): Promise<Plugin> => {
   const jsxConfig = resolveJsxOptions(jsx)
 

--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -105,14 +105,15 @@ export const createBuildHtmlPlugin = async (
   }
 
   const renderIndex = async (bundleOutput: RollupOutput['output']) => {
+    let result = processedHtml
     for (const chunk of bundleOutput) {
       if (chunk.type === 'chunk') {
         if (chunk.isEntry) {
           // js entry chunk
-          processedHtml = injectScript(processedHtml, chunk.fileName)
+          result = injectScript(result, chunk.fileName)
         } else if (shouldPreload && shouldPreload(chunk)) {
           // async preloaded chunk
-          processedHtml = injectPreload(processedHtml, chunk.fileName)
+          result = injectPreload(result, chunk.fileName)
         }
       } else {
         // imported css chunks
@@ -121,12 +122,13 @@ export const createBuildHtmlPlugin = async (
           chunk.source &&
           !assets.has(chunk.fileName)
         ) {
-          processedHtml = injectCSS(processedHtml, chunk.fileName)
+          result = injectCSS(result, chunk.fileName)
         }
       }
     }
+
     return await transformIndexHtml(
-      processedHtml,
+      result,
       config.indexHtmlTransforms,
       'post',
       true

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -411,7 +411,9 @@ export interface BuildConfig extends Required<SharedConfig> {
    */
   enableRollupPluginVue?: boolean,
   /**
-   * Plugin functions that mutate the Vite build config.
+   * Plugin functions that mutate the Vite build config. The `builds` array can
+   * be added to if the plugin wants to add another Rollup build that Vite writes
+   * to disk. Return a function to gain access to each build's output.
    * @internal
    */
   configureBuild?: BuildPlugin | BuildPlugin[]

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -19,7 +19,7 @@ import { createServerTransformPlugin } from '../transform'
 import { htmlRewritePlugin } from './serverPluginHtml'
 import { proxyPlugin } from './serverPluginProxy'
 import { createCertificate } from '../utils/createCertificate'
-import { cachedRead } from '../utils'
+import { cachedRead, toArray } from '../utils'
 import { envPlugin } from './serverPluginEnv'
 export { rewriteImports } from './serverPluginModuleRewrite'
 import { sourceMapPlugin, SourceMap } from './serverPluginSourceMap'
@@ -106,7 +106,7 @@ export function createServer(config: ServerConfig): Server {
     moduleRewritePlugin,
     htmlRewritePlugin,
     // user plugins
-    ...(Array.isArray(configureServer) ? configureServer : [configureServer]),
+    ...toArray(configureServer),
     envPlugin,
     moduleResolvePlugin,
     proxyPlugin,

--- a/src/node/utils/index.ts
+++ b/src/node/utils/index.ts
@@ -2,3 +2,7 @@ export * from './fsUtils'
 export * from './pathUtils'
 export * from './transformUtils'
 export * from './resolveVue'
+
+export function toArray<T>(arg: T | T[] | undefined) {
+  return arg === void 0 ? [] : Array.isArray(arg) ? arg : [arg]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4105,6 +4105,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+klona@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
+  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+
 koa-compose@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-3.2.1.tgz#a85ccb40b7d986d8e5a345b3a1ace8eabcf54de7"


### PR DESCRIPTION
This is another approach to the proposed `configureBuild` hook. (See #870 for the first approach)

In this PR, the `configureBuild` hooks are called before anything is done by the `build` function (except initializing the build config). When initializing the build config, it gets deep-cloned and filled with default values, so that `configureBuild` hooks can more easily inspect & mutate it (without checking for `undefined` everywhere).

Whereas #870 only exposes the Rollup input options to `configureBuild`, this PR exposes the entire Vite build config, which allows Vite plugins to better manipulate the build process as needed. This means more powerful Vite plugins will be possible.