### PR TITLE
feat: let `configureBuild` hooks inject Rollup bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "fs-extra": "^9.0.1",
     "hash-sum": "^2.0.0",
     "isbuiltin": "^1.0.0",
+    "klona": "^2.0.4",
     "koa": "^2.13.0",
     "koa-conditional-get": "^3.0.0",
     "koa-etag": "^4.0.0",

--- a/src/node/build/buildPluginEsbuild.ts
+++ b/src/node/build/buildPluginEsbuild.ts
@@ -10,7 +10,7 @@ import {
 import { SharedConfig } from '../config'
 
 export const createEsbuildPlugin = async (
-  jsx: SharedConfig['jsx']
+  jsx: SharedConfig['jsx'] = 'vue'
 ): Promise<Plugin> => {
   const jsxConfig = resolveJsxOptions(jsx)
 

--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -92,14 +92,15 @@ export const createBuildHtmlPlugin = async (
   }
 
   const renderIndex = (bundleOutput: RollupOutput['output']) => {
+    let result = processedHtml
     for (const chunk of bundleOutput) {
       if (chunk.type === 'chunk') {
         if (chunk.isEntry) {
           // js entry chunk
-          processedHtml = injectScript(processedHtml, chunk.fileName)
+          result = injectScript(result, chunk.fileName)
         } else if (shouldPreload && shouldPreload(chunk)) {
           // async preloaded chunk
-          processedHtml = injectPreload(processedHtml, chunk.fileName)
+          result = injectPreload(result, chunk.fileName)
         }
       } else {
         // imported css chunks
@@ -108,11 +109,11 @@ export const createBuildHtmlPlugin = async (
           chunk.source &&
           !assets.has(chunk.fileName)
         ) {
-          processedHtml = injectCSS(processedHtml, chunk.fileName)
+          result = injectCSS(result, chunk.fileName)
         }
       }
     }
-    return processedHtml
+    return result
   }
 
   return {

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -259,14 +259,14 @@ function prepareConfig(config: Partial<BuildConfig>): BuildConfig {
     jsx = 'vue',
     minify = true,
     mode = 'production',
+    optimizeDeps = {},
+    outDir = 'dist',
     resolvers = [],
     rollupDedupe = [],
     rollupInputOptions = {},
     rollupOutputOptions = {},
     rollupPluginVueOptions = {},
     root = process.cwd(),
-    optimizeDeps = {},
-    outDir = path.resolve(root, 'dist'),
     shouldPreload = null,
     silent = false,
     sourcemap = false,
@@ -332,7 +332,6 @@ export async function build(
   )
   const {
     root,
-    outDir,
     assetsDir,
     assetsInlineLimit,
     emitIndex,
@@ -358,8 +357,8 @@ export async function build(
       spinner = require('ora')(msg + '\n').start()
     }
   }
-  await fs.emptyDir(outDir)
 
+  const outDir = path.resolve(root, config.outDir)
   const indexPath = path.resolve(root, 'index.html')
   const publicBasePath = config.base.replace(/([^/])$/, '$1/') // ensure ending slash
   const resolvedAssetsPath = path.join(outDir, assetsDir)
@@ -534,6 +533,7 @@ export async function build(
       }
     }
 
+    await fs.emptyDir(outDir)
     await fs.ensureDir(outDir)
 
     // write js chunks and assets
@@ -616,7 +616,7 @@ export async function ssrBuild(
   } = options
 
   return build({
-    outDir: path.resolve(options.root || process.cwd(), 'dist-ssr'),
+    outDir: 'dist-ssr',
     assetsDir: '.',
     ...options,
     rollupPluginVueOptions: {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -335,7 +335,9 @@ export interface BuildConfig extends Required<SharedConfig> {
    */
   enableRollupPluginVue: boolean
   /**
-   * Plugin functions that mutate the Vite build config.
+   * Plugin functions that mutate the Vite build config. The `builds` array can
+   * be added to if the plugin wants to add another Rollup build that Vite writes
+   * to disk. Return a function to gain access to each build's output.
    * @internal
    */
   configureBuild?: BuildPlugin | BuildPlugin[]

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -19,7 +19,7 @@ import { createServerTransformPlugin } from '../transform'
 import { htmlRewritePlugin } from './serverPluginHtml'
 import { proxyPlugin } from './serverPluginProxy'
 import { createCertificate } from '../utils/createCertificate'
-import { cachedRead } from '../utils'
+import { cachedRead, toArray } from '../utils'
 import { envPlugin } from './serverPluginEnv'
 export { rewriteImports } from './serverPluginModuleRewrite'
 import { sourceMapPlugin, SourceMap } from './serverPluginSourceMap'
@@ -97,7 +97,7 @@ export function createServer(config: ServerConfig): Server {
     moduleRewritePlugin,
     htmlRewritePlugin,
     // user plugins
-    ...(Array.isArray(configureServer) ? configureServer : [configureServer]),
+    ...toArray(configureServer),
     envPlugin,
     moduleResolvePlugin,
     proxyPlugin,

--- a/src/node/utils/index.ts
+++ b/src/node/utils/index.ts
@@ -2,3 +2,7 @@ export * from './fsUtils'
 export * from './pathUtils'
 export * from './transformUtils'
 export * from './resolveVue'
+
+export function toArray<T>(arg: T | T[] | undefined) {
+  return arg === void 0 ? [] : Array.isArray(arg) ? arg : [arg]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2351,13 +2351,6 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
 
 enquirer@^2.3.6:
   version "2.3.6"
-  resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
-
-enquirer@^2.3.6:
-  version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
   dependencies:
@@ -4146,6 +4139,11 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+klona@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
+  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
 
 koa-compose@^3.0.0:
   version "3.2.1"


### PR DESCRIPTION
This PR depends on #874

It passes a `builds` array to `configureBuild` hooks. Plugins can add their own Rollup bundle promises to the `builds` array, and Vite will generate them sequentially. For each bundle, an `.html` entry point is written to the `outDir` based on the `build.id` string + `.html` extension.

**Why is this needed?** It makes plugins like [vite-plugin-mobile](https://github.com/alloc/vite-plugin-mobile) and [vite-plugin-legacy](https://github.com/alloc/vite-plugin-legacy) possible.