### PR TITLE
feat: inject module scripts into head instead of body (fixes #881)

### DIFF
--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -72,8 +72,8 @@ export const createBuildHtmlPlugin = async (
       ? filename
       : `${publicBasePath}${path.posix.join(assetsDir, filename)}`
     const tag = `<script type="module" src="${filename}"></script>`
-    if (/<\/body>/.test(html)) {
-      return html.replace(/<\/body>/, `${tag}\n</body>`)
+    if (/<\/head>/.test(html)) {
+      return html.replace(/<\/head>/, `${tag}\n</head>`)
     } else {
       return html + '\n' + tag
     }


### PR DESCRIPTION
not sure if this should be configurable or if body should be used as a fallback in case head does not exist.