### PR TITLE
chore: add indent when injecting

### DIFF
--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -61,7 +61,7 @@ export const createBuildHtmlPlugin = async (
       filename
     )}">`
     if (/<\/head>/.test(html)) {
-      return html.replace(/<\/head>/, `${tag}\n</head>`)
+      return html.replace(/<\/head>/, `  ${tag}\n</head>`)
     } else {
       return tag + '\n' + html
     }
@@ -73,7 +73,7 @@ export const createBuildHtmlPlugin = async (
       : `${publicBasePath}${path.posix.join(assetsDir, filename)}`
     const tag = `<script type="module" src="${filename}"></script>`
     if (/<\/body>/.test(html)) {
-      return html.replace(/<\/body>/, `${tag}\n</body>`)
+      return html.replace(/<\/body>/, `  ${tag}\n</body>`)
     } else {
       return html + '\n' + tag
     }
@@ -85,7 +85,7 @@ export const createBuildHtmlPlugin = async (
       : `${publicBasePath}${path.posix.join(assetsDir, filename)}`
     const tag = `<link rel="modulepreload" href="${filename}" />`
     if (/<\/head>/.test(html)) {
-      return html.replace(/<\/head>/, `${tag}\n</head>`)
+      return html.replace(/<\/head>/, `  ${tag}\n</head>`)
     } else {
       return tag + '\n' + html
     }


### PR DESCRIPTION
Use
```
npm run build
```
dist/index.html
```html
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="UTF-8">
  <link rel="icon" href="/favicon.ico" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title></title>
<link rel="stylesheet" href="/_assets/style.2e60e7a6.css">
</head>

<body>
  <div id="app"></div>
  
<script type="module" src="/_assets/index.1cdf953d.js"></script>
</body>

</html>
```
To:
```html
<!DOCTYPE html>
<html lang="en">

<head>
  <meta charset="UTF-8">
  <link rel="icon" href="/favicon.ico" />
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title></title>
  <link rel="stylesheet" href="/_assets/style.2e60e7a6.css">
</head>

<body>
  <div id="app"></div>
  
  <script type="module" src="/_assets/index.1cdf953d.js"></script>
</body>

</html>
```