### PR TITLE
feat: allow backend custom host

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,7 +1,7 @@
 // This file runs in the browser.
 
 // injected by serverPluginHmr when served
-declare const __PORT__: number
+declare const __HOST__: string
 declare const __MODE__: string
 declare const __DEFINES__: Record<string, any>
 ;(window as any).process = (window as any).process || {}
@@ -29,9 +29,7 @@ console.log('[vite] connecting...')
 
 declare var __VUE_HMR_RUNTIME__: HMRRuntime
 
-const socketProtocol = location.protocol === 'https:' ? 'wss' : 'ws'
-const socketUrl = `${socketProtocol}://${location.hostname}:${__PORT__}`
-const socket = new WebSocket(socketUrl, 'vite-hmr')
+const socket = new WebSocket(__HOST__, 'vite-hmr')
 
 function warnFailedFetch(err: Error, path: string | string[]) {
   if (!err.message.match('fetch')) {

--- a/src/node/server/serverPluginClient.ts
+++ b/src/node/server/serverPluginClient.ts
@@ -24,9 +24,12 @@ export const clientPlugin: ServerPlugin = ({ app, config }) => {
 
   app.use(async (ctx, next) => {
     if (ctx.path === clientPublicPath) {
+      const socketProtocol = ctx.protocol.toString() === 'https' ? 'wss' : 'ws'
+      const socketUrl = `${socketProtocol}://${ctx.host.toString()}`
+
       ctx.type = 'js'
       ctx.status = 200
-      ctx.body = clientCode.replace(`__PORT__`, ctx.port.toString())
+      ctx.body = clientCode.replace(`__HOST__`, JSON.stringify(socketUrl))
     } else {
       if (ctx.path === legacyPublicPath) {
         console.error(


### PR DESCRIPTION
This PR allow to serve the frontend by Vite through a custom host in backend.

Running backend at `https://laravel.test`, frontend at `http://localhost:3000` and a view in backend like this:

```html
<body>
  <div id="app"></div>
  <!-- This will be injected only for dev mode -->
  <script type="module" src="http://localhost:3000/vite/client"></script>
  <script type="module" src="http://localhost:3000/src/main.js"></script>
</body>
```

This will allow that a different backend host, connect to Websocket correctly https://github.com/vitejs/vite/issues/460.

**Context:**

Instead of get the host info from browser `https://laravel.test`, Vite will get from your own host/port `http://localhost:3000`. 

**Limitation:**

It's necessary to use this approach https://github.com/vitejs/vite/issues/341#issuecomment-657039140 to add CORS into Vite server.

```js
// vite.config.js 

const cors = require('@koa/cors');

export default {
  configureServer: function ({ app }) {
    app.use(cors({ origin: '*' }));
  },
};

```

And the backend will need to have a symlink in `public` folder to serve assets/static files correctly because relative paths will have base URL from backend now, something like this:

```
/backend
  /public
    /assets -> ../vite-project/src/assets
    /index.php
```

Fixing partially https://github.com/vitejs/vite/issues/341.

Credits:
- @Grafikart https://github.com/vitejs/vite/issues/341#issuecomment-657039140.
- @andrefelipe https://github.com/andrefelipe/vite-php-setup

---

**Update 19/01/2021**

For Vite 2.0 is needed change script URL injected in backend view to `http://localhost:3000/@vite/client`:

```html
<body>
  <div id="app"></div>
  <!-- This will be injected only for dev mode -->
  <script type="module" src="http://localhost:3000/@vite/client"></script>
  <script type="module" src="http://localhost:3000/src/main.js"></script>
</body>
```

And assets symlink will be changed to:

```
/backend
  /public
    /src -> ../vite-project/src
    /index.php
```

