### PR TITLE
fix: relative `sources` in production bundle sourcemap

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -415,6 +415,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
   })
 
   const { output } = await bundle.generate({
+    dir: resolvedAssetsPath,
     format: 'es',
     sourcemap,
     entryFileNames: `[name].[hash].js`,


### PR DESCRIPTION
Previously, the sources were relative to the working directory, instead of the assets directory (where the sourcemap lives).