### PR TITLE
feat(config): add pluginsPreBuild, etc. for rollup

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -350,6 +350,8 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
     onwarn: onRollupWarning(spinner, options.optimizeDeps),
     ...rollupInputOptions,
     plugins: [
+      ...(rollupInputOptions.plugins || []),
+      ...(rollupInputOptions.pluginsPreBuild || []),
       ...basePlugins,
       // vite:html
       htmlPlugin,
@@ -412,7 +414,7 @@ export async function build(options: BuildConfig): Promise<BuildResult> {
         : undefined,
       // #728 user plugins should apply after `@rollup/plugin-commonjs`
       // #471#issuecomment-683318951 user plugin after internal plugin
-      ...(rollupInputOptions.plugins || [])
+      ...(rollupInputOptions.pluginsPostBuild || [])
     ].filter(Boolean)
   })
 

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -13,6 +13,7 @@ import {
 import Rollup, {
   InputOptions as RollupInputOptions,
   OutputOptions as RollupOutputOptions,
+  Plugin as RollupPlugin,
   OutputChunk
 } from 'rollup'
 import {
@@ -219,7 +220,7 @@ export interface ServerConfig extends SharedConfig {
   proxy?: Record<string, string | ProxiesOptions>
   /**
    * A plugin function that configures the dev server. Receives a server plugin
-   * context object just like the internal server plguins. Can also be an array
+   * context object just like the internal server plugins. Can also be an array
    * of multiple server plugin functions.
    */
   configureServer?: ServerPlugin | ServerPlugin[]
@@ -289,7 +290,7 @@ export interface BuildConfig extends SharedConfig {
    *
    * https://rollupjs.org/guide/en/#big-list-of-options
    */
-  rollupInputOptions?: RollupInputOptions
+  rollupInputOptions?: ViteRollupInputOptions
   /**
    * Will be passed to bundle.generate()
    *
@@ -337,6 +338,25 @@ export interface BuildConfig extends SharedConfig {
    * @default true
    */
   enableRollupPluginVue?: boolean
+}
+
+export interface ViteRollupInputOptions extends RollupInputOptions {
+  /**
+   * @deprecated use `pluginsPreBuild` or `pluginsPostBuild` instead
+   */
+  plugins?: RollupPlugin[]
+  /**
+   * Rollup plugins that passed before Vite's transform plugins
+   */
+  pluginsPreBuild?: RollupPlugin[]
+  /**
+   * Rollup plugins that passed after Vite's transform plugins
+   */
+  pluginsPostBuild?: RollupPlugin[]
+  /**
+   * Rollup plugins for optimizer
+   */
+  pluginsOptimizer?: RollupPlugin[]
 }
 
 export interface UserConfig extends BuildConfig, ServerConfig {

--- a/src/node/optimizer/index.ts
+++ b/src/node/optimizer/index.ts
@@ -197,8 +197,8 @@ export async function optimizeDeps(
         createDepAssetExternalPlugin(resolver),
         ...(await createBaseRollupPlugins(root, resolver, config)),
         createDepAssetPlugin(resolver, root),
-        // #728 user plugins should apply after `@rollup/plugin-commonjs`
-        ...((config.rollupInputOptions && config.rollupInputOptions.plugins) ||
+        ...((config.rollupInputOptions &&
+          config.rollupInputOptions.pluginsOptimizer) ||
           [])
       ]
     })


### PR DESCRIPTION
Fix #952 

- new `pluginsPreBuild`, `pluginsPostBuild` and `pluginsOptimizer` to config rollup plugins for different needs.
- revert #746 and #855 to serve `plugins` matches with the original behavior while mark it as deprecated to advocate users to use explicit options.