### PR TITLE
fix(build): resolve rollup warning when using pluginsPreBuild

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -451,6 +451,14 @@ export async function build(
     userDefineReplacements[key] = JSON.stringify(userDefineReplacements[key])
   })
 
+  const {
+    pluginsPreBuild = [],
+    plugins = [],
+    pluginsPostBuild = [],
+    pluginsOptimizer,
+    ...rollupOptions
+  } = rollupInputOptions
+
   // lazy require rollup so that we don't load it when only using the dev server
   // importing it just for the types
   const rollup = require('rollup').rollup as typeof Rollup
@@ -459,10 +467,10 @@ export async function build(
     preserveEntrySignatures: false,
     treeshake: { moduleSideEffects: 'no-external' },
     onwarn: onRollupWarning(spinner, config.optimizeDeps),
-    ...config.rollupInputOptions,
+    ...rollupOptions,
     plugins: [
-      ...(rollupInputOptions.plugins || []),
-      ...(rollupInputOptions.pluginsPreBuild || []),
+      ...plugins,
+      ...pluginsPreBuild,
       ...basePlugins,
       // vite:html
       htmlPlugin,
@@ -535,7 +543,7 @@ export async function build(
         : undefined,
       // #728 user plugins should apply after `@rollup/plugin-commonjs`
       // #471#issuecomment-683318951 user plugin after internal plugin
-      ...(rollupInputOptions.pluginsPostBuild || []),
+      ...pluginsPostBuild,
       // vite:manifest
       config.emitManifest ? createBuildManifestPlugin() : undefined
     ].filter(Boolean)

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -364,9 +364,7 @@ export async function build(
     shouldPreload,
     env,
     mode: configMode,
-    define: userDefineReplacements,
-    rollupInputOptions,
-    rollupOutputOptions
+    define: userDefineReplacements
   } = config
 
   const isTest = process.env.NODE_ENV === 'test'
@@ -456,8 +454,8 @@ export async function build(
     plugins = [],
     pluginsPostBuild = [],
     pluginsOptimizer,
-    ...rollupOptions
-  } = rollupInputOptions
+    ...rollupInputOptions
+  } = config.rollupInputOptions
 
   // lazy require rollup so that we don't load it when only using the dev server
   // importing it just for the types
@@ -467,7 +465,7 @@ export async function build(
     preserveEntrySignatures: false,
     treeshake: { moduleSideEffects: 'no-external' },
     onwarn: onRollupWarning(spinner, config.optimizeDeps),
-    ...rollupOptions,
+    ...rollupInputOptions,
     plugins: [
       ...plugins,
       ...pluginsPreBuild,
@@ -563,7 +561,7 @@ export async function build(
       entryFileNames: `[name].[hash].js`,
       chunkFileNames: `[name].[hash].js`,
       assetFileNames: `[name].[hash].[ext]`,
-      ...rollupOutputOptions
+      ...config.rollupOutputOptions
     })
     build.html = emitIndex ? await renderIndex(output) : ''
     build.assets = output


### PR DESCRIPTION
When using `pluginsPreBuild` or `pluginsPostBuild` rollup will emit this warning

```
Unknown input options: pluginsPostBuild. Allowed options: acorn, acornInjectPlugins, cache, context, experimentalCacheExpiry, external, inlineDynamicImports, input, manualChunks, moduleContext, onwarn, perf, plugins, preserveEntrySignatures, preserveModules, preserveSymlinks, shimMissingExports, strictDeprecations, treeshake, watch
```

This PR resolves it.