### PR TITLE
feat(types): add `ImportMetaEnv` global type

### DIFF
--- a/importMeta.d.ts
+++ b/importMeta.d.ts
@@ -15,11 +15,13 @@ declare interface ImportMeta {
     on(event: string, cb: (...args: any[]) => void): void
   }
 
-  readonly env: {
-    [key: string]: string | boolean | undefined
-    BASE_URL: string
-    MODE: string
-    DEV: boolean
-    PROD: boolean
-  }
+  readonly env: ImportMetaEnv
+}
+
+declare interface ImportMetaEnv {
+  [key: string]: string | boolean | undefined
+  BASE_URL: string
+  MODE: string
+  DEV: boolean
+  PROD: boolean
 }


### PR DESCRIPTION
So developers can extend it with their own variables, reducing the need for type casting.

### Example

In a `.d.ts` module of your choosing:

```ts
declare interface ImportMetaEnv {
  // Value set via "env" option in Vite config
  MY_VAR: boolean

  // Value set via ".env" file (must start with "VITE_")
  VITE_CUSTOM_VAR: string
}
```

Then in another module:

```ts
// Before
fetch(import.meta.env.VITE_CUSTOM_VAR as string)

// After
fetch(import.meta.env.VITE_CUSTOM_VAR)

// Typically no need for type casting with booleans, 
// but now you get auto-completion.
if (import.meta.env.MY_VAR) {
  console.log('sup')
}
```