### PR TITLE
feat(build): add "vite:emit" output plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "minimist": "^1.2.5",
     "open": "^7.2.1",
     "ora": "^5.1.0",
+    "p-map-series": "^2.1.0",
     "postcss-discard-comments": "^4.0.2",
     "postcss-import": "^12.0.1",
     "postcss-load-config": "^3.0.0",

--- a/playground/multi-build/index.html
+++ b/playground/multi-build/index.html
@@ -1,0 +1,3 @@
+<body>
+  <script src="./src/index.js" type="module" />
+</body>

--- a/playground/multi-build/src/hello.js
+++ b/playground/multi-build/src/hello.js
@@ -1,0 +1,1 @@
+export default 'hello'

--- a/playground/multi-build/src/index.js
+++ b/playground/multi-build/src/index.js
@@ -1,0 +1,2 @@
+import hello from './hello'
+document.body.append([hello, 'world'].join(' '))

--- a/playground/multi-build/src/index.mobile.js
+++ b/playground/multi-build/src/index.mobile.js
@@ -1,0 +1,2 @@
+import hello from './hello'
+document.body.append([hello, 'mobile'].join(' '))

--- a/playground/multi-build/vite.config.js
+++ b/playground/multi-build/vite.config.js
@@ -1,0 +1,40 @@
+import path from 'path'
+import fs from 'fs'
+
+export default {
+  configureBuild: buildMobile
+}
+
+function buildMobile(config, builds) {
+  builds.push({
+    id: 'index.mobile',
+    get options() {
+      // Reuse the options of main build.
+      const { options } = builds[0]
+      return {
+        ...options,
+        plugins: [
+          {
+            name: 'resolveMobile',
+            async resolveId(id, parent) {
+              if (id[0] === '.') {
+                const resolved = await this.resolve(id, parent, {
+                  skipSelf: true
+                })
+                const ext = path.extname(resolved.id)
+                const mobileId =
+                  resolved.id.slice(0, -ext.length) + '.mobile' + ext
+
+                // Use .mobile version if it exists
+                if (fs.existsSync(mobileId)) {
+                  return mobileId
+                }
+              }
+            }
+          },
+          ...options.plugins
+        ]
+      }
+    }
+  })
+}

--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -137,16 +137,6 @@ export const createBuildAssetPlugin = (
         }
       }
       return { code, map: null }
-    },
-
-    generateBundle(_options, bundle) {
-      if (!emitAssets) {
-        for (const name in bundle) {
-          if (bundle[name].type === 'asset') {
-            delete bundle[name]
-          }
-        }
-      }
     }
   }
 }

--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -93,8 +93,7 @@ export const createBuildAssetPlugin = (
   resolver: InternalResolver,
   publicBase: string,
   assetsDir: string,
-  inlineLimit: number,
-  emitAssets: boolean
+  inlineLimit: number
 ): Plugin => {
   const handleToIdMap = new Map()
 

--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -22,7 +22,7 @@ import {
 
 export const createBuildHtmlPlugin = async (
   root: string,
-  indexPath: string | null,
+  indexPath: string,
   publicBasePath: string,
   assetsDir: string,
   inlineLimit: number,
@@ -30,7 +30,7 @@ export const createBuildHtmlPlugin = async (
   shouldPreload: ((chunk: OutputChunk) => boolean) | null,
   config: UserConfig
 ) => {
-  if (!indexPath || !fs.existsSync(indexPath)) {
+  if (!fs.existsSync(indexPath)) {
     return {
       renderIndex: () => '',
       htmlPlugin: null

--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -1,4 +1,4 @@
-import { Plugin, RollupOutput, OutputChunk } from 'rollup'
+import { Plugin, OutputChunk, RollupOutput } from 'rollup'
 import path from 'path'
 import fs from 'fs-extra'
 import MagicString from 'magic-string'

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -518,8 +518,7 @@ export async function build(
         resolver,
         publicBasePath,
         assetsDir,
-        assetsInlineLimit,
-        emitAssets
+        assetsInlineLimit
       ),
       config.enableEsbuild &&
         createEsbuildRenderChunkPlugin(

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -565,7 +565,10 @@ export async function build(
     const bundle = await rollup({
       ...inputOptions,
       plugins: [
-        ...(inputOptions.plugins || []),
+        ...(inputOptions.plugins || []).filter(
+          // remove vite:emit in case this build copied another build's plugins
+          (plugin) => plugin.name !== 'vite:emit'
+        ),
         // vite:emit
         createEmitPlugin(
           build as Required<Build>,

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -565,7 +565,7 @@ export async function build(
             (plugin) => plugin.name !== 'vite:emit'
           ),
           // vite:emit
-          createEmitPlugin(async (assets) => {
+          createEmitPlugin(emitAssets, async (assets) => {
             indexHtml = emitIndex ? await renderIndex(assets) : ''
             result = { build, assets, html: indexHtml }
             if (onResult) {
@@ -697,6 +697,7 @@ export async function ssrBuild(
 }
 
 function createEmitPlugin(
+  emitAssets: boolean,
   emit: (assets: BuildResult['assets']) => Promise<void>
 ): OutputPlugin {
   return {
@@ -711,6 +712,15 @@ function createEmitPlugin(
       // write any assets injected by post-build hooks
       for (const asset of assets) {
         output[asset.fileName] = asset
+      }
+
+      // remove assets from bundle if emitAssets is false
+      if (!emitAssets) {
+        for (const name in output) {
+          if (output[name].type === 'asset') {
+            delete output[name]
+          }
+        }
       }
     }
   }

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -37,7 +37,7 @@ import { createBuildWasmPlugin } from './buildPluginWasm'
 import { createBuildManifestPlugin } from './buildPluginManifest'
 
 interface Build {
-  id: string
+  readonly id: string
   options: InputOptions & {
     output?: OutputOptions
   }

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -386,7 +386,7 @@ export async function build(
   }
 
   const outDir = path.resolve(root, config.outDir)
-  const indexPath = path.resolve(root, config.entry)
+  const indexPath = path.resolve(root, 'index.html')
   const publicDir = path.join(root, 'public')
   const publicBasePath = config.base.replace(/([^/])$/, '$1/') // ensure ending slash
   const resolvedAssetsPath = path.join(outDir, assetsDir)
@@ -461,7 +461,7 @@ export async function build(
   } = config.rollupInputOptions
 
   builds.unshift({
-    input: indexPath,
+    input: config.entry,
     preserveEntrySignatures: false,
     treeshake: { moduleSideEffects: 'no-external' },
     ...rollupInputOptions,

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -694,6 +694,7 @@ function createEmitPlugin(
     | false,
   postBuildHooks: PostBuildHook[]
 ): OutputPlugin {
+  const isFirstBuild = build.id === 'index'
   return {
     name: 'vite:emit',
     async generateBundle(_, output, isWrite) {
@@ -712,7 +713,7 @@ function createEmitPlugin(
         output[asset.fileName] = asset
       }
 
-      if (isWrite) {
+      if (isFirstBuild && isWrite) {
         await fs.emptyDir(outDir)
       }
     },
@@ -721,7 +722,7 @@ function createEmitPlugin(
         await fs.writeFile(path.join(outDir, build.id + '.html'), build.html)
       }
       // copy over /public if it exists
-      if (publicDir && fs.existsSync(publicDir)) {
+      if (isFirstBuild && publicDir && fs.existsSync(publicDir)) {
         for (const file of await fs.readdir(publicDir)) {
           await fs.copy(path.join(publicDir, file), path.resolve(outDir, file))
         }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -317,7 +317,7 @@ export interface BuildConfig extends Required<SharedConfig> {
    * Whether to generate sourcemap
    * @default false
    */
-  sourcemap: RollupOutputOptions['sourcemap']
+  sourcemap: boolean | 'inline'
   /**
    * Set to `false` to disable minification, or specify the minifier to use.
    * Available options are 'terser' or 'esbuild'.

--- a/test/test.js
+++ b/test/test.js
@@ -734,6 +734,19 @@ describe('vite', () => {
     })
   }
 
+  fdescribe('build (multi)', () => {
+    beforeAll(async () => {
+      const buildOutput = await execa(binPath, ['build'], {
+        cwd: path.join(tempDir, 'multi-build')
+      })
+      expect(buildOutput.stdout).toMatch('Build completed')
+      expect(buildOutput.stderr).toBe('')
+    })
+
+    test.todo('index.html renders "hello world"')
+    test.todo('index.mobile.html renders "hello mobile"')
+  })
+
   describe('build', () => {
     let staticServer
     beforeAll(async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4937,7 +4937,7 @@ ora@^5.1.0:
 
 p-each-series@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
+  resolved "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz#961c8dd3f195ea96c747e636b262b800a6b1af48"
   integrity sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==
 
 p-finally@^1.0.0:
@@ -4972,6 +4972,11 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-map-series@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/p-map-series/-/p-map-series-2.1.0.tgz#7560d4c452d9da0c07e692fdbfe6e2c81a2a91f2"
+  integrity sha512-RpYIIK1zXSNEOdwxcfe7FdvGcs7+y5n8rifMhMNWvaxRNMPINJHF5GDeuVxWqnfrcHPSCnp7Oo5yNXHId9Av2Q==
 
 p-map@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Run post-build hooks before the `writeBundle` phase
- Allow post-build hooks to write assets by mutating the `build.assets` array
- Empty the `outDir` after the build succeeds (right before the `writeBundle` phase)
- Write the index.html in the `writeBundle` phase
- Copy the public dir in the `writeBundle` phase
- Respect `emitAssets: true` even if `write` is false
- Respect `emitIndex: true` even if `write` is false

---

- Fixes `vite-plugin-legacy`, which was broken by https://github.com/vitejs/vite/pull/957#issuecomment-717926853
- Reverts https://github.com/vitejs/vite/commit/5e7c309baa16b78fbfdfbf3fffff7af775c26047, which I tacked onto another PR without understanding the `emitIndex` option's purpose, which is to prevent `index.html` rendering entirely, not just to prevent writing. (emit !== write)