### PR TITLE
fix(hmr): infer hmr hostname on client

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -2,7 +2,8 @@
 
 // injected by serverPluginClient when served
 declare const __HMR_PROTOCOL__: string
-declare const __HMR_HOST__: string
+declare const __HMR_HOSTNAME__: string
+declare const __HMR_PORT__: string
 declare const __MODE__: string
 declare const __DEFINES__: Record<string, any>
 ;(window as any).process = (window as any).process || {}
@@ -33,7 +34,8 @@ declare var __VUE_HMR_RUNTIME__: HMRRuntime
 // use server configuration, then fallback to inference
 const socketProtocol =
   __HMR_PROTOCOL__ || (location.protocol === 'https:' ? 'wss' : 'ws')
-const socket = new WebSocket(`${socketProtocol}://${__HMR_HOST__}`, 'vite-hmr')
+const socketHost = `${__HMR_HOSTNAME__ || location.hostname}:${__HMR_PORT__}`
+const socket = new WebSocket(`${socketProtocol}://${socketHost}`, 'vite-hmr')
 
 function warnFailedFetch(err: Error, path: string | string[]) {
   if (!err.message.match('fetch')) {

--- a/src/node/server/serverPluginClient.ts
+++ b/src/node/server/serverPluginClient.ts
@@ -24,23 +24,25 @@ export const clientPlugin: ServerPlugin = ({ app, config }) => {
 
   app.use(async (ctx, next) => {
     if (ctx.path === clientPublicPath) {
-      let socketProtocol = null // infer on client by default
-      let socketHost = ctx.host.toString()
+      let socketPort: number | string = ctx.port
+      // infer on client by default
+      let socketProtocol = null
+      let socketHostname = null
       if (config.hmr && typeof config.hmr === 'object') {
         // hmr option has highest priory
         socketProtocol = config.hmr.protocol || null
-        const hostname = config.hmr.hostname || ctx.hostname
-        const port = config.hmr.port || ctx.port
-        socketHost = `${hostname}:${port}`
+        socketHostname = config.hmr.hostname || null
+        socketPort = config.hmr.port || ctx.port
         if (config.hmr.path) {
-          socketHost += `/${config.hmr.path}`
+          socketPort = `${socketPort}/${config.hmr.path}`
         }
       }
       ctx.type = 'js'
       ctx.status = 200
       ctx.body = clientCode
         .replace(`__HMR_PROTOCOL__`, JSON.stringify(socketProtocol))
-        .replace(`__HMR_HOST__`, JSON.stringify(socketHost))
+        .replace(`__HMR_HOSTNAME__`, JSON.stringify(socketHostname))
+        .replace(`__HMR_PORT__`, JSON.stringify(socketPort))
     } else {
       if (ctx.path === legacyPublicPath) {
         console.error(


### PR DESCRIPTION
Github/VS Codespaces don't forward WebSocket requests so the HMR hostname must be manually configured in vite config like so:

```js
hmr: {
  port: 443,
  hostname: '{uuid}-{port}.apps.codespaces.githubusercontent.com'
}
```

New codespaces get a different UUID so need to be reconfigured each time. This PR infers hostname on the client rather than server by default so codespace users only need to specify the WS port (443) in vite config.

This is the same behaviour as prior to bec6b3c. Use cases such as #918 can now be addressed by defining a hostname in the config as above (introduced subsequently with b753478); these users are less inconvenienced as their backend URL is unlikely to change.