### PR TITLE
fix: Url isn't present in SSR build

### DIFF
--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -116,7 +116,7 @@ export const createBuildAssetPlugin = (
               source: content
             })
         }
-        debug(`${id} -> ${url!.startsWith('data:') ? `base64 inlined` : id}`)
+        debug(`${id} -> ${url?.startsWith('data:') ? `base64 inlined` : id}`)
         return `export default ${JSON.stringify(url)}`
       }
     },


### PR DESCRIPTION
Because `emitAssets` is false there.

My `vitepress` build breaks because of that.

Otherwise I'm in a rabbit hole figuring out why including an image doesn't work anymore, but that might not be an issue of `vite`.