### PR TITLE
feat: add `BuildContext` class

### DIFF
--- a/src/node/build/buildPluginAsset.ts
+++ b/src/node/build/buildPluginAsset.ts
@@ -1,77 +1,9 @@
-import path from 'path'
-import fs from 'fs-extra'
 import { Plugin, OutputBundle } from 'rollup'
-import { cleanUrl } from '../utils'
-import slash from 'slash'
-import mime from 'mime-types'
-import { InternalResolver } from '../resolver'
+import { BuildContext } from './context'
 
 const debug = require('debug')('vite:build:asset')
 
-interface AssetCacheEntry {
-  content?: Buffer
-  fileName?: string
-  url: string | undefined
-}
-
-const assetResolveCache = new Map<string, AssetCacheEntry>()
-const publicDirRE = /^public(\/|\\)/
 export const injectAssetRe = /import.meta.ROLLUP_FILE_URL_(\w+)/
-
-export const resolveAsset = async (
-  id: string,
-  root: string,
-  publicBase: string,
-  assetsDir: string,
-  inlineLimit: number
-): Promise<AssetCacheEntry> => {
-  id = cleanUrl(id)
-  const cached = assetResolveCache.get(id)
-  if (cached) {
-    return cached
-  }
-
-  let resolved: AssetCacheEntry | undefined
-  const relativePath = path.relative(root, id)
-
-  if (!fs.existsSync(id)) {
-    // try resolving from public dir
-    const publicDirPath = path.join(root, 'public', relativePath)
-    if (fs.existsSync(publicDirPath)) {
-      // file is resolved from public dir, it will be copied verbatim so no
-      // need to read content here.
-      resolved = {
-        url: publicBase + slash(relativePath)
-      }
-    }
-  }
-
-  if (!resolved) {
-    if (publicDirRE.test(relativePath)) {
-      resolved = {
-        url: publicBase + slash(relativePath.replace(publicDirRE, ''))
-      }
-    }
-  }
-
-  if (!resolved) {
-    let url: string | undefined
-    let content: Buffer | undefined = await fs.readFile(id)
-    if (!id.endsWith(`.svg`) && content.length < Number(inlineLimit)) {
-      url = `data:${mime.lookup(id)};base64,${content.toString('base64')}`
-      content = undefined
-    }
-
-    resolved = {
-      content,
-      fileName: path.basename(id),
-      url
-    }
-  }
-
-  assetResolveCache.set(id, resolved)
-  return resolved
-}
 
 export const registerAssets = (
   assets: Map<string, Buffer>,
@@ -88,26 +20,14 @@ export const registerAssets = (
   }
 }
 
-export const createBuildAssetPlugin = (
-  root: string,
-  resolver: InternalResolver,
-  publicBase: string,
-  assetsDir: string,
-  inlineLimit: number
-): Plugin => {
+export const createBuildAssetPlugin = (ctx: BuildContext): Plugin => {
   const handleToIdMap = new Map()
 
   return {
     name: 'vite:asset',
     async load(id) {
-      if (resolver.isAssetRequest(id)) {
-        let { fileName, content, url } = await resolveAsset(
-          id,
-          root,
-          publicBase,
-          assetsDir,
-          inlineLimit
-        )
+      if (ctx.resolver.isAssetRequest(id)) {
+        let { fileName, content, url } = await ctx.resolveAsset(id)
         if (!url && fileName && content) {
           const fileHandle = this.emitFile({
             name: fileName,
@@ -127,12 +47,13 @@ export const createBuildAssetPlugin = (
       let match
       while ((match = injectAssetRe.exec(code))) {
         const fileHandle = match[1]
-        const outputFilepath =
-          publicBase + slash(path.join(assetsDir, this.getFileName(fileHandle)))
-        code = code.replace(match[0], outputFilepath)
+        const basedAssetPath = ctx.getBasedAssetPath(
+          this.getFileName(fileHandle)
+        )
+        code = code.replace(match[0], basedAssetPath)
         const originalId = handleToIdMap.get(fileHandle)
         if (originalId) {
-          debug(`${originalId} -> ${outputFilepath}`)
+          debug(`${originalId} -> ${basedAssetPath}`)
         }
       }
       return { code, map: null }

--- a/src/node/build/buildPluginEsbuild.ts
+++ b/src/node/build/buildPluginEsbuild.ts
@@ -9,9 +9,9 @@ import {
 } from '../esbuildService'
 import { SharedConfig } from '../config'
 
-export const createEsbuildPlugin = async (
+export const createEsbuildPlugin = (
   jsx: SharedConfig['jsx'] = 'vue'
-): Promise<Plugin> => {
+): Plugin => {
   const jsxConfig = resolveJsxOptions(jsx)
 
   return {

--- a/src/node/build/buildPluginWasm.ts
+++ b/src/node/build/buildPluginWasm.ts
@@ -1,5 +1,5 @@
 import { Plugin } from 'rollup'
-import { resolveAsset } from './buildPluginAsset'
+import { BuildContext } from './context'
 
 const wasmHelperId = 'vite/wasm-helper'
 
@@ -32,12 +32,7 @@ const wasmHelper = (opts = {}, url: string) => {
 
 const wasmHelperCode = wasmHelper.toString()
 
-export const createBuildWasmPlugin = (
-  root: string,
-  publicBase: string,
-  assetsDir: string,
-  inlineLimit: number
-): Plugin => {
+export const createBuildWasmPlugin = (ctx: BuildContext): Plugin => {
   return {
     name: 'vite:wasm',
 
@@ -53,13 +48,7 @@ export const createBuildWasmPlugin = (
       }
 
       if (id.endsWith('.wasm')) {
-        let { fileName, content, url } = await resolveAsset(
-          id,
-          root,
-          publicBase,
-          assetsDir,
-          inlineLimit
-        )
+        let { fileName, content, url } = await ctx.resolveAsset(id)
         if (!url && fileName && content) {
           url =
             'import.meta.ROLLUP_FILE_URL_' +

--- a/src/node/build/context.ts
+++ b/src/node/build/context.ts
@@ -1,0 +1,272 @@
+import { InputOption, InputOptions, OutputOptions, RollupOutput } from 'rollup'
+import { klona } from 'klona/json'
+import fs from 'fs-extra'
+import path from 'path'
+import mime from 'mime-types'
+import slash from 'slash'
+import { BuildConfig } from '../config'
+import { createLogger } from '../utils/logger'
+import { cleanUrl, isStaticAsset, toArray } from '../utils'
+import { createResolver, InternalResolver } from '../resolver'
+
+export interface Build extends InputOptions {
+  input: InputOption
+  output: OutputOptions
+  /** Runs before global post-build hooks. */
+  onResult?: PostBuildHook
+}
+
+export interface BuildResult {
+  build: Build
+  html: string
+  assets: RollupOutput['output']
+}
+
+export type PreBuildHook = (build: Build, index: number) => Promise<void> | void
+export type PostBuildHook = (
+  result: BuildResult,
+  index: number
+) => Promise<void> | void
+export type TailHook = (results: BuildResult[]) => Promise<void> | void
+
+interface AssetCacheEntry {
+  content?: Buffer
+  fileName?: string
+  url: string | undefined
+}
+
+const publicDirRE = /^public(\/|\\)/
+
+export class BuildContext {
+  private config: BuildConfig
+  private preBuildHooks: PreBuildHook[] = []
+  private postBuildHooks: PostBuildHook[] = []
+  private tailHooks: TailHook[] = []
+  private assetResolveCache = new Map<string, AssetCacheEntry>()
+
+  readonly log = createLogger()
+  readonly builds: Build[] = []
+  readonly resolver: InternalResolver
+
+  constructor({ configureBuild, ...userConfig }: Partial<BuildConfig>) {
+    this.config = prepareConfig(userConfig)
+
+    // define config accessors on the context
+    const configKeys = Object.keys(this.config) as (keyof BuildConfig)[]
+    for (const configKey of configKeys) {
+      // prefer getters from BuildContext.prototype
+      const { get = () => this.config[configKey] } =
+        Object.getOwnPropertyDescriptor(BuildContext.prototype, configKey) || {}
+
+      Object.defineProperty(this, configKey, {
+        get,
+        set(value) {
+          this.config[configKey] = value
+        }
+      })
+    }
+
+    // let plugins mutate the build context
+    toArray(configureBuild).forEach((configureBuild) => configureBuild(this))
+
+    this.resolver = createResolver(
+      this.root,
+      this.resolvers,
+      this.alias,
+      this.assetsInclude
+    )
+  }
+
+  get base() {
+    return this.config.base.replace(/([^/])$/, '$1/') // ensure ending slash
+  }
+
+  get outDir() {
+    return path.resolve(this.root, this.config.outDir)
+  }
+
+  get assetsDir() {
+    return path.join(this.outDir, this.config.assetsDir)
+  }
+
+  get publicDir() {
+    return path.join(this.root, 'public')
+  }
+
+  getBasedAssetPath(name: string) {
+    return this.base + slash(path.join(this.config.assetsDir, name))
+  }
+
+  async resolveAsset(id: string): Promise<AssetCacheEntry> {
+    id = cleanUrl(id)
+
+    const cached = this.assetResolveCache.get(id)
+    if (cached) {
+      return cached
+    }
+
+    let resolved: AssetCacheEntry | undefined
+    const relativePath = path.relative(this.root, id)
+
+    if (!fs.existsSync(id)) {
+      // try resolving from public dir
+      const publicDirPath = path.join(this.publicDir, relativePath)
+      if (fs.existsSync(publicDirPath)) {
+        // file is resolved from public dir, it will be copied verbatim so no
+        // need to read content here.
+        resolved = {
+          url: this.base + slash(relativePath)
+        }
+      }
+    }
+
+    if (!resolved) {
+      if (publicDirRE.test(relativePath)) {
+        resolved = {
+          url: this.base + slash(relativePath.replace(publicDirRE, ''))
+        }
+      }
+    }
+
+    if (!resolved) {
+      let url: string | undefined
+      let content: Buffer | undefined = await fs.readFile(id)
+      if (!/\.(css|svg)$/.test(id) && content.length < this.assetsInlineLimit) {
+        url = `data:${mime.lookup(id)};base64,${content.toString('base64')}`
+        content = undefined
+      }
+
+      resolved = {
+        content,
+        fileName: path.basename(id),
+        url
+      }
+    }
+
+    this.assetResolveCache.set(id, resolved)
+    return resolved
+  }
+
+  /**
+   * Enqueue another build.
+   */
+  build(build: Build) {
+    this.builds.push(build)
+  }
+
+  /**
+   * Run the given function before each `Build` starts.
+   */
+  beforeEach(hook: (build: Build, index: number) => void) {
+    this.preBuildHooks.push(hook)
+  }
+
+  /**
+   * Run the given function after each `Build` is completed.
+   */
+  afterEach(hook: (result: BuildResult, index: number) => void) {
+    this.postBuildHooks.push(hook)
+  }
+
+  /**
+   * Run the given function after all `Build`s are completed.
+   */
+  afterAll(hook: (results: BuildResult[]) => void) {
+    this.tailHooks.push(hook)
+  }
+}
+
+// Every option is exposed on the build context.
+export interface BuildContext extends Omit<BuildConfig, 'configureBuild'> {}
+
+/**
+ * Clone the given config object and fill it with default values.
+ */
+function prepareConfig(config: Partial<BuildConfig>): BuildConfig {
+  const {
+    alias = {},
+    assetsDir = '_assets',
+    assetsInclude = isStaticAsset,
+    assetsInlineLimit = 4096,
+    base = '/',
+    cssCodeSplit = true,
+    cssModuleOptions = {},
+    cssPreprocessOptions = {},
+    define = {},
+    emitAssets = true,
+    emitIndex = true,
+    emitManifest = false,
+    enableEsbuild = true,
+    enableRollupPluginVue = true,
+    entry = 'index.html',
+    env = {},
+    esbuildTarget = 'es2020',
+    indexHtmlTransforms = [],
+    jsx = 'vue',
+    minify = true,
+    mode = 'production',
+    optimizeDeps = {},
+    outDir = 'dist',
+    resolvers = [],
+    rollupDedupe = [],
+    rollupInputOptions = {},
+    rollupOutputOptions = {},
+    rollupPluginVueOptions = {},
+    root = process.cwd(),
+    shouldPreload = null,
+    silent = false,
+    sourcemap = false,
+    ssr = false,
+    terserOptions = {},
+    transforms = [],
+    vueCompilerOptions = {},
+    vueCustomBlockTransforms = {},
+    vueTransformAssetUrls = {},
+    vueTemplatePreprocessOptions = {},
+    write = true
+  } = klona(config)
+
+  return {
+    ...config,
+    alias,
+    assetsDir,
+    assetsInclude,
+    assetsInlineLimit,
+    base,
+    cssCodeSplit,
+    cssModuleOptions,
+    cssPreprocessOptions,
+    define,
+    emitAssets,
+    emitIndex,
+    emitManifest,
+    enableEsbuild,
+    enableRollupPluginVue,
+    entry,
+    env,
+    esbuildTarget,
+    indexHtmlTransforms,
+    jsx,
+    minify,
+    mode,
+    optimizeDeps,
+    outDir,
+    resolvers,
+    rollupDedupe,
+    rollupInputOptions,
+    rollupOutputOptions,
+    rollupPluginVueOptions,
+    root,
+    shouldPreload,
+    silent,
+    sourcemap,
+    ssr,
+    terserOptions,
+    transforms,
+    vueCompilerOptions,
+    vueCustomBlockTransforms,
+    vueTransformAssetUrls,
+    vueTemplatePreprocessOptions,
+    write
+  }
+}

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -20,7 +20,7 @@ import {
   createEsbuildPlugin,
   createEsbuildRenderChunkPlugin
 } from './build/buildPluginEsbuild'
-import { BuildPlugin } from './build'
+import { BuildContext } from './build/context'
 import { Context, ServerPlugin } from './server'
 import { Resolver, supportedExts } from './resolver'
 import {
@@ -288,7 +288,18 @@ export interface ServerConfig extends SharedConfig {
   chokidarWatchOptions?: chokidarWatchOptions
 }
 
+export interface BuildPlugin {
+  (ctx: BuildContext): void
+}
+
 export interface BuildConfig extends Required<SharedConfig> {
+  /**
+   * Plugin functions that mutate the Vite build config. The `builds` array can
+   * be added to if the plugin wants to add another Rollup build that Vite writes
+   * to disk. Return a function to gain access to each build's output.
+   * @internal
+   */
+  configureBuild?: BuildPlugin | BuildPlugin[]
   /**
    * Entry. Use this to specify a js entry file in use cases where an
    * `index.html` does not exist (e.g. serving vite assets from a different host)
@@ -411,7 +422,7 @@ export interface BuildConfig extends Required<SharedConfig> {
    * ```
    * @default false
    */
-  emitManifest?: boolean
+  emitManifest: boolean
   /**
    * Predicate function that determines whether a link rel=modulepreload shall be
    * added to the index.html for the chunk passed in
@@ -421,14 +432,7 @@ export interface BuildConfig extends Required<SharedConfig> {
    * Enable 'rollup-plugin-vue'
    * @default true
    */
-  enableRollupPluginVue?: boolean
-  /**
-   * Plugin functions that mutate the Vite build config. The `builds` array can
-   * be added to if the plugin wants to add another Rollup build that Vite writes
-   * to disk. Return a function to gain access to each build's output.
-   * @internal
-   */
-  configureBuild?: BuildPlugin | BuildPlugin[]
+  enableRollupPluginVue: boolean
 }
 
 export interface ViteRollupInputOptions extends RollupInputOptions {
@@ -530,7 +534,7 @@ export async function resolveConfig(mode: string, configPath?: string) {
       // the user has type: "module" in their package.json (#917)
       // transpile es import syntax to require syntax using rollup.
       const rollup = require('rollup') as typeof Rollup
-      const esbuildPlugin = await createEsbuildPlugin({})
+      const esbuildPlugin = createEsbuildPlugin({})
       const esbuildRenderChunkPlugin = createEsbuildRenderChunkPlugin(
         'es2019',
         false

--- a/src/node/utils/logger.ts
+++ b/src/node/utils/logger.ts
@@ -1,0 +1,133 @@
+import { Ora } from 'ora'
+import chalk from 'chalk'
+
+export interface LoggerOptions {
+  /**
+   * Suppress all logs.
+   * @default false
+   */
+  silent?: boolean
+  /**
+   * Control how logs are handled.
+   * @default console.log
+   */
+  print?: (text: string) => void
+  /**
+   * Control how warnings are handled.
+   * @default console.warn
+   */
+  warn?: (text: string) => void
+}
+
+export interface Logger {
+  (text: string): void
+  /** Log with a [warn] prefix. */
+  warn(text: string): void
+  /** Start an `ora` spinner. */
+  start(text: string): Logger.Task
+  /** @internal Destroy all `ora` spinners. */
+  halt(): void
+}
+
+export namespace Logger {
+  // Tasks wrap an `ora` spinner with a simpler interface,
+  // so the "silent" option takes less code to implement.
+  export interface Task {
+    update(text: string): void
+    done(text?: string): void
+    fail(text?: string): void
+  }
+}
+
+interface Task extends Logger.Task {
+  spinner: Ora
+}
+
+export function createLogger({
+  silent,
+  print = console.log,
+  warn = console.warn
+}: LoggerOptions = {}): Logger {
+  if (silent) {
+    return createSilentLogger()
+  }
+
+  // Hide task spinners when debugging or testing.
+  const showTasks = !process.env.DEBUG && process.env.NODE_ENV !== 'test'
+
+  // Only the last task is visible.
+  const tasks: Task[] = []
+
+  const getTask = () => tasks[tasks.length - 1]
+  const showTask = () => showTasks && getTask() && getTask().spinner.start()
+  const hideTask = () => showTasks && getTask() && getTask().spinner.stop()
+
+  function log(text: string) {
+    hideTask()
+    print(text)
+    showTask()
+  }
+
+  log.warn = (text: string) => {
+    hideTask()
+    warn(chalk.yellow('[warn] ') + text)
+    showTask()
+  }
+
+  log.start = (text: string) => {
+    const spinner: Ora = require('ora')(text)
+    if (!showTasks) {
+      spinner.render()
+    }
+    const task: Task = {
+      spinner,
+      update(text) {
+        spinner.text = text
+        if (!showTasks) {
+          spinner.render()
+        }
+      },
+      done(text) {
+        const index = tasks.indexOf(task)
+        if (index >= 0) {
+          hideTask()
+          if (text) spinner.succeed(text)
+          else spinner.stop()
+          tasks.splice(index, 1)
+          showTask()
+        }
+      },
+      fail(text) {
+        const index = tasks.indexOf(task)
+        if (index >= 0) {
+          hideTask()
+          spinner.fail(text)
+          tasks.splice(index, 1)
+          showTask()
+        }
+      }
+    }
+    hideTask()
+    tasks.push(task)
+    showTask()
+    return task
+  }
+
+  log.halt = () => {
+    hideTask()
+    tasks.length = 0
+  }
+
+  return log
+}
+
+function createSilentLogger(): Logger {
+  function log() {}
+  log.warn = log.halt = log
+  log.start = () => ({
+    update: log,
+    done: log,
+    fail: log
+  })
+  return log
+}


### PR DESCRIPTION
The `BuildContext` object is shared between all `configureBuild` hooks, as well as internal plugins. Its methods let them add `Build` objects (see `build`), run functions before/after each `Build` is processed (see `beforeEach` and `afterEach`), run functions after *all* builds are processed (see `afterAll`), and resolve assets (see `resolveAsset`). It even has a `log` function that plays nice with the active `ora` spinner (at least, ones created with `log.start`). All properties of the `BuildConfig` object are exposed on `BuildContext` with default values added, and some of the path-related properties even resolve themselves on access (see `outDir` and `assetsDir`). Plugins can mutate the `BuildConfig` object through the `BuildContext` property setters. The `resolver` property exposes the `InternalResolver` object to plugins, in case they need `requestToFile` or whatever.

And that's about it. Check out the `createLogger` function, too!

### Breaking Changes

- The `configureBuild` hook has different arguments.
  - Its 1st argument is now the `BuildContext` object.
  - It has no 2nd argument anymore. Use `ctx.build()` instead.
- The `configureBuild` hook now has no return value. Use `ctx.afterEach()` instead.