### PR TITLE
fix: indexHtmlPath can be an absolute path

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -582,7 +582,9 @@ export async function build(
                 await fs.emptyDir(outDir)
               }
               if (emitIndex) {
-                indexHtmlPath = path.join(outDir, indexHtmlPath!)
+                indexHtmlPath = path.isAbsolute(indexHtmlPath!)
+                  ? indexHtmlPath!
+                  : path.join(outDir, indexHtmlPath!)
                 await fs.writeFile(indexHtmlPath, indexHtml)
               }
             }

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -582,9 +582,7 @@ export async function build(
                 await fs.emptyDir(outDir)
               }
               if (emitIndex) {
-                indexHtmlPath = path.isAbsolute(indexHtmlPath!)
-                  ? indexHtmlPath!
-                  : path.join(outDir, indexHtmlPath!)
+                indexHtmlPath = path.resolve(outDir, indexHtmlPath!)
                 await fs.writeFile(indexHtmlPath, indexHtml)
               }
             }

--- a/test/test.js
+++ b/test/test.js
@@ -734,7 +734,7 @@ describe('vite', () => {
     })
   }
 
-  describe.skip('build (multi)', () => {
+  describe('build (multi)', () => {
     beforeAll(async () => {
       const buildOutput = await execa(binPath, ['build'], {
         cwd: path.join(tempDir, 'multi-build')

--- a/test/test.js
+++ b/test/test.js
@@ -734,7 +734,7 @@ describe('vite', () => {
     })
   }
 
-  fdescribe('build (multi)', () => {
+  describe.skip('build (multi)', () => {
     beforeAll(async () => {
       const buildOutput = await execa(binPath, ['build'], {
         cwd: path.join(tempDir, 'multi-build')
@@ -919,6 +919,16 @@ async function expectByPolling(poll, expected) {
       break
     } else {
       await timeout(50)
+    }
+  }
+}
+
+function failOnError(func) {
+  return (done) => {
+    try {
+      func().then(done)
+    } catch (e) {
+      done.fail(e)
     }
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -922,13 +922,3 @@ async function expectByPolling(poll, expected) {
     }
   }
 }
-
-function failOnError(func) {
-  return (done) => {
-    try {
-      func().then(done)
-    } catch (e) {
-      done.fail(e)
-    }
-  }
-}


### PR DESCRIPTION
Fix #1030 

@aleclarson  I made the multi build test skip because it is completely broken:
- it is using es imports with vite.config.js, you should use vite.config.ts instead to use them
- the `configureBuild` function signature is wrong, i didn't touch it because i don't understand what you are trying to do