### PR TITLE
chore: include src files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "types": "dist/node/index.d.ts",
   "files": [
     "bin",
+    "src",
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts"


### PR DESCRIPTION
If you try to debug a vite application with `--debug` the stack traces will point to the files inside of the `src` directory but this folder is not included in the npm package