### PR TITLE
fix(build): ensure a non-zero exit code on failure

### DIFF
--- a/src/node/build/buildPluginCss.ts
+++ b/src/node/build/buildPluginCss.ts
@@ -83,6 +83,7 @@ export const createBuildCssPlugin = ({
           if (result.errors.length) {
             console.error(`[vite] error applying css transforms: `)
             result.errors.forEach(console.error)
+            process.exit(1)
           }
           css = result.code
           modules = result.modules

--- a/src/node/build/buildPluginCss.ts
+++ b/src/node/build/buildPluginCss.ts
@@ -205,6 +205,7 @@ function minifyCSS(css: string) {
   if (res.errors && res.errors.length) {
     console.error(chalk.red(`[vite] error when minifying css:`))
     console.error(res.errors)
+    process.exit(1)
   }
 
   if (res.warnings && res.warnings.length) {

--- a/src/node/build/buildPluginEsbuild.ts
+++ b/src/node/build/buildPluginEsbuild.ts
@@ -39,7 +39,8 @@ export const createEsbuildPlugin = async (
             ...jsxConfig,
             ...(isVueTs ? { loader: 'ts' } : null)
           },
-          jsx
+          jsx,
+          true // exitOnFailure
         )
       }
     }

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -67,7 +67,8 @@ export const transform = async (
   src: string,
   request: string,
   options: TransformOptions = {},
-  jsxOption?: SharedConfig['jsx']
+  jsxOption?: SharedConfig['jsx'],
+  exitOnFailure?: boolean
 ) => {
   const service = await ensureService()
   const file = cleanUrl(request)
@@ -112,6 +113,9 @@ export const transform = async (
       e.errors.forEach((m: Message) => printMessage(m, src))
     } else {
       console.error(e)
+    }
+    if (exitOnFailure) {
+      process.exit(1)
     }
     debug(`options used: `, options)
     return {

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -114,10 +114,10 @@ export const transform = async (
     } else {
       console.error(e)
     }
+    debug(`options used: `, options)
     if (exitOnFailure) {
       process.exit(1)
     }
-    debug(`options used: `, options)
     return {
       code: '',
       map: undefined

--- a/src/node/utils/cssUtils.ts
+++ b/src/node/utils/cssUtils.ts
@@ -67,7 +67,7 @@ export async function compileCss(
   isBuild: boolean = false
 ): Promise<SFCStyleCompileResults | string> {
   const id = hash_sum(publicPath)
-  const postcssConfig = await loadPostcssConfig(root)
+  const postcssConfig = await loadPostcssConfig(root, isBuild)
   const { compileStyleAsync } = resolveCompiler(root)
 
   if (
@@ -136,7 +136,8 @@ type PostCSSConfigResult = ReturnType<typeof postcssrc> extends Promise<infer T>
 let cachedPostcssConfig: PostCSSConfigResult | null | undefined
 
 async function loadPostcssConfig(
-  root: string
+  root: string,
+  exitOnFailure?: boolean
 ): Promise<PostCSSConfigResult | null> {
   if (cachedPostcssConfig !== undefined) {
     return cachedPostcssConfig
@@ -148,13 +149,16 @@ async function loadPostcssConfig(
     if (!/No PostCSS Config found/.test(e.message)) {
       console.error(chalk.red(`[vite] Error loading postcss config:`))
       console.error(e)
+      if (exitOnFailure) {
+        process.exit(1)
+      }
     }
     return (cachedPostcssConfig = null)
   }
 }
 
 export async function resolvePostcssOptions(root: string, isBuild: boolean) {
-  const config = await loadPostcssConfig(root)
+  const config = await loadPostcssConfig(root, isBuild)
   const options = config && config.options
   const plugins = config && config.plugins ? config.plugins.slice() : []
   plugins.unshift(require('postcss-import')())


### PR DESCRIPTION
This ensures CI will not succeed when a module has a syntax error.

Closes #708

### Reproduce

1. Clone https://github.com/aleclarson/repro/tree/vite-708
2. Run `yarn` and `yarn build`
3. See how the build succeeds, despite a failed transform