### PR TITLE
fix: indentation for injected html tags

### DIFF
--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -74,7 +74,7 @@ export const createBuildHtmlPlugin = async (
       filename
     )}">`
     if (/<\/head>/.test(html)) {
-      return html.replace(/<\/head>/, `${tag}\n</head>`)
+      return html.replace(/(^\s*)?<\/head>/m, `$1$1${tag}\n$&`)
     } else {
       return tag + '\n' + html
     }
@@ -86,7 +86,7 @@ export const createBuildHtmlPlugin = async (
       : `${publicBasePath}${path.posix.join(assetsDir, filename)}`
     const tag = `<script type="module" src="${filename}"></script>`
     if (/<\/head>/.test(html)) {
-      return html.replace(/<\/head>/, `${tag}\n</head>`)
+      return html.replace(/(^\s*)?<\/head>/m, `$1$1${tag}\n$&`)
     } else {
       return html + '\n' + tag
     }
@@ -98,7 +98,7 @@ export const createBuildHtmlPlugin = async (
       : `${publicBasePath}${path.posix.join(assetsDir, filename)}`
     const tag = `<link rel="modulepreload" href="${filename}" />`
     if (/<\/head>/.test(html)) {
-      return html.replace(/<\/head>/, `${tag}\n</head>`)
+      return html.replace(/(^\s*)?<\/head>/m, `$1$1${tag}\n$&`)
     } else {
       return tag + '\n' + html
     }


### PR DESCRIPTION
### Before
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8">
    <link rel="icon" href="/favicon.ico" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Vite App</title>
  <script type="module" src="/_assets/index.2cd1a001.js"></script>
<link rel="stylesheet" href="/_assets/style.0637ccc5.css">
</head>
  <body>
    <div id="app"></div>

  </body>
</html>
```

### After
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <link rel="icon" href="/favicon.ico" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Vite App</title>
    <script type="module" src="/_assets/index.1647be0c.js"></script>
    <link rel="stylesheet" href="/_assets/style.aa19ad30.css">
  </head>
  <body>
    <div id="app"></div>

  </body>
</html>
```