### PR TITLE
refactor(config): Export loadEnv() function

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -140,14 +140,17 @@ async function resolveOptions({
     argv.mode || defaultMode,
     argv.config || argv.c
   )
-  if (userConfig) {
-    return {
-      ...userConfig,
-      ...argv // cli options take higher priority
-    }
+
+  // when NODE_ENV is set in .env file or Vite `env` option, it overrides the
+  // `DEV` and `PROD` values of `import.meta.env` and even `process.env.NODE_ENV`
+  // in the client bundle, which would use `argv.mode` otherwise.
+  if (userConfig.env.NODE_ENV) {
+    process.env.VITE_ENV = userConfig.env.NODE_ENV
+    delete userConfig.env.NODE_ENV
   }
 
-  return argv
+  // cli options take higher priority
+  return { ...userConfig, ...argv }
 }
 
 function runServe(options: UserConfig) {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -746,7 +746,7 @@ export function loadEnv(
 
       // only keys that start with prefix are exposed.
       for (const [key, value] of Object.entries(parsed)) {
-        if (key.startsWith(prefix)) {
+        if (key.startsWith(prefix) && clientEnv[key] === undefined) {
           clientEnv[key] = value
         }
       }

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -712,7 +712,7 @@ function mergeObjectOptions(to: any, from: any) {
   return res
 }
 
-function loadEnv(mode: string, root: string): Record<string, string> {
+export function loadEnv(mode: string, root: string, prefix = 'VITE_'): Record<string, string> {
   if (mode === 'local') {
     throw new Error(
       `"local" cannot be used as a mode name because it conflicts with ` +
@@ -751,9 +751,9 @@ function loadEnv(mode: string, root: string): Record<string, string> {
         process.env.VITE_ENV = parsed.NODE_ENV
       }
 
-      // only keys that start with VITE_ are exposed.
+      // only keys that start with prefix are exposed.
       for (const [key, value] of Object.entries(parsed)) {
-        if (key.startsWith(`VITE_`)) {
+        if (key.startsWith(prefix)) {
           clientEnv[key] = value
         }
       }


### PR DESCRIPTION
For some projects, such as [electron-vue-next](https://github.com/ci010/electron-vue-next), there is a need to load environment variables from non-standard locations and to transfer these environments to other builders (such as rollup, etc.).

This PR will allow simply import `loadEnv` function from vite and use its algorithm instead of duplicating this algorithm in your own code.

### Use cases

Configuring the building of two bundles using a single mechanism for loading environment variables.
```js
import { loadEnv } from 'vite';


// The location of env files can be arbitrary
const dotenvLocation = path.resolve(__dirname, '../../')


// Load all environment variables with the prefix VITE_ to build a web interface
const envForRenderer = loadEnv('production', dotenvLocation)
buildRendererProcessWithEnv(envForRenderer)


// Load all environment variables with the prefix ELECTRON_ to build a backend
const envForMain = loadEnv('production', dotenvLocation, 'ELECTRON_')
buildMainProcessWithEnv(envForMain)
```

Another use case:
The development environment can be configured to automatically generate `*.d.ts` files based on `.env*` and describing environment variables and their types for each mode.