### PR TITLE
feat(dev): Allow native ESM in config file

### DIFF
--- a/scripts/patchTypes.js
+++ b/scripts/patchTypes.js
@@ -12,3 +12,10 @@ fs.writeFileSync(
 const indexPath = path.resolve(__dirname, '../dist/node/index.d.ts')
 const content = fs.readFileSync(indexPath, 'utf-8')
 fs.writeFileSync(indexPath, content + `\nimport '../importMeta'`)
+
+const configPath = path.resolve(__dirname, '../dist/node/config.js')
+const configContent = fs.readFileSync(configPath, 'utf-8')
+fs.writeFileSync(
+  configPath,
+  configContent.replace(/__DYNAMIC__IMPORT__/, 'import')
+)

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -42,6 +42,7 @@ cli
     `[boolean]  force the optimizer to ignore the cache and re-bundle`
   )
   .option('--open', `[boolean]  open browser on server start`)
+  .option('--esm', `[boolean]  import config file as an ES Module`)
   .action(async (root: string, argv: any) => {
     if (root) {
       argv.root = root
@@ -138,7 +139,8 @@ async function resolveOptions({
 
   const userConfig = await resolveConfig(
     argv.mode || defaultMode,
-    argv.config || argv.c
+    argv.config || argv.c,
+    argv.esm || false
   )
   if (userConfig) {
     return {


### PR DESCRIPTION
Hello! First of all, thanks for this amazing project, it's super flexible!

This PR allows using native ESM in the `vite.config.js` file in modern Node (>=12) without falling back to Rollup. I'm not sure this is the best way to implement it but is the simplest I could think of (with backward compatibility for commonjs).

The reason for having `__DYNAMIC__IMPORT__` instead of `import` directly is because the current Vite build `tsc --module commonjs` will change this `import` to a glorified `require` and that breaks the feature. This way, the `import` is maintained after build and should only be reached if `--esm` flag is provided to the CLI.

#### Why?

Some context: I'm making an SSR project with Vite ([Vitedge](https://github.com/frandiox/vitedge)) and I've found a limitation when extending Vite's dev-server. I need to add a middleware to handle `/api/` and `/props/` requests, and then run the appropriate API handler for that endpoint. This handler is a user-provided JS function with ESM so I would like to use **dynamic imports** to require these functions. You can see the implementation [here](https://github.com/frandiox/vitedge/blob/master/core/plugin.js).

The alternatives to using dynamic imports would be relying on Rollup + Chokidar but I think this solution matches Vite's philosophy of using native ESM (in the browser and in Node) better.