### PR TITLE
fix(types): buildPluginHtml does not need `config.env` to exist

### DIFF
--- a/src/node/build/buildPluginHtml.ts
+++ b/src/node/build/buildPluginHtml.ts
@@ -28,7 +28,7 @@ export const createBuildHtmlPlugin = async (
   inlineLimit: number,
   resolver: InternalResolver,
   shouldPreload: ((chunk: OutputChunk) => boolean) | null,
-  config: UserConfig
+  config: Partial<UserConfig>
 ) => {
   if (!fs.existsSync(indexPath)) {
     return {


### PR DESCRIPTION
Master does not compile because of this ts error

```
src/node/build/index.ts:408:5 - error TS2345: Argument of type 'Partial<BuildConfig>' is not assignable to parameter of type 'UserConfig'.
  Types of property 'env' are incompatible.
    Type 'DotenvParseOutput | undefined' is not assignable to type 'DotenvParseOutput'.
      Type 'undefined' is not assignable to type 'DotenvParseOutput'.

408     options
        ~~~~~~~˙
```