### PR TITLE
fix: old CSS cache is still used after refreshing the page. #1087

### DIFF
--- a/src/node/server/serverPluginHtml.ts
+++ b/src/node/server/serverPluginHtml.ts
@@ -68,6 +68,11 @@ export const htmlRewritePlugin: ServerPlugin = ({
   app.use(async (ctx, next) => {
     await next()
 
+    // Fix the old CSS cache is still used after refreshing the page. #1087
+    if (ctx.response.is('js') && ctx.path.endsWith('.css')) {
+      ctx.set('catch-concontrol', 'no-store')
+    }
+
     if (ctx.status === 304) {
       return
     }


### PR DESCRIPTION
From this issue #1087

Because there is a cache when refreshing the page during development,the `.css` file cache is changed to `no-store`.

Hope it helps.