### PR TITLE
fix: old CSS cache is still used after refreshing the page. #1087

### DIFF
--- a/src/node/server/serverPluginHtml.ts
+++ b/src/node/server/serverPluginHtml.ts
@@ -68,6 +68,11 @@ export const htmlRewritePlugin: ServerPlugin = ({
   app.use(async (ctx, next) => {
     await next()
 
+    // Fix the old CSS cache is still used after refreshing the page. #1087
+    if (ctx.response.is('js') && ctx.path.endsWith('.css')) {
+      ctx.set('Cache-Control', 'no-store')
+    }
+
     if (ctx.status === 304) {
       return
     }


### PR DESCRIPTION
From this issue #1087 

In the development environment, whenever the page is refreshed, the old `.css` file is cached by the browser.

This will cause the original file to be modified and the hot update is successful, but the old style may appear when the page is refreshed, causing confusion to users

so in order to fix it, I change the catch control of the. CSS file.

Hope it helps.

