### PR TITLE
fix: target ES2018 instead of ESNEXT

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES2018",
     "moduleResolution": "node",
     "strict": true,
     "declaration": true,


### PR DESCRIPTION
I made the typescript target `ES2018` to support node 10 and correctly transpile the `?.` operator