### PR TITLE
feat(build): make `rollupOutputOptions` and `rollupPluginVueOptions` overridable

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -679,22 +679,22 @@ export async function ssrBuild(
     outDir: 'dist-ssr',
     ...options,
     rollupPluginVueOptions: {
-      ...rollupPluginVueOptions,
-      target: 'node'
+      target: 'node',
+      ...rollupPluginVueOptions
     },
     rollupInputOptions: {
-      ...rollupInputOptions,
       external: resolveExternal(
         rollupInputOptions && rollupInputOptions.external
-      )
+      ),
+      ...rollupInputOptions
     },
     rollupOutputOptions: {
-      ...rollupOutputOptions,
       format: 'cjs',
       exports: 'named',
       entryFileNames: '[name].js',
       // 764 add `Symbol.toStringTag` when build es module into cjs chunk
-      namespaceToStringTag: true
+      namespaceToStringTag: true,
+      ...rollupOutputOptions
     },
     emitIndex: false,
     emitAssets: false,

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -683,10 +683,10 @@ export async function ssrBuild(
       ...rollupPluginVueOptions
     },
     rollupInputOptions: {
+      ...rollupInputOptions,
       external: resolveExternal(
         rollupInputOptions && rollupInputOptions.external
-      ),
-      ...rollupInputOptions
+      )
     },
     rollupOutputOptions: {
       format: 'cjs',


### PR DESCRIPTION
I'm not sure if this was intended but right now it can only build for CommonJS. It would be useful to support ES output (`format: 'es'`).