### PR TITLE
Expose source maps in server plugin transforms

### DIFF
--- a/src/node/transform.ts
+++ b/src/node/transform.ts
@@ -33,6 +33,7 @@ interface TransformTestContext {
 
 export interface TransformContext extends TransformTestContext {
   code: string
+  map?: SourceMap
 }
 
 export interface TransformResult {
@@ -115,7 +116,8 @@ export function createServerTransformPlugin(
           code = code || (await readBody(ctx.body))!
           const result = await t.transform({
             ...transformContext,
-            code
+            code,
+            map: ctx.map
           })
           if (typeof result === 'string') {
             code = result

--- a/src/node/transform.ts
+++ b/src/node/transform.ts
@@ -33,7 +33,7 @@ interface TransformTestContext {
 
 export interface TransformContext extends TransformTestContext {
   code: string
-  map?: SourceMap
+  map?: SourceMap | null
 }
 
 export interface TransformResult {


### PR DESCRIPTION
To be able to use the sourceMap of (all) previous transforms in [vite-plugin-istanbul](https://github.com/ifaxity/vite-plugin-istanbul) the sourceMap has to be exposed in the TransformContext.

Otherwise when using the plugin to instrument Vue Single File Components for testing with istanbul, the sourceMap will show the wrong lines in the code coverage report. As it assumes the source map from the bundled Single File Components.

Referenced issue: iFaxity/vite-plugin-istanbul/issues/1