### PR TITLE
Fix 1098

### DIFF
--- a/playground/TestSyntax.vue
+++ b/playground/TestSyntax.vue
@@ -4,10 +4,11 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 const foo = {
   bar: 'baz'
 }
-export const a = {
+const a = ref({
   b: foo?.bar
-}
+})
 </script>

--- a/playground/script-setup/TestScriptSetupStyleVars.vue
+++ b/playground/script-setup/TestScriptSetupStyleVars.vue
@@ -9,25 +9,24 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
-export { default as TestScriptSetupChild } from './TestScriptSetupChild.vue'
+import { ref, defineOptions } from 'vue'
+import TestScriptSetupChild from './TestScriptSetupChild.vue'
 
-export default {
+defineOptions({
   props: {
     msg: String
   }
-}
+})
 
-export const color = ref('red')
+const color = ref('red')
 
-export function change() {
+function change() {
   color.value = color.value === 'red' ? 'green' : 'red'
 }
-
 </script>
 
-<style scoped vars="{ color }">
+<style>
 span {
-  color: var(--color);
+  color: v-bind(color);
 }
 </style>

--- a/src/node/esbuildService.ts
+++ b/src/node/esbuildService.ts
@@ -47,7 +47,11 @@ export function resolveJsxOptions(options: SharedConfig['jsx'] = 'vue') {
 // lazy start the service
 let _servicePromise: Promise<Service> | undefined
 
+// track transform calls in multiple builds to stop service properly
+let _transformCount = 0
+
 const ensureService = async () => {
+  _transformCount++;
   if (!_servicePromise) {
     _servicePromise = startService()
   }
@@ -55,7 +59,7 @@ const ensureService = async () => {
 }
 
 export const stopService = async () => {
-  if (_servicePromise) {
+  if (_servicePromise && --_transformCount === 0) {
     const service = await _servicePromise
     service.stop()
     _servicePromise = undefined

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -255,14 +255,7 @@ export const vuePlugin: ServerPlugin = ({
     }
 
     // force reload if CSS vars injection changed
-    if (
-      prevStyles.some((s, i) => {
-        const next = nextStyles[i]
-        if (s.attrs.vars && (!next || next.attrs.vars !== s.attrs.vars)) {
-          return true
-        }
-      })
-    ) {
+    if (prevDescriptor.cssVars.join('') !== descriptor.cssVars.join('')) {
       return sendReload()
     }
 
@@ -439,7 +432,10 @@ async function compileSFCMain(
   const compiler = resolveCompiler(root)
   if ((descriptor.script || descriptor.scriptSetup) && compiler.compileScript) {
     try {
-      script = compiler.compileScript(descriptor)
+      script = compiler.compileScript(descriptor, {
+        // @ts-ignore TODO remove when @vue/compiler-sfc is updated
+        id
+      })
     } catch (e) {
       console.error(
         chalk.red(
@@ -630,7 +626,6 @@ async function compileSFCStyle(
     filename: resource,
     id: ``, // will be computed in compileCss
     scoped: style.scoped != null,
-    vars: style.vars != null,
     modules: style.module != null,
     preprocessLang: style.lang as SFCStyleCompileOptions['preprocessLang'],
     preprocessOptions: cssPreprocessOptions,

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -255,8 +255,10 @@ export const vuePlugin: ServerPlugin = ({
     }
 
     // force reload if CSS vars injection changed
-    if (prevDescriptor.cssVars.join('') !== descriptor.cssVars.join('')) {
-      return sendReload()
+    if (descriptor.cssVars) {
+      if (prevDescriptor.cssVars.join('') !== descriptor.cssVars.join('')) {
+        return sendReload()
+      }
     }
 
     // force reload if scoped status has changed

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -434,10 +434,7 @@ async function compileSFCMain(
   const compiler = resolveCompiler(root)
   if ((descriptor.script || descriptor.scriptSetup) && compiler.compileScript) {
     try {
-      script = compiler.compileScript(descriptor, {
-        // @ts-ignore TODO remove when @vue/compiler-sfc is updated
-        scopeId: id
-      })
+      script = compiler.compileScript(descriptor, { id })
     } catch (e) {
       console.error(
         chalk.red(
@@ -564,16 +561,20 @@ function compileSFCTemplate(
     }
   }
 
+  const id = hash_sum(publicPath)
   const { code, map, errors } = compileTemplate({
     source: template.content,
+    id,
+    scoped,
     filename: filePath,
     inMap: template.map,
     transformAssetUrls: vueTransformAssetUrls,
     compilerOptions: {
       ...vueCompilerOptions,
-      scopeId: scoped ? `data-v-${hash_sum(publicPath)}` : null,
       bindingMetadata,
-      runtimeModuleName: vueSpecifier
+      runtimeModuleName: vueSpecifier,
+      // for backwards compat only
+      scopeId: scoped ? `data-v-${id}` : null
     },
     preprocessLang,
     preprocessOptions,

--- a/src/node/server/serverPluginVue.ts
+++ b/src/node/server/serverPluginVue.ts
@@ -436,7 +436,7 @@ async function compileSFCMain(
     try {
       script = compiler.compileScript(descriptor, {
         // @ts-ignore TODO remove when @vue/compiler-sfc is updated
-        id
+        scopeId: id
       })
     } catch (e) {
       console.error(

--- a/src/node/utils/cssUtils.ts
+++ b/src/node/utils/cssUtils.ts
@@ -58,7 +58,6 @@ export async function compileCss(
     source,
     filename,
     scoped,
-    vars,
     modules,
     preprocessLang,
     preprocessOptions = {},
@@ -111,7 +110,6 @@ export async function compileCss(
     filename,
     id: `data-v-${id}`,
     scoped,
-    vars,
     modules,
     modulesOptions: {
       generateScopedName: `[local]_${id}`,


### PR DESCRIPTION
I doubt whether should we listen to process exit as [said](https://github.com/vitejs/vite/issues/1098#issuecomment-731620564) because the esbuild process is `spawn`-ed from main process without detachment, so if the main process exit then the esbuild should be automatically stopped by os.

If we are going to add something just before exit, [this gist](https://gist.github.com/hyrious/30a878f6e6a057f09db87638567cb11a#file-nodejs-on-exit-js) may be helpful.