### PR TITLE
fix: multiple builds share esbuild process

### DIFF
--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -30,7 +30,6 @@ import {
   createEsbuildRenderChunkPlugin
 } from './buildPluginEsbuild'
 import { createReplacePlugin } from './buildPluginReplace'
-import { stopService } from '../esbuildService'
 import { BuildConfig, defaultDefines } from '../config'
 import { createBuildJsTransformPlugin } from '../transform'
 import hash_sum from 'hash-sum'
@@ -653,9 +652,6 @@ export async function build(
       `Build completed in ${((Date.now() - start) / 1000).toFixed(2)}s.\n`
     )
   }
-
-  // stop the esbuild service after each build
-  await stopService()
 
   return results
 }


### PR DESCRIPTION
I doubt whether should we listen to process exit as [said](https://github.com/vitejs/vite/issues/1098#issuecomment-731620564) because the esbuild process is `spawn`-ed from main process without detachment, so if the main process exit then the esbuild should be automatically stopped by os.

If we are going to add something just before exit, [this gist](https://gist.github.com/hyrious/30a878f6e6a057f09db87638567cb11a#file-nodejs-on-exit-js) may be helpful.

Fix #1098