### PR TITLE
refactor: simplify the `transformIndexHtml` utility function

### DIFF
--- a/src/node/utils/transformUtils.ts
+++ b/src/node/utils/transformUtils.ts
@@ -36,11 +36,16 @@ export async function transformIndexHtml(
   apply: 'pre' | 'post',
   isBuild = false
 ) {
+  
+  // shorthand, assume a plain function is a "post transform"
+  transforms.forEach((t, i)=> {
+    if (typeof t==='function') transforms[i] = { apply: 'post', transform: t };
+  });
+  
   const currentStepTransforms = transforms.filter((t) => t.apply === apply);
   let code = html;
   for (const t of currentStepTransforms) {
-    if(typeof t.transform === 'function')
-      code = await t.transform({ isBuild, code });
+    code = await t.transform({ isBuild, code });
   }
   return code;
 }

--- a/src/node/utils/transformUtils.ts
+++ b/src/node/utils/transformUtils.ts
@@ -36,18 +36,11 @@ export async function transformIndexHtml(
   apply: 'pre' | 'post',
   isBuild = false
 ) {
-  const trans = transforms
-    .map((t) => {
-      return typeof t === 'function' && apply === 'post'
-        ? t
-        : t.apply === apply
-        ? t.transform
-        : undefined
-    })
-    .filter(Boolean)
-  let code = html
-  for (const transform of trans) {
-    code = await transform!({ isBuild, code })
+  const currentStepTransforms = transforms.filter((t) => t.apply === apply);
+  let code = html;
+  for (const t of currentStepTransforms) {
+    if(typeof t.transform === 'function')
+      code = await t.transform({ isBuild, code });
   }
-  return code
+  return code;
 }

--- a/src/node/utils/transformUtils.ts
+++ b/src/node/utils/transformUtils.ts
@@ -36,16 +36,14 @@ export async function transformIndexHtml(
   apply: 'pre' | 'post',
   isBuild = false
 ) {
-  
-  // shorthand, assume a plain function is a "post transform"
-  transforms.forEach((t, i)=> {
-    if (typeof t==='function') transforms[i] = { apply: 'post', transform: t };
-  });
-  
-  const currentStepTransforms = transforms.filter((t) => t.apply === apply);
-  let code = html;
-  for (const t of currentStepTransforms) {
-    code = await t.transform({ isBuild, code });
+  let code = html
+  for (let t of transforms) {
+    if (typeof t === 'function') {
+      t = { apply: 'post', transform: t }
+    }
+    if (t.apply === apply) {
+      code = await t.transform({ isBuild, code })
+    }
   }
-  return code;
+  return code
 }


### PR DESCRIPTION
The original function was very oddly written IMHO, I had to long stare at this code trying make sense of it, until I figured what it was supposed to do. So I tried to make it very straightforward and make the intent more clear.