### PR TITLE
feat(dev): Detect ts-node in config resolution

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -509,7 +509,8 @@ export async function resolveConfig(mode: string, configPath?: string) {
   try {
     let userConfig: UserConfig | ((mode: string) => UserConfig) | undefined
 
-    if (!isTS) {
+    // @ts-ignore
+    if (!isTS || process[Symbol.for('ts-node.register.instance')]) {
       try {
         userConfig = require(resolvedPath)
       } catch (e) {


### PR DESCRIPTION
If the process is running with `ts-node`, it would be better if the configuration file is imported directly rather than transpiled with Rollup.

This can be combined with the dynamic import syntax introduced in https://github.com/vitejs/vite/pull/1079 
