### PR TITLE
feat: let plugins be functions with config access

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "fs-extra": "^9.0.1",
     "hash-sum": "^2.0.0",
     "isbuiltin": "^1.0.0",
-    "klona": "^2.0.4",
     "koa": "^2.13.0",
     "koa-conditional-get": "^3.0.0",
     "koa-etag": "^4.0.0",

--- a/playground/App.vue
+++ b/playground/App.vue
@@ -11,7 +11,7 @@
   <TestCssModules />
   <TestCssAtImport />
   <TestPreprocessors />
-  <TestScssAtImport/>
+  <TestScssAtImport />
   <TestAssets />
   <TestSrcImport />
   <TestJsonImport />
@@ -32,6 +32,7 @@
   <TestScriptSetupStyleVars msg="Test message" />
   <TestSyntax />
   <TestCjsDepNamedExport />
+  <TestPluginChangeConfig />
 </template>
 
 <script>
@@ -64,6 +65,7 @@ import TestWasm from './wasm/TestWasm.vue'
 import TestScriptSetupStyleVars from './script-setup/TestScriptSetupStyleVars.vue'
 import TestSyntax from './TestSyntax.vue'
 import TestCjsDepNamedExport from './cjs-dep-named-export/TestCjsDepNamedExport.vue'
+import TestPluginChangeConfig from './TestPluginChangeConfig.vue'
 
 const App = {
   components: {
@@ -95,8 +97,9 @@ const App = {
     TestWasm,
     TestScriptSetupStyleVars,
     TestSyntax,
-    TestCjsDepNamedExport
+    TestCjsDepNamedExport,
+    TestPluginChangeConfig
   }
 }
-export { App as default}
+export { App as default }
 </script>

--- a/playground/TestPluginChangeConfig.vue
+++ b/playground/TestPluginChangeConfig.vue
@@ -1,0 +1,20 @@
+<template>
+  <h2>Change config by plugin</h2>
+  <p class="plugin-change-config-1">
+  <p>changeConfigPlugin1: {{ changeConfigPlugin1 }}</p>
+  </p>
+  <p class="plugin-change-config-2">
+  <p>changeConfigPlugin2: {{ changeConfigPlugin2 }}</p>
+  </p>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      changeConfigPlugin1: __changeConfigPlugin1__,
+      changeConfigPlugin2: __changeConfigPlugin2__
+    }
+  }
+}
+</script>

--- a/playground/plugins/changeConfig.ts
+++ b/playground/plugins/changeConfig.ts
@@ -1,0 +1,16 @@
+import { Plugin } from 'vite'
+
+export const changeConfigPlugin1: Plugin = {
+  changeConfig: (prev) => {
+    prev.define['__changeConfigPlugin1__'] = 'success'
+    prev.plugins.push(changeConfigPlugin2)
+    return prev
+  }
+}
+
+const changeConfigPlugin2: Plugin = {
+  changeConfig: (prev) => {
+    prev.define['__changeConfigPlugin2__'] = 'success'
+    return prev
+  }
+}

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,5 +1,6 @@
 import type { UserConfig } from '../src/node/config'
 import { jsPlugin } from './plugins/jsPlugin'
+import { changeConfigPlugin1 } from './plugins/changeConfig'
 import { i18nTransform } from './custom-blocks/i18nTransform'
 
 const config: UserConfig = {
@@ -11,7 +12,7 @@ const config: UserConfig = {
     __VALUE__: 'value'
   },
   jsx: 'preact',
-  plugins: [jsPlugin],
+  plugins: [jsPlugin, changeConfigPlugin1],
   vueCustomBlockTransforms: { i18n: i18nTransform },
   optimizeDeps: {
     exclude: ['bootstrap', 'rewrite-unoptimized-test-package'],

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -3,7 +3,6 @@ import fs from 'fs-extra'
 import chalk from 'chalk'
 import pMapSeries from 'p-map-series'
 import { Ora } from 'ora'
-import { klona } from 'klona/json'
 import { resolveFrom, lookupFile, toArray } from '../utils'
 import {
   rollup as Rollup,

--- a/src/node/build/index.ts
+++ b/src/node/build/index.ts
@@ -257,59 +257,30 @@ async function createVuePlugin(
 /**
  * Clone the given config object and fill it with default values.
  */
-function prepareConfig(config: ResolvedConfig): BuildConfig {
-  const {
-    assetsDir = '_assets',
-    assetsInlineLimit = 4096,
-    base = '/',
-    cssCodeSplit = true,
-    emitAssets = true,
-    emitIndex = true,
-    enableRollupPluginVue = true,
-    entry = 'index.html',
-    env = {},
-    esbuildTarget = 'es2020',
-    minify = true,
-    mode = 'production',
-    outDir = 'dist',
-    rollupDedupe = [],
-    rollupInputOptions = {},
-    rollupOutputOptions = {},
-    rollupPluginVueOptions = {},
-    shouldPreload = null,
-    silent = false,
-    sourcemap = false,
-    terserOptions = {},
-    transforms = [],
-    write = true
-  } = klona(config)
+function prepareConfig(config: Partial<BuildConfig>) {
+  config.assetsDir ??= '_assets'
+  config.assetsInlineLimit ??= 4096
+  config.base ??= '/'
+  config.cssCodeSplit ??= true
+  config.emitAssets ??= true
+  config.emitIndex ??= true
+  config.enableRollupPluginVue ??= true
+  config.entry ??= 'index.html'
+  config.esbuildTarget ??= 'es2020'
+  config.minify ??= true
+  config.mode ??= 'production'
+  config.outDir ??= 'dist'
+  config.rollupDedupe ??= []
+  config.rollupInputOptions ??= {}
+  config.rollupOutputOptions ??= {}
+  config.rollupPluginVueOptions ??= {}
+  config.shouldPreload ??= null
+  config.silent ??= false
+  config.sourcemap ??= false
+  config.terserOptions ??= {}
+  config.write ??= true
 
-  return {
-    ...config,
-    assetsDir,
-    assetsInlineLimit,
-    base,
-    cssCodeSplit,
-    emitAssets,
-    emitIndex,
-    enableRollupPluginVue,
-    entry,
-    env,
-    esbuildTarget,
-    minify,
-    mode,
-    outDir,
-    rollupDedupe,
-    rollupInputOptions,
-    rollupOutputOptions,
-    rollupPluginVueOptions,
-    shouldPreload,
-    silent,
-    sourcemap,
-    terserOptions,
-    transforms,
-    write
-  }
+  return config as BuildConfig
 }
 
 /**
@@ -336,10 +307,12 @@ export async function build(
   }
 }
 
-async function doBuild(resolvedConfig: ResolvedConfig): Promise<BuildResult[]> {
-  const builds: Build[] = []
+async function doBuild(
+  partialConfig: Partial<BuildConfig>
+): Promise<BuildResult[]> {
+  const config = prepareConfig(partialConfig)
 
-  const config = prepareConfig(resolvedConfig)
+  const builds: Build[] = []
   const postBuildHooks = toArray(config.configureBuild)
     .map((configureBuild) => configureBuild(config, builds))
     .filter(Boolean) as PostBuildHook[]

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -151,8 +151,21 @@ async function resolveOptions({
     delete userConfig.env.NODE_ENV
   }
 
+  let updatedConfig = userConfig
+  // use for loop instead of forEach
+  // because changeConfig may add plugins into updatedConfig
+  // and we should call the changeConfig of new-added plugins
+  for (
+    let i = 0;
+    updatedConfig.plugins && i < updatedConfig.plugins.length;
+    i++
+  ) {
+    const plugin = updatedConfig.plugins[i]
+    updatedConfig = plugin.changeConfig?.(updatedConfig) ?? updatedConfig
+  }
+
   // cli options take higher priority
-  return { ...userConfig, ...argv }
+  return { ...updatedConfig, ...argv }
 }
 
 function runServe(options: UserConfig) {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -138,21 +138,21 @@ async function resolveOptions({
     argv.jsx = { factory: argv.jsxFactory, fragment: argv.jsxFragment }
   }
 
-  const userConfig = await resolveConfig(
+  const config = await resolveConfig(
     argv.mode || defaultMode,
-    argv.config || argv.c
+    argv.config || argv.c,
+    argv
   )
 
   // when NODE_ENV is set in .env file or Vite `env` option, it overrides the
   // `DEV` and `PROD` values of `import.meta.env` and even `process.env.NODE_ENV`
   // in the client bundle, which would use `argv.mode` otherwise.
-  if (userConfig.env.NODE_ENV) {
-    process.env.VITE_ENV = userConfig.env.NODE_ENV
-    delete userConfig.env.NODE_ENV
+  if (config.env.NODE_ENV) {
+    process.env.VITE_ENV = config.env.NODE_ENV
+    delete config.env.NODE_ENV
   }
 
-  // cli options take higher priority
-  return { ...userConfig, ...argv }
+  return config
 }
 
 function runServe(options: UserConfig) {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -121,10 +121,6 @@ async function resolveOptions({
     }
   })
 
-  if (argv.root) {
-    argv.root = path.isAbsolute(argv.root) ? argv.root : path.resolve(argv.root)
-  }
-
   // deprecation warning
   if (argv.sw || argv.serviceWorker) {
     console.warn(

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -151,21 +151,8 @@ async function resolveOptions({
     delete userConfig.env.NODE_ENV
   }
 
-  let updatedConfig = userConfig
-  // use for loop instead of forEach
-  // because changeConfig may add plugins into updatedConfig
-  // and we should call the changeConfig of new-added plugins
-  for (
-    let i = 0;
-    updatedConfig.plugins && i < updatedConfig.plugins.length;
-    i++
-  ) {
-    const plugin = updatedConfig.plugins[i]
-    updatedConfig = plugin.changeConfig?.(updatedConfig) ?? updatedConfig
-  }
-
   // cli options take higher priority
-  return { ...updatedConfig, ...argv }
+  return { ...userConfig, ...argv }
 }
 
 function runServe(options: UserConfig) {

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -454,7 +454,9 @@ export interface UserConfig extends Partial<BuildConfig>, ServerConfig {
   plugins?: Plugin[]
 }
 
-export type Plugin = PluginConfig | ((config: ResolvedConfig) => PluginConfig)
+export type Plugin =
+  | PluginConfig
+  | ((config: ResolvedConfig) => PluginConfig | void)
 
 export interface PluginConfig
   extends Pick<
@@ -633,6 +635,9 @@ async function loadConfigFromBundledFile(
 function mergePlugin(config: ResolvedConfig, plugin: Plugin) {
   if (typeof plugin === 'function') {
     plugin = plugin(config)
+    if (!plugin) {
+      return
+    }
   }
   for (const key in plugin) {
     let value = (plugin as any)[key]

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -471,7 +471,12 @@ export interface Plugin
     | 'rollupInputOptions'
     | 'rollupOutputOptions'
     | 'enableRollupPluginVue'
-  > {}
+  > {
+  /**
+   * plugins can change vite config
+   */
+  changeConfig?: (prevConfig: ResolvedConfig) => ResolvedConfig
+}
 
 export type ResolvedConfig = UserConfig & {
   env: DotenvParseOutput

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -485,7 +485,11 @@ export type ResolvedConfig = UserConfig & {
 
 const debug = require('debug')('vite:config')
 
-export async function resolveConfig(mode: string, configPath?: string) {
+export async function resolveConfig(
+  mode: string,
+  configPath?: string,
+  argv?: any
+) {
   const start = Date.now()
   const cwd = process.cwd()
 
@@ -569,6 +573,11 @@ export async function resolveConfig(mode: string, configPath?: string) {
       for (const plugin of config.plugins) {
         mergePlugin(config, plugin)
       }
+    }
+
+    // cli options take higher priority
+    if (argv) {
+      mergePlugin(config, argv)
     }
 
     // normalize config root to absolute

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -564,9 +564,12 @@ export async function resolveConfig(
       userConfig = await loadConfigFromBundledFile(resolvedPath, code)
     }
 
-    let config = (typeof userConfig === 'function'
-      ? userConfig(mode)
-      : userConfig) as ResolvedConfig
+    if (typeof userConfig === 'function') {
+      userConfig = userConfig(mode)
+    }
+
+    const config = {} as ResolvedConfig
+    mergePlugin(config, userConfig)
 
     // resolve plugins
     if (config.plugins) {
@@ -583,12 +586,6 @@ export async function resolveConfig(
     // normalize config root to absolute
     if (config.root && !path.isAbsolute(config.root)) {
       config.root = path.resolve(path.dirname(resolvedPath), config.root)
-    }
-
-    if (typeof config.vueTransformAssetUrls === 'object') {
-      config.vueTransformAssetUrls = normalizeAssetUrlOptions(
-        config.vueTransformAssetUrls
-      )
     }
 
     const env = loadEnv(mode, config.root || cwd)

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -589,10 +589,8 @@ export async function resolveConfig(
     }
 
     const env = loadEnv(mode, config.root || cwd)
-    config.env = {
-      ...config.env,
-      ...env
-    }
+    Object.assign(config.env, env)
+
     debug(`config resolved in ${Date.now() - start}ms`)
 
     config.__path = resolvedPath

--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -571,21 +571,23 @@ export async function resolveConfig(
     const config = {} as ResolvedConfig
     mergePlugin(config, userConfig)
 
-    // resolve plugins
+    // ensure plugin functions have access to the resolved root
+    config.root =
+      argv && argv.root
+        ? path.resolve(argv.root)
+        : config.root
+        ? path.resolve(path.dirname(resolvedPath), config.root)
+        : process.cwd()
+
     if (config.plugins) {
       for (const plugin of config.plugins) {
         mergePlugin(config, plugin)
       }
     }
 
-    // cli options take higher priority
+    // cli options take highest priority
     if (argv) {
       mergePlugin(config, argv)
-    }
-
-    // normalize config root to absolute
-    if (config.root && !path.isAbsolute(config.root)) {
-      config.root = path.resolve(path.dirname(resolvedPath), config.root)
     }
 
     const env = loadEnv(mode, config.root || cwd)

--- a/src/node/server/index.ts
+++ b/src/node/server/index.ts
@@ -50,14 +50,14 @@ export type Context = DefaultContext &
 
 export function createServer(config: ServerConfig): Server {
   const {
-    root = process.cwd(),
+    root,
     configureServer = [],
-    resolvers = [],
-    alias = {},
-    transforms = [],
-    vueCustomBlockTransforms = {},
-    optimizeDeps = {},
-    enableEsbuild = true,
+    resolvers,
+    alias,
+    transforms,
+    vueCustomBlockTransforms,
+    optimizeDeps,
+    enableEsbuild,
     assetsInclude,
     chokidarWatchOptions = {}
   } = config

--- a/test/test.js
+++ b/test/test.js
@@ -744,6 +744,15 @@ describe('vite', () => {
         'dynamic import result: success'
       )
     })
+
+    test('changeConfig plugin hook', async () => {
+      expect((await getText('.plugin-change-config-1')).trim()).toBe(
+        'changeConfigPlugin1: success'
+      )
+      expect((await getText('.plugin-change-config-2')).trim()).toBe(
+        'changeConfigPlugin2: success'
+      )
+    })
   }
 
   describe('build (multi)', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4093,11 +4093,6 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-klona@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
-  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
-
 koa-compose@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-3.2.1.tgz#a85ccb40b7d986d8e5a345b3a1ace8eabcf54de7"


### PR DESCRIPTION
Provide a plugin hook to access and alter vite config. It imitates rollup's [options](https://rollupjs.org/guide/en/#options) hook.

Usage:
```ts
import { Plugin } from 'vite'

export const changeConfigPlugin1: Plugin = {
  changeConfig: (prev) => {
    prev.define['__changeConfigPlugin1__'] = 'success'
    prev.plugins.push(changeConfigPlugin2)
    return prev
  }
}

const changeConfigPlugin2: Plugin = {
  changeConfig: (prev) => {
    prev.define['__changeConfigPlugin2__'] = 'success'
    return prev
  }
}
```

fix: https://github.com/vitejs/vite/issues/1162