### PR TITLE
fix(dev): fix invalid merge with vueTransformAssetUrls

### DIFF
--- a/src/node/config.ts
+++ b/src/node/config.ts
@@ -690,10 +690,10 @@ function mergeAssetUrlOptions(
   if (typeof to === 'boolean') {
     return from || to
   }
-  return {
-    ...normalizeAssetUrlOptions(to),
-    ...normalizeAssetUrlOptions(from)
-  }
+  return normalizeAssetUrlOptions({
+    ...normalizeAssetUrlOptions(to)?.tags,
+    ...normalizeAssetUrlOptions(from)?.tags
+  })
 }
 
 function normalizeAssetUrlOptions(o: Record<string, any> | undefined) {


### PR DESCRIPTION
the new config's vueTransformAssetUrls is always override the before's vueTransformAssetUrls