### PR TITLE
[2.0] Fix resolution error in public types

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "esbuild": "^0.8.26",
     "postcss": "^8.2.1",
-    "rollup": "^2.35.1"
+    "rollup": "^2.35.1",
+    "types": "link:./types"
   },
   "optionalDependencies": {
     "fsevents": "~2.1.2"

--- a/packages/vite/src/node/tsconfig.json
+++ b/packages/vite/src/node/tsconfig.json
@@ -8,10 +8,6 @@
     "outDir": "../../dist/node",
     "module": "commonjs",
     "lib": ["ESNext"],
-    "sourceMap": true,
-    "baseUrl": ".",
-    "paths": {
-      "types/*": ["../../types/*"]
-    }
+    "sourceMap": true
   }
 }

--- a/packages/vite/types/package.json
+++ b/packages/vite/types/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@vite/types",
+  "private": true,
+  "version": "2.0.0"
+}


### PR DESCRIPTION
Using the `"paths"` feature of tsconfig.json is off limits for public types, because node_modules packages never have their tsconfig.json applied. This resulted in resolution errors for the `types/*` imports in Vite's type declarations.

To fix this, I've added a package.json to the `./packages/vite/types` directory and linked to it from `dependencies` in `./packages/vite/package.json`. 👍 