### PR TITLE
fix(types): add index.d.ts to plugin-react-refresh

### DIFF
--- a/packages/plugin-react-refresh/index.d.ts
+++ b/packages/plugin-react-refresh/index.d.ts
@@ -1,0 +1,2 @@
+declare const reactRefreshPlugin: () => import('vite').Plugin
+export = reactRefreshPlugin


### PR DESCRIPTION
Otherwise, TypeScript complains when `vite.config.ts` imports the plugin.