### PR TITLE
docs: fix typos

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -15,7 +15,7 @@ export default {
 }
 ```
 
-Note Vite supports using ES modules syntax in the config file even if the project is not using native Node ESM via `type: "module"`. In this case the config file is auto pre-procssed before load.
+Note Vite supports using ES modules syntax in the config file even if the project is not using native Node ESM via `type: "module"`. In this case the config file is auto pre-processed before load.
 
 You can also explicitly specify a config file to use with the `--config` CLI option (resolved relative to `cwd`):
 
@@ -377,7 +377,7 @@ export default ({ command, mode }) => {
 
 - **Type:** `string[]`
 
-  A list of depdendencies that imports Node built-ins, but do not actually use them in browsers. Suppresses related warnings.
+  A list of dependencies that imports Node built-ins, but do not actually use them in browsers. Suppresses related warnings.
 
 ### optimizeDeps.auto
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -83,7 +83,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 - **Type:** `(config: UserConfig) => UserConfig | null | void`
 - **Kind:** `sync`, `sequential`
 
-  Modify Vite config before it's resolved. The hook receives the raw user config (CLI options merged with config file). It can return a partial config object that will be deeply merged into existing config, or directly mutate the config (if the default merging cannot acheive desired result).
+  Modify Vite config before it's resolved. The hook receives the raw user config (CLI options merged with config file). It can return a partial config object that will be deeply merged into existing config, or directly mutate the config (if the default merging cannot achieve the desired result).
 
   **Example**
 
@@ -203,14 +203,14 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
   }
   ```
 
-  Note `configureServer` is not called when running the production build so your other hooks need to guard against its absense.
+  Note `configureServer` is not called when running the production build so your other hooks need to guard against its absence.
 
 ### `transformIndexHtml`
 
 - **Type:** `IndexHtmlTransformHook | { enforce?: 'pre' | 'post' transform: IndexHtmlTransformHook }`
 - **Kind:** `async`, `sequential`
 
-  Dedicated hook for transforming `index.html`. The hook receives the curreht HTML string and a transform context. The context exposes the [`ViteDevServer`](./api-javascript#vitedevserver) instance during dev, and exposes the Rollup output bundle during build.
+  Dedicated hook for transforming `index.html`. The hook receives the current HTML string and a transform context. The context exposes the [`ViteDevServer`](./api-javascript#vitedevserver) instance during dev, and exposes the Rollup output bundle during build.
 
   The hook can be async and can return one of the following:
 
@@ -285,7 +285,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
   The hook can choose to:
 
-  - Filter and narrow down the affected mdoule list so that the HMR is more accurate.
+  - Filter and narrow down the affected module list so that the HMR is more accurate.
 
   - Return an empty array and perform complete custom HRM handling by sending custom events to the client:
 

--- a/docs/guide/comparisons.md
+++ b/docs/guide/comparisons.md
@@ -6,19 +6,19 @@
 
 **Production Build Handling**
 
-Snowpack's default build output is unbundled: it transforms each file into separate built modules, which can then be feeded into different "optimizers" that perform the actual bundling. The benefit of this is that you can choose between different end-bundlers (e.g. webpack, Rollup, or even ESbuild), the downside is that it's a bit of a fragmented experience - for example, the `esbuild` optimizer is still unstable, the Rollup optimizer is not officially maintained, and different optimzers have different output and configurations.
+Snowpack's default build output is unbundled: it transforms each file into separate built modules, which can then be fed into different "optimizers" that perform the actual bundling. The benefit of this is that you can choose between different end-bundlers (e.g. webpack, Rollup, or even ESbuild), the downside is that it's a bit of a fragmented experience - for example, the `esbuild` optimizer is still unstable, the Rollup optimizer is not officially maintained, and different optimizers have different output and configurations.
 
 Vite opts to have a deeper integration with one single bundler (Rollup) in order to provide a more streamlined experience. The reason for going with Rollup is because we believe for the foreseeable future, Rollup offers the best balance between maturity, extensibility, build speed, and output bundle size. Vite supports a [Universal Plugin API](./api-plugin) that extends Rollup's plugin interface, and offers more build features such as [multi-page support](./build#multi-page-app) and [library mode](./build#library-mode).
 
 **First Class Vue Support**
 
-Vite was initially created to serve as the future foundation of [Vue.js](https://vuejs.org/) tooling. Although as of 2.0 Vite is now fully framework-agnostic, the offical Vue plugin still provides first-class support for Vue's Single File Component format, covering all advanced features such as template asset reference resolving, `<script setup>`, `<style module>`, custom blocks and more. In addition, Vite provides fine-grained HMR for Vue SFCs. For example, updating the `<template>` or `<style>` of an SFC will perform hot updates without resetting its state.
+Vite was initially created to serve as the future foundation of [Vue.js](https://vuejs.org/) tooling. Although as of 2.0 Vite is now fully framework-agnostic, the official Vue plugin still provides first-class support for Vue's Single File Component format, covering all advanced features such as template asset reference resolving, `<script setup>`, `<style module>`, custom blocks and more. In addition, Vite provides fine-grained HMR for Vue SFCs. For example, updating the `<template>` or `<style>` of an SFC will perform hot updates without resetting its state.
 
 ## WMR
 
 [WMR](https://github.com/preactjs/wmr) by the Preact team provides a similar feature set, and Vite 2.0's support for Rollup's plugin interface is inspired by it.
 
-WMR is mainly designed for [Preact](https://preactjs.com/) projects, and offers more integrated features such as pre-rendering. In terms of scope, it's closer to a Preact meta framework, with the same emphasize on compact size as Preact itself. If you are using Preact, WMR is likely going to offer a more fine-tuned experience. However, it's unlikely for WMR to prioritize support for other frameworks.
+WMR is mainly designed for [Preact](https://preactjs.com/) projects, and offers more integrated features such as pre-rendering. In terms of scope, it's closer to a Preact meta framework, with the same emphasis on compact size as Preact itself. If you are using Preact, WMR is likely going to offer a more fine-tuned experience. However, it's unlikely for WMR to prioritize support for other frameworks.
 
 ## @web/dev-server
 

--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -47,7 +47,7 @@ The default pre-bundling heuristics may not always be desirable. In cases where 
 
 ## Caching
 
-Vite caches the pre-bundled dependencies in `node_modules/.vite`. It determins whether it needs to re-run the pre-bundling step based on a few sources:
+Vite caches the pre-bundled dependencies in `node_modules/.vite`. It determines whether it needs to re-run the pre-bundling step based on a few sources:
 
 - The `dependencies` list in your `package.json`
 - Package manager lockfiles, e.g. `package-lock.json`, `yarn.lock`, or `pnpm-lock.yaml`.

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -6,7 +6,7 @@ Vite exposes env variables on the special **`import.meta.env`** object. Some bui
 
 - **`import.meta.env.MODE`**: {string} the [mode](#mode) the app is running in.
 
-- **`import.meta.env.BASE_URL`**: {string} the base url the app is being served from. In development, this is always `/`. In production, this is detemrined by the [`build.base` config option](/config/#build-base).
+- **`import.meta.env.BASE_URL`**: {string} the base url the app is being served from. In development, this is always `/`. In production, this is determined by the [`build.base` config option](/config/#build-base).
 
 - **`import.meta.env.PROD`**: {boolean} whether the app is running in production.
 
@@ -29,7 +29,7 @@ Vite uses [dotenv](https://github.com/motdotla/dotenv) to load additional enviro
 
 Loaded env variables are also exposed to your client source code via `import.meta.env`.
 
-To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-procssed code. e.g. the following file:
+To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code. e.g. the following file:
 
 ```
 DB_PASSWORD=foobar

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -124,11 +124,11 @@ If you have assets that are:
 - Must retain the exact same file name (without hashing)
 - ...or you simply don't want to have to import an asset first just to get its URL
 
-Then you can place the asset in a sepcial `public` directory under your project root. Assets in this directory will be served at root path `/` during dev, and copied to the root of the dist directory as-is.
+Then you can place the asset in a special `public` directory under your project root. Assets in this directory will be served at root path `/` during dev, and copied to the root of the dist directory as-is.
 
 Note that:
 
-- You should awlays reference `public` assets using root absolute path - for example, `public/icon.png` should be referenced in source code as `/icon.png`.
+- You should always reference `public` assets using root absolute path - for example, `public/icon.png` should be referenced in source code as `/icon.png`.
 - Assets in `public` cannot be imported from JavaScript.
 
 ## JSON

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,7 +4,7 @@ If you are interested to learn more about Vite before trying it, check out the [
 
 ## Scaffolding Your First Vite Project
 
-::: tip Comaptibility Note
+::: tip Compatibility Note
 Vite requires [Node.js](https://nodejs.org/en/) version >=12.0.0.
 :::
 
@@ -56,7 +56,7 @@ You can specify additional CLI options like `--port` or `--https`. For a full li
 
 Since Vite is a dev server, it has the concept of a "root directory" from which your files are served from, similar to a static file server (although much more powerful).
 
-Running `vite` starts the dev server using the current working direcotry as root. You can specify an alternative root with `vite serve some/sub/dir`.
+Running `vite` starts the dev server using the current working directory as root. You can specify an alternative root with `vite serve some/sub/dir`.
 
 Vite will serve **`<root>/index.html`** when you open the server's local address. It is also used as the default build entry point. Unlike some bundlers that treat HTML as an afterthought, Vite treats HTML files as part of the application graph (similar to Parcel). Therefore you should treat `index.html` as part of your source code instead of a static file. Vite also supports [multi-page apps](./build#multi-page-app) with multiple `.html` entry points.
 

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -22,7 +22,7 @@ Today, this syntax has [wide native support in major browsers](https://caniuse.c
 
 There are two downsides to bundling during development:
 
-- **Slow server start:** When starting the dev server, the bundler always eagerly crawls your entire application, even when there are code-split points present. For example, in an application with a dozen routes where ecah route is lazy loaded, you still have to wait for the bundler to process every single file in your app before you can start working on a single route page.
+- **Slow server start:** When starting the dev server, the bundler always eagerly crawls your entire application, even when there are code-split points present. For example, in an application with a dozen routes where each route is lazy loaded, you still have to wait for the bundler to process every single file in your app before you can start working on a single route page.
 
   ![bundler based dev server](/images/bundler.png)
 
@@ -30,7 +30,7 @@ There are two downsides to bundling during development:
 
   ![esm based dev server](/images/esm.png)
 
-- **Slow updates:** When a file is edited, in addition to re-building the file itself, the bundler also needs to invalidate part of its module graph and re-construct the entire bundle. This means the feedback speed between saving a file and seeing the changes reflected in the browser deteriorates linearly as the size of your application grows. In large applications, this bundle re-constrction step can become prohibitively expensive even with Hot Module Replacement enabled.
+- **Slow updates:** When a file is edited, in addition to re-building the file itself, the bundler also needs to invalidate part of its module graph and re-construct the entire bundle. This means the feedback speed between saving a file and seeing the changes reflected in the browser deteriorates linearly as the size of your application grows. In large applications, this bundle re-construction step can become prohibitively expensive even with Hot Module Replacement enabled.
 
   **How Vite solves it:** Every served file is cached via HTTP headers (304 Not Modified whenever possible) and, if browser cache is disabled, Vite's in-memory cache. On file edits, we simply invalidate the cache for that file. In addition, [Hot Module Replacement](./features#hot-module-replacement) over native ESM only needs to precisely re-fetch the invalidated modules, making it consistently fast regardless of the size of your application.
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -117,4 +117,4 @@ Some general pointers on migrating a v1 plugin to v2:
 - Serving virtual files -> use [`resolveId`](https://rollupjs.org/guide/en/#resolveid) + [`load`](https://rollupjs.org/guide/en/#load) hooks
 - Adding `alias`, `define` or other config options -> use the [`config`](./api-plugin#config) hook
 
-Since most of the logic should be done via plugin hooks instead of middlewares, the need for middlewares are greatly reduced. The ineternal server app is now a good old [connect](https://github.com/senchalabs/connect) instance instead of Koa.
+Since most of the logic should be done via plugin hooks instead of middlewares, the need for middlewares is greatly reduced. The internal server app is now a good old [connect](https://github.com/senchalabs/connect) instance instead of Koa.


### PR DESCRIPTION
Corrected a few typos while reading the new docs. 

PS: Really amazing work on Vite 2 and the new documentation ❤️ 