### PR TITLE
fix: prevent `require` of .d.ts in local vite clone

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -1,3 +1,6 @@
+/// <reference path="../../types/fileTypes.d.ts" />
+/// <reference path="../../types/importMeta.d.ts" />
+
 export * from './server'
 export * from './build'
 export * from './optimizer'


### PR DESCRIPTION
This commit prevents the following error when using a local clone of vite:

    Error: Cannot find module 'types/fileTypes'