### PR TITLE
feat: expose `loadEnv` in public api

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -476,7 +476,7 @@ async function loadConfigFromBundledFile(
   return config
 }
 
-function loadEnv(mode: string, root: string, prefix = 'VITE_') {
+export function loadEnv(mode: string, root: string, prefix = 'VITE_') {
   if (mode === 'local') {
     throw new Error(
       `"local" cannot be used as a mode name because it conflicts with ` +


### PR DESCRIPTION
This function was in the public api, but now - no