### PR TITLE
feat(plugin-vue): export vue query parser API

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -31,6 +31,8 @@ declare module '@vue/compiler-sfc' {
   }
 }
 
+export { parseVueRequest, VueQuery } from './utils/query'
+
 export interface Options {
   include?: string | RegExp | (string | RegExp)[]
   exclude?: string | RegExp | (string | RegExp)[]


### PR DESCRIPTION
I hope that `@vitejs/plugin-vue` export Vue SFC query parser API.
As the use-case, i18n custom block that have `lang`, `locale`, and `global` attribute.

e.g. `locale` attribute:
- `locale` attribute: https://vue-i18n-next.intlify.dev/advanced/sfc.html#define-locale-messages-each-locales

We can have the same parse on the plugin (vite-plugin-vue-i18n) side, since parse is not that hard, but I would like to use the exported Vue SFC query parser to comply official  spec.