### PR TITLE
feat: export `resolvePackageData` and `resolvePackageEntry` helpers

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -24,6 +24,7 @@ export type {
 } from './plugins/html'
 export type { CSSOptions, CSSModulesOptions } from './plugins/css'
 export type { EsbuildTransformResult } from './plugins/esbuild'
+export type { PackageData } from './plugins/resolve'
 export type { WebSocketServer } from './server/ws'
 export type { PluginContainer } from './server/pluginContainer'
 export type { ModuleGraph, ModuleNode } from './server/moduleGraph'

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -4,6 +4,7 @@ export * from './optimizer'
 export * from './config'
 export { send } from './server/send'
 export { createLogger } from './logger'
+export { resolvePackageData, resolvePackageEntry } from './plugins/resolve'
 
 // additional types
 export type { Plugin } from './plugin'

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -268,7 +268,7 @@ interface PackageData {
 
 const packageCache = new Map<string, PackageData>()
 
-function resolvePackageData(
+export function resolvePackageData(
   id: string,
   basedir: string
 ): PackageData | undefined {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -255,7 +255,7 @@ function tryOptimizedResolve(
   }
 }
 
-interface PackageData {
+export interface PackageData {
   dir: string
   hasSideEffects: (id: string) => boolean
   data: {


### PR DESCRIPTION
These functions can be useful to plugins.

  - `resolvePackageData` provides cache reuse
  - `resolvePackageEntry` is complicated enough to be burdensome to reimplement for a plugin to achieve the same behavior