### PR TITLE
feat: export normalizePath helper

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -5,6 +5,7 @@ export * from './config'
 export { send } from './server/send'
 export { createLogger } from './logger'
 export { resolvePackageData, resolvePackageEntry } from './plugins/resolve'
+export { normalizePath } from './utils'
 
 // additional types
 export type { Plugin } from './plugin'


### PR DESCRIPTION
Expose `normalizePath` from utils so it can be used by VitePress when comparing paths against `chunk.facadeModuleId`

Needed as part of fixing https://github.com/vuejs/vitepress/issues/193