### PR TITLE
fix: dev server resolve plugin for win32

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -60,7 +60,7 @@ export function resolvePlugin({
       // explicit fs paths that starts with /@fs/*
       if (asSrc && id.startsWith(FS_PREFIX)) {
         let fsPath = id.slice(FS_PREFIX.length - 1)
-        if (fsPath.startsWith('//')) fsPath = fsPath.slice(1)
+        if (fsPath.startsWith('/')) fsPath = fsPath.slice(1)
         res = tryFsResolve(fsPath, false)
         isDebug && debug(`[@fs] ${chalk.cyan(id)} -> ${chalk.dim(res)}`)
         // always return here even if res doesn't exist since /@fs/ is explicit

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -12,6 +12,7 @@ import {
   isExternalUrl,
   isObject,
   normalizePath,
+  fsPathFromId,
   resolveFrom
 } from '../utils'
 import { ViteDevServer } from '..'
@@ -59,8 +60,7 @@ export function resolvePlugin({
 
       // explicit fs paths that starts with /@fs/*
       if (asSrc && id.startsWith(FS_PREFIX)) {
-        let fsPath = id.slice(FS_PREFIX.length - 1)
-        if (fsPath.startsWith('/')) fsPath = fsPath.slice(1)
+        const fsPath = fsPathFromId(id)
         res = tryFsResolve(fsPath, false)
         isDebug && debug(`[@fs] ${chalk.cyan(id)} -> ${chalk.dim(res)}`)
         // always return here even if res doesn't exist since /@fs/ is explicit

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -59,6 +59,17 @@ export function normalizePath(id: string): string {
   return path.posix.normalize(id)
 }
 
+const SLASH_VOLUME_RE = /^\/[A-Z]:/
+export function fsPathFromId(id: string): string {
+  let fsPath = id.slice(FS_PREFIX.length - 1)
+  if (fsPath.startsWith('//')) {
+    fsPath = fsPath.slice(1)
+  } else if (isWindows && SLASH_VOLUME_RE.test(fsPath)) {
+    fsPath = normalizePath(fsPath.slice(1))
+  }
+  return fsPath
+}
+
 export const queryRE = /\?.*$/
 export const hashRE = /#.*$/
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -59,15 +59,9 @@ export function normalizePath(id: string): string {
   return path.posix.normalize(id)
 }
 
-const SLASH_VOLUME_RE = /^\/[A-Z]:/
 export function fsPathFromId(id: string): string {
-  let fsPath = id.slice(FS_PREFIX.length - 1)
-  if (fsPath.startsWith('//')) {
-    fsPath = fsPath.slice(1)
-  } else if (isWindows && SLASH_VOLUME_RE.test(fsPath)) {
-    fsPath = normalizePath(fsPath.slice(1))
-  }
-  return fsPath
+  const fsPath = normalizePath(id.slice(FS_PREFIX.length))
+  return fsPath.startsWith('/') ? fsPath : `/${fsPath}`
 }
 
 export const queryRE = /\?.*$/


### PR DESCRIPTION
Fixed a slash check in `plugins/resolve.ts` `resolved()` that was causing the dev server to fail for paths in windows.