### PR TITLE
fix(create-app): vue package name

### DIFF
--- a/packages/create-app/template-vue/package.json
+++ b/packages/create-app/template-vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-starter",
+  "name": "vite-vue-starter",
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Fixes starter name collision reported by jest (both vanilla and vue were named `vite-starter`)
Changed it to `vite-vue-starter` following the convention of other starters. 