### PR TITLE
fix: generate source map if lines are prepended

### DIFF
--- a/packages/vite/src/node/plugins/importsAnalysis.ts
+++ b/packages/vite/src/node/plugins/importsAnalysis.ts
@@ -375,6 +375,13 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         )
 
       if (s) {
+        if (hasEnv || hasHMR)
+          return {
+            code: s.toString(),
+            map: s.generateMap({
+              source: importer
+            })
+          }
         return s.toString()
       } else {
         return source


### PR DESCRIPTION
This corrects the line offset when debugging a module that has lines injected by the `importAnalysisPlugin` (ie: `import.meta.env` or `import.meta.hot`)