### PR TITLE
docs: add migration hint for alias resolving

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -36,11 +36,16 @@
 
 - All Vue specific options are removed; Pass options to the Vue plugin instead.
 
-- [`alias`](/config/#alias) is now being passed to `@rollup/plugin-alias`. Thus, directory aliases need to end with a slash since they are direct string replacements: 
+## Alias Behavior Change
+
+[`alias`](/config/#alias) is now being passed to `@rollup/plugin-alias` and no longer require start/ending slashes. The behavior is now a direct replacement, so 1.0-style directory aliases now require an ending slash:
+
 ```diff
 - alias: { '/@foo/': path.resolve(__dirname, 'some-special-dir') }
 + alias: { '/@foo/': path.resolve(__dirname, 'some-special-dir') + '/' }
 ```
+
+Alternatively, you can use the `[{ find: RegExp, replacement: string }]` option format for more precise control.
 
 ## Vue Support
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -36,10 +36,10 @@
 
 - All Vue specific options are removed; Pass options to the Vue plugin instead.
 
-- [`alias`](/config/#alias) is now being passed to `@rollup/plugin-alias`. Thus, directory aliases now require RegEx: 
+- [`alias`](/config/#alias) is now being passed to `@rollup/plugin-alias`. Thus, directory aliases need to end with a slash since they are direct string replacements: 
 ```diff
 - alias: { '/@foo/': path.resolve(__dirname, 'some-special-dir') }
-+ alias: [ { find: /^\/@foo\/(.*)/, replacement: `${path.resolve(__dirname, 'some-special-dir')}/$1`, } ]
++ alias: { '/@foo/': path.resolve(__dirname, 'some-special-dir') + '/' }
 ```
 
 ## Vue Support

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -36,6 +36,12 @@
 
 - All Vue specific options are removed; Pass options to the Vue plugin instead.
 
+- [`alias`](/config/#alias) is now being passed to `@rollup/plugin-alias`. Thus, directory aliases now require RegEx: 
+```diff
+- alias: { '/@foo/': path.resolve(__dirname, 'some-special-dir') }
++ alias: [ { find: /^\/@foo\/(.*)/, replacement: `${path.resolve(__dirname, 'some-special-dir')}/$1`, } ]
+```
+
 ## Vue Support
 
 Vite 2.0 core is now framework agnostic. Vue support is now provided via [`@vitejs/plugin-vue`](https://github.com/vitejs/vite/tree/main/packages/plugin-vue). Simply install it and add it in the Vite config:


### PR DESCRIPTION
While migrating to Vite 2, I found myself having trouble with my `alias` config. The Migration guide did not explicitly mention the change to `@rollup/plugin-alias` and the implications of that.

PR aims at clarifying that. 😄 