### PR TITLE
fix: Cannot find module './logo.svg' 

### DIFF
--- a/packages/create-app/template-react-ts/src/custom.d.ts
+++ b/packages/create-app/template-react-ts/src/custom.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: any
+  export default content
+}


### PR DESCRIPTION
使用 create-app 创建的 react-ts 项目，运行 npm run build 会报错 ”Cannot find module './logo.svg' or its corresponding type declarations.“，添加了一个类型声明文件修复此报错