### PR TITLE
fix(optimizer): resolve linked dep from relative root

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -124,6 +124,7 @@ export async function optimizeDeps(
   if (options.link) {
     for (const linkedDep of options.link) {
       await resolveLinkedDeps(
+        config.root,
         linkedDep,
         qualified,
         external,
@@ -364,7 +365,14 @@ async function resolveQualifiedDeps(
 
   if (linked.length) {
     for (const dep of linked) {
-      await resolveLinkedDeps(dep, qualified, external, config, aliasResolver)
+      await resolveLinkedDeps(
+        root,
+        dep,
+        qualified,
+        external,
+        config,
+        aliasResolver
+      )
     }
   }
 
@@ -375,13 +383,14 @@ async function resolveQualifiedDeps(
 }
 
 async function resolveLinkedDeps(
+  root: string,
   dep: string,
   qualified: Record<string, string>,
   external: string[],
   config: ResolvedConfig,
   aliasResolver: PluginContainer
 ) {
-  const depRoot = path.dirname(resolveFrom(`${dep}/package.json`, config.root))
+  const depRoot = path.dirname(resolveFrom(`${dep}/package.json`, root))
   const { qualified: q, external: e } = await resolveQualifiedDeps(
     depRoot,
     config,


### PR DESCRIPTION
see: #1353 

Suppose we have a monorepo such as:
```
|_ Vite App  (require A)
|_ Dep A (require B)
|_ Dep B
```
We need to resolve link dep recursively by resolving the dep from the importer root as opposed to config.root.