### PR TITLE
feat: add `build.getPublicHash` option

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -297,8 +297,12 @@ async function doBuild(
         const { getPublicHash } = options
         const publicMap: { [file: string]: string } = {}
 
-        fs.mkdirSync(outDir, { recursive: true })
-        crawlDir(publicDir, (file, name) => {
+        const dirs = new Set<string>()
+        const ensureDir = (dir: string) =>
+          dirs.has(dir) ||
+          (dirs.add(dir), fs.mkdirSync(dir, { recursive: true }))
+
+        crawlDir(publicDir, (file, name, parent) => {
           const srcFile = path.join(publicDir, file)
           const assetHash = getPublicHash(srcFile)
 
@@ -309,6 +313,7 @@ async function doBuild(
               file.slice(0, -assetExt.length) + '.' + assetHash + assetExt
           }
 
+          ensureDir(path.join(outDir, parent))
           fs.copyFileSync(srcFile, path.join(outDir, outFile))
           publicMap['/' + slash(file)] = '/' + slash(outFile)
         })

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -17,6 +17,7 @@ import { resolvePlugin } from './plugins/resolve'
 import { createLogger, Logger, LogLevel } from './logger'
 import { DepOptimizationOptions } from './optimizer'
 import { createFilter } from '@rollup/pluginutils'
+import { checkPublicFiles } from './plugins/asset'
 
 const debug = createDebugger('vite:config')
 
@@ -111,6 +112,7 @@ export type ResolvedConfig = Readonly<
     build: Required<BuildOptions>
     assetsInclude: (file: string) => boolean
     logger: Logger
+    publicUrls: { [file: string]: string }
   }
 >
 
@@ -214,7 +216,8 @@ export async function resolveConfig(
     assetsInclude(file: string) {
       return DEFAULT_ASSETS_RE.test(file) || assetsFilter(file)
     },
-    logger: createLogger(config.logLevel)
+    logger: createLogger(config.logLevel),
+    publicUrls: command == 'serve' ? checkPublicFiles(resolvedRoot) : {}
   }
 
   resolved.plugins = await resolvePlugins(

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -59,6 +59,10 @@ export interface Plugin extends RollupPlugin {
    */
   configResolved?: (config: ResolvedConfig) => void
   /**
+   * Use this hook to read and store the final resolved vite config.
+   */
+  assetsCopied?: (publicMap: { readonly [file: string]: string }) => void
+  /**
    * Configure the vite server. The hook receives the {@link ViteDevServer}
    * instance. This can also be used to store a reference to the server
    * for use in other hooks.

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -59,10 +59,6 @@ export interface Plugin extends RollupPlugin {
    */
   configResolved?: (config: ResolvedConfig) => void
   /**
-   * Use this hook to read and store the final resolved vite config.
-   */
-  assetsCopied?: (publicMap: { readonly [file: string]: string }) => void
-  /**
    * Configure the vite server. The hook receives the {@link ViteDevServer}
    * instance. This can also be used to store a reference to the server
    * for use in other hooks.

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -131,8 +131,9 @@ async function fileToBuiltUrl(
   pluginContext: PluginContext,
   skipPublicCheck = false
 ): Promise<string> {
-  if (!skipPublicCheck && checkPublicFile(id, config.root)) {
-    return config.build.base + id.slice(1)
+  const publicUrl = !skipPublicCheck && config.publicUrls[id]
+  if (publicUrl) {
+    return config.build.base + publicUrl.slice(1)
   }
 
   let cache = assetCache.get(config)
@@ -183,8 +184,9 @@ export async function urlToBuiltUrl(
   config: ResolvedConfig,
   pluginContext: PluginContext
 ): Promise<string> {
-  if (checkPublicFile(url, config.root)) {
-    return config.build.base + url.slice(1)
+  const publicUrl = config.publicUrls[url]
+  if (publicUrl) {
+    return config.build.base + publicUrl.slice(1)
   }
   const file = url.startsWith('/')
     ? path.join(config.root, url)

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -74,6 +74,11 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
+export function checkPublicFiles(root: string): { [file: string]: string } {
+  const get = (_: any, file: string) => checkPublicFile(file, root) && file
+  return new Proxy({}, { get })
+}
+
 export function checkPublicFile(url: string, root: string): string | undefined {
   // note if the file is in /public, the resolver would have returned it
   // as-is so it's not going to be a fully resolved path.

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -14,7 +14,7 @@ import {
   transform
 } from '@vue/compiler-dom'
 import MagicString from 'magic-string'
-import { checkPublicFile, assetUrlRE, urlToBuiltUrl } from './asset'
+import { assetUrlRE, checkPublicFiles, urlToBuiltUrl } from './asset'
 import { isCSSRequest, chunkToEmittedCssFileMap } from './css'
 
 const htmlProxyRE = /\?html-proxy&index=(\d+)\.js$/
@@ -69,11 +69,15 @@ const assetAttrsConfig: Record<string, string[]> = {
 export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   const [preHooks, postHooks] = resolveHtmlTransforms(config.plugins)
   const processedHtml = new Map<string, string>()
-  const isExcludedUrl = (url: string) =>
-    isExternalUrl(url) || isDataUrl(url) || checkPublicFile(url, config.root)
+  const isExcludedUrl = (url: string) => isExternalUrl(url) || isDataUrl(url)
 
+  let publicMap = checkPublicFiles(config.root)
   return {
     name: 'vite:build-html',
+
+    assetsCopied(_publicMap) {
+      publicMap = _publicMap
+    },
 
     async transform(html, id) {
       if (id.endsWith('.html')) {
@@ -126,16 +130,15 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               typeAttr && typeAttr.value && typeAttr.value.content === 'module'
 
             const url = srcAttr && srcAttr.value && srcAttr.value.content
-            if (url && checkPublicFile(url, config.root)) {
+            const publicUrl = url && publicMap[url]
+            if (publicUrl) {
               // referencing public dir url, prefix with base
               s.overwrite(
                 srcAttr.value!.loc.start.offset,
                 srcAttr.value!.loc.end.offset,
-                config.build.base + url.slice(1)
+                config.build.base + publicUrl.slice(1)
               )
-            }
-
-            if (isJsModule) {
+            } else if (isJsModule) {
               inlineModuleIndex++
               if (url && !isExcludedUrl(url)) {
                 // <script type="module" src="..."/>
@@ -161,7 +164,14 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 assetAttrs.includes(p.name)
               ) {
                 const url = p.value.content
-                if (!isExcludedUrl(url)) {
+                const publicUrl = publicMap[url]
+                if (publicUrl) {
+                  s.overwrite(
+                    p.value.loc.start.offset,
+                    p.value.loc.end.offset,
+                    config.build.base + publicUrl.slice(1)
+                  )
+                } else if (!isExcludedUrl(url)) {
                   if (node.tag === 'link' && isCSSRequest(url)) {
                     // CSS references, convert to import
                     js += `\nimport ${JSON.stringify(url)}`
@@ -169,12 +179,6 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   } else {
                     assetUrls.push(p)
                   }
-                } else if (checkPublicFile(url, config.root)) {
-                  s.overwrite(
-                    p.value.loc.start.offset,
-                    p.value.loc.end.offset,
-                    config.build.base + url.slice(1)
-                  )
                 }
               }
             }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -14,7 +14,7 @@ import {
   transform
 } from '@vue/compiler-dom'
 import MagicString from 'magic-string'
-import { assetUrlRE, checkPublicFiles, urlToBuiltUrl } from './asset'
+import { assetUrlRE, urlToBuiltUrl } from './asset'
 import { isCSSRequest, chunkToEmittedCssFileMap } from './css'
 
 const htmlProxyRE = /\?html-proxy&index=(\d+)\.js$/
@@ -71,13 +71,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   const processedHtml = new Map<string, string>()
   const isExcludedUrl = (url: string) => isExternalUrl(url) || isDataUrl(url)
 
-  let publicMap = checkPublicFiles(config.root)
   return {
     name: 'vite:build-html',
-
-    assetsCopied(_publicMap) {
-      publicMap = _publicMap
-    },
 
     async transform(html, id) {
       if (id.endsWith('.html')) {
@@ -130,7 +125,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               typeAttr && typeAttr.value && typeAttr.value.content === 'module'
 
             const url = srcAttr && srcAttr.value && srcAttr.value.content
-            const publicUrl = url && publicMap[url]
+            const publicUrl = url && config.publicUrls[url]
             if (publicUrl) {
               // referencing public dir url, prefix with base
               s.overwrite(
@@ -164,7 +159,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 assetAttrs.includes(p.name)
               ) {
                 const url = p.value.content
-                const publicUrl = publicMap[url]
+                const publicUrl = config.publicUrls[url]
                 if (publicUrl) {
                   s.overwrite(
                     p.value.loc.start.offset,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -291,7 +291,7 @@ export function emptyDir(dir: string) {
 
 export function crawlDir(
   root: string,
-  onFile: (file: string, name: string) => void
+  onFile: (file: string, name: string, parent: string) => void
 ) {
   const recurse = (parent: string) =>
     fs.readdirSync(path.join(root, parent)).forEach((name) => {
@@ -300,7 +300,7 @@ export function crawlDir(
       if (stat.isDirectory()) {
         recurse(child)
       } else {
-        onFile(child, name)
+        onFile(child, name, parent)
       }
     })
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -289,16 +289,20 @@ export function emptyDir(dir: string) {
   }
 }
 
-export function copyDir(srcDir: string, destDir: string) {
-  fs.mkdirSync(destDir, { recursive: true })
-  for (const file of fs.readdirSync(srcDir)) {
-    const srcFile = path.resolve(srcDir, file)
-    const destFile = path.resolve(destDir, file)
-    const stat = fs.statSync(srcFile)
-    if (stat.isDirectory()) {
-      copyDir(srcFile, destFile)
-    } else {
-      fs.copyFileSync(srcFile, destFile)
-    }
-  }
+export function crawlDir(
+  root: string,
+  onFile: (file: string, name: string) => void
+) {
+  const recurse = (parent: string) =>
+    fs.readdirSync(path.join(root, parent)).forEach((name) => {
+      const child = path.join(parent, name)
+      const stat = fs.statSync(path.join(root, child))
+      if (stat.isDirectory()) {
+        recurse(child)
+      } else {
+        onFile(child, name)
+      }
+    })
+
+  recurse('')
 }


### PR DESCRIPTION
Generate a revision hash for each asset in the public directory.

```ts
import revHash from 'rev-hash'
import fs from 'fs'

export default {
  build: {
    getPublicHash: file => revHash(fs.readFileSync(file)),
  },
}
```

### Features
- Easy HTTP caching of `public/` assets. Cache forever, effortless "invalidation".
- **Internal:** Avoids `checkPublicFile` calls when building, thereby reducing FS calls.