### PR TITLE
feat: add a way to include tag attributes without values on plugins

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -263,7 +263,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
   interface HtmlTagDescriptor {
     tag: string
-    attrs?: Record<string, string>
+    attrs?: Record<string, string | boolean>
     children?: string | HtmlTagDescriptor[]
     /**
      * default: 'head-prepend'

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -303,7 +303,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
 export interface HtmlTagDescriptor {
   tag: string
-  attrs?: Record<string, string>
+  attrs?: Record<string, string | boolean>
   children?: string | HtmlTagDescriptor[]
   /**
    * default: 'head-prepend'
@@ -484,7 +484,11 @@ function serializeTags(tags: HtmlTagDescriptor['children']): string {
 function serializeAttrs(attrs: HtmlTagDescriptor['attrs']): string {
   let res = ''
   for (const key in attrs) {
-    res += ` ${key}=${JSON.stringify(attrs[key])}`
+    if (typeof attrs[key] === 'boolean' && attrs[key]) {
+      res += ` ${key}`
+    } else {
+      res += ` ${key}=${JSON.stringify(attrs[key])}`
+    }
   }
   return res
 }


### PR DESCRIPTION
Change `HtmlTagDescriptor` to allow attribute's values to be boolean

so this 
```js
{
  tag: 'link',
  attrs: {
    rel: 'preconnect',
    href: 'https://fonts.gstatic.com/',
    crossorigin: true,
  }
}
```
> note: setting value to false will skip the attribute

html:
```js
<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
```
