### PR TITLE
fix(build): Pass `allowNodeBuiltins` to rollup instead of empty array…

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -280,7 +280,7 @@ async function doBuild(
       ...options.rollupOptions,
       plugins: config.plugins as Plugin[],
       onwarn(warning, warn) {
-        onRollupWarning(warning, warn, [], options.rollupOptions?.onwarn)
+        onRollupWarning(warning, warn, config.optimizeDeps.allowNodeBuiltins, options.rollupOptions?.onwarn)
       }
     })
 


### PR DESCRIPTION
Fixes #1392 