### PR TITLE
Fixed incorrect server.proxy example in docs

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -224,14 +224,16 @@ export default ({ command, mode }) => {
 
   ```js
   export default {
-    proxy: {
-      // string shorthand
-      '/foo': 'http://localhost:4567/foo',
-      // with options
-      '/api': {
-        target: 'http://jsonplaceholder.typicode.com',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '')
+    server: {
+      proxy: {
+        // string shorthand
+        '/foo': 'http://localhost:4567/foo',
+        // with options
+        '/api': {
+          target: 'http://jsonplaceholder.typicode.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, '')
+        }
       }
     }
   }


### PR DESCRIPTION
The example proxy configuration here: https://vitejs.dev/config/#server-proxy doesn't work because it needs to be in a containing server {} block