### PR TITLE
fix: excessive quoting in rewritten css urls

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -165,7 +165,9 @@ async function fileToBuiltUrl(
       type: 'asset',
       source: content
     })
-    url = `__VITE_ASSET__${fileId}${postfix ? `__${postfix}__` : ``}`
+    url = JSON.stringify(
+      `__VITE_ASSET__${fileId}${postfix ? `__${postfix}__` : ``}`
+    )
   }
 
   cache.set(id, url)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -118,10 +118,9 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
         // account for comments https://github.com/vitejs/vite/issues/426
         css = css.replace(/\/\*[\s\S]*?\*\//gm, '')
         if (cssUrlRE.test(css)) {
-          css = await rewriteCssUrls(css, async (url) => {
-            url = await urlToBuiltUrl(url, id, config, this)
-            return isDataUrl(url) ? url : JSON.stringify(url)
-          })
+          css = await rewriteCssUrls(css, (url) =>
+            urlToBuiltUrl(url, id, config, this)
+          )
         }
       }
       return css


### PR DESCRIPTION
Using `JSON.stringify` is unnecessary, since `rewriteCssUrls` wraps the url with quotes already. Checking for external urls and data urls is also unnecessary, since `rewriteCssUrls` does that too.