### PR TITLE
docs: adding solid plugin to community plugins

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -16,4 +16,8 @@
 
 ## Community Plugins
 
+### [vite-plugin-solid](https://github.com/amoutonbrady/vite-plugin-solid)
+
+- Provides [solid](https://github.com/ryansolid/solid) JSX transformation.
+
 > Submit a PR to add yours.


### PR DESCRIPTION
This is the official vite plugin for [solid](https://github.com/ryansolid/solid). I was already quite into v1 but v2 has been a joy to hack around so far. Impressive work.

I wasn't sure if there was a convention regarding the name of the plugin or the name of the package. This plugin isn't being actively used, I can still change it if that doesn't match your philosophy.