### PR TITLE
feat: allow tag injection after body open (body-prepend)

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -269,7 +269,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
     /**
      * default: 'head-prepend'
      */
-    injectTo?: 'head' | 'body' | 'head-prepend'
+    injectTo?: 'head' | 'body' | 'head-prepend' | 'body-prepend'
   }
   ```
 

--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -55,6 +55,12 @@ function testPage(isNested: boolean) {
     }
   })
 
+  test('body prepend/append transform', async () => {
+    expect(await page.innerHTML('body')).toMatch(
+      /prepended to body(.*)appended to body/s
+    )
+  })
+
   test('css', async () => {
     expect(await getColor('h1')).toBe(isNested ? 'red' : 'blue')
     expect(await getColor('p')).toBe('grey')

--- a/packages/playground/html/vite.config.js
+++ b/packages/playground/html/vite.config.js
@@ -121,6 +121,23 @@ module.exports = {
           ]
         }
       }
+    },
+    {
+      name: 'body-prepend-transform',
+      transformIndexHtml() {
+        return [
+          {
+            tag: 'noscript',
+            children: '<!-- this is appended to body -->',
+            injectTo: 'body'
+          },
+          {
+            tag: 'noscript',
+            children: '<!-- this is prepended to body -->',
+            injectTo: 'body-prepend'
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Add `injectTo: 'body-prepend'` option to `HtmlTagDescriptor` to allow tag injection after body open

so this 
```js
{
  tag: 'noscript',
  injectTo: 'body-prepend',
  children: '<!-- no script content -->'
}
```

renders:
```html
<body>
  <noscript><!-- no script content --></noscript>
  ....
</body>
```
