### PR TITLE
feat(server): add strict-port option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -215,6 +215,12 @@ export default ({ command, mode }) => {
 
   Specify server port. Note if the port is already being used, Vite will automatically try the next available port so this may not be the actual port the server ends up listening on.
 
+### server.strictPort
+
+- **Type:** `boolean`
+
+  Set to `true` to exit if port is already in use, instead of automatically try the next available port.
+
 ### server.https
 
 - **Type:** `boolean | https.ServerOptions`

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -61,7 +61,7 @@ cli
   .option('--https', `[boolean] use TLS + HTTP/2`)
   .option('--open [browser]', `[boolean | string] open browser on startup`)
   .option('--cors', `[boolean] enable CORS`)
-  .option('--sticky-port', `[boolean] exit if specified port is already in use`)
+  .option('--strict-port', `[boolean] exit if specified port is already in use`)
   .option('-m, --mode <mode>', `[string] set env mode`)
   .option(
     '--force',

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -61,6 +61,7 @@ cli
   .option('--https', `[boolean] use TLS + HTTP/2`)
   .option('--open [browser]', `[boolean | string] open browser on startup`)
   .option('--cors', `[boolean] enable CORS`)
+  .option('--sticky-port', `[boolean] exit if specified port is already in use`)
   .option('-m, --mode <mode>', `[string] set env mode`)
   .option(
     '--force',

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -101,7 +101,7 @@ export interface ServerOptions {
   /**
    * If enabled, vite will exit if specified port is already in use
    */
-  stickyPort?: boolean
+  strictPort?: boolean
 }
 
 /**
@@ -406,7 +406,7 @@ async function startServer(
   return new Promise((resolve, reject) => {
     const onError = (e: Error & { code?: string }) => {
       if (e.code === 'EADDRINUSE') {
-        if (options.stickyPort) {
+        if (options.strictPort) {
           httpServer.removeListener('error', onError)
           reject(new Error(`Port ${port} is already in use`))
         } else {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -98,6 +98,10 @@ export interface ServerOptions {
    * using an object.
    */
   cors?: CorsOptions | boolean
+  /**
+   * If enabled, vite will exit if specified port is already in use
+   */
+  stickyPort?: boolean
 }
 
 /**
@@ -402,8 +406,13 @@ async function startServer(
   return new Promise((resolve, reject) => {
     const onError = (e: Error & { code?: string }) => {
       if (e.code === 'EADDRINUSE') {
-        info(`Port ${port} is in use, trying another one...`)
-        httpServer.listen(++port)
+        if (options.stickyPort) {
+          httpServer.removeListener('error', onError)
+          reject(new Error(`Port ${port} is already in use`))
+        } else {
+          info(`Port ${port} is in use, trying another one...`)
+          httpServer.listen(++port)
+        }
       } else {
         httpServer.removeListener('error', onError)
         reject(e)


### PR DESCRIPTION
## Add server strict port option

See #1425

### Enable strict port

exit with code 1 if port is already in use

**`cli`**
```sh
$ vite --strict-port

error when starting dev server:
Error: Port 3000 is already in use
```

**`vite.config.ts`**
```typescript
import { defineConfig } from 'vite'

export default defineConfig({
  server: {
    port: 3000,
    strictPort: true,
  },,
})
```
## Todo
- [ ] Tests
- [x] Update documentation