### PR TITLE
fix(publish): Types missing for plugin-legacy

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "author": "Evan You",
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Hi,

The currently published version of `plugin-legacy` does not include the `index.d.ts` file.