### PR TITLE
fix(optimizer): exclude should not be resolve

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -265,7 +265,8 @@ async function resolveQualifiedDeps(
   const pkg = JSON.parse(pkgContent)
   const deps = Object.keys(pkg.dependencies || {})
   const linked: string[] = []
-  const excludeFilter = exclude && createFilter(exclude)
+  const excludeFilter =
+    exclude && createFilter(exclude, null, { resolve: false })
 
   for (const id of deps) {
     if (include && include.includes(id)) {


### PR DESCRIPTION
`optimizeDeps.exclude` does not work after https://github.com/vitejs/vite/commit/8b8d5061ea44affd3b9bed97da2e629254a6ec28

```js
// vite.config.ts
export default defineConfig({
  plugins: [
    vue()
  ],
  optimizeDeps: {
    exclude: ['element-plus']
  }
})
```