### PR TITLE
fix: typo in the Safari 10 nomodule snippet

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -267,7 +267,7 @@ function viteLegacyPlugin(options = {}) {
       // 2. inject Safari 10 nomodule fix
       tags.push({
         tag: 'script',
-        attrs: { nomdoule: true },
+        attrs: { nomodule: true },
         children: safari10NoModuleFix,
         injectTo: 'body'
       })


### PR DESCRIPTION
I noticed a typo in the snippet injected for the handling of `nomodule` scripts in Safari 10. This PR fixes it.