### PR TITLE
docs: fix typos

### DIFF
--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -24,7 +24,7 @@ This is Vite performing what we call "dependency pre-bundling". This process ser
 
 2. **Performance:** Vite converts ESM dependencies with many internal modules into a single module to improve subsequent page load performance.
 
-   Some packages ship their ES modules builds as many separate files importing one another. For example, [`lodash-es` has over 600 internal modules](https://unpkg.com/browse/lodash-es/)! When we do `import { debounce } from 'lodash-es'`, the browser fires off 600+ HTTP requests at the same time! Even though the server has no problem handling them, the large amount of requests create a network congestion on the browser side, causing the page the load quite a bit slower.
+   Some packages ship their ES modules builds as many separate files importing one another. For example, [`lodash-es` has over 600 internal modules](https://unpkg.com/browse/lodash-es/)! When we do `import { debounce } from 'lodash-es'`, the browser fires off 600+ HTTP requests at the same time! Even though the server has no problem handling them, the large amount of requests create a network congestion on the browser side, causing the page to load noticeably slower.
 
    By pre-bundling `lodash-es` into a single module, we now only need one HTTP request instead!
 

--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -54,7 +54,7 @@ Some dependencies may be designed to be used via deep imports, e.g. `firebase` e
 
 ## Dependency Compatibility
 
-While Vite tries its best to accomodate non-ESM dependencies, there are going to be some dependencies that won't work out of the box. The most common types are those that imports Node.js built-in modules (e.g. `os` or `path`) and expects the bundler to automatically shim them. These packages are typically written assuming all users will be consuming it with `webpack`, but such usage does not make sense when targeting browser environments.
+While Vite tries its best to accomodate non-ESM dependencies, there are going to be some dependencies that won't work out of the box. The most common types are those that import Node.js built-in modules (e.g. `os` or `path`) and expect the bundler to automatically shim them. These packages are typically written assuming all users will be consuming it with `webpack`, but such usage does not make sense when targeting browser environments.
 
 When using Vite, it is strongly recommended to always prefer dependencies that provide ESM formats. This will make your build faster, and results in smaller production bundles due to more efficient tree-shaking.
 

--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -24,7 +24,7 @@ This is Vite performing what we call "dependency pre-bundling". This process ser
 
 2. **Performance:** Vite converts ESM dependencies with many internal modules into a single module to improve subsequent page load performance.
 
-   Some packages ship their ES modules builds as many separate files importing one another. For example, [`lodash-es` has over 600 internal modules](https://unpkg.com/browse/lodash-es/)! When we do `import { debounce } from 'lodash-es`, the browser fires off 600+ HTTP requests at the same time! Even though the server has no problem handling them, the large amount of requests create a network congestion on the browser side, causing the page the load quite a bit slower.
+   Some packages ship their ES modules builds as many separate files importing one another. For example, [`lodash-es` has over 600 internal modules](https://unpkg.com/browse/lodash-es/)! When we do `import { debounce } from 'lodash-es'`, the browser fires off 600+ HTTP requests at the same time! Even though the server has no problem handling them, the large amount of requests create a network congestion on the browser side, causing the page the load quite a bit slower.
 
    By pre-bundling `lodash-es` into a single module, we now only need one HTTP request instead!
 


### PR DESCRIPTION
b9d1c2a closes single quote:
```diff
- `import { debounce } from 'lodash-es`
+ `import { debounce } from 'lodash-es'`
```

a56e2bc changes wording:
```diff
- causing the page the load quite a bit slower.
+ causing the page to load noticeably slower.
```

7be0188 fixes case:
```diff
- The most common types are those that imports Node.js
+ The most common types are those that import Node.js
```