### PR TITLE
fix: display outdir correctly after build

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -1,4 +1,3 @@
-import path from 'path'
 import chalk from 'chalk'
 import { Plugin } from 'rollup'
 import { ResolvedConfig } from '../config'
@@ -38,8 +37,9 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
         ).toFixed(2)}kb`
       : ``
 
-    let outDir = path.posix.relative(process.cwd(), config.build.outDir)
-    if (!outDir.endsWith('/')) outDir += '/'
+    let outDir = config.build.outDir.replace(/\\/g, '/')
+    !outDir.startsWith('.') && (outDir = './' + outDir)
+    !outDir.endsWith('/') && (outDir += '/')
     config.logger.info(
       `${chalk.gray(chalk.white.dim(outDir))}${writeColors[type](
         filePath.padEnd(maxLength + 2)


### PR DESCRIPTION
About https://github.com/vitejs/vite/commit/2da0f2f66e6efe454755d663d00ba984c09031be#diff-804926239ab7ce5dd12d3ba02244733917a7a54582b67c8212e130679aa00508R41
```ts
// default outDir = 'dist'
export default defineConfig({
  plugins: [vue()]
})
// ../dist/index.html
```

```ts
// I am not sure it is be allowed, but it work fine for me
export default defineConfig({
  plugins: [vue()],
  build: {
    outDir: '.\\dist'
  }
})
// ../.\dist/index.html
```

```ts
// Here are some tests after this fix
const outDirs = ['dist', 'dist/', './dist', './dist/', '../dist', '../dist/', '.\\dist']

outDirs.forEach(outDir => {
  outDir = outDir.replace(/\\/g, '/')
  !outDir.startsWith('.') && (outDir = './' + outDir)
  !outDir.endsWith('/') && (outDir += '/')
  console.log(outDir)
})

// ./dist/
// ./dist/
// ./dist/
// ./dist/
// ../dist/
// ../dist/
// ./dist/
```