### PR TITLE
fix(vite): Show target build mode in logs

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -264,7 +264,7 @@ async function doBuild(
   inlineConfig: InlineConfig = {}
 ): Promise<RollupOutput | RollupOutput[]> {
   const config = await resolveConfig(inlineConfig, 'build', 'production')
-  config.logger.info(chalk.cyan(`building for production...`))
+  config.logger.info(chalk.cyan(`building for ${config.mode}...`))
 
   const options = config.build
   const libOptions = options.lib


### PR DESCRIPTION
When building the inscription "Build for production ..." is always displayed in the console. This PR fix this: the name of the target mode is displayed in the console:
```
$ vite build --mode development
building for development...
../dist/assets/main.90d02498.js      0.07kb / brotli: 0.07kb
```

```
$ vite build --mode test
building for test...
../dist/assets/main.90d02498.js      0.07kb / brotli: 0.07kb
```