### PR TITLE
feat(vite): Allow RegEx as server.proxy keys

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -85,7 +85,7 @@ export default ({ command, mode }) => {
 
 ### plugins
 
-- **Type:** `(Plugin | Plugin[])[]`
+- **Type:** ` (Plugin | Plugin[])[]`
 
   Array of plugins to use. See [Plugin API](/guide/api-plugin) for more details on Vite plugins.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -85,7 +85,7 @@ export default ({ command, mode }) => {
 
 ### plugins
 
-- **Type:** ` (Plugin | Plugin[])[]`
+- **Type:** `(Plugin | Plugin[])[]`
 
   Array of plugins to use. See [Plugin API](/guide/api-plugin) for more details on Vite plugins.
 
@@ -257,7 +257,7 @@ export default ({ command, mode }) => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, '')
         }
-        // with RegEx expression
+        // with RegEx
         '^\/fallback\/.*': {
           target: 'http://jsonplaceholder.typicode.com',
           changeOrigin: true,

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -239,7 +239,9 @@ export default ({ command, mode }) => {
 
 - **Type:** `Record<string, string | ProxyOptions>`
 
-  Configure custom proxy rules for the dev server. Expects an object of `{ key: options }` pairs. Uses [`http-proxy`](https://github.com/http-party/node-http-proxy). Full options [here](https://github.com/http-party/node-http-proxy#options).
+  Configure custom proxy rules for the dev server. Expects an object of `{ key: options }` pairs. If the key starts with `^`, it will be interpreted as a `RegExp`.
+
+  Uses [`http-proxy`](https://github.com/http-party/node-http-proxy). Full options [here](https://github.com/http-party/node-http-proxy#options).
 
   **Example:**
 
@@ -254,6 +256,12 @@ export default ({ command, mode }) => {
           target: 'http://jsonplaceholder.typicode.com',
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, '')
+        }
+        // with RegEx expression
+        '^\/fallback\/.*': {
+          target: 'http://jsonplaceholder.typicode.com',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/fallback/, '')
         }
       }
     }

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -258,7 +258,7 @@ export default ({ command, mode }) => {
           rewrite: (path) => path.replace(/^\/api/, '')
         }
         // with RegEx
-        '^\/fallback\/.*': {
+        '^/fallback/.*': {
           target: 'http://jsonplaceholder.typicode.com',
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/fallback/, '')

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -1,11 +1,11 @@
+import chalk from 'chalk'
 import * as http from 'http'
-import { createDebugger } from '../../utils'
 import httpProxy from 'http-proxy'
-import { HMR_HEADER } from '../ws'
-import { ViteDevServer } from '..'
 import { Connect } from 'types/connect'
 import { HttpProxy } from 'types/http-proxy'
-import chalk from 'chalk'
+import { ViteDevServer } from '..'
+import { createDebugger } from '../../utils'
+import { HMR_HEADER } from '../ws'
 
 const debug = createDebugger('vite:proxy')
 
@@ -78,7 +78,10 @@ export function proxyMiddleware({
   return (req, res, next) => {
     const url = req.url!
     for (const context in proxies) {
-      if (url.startsWith(context)) {
+      if (
+        (context.startsWith('^') && new RegExp(context).test(url)) ||
+        url.startsWith(context)
+      ) {
         const [proxy, opts] = proxies[context]
 
         if (opts.bypass) {

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -1,11 +1,11 @@
-import chalk from 'chalk'
 import * as http from 'http'
+import { createDebugger } from '../../utils'
 import httpProxy from 'http-proxy'
+import { HMR_HEADER } from '../ws'
+import { ViteDevServer } from '..'
 import { Connect } from 'types/connect'
 import { HttpProxy } from 'types/http-proxy'
-import { ViteDevServer } from '..'
-import { createDebugger } from '../../utils'
-import { HMR_HEADER } from '../ws'
+import chalk from 'chalk'
 
 const debug = createDebugger('vite:proxy')
 


### PR DESCRIPTION
Implements #1416 

Requiring `^` as the beginning of the string is desirable IMO to avoid unnecessary RegEx parsing of all literals