### PR TITLE
feat: server.open API support open page

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -235,6 +235,12 @@ export default ({ command, mode }) => {
 
   Automatically open the app in the browser on server start.
 
+### server.openPage
+
+- **Type:** `string`
+
+  Specify a page to navigate to when opening the browser.
+
 ### server.proxy
 
 - **Type:** `Record<string, string | ProxyOptions>`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -231,15 +231,19 @@ export default ({ command, mode }) => {
 
 ### server.open
 
-- **Type:** `boolean`
+- **Type:** `boolean | string`
 
-  Automatically open the app in the browser on server start.
+  Automatically open the app in the browser on server start. When `path` string is provided, the browser will automatically open the page.
+  
+  **Example:**
+  ```js
+  export default {
+    server: {
+      open: '/docs/index.html'
+    }
+  }
+  ```
 
-### server.openPage
-
-- **Type:** `string`
-
-  Specify a page to navigate to when opening the browser.
 
 ### server.proxy
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -233,7 +233,7 @@ export default ({ command, mode }) => {
 
 - **Type:** `boolean | string`
 
-  Automatically open the app in the browser on server start. When `path` string is provided, the browser will automatically open the page.
+  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.
   
   **Example:**
   ```js
@@ -243,7 +243,6 @@ export default ({ command, mode }) => {
     }
   }
   ```
-
 
 ### server.proxy
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -55,6 +55,10 @@ export interface ServerOptions {
    */
   open?: boolean
   /**
+   * Specify a page to navigate to when opening the browser.
+   */
+  openPage?: string
+  /**
    * Force dep pre-optimization regardless of whether deps have changed.
    */
   force?: boolean
@@ -414,6 +418,7 @@ async function startServer(
   let port = inlinePort || options.port || 3000
   let hostname = options.host || 'localhost'
   const protocol = options.https ? 'https' : 'http'
+  const openPage = options.openPage || ''
   const info = server.config.logger.info
 
   return new Promise((resolve, reject) => {
@@ -487,7 +492,7 @@ async function startServer(
 
       if (options.open) {
         openBrowser(
-          `${protocol}://${hostname}:${port}`,
+          `${protocol}://${hostname}:${port}${openPage}`,
           options.open,
           server.config.logger
         )

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -53,11 +53,7 @@ export interface ServerOptions {
   /**
    * Open browser window on startup
    */
-  open?: boolean
-  /**
-   * Specify a page to navigate to when opening the browser.
-   */
-  openPage?: string
+  open?: boolean | string
   /**
    * Force dep pre-optimization regardless of whether deps have changed.
    */
@@ -418,7 +414,6 @@ async function startServer(
   let port = inlinePort || options.port || 3000
   let hostname = options.host || 'localhost'
   const protocol = options.https ? 'https' : 'http'
-  const openPage = options.openPage || ''
   const info = server.config.logger.info
 
   return new Promise((resolve, reject) => {
@@ -491,9 +486,10 @@ async function startServer(
       }
 
       if (options.open) {
+        const path = typeof options.open === 'string' ? options.open : ''
         openBrowser(
-          `${protocol}://${hostname}:${port}${openPage}`,
-          options.open,
+          `${protocol}://${hostname}:${port}${path}`,
+          true,
           server.config.logger
         )
       }


### PR DESCRIPTION
Specify a page to navigate to when opening the browser.