### PR TITLE
docs: Add Packages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ In addition, Vite is highly extensible via its [Plugin API](https://vitejs.dev/g
 
 Vite is now in 2.0 beta. Check out the [Migration Guide](https://vitejs.dev/guide/migration.html) if you are upgrading from 1.x.
 
+## Packages
+
+| Package                                                       | Version                                                                                                                                                |
+|---------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [vite](packages/vite)                                         | [![vite version](https://img.shields.io/npm/v/vite.svg?label=%20)](packages/vite/CHANGELOG.md)                                                         |
+| [@vitejs/plugin-vue](packages/plugin-vue)                     | [![plugin-vue version](https://img.shields.io/npm/v/@vitejs/plugin-vue.svg?label=%20)](packages/plugin-vue/CHANGELOG.md)                               |
+| [@vitejs/plugin-vue-jsx](packages/plugin-vue-jsx)             | [![plugin-vue-jsx version](https://img.shields.io/npm/v/@vitejs/plugin-vue-jsx.svg?label=%20)](packages/plugin-vue-jsx/CHANGELOG.md)                   |
+| [@vitejs/plugin-react-refresh](packages/plugin-react-refresh) | [![plugin-react-refresh version](https://img.shields.io/npm/v/@vitejs/plugin-react-refresh.svg?label=%20)](packages/plugin-react-refresh/CHANGELOG.md) |
+| [@vitejs/plugin-legacy](packages/plugin-legacy)               | [![plugin-legacy version](https://img.shields.io/npm/v/@vitejs/plugin-legacy.svg?label=%20)](packages/plugin-legacy/CHANGELOG.md)                      |
+| [@vitejs/create-app](packages/create-app)                     | [![create-app version](https://img.shields.io/npm/v/@vitejs/create-app.svg?label=%20)](packages/create-app/CHANGELOG.md)  
+
 ## Contribution
 
 See [Contributing Guide](https://github.com/vitejs/vite/tree/main/.github/contributing.md).


### PR DESCRIPTION
I often come to this repository from the main page of the github. And for me it is a little inconvenient to go to subdirectories for a long time if I want to look at the actual version or changelog of some package.

Other users may feel the same.

How about add a simple table with a list of all packages, theirs current versions and direct links to sources and changelogs?