### PR TITLE
chore: fix commit-convention.md RegEx

### DIFF
--- a/.github/commit-convention.md
+++ b/.github/commit-convention.md
@@ -7,7 +7,7 @@
 Messages must be matched by the following regex:
 
 ``` js
-/^(revert: )?(feat|fix|docs|style|refactor|perf|test|workflow|build|ci|chore|types|wip): .{1,50}/
+/^(revert: )?(feat|fix|docs|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(\(.+\))?: .{1,50}/
 ```
 
 #### Examples


### PR DESCRIPTION
See https://github.com/vitejs/vite/blob/main/scripts/verifyCommit.js

The pattern described in the docs did not match the actual regex. Since `verifyCommit` last change is more recent, I used that