### PR TITLE
feat(plugin-vue-jsx): support `tsxLegacyDecorator` option

### DIFF
--- a/packages/plugin-vue-jsx/index.d.ts
+++ b/packages/plugin-vue-jsx/index.d.ts
@@ -1,6 +1,11 @@
 import { Plugin } from 'vite'
 import { VueJSXPluginOptions } from '@vue/babel-plugin-jsx'
 
-declare function createPlugin(options?: VueJSXPluginOptions): Plugin
+export type Options = VueJSXPluginOptions & {
+  /** enable the legacy (stage 1) decorators syntax support for TSX */
+  tsxLegacyDecorator?: boolean;
+}
+
+declare function createPlugin(options?: Options): Plugin
 
 export default createPlugin

--- a/packages/plugin-vue-jsx/index.js
+++ b/packages/plugin-vue-jsx/index.js
@@ -37,8 +37,19 @@ function vueJsxPlugin(options = {}) {
 
     transform(code, id) {
       if (/\.[jt]sx$/.test(id)) {
+        /** @type {any[]} */
         const plugins = [importMeta, [jsx, options]]
         if (id.endsWith('.tsx')) {
+          if (options.tsxLegacyDecorator) {
+            plugins.push([
+              require('@babel/plugin-proposal-decorators'),
+              { legacy: true }
+            ], [
+              require('@babel/plugin-proposal-class-properties'),
+              { loose: true }
+            ])
+          }
+
           plugins.push([
             require('@babel/plugin-transform-typescript'),
             // @ts-ignore

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -26,6 +26,8 @@
   "homepage": "https://github.com/vitejs/vite/tree/main/packages/plugin-vue-jsx#readme",
   "dependencies": {
     "@babel/core": "^7.12.10",
+    "@babel/plugin-proposal-class-properties": "^7.12.1",
+    "@babel/plugin-proposal-decorators": "^7.12.12",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-transform-typescript": "^7.12.1",
     "@vue/babel-plugin-jsx": "^1.0.1",


### PR DESCRIPTION
Also fixes a jsdoc error in `plugin-vue-jsx` which says `import('.').Options` but there's no such type in index.d.ts