### PR TITLE
feat: local non-module scripts in index.html

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -144,6 +144,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 js += `\nimport "${id}?html-proxy&index=${inlineModuleIndex}.js"`
                 shouldRemove = true
               }
+            } else if (url && !isExcludedUrl(url)) {
+              assetUrls.push(srcAttr)
             }
           }
 


### PR DESCRIPTION
If a `<script>` points to a local file (eg: `/a/b.js`) and is *not* a `module` type, it should be treated like a static asset.

I'm working on [a plugin](https://github.com/alloc/vite-plugin-rehost) that expects this behavior.