### PR TITLE
fix: manually test global regex codeframeRE index

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -121,6 +121,7 @@ export class ErrorOverlay extends HTMLElement {
     this.root = this.attachShadow({ mode: 'open' })
     this.root.innerHTML = template
 
+    codeframeRE.lastIndex = 0
     const hasFrame = err.frame && codeframeRE.test(err.frame)
     const message = hasFrame
       ? err.message.replace(codeframeRE, '')


### PR DESCRIPTION
`codeframeRE.test` may return `false` incorrectly, because `codeframeRE` has the `g` flag and the search may begin from middle of string after first time calling `test`. This pr is manually resetting the index before `test` gets `called`


```js
const pattern = /^foo/g
pattern.test('foo') // true
pattern.test('foo') // false
```