### PR TITLE
manifest plugin: handle dynamic imports

### DIFF
--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -6,7 +6,8 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
     string,
     {
       file: string
-      imports?: string[]
+      imports?: string[],
+      dynamicImports?: string[]
     }
   > = {}
 
@@ -18,14 +19,15 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
       for (const file in bundle) {
         const chunk = bundle[file]
         if (chunk.type === 'chunk') {
-          if (chunk.isEntry) {
+          if (chunk.isEntry || chunk.isDynamicEntry) {
             const name =
               format === 'system' && !chunk.name.includes('-legacy')
                 ? chunk.name + '-legacy'
                 : chunk.name
             manifest[name + '.js'] = {
               file: chunk.fileName,
-              imports: chunk.imports
+              imports: chunk.imports,
+              dynamicImports: chunk.dynamicImports
             }
           }
         } else if (chunk.name) {


### PR DESCRIPTION
I'm using vite with Vue 3 TS and lazy loading routes.

Previously (with vite 1) I was able to generate preload meta tags using `shouldPreload()` function, but now I'm trying to migrate this functionality to a custom plugin using the `manifest.json` file.

Currently the manifest plugin generates the following output:

```json
{
  "index.js": {
    "file": "assets/index.47f0281f.js",
    "imports": []
  }
}
```

With this little PR the `manifest.json` will contain all the dynamic imports in the following way, allowing a much wider area of use:

``` json
{
  "index.js": {
    "file": "assets/index.47f0281f.js",
    "imports": [],
    "dynamicImports": [
      "assets/About.e27cd12c.js"
    ]
  },
  "About.js": {
    "file": "assets/About.e27cd12c.js",
    "imports": [
       "assets/index.47f0281f.js",
     ],
    "dynamicImports": []
  }
}
```