### PR TITLE
fix(plugin-dynamic-import): add assetDir in module path

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -1,6 +1,7 @@
 import { ResolvedConfig } from '..'
 import { Plugin } from '../plugin'
 import { isModernFlag } from './importAnaysisBuild'
+import path from 'path'
 
 export const polyfillId = 'vite/dynamic-import-polyfill'
 
@@ -9,7 +10,9 @@ export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
   let polyfillLoaded = false
   const polyfillString =
     `const p = ${polyfill.toString()};` +
-    `${isModernFlag}&&p(${JSON.stringify(config.build.base)});`
+    `${isModernFlag}&&p(${JSON.stringify(
+      path.join(config.build.base, config.build.assetsDir, '/')
+    )});`
 
   return {
     name: 'vite:dynamic-import-polyfill',

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -1,7 +1,6 @@
 import { ResolvedConfig } from '..'
 import { Plugin } from '../plugin'
 import { isModernFlag } from './importAnaysisBuild'
-import path from 'path'
 
 export const polyfillId = 'vite/dynamic-import-polyfill'
 
@@ -11,7 +10,7 @@ export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
   const polyfillString =
     `const p = ${polyfill.toString()};` +
     `${isModernFlag}&&p(${JSON.stringify(
-      path.join(config.build.base, config.build.assetsDir, '/')
+      path.posix.join(config.build.base, config.build.assetsDir, '/')
     )});`
 
   return {


### PR DESCRIPTION
This is fixing dynamic import polyfill by adding the assets dir in the basePath

<img width="2469" alt="Screen Shot 2021-01-20 at 11 05 52 AM" src="https://user-images.githubusercontent.com/4596409/105202175-b12bb200-5b0f-11eb-90d8-1bd04f6eb9d8.png">

Screenshot above highlights the issue (run the app in edge 18)

repro: https://github.com/AlexandreBonaventure/vite-dynamic-import-bug