### PR TITLE
docs: vite rollup plugins

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -345,7 +345,7 @@ function myPlugin() {
 }
 ```
 
-## Rollup Plugin Compatiblity
+## Rollup Plugin Compatibility
 
 A fair number of Rollup plugins will work directly as a Vite plugin (e.g. `@rollup/plugin-alias` or `@rollup/plugin-json`), but not all of them, since some plugin hooks do not make sense in an unbundled dev server context.
 
@@ -372,3 +372,5 @@ export default {
   ]
 }
 ```
+
+Check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official rollup plugins with usage instructions.

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -21,3 +21,7 @@
 ## Community Plugins
 
 Check out [awesome-vite](https://github.com/vitejs/awesome-vite) - you can also submit a PR to list your plugins there.
+
+## Rollup Plugins
+
+[Vite plugins](../guide/api-plugin) are an extension of Rollup's plugin interface. Check out the [Rollup Plugin Compatibility section](../guide/api-plugin#rollup-plugin-compatibility) for more information.


### PR DESCRIPTION
As suggested in https://github.com/vitejs/vite/issues/1549#issuecomment-761253020, this PR adds a link to https://vite-rollup-plugins.patak.dev in the rollup plugin compat section.

Also fixed a typo and added a section in Plugins/index that links to Rollup Plugin Compatibility Section.