### PR TITLE
fix: optimized cjs deps checking in windows

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -480,7 +480,7 @@ function isOptimizedCjs(
   }: ViteDevServer
 ): boolean {
   if (optimizeDepsMetadata && optimizeCacheDir) {
-    const relative = path.relative(optimizeCacheDir, cleanUrl(id))
+    const relative = path.posix.relative(optimizeCacheDir, cleanUrl(id))
     return relative in optimizeDepsMetadata.cjsEntries
   }
   return false


### PR DESCRIPTION
Fix https://github.com/vitejs/vite/issues/1630

Use `path.posix` for relative path because `cjsEntries` from rollup chunks are all POSIX path