### PR TITLE
feat: call `resolveId` hooks in `urlToBuiltUrl`

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -203,6 +203,10 @@ export async function urlToBuiltUrl(
     return url.slice(1)
   }
 
+  if (url.startsWith(config.root + '/')) {
+    url = url.split(config.root)[1]
+  }
+
   if (checkPublicFile(url, config.root)) {
     return config.build.base + url.slice(1)
   }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -196,12 +196,16 @@ export async function urlToBuiltUrl(
   config: ResolvedConfig,
   pluginContext: PluginContext
 ): Promise<string> {
+  url = (await pluginContext.resolve(url, importer))?.id || url
+
   if (checkPublicFile(url, config.root)) {
     return config.build.base + url.slice(1)
   }
+
   const file = url.startsWith('/')
     ? path.join(config.root, url)
     : path.join(path.dirname(importer), url)
+
   return fileToBuiltUrl(
     file,
     config,

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -198,6 +198,11 @@ export async function urlToBuiltUrl(
 ): Promise<string> {
   url = (await pluginContext.resolve(url, importer))?.id || url
 
+  // The resolving plugin wants to force its own url.
+  if (url.startsWith('!')) {
+    return url.slice(1)
+  }
+
   if (checkPublicFile(url, config.root)) {
     return config.build.base + url.slice(1)
   }


### PR DESCRIPTION
This is useful for rewriting asset urls in `index.html` and `.css` files.

**Also in this PR:** When a `resolveId` hook's `importer` ends with `.css` or `.html`,  the hook can prepend its return value with `!` to signify a built url, which skips the `fileToBuiltUrl` call in `urlToBuiltUrl`.     For example, if the resolving plugin called `emitFile` from its `resolveId` hook, it can return `!__VITE_ASSET__xxx` to be replaced by Vite later on. 

I use these features in both [`vite-plugin-public`](https://github.com/alloc/vite-plugin-public) and [`vite-plugin-rehost`](https://github.com/alloc/vite-plugin-rehost).