### PR TITLE
fix: Specifying server.watch.ignored makes vite watch node_modules

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -255,12 +255,12 @@ export async function createServer(
     : await resolveHttpServer(serverConfig, middlewares)
   const ws = createWebSocketServer(httpServer, config)
 
-  const watchOptions = serverConfig.watch || {}
+  const {ignored = [], ...watchOptions} = serverConfig.watch || {}
   const watcher = chokidar.watch(root, {
     ignored: [
       '**/node_modules/**',
       '**/.git/**',
-      ...(watchOptions.ignored || [])
+      ...ignored
     ],
     ignoreInitial: true,
     ignorePermissionErrors: true,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -255,7 +255,7 @@ export async function createServer(
     : await resolveHttpServer(serverConfig, middlewares)
   const ws = createWebSocketServer(httpServer, config)
 
-  const {ignored = [], ...watchOptions} = serverConfig.watch || {}
+  const { ignored = [], ...watchOptions } = serverConfig.watch || {}
   const watcher = chokidar.watch(root, {
     ignored: [
       '**/node_modules/**',


### PR DESCRIPTION
Hi Evan,

Just discovered while looking through the code that when `ignored` is specified for the `server.watch` options the default values are discarded, which makes vite watch the node_modules directory.