### PR TITLE
feat: resolved ids rollup compat for win32 (#1522)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -13,6 +13,7 @@ import {
   isObject,
   normalizePath,
   fsPathFromId,
+  ensureVolumeInPath,
   resolveFrom,
   isDataUrl,
   cleanUrl,
@@ -262,7 +263,7 @@ function tryResolveFile(
         if (index) return normalizePath(index) + query
       }
     } else {
-      return normalizePath(file) + query
+      return normalizePath(ensureVolumeInPath(file)) + query
     }
   }
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -60,15 +60,18 @@ const isWindows = os.platform() === 'win32'
 const VOLUME_RE = /^[A-Z]:/i
 
 export function normalizePath(id: string): string {
-  if (isWindows) {
-    return path.posix.normalize(slash(id.replace(VOLUME_RE, '')))
-  }
-  return path.posix.normalize(id)
+  return path.posix.normalize(isWindows ? slash(id) : id)
 }
 
 export function fsPathFromId(id: string): string {
   const fsPath = normalizePath(id.slice(FS_PREFIX.length))
-  return fsPath.startsWith('/') ? fsPath : `/${fsPath}`
+  return fsPath.startsWith('/') || fsPath.match(VOLUME_RE)
+    ? fsPath
+    : `/${fsPath}`
+}
+
+export function ensureVolumeInPath(file: string): string {
+  return isWindows ? path.resolve(file) : file
 }
 
 export const queryRE = /\?.*$/


### PR DESCRIPTION
### Context

This PR aligns Vite server resolved ids in Windows with the way paths are handled in Rollup. I tried to assess the impact of this change as best as I could, further review and testing may be needed.

In Rollup, if the `resolveId` hook defaults the resolution of absolute paths to a fully resolved path that [includes the volume](https://github.com/rollup/rollup/blob/1ad8289205b7af3d5adf3043f782934adbcb8b65/src/utils/resolveId.ts#L30). 

[@rollup/plugin-alias](https://github.com/rollup/plugins/tree/master/packages/alias) internally normalizes paths by [removing the volume](https://github.com/rollup/plugins/blob/master/packages/alias/src/index.ts#L32), but this id is fed to the [resolveId hook manually](https://github.com/rollup/plugins/blob/f75d5a7fff89bff5f3d59cb268926337b709598a/packages/alias/src/index.ts#L114), and ends up being resolved so the volume is part of the final id.

The rest of the official rollup plugins, uses the `createFilter(include,exclude)` pattern internally that normalizes paths by switching all slashes to posix, but leaves the volume untouched.

Vite server is currently removing the volume as part of its path normalization, so the filters for rollup plugins are not compatible. The `createFilter` pattern is common practice in official rollup plugins, so I think it is important to try to fix this compatibility issue.

### Changes

These changes only affect windows

- `normalizePath` only changes slashes to posix, aligned with rollup
- `fsPathFromId` keeps the volume in windows
- `tryResolveFile` in `vite:resolve` plugin uses `path.resolve` in windows to ensure the volume is present

### Tests

- In windows, all tests were green after these changes (Windows 10 Home, 10.0.18363 N/A Build 18363, Node version: v15.5.0, yarn v1.22.10)
- @rollup/plugin-replace include/exclude filters now works. Fixes https://github.com/vitejs/vite/issues/1522
- @rollup/plugin-strip default include config now works. Fixes https://github.com/vitejs/vite/issues/1522#issuecomment-761819314
- Other rollup plugins that are using the `createFilter(include,exclude)` pattern should also work now.

### Observations

- I also tested wmr, and it looks like it is also removing the volume so they should be experiencing the same compatibility issues
- [`normalizePath` from @rolluputils](https://github.com/rollup/plugins/blob/f75d5a7fff89bff5f3d59cb268926337b709598a/packages/typescript/src/index.ts#L40) could be used instead of the current version. This may help avoid compatibility issues in the future.
- In Rollup, ids are only normalized inside filters, but slashes are not normalized to posix in windows as part of the default id resolution. There remains a compat issue because of this difference with vite in [@rollup/plugin-legacy](https://github.com/rollup/plugins/blob/master/packages/legacy) (https://github.com/vitejs/vite/issues/1521). Aligning the usage of slashes is more involved though, and I do not know how important it is. I think rollup plugins should normalize paths, and @rollup/plugin-legacy could be patched to do so.



