### PR TITLE
feat: add vue sfc typescript module declare

### DIFF
--- a/packages/create-app/template-vue-ts/src/shims-vue.d.ts
+++ b/packages/create-app/template-vue-ts/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+/* eslint-disable */
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}


### PR DESCRIPTION
Add `.vue` sfc typescript module declare file to avoid error like `Cannot find module './App.vue' or its corresponding type declarations.ts(2307)`.