### PR TITLE
Patch include & exclude

### DIFF
--- a/packages/plugin-react-refresh/index.d.ts
+++ b/packages/plugin-react-refresh/index.d.ts
@@ -1,6 +1,12 @@
 import { Plugin } from 'vite'
+import { FilterPattern } from '@rollup/pluginutils'
 
-type PluginFactory = () => Plugin
+type PluginOptions = {
+  include?: FilterPattern
+  exclude?: FilterPattern
+}
+
+type PluginFactory = (options: PluginOptions) => Plugin
 
 declare const createPlugin: PluginFactory & { preambleCode: string }
 

--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 const fs = require('fs')
 const { transformSync } = require('@babel/core')
+const { createFilter } = require('@rollup/pluginutils')
 
 const runtimePublicPath = '/@react-refresh'
 const runtimeFilePath = require.resolve(
@@ -34,8 +35,12 @@ window.__vite_plugin_react_preamble_installed__ = true
  *
  * @returns {import('vite').Plugin}
  */
-module.exports = function reactRefreshPlugin() {
+module.exports = function reactRefreshPlugin(options) {
   let shouldSkip = false
+  const filter = createFilter(
+    options.include || /\.(t|j)sx?$/,
+    options.exclude || /node_modules/
+  )
 
   return {
     name: 'react-refresh',
@@ -61,7 +66,7 @@ module.exports = function reactRefreshPlugin() {
         return
       }
 
-      if (!/\.(t|j)sx?$/.test(id) || id.includes('node_modules')) {
+      if (!filter(id)) {
         return
       }
 

--- a/packages/plugin-react-refresh/package.json
+++ b/packages/plugin-react-refresh/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
+    "@rollup/pluginutils": "^4.1.0",
     "react-refresh": "^0.9.0"
   }
 }


### PR DESCRIPTION
To use Vite in a CRA app, it's necessary to override the include & exclude options.

Sample config, <https://github.com/ambar/cra-to-vite/blob/main/vite.config.js>: 

```js
import {defineConfig} from 'vite'
import reactRefresh from '@vitejs/plugin-react-refresh'
import inject from '@rollup/plugin-inject'

const include = 'src/**/*.js'

export default defineConfig({
  plugins: [
    // provider global `React` variable to `jsxFactory`
    inject({React: 'react', include}),
    reactRefresh({include}),
  ],
  esbuild: {
    include,
    // unexpected, unnecessary
    exclude: [],
    loader: 'jsx',
    // Uncaught ReferenceError
    // jsxInject: `import React from 'react'`,
  },
})
```