### PR TITLE
fix(optimizer): pnp compat to match relative paths

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -105,10 +105,10 @@ export function esbuildDepPlugin(
 
       // yarn 2 pnp compat
       if (isRunningWithYarnPnp) {
-        build.onResolve({ filter: /\.yarn.*/ }, (args) => ({
+        build.onResolve({ filter: /.*/ }, (args) => ({
           path: require.resolve(args.path, { paths: [args.resolveDir] })
         }))
-        build.onLoad({ filter: /\.yarn.*/ }, async (args) => ({
+        build.onLoad({ filter: /.*/ }, async (args) => ({
           contents: await require('fs').promises.readFile(args.path),
           loader: 'default'
         }))


### PR DESCRIPTION
https://github.com/vitejs/vite/commit/028c3bb1a6c5f56eaa7f8f122200d6262a1a8683 tries to match only dependencies with .yarn match but this is not working when 3rd party dependencies import relative paths (ie lodash: `import unzip from './unzip.js'`)

This code was not tested but it _should_ do the trick (could maybe conflicts with other resolvers)