### PR TITLE
fix: handle path with dollar signs

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -223,6 +223,7 @@ export async function resolveConfig(
 
   // resolve alias with internal client alias
   const resolvedAlias = mergeAlias(
+    // @ts-ignore
     [{ find: /^\/@vite\//, replacement: () => CLIENT_DIR + '/' }],
     config.alias || []
   )

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -223,7 +223,7 @@ export async function resolveConfig(
 
   // resolve alias with internal client alias
   const resolvedAlias = mergeAlias(
-    [{ find: /^\/@vite\//, replacement: CLIENT_DIR + '/' }],
+    [{ find: /^\/@vite\//, replacement: () => CLIENT_DIR + '/' }],
     config.alias || []
   )
 


### PR DESCRIPTION
**What's the problem this PR addresses?**

Vite doesn't work when the path it is in contains dollar signs

Fixes https://github.com/vitejs/vite/issues/1423
Ref https://twitter.com/youyuxi/status/1354094331876016134

**How did you fix it?**

Use the callback version of `.replace`.

**More**

This should be handled correctly in all places that uses `.replace` (for example https://github.com/vitejs/vite/blob/1e67d669318fac320c61ea00e0e01e972183fa27/packages/vite/src/node/plugins/clientInjections.ts#L43-L51) but this serves more as a pointer than a full fix in the entire codebase