### PR TITLE
fix: allow ssr css preloads in preload-helper

### DIFF
--- a/packages/vite/src/node/plugins/importAnaysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnaysisBuild.ts
@@ -47,7 +47,7 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
       if (dep in seen) return
       // @ts-ignore
       seen[dep] = true
-      const isCss = /\.css$/.test(dep)
+      const isCss = dep.endsWith('.css')
       // @ts-ignore check if the file is already preloaded by SSR markup
       if (document.querySelector(`link[href="${dep}"]`)) {
         return

--- a/packages/vite/src/node/plugins/importAnaysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnaysisBuild.ts
@@ -48,8 +48,9 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
       // @ts-ignore
       seen[dep] = true
       const isCss = dep.endsWith('.css')
+      const cssSelector = isCss ? '[rel="stylesheet"]' : ''
       // @ts-ignore check if the file is already preloaded by SSR markup
-      if (document.querySelector(`link[href="${dep}"]`)) {
+      if (document.querySelector(`link[href="${dep}"]${cssSelector}`)) {
         return
       }
       // @ts-ignore


### PR DESCRIPTION
I came across this bug while I was experimenting with preloading css that I know would end up being loaded during app execution.

In my app, I know various components that my page is going to load ahead of time, so I use the manifest.json to inject `link[rel=modulepreload/preload][as=script/style]` preloads in `<head>` before delivering it to the browser that I know will be loaded later on.

In built index.html file, if you add css preloads for the same href as the app is going to load, the app does not append link[rel="stylesheet"] to the document. This is due to a conditional in [importAnaysisBuild](https://github.com/vitejs/vite/blob/82d87d91048b90282c4cae079ee142deb2a782d5/packages/vite/src/node/plugins/importAnaysisBuild.ts#L40)

Example:
```
<head>
   ...
   <link rel="preload" as="style" href="/assets/MyComponent.32451e5d.css">
   ...
</head>
```

During app page execution, the following should have been appended to the document head, but was not:
```
<link rel="stylesheet" href="/assets/MyComponent.32451e5d.css">
```

This PR fixes this issue and also includes some performance improvements to the surrounding logic.
