### PR TITLE
fix: don't override resolver options

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -322,9 +322,9 @@ export async function resolveConfig(
                 dedupe: resolved.dedupe,
                 isProduction,
                 isBuild: command === 'build',
-                asSrc: options?.asSrc || true,
-                relativeFirst: options?.relativeFirst || false,
-                tryIndex: options?.tryIndex || true,
+                asSrc: options?.asSrc ?? true,
+                relativeFirst: options?.relativeFirst ?? false,
+                tryIndex: options?.tryIndex ?? true,
                 extensions: options?.extensions
               })
             ]


### PR DESCRIPTION
The `asSrc` and `tryIndex` options were always getting resolved to true here.