### PR TITLE
Fix HMR for @fs imported modules caused by module duplication

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -138,7 +138,7 @@ function fileToDevUrl(id: string, { root, base }: ResolvedConfig) {
   } else {
     // outside of project root, use absolute fs path
     // (this is special handled by the serve static middleware
-    rtn = FS_PREFIX + id
+    rtn = path.posix.join(FS_PREFIX, id)
   }
 
   return path.posix.join(base, rtn)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -183,7 +183,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           url = resolved.id.slice(config.root.length)
         } else if (fs.existsSync(cleanUrl(resolved.id))) {
           // exists but out of root: rewrite to absolute /@fs/ paths
-          url = FS_PREFIX + resolved.id
+          url = path.posix.join(FS_PREFIX, resolved.id)
         } else {
           url = resolved.id
         }


### PR DESCRIPTION
### Description 📖 

This pull request is an attempt to fix #1749.

### Background 📜 

The urls for files imported from outside the root are prefixed with `/@fs/`.

If the file path was absolute, the result is a `/@fs//...` url, with two slashes.

Have in mind that `path.join` and `path.posix.join` will return a joined path with any double slashes __removed__.

### The Bug 🐞 

Modules with an `@fs` url are duplicated in the module graph, because they are:

- Added first in `ensureEntryFromUrl` with a url that has a double slash
- Updated in `updateModuleInfo` with a url without a double slash

The reason it doesn't have a double slash when updates, is that `path.posix.join` removes the double slash from `/@fs//...` and turns it into `/@fs/...`.

`join` is called [__after__ calling `ensureEntryFromUrl`](https://github.com/vitejs/vite/blob/2950c3c278e20174184e44c194393b098c0d4305/packages/vite/src/node/plugins/importAnalysis.ts#L222-L234), and [__before__ calling `updateModuleInfo`](https://github.com/vitejs/vite/blob/2950c3c278e20174184e44c194393b098c0d4305/packages/vite/src/node/plugins/importAnalysis.ts#L354-L458).


### Summary

HMR works again with this fix, and the patch added in #1323 ensures the double slash is added again.