### PR TITLE
fix(build): ensure dist file name is correctly inferred

### DIFF
--- a/packages/playground/lib/package.json
+++ b/packages/playground/lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-lib",
+  "name": "@example/my-lib",
   "private": true,
   "version": "0.0.0",
   "scripts": {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -340,9 +340,7 @@ async function doBuild(
 
     paralellBuilds.push(bundle)
 
-    const pkgName =
-      libOptions &&
-      JSON.parse(lookupFile(config.root, ['package.json']) || `{}`).name
+    const pkgName = libOptions && getPkgName(config.root)
 
     const generate = (output: OutputOptions = {}) => {
       return bundle[options.write ? 'write' : 'generate']({
@@ -430,6 +428,14 @@ async function doBuild(
     }
     throw e
   }
+}
+
+function getPkgName(root: string) {
+  const { name } = JSON.parse(lookupFile(root, ['package.json']) || `{}`)
+
+  if (!name) throw new Error('no name found in package.json')
+
+  return name.startsWith('@') ? name.split('/')[1] : name
 }
 
 function createMoveToVendorChunkFn(config: ResolvedConfig): GetManualChunk {


### PR DESCRIPTION
When building a package with a scoped name like:
```json
{
  "name": "@linusborg/my-cool-lib"
}
```
this will create the following folder structure:

```ascii
dist/
  |- @linusborg/
    |- my-cool-lib.es.js
```

But what we want is:

```ascii
dist/
  |- my-cool-lib.es.js
```

This PR solves this by stripping the package name's scope before using it as the output filename for rollup.