### PR TITLE
docs: plugin naming conventions

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -4,6 +4,26 @@ Vite plugins extends Rollup's well-designed plugin interface with a few extra vi
 
 **It is recommended to go through [Rollup's plugin documentation](https://rollupjs.org/guide/en/#plugin-development) first before reading the sections below.**
 
+## Conventions
+
+If the plugin doesn't use Vite specific hooks and can be implemented as a [Compatible Rollup Plugin](#rollup-plugin-compatibility), then it is recommended to use the [Rollup Plugin naming conventions](https://rollupjs.org/guide/en/#conventions)
+
+- Rollup Plugins should have a clear name with `rollup-plugin-` prefix.
+- Include `rollup-plugin` and `vite-plugin` keywords in package.json.
+
+This exposes the plugin to be also used in pure Rollup or WMR based projects
+
+For Vite only plugins
+
+- Vite Plugins should have a clear name with `vite-plugin-` prefix.
+- Include `vite-plugin` keyword in package.json.
+
+If your plugin is only going to work for a particular framework, its name should be included as part of the prefix
+
+- `vite-plugin-vue-` prefix for Vue Plugins
+- `vite-plugin-react-` prefix for React Plugins
+- `vite-plugin-svelte-` prefix for Svelte Plugins
+
 ## Simple Examples
 
 :::tip


### PR DESCRIPTION
Based on a discussion with @antfu, this PR adds a plugin naming conventions section to the docs.

There are plugins being created for Vite with the `vite-plugin-` prefix when they could work fine as Rollup plugins. I think it should be recommended that if a plugin could be implemented as a pure rollup plugin, it should use the `rollup-plugin-` prefix.
We also discussed framework-specific plugins. Having a consistent convention for each framework could also be helpful.