### PR TITLE
fix(dev): do not update when there are no modules

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -174,12 +174,14 @@ export async function handleFileAddUnlink(
         modules.push(module)
       }
     }
-    updateModules(
-      getShortName(file, server.config.root),
-      modules,
-      Date.now(),
-      server
-    )
+    if (modules.length > 0) {
+      updateModules(
+        getShortName(file, server.config.root),
+        modules,
+        Date.now(),
+        server
+      )
+    }
   }
 }
 


### PR DESCRIPTION
Mini reproduction:
1. create a new vite project
2. `yarn dev`
3. add a file in the root directory

The logger prints `上午1:57:12 [vite]`, there are no message
https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/hmr.ts#L148-L153