### PR TITLE
fix(vite): Forbid injecting URL timestamp in ssr environment

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -218,16 +218,18 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         // check if the dep has been hmr updated. If yes, we need to attach
         // its last updated timestamp to force the browser to fetch the most
         // up-to-date version of this module.
-        try {
-          const depModule = await moduleGraph.ensureEntryFromUrl(url)
-          if (depModule.lastHMRTimestamp > 0) {
-            url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)
+        if (!ssr) {
+          try {
+            const depModule = await moduleGraph.ensureEntryFromUrl(url)
+            if (depModule.lastHMRTimestamp > 0) {
+              url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)
+            }
+          } catch (e) {
+            // it's possible that the dep fails to resolve (non-existent import)
+            // attach location to the missing import
+            e.pos = pos
+            throw e
           }
-        } catch (e) {
-          // it's possible that the dep fails to resolve (non-existent import)
-          // attach location to the missing import
-          e.pos = pos
-          throw e
         }
 
         // prepend base (dev base is guaranteed to have ending slash)


### PR DESCRIPTION
When vite-server started and changed the `create-app.ts` file.
the ssrLoadModule method will be converted to the following code example

Example:
```javascript
const __vite_ssr_import_0__ = __vite_ssr_import__("/.create-app.ts?t=1612082979827")
```

`__vite_ssr_import__("/.create-app.ts?t=1612082979827")`Cannot get the module
