### PR TITLE
fix(vite): esbuild dep scan handle tsx lang

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -186,8 +186,8 @@ function esbuildScanPlugin(
           const langMatch = openTag.match(langRE)
           const lang =
             langMatch && (langMatch[1] || langMatch[2] || langMatch[3])
-          if (lang === 'ts') {
-            loader = 'ts'
+          if (lang === 'ts' || lang === 'tsx') {
+            loader = lang
           }
           if (srcMatch) {
             const src = srcMatch[1] || srcMatch[2] || srcMatch[3]


### PR DESCRIPTION
Check if lang for esbuild parse is tsx, changing esbuild loader time to match lang. This ensures tsx based Vue files (possibly tsx files) are correctly parsed.