### PR TITLE
docs: update plugin-react-refresh README.md for middleware mode

### DIFF
--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -28,6 +28,14 @@ export default {
 
 [Full list of Babel parser plugins](https://babeljs.io/docs/en/babel-parser#ecmascript-proposalshttpsgithubcombabelproposals).
 
+**Notes**
+
+- If using TSX, any TS-supported syntax will already be transpiled away so you won't need to specify them here.
+
+- This option only enables the plugin to parse these syntax - it does not perform any transpilation since this plugin is dev-only.
+
+- If you wish to transpile the syntax for production, you will need to configure the transform separately using [@rollup/plugin-babel](https://github.com/rollup/plugins/tree/master/packages/babel) as a build-only plugin.
+
 ## Middleware Mode Notes
 
 When Vite is launched in **Middleware Mode**, you need to make sure your entry `index.html` file is transformed with `ViteDevServer.transformIndexHtml`. Otherwise, you may get an error prompting `Uncaught Error: vite-plugin-react can't detect preamble. Something is wrong.`
@@ -48,11 +56,3 @@ app.get('/', async (req, res, next) => {
   }
 });
 ```
-
-**Notes**
-
-- If using TSX, any TS-supported syntax will already be transpiled away so you won't need to specify them here.
-
-- This option only enables the plugin to parse these syntax - it does not perform any transpilation since this plugin is dev-only.
-
-- If you wish to transpile the syntax for production, you will need to configure the transform separately using [@rollup/plugin-babel](https://github.com/rollup/plugins/tree/master/packages/babel) as a build-only plugin.

--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -28,6 +28,27 @@ export default {
 
 [Full list of Babel parser plugins](https://babeljs.io/docs/en/babel-parser#ecmascript-proposalshttpsgithubcombabelproposals).
 
+## Middleware Mode Notes
+
+When Vite is launched in **Middleware Mode**, you need to make sure your entry `index.html` file is transformed with `ViteDevServer.transformIndexHtml`. Otherwise, you may get an error prompting `Uncaught Error: vite-plugin-react can't detect preamble. Something is wrong.`
+
+To mitigate this issue, you can explicitly transform your `index.html` like this when configuring your express server:
+
+```ts
+app.get('/', async (req, res, next) => {
+  try {
+    let html = fs.readFileSync(
+      path.resolve(root, 'index.html'),
+      'utf-8'
+    );
+    html = await viteServer.transformIndexHtml(req.url, html);
+    res.send(html);
+  } catch (e) {
+    return next(e);
+  }
+});
+```
+
 **Notes**
 
 - If using TSX, any TS-supported syntax will already be transpiled away so you won't need to specify them here.


### PR DESCRIPTION
While I was setting up a react app with Vite, everything works fine before enabling `reactRefresh` plugin.
When this is enabled, we will get a "vite-plugin-react can't detect preamble" error. After some investigation, looks like on the userland we need to explicitly transform the index file with `ViteDevServer.transformIndexHtml`.

Related:
- https://github.com/vitejs/vite/blob/da365475b157576427a92f8cfecaacf36e20b97e/packages/vite/src/node/server/index.ts#L447-L455
- https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201