### PR TITLE
fix(vite): close server and exit if stdin ends

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -337,13 +337,20 @@ export async function createServer(
 
   server.transformIndexHtml = createDevHtmlTransformFn(server)
 
-  process.once('SIGTERM', async () => {
+  const exitProcess = async () => {
     try {
       await server.close()
     } finally {
       process.exit(0)
     }
-  })
+  }
+
+  process.once('SIGTERM', exitProcess)
+
+  if (!process.stdin.isTTY) {
+    process.stdin.on('end', exitProcess)
+    process.stdin.resume()
+  }
 
   watcher.on('change', async (file) => {
     file = normalizePath(file)


### PR DESCRIPTION
## Description

When running Vite from a parent process (Elixir Phoenix dev watcher in my case) the process doesn't shut down and keeps running in the background after the parent process is stopped.

### Example

Starting and then stopping `mix phx.server` with watchers set up to run `npx vite` leaves two ghost processes still running:

```
# ps aux | grep vite  ### simplified output
nullpilot   ?   S   14:31   0:00 sh -c vite
nullpilot   ?   Sl  14:31   0:00 node /home/nullpilot/demo_project/assets/node_modules/.bin/vite
```

## Solution 

In vue-cli the webpack approach was used, and a flag was added to address this (vuejs/vue-cli#1597)

Here I am instead using the same approach used in rollup (rollup/rollup#3493) to do it without adding an extra flag.

With the change, running the same as above no longer leaves any dangling processes running and everything shuts down as expected.


