### PR TITLE
check wasClean in onclose event

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -169,7 +169,8 @@ async function queueUpdate(p: Promise<(() => void) | undefined>) {
 }
 
 // ping server
-socket.addEventListener('close', () => {
+socket.addEventListener('close', ({ wasClean }) => {
+  if (wasClean) return
   console.log(`[vite] server connection lost. polling for restart...`)
   setInterval(() => {
     fetch('/')


### PR DESCRIPTION
Chrome does not trigger an onclose if it was caused by a user page navigation/refresh. However, Firefox does trigger the onclose, this results in a confusing message. The wasClean check avoids this.