### PR TITLE
fix(create-app): add resolveJsonModule to tsconfig.json for vue-ts template

### DIFF
--- a/packages/create-app/template-vue-ts/tsconfig.json
+++ b/packages/create-app/template-vue-ts/tsconfig.json
@@ -8,7 +8,8 @@
     "sourceMap": true,
     "lib": ["esnext", "dom"],
     "types": ["vite/client"],
-    "plugins": [{ "name": "@vuedx/typescript-plugin-vue" }]
+    "plugins": [{ "name": "@vuedx/typescript-plugin-vue" }],
+    "resolveJsonModule": true
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/packages/create-app/template-vue-ts/tsconfig.json
+++ b/packages/create-app/template-vue-ts/tsconfig.json
@@ -9,7 +9,8 @@
     "lib": ["esnext", "dom"],
     "types": ["vite/client"],
     "plugins": [{ "name": "@vuedx/typescript-plugin-vue" }],
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
Since Vite has built-in support for importing json, I think it's reasonable to have this enabled so the json be imported out-of-the-box.