### PR TITLE
fix: allow scan to use user provided loaders

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -330,21 +330,32 @@ function esbuildScanPlugin(
         let ext = path.extname(id).slice(1)
         if (ext === 'mjs') ext = 'js'
 
+        let loader = ext as Loader
+
+        // Use the user given loader if it is explicitly set
+        if (config.esbuild && config.esbuild.loader) {
+          loader = config.esbuild.loader
+        }
+
         let contents = fs.readFileSync(id, 'utf-8')
-        if (ext.endsWith('x') && config.esbuild && config.esbuild.jsxInject) {
-          contents = config.esbuild.jsxInject + `\n` + contents
+        if (
+          loader.endsWith('x') &&
+          config.esbuild &&
+          config.esbuild.jsxInject
+        ) {
+          contents = `${config.esbuild.jsxInject}\n${contents}`
         }
 
         if (contents.includes('import.meta.glob')) {
-          return transformGlob(contents, id, config.root, ext as Loader).then(
+          return transformGlob(contents, id, config.root, loader).then(
             (contents) => ({
-              loader: ext as Loader,
+              loader: loader,
               contents
             })
           )
         }
         return {
-          loader: ext as Loader,
+          loader: loader,
           contents
         }
       })

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -349,13 +349,13 @@ function esbuildScanPlugin(
         if (contents.includes('import.meta.glob')) {
           return transformGlob(contents, id, config.root, loader).then(
             (contents) => ({
-              loader: loader,
+              loader,
               contents
             })
           )
         }
         return {
-          loader: loader,
+          loader,
           contents
         }
       })


### PR DESCRIPTION
If the user js sources have `jsx` syntaxes, but the file extension ends with `js`, he may want to force esbuild to use "jsx/tsx" loaders in the `vite.config.js`.
However, during the dep scan phase, the `esbuildScanPlugin` will fail because esbuild will complain that js contains `jsx` tags.
This fix will force the esbuild to use user-provided loader configs during dep scan phase to mitage this issue.