### PR TITLE
docs: fix pre-bundling link

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -12,7 +12,7 @@ import { someMethod } from 'my-dep'
 
 The above will throw an error in the browser. Vite will detect such bare module imports in all served source files and perform the following:
 
-1. [Pre-bundle](./dep-rep-bundling) them to improve page loading speed and convert CommonJS / UMD modules to ESM. The pre-bundling step is performed with [esbuild](http://esbuild.github.io/) and makes Vite's cold start time significantly faster than any JavaScript-based bundler.
+1. [Pre-bundle](./dep-pre-bundling) them to improve page loading speed and convert CommonJS / UMD modules to ESM. The pre-bundling step is performed with [esbuild](http://esbuild.github.io/) and makes Vite's cold start time significantly faster than any JavaScript-based bundler.
 
 2. Rewrite the imports to valid URLs like `/node_modules/.vite/my-dep.js?v=f3sf2ebd` so that the browser can import them properly.
 


### PR DESCRIPTION
Fix Pre-bundling link from https://vitejs.dev/guide/features.html#npm-dependency-resolving-and-pre-bundling to redirect to https://vitejs.dev/guide/dep-pre-bundling.html instead of https://vitejs.dev/guide/dep-rep-bundling.html