### PR TITLE
feat(create-app): clearer vue-ts setup recommend

### DIFF
--- a/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
+++ b/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
@@ -3,7 +3,7 @@
 
   <label>
     <input type="checkbox" v-model="useScriptSetup" /> Use
-    <code>&lt;script setup&gt</code>
+    <code>&lt;script setup&gt;</code>
   </label>
   <label>
     <input type="checkbox" v-model="useTsPlugin" /> Provide types for

--- a/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
+++ b/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
@@ -6,35 +6,41 @@
     <a href="https://v3.vuejs.org/" target="_blank">Vue 3 Documentation</a>
   </p>
 
+  <label>
+    <input type="checkbox" v-model="toggle_1" /> use &lt;script setup&gt;
+  </label>
+  <label>
+    <input type="checkbox" v-model="toggle_2" /> provide types for `*.vue` imports
+  </label>
+
   <p>
     Recommended IDE setup:
     <a href="https://code.visualstudio.com/" target="_blank">VSCode</a>
     +
-    <a
-      href="https://marketplace.visualstudio.com/items?itemName=octref.vetur"
-      target="_blank"
-    >Vetur</a>
-    +
-    <a
-      href="https://marketplace.visualstudio.com/items?itemName=znck.vue-language-features"
-      target="_blank"
-    >Vue DX</a>
+    <template v-if="!toggle_1">
+      <a
+        href="https://marketplace.visualstudio.com/items?itemName=octref.vetur"
+        target="_blank"
+      >Vetur</a>
+      +
+      <a
+        href="https://marketplace.visualstudio.com/items?itemName=znck.vue-language-features"
+        target="_blank"
+      >Vue DX</a>
+    </template>
+    <template v-else>
+      <a href="https://github.com/johnsoncodehk/volar" target="_blank">Volar</a>
+    </template>
   </p>
-  <p>
-    If using &lt;script setup&gt;: use
-    <a
-      href="https://github.com/johnsoncodehk/volar"
-      target="_blank"
-    >Volar</a> instead (and disable Vetur)
-  </p>
-  <p>
-    <b style="color:red">Make sure to use workspace version of TypeScript!!!</b>
-    <br />This leverages the
-    <code>@vuex/typescript-plugin-vue</code> to provide types for `*.vue` imports.
-    <br />1. Open
+  <p v-if="toggle_2">
+    tsconfig setup:
+    <br />1. Add
+    <code>@vuex/typescript-plugin-vue</code> to tsconfig plugins
+    <br />2. Delete shims-vue.d.ts
+    <br />3. Open
     <code>src/main.ts</code> in VSCode
-    <br />2. Open VSCode command input
-    <br />3. Search and run "Select TypeScript version" -> "Use workspace version"
+    <br />4. Open VSCode command input
+    <br />5. Search and run "Select TypeScript version" -> "Use workspace version"
   </p>
   <button @click="count++">count is: {{ count }}</button>
   <p>
@@ -56,7 +62,9 @@ export default defineComponent({
   },
   setup: () => {
     const count = ref(0)
-    return { count }
+    const toggle_1 = ref(false);
+    const toggle_2 = ref(false);
+    return { count, toggle_1, toggle_2 }
   }
 })
 </script>

--- a/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
+++ b/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
@@ -1,23 +1,20 @@
 <template>
   <h1>{{ msg }}</h1>
 
-  <p>
-    <a href="https://vitejs.dev/guide/features.html" target="_blank">Vite Documentation</a> |
-    <a href="https://v3.vuejs.org/" target="_blank">Vue 3 Documentation</a>
-  </p>
-
   <label>
-    <input type="checkbox" v-model="toggle_1" /> use &lt;script setup&gt;
+    <input type="checkbox" v-model="useScriptSetup" /> Use
+    <code>&lt;script setup&gt</code>
   </label>
   <label>
-    <input type="checkbox" v-model="toggle_2" /> provide types for `*.vue` imports
+    <input type="checkbox" v-model="useTsPlugin" /> Provide types for
+    <code>*.vue</code> imports
   </label>
 
   <p>
     Recommended IDE setup:
     <a href="https://code.visualstudio.com/" target="_blank">VSCode</a>
     +
-    <template v-if="!toggle_1">
+    <template v-if="!useScriptSetup">
       <a
         href="https://marketplace.visualstudio.com/items?itemName=octref.vetur"
         target="_blank"
@@ -32,9 +29,9 @@
       <a href="https://github.com/johnsoncodehk/volar" target="_blank">Volar</a>
     </template>
   </p>
-  <p v-if="toggle_2">
+  <p v-if="useTsPlugin">
     tsconfig setup:
-    <br />1. Add
+    <br />1. Install and add
     <code>@vuex/typescript-plugin-vue</code> to tsconfig plugins
     <br />2. Delete shims-vue.d.ts
     <br />3. Open
@@ -47,11 +44,15 @@
     Edit
     <code>components/HelloWorld.vue</code> to test hot module replacement.
   </p>
+
+  <p>
+    <a href="https://vitejs.dev/guide/features.html" target="_blank">Vite Docs</a> |
+    <a href="https://v3.vuejs.org/" target="_blank">Vue 3 Docs</a>
+  </p>
 </template>
 
 <script lang="ts">
 import { ref, defineComponent } from 'vue'
-
 export default defineComponent({
   name: 'HelloWorld',
   props: {
@@ -62,9 +63,9 @@ export default defineComponent({
   },
   setup: () => {
     const count = ref(0)
-    const toggle_1 = ref(false);
-    const toggle_2 = ref(false);
-    return { count, toggle_1, toggle_2 }
+    const useScriptSetup = ref(false);
+    const useTsPlugin = ref(false);
+    return { count, useScriptSetup, useTsPlugin }
   }
 })
 </script>
@@ -72,5 +73,17 @@ export default defineComponent({
 <style scoped>
 a {
   color: #42b983;
+}
+
+label {
+  margin: 0 0.5em;
+  font-weight: bold;
+}
+
+code {
+  background-color: #eee;
+  padding: 2px 4px;
+  border-radius: 4px;
+  color: #304455;
 }
 </style>

--- a/packages/create-app/template-vue-ts/src/main.ts
+++ b/packages/create-app/template-vue-ts/src/main.ts
@@ -1,6 +1,4 @@
 import { createApp } from 'vue'
-// TypeScript error? Run VSCode command
-// TypeScript: Select TypeScript version - > Use Workspace Version
 import App from './App.vue'
 
 createApp(App).mount('#app')

--- a/packages/create-app/template-vue-ts/src/shims-vue.d.ts
+++ b/packages/create-app/template-vue-ts/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}

--- a/packages/create-app/template-vue-ts/tsconfig.json
+++ b/packages/create-app/template-vue-ts/tsconfig.json
@@ -7,8 +7,7 @@
     "jsx": "preserve",
     "sourceMap": true,
     "lib": ["esnext", "dom"],
-    "types": ["vite/client"],
-    "plugins": [{ "name": "@vuedx/typescript-plugin-vue" }]
+    "types": ["vite/client"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
Similar: https://github.com/vitejs/vite/pull/1862

I think we should not add too many things without the user's knowledge, especially:
1. ts plugin is easy to confuse users
2. I think this is not a feature most users need

Moving the ts plugin description to HelloWorld makes it clear to users what they are doing and integrating with past experience.