### PR TITLE
chore: Update fsevents, chokidar, rollup

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -36,7 +36,7 @@
     "@vue/compiler-sfc": "^3.0.4",
     "debug": "^4.3.1",
     "hash-sum": "^2.0.0",
-    "rollup": "^2.35.1",
+    "rollup": "^2.38.5",
     "slash": "^3.0.0",
     "source-map": "^0.6.1"
   }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -47,10 +47,10 @@
     "esbuild": "^0.8.34",
     "postcss": "^8.2.1",
     "resolve": "^1.19.0",
-    "rollup": "^2.35.1"
+    "rollup": "^2.38.5"
   },
   "optionalDependencies": {
-    "fsevents": "~2.1.2"
+    "fsevents": "~2.3.1"
   },
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.1",
@@ -81,7 +81,7 @@
     "builtin-modules": "^3.2.0",
     "cac": "^6.6.1",
     "chalk": "^4.1.0",
-    "chokidar": "^3.4.3",
+    "chokidar": "^3.5.1",
     "clean-css": "^4.2.3",
     "compression": "^1.7.4",
     "connect": "^3.7.0",

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -123,7 +123,7 @@ const nodeConfig = {
         src: `require.resolve('terser'`,
         replacement: `require.resolve('vite/dist/node/terser'`
       },
-      // chokidar -> fs-events
+      // chokidar -> fsevents
       'fsevents-handler.js': {
         src: `require('fsevents')`,
         replacement: `eval('require')('fsevents')`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1880,7 +1880,7 @@ character-parser@^2.2.0:
   dependencies:
     is-regex "^1.0.3"
 
-"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.3:
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -3314,11 +3314,6 @@ fsevents@^2.1.2, fsevents@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
   integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
-
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -6746,10 +6741,10 @@ rollup-plugin-license@^2.2.0:
     spdx-expression-validate "2.0.0"
     spdx-satisfies "5.0.0"
 
-rollup@^2.35.1:
-  version "2.38.4"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.38.4.tgz#1b84ea8728c73b1a00a6a6e9c630ec8c3fe48cea"
-  integrity sha512-B0LcJhjiwKkTl79aGVF/u5KdzsH8IylVfV56Ut6c9ouWLJcUK17T83aZBetNYSnZtXf2OHD4+2PbmRW+Fp5ulg==
+rollup@^2.38.5:
+  version "2.38.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.38.5.tgz#be41ad4fe0c103a8794377afceb5f22b8f603d6a"
+  integrity sha512-VoWt8DysFGDVRGWuHTqZzT02J0ASgjVq/hPs9QcBOGMd7B+jfTr/iqMVEyOi901rE3xq+Deq66GzIT1yt7sGwQ==
   optionalDependencies:
     fsevents "~2.3.1"
 


### PR DESCRIPTION
The installed version of `fsevents`, ~2.1.2 (2.1.3, to be precise) has issues with Apple M1 machines. So if you use `vite` to create an app, you'll get a warning `vite > fsevents@2.1.3: "Please update to latest v2.3 or v2.2"`.

So, this PR updates `fsevents` to 2.3.1. `chokidar` also updated their usage of `fsevents`, so I updated `chokidar` as well to 3.5.1. Both these packages were already available transitively. `rollup` updated it's usage as well (via me, https://github.com/rollup/rollup/pull/3945), so I updated `rollup` here too.

