### PR TITLE
docs(create-app): add link to script setup RFC

### DIFF
--- a/packages/create-app/template-vue/src/App.vue
+++ b/packages/create-app/template-vue/src/App.vue
@@ -5,6 +5,9 @@
 
 <script setup>
 import HelloWorld from './components/HelloWorld.vue'
+
+// This starter template is using Vue 3 experimental <script setup> SFCs
+// Check out https://github.com/vuejs/rfcs/blob/script-setup-2/active-rfcs/0000-script-setup.md
 </script>
 
 <style>


### PR DESCRIPTION
Vue users may not yet know what is <script setup>. This PR adds a link in `App.vue` to the RFC documentation.
Another option would be to use normal scripts like it is done in the vue-ts template.