### PR TITLE
dx(cli): adjust whitespace in console

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -537,7 +537,7 @@ async function startServer(
     httpServer.listen(port, () => {
       httpServer.removeListener('error', onError)
 
-      info(`\n  ⚡Vite dev server running at:\n`, {
+      info(`\n ⚡ Vite dev server running at:\n`, {
         clear: !server.config.logger.hasWarned
       })
       const interfaces = os.networkInterfaces()


### PR DESCRIPTION
This is a pretty small tweak, it changes the message on running `vite`. It moves the ⚡️ back by a space, so it doesn't read like "svite" anymore, and aligns with the `>` beneath it.

Before 
![image](https://user-images.githubusercontent.com/18808/107134929-4095db00-68ee-11eb-9015-09b2541b7aee.png)

After
![image](https://user-images.githubusercontent.com/18808/107134931-45f32580-68ee-11eb-84cb-55acf0a11807.png)

