### PR TITLE
chore: add issues helper action

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -1,0 +1,17 @@
+name: Issue Close Require
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: need reproduction
+        uses: actions-cool/issues-helper@v2.1.1
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'need reproduction'
+          inactive-day: 3

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -1,0 +1,40 @@
+name: Issue Labeled
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  reply-labeled:
+    runs-on: ubuntu-latest
+    steps:
+      - name: contribution welcome
+        if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
+        uses: actions-cool/issues-helper@v2.1.1
+        with:
+          actions: 'create-comment, remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. We totally like your proposal/feedback, welcome to send us a Pull Request for it. Please provide changelog/TypeScript/documentation/test cases if needed and make sure CI passed, we will review it soon. We appreciate your effort in advance and looking forward to your contribution!
+          labels: 'bug: pending triage, need reproduction'
+
+      - name: remove pending
+        if: github.event.label.name == 'enhancement' || github.event.label.name == 'bug: upstream' || github.event.label.name == 'bug: hmr' || github.event.label.name == 'bug'
+        uses: actions-cool/issues-helper@v2.1.1
+        with:
+          actions: 'remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: 'bug: pending triage'
+
+      - name: need reproduction
+        if: github.event.label.name == 'need reproduction'
+        uses: actions-cool/issues-helper@v2.1.1
+        with:
+          actions: 'create-comment, remove-labels'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            Hello @${{ github.event.issue.user.login }}. Please provide a online reproduction by [codesandbox](https://codesandbox.io/) or a minimal GitHub repository. Issues labeled by `need reproduction` will be closed if no activities in 3 days.
+          labels: 'bug: pending triage'

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -20,8 +20,7 @@ jobs:
           labels: 'bug: pending triage, need reproduction'
 
       - name: remove pending
-        if: github.event.label.name == 'enhancement' || github.event.label.name == 'bug: upstream' || github.event.label.name == 'bug: hmr' || github.event.label.name == 'bug'
-        uses: actions-cool/issues-helper@v2.1.1
+        if: github.event.label.name == 'enhancement' || github.event.label.name == 'bug' || (contains(github.event.label.name, 'pending triage') == false && startsWith(github.event.label.name, 'bug:') == true)
         with:
           actions: 'remove-labels'
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Background

利用 GitHub Actions 帮助你处理 issues。根据该仓库以往处理 issues 的记录加了一些功能，不对或欠缺地方可以提出来。

### Changelog

- 给 Issue 加 Label
    -  `contribution welcome` 或 `help wanted`
        - github actions bot 自动评论
        - 自动移除 `bug: pending triage` `need reproduction` label，如果有的话
    - `enhancement` 或 `bug: upstream` 或 `bug: hmr` 或 `bug`
        - 自动移除 `bug: pending triage` label
    - `need reproduction` 
        - 自动评论，评论内容若有需要改动地方，可提出
        - 自动移除 `bug: pending triage` label
- 每天定时触发
   - 检测标记有 `need reproduction` 的 issues，若 3 天未活跃，则自动关闭 issue