### PR TITLE
chore(create-app): add .gitignore to vanilla template

### DIFF
--- a/packages/create-app/template-vanilla/_gitignore
+++ b/packages/create-app/template-vanilla/_gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+dist-ssr
+*.local


### PR DESCRIPTION
IIUC of the vanilla template is to be a minimal as possible, but I think including a `.gitignore` file like in other templates may 
 provide a better experience.