### PR TITLE
fix: add metadata to jsx when using @vite/plugin-react-refresh

### DIFF
--- a/packages/playground/react/__tests__/react.spec.ts
+++ b/packages/playground/react/__tests__/react.spec.ts
@@ -16,3 +16,24 @@ test('should hmr', async () => {
   // preserve state
   expect(await page.textContent('button')).toMatch('count is: 1')
 })
+
+test('should have annotated jsx with file location metadata', async () => {
+  // we're not annotating in prod,
+  // so we skip this test when isBuild is true
+  if (isBuild) return
+
+  const meta = await page.evaluate(() => {
+    const button = document.querySelector('button')
+    const key = Object.keys(button).find(
+      (key) => key.indexOf('__reactFiber') === 0
+    )
+    return button[key]._debugSource
+  })
+  // If the evaluate call doesn't crash, and the returned metadata has
+  // the expected fields, we're good.
+  expect(Object.keys(meta).sort()).toEqual([
+    'columnNumber',
+    'fileName',
+    'lineNumber'
+  ])
+})

--- a/packages/plugin-react-refresh/package.json
+++ b/packages/plugin-react-refresh/package.json
@@ -27,6 +27,8 @@
   "dependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
+    "@babel/plugin-transform-react-jsx-self": "^7.12.10",
+    "@babel/plugin-transform-react-jsx-source": "^7.12.10",
     "react-refresh": "^0.9.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -366,6 +366,20 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
+"@babel/plugin-transform-react-jsx-self@^7.12.10":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.12.13.tgz#422d99d122d592acab9c35ea22a6cfd9bf189f60"
+  integrity sha512-FXYw98TTJ125GVCCkFLZXlZ1qGcsYqNQhVBQcZjyrwf8FEUtVfKIoidnO8S0q+KBQpDYNTmiGo1gn67Vti04lQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-transform-react-jsx-source@^7.12.10":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.12.13.tgz#051d76126bee5c9a6aa3ba37be2f6c1698856bcb"
+  integrity sha512-O5JJi6fyfih0WfDgIJXksSPhGP/G0fQpfxYy87sDc+1sFmsCS6wr3aAn+whbzkhbjtq4VMqLRaSzR6IsshIC0Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.12.13"
+
 "@babel/plugin-transform-typescript@^7.12.1":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.13.tgz#8bcb5dd79cb8bba690d6920e19992d9228dfed48"


### PR DESCRIPTION
This PR is derived from the work at https://github.com/threepointone/vite-plugin-react-jsx. It has 2 specific changes:

- It adds `enforce: 'pre'` to the plugin, so that it gets called before it gets passed through `esbuild` (i.e. before it loses jsx tags). It modifies the parserOpts passed to babel to account for this.
- It adds 2 babel plugins (`transform-react-jsx-self`,  `transform-react-jsx-source`) which adds metadata on to jsx tags, allowing tools like React Devtools to show filename and line number information for an element.

There's a separate conversation to have about providing support for React's new jsx transform, and potentially renaming this plugin (if at all), but we can talk about that later. There's value in just landing this separately right now imo.
