### PR TITLE
fix: Adds a newline before "Scaffolding project in..."

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -48,7 +48,7 @@ async function init() {
   }
 
   const root = path.join(cwd, targetDir)
-  console.log(`Scaffolding project in ${root}...`)
+  console.log(`\nScaffolding project in ${root}...`)
 
   if (!fs.existsSync(root)) {
     fs.mkdirSync(root, { recursive: true })


### PR DESCRIPTION
Another tiny PR. When you currently make a new project with `yarn create @vitejs/app`, the yarn progress bar is flush with the `Scaffolding project in...` line. This PR adds a newline to fix that.

Here's a "before" pic. I'm not sure how I would make an "after" pic, but I'm confident with this one :) To compensate, I added too many arrows to the screenshot. 
![image](https://user-images.githubusercontent.com/18808/107282996-aea7e280-6a53-11eb-8e25-b6d3ba7d45e2.png)
 