### PR TITLE
workflow: avoid custom eslint rule conflicts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,13 @@ module.exports = {
       rules: {
         'node/no-missing-import': 'off'
       }
+    },
+    {
+      files: ['scripts/**', 'packages/create-app/**'],
+      rules: {
+        'node/no-extraneous-require': 'off',
+        'node/no-restricted-require': 'off'
+      }
     }
   ]
 }


### PR DESCRIPTION
The npm package `enquirer` used in` create-app` is also defined as `devDependencies` in vite. 
The content in the scripts folder also has similar problems.