### PR TITLE
fix: enable react refresh on .js files

### DIFF
--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -69,9 +69,9 @@ function reactRefreshPlugin(opts) {
         return
       }
 
-      // plain js/ts files can't use React without importing it, so skip
+      // plain .ts files can't use React without importing it, so skip
       // them whenever possible
-      if (!id.endsWith('x') && !code.includes('react')) {
+      if (id.endsWith('.ts') || !code.includes('react')) {
         return
       }
 


### PR DESCRIPTION
This PR allows `react-refresh` to work on `.js` files. The code assumes that `.js` files wouldn't have any jsx in them, which isn't right. This PR changes the condition to only exclude `.ts` files.

(Honestly, I think most react folks just use `.js` files anyway.)