### PR TITLE
fix: Remove negative count in stdout with 0 rows (#1981)

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -31,7 +31,7 @@ let sameCount = 0
 
 function clearScreen() {
   const repeatCount = process.stdout.rows - 2
-  const blank = '\n'.repeat(repeatCount >= 0 ? repeatCount : 0)
+  const blank = repeatCount > 0 ? '\n'.repeat(repeatCount) : ''
   console.log(blank)
   readline.cursorTo(process.stdout, 0, 0)
   readline.clearScreenDown(process.stdout)

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -30,7 +30,8 @@ let lastMsg: string | undefined
 let sameCount = 0
 
 function clearScreen() {
-  const blank = '\n'.repeat(process.stdout.rows - 2)
+  const repeatCount = process.stdout.rows - 2
+  const blank = '\n'.repeat(repeatCount >= 0 ? repeatCount : 0)
   console.log(blank)
   readline.cursorTo(process.stdout, 0, 0)
   readline.clearScreenDown(process.stdout)


### PR DESCRIPTION
Vitejs fails inside docker with: 

```
vite   | /srv/www/node_modules/vite/dist/node/chunks/dep-f0a7a70d.js:3309
vite   |     const blank = '\n'.repeat(process.stdout.rows - 2);
vite   |                        ^
vite   | 
vite   | RangeError: Invalid count value
```

Example repo here: https://github.com/alykamb/vite-docker-issue/tree/main