### PR TITLE
refactor(create): detects pkgManager for run instructions

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -111,12 +111,14 @@ async function init() {
   pkg.name = path.basename(root)
   write('package.json', JSON.stringify(pkg, null, 2))
 
+  const pkgManager = /yarn/.test(process.env.npm_execpath) ? 'yarn' : 'npm'
+
   console.log(`\nDone. Now run:\n`)
   if (root !== cwd) {
     console.log(`  cd ${path.relative(cwd, root)}`)
   }
-  console.log(`  npm install (or \`yarn\`)`)
-  console.log(`  npm run dev (or \`yarn dev\`)`)
+  console.log(`  ${pkgManager === 'yarn' ? `yarn` : `npm install`}`)
+  console.log(`  ${pkgManager === 'yarn' ? `yarn dev` : `npm run dev`}`)
   console.log()
 }
 


### PR DESCRIPTION
This change allows `create-app` to determine which package manager is used and output run instructions only for that manager. If a user runs `yarn create ...` then they don't really need to see NPM install / run instructions. 

The regex test is for `yarn` so that `npx @vitejs/create-app` still works and gives the correct (`npm`) output. 