### PR TITLE
fix(hmr): respect server https options when running as middleware

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -6,7 +6,7 @@ import connect from 'connect'
 import compression from 'compression'
 import { ResolvedConfig } from '.'
 import { Connect } from 'types/connect'
-import { resolveHttpServer } from './server/http'
+import { resolveHttpsConfig, resolveHttpServer } from './server/http'
 import { openBrowser } from './server/openBrowser'
 import corsMiddleware from 'cors'
 import { proxyMiddleware } from './server/middlewares/proxy'
@@ -16,7 +16,11 @@ export async function preview(
   port = 5000
 ): Promise<void> {
   const app = connect() as Connect.Server
-  const httpServer = await resolveHttpServer(config.server, app)
+  const httpServer = await resolveHttpServer(
+    config.server,
+    app,
+    await resolveHttpsConfig(config)
+  )
 
   // cors
   const { cors } = config.server

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -9,7 +9,7 @@ import corsMiddleware from 'cors'
 import chalk from 'chalk'
 import { AddressInfo } from 'net'
 import chokidar from 'chokidar'
-import { resolveHttpServer } from './http'
+import { resolveHttpsConfig, resolveHttpServer } from './http'
 import { resolveConfig, InlineConfig, ResolvedConfig } from '../config'
 import {
   createPluginContainer,
@@ -264,12 +264,13 @@ export async function createServer(
   const root = config.root
   const serverConfig = config.server || {}
   const middlewareMode = !!serverConfig.middlewareMode
+  const httpsOptions = await resolveHttpsConfig(config)
 
   const middlewares = connect() as Connect.Server
   const httpServer = middlewareMode
     ? null
-    : await resolveHttpServer(serverConfig, middlewares)
-  const ws = createWebSocketServer(httpServer, config)
+    : await resolveHttpServer(serverConfig, middlewares, httpsOptions)
+  const ws = createWebSocketServer(httpServer, config, httpsOptions)
 
   const { ignored = [], ...watchOptions } = serverConfig.watch || {}
   const watcher = chokidar.watch(path.resolve(root), {


### PR DESCRIPTION
If you are running vite over https, HMR works great in the standalone mode, but when in middleware mode, the middleware might be served over https and the websocket server wouldn't listen on https. This updates the websocket server to respect the config.server.https option when in middleware mode too.

 - Moves the https config into a top level key of the resolved config, so its only resolved once (and only one set of certs is generated) and can be shared between different consumers
 - Boots a secure websocket server when in middleware mode if the `config.server` https option is on