### PR TITLE
feat: Closer parity to Preact template on Preact Typescript template.

### DIFF
--- a/packages/create-app/template-preact-ts/src/app.tsx
+++ b/packages/create-app/template-preact-ts/src/app.tsx
@@ -1,4 +1,3 @@
-import { h, Fragment } from 'preact'
 import { Logo } from './logo'
 
 export function App() {

--- a/packages/create-app/template-preact-ts/src/logo.tsx
+++ b/packages/create-app/template-preact-ts/src/logo.tsx
@@ -1,5 +1,3 @@
-import { h } from 'preact'
-
 export const Logo = () => (
   <svg
     class="logo"

--- a/packages/create-app/template-preact-ts/src/main.tsx
+++ b/packages/create-app/template-preact-ts/src/main.tsx
@@ -1,4 +1,4 @@
-import { render, h } from 'preact'
+import { render } from 'preact'
 import { App } from './app'
 import './index.css'
 

--- a/packages/create-app/template-preact-ts/src/preact.d.ts
+++ b/packages/create-app/template-preact-ts/src/preact.d.ts
@@ -1,0 +1,1 @@
+import JSX = preact.JSX

--- a/packages/create-app/template-preact-ts/tsconfig.json
+++ b/packages/create-app/template-preact-ts/tsconfig.json
@@ -1,4 +1,3 @@
-
 {
   "compilerOptions": {
     "target": "ESNext",
@@ -15,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "preserve",
     "jsxFactory": "h",
     "jsxFragmentFactory": "Fragment"
   },

--- a/packages/create-app/template-preact-ts/vite.config.ts
+++ b/packages/create-app/template-preact-ts/vite.config.ts
@@ -5,7 +5,8 @@ import preactRefresh from '@prefresh/vite'
 export default defineConfig({
   esbuild: {
     jsxFactory: 'h',
-    jsxFragment: 'Fragment'
+    jsxFragment: 'Fragment',
+    jsxInject: `import { h, Fragment } from 'preact'`
   },
   plugins: [preactRefresh()]
 })


### PR DESCRIPTION
Having played with both the Preact and Preact TypeScript templates on Vite, I find that the vanilla Preact one offers a stronger starting point than the TypeScript one as it allows you to `import { h, Fragment } from 'preact'` automatically, and not have to add it to every file. 

This could also be added to the TypeScript version to allow for a faster and nicer development experience. This PR attempts to implement that feature by using the same methods as the vanilla Preact template. It requires creating a `preact.d.ts` in the `src` directory to  ensure code checking works in VS Code.

The change is fairly small so thought it better to make a PR than a discussion first as it'll be easier to just see the code.

(I tried to ensure following the contribution guidelines, but apologies if I missed anything).