### PR TITLE
fix(plugin-legacy): prevent dead code elimination from env.LEGACY marker

### DIFF
--- a/packages/playground/legacy/__tests__/legacy.spec.ts
+++ b/packages/playground/legacy/__tests__/legacy.spec.ts
@@ -5,5 +5,22 @@ test('should work', async () => {
 })
 
 test('import.meta.env.LEGACY', async () => {
-  expect(await page.textContent('#env')).toMatch(isBuild ? 'true' : 'false')
+  if (isBuild) {
+    expect(await page.textContent('#env')).toMatch('true')
+
+    const modernSrc = await page.$eval(
+      'script[type="module-disabled"]',
+      (el: HTMLScriptElement) => el.src
+    )
+
+    // false after the modern chunk was executed
+    await page.addScriptTag({ url: modernSrc, type: 'module' })
+    expect(await page.textContent('#env')).toMatch('false')
+
+    // reload so execution of the modern chunk can't mess with other tests
+    await page.reload()
+  } else {
+    // always false in dev
+    expect(await page.textContent('#env')).toMatch('false')
+  }
 })

--- a/packages/playground/legacy/main.js
+++ b/packages/playground/legacy/main.js
@@ -5,6 +5,13 @@ async function run() {
 
 run()
 
-document.getElementById('env').textContent = `is legacy: ${
-  import.meta.env.LEGACY
-}`
+let isLegacy
+
+// make sure that branching works despite esbuild's constant folding (#1999)
+if (import.meta.env.LEGACY) {
+  if (import.meta.env.LEGACY === true) isLegacy = true
+} else {
+  if (import.meta.env.LEGACY === false) isLegacy = false
+}
+
+document.getElementById('env').textContent = `is legacy: ${isLegacy}`

--- a/packages/playground/legacy/vite.config.js
+++ b/packages/playground/legacy/vite.config.js
@@ -15,13 +15,13 @@ module.exports = {
   },
 
   // special test only hook
-  // for tests, remove `<script type="module">` tags and remove `nomodule`
+  // for tests, disable `<script type="module">` tags and remove `nomodule`
   // attrs so that we run the legacy bundle instead.
   __test__() {
     const indexPath = path.resolve(__dirname, './dist/index.html')
     let index = fs.readFileSync(indexPath, 'utf-8')
     index = index
-      .replace(/<script type="module".*?<\/script>/g, '')
+      .replace(/<script type="module"/g, '<script type="module-disabled"')
       .replace(/<script nomodule/g, '<script')
     fs.writeFileSync(indexPath, index)
   }


### PR DESCRIPTION
fix #1999 

close #2004 (also includes typo fix)

**TL;DR**:

Currently `if (import.meta.env.LEGACY)` is treated as `if ('__VITE_IS_LEGACY__')` so it's always true.
Likewise, `if (import.meta.env.LEGACY === true)` is always false because it's treated as `if ('__VITE_IS_LEGACY__' === true)`.

This is due to esbuild's constant folding – using an array (or object) as marker the way it's implemented in this PR circumvents that.
