### PR TITLE
Update sample manifest.json to reflect CSS array

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -55,7 +55,7 @@ If you want to serve the HTML using a traditional backend (e.g. Rails, Laravel) 
        "src": "main.js",
        "isEntry": true,
        "dynamicImports": ["views/foo.js"],
-       "css": "assets/main.b82dbe22.css",
+       "css": ["assets/main.b82dbe22.css"],
        "assets": ["assets/asset.0ab0f9cd.png"]
      },
      "views/foo.js": {


### PR DESCRIPTION
In my case, the build process generated a manifest.json with a single CSS path wrapped in an array. Perhaps that's the default behavior?