### PR TITLE
fix(plugin-legacy): use correct string length in legacy env replacement

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -196,7 +196,7 @@ function viteLegacyPlugin(options = {}) {
             while ((match = re.exec(raw))) {
               s.overwrite(
                 match.index,
-                match.index + legacyEnvVarMarker.length + 2,
+                match.index + legacyEnvVarMarker.length,
                 `false`
               )
             }


### PR DESCRIPTION
The `+ 2` accounted for the quotes – which are gone now that `__VITE_IS_LEGACY__` isn't a string anymore.
So currently too much of the source code is removed and builds break with `build.sourcemap: true`