### PR TITLE
feat: expose `postcss-modules` `getJSON` option on `css.modules`

### DIFF
--- a/packages/playground/css/vite.config.js
+++ b/packages/playground/css/vite.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+const fs = require('fs')
 /**
  * @type {import('vite').UserConfig}
  */
@@ -9,6 +11,21 @@ module.exports = {
   },
   css: {
     modules: {
+      // example of how getJSON can be used to generate
+      // typescript typings for css modules class names
+      getJSON(cssFileName, json, _outputFileName) {
+        let typings = 'declare const classNames: {\n'
+        for (let className in json) {
+          typings += `    "${className}": string;\n`
+        }
+        typings += '};\n'
+        typings += 'export default classNames;\n'
+        const typingsFile = path.join(
+          path.dirname(cssFileName),
+          path.basename(cssFileName) + '.d.ts'
+        )
+        fs.writeFileSync(typingsFile, typings)
+      },
       generateScopedName: '[name]__[local]___[hash:base64:5]'
     },
     preprocessorOptions: {

--- a/packages/playground/css/vite.config.js
+++ b/packages/playground/css/vite.config.js
@@ -1,5 +1,3 @@
-const path = require('path')
-const fs = require('fs')
 /**
  * @type {import('vite').UserConfig}
  */
@@ -11,22 +9,25 @@ module.exports = {
   },
   css: {
     modules: {
+      generateScopedName: '[name]__[local]___[hash:base64:5]'
+
       // example of how getJSON can be used to generate
       // typescript typings for css modules class names
-      getJSON(cssFileName, json, _outputFileName) {
-        let typings = 'declare const classNames: {\n'
-        for (let className in json) {
-          typings += `    "${className}": string;\n`
-        }
-        typings += '};\n'
-        typings += 'export default classNames;\n'
-        const typingsFile = path.join(
-          path.dirname(cssFileName),
-          path.basename(cssFileName) + '.d.ts'
-        )
-        fs.writeFileSync(typingsFile, typings)
-      },
-      generateScopedName: '[name]__[local]___[hash:base64:5]'
+
+      // getJSON(cssFileName, json, _outputFileName) {
+      //   let typings = 'declare const classNames: {\n'
+      //   for (let className in json) {
+      //     typings += `    "${className}": string;\n`
+      //   }
+      //   typings += '};\n'
+      //   typings += 'export default classNames;\n'
+      //   const { join, dirname, basename } = require('path')
+      //   const typingsFile = join(
+      //     dirname(cssFileName),
+      //     basename(cssFileName) + '.d.ts'
+      //   )
+      //   require('fs').writeFileSync(typingsFile, typings)
+      // },
     },
     preprocessorOptions: {
       scss: {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -52,6 +52,11 @@ export interface CSSOptions {
 }
 
 export interface CSSModulesOptions {
+  getJSON?: (
+    cssFileName: string,
+    json: Record<string, string>,
+    outputFileName: string
+  ) => void
   scopeBehaviour?: 'global' | 'local'
   globalModulePaths?: string[]
   generateScopedName?:
@@ -566,8 +571,15 @@ async function compileCSS(
     postcssPlugins.unshift(
       (await import('postcss-modules')).default({
         ...modulesOptions,
-        getJSON(_: string, _modules: Record<string, string>) {
+        getJSON(
+          cssFileName: string,
+          _modules: Record<string, string>,
+          outputFileName: string
+        ) {
           modules = _modules
+          if (modulesOptions && typeof modulesOptions.getJSON === 'function') {
+            modulesOptions.getJSON(cssFileName, _modules, outputFileName)
+          }
         }
       })
     )


### PR DESCRIPTION
This is particularly useful to generate typescript typings files for css modules class names.

I've added an example of how to do it in the css playground.