### PR TITLE
fix: reject preload promise if link fails to load

### DIFF
--- a/packages/vite/src/node/plugins/importAnaysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnaysisBuild.ts
@@ -65,8 +65,9 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
       // @ts-ignore
       document.head.appendChild(link)
       if (isCss) {
-        return new Promise((res) => {
+        return new Promise((res, rej) => {
           link.addEventListener('load', res)
+          link.addEventListener('error', rej)
         })
       }
     })


### PR DESCRIPTION
Addresses part of #2009 — if a `<link>` fails to load (likely because of a network error, or because the developer misconfigured `base`), `__vitePreload` promises will reject.

Wasn't sure where or how to add tests for something like this, so I didn't — hope that's okay.