### PR TITLE
fix: always transform applicable requests

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -37,11 +37,7 @@ export function transformMiddleware(
   } = server
 
   return async (req, res, next) => {
-    if (
-      req.method !== 'GET' ||
-      req.headers.accept?.includes('text/html') ||
-      knownIgnoreList.has(req.url!)
-    ) {
+    if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
       return next()
     }
 


### PR DESCRIPTION
As shown in https://github.com/Rich-Harris/vite-repro-transformation, Vite only transforms files when they are imported, and not requested any other way, because `transformMiddleware` has the following check:

```js
req.headers.accept?.includes('text/html')
```

This line was removed in https://github.com/vitejs/vite/pull/1496 so that it's possible to view transformed files in a new tab, but that change was reverted in https://github.com/vitejs/vite/commit/64fde3883e07f66fee6f6234f84ad35288a24b62 due to #1507. I'm not sure what's happening in #1507 but it feels like the `accept` check might be masking the real issue?

The current behaviour does cause problems — as alluded to in #1496, it makes debugging harder, but it also means that you can't (for the example that motivated this PR) inject a `<link>` in SSR'd content that contains a stylesheet that was imported by a module loaded with `ssrLoadModule`.

More broadly, I'd argue it makes things less predictable. Unless there's a rationale for the current behaviour that I'm missing?