### PR TITLE
docs: fix learn more button

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ actionText: Get Started
 actionLink: /guide/
 
 altActionText: Learn More
-altActionLink: /guide/introduction
+altActionLink: /guide/why
 
 features:
   - title: 💡 Instant Server Start


### PR DESCRIPTION
"introduction" was renamed to "why", fixes the Learn More button in the home page