### PR TITLE
fix: builtin `process.env` define overrides user's config

### DIFF
--- a/packages/playground/define/__tests__/define.spec.ts
+++ b/packages/playground/define/__tests__/define.spec.ts
@@ -9,6 +9,6 @@ test('string', async () => {
     JSON.stringify(defines.__OBJ__, null, 2)
   )
   expect(await page.textContent('.env-var')).toBe(
-    String(defines['process.env.SOMEVAR'])
+    JSON.parse(defines['process.env.SOMEVAR'])
   )
 })

--- a/packages/playground/define/__tests__/define.spec.ts
+++ b/packages/playground/define/__tests__/define.spec.ts
@@ -8,4 +8,7 @@ test('string', async () => {
   expect(await page.textContent('.object')).toBe(
     JSON.stringify(defines.__OBJ__, null, 2)
   )
+  expect(await page.textContent('.env-var')).toBe(
+    String(defines['process.env.SOMEVAR'])
+  )
 })

--- a/packages/playground/define/index.html
+++ b/packages/playground/define/index.html
@@ -5,6 +5,7 @@
 <p>Number <code class="number"></code></p>
 <p>Boolean <code class="boolean"></code></p>
 <p>Object <span class="pre object"></span></p>
+<p>Env Var <code class="env-var"></code></p>
 
 <script type="module">
   text('.exp', __EXP__)
@@ -12,6 +13,7 @@
   text('.number', __NUMBER__)
   text('.boolean', __BOOLEAN__)
   text('.object', JSON.stringify(__OBJ__, null, 2))
+  text('.env-var', process.env.SOMEVAR)
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/packages/playground/define/vite.config.js
+++ b/packages/playground/define/vite.config.js
@@ -9,6 +9,7 @@ module.exports = {
       bar: {
         baz: 2
       }
-    }
+    },
+    'process.env.SOMEVAR': '"SOMEVAR"'
   }
 }

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -32,20 +32,14 @@ export function definePlugin(config: ResolvedConfig): Plugin {
 
   const replacements: Record<string, string | undefined> = {
     'process.env.NODE_ENV': JSON.stringify(config.mode),
-    'process.env.': `({}).`,
     ...userDefine,
-    ...importMetaKeys
+    ...importMetaKeys,
+    'process.env.': `({}).`
   }
 
-  // sort and reverse to make a more clear replacement matches first
-  // for example:
-  // ['process.env.', 'process.env.var'] should be ordered as
-  // ['process.env.var', 'process.env.'] to make the longer key be replaced earlier
   const pattern = new RegExp(
     '\\b(' +
       Object.keys(replacements)
-        .sort()
-        .reverse()
         .map((str) => {
           return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')
         })

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -32,8 +32,8 @@ export function definePlugin(config: ResolvedConfig): Plugin {
 
   const replacements: Record<string, string | undefined> = {
     'process.env.NODE_ENV': JSON.stringify(config.mode),
-    'process.env.': `({}).`,
     ...userDefine,
+    'process.env.': userDefine['process.env.'] ?? `({}).`,
     ...importMetaKeys
   }
 

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -32,14 +32,20 @@ export function definePlugin(config: ResolvedConfig): Plugin {
 
   const replacements: Record<string, string | undefined> = {
     'process.env.NODE_ENV': JSON.stringify(config.mode),
+    'process.env.': `({}).`,
     ...userDefine,
-    'process.env.': userDefine['process.env.'] ?? `({}).`,
     ...importMetaKeys
   }
 
+  // sort and reverse to make a more clear replacement matches first
+  // for example:
+  // ['process.env.', 'process.env.var'] should be ordered as
+  // ['process.env.var', 'process.env.'] to make the longer key be replaced earlier
   const pattern = new RegExp(
     '\\b(' +
       Object.keys(replacements)
+        .sort()
+        .reverse()
         .map((str) => {
           return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')
         })


### PR DESCRIPTION
Currently if you config
```
define: {
  'process.env.XXX': 'myVar'
}
```
for
```
console.log(process.env.XXX)
```
the output will be `console.log({}.xxx)`.

It is caused by the order of the generated replacement regexp.

The builtin `process.env.` to `({}).`'s replacement took place firstly.