### PR TITLE
docs: Add README.md with info from HelloWorld.vue to Typescript + Vue 3 template 

### DIFF
--- a/packages/create-app/template-vue-ts/README.md
+++ b/packages/create-app/template-vue-ts/README.md
@@ -1,0 +1,18 @@
+# Vue 3 + Typescript + Vite
+This template should help get you started developing with Vue 3 and Typescript in Vite.
+
+## Recommended IDE Setup
+[VSCode](https://code.visualstudio.com/) with [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) allows
+for syntax highlighting and autocomplete, and adding the [VueDX](https://marketplace.visualstudio.com/items?itemName=znck.vue-language-features) extension provides improved type checking, completion, and refactoring tools.
+
+If you would like to use the new `<script setup>` feature, [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) is recommended for VSCode instead.
+
+##Type Support For .vue Modules
+
+Without the following steps, TypeScript won't be able to identify the types of `.vue` files when they're imported as modules. The [VueDX Typescript plugin](https://www.npmjs.com/package/@vuedx/typescript-plugin-vue) provides this functionality along with other type-checking improvements.
+
+   1. Install and add `@vuedx/typescript-plugin-vue` to the [plugins section](https://www.typescriptlang.org/tsconfig#plugins) in `tsconfig.json`
+   2. Delete `src/shims-vue.d.ts` as it is no longer needed to provide module info to Typescript 
+   3. Open `src/main.ts` in VSCode 
+   4. Open the VSCode command palette
+   5. Search and run "Select TypeScript version" -> "Use workspace version"

--- a/packages/create-app/template-vue-ts/README.md
+++ b/packages/create-app/template-vue-ts/README.md
@@ -1,18 +1,11 @@
 # Vue 3 + Typescript + Vite
+
 This template should help get you started developing with Vue 3 and Typescript in Vite.
 
 ## Recommended IDE Setup
-[VSCode](https://code.visualstudio.com/) with [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) allows
-for syntax highlighting and autocomplete, and adding the [VueDX](https://marketplace.visualstudio.com/items?itemName=znck.vue-language-features) extension provides improved type checking, completion, and refactoring tools.
 
-If you would like to use the new `<script setup>` feature, [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar) is recommended for VSCode instead.
+[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar). With this setup, you should get type inference and checks for bindings and component props in SFC templates.
 
-##Type Support For .vue Modules
+## Type Support For `.vue` Imports in TS
 
-Without the following steps, TypeScript won't be able to identify the types of `.vue` files when they're imported as modules. The [VueDX Typescript plugin](https://www.npmjs.com/package/@vuedx/typescript-plugin-vue) provides this functionality along with other type-checking improvements.
-
-   1. Install and add `@vuedx/typescript-plugin-vue` to the [plugins section](https://www.typescriptlang.org/tsconfig#plugins) in `tsconfig.json`
-   2. Delete `src/shims-vue.d.ts` as it is no longer needed to provide module info to Typescript 
-   3. Open `src/main.ts` in VSCode 
-   4. Open the VSCode command palette
-   5. Search and run "Select TypeScript version" -> "Use workspace version"
+Since TypeScript cannot handle type information for `.vue` imports, they are shimmed to be a generic Vue component type by default. In most cases this is fine if you don't really care about component prop types outside of templates. However, if you wish to get actual prop types in `.vue` imports (for example to get props validation when using manual `h(...)` calls), you can run `Volar: Switch TS Plugin on/off` from VSCode command palette to enable the support.


### PR DESCRIPTION
This allows the user to delete `HelloWord.vue` without losing the developer experience info. It also tweaks the language and adds clarifying info, and paves the way to elaborate more on the .vue module types issue, as per #2017.