### PR TITLE
fix(create-app): prompt the user on supplying an invalid template

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -76,14 +76,21 @@ async function init() {
 
   // determine template
   let template = argv.t || argv.template
-  if (!template) {
+
+  const availableTemplates = TEMPLATES.map((template) => stripColors(template))
+  const isValidTemplate = availableTemplates.includes(template)
+  const message = isValidTemplate
+    ? `Select a template:`
+    : `${template} isn't a valid template. Please choose from below: `
+
+  if (!template || !isValidTemplate) {
     /**
      * @type {{ t: string }}
      */
     const { t } = await prompt({
       type: 'select',
       name: 't',
-      message: `Select a template:`,
+      message,
       choices: TEMPLATES
     })
     template = stripColors(t)


### PR DESCRIPTION
## Current behavior

An attempt to create a new `vite` project fails if the user makes a typo while supplying the template (or maybe an unsupported template).

```bash
$ yarn create @vitejs/app app -t default
```

<img width="1414" alt="Screenshot 2021-02-18 at 4 52 17 PM" src="https://user-images.githubusercontent.com/25279263/108350619-71d5ab80-720a-11eb-860c-824697857654.png">

## Proposed change

<img width="846" alt="Screenshot 2021-02-18 at 5 00 42 PM" src="https://user-images.githubusercontent.com/25279263/108350959-dee94100-720a-11eb-93bd-6cd7e2e98f71.png">