### PR TITLE
fix: reject ssrLoadModule promises if evaluation fails

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -121,9 +121,10 @@ export async function ssrLoadModule(
       `Error when evaluating SSR module ${url}:\n${e.stack}`,
       {
         timestamp: true,
-        clear: true
+        clear: server.config.clearScreen
       }
     )
+    throw e
   }
 
   mod.ssrModule = ssrModule


### PR DESCRIPTION
Closes #2078, and also respects the `clearScreen` option