### PR TITLE
fix(create-app): update prompt message based on user input

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -76,12 +76,17 @@ async function init() {
 
   // determine template
   let template = argv.t || argv.template
+  let message = 'Select a template:'
+  let isValidTemplate
 
-  const availableTemplates = TEMPLATES.map((template) => stripColors(template))
-  const isValidTemplate = availableTemplates.includes(template)
-  const message = isValidTemplate
-    ? `Select a template:`
-    : `${template} isn't a valid template. Please choose from below: `
+  // --template expects a value
+  if (template && typeof template === 'string') {
+    const availableTemplates = TEMPLATES.map((template) =>
+      stripColors(template)
+    )
+    isValidTemplate = availableTemplates.includes(template)
+    message = `${template} isn't a valid template. Please choose from below:`
+  }
 
   if (!template || !isValidTemplate) {
     /**

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -77,13 +77,11 @@ async function init() {
   // determine template
   let template = argv.t || argv.template
   let message = 'Select a template:'
-  let isValidTemplate
+  let isValidTemplate = false
 
   // --template expects a value
-  if (template && typeof template === 'string') {
-    const availableTemplates = TEMPLATES.map((template) =>
-      stripColors(template)
-    )
+  if (typeof template === 'string') {
+    const availableTemplates = TEMPLATES.map(stripColors)
     isValidTemplate = availableTemplates.includes(template)
     message = `${template} isn't a valid template. Please choose from below:`
   }


### PR DESCRIPTION
Follow up of #2072

https://github.com/vitejs/vite/blob/c391ea3de901810122d73c86747427b2aafdd570/packages/create-app/index.js#L84

- Boolean value for `--template`.

```bash
create-app app -t
```

<img width="647" alt="boolean-template" src="https://user-images.githubusercontent.com/25279263/108529934-08819580-72fb-11eb-91e9-31f4e7a0fc80.png">

- Not supplying a template.

```bash
create-app app
```

<img width="689" alt="no-template" src="https://user-images.githubusercontent.com/25279263/108529947-0c151c80-72fb-11eb-8686-d39cb835c2a9.png">

## Patch

<img width="681" alt="Screenshot 2021-02-19 at 9 25 08 PM" src="https://user-images.githubusercontent.com/25279263/108529950-0d464980-72fb-11eb-949d-1f30a8b1e68a.png">
