### PR TITLE
fix: vue-ts template checkbox type mismatch

### DIFF
--- a/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
+++ b/packages/create-app/template-vue-ts/src/components/HelloWorld.vue
@@ -2,12 +2,23 @@
   <h1>{{ msg }}</h1>
 
   <label>
-    <input type="checkbox" v-model="useScriptSetup" /> Use
+    <input
+      type="checkbox"
+      v-model="useScriptSetup"
+      :true-value="true"
+      :false-value="false"
+    />
+    Use
     <code>&lt;script setup&gt;</code>
   </label>
   <label>
-    <input type="checkbox" v-model="useTsPlugin" /> Provide types for
-    <code>*.vue</code> imports
+    <input
+      type="checkbox"
+      v-model="useTsPlugin"
+      :true-value="true"
+      :false-value="false"
+    />
+    Provide types for <code>*.vue</code> imports
   </label>
 
   <p>


### PR DESCRIPTION
Fix for issue: [vue/ts template broken](https://github.com/vitejs/vite/issues/2109)