### PR TITLE
fix(css): prevent commonjs-proxy module been bundled into css chunk

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -78,6 +78,7 @@ const cssLangs = `\\.(css|less|sass|scss|styl|stylus|postcss)($|\\?)`
 const cssLangRE = new RegExp(cssLangs)
 const cssModuleRE = new RegExp(`\\.module${cssLangs}`)
 const directRequestRE = /(\?|&)direct\b/
+const commjsProxyRE = /\?commonjs-proxy/
 
 export const isCSSRequest = (request: string) =>
   cssLangRE.test(request) && !directRequestRE.test(request)
@@ -264,7 +265,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       let isPureCssChunk = true
       const ids = Object.keys(chunk.modules)
       for (const id of ids) {
-        if (!isCSSRequest(id) || cssModuleRE.test(id)) {
+        if (
+          !isCSSRequest(id) ||
+          cssModuleRE.test(id) ||
+          commjsProxyRE.test(id)
+        ) {
           isPureCssChunk = false
         }
         if (styles.has(id)) {


### PR DESCRIPTION
Which will cause minifying css warning.

### reproduce
```javascript
// node_modules/some-package-for-test/index.js
require('./index.css');
```

```javascript
// the entry js file
import 'some-package-for-test'
```

```sh
// run build
vite build
```

```
// output
warnings when minifying css:
Invalid character(s) 'getAugmentedNamespace from "commonjsHelpers.js"; export default getAugmentedNamespace(test);' at 1:149. Ignoring.
Invalid selector 'import * as test from "/path/project/node_modules/test/index.css"; import' at 1:20. Ignoring.
```