### PR TITLE
fix: Bug where short flags are ignored

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -10,8 +10,14 @@ if (!__dirname.includes('node_modules')) {
 global.__vite_start_time = Date.now()
 
 // check debug mode first before requiring the CLI.
-const debugIndex = process.argv.indexOf('--debug')
-const filterIndex = process.argv.indexOf('--filter')
+const debugIndex =
+  process.argv.indexOf('--debug') > 0
+    ? process.argv.indexOf('--debug')
+    : process.argv.indexOf('-d')
+const filterIndex =
+  process.argv.indexOf('--filter') > 0
+    ? process.argv.indexOf('--filter')
+    : process.argv.indexOf('-f')
 const profileIndex = process.argv.indexOf('--profile')
 
 if (debugIndex > 0) {

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -10,14 +10,10 @@ if (!__dirname.includes('node_modules')) {
 global.__vite_start_time = Date.now()
 
 // check debug mode first before requiring the CLI.
-const debugIndex =
-  process.argv.indexOf('--debug') > 0
-    ? process.argv.indexOf('--debug')
-    : process.argv.indexOf('-d')
-const filterIndex =
-  process.argv.indexOf('--filter') > 0
-    ? process.argv.indexOf('--filter')
-    : process.argv.indexOf('-f')
+const debugIndex = process.argv.findIndex((arg) => /^(?:-d|--debug)$/.test(arg))
+const filterIndex = process.argv.findIndex((arg) =>
+  /^(?:-f|--filter)$/.test(arg)
+)
 const profileIndex = process.argv.indexOf('--profile')
 
 if (debugIndex > 0) {


### PR DESCRIPTION
I'm not entirely sure that this is the best version of the solution, but it solves an issue where the short flags for `--debug` and `--filter` get ignored.

I'm not sure if `--profile` needs the same treatment? I took a look around but didn't see where it was used, let alone if it should have a functional short flag. 