### PR TITLE
fix: do not overwrite asset url when it starts with double slash

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -38,6 +38,7 @@ function getHtmlFilename(url: string, server: ViteDevServer) {
   }
 }
 
+const startsWithSingleSlashRE = /^\/(?!\/)/
 const devHtmlHook: IndexHtmlTransformHook = async (
   html,
   { path: htmlPath, server }
@@ -62,7 +63,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
       if (src) {
         const url = src.value?.content || ''
-        if (/^\/(?!\/)/.test(url)) {
+        if (startsWithSingleSlashRE.test(url)) {
           // prefix with base
           s.overwrite(
             src.value!.loc.start.offset,
@@ -92,7 +93,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
           assetAttrs.includes(p.name)
         ) {
           const url = p.value.content || ''
-          if (url.startsWith('/')) {
+          if (startsWithSingleSlashRE.test(url)) {
             s.overwrite(
               p.value.loc.start.offset,
               p.value.loc.end.offset,

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -62,7 +62,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
       if (src) {
         const url = src.value?.content || ''
-        if (url.startsWith('/')) {
+        if (/^\/(?!\/)/.test(url)) {
           // prefix with base
           s.overwrite(
             src.value!.loc.start.offset,


### PR DESCRIPTION
Fix https://github.com/vitejs/vite/issues/2114