### PR TITLE
feat: Supports ES SSR build based on `module` type

### DIFF
--- a/packages/playground/esm-ssr/__tests__/build.spec.ts
+++ b/packages/playground/esm-ssr/__tests__/build.spec.ts
@@ -1,0 +1,13 @@
+import fs from 'fs'
+import path from 'path'
+import { isBuild } from '../../testUtils'
+
+if (isBuild) {
+  test('outputs ESM', () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, '..', 'dist', 'App.js'),
+      'utf8'
+    )
+    expect(/^import/.test(content)).toBeTruthy()
+  })
+}

--- a/packages/playground/esm-ssr/package.json
+++ b/packages/playground/esm-ssr/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "test-esm-ssr",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "vite build --ssr src/App.jsx"
+  },
+  "dependencies": {
+    "preact": "^10.5.13",
+    "preact-render-to-string": "^5.1.19"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "2.0.1",
+    "vite": "^2.2.3"
+  }
+}

--- a/packages/playground/esm-ssr/src/App.jsx
+++ b/packages/playground/esm-ssr/src/App.jsx
@@ -1,0 +1,23 @@
+import { render } from 'preact-render-to-string';
+
+export function App() {
+  return (
+    <>
+      <p>Hello Vite + Preact!</p>
+      <p>
+        <a
+          class="link"
+          href="https://preactjs.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn Preact
+        </a>
+      </p>
+    </>
+  )
+}
+
+export async function prerender() {
+	return await render(<App />);
+}

--- a/packages/playground/esm-ssr/vite.config.js
+++ b/packages/playground/esm-ssr/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import preact from '@preact/preset-vite'
+
+export default defineConfig({
+  plugins: [preact.default()]
+})

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -399,7 +399,12 @@ async function doBuild(
     const buildOuputOptions = (output: OutputOptions = {}): OutputOptions => {
       return {
         dir: outDir,
-        format: ssr ? 'cjs' : 'es',
+        format:
+          ssr &&
+          JSON.parse(fs.readFileSync(resolve('package.json'), 'utf-8')).type !=
+            'module'
+            ? 'cjs'
+            : 'es',
         exports: ssr ? 'named' : 'auto',
         sourcemap: options.sourcemap,
         name: libOptions ? libOptions.name : undefined,

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -396,7 +396,7 @@ async function doBuild(
   try {
     const pkgName = libOptions && getPkgName(config.root)
 
-    const buildOuputOptions = (output: OutputOptions = {}): OutputOptions => {
+    const buildOutputOptions = (output: OutputOptions = {}): OutputOptions => {
       return {
         dir: outDir,
         format:
@@ -448,10 +448,10 @@ async function doBuild(
       const output: OutputOptions[] = []
       if (Array.isArray(outputs)) {
         for (const resolvedOutput of outputs) {
-          output.push(buildOuputOptions(resolvedOutput))
+          output.push(buildOutputOptions(resolvedOutput))
         }
       } else {
-        output.push(buildOuputOptions(outputs))
+        output.push(buildOutputOptions(outputs))
       }
 
       const watcherOptions = config.build.watch
@@ -499,7 +499,7 @@ async function doBuild(
 
     const generate = (output: OutputOptions = {}) => {
       return bundle[options.write ? 'write' : 'generate'](
-        buildOuputOptions(output)
+        buildOutputOptions(output)
       )
     }
 

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -115,6 +115,10 @@ cli
     `[string] build specified entry for server-side rendering`
   )
   .option(
+    '-ssrFormat [format]',
+    '[string] SSR module format, either "cjs" or "es"'
+  )
+  .option(
     '--sourcemap',
     `[boolean] output source maps for build (default: false)`
   )


### PR DESCRIPTION
## Summary

Closes #2152 

When `"type": "module"` is set for a package, `vite build --ssr` will not build to CJS, but ESM

I'm not sure if it's worth adding a test for this? It would basically just be a test checking the the ability to read the package file and Rollup's ability to output ES. Let me know if I should though, I certainly can.