### PR TITLE
docs: fix type in [Env Variables and Modes] page

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -53,7 +53,7 @@ Only `VITE_SOME_KEY` will be exposed as `import.meta.env.VITE_SOME_KEY` to your 
 
 ## Modes
 
-By default, the dev server (`serve` command) runs in `development` mode, and the `build` command runs in `production` mode.
+By default, the dev server (`dev` command) runs in `development` mode, and the `build` command runs in `production` mode.
 
 This means when running `vite build`, it will load the env variables from `.env.production` if there is one:
 


### PR DESCRIPTION
```diff
- By default, the dev server (`serve` command) runs in `development` mode, and the `build` command runs in `production` mode.
+ By default, the dev server (`dev` command) runs in `development` mode, and the `build` command runs in `production` mode.
```

When using the `serve` command, it is actually in production mode, here should be the `dev` command.