### PR TITLE
fix(scan): set namespace when resolving to html

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -298,8 +298,12 @@ function esbuildScanPlugin(
             if (shouldExternalizeDep(resolved, id)) {
               return externalUnlessEntry({ path: id })
             }
+
+            const namespace = htmlTypesRE.test(resolved) ? 'html' : undefined
+
             return {
-              path: path.resolve(cleanUrl(resolved))
+              path: path.resolve(cleanUrl(resolved)),
+              namespace
             }
           } else {
             // resolve failed... probably usupported type


### PR DESCRIPTION
fix #2163

When the wildcard resolver used by the dependency scanner resolves an import to an HTML/Vue/Svelte file, it currently doesn't set the `'html'` namespace. Because of this, the HTML loader doesn't handle the import and it is handled by esbuild instead, which can't handle the file and throws.

```
import './App'
↓
handled by build.onResolve({ filter: /.*/ })
↓
resolved to '/.../App.vue' because of resolve.extensions: ['.vue', ...]
↓
NOT handled by build.onLoad({ filter: htmlTypesRE }) because of missing namespace
↓
error
```

By the way, wasn't sure why namespacing the HTML loader was necessary in the first place, is there a reason why it was only meant to handle files resolved from the main HTML file resolver and not the wildcard one?
But tests still pass now that HTML deps resolved from the wildcard resolver are handled too, so hope this is fine :)