### PR TITLE
chore: upgrade dep open to 7.4.2

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -104,7 +104,7 @@
     "mime": "^2.4.7",
     "minimatch": "^3.0.4",
     "okie": "^1.0.1",
-    "open": "^7.3.0",
+    "open": "^7.4.2",
     "open-in-editor": "^2.2.0",
     "periscopic": "^2.0.3",
     "postcss-import": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,10 +5596,10 @@ open-in-editor@^2.2.0:
     clap "^1.1.3"
     os-homedir "~1.0.2"
 
-open@^7.3.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/open/-/open-7.4.0.tgz#ad95b98f871d9acb0ec8fecc557082cc9986626b"
-  integrity sha512-PGoBCX/lclIWlpS/R2PQuIR4NJoXh6X5AwVzE7WXnWRGvHg7+4TBCgsujUgiPpm0K1y4qvQeWnCWVTpTKZBtvA==
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
   dependencies:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"


### PR DESCRIPTION
`7.4.1` and `7.4.2` include fixes for WSL support