### PR TITLE
fix(vue-jsx): error reading the babel configuration

### DIFF
--- a/packages/plugin-vue-jsx/index.js
+++ b/packages/plugin-vue-jsx/index.js
@@ -85,7 +85,8 @@ function vueJsxPlugin(options = {}) {
           ast: true,
           plugins,
           sourceMaps: needSourceMap,
-          sourceFileName: id
+          sourceFileName: id,
+          configFile: false
         })
 
         if (!ssr && !needHmr) {


### PR DESCRIPTION
When `babel.config.js` is used in the project, the jsx plug-in or reading the configuration incorrectly causes jsx to fail to parse.

e.g: When jest uses the `babel.config.js` file, the jsx file will fail to parse