### PR TITLE
docs: add note about assetsInlineLimit in library mode

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -454,6 +454,10 @@ export default ({ command, mode }) => {
 - **Default:** `4096` (4kb)
 
   Imported or referenced assets that are smaller than this threshold will be inlined as base64 URLs to avoid extra http requests. Set to `0` to disable inlining altogether.
+  
+  :::tip Note
+Assets will **always** be inlined, regardless of file size, and `build.assetsInlineLimit` will be ignored if you specify `build.lib`
+:::
 
 ### build.cssCodeSplit
 


### PR DESCRIPTION
I added a small note that attachments always inline in library mode, ignoring `assetsInlineLimit` option.