### PR TITLE
fix: treat the watcher path as literal name

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -275,6 +275,7 @@ export async function createServer(
     ignored: ['**/node_modules/**', '**/.git/**', ...ignored],
     ignoreInitial: true,
     ignorePermissionErrors: true,
+    disableGlobbing: true,
     ...watchOptions
   }) as FSWatcher
 


### PR DESCRIPTION
Fix https://github.com/vitejs/vite/issues/2179

Note: the strings passed to `chokidar.watch()` and `watcher.add()` will treat as literal path names after setting `disableGlobbing` , so this may affect subsequent `watcher.add()` like `configureServer` hook in user plugin.