### PR TITLE
Add support for .mjs and .cjs in output file names

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -58,7 +58,7 @@ export async function transformWithEsbuild(
   )
   
   let loader = ext.slice(1) as Loader
-  if (/^(c|m)js$/.test(loader)) {
+  if (loader === 'cjs' || loader === 'mjs') {
     loader = 'js'
   }
   

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -56,8 +56,14 @@ export async function transformWithEsbuild(
   const ext = path.extname(
     /\.\w+$/.test(filename) ? filename : cleanUrl(filename)
   )
+  
+  let loader = ext.slice(1) as Loader
+  if (/^(c|m)js$/.test(loader)) {
+    loader = 'js'
+  }
+  
   const resolvedOptions = {
-    loader: ext.slice(1) as Loader,
+    loader,
     sourcemap: true,
     // ensure source file name contains full query
     sourcefile: filename,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -57,13 +57,13 @@ export async function transformWithEsbuild(
     /\.\w+$/.test(filename) ? filename : cleanUrl(filename)
   )
   
-  let loader = ext.slice(1) as Loader
+  let loader = ext.slice(1)
   if (loader === 'cjs' || loader === 'mjs') {
     loader = 'js'
   }
   
   const resolvedOptions = {
-    loader,
+    loader: loader as Loader,
     sourcemap: true,
     // ensure source file name contains full query
     sourcefile: filename,


### PR DESCRIPTION
In some situations, the catfish may need to generate a source file with the `.cjs` or `.mjs` extensions in output file names.

At the moment this will lead to error:
```
Invalid loader: "cjs" (valid: js, jsx, ts, tsx, css, json, text, base64, dataurl, file, binary)
```