### PR TITLE
chore: upgrade @vue/babel-plugin-jsx  to 1.0.3

### DIFF
--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-transform-typescript": "^7.12.1",
-    "@vue/babel-plugin-jsx": "^1.0.1",
+    "@vue/babel-plugin-jsx": "^1.0.3",
     "hash-sum": "^2.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,7 +1141,7 @@
   resolved "https://registry.yarnpkg.com/@vue/babel-helper-vue-transform-on/-/babel-helper-vue-transform-on-1.0.2.tgz#9b9c691cd06fc855221a2475c3cc831d774bc7dc"
   integrity sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==
 
-"@vue/babel-plugin-jsx@^1.0.1":
+"@vue/babel-plugin-jsx@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@vue/babel-plugin-jsx/-/babel-plugin-jsx-1.0.3.tgz#ad5ee86ebc9fc40900add9914534e223c719eace"
   integrity sha512-+52ZQFmrM0yh61dQlgwQlfHZXmYbswbQEL25SOSt9QkjegAdfIGu87oELw0l8H6cuJYazZCiNjPR9eU++ZIbxg==


### PR DESCRIPTION
I think this upgrade is necessary , because I can't upgrade babel-plugin-jsx by upgrade @vitejs/plugin-vue-jsx
![image](https://user-images.githubusercontent.com/17829108/109019237-29335c00-76fc-11eb-8ba5-6a7f15fe3198.png)
