### PR TITLE
fix: can overwrite variable of the ssr module export

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -43,7 +43,7 @@ test('export function decl', async () => {
   expect((await ssrTransform(`export function foo() {}`, null)).code)
     .toMatchInlineSnapshot(`
     "function foo() {}
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, get(){ return foo }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
   `)
 })
 
@@ -51,7 +51,7 @@ test('export class decl', async () => {
   expect((await ssrTransform(`export class foo {}`, null)).code)
     .toMatchInlineSnapshot(`
     "class foo {}
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, get(){ return foo }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
   `)
 })
 
@@ -59,8 +59,8 @@ test('export var decl', async () => {
   expect((await ssrTransform(`export const a = 1, b = 2`, null)).code)
     .toMatchInlineSnapshot(`
     "const a = 1, b = 2
-    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, get(){ return a }})
-    Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, get(){ return b }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
+    Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }})"
   `)
 })
 
@@ -69,8 +69,8 @@ test('export named', async () => {
     (await ssrTransform(`const a = 1, b = 2; export { a, b as c }`, null)).code
   ).toMatchInlineSnapshot(`
     "const a = 1, b = 2; 
-    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, get(){ return a }})
-    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, get(){ return b }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
+    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }})"
   `)
 })
 
@@ -80,8 +80,8 @@ test('export named from', async () => {
   ).toMatchInlineSnapshot(`
     "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
-    Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, get(){ return __vite_ssr_import_0__.ref }})
-    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, get(){ return __vite_ssr_import_0__.computed }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.ref }})
+    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.computed }})"
   `)
 })
 
@@ -96,7 +96,7 @@ test('named exports of imported binding', async () => {
   ).toMatchInlineSnapshot(`
     "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
-    Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, get(){ return __vite_ssr_import_0__.createApp }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.createApp }})"
   `)
 })
 
@@ -126,6 +126,6 @@ test('dynamic import', async () => {
     (await ssrTransform(`export const i = () => import('./foo')`, null)).code
   ).toMatchInlineSnapshot(`
     "const i = () => __vite_ssr_dynamic_import__('./foo')
-    Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, get(){ return i }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, configurable: true, get(){ return i }})"
   `)
 })

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -109,6 +109,7 @@ async function instantiateModule(
       if (key !== 'default') {
         Object.defineProperty(ssrModule, key, {
           enumerable: true,
+          configurable: true,
           get() {
             return sourceModule[key]
           }

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -52,7 +52,7 @@ export async function ssrTransform(
   function defineExport(name: string, local = name) {
     s.append(
       `\nObject.defineProperty(${ssrModuleExportsKey}, "${name}", ` +
-        `{ enumerable: true, get(){ return ${local} }})`
+        `{ enumerable: true, configurable: true, get(){ return ${local} }})`
     )
   }
 


### PR DESCRIPTION
For example:
```ts
export * from 'test-module'

// The testFunc exists in the `test-module`
// Export to overwrite that one
export const testFunc () {

}
```