### PR TITLE
docs: why section convention for Vite only plugins

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -17,6 +17,7 @@ For Vite only plugins
 
 - Vite Plugins should have a clear name with `vite-plugin-` prefix.
 - Include `vite-plugin` keyword in package.json.
+- Include a section in the plugin docs detailing why it is a Vite only plugin (for example, it uses Vite specific plugin hooks).
 
 If your plugin is only going to work for a particular framework, its name should be included as part of the prefix
 


### PR DESCRIPTION
From a discussion with @antfu
There are several plugins being created for Vite that already exists as rollup plugins. This PR adds a short note in the conventions for Vite only plugins that authors are recommended to add a section explaining why it is a Vite only plugin. Hopefully writing this section may push them to realize that the plugin could be a general rollup plugin (or look if there is already an established rollup alternative). In case this is merged, the same note will be added to the PR template in awesome-vite.