### PR TITLE
Allow prefixing the generated path

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -153,7 +153,7 @@ function fileToDevUrl(id: string, config: ResolvedConfig) {
     // (this is special handled by the serve static middleware
     rtn = path.posix.join(FS_PREFIX + id)
   }
-  return config.base + rtn.replace(/^\//, '')
+  return (process.env.VITE_BASE || '') + config.base + rtn.replace(/^\//, '')
 }
 
 const assetCache = new WeakMap<ResolvedConfig, Map<string, string>>()


### PR DESCRIPTION
This will allow working with vite with any backend.

It's not possible to inject a full path with the config since the full URL is transformed by `resolveBaseUrl()`

```js
{
    base: 'http://localhost:3000/assets/',
}
// Will set config.path = "/assets/"
```

So every path generated by `fileToDevUrl()` will be `/assets/...` instead of `http://localhost:3000/assets/`.

With this fix we can use 

```
VITE_BASE=http://localhost:3000 yarn run dev
```

And the generated paths will contain the full path (so vite can be used with any server) and fix #2196