### PR TITLE
fix: css tags injection priority

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -294,6 +294,12 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         seen: Set<string> = new Set()
       ): HtmlTagDescriptor[] => {
         const tags: HtmlTagDescriptor[] = []
+        chunk.imports.forEach((file) => {
+          const importee = bundle[file]
+          if (importee && importee.type === 'chunk') {
+            tags.push(...getCssTagsForChunk(importee, seen))
+          }
+        })
         const cssFiles = chunkToEmittedCssFileMap.get(chunk)
         if (cssFiles) {
           cssFiles.forEach((file) => {
@@ -309,12 +315,6 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             }
           })
         }
-        chunk.imports.forEach((file) => {
-          const importee = bundle[file]
-          if (importee && importee.type === 'chunk') {
-            tags.push(...getCssTagsForChunk(importee, seen))
-          }
-        })
         return tags
       }
 


### PR DESCRIPTION
In vite/html plugin, The importer css chunk should inject after importee chunk for higher css class priority.
e.g `index.page.css` import `vendor.css`，`vendor.css` should be placed before `index.page.css` in built html.

current build result:
![image](https://user-images.githubusercontent.com/7200477/109287065-0faa2580-785e-11eb-8ddf-291d202d75dd.png)

preferred:
![image](https://user-images.githubusercontent.com/7200477/109287153-323c3e80-785e-11eb-8439-c7d9e04b87f7.png)
