### PR TITLE
docs: note about community templates

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -65,6 +65,24 @@ Supported template presets include:
 
 See [@vitejs/create-app](https://github.com/vitejs/vite/tree/main/packages/create-app) for more details on each template.
 
+## Community Templates
+
+@vitejs/create-app is a tool to quickly start a project from a basic template for popular frameworks. Check out Awesome Vite for [community maintained templates](https://github.com/vitejs/awesome-vite#templates) that include other tools or target different frameworks. You can use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates.
+
+```bash
+npx degit user/project my-project
+cd my-project
+
+npm install
+npm run dev
+```
+
+If the project uses `main` as the default branch, suffix the project repo with `#main`
+
+```bash
+npx degit user/project#main my-project
+```
+
 ## `index.html` and Project Root
 
 One thing you may have noticed is that in a Vite project, `index.html` is front-and-central instead of being tucked away inside `public`. This is intentional: during development Vite is a server, and `index.html` is the entry point to your application.

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -36,3 +36,21 @@ Currently supported template presets include:
 - `preact-ts`
 - `lit-element`
 - `lit-element-ts`
+
+## Community Templates
+
+@vitejs/create-app is a tool to quickly start a project from a basic template for popular frameworks. Check out Awesome Vite for [community maintained templates](https://github.com/vitejs/awesome-vite#templates) that include other tools or target different frameworks. You can use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates.
+
+```bash
+npx degit user/project my-project
+cd my-project
+
+npm install
+npm run dev
+```
+
+If the project uses `main` as the default branch, suffix the project repo with `#main`
+
+```bash
+npx degit user/project#main my-project
+```


### PR DESCRIPTION
There have been several issues and PRs in the past weeks asking for new starter templates for @vitejs/create-app. 
This PR adds a note to the Vite Docs and the readme of create-app that clarifies the scope of the tool and points users to Awesome Vite to discover other templates.
It recommends using [degit](https://github.com/Rich-Harris/degit) to copy the templates. I had to add a note about adding the `#main` suffix in case the project uses that as the default branch. There is an open PR to fix this in `degit`, if that is merged, we can remove the note. There is also a community fork that includes this PR and others (https://github.com/tiged/tiged), but I don't know enough about it to recommend it.