### PR TITLE
fix: inject `sourcesContent` into sourcemaps if missing

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -1,0 +1,20 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export async function injectSourcesContent(
+  map: { sources: string[]; sourcesContent?: string[]; sourceRoot?: string },
+  file: string
+) {
+  const sourceRoot = await fs.realpath(
+    path.resolve(path.dirname(file), map.sourceRoot || '')
+  )
+  map.sourcesContent = []
+  await Promise.all(
+    map.sources.map(async (sourcePath, i) => {
+      map.sourcesContent![i] = await fs.readFile(
+        path.resolve(sourceRoot, sourcePath),
+        'utf-8'
+      )
+    })
+  )
+}

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils'
 import { checkPublicFile } from '../plugins/asset'
 import { ssrTransform } from '../ssr/ssrTransform'
+import { injectSourcesContent } from './sourcemap'
 
 const debugLoad = createDebugger('vite:load')
 const debugTransform = createDebugger('vite:transform')
@@ -133,6 +134,13 @@ export async function transformRequest(
     isDebug && debugTransform(`${timeFrom(transformStart)} ${prettyUrl}`)
     code = transformResult.code!
     map = transformResult.map
+  }
+
+  if (map && mod.file) {
+    map = (typeof map === 'string' ? JSON.parse(map) : map) as SourceMap
+    if (map.mappings && !map.sourcesContent) {
+      await injectSourcesContent(map, mod.file)
+    }
   }
 
   if (ssr) {


### PR DESCRIPTION
Otherwise, devtools will request sources using /@fs/ urls, which are transformed!

This was previously fixed by #886, but it was removed in v2.