### PR TITLE
chore: github discussions and discord in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,7 @@ assignees: ''
 
 - [ ] Read [the docs](https://vitejs.dev/guide/).
 - [ ] Make sure this is a Vite issue and not a framework-specific issue. For example, if it's a Vue SFC related bug, it should likely be reported to https://github.com/vuejs/vue-next instead.
+- [ ] This is a concrete bug. For Q&A open a [GitHub Discussion](https://github.com/vitejs/vite/discussions) or join our [Discord Chat Server](https://chat.vitejs.dev/).
 
 ## Describe the bug
 


### PR DESCRIPTION
This PR adds a step to the Bug Report checklist to confirm that the report is a concrete bug. And points people to Discussions and Discord for Q&A. Hopefully this should help to push some users in the right direction before they ask a question by creating a bug report.