### PR TITLE
fix(types): add missing types field in template-preact-ts

### DIFF
--- a/packages/create-app/template-preact-ts/tsconfig.json
+++ b/packages/create-app/template-preact-ts/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "types": [],
+    "types": ["vite/client"],
     "allowJs": false,
     "skipLibCheck": false,
     "esModuleInterop": false,


### PR DESCRIPTION
unlike other ts templates,`template-preact-ts` leaves the "types" field empty in `tsconfig.json`, which causes import.meta related types to be not found.