### PR TITLE
fix(scan): handle race condition for tempDir removal

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -96,8 +96,10 @@ export async function scanImports(
     )
   )
 
-  emptyDir(tempDir)
-  fs.rmdirSync(tempDir)
+  if (fs.existsSync(tempDir)) {
+    emptyDir(tempDir)
+    fs.rmdirSync(tempDir)
+  }
 
   debug(`Scan completed in ${Date.now() - s}ms:`, deps)
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -96,9 +96,13 @@ export async function scanImports(
     )
   )
 
-  emptyDir(tempDir)
-  if (fs.existsSync(tempDir)) {
+  try {
+    emptyDir(tempDir)
     fs.rmdirSync(tempDir)
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
   }
 
   debug(`Scan completed in ${Date.now() - s}ms:`, deps)

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -96,8 +96,8 @@ export async function scanImports(
     )
   )
 
+  emptyDir(tempDir)
   if (fs.existsSync(tempDir)) {
-    emptyDir(tempDir)
     fs.rmdirSync(tempDir)
   }
 


### PR DESCRIPTION
When calling `vite.build` rapidly, there is a race condition situation where directory is already removed already by previous build ([nuxt-vite issue](https://github.com/nuxt/vite#no-such-file-or-directory-rmdir-node_modulesvitetemp))