### PR TITLE
fix: serving static files from root

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -71,6 +71,8 @@ export function serveRawFsMiddleware(): Connect.NextHandleFunction {
     if (url.startsWith(FS_PREFIX)) {
       url = url.slice(FS_PREFIX.length)
       if (isWin) url = url.replace(/^[A-Z]:/i, '')
+      
+      req.url = url
       serveFromRoot(req, res, next)
     } else {
       next()


### PR DESCRIPTION
This fixes a critical error when loading static files from the root of the file system. This problem is observed on Windows. Not sure if it is relevant for other systems. 