### PR TITLE
fix: await bundle close

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -284,7 +284,7 @@ export async function build(
   } finally {
     parallelCallCounts--
     if (parallelCallCounts <= 0) {
-      paralellBuilds.forEach((bundle) => bundle.close())
+      await Promise.all(paralellBuilds.map((bundle) => bundle.close()))
       paralellBuilds.length = 0
     }
   }


### PR DESCRIPTION
Should `await bundle.close()` in build,
because some async rollup hooks will emit when `bundle.close()` called.