### PR TITLE
Update docs on `localsConvention`

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -65,7 +65,7 @@ export interface CSSModulesOptions {
     | ((name: string, filename: string, css: string) => string)
   hashPrefix?: string
   /**
-   * default: 'camelCase'
+   * default: null
    */
   localsConvention?:
     | 'camelCase'


### PR DESCRIPTION
Update docs on `localsConvention`

CSS modules now defaults to export class names as-is. https://github.com/vitejs/vite/commit/fee739325fd4dbf7f6d842c205608e39271db513

According to the [postcss-module docs](https://github.com/madyankin/postcss-modules#user-content-localsconvention), the default value for `localsConvention` should be `null`.