### PR TITLE
fix: can't import fonts outside the `root`

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -71,6 +71,7 @@ export function serveRawFsMiddleware(): Connect.NextHandleFunction {
     if (url.startsWith(FS_PREFIX)) {
       url = url.slice(FS_PREFIX.length)
       if (isWin) url = url.replace(/^[A-Z]:/i, '')
+      req.url = url
       serveFromRoot(req, res, next)
     } else {
       next()


### PR DESCRIPTION
closes #1531