### PR TITLE
dx: Improve how @fs urls are printed

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -166,10 +166,7 @@ export function prettifyUrl(url: string, root: string) {
   url = removeTimestampQuery(url)
   const isAbsoluteFile = url.startsWith(root)
   if (isAbsoluteFile || url.startsWith(FS_PREFIX)) {
-    let file = path.relative(
-      root,
-      isAbsoluteFile ? url : url.slice(FS_PREFIX.length)
-    )
+    let file = isAbsoluteFile ? path.relative(root, url) : fsPathFromId(url)
     const seg = file.split('/')
     const npmIndex = seg.indexOf(`node_modules`)
     const isSourceMap = file.endsWith('.map')

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -166,7 +166,7 @@ export function prettifyUrl(url: string, root: string) {
   url = removeTimestampQuery(url)
   const isAbsoluteFile = url.startsWith(root)
   if (isAbsoluteFile || url.startsWith(FS_PREFIX)) {
-    let file = isAbsoluteFile ? path.relative(root, url) : fsPathFromId(url)
+    let file = path.relative(root, isAbsoluteFile ? url : fsPathFromId(url))
     const seg = file.split('/')
     const npmIndex = seg.indexOf(`node_modules`)
     const isSourceMap = file.endsWith('.map')


### PR DESCRIPTION
### Description 📖 

This pull request changes the way `@fs` paths are processed by `prettifyUrl`.

#### Before

Prior to these changes, `@fs` URLs were incorrectly printed if they were absolute paths:

```
vite:load 0ms   [fs] ../../../Projects/pingcrm-vite/app/javascript/Shared/SelectInput.vue +10ms
vite:transform 6ms   ../../../Projects/pingcrm-vite/app/javascript/Shared/SelectInput.vue +11ms
vite:time 9ms   ../../../Projects/pingcrm-vite/app/javascript/Shared/SelectInput.vue +11ms
```

#### After

Now `@fs` paths are printed relative to the root:

```
vite:load 0ms   [fs] ../Shared/SelectInput.vue +14s
vite:transform 14ms  ../Shared/SelectInput.vue +14s
vite:time 16ms  ../Shared/SelectInput.vue +14s
```