### PR TITLE
feat(config): add `defineHtml` config to make define works for html files

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -111,6 +111,14 @@ export default ({ command, mode }) => {
 
   - Replacements are performed only when the match is surrounded by word boundaries (`\b`).
 
+### defineHtml
+
+- **Type:** `boolean`
+
+  Above `define` replacements only works for scripts files by default. Setting `defineHtml` to `true` to make it also works for html files.
+
+  If you need more complicated replacements, please write your own plugin with [transformIndexHtml](/guide/api-plugin.html#transformindexhtml) hook instead.
+
 ### plugins
 
 - **Type:** ` (Plugin | Plugin[])[]`

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -88,6 +88,11 @@ export interface UserConfig {
    */
   define?: Record<string, any>
   /**
+   * `define` only works for script files by default
+   * set `defineHtml` to true to make it also works for html files
+   */
+  defineHtml?: boolean
+  /**
    * Array of vite plugins to use.
    */
   plugins?: (Plugin | Plugin[])[]

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -93,6 +93,12 @@ export function definePlugin(config: ResolvedConfig): Plugin {
         result.map = s.generateMap({ hires: true })
       }
       return result
+    },
+    transformIndexHtml(html: string) {
+      if (config.defineHtml !== true) return html
+      return html.replace(pattern, (_, match) => {
+        return '' + replacements[match]
+      })
     }
   }
 }


### PR DESCRIPTION
It is a quite common scenario for users to use node environment variables in **both script files and  HTML files**, for example, in my real project, I use `process.env.COMMIT_HASH` in js

```jsx
function Version(){
  return <div>{process.env.COMMIT_HASH}</div>
}
```

and also in an inlined script in HTML template:

```html
<script src="path/to/error-tracker.js"></script>
<script>
ErrorTracker.init({
  version: process.env.COMMIT_HASH
})
</script>
```

With the current version of `vite`, I can easily config [`define`](https://vitejs.dev/config/#define) to accomplish that in **js files**, but I have to write another plugin with `transformIndexHtml` hook to replace the same node envs in HTML files.

This PR adds a boolean property `defineHtml ` to simplify and unify that replacement. And they both shared the same define config, so I can config once, use in both HTML and js files.

```js
// vite.config.js
export default defineConfig({
  define: {
    'process.env.COMMIT_HASH': JSON.stringify(process.env.COMMIT_HASH),
  },
  defineHtml: true,
  // ...other configs
})
```