### PR TITLE
docs: fix build.sourcemap type

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -466,7 +466,7 @@ export default ({ command, mode }) => {
 
 ### build.sourcemap
 
-- **Type:** `boolean`
+- **Type:** `boolean | 'inline'`
 - **Default:** `false`
 
   Generate production source maps.


### PR DESCRIPTION
Inlined sourcemap is undocumented feature. 