### PR TITLE
feat(proxy): add server.proxy.router config like http-proxy-middlewar…

### DIFF
--- a/packages/playground/proxy/__tests__/proxy.spec.ts
+++ b/packages/playground/proxy/__tests__/proxy.spec.ts
@@ -1,0 +1,6 @@
+test('/router', async () => {
+  const port = require('../vite.config.js').server.port
+  const url = `http://localhost:${port}`
+  await page.goto(url + '/')
+  expect(await page.textContent('.app')).toMatch('router')
+})

--- a/packages/playground/proxy/__tests__/serve.js
+++ b/packages/playground/proxy/__tests__/serve.js
@@ -1,0 +1,47 @@
+// @ts-check
+// this is automtically detected by scripts/jestPerTestSetup.ts and will replace
+// the default e2e test serve behavior
+
+const path = require('path')
+
+const port = (exports.port = 9527)
+
+/**
+ * @param {string} root
+ * @param {boolean} isProd
+ */
+exports.serve = async function serve(root, isProd) {
+  const { createServer } = require('vite')
+  const { createHostServer } = require(path.resolve(root, 'server.js'))
+  const InlineConfig = require(path.resolve(root, 'vite.config.js'))
+
+  const hostApp = await createHostServer(root, isProd)
+
+  const hostHandler = new Promise((resolve, reject) => {
+    try {
+      const hostServer = hostApp.listen(8080, () => {
+        resolve({
+          close() {
+            hostServer.close()
+            return devServer && devServer.close()
+          }
+        })
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+
+  const devServer = await createServer({
+    root,
+    base: InlineConfig.base,
+    mode: InlineConfig.mode,
+    configFile: InlineConfig.config,
+    logLevel: InlineConfig.logLevel,
+    clearScreen: InlineConfig.clearScreen,
+    server: InlineConfig.server
+  })
+  await devServer.listen()
+
+  return hostHandler
+}

--- a/packages/playground/proxy/index.html
+++ b/packages/playground/proxy/index.html
@@ -1,0 +1,10 @@
+<div class="app"></div>
+<script type="module">
+  fetch('/v1/get')
+    .then(function (response) {
+      return response.json()
+    })
+    .then(function (json) {
+      document.querySelector('.app').textContent = json.key
+    })
+</script>

--- a/packages/playground/proxy/package.json
+++ b/packages/playground/proxy/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-proxy",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "serve": "vite preview"
+  }
+}

--- a/packages/playground/proxy/server.js
+++ b/packages/playground/proxy/server.js
@@ -1,0 +1,21 @@
+const http = require('http')
+
+async function createServer(root, isProd) {
+  http
+    .createServer((req, res) => {
+      res.end()
+    })
+    .listen(8081, () => {
+      console.log('http://localhos:8081/')
+    })
+  http
+    .createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ key: 'router' }))
+    })
+    .listen(8080, () => {
+      console.log('http://localhos:8080/')
+    })
+}
+
+exports.createServer = createServer

--- a/packages/playground/proxy/server.js
+++ b/packages/playground/proxy/server.js
@@ -1,21 +1,14 @@
-const http = require('http')
+const express = require('express')
 
-async function createServer(root, isProd) {
-  http
-    .createServer((req, res) => {
-      res.end()
-    })
-    .listen(8081, () => {
-      console.log('http://localhos:8081/')
-    })
-  http
-    .createServer((req, res) => {
-      res.writeHead(200, { 'Content-Type': 'application/json' })
-      res.end(JSON.stringify({ key: 'router' }))
-    })
-    .listen(8080, () => {
-      console.log('http://localhos:8080/')
-    })
+async function createHostServer(root, isProd) {
+  const app = express()
+
+  app.use('*', async (req, res) => {
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ key: 'router' }))
+  })
+
+  return app
 }
 
-exports.createServer = createServer
+exports.createHostServer = createHostServer

--- a/packages/playground/proxy/vite.config.js
+++ b/packages/playground/proxy/vite.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  plugins: [
+    {
+      name: 'proxy',
+      config: async () => {
+        const { createServer } = require('./server')
+        await createServer()
+      }
+    }
+  ],
+  server: {
+    port: 3000,
+    proxy: {
+      '/v1': {
+        target: 'http://localhost:8081',
+        router: {
+          'localhost:3000': 'http://localhost:8080'
+        }
+      }
+    }
+  }
+}

--- a/packages/playground/proxy/vite.config.js
+++ b/packages/playground/proxy/vite.config.js
@@ -1,13 +1,4 @@
 module.exports = {
-  plugins: [
-    {
-      name: 'proxy',
-      config: async () => {
-        const { createServer } = require('./server')
-        await createServer()
-      }
-    }
-  ],
   server: {
     port: 3000,
     proxy: {

--- a/packages/playground/ssr-vue/__tests__/serve.js
+++ b/packages/playground/ssr-vue/__tests__/serve.js
@@ -11,7 +11,6 @@ const port = (exports.port = 9527)
  * @param {boolean} isProd
  */
 exports.serve = async function serve(root, isProd) {
-  console.log('serve111')
   if (isProd) {
     // build first
     const { build } = require('vite')

--- a/packages/playground/ssr-vue/__tests__/serve.js
+++ b/packages/playground/ssr-vue/__tests__/serve.js
@@ -11,6 +11,7 @@ const port = (exports.port = 9527)
  * @param {boolean} isProd
  */
 exports.serve = async function serve(root, isProd) {
+  console.log('serve111')
   if (isProd) {
     // build first
     const { build } = require('vite')

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -125,7 +125,7 @@ async function prepareProxyRequest(
   const newProxyOptions = Object.assign({}, opts)
 
   if (opts.router) {
-    let newTarget = await getTarget(req, opts)
+    const newTarget = await getTarget(req, opts)
     if (newTarget) {
       debug('[proxy] Router new target: %s -> "%s"', opts.target, newTarget)
       newProxyOptions.target = newTarget
@@ -164,23 +164,23 @@ function getTargetFromProxyTable(
 
   const hostAndPath = host + path
 
-  Object.keys(table).forEach((key) => {
+  for (const [key, value] of Object.entries(table)) {
     if (key.indexOf('/') > -1) {
       if (hostAndPath.indexOf(key) > -1) {
         // match 'localhost:3000/api'
-        result = table[key]
+        result = value
         debug('[proxy] Router table match: "%s"', key)
-        return false
+        continue
       }
     } else {
       if (key === host) {
         // match 'localhost:3000'
-        result = table[key]
+        result = value
         debug('[proxy] Router table match: "%s"', host)
-        return false
+        continue
       }
     }
-  })
+  }
 
   return result
 }


### PR DESCRIPTION
1. run `yarn build-vite` to rebuild vite first.
2. run `npx jest proxy` and get the result:
```sh
PS C:\Users\cisen\Desktop\develop\pr\vite\2\vite> npx jest proxy
  console.log
    http://localhos:8081/

      at Server.<anonymous> (temp/proxy/server.js:9:15)

  console.log
    http://localhos:8080/

      at Server.<anonymous> (temp/proxy/server.js:17:15)

 PASS  packages/playground/proxy/__tests__/proxy.spec.ts
  √ /router (69 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.059 s
Ran all test suites matching /proxy/i.
```