### PR TITLE
fix: fix early logger definiton in resolveConfig

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -197,7 +197,6 @@ export async function resolveConfig(
 ): Promise<ResolvedConfig> {
   let config = inlineConfig
   let mode = inlineConfig.mode || defaultMode
-  const logger = createLogger(config.logLevel, config.clearScreen)
 
   // some dependencies e.g. @vue/compiler-* relies on NODE_ENV for getting
   // production-specific behavior, so set it here even though we haven't
@@ -224,6 +223,10 @@ export async function resolveConfig(
       configFile = loadResult.path
     }
   }
+
+  // Define logger
+  const logger = createLogger(config.logLevel, config.clearScreen)
+
   // user config may provide an alternative mode
   mode = config.mode || mode
 


### PR DESCRIPTION
The config was defined too early in resolveConfig. `config.logLevel` and `config.clearScreen` both aren't defined yet, so these options do not work.