### PR TITLE
fix: Improve injectQuery path handling (fix #2422)

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { parse as parseUrl } from 'url'
+import { pathToFileURL, URL } from 'url'
 import { FS_PREFIX, DEFAULT_EXTENSIONS, VALID_ID_PREFIX } from './constants'
 import resolve from 'resolve'
 import builtins from 'builtin-modules'
@@ -119,7 +119,14 @@ export function removeImportQuery(url: string) {
 }
 
 export function injectQuery(url: string, queryToInject: string) {
-  const { pathname, search, hash } = parseUrl(url)
+  let resolvedUrl = new URL(url, 'relative:///')
+  if (resolvedUrl.protocol !== 'relative:') {
+    resolvedUrl = pathToFileURL(url)
+  }
+  let { protocol, pathname, search, hash } = resolvedUrl
+  if (protocol === 'file:') {
+    pathname = pathname.slice(1)
+  }
   return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
     hash || ''
   }`


### PR DESCRIPTION
Fixes #2422.

This PR updates `injectQuery` to handle Windows paths in a saner manner.
- As `url.parse` has been deprecated in Node, relative paths are now resolved using `new URL(url, 'relative:///')`.
- When a Windows drive letter is erroneously used as a protocol (e.g. `c:`), it instead resolves it using `url.pathToFileURL` and removes the first character (a forward slash) so that the following code in importAnalysis can properly handle it as an in-root URL:

https://github.com/vitejs/vite/blob/76f35352dbfc4e16cb65005e57e2757a97675bfd/packages/vite/src/node/plugins/importAnalysis.ts#L182-L192