### PR TITLE
feat: support postcss sugarss

### DIFF
--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -46,6 +46,8 @@
   <p class="css-dep-sass">
     @import dependency w/ sass enrtrypoints: this should be orange
   </p>
+  <p>Imported SugarSS indent-based CSS syntax for PostCSS:</p>
+  <pre class="imported-sugarss"></pre>
 </div>
 
 <script type="module" src="./main.js"></script>

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -17,6 +17,9 @@ text('.modules-sass-code', JSON.stringify(sassMod, null, 2))
 
 import './dep.css'
 
+import sss from './sugarss.sss'
+text('.imported-sugarss', sss)
+
 function text(el, text) {
   document.querySelector(el).textContent = text
 }

--- a/packages/playground/css/package.json
+++ b/packages/playground/css/package.json
@@ -9,9 +9,11 @@
     "serve": "vite preview"
   },
   "devDependencies": {
+    "css-dep": "link:./css-dep",
     "less": "^4.1.0",
     "postcss-nested": "^5.0.3",
+    "postcss-simple-vars": "^6.0.3",
     "sass": "^1.32.5",
-    "css-dep": "link:./css-dep"
+    "sugarss": "^3.0.3"
   }
 }

--- a/packages/playground/css/postcss.config.js
+++ b/packages/playground/css/postcss.config.js
@@ -1,3 +1,12 @@
-module.exports = {
-  plugins: [require('postcss-nested')]
+module.exports = (api) => {
+  if (/\.sss$/.test(api.file)) {
+    return {
+      parser: 'sugarss',
+      plugins: [require('postcss-simple-vars'), require('postcss-nested')]
+    }
+  }
+
+  return {
+    plugins: [require('postcss-nested')]
+  }
 }

--- a/packages/playground/css/sugarss.sss
+++ b/packages/playground/css/sugarss.sss
@@ -1,0 +1,4 @@
+$black: #000
+
+.sugarss
+  border: thick double $black

--- a/packages/vite/types/shims.d.ts
+++ b/packages/vite/types/shims.d.ts
@@ -54,6 +54,7 @@ declare module 'postcss-load-config' {
   ): Promise<{
     options: ProcessOptions
     plugins: Plugin[]
+    file: string
   }>
   export = load
 }

--- a/packages/vite/types/shims.d.ts
+++ b/packages/vite/types/shims.d.ts
@@ -46,19 +46,6 @@ declare module 'merge-source-map' {
   export default function merge(oldMap: object, newMap: object): object
 }
 
-declare module 'postcss-load-config' {
-  import { ProcessOptions, Plugin } from 'postcss'
-  function load(
-    inline: any,
-    root: string
-  ): Promise<{
-    options: ProcessOptions
-    plugins: Plugin[]
-    file: string
-  }>
-  export = load
-}
-
 declare module 'postcss-import' {
   import { Plugin } from 'postcss'
   const plugin: (options: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,7 +2079,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.1:
+colorette@^1.2.1, colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -6078,6 +6078,11 @@ postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
+postcss-simple-vars@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-simple-vars/-/postcss-simple-vars-6.0.3.tgz#e66516c7fe980da3498f4a8ad400b9c53861806c"
+  integrity sha512-fkNn4Zio8vN4vIig9IFdb8lVlxWnYR769RgvxCM6YWlFKie/nQaOcaMMMFz/s4gsfHW4/5bJW+i57zD67mQU7g==
+
 postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
@@ -6089,6 +6094,15 @@ postcss@^8.1.10, postcss@^8.2.1:
   integrity sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==
   dependencies:
     colorette "^1.2.1"
+    nanoid "^3.1.20"
+    source-map "^0.6.1"
+
+postcss@^8.1.6:
+  version "8.2.7"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.7.tgz#48ed8d88b4de10afa0dfd1c3f840aa57b55c4d47"
+  integrity sha512-DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==
+  dependencies:
+    colorette "^1.2.2"
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
@@ -7362,6 +7376,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1, strip-json-comments@~3.1
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+sugarss@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/sugarss/-/sugarss-3.0.3.tgz#bb2489961b98fbd15e4e35d6b9f4f2ee5547a6cb"
+  integrity sha512-uxa2bbuc+w7ov7DyYIhF6bM0qZF3UkFT5/nE8AJgboiVnKsBDbwxs++dehEIe1JNhpMaGJc37wGQ2QrrWey2Sg==
+  dependencies:
+    postcss "^8.1.6"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Hi, this PR adds support for handling https://github.com/postcss/sugarss in css plugin, it's Indent-based CSS syntax for PostCSS.

Biggest change here is how the postcss config is resolve. 

For handling `.sss` we need tell postcss to use the sugarss parser but not for css files. This can be achieved via passing a `id` that will be passed  `ctx: { file: string }` to config. Similar as https://github.com/webpack-contrib/postcss-loader does it.

Current implementation was caching resolved config, this is not true now as we resolved it per id. Changed it to keep cache for each id, but wondering now if that will give any significant performance improvement, or just increase memory 🤔 

Added `cachedPostcssConfigPath` that will keep path to resolved config this can impact performance.
