### PR TITLE
fix: check if postcss-import is already included in plugins

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -575,7 +575,11 @@ async function compileCSS(
   const postcssPlugins =
     postcssConfig && postcssConfig.plugins ? postcssConfig.plugins.slice() : []
 
-  if (needInlineImport) {
+  const hasImportPlugin = postcssPlugins.some(
+    (plugin) => plugin.postcssPlugin === 'postcss-import'
+  )
+
+  if (needInlineImport && !hasImportPlugin) {
     postcssPlugins.unshift(
       (await import('postcss-import')).default({
         async resolve(id, basedir) {


### PR DESCRIPTION
Hi, in cases when there is already defined `postcss-import` in config plugins let's not add default one from vite