### PR TITLE
fix: make import resolution failures easier to track down

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -172,7 +172,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
         if (!resolved) {
           this.error(
-            `Failed to resolve import "${url}". Does the file exist?`,
+            `Failed to resolve import "${url}" from "${path.relative(
+              process.cwd(),
+              importer
+            )}". Does the file exist?`,
             pos
           )
         }


### PR DESCRIPTION
An alternative would be to use `importer` instead of `path.relative(process.cwd(), importer)`, though personally I find the latter easier to read when I encounter it
