### PR TITLE
fix(hmr): never invalidate an accepting importer

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -234,7 +234,11 @@ function invalidate(mod: ModuleNode, timestamp: number, seen: Set<ModuleNode>) {
   seen.add(mod)
   mod.lastHMRTimestamp = timestamp
   mod.transformResult = null
-  mod.importers.forEach((importer) => invalidate(importer, timestamp, seen))
+  mod.importers.forEach((importer) => {
+    if (!importer.acceptedHmrDeps.has(mod)) {
+      invalidate(importer, timestamp, seen)
+    }
+  })
 }
 
 export function handlePrunedModules(


### PR DESCRIPTION
A module that uses `hot.accept` for a dependency should **not** be invalidated when that dependency is hot-reloaded. Otherwise, the accepting module will be reloaded by its own importers (but only when an importer is reloaded), which is both unnecessary and unexpected.

This behavior led to a bug in a PR to `vite-plugin-react-pages` where HMR updates to a virtual module are merged intelligently to avoid a full page reload. https://github.com/vitejs/vite-plugin-react-pages/pull/11