### PR TITLE
feat: add inlineConfig.envFile option to disable .env files

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -33,6 +33,7 @@ const { createServer } = require('vite')
 The `InlineConfig` interface extends `UserConfig` with additional properties:
 
 - `configFile`: specify config file to use. If not set, Vite will try to automatically resolve one from project root. Set to `false` to disable auto resolving.
+- `envFile`: Set to `false` to disable `.env` files.
 
 ## `ViteDevServer`
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -158,12 +158,13 @@ export interface SSROptions {
 
 export interface InlineConfig extends UserConfig {
   configFile?: string | false
+  envFile?: false
 }
 
 export type ResolvedConfig = Readonly<
   Omit<UserConfig, 'plugins' | 'alias' | 'dedupe' | 'assetsInclude'> & {
     configFile: string | undefined
-    inlineConfig: UserConfig
+    inlineConfig: InlineConfig
     root: string
     base: string
     publicDir: string
@@ -268,7 +269,7 @@ export async function resolveConfig(
   }
 
   // load .env files
-  const userEnv = loadEnv(mode, resolvedRoot)
+  const userEnv = inlineConfig.envFile !== false && loadEnv(mode, resolvedRoot)
 
   // Note it is possible for user to have a custom mode, e.g. `staging` where
   // production-like behavior is expected. This is indicated by NODE_ENV=production

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -41,11 +41,15 @@ export async function handleHMRUpdate(
   const { ws, config, moduleGraph } = server
   const shortFile = getShortName(file, config.root)
 
-  if (file === config.configFile || file.endsWith('.env')) {
+  const isConfig = file === config.configFile
+  const isEnv = config.inlineConfig.envFile !== false && file.endsWith('.env')
+  if (isConfig || isEnv) {
     // auto restart server
     debugHmr(`[config change] ${chalk.dim(shortFile)}`)
     config.logger.info(
-      chalk.green('config or .env file changed, restarting server...'),
+      chalk.green(
+        `${isConfig ? 'config' : '.env'} file changed, restarting server...`
+      ),
       { clear: true, timestamp: true }
     )
     await restartServer(server)


### PR DESCRIPTION
This feature is primarily for frameworks that use Vite under the hood:

- Frameworks might need to load `.env` before starting Vite dev server, so they use the `loadEnv` function provided by Vite.
- Vite loads .env again when it's unnecessary
- Vite restarts when .env changes but this should be left to user in this case