### PR TITLE
chore: Use @preact/preset-vite for Preact templates

### DIFF
--- a/packages/create-app/template-preact-ts/package.json
+++ b/packages/create-app/template-preact-ts/package.json
@@ -10,7 +10,7 @@
     "preact": "^10.5.9"
   },
   "devDependencies": {
-    "@prefresh/vite": "^2.0.0",
+    "@preact/preset-vite": "^2.0.0",
     "typescript": "^4.1.3",
     "vite": "^2.1.0"
   }

--- a/packages/create-app/template-preact-ts/package.json
+++ b/packages/create-app/template-preact-ts/package.json
@@ -7,7 +7,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "preact": "^10.5.9"
+    "preact": "^10.5.13"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.0.0",

--- a/packages/create-app/template-preact-ts/vite.config.ts
+++ b/packages/create-app/template-preact-ts/vite.config.ts
@@ -1,12 +1,7 @@
 import { defineConfig } from 'vite'
-import preactRefresh from '@prefresh/vite'
+import preact from '@preact/preset-vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  esbuild: {
-    jsxFactory: 'h',
-    jsxFragment: 'Fragment',
-    jsxInject: `import { h, Fragment } from 'preact'`
-  },
-  plugins: [preactRefresh()]
+  plugins: [preact()]
 })

--- a/packages/create-app/template-preact/package.json
+++ b/packages/create-app/template-preact/package.json
@@ -10,7 +10,7 @@
     "preact": "^10.5.9"
   },
   "devDependencies": {
-    "@prefresh/vite": "^2.0.0",
+    "@preact/preset-vite": "^2.0.0",
     "vite": "^2.1.0"
   }
 }

--- a/packages/create-app/template-preact/package.json
+++ b/packages/create-app/template-preact/package.json
@@ -7,7 +7,7 @@
     "serve": "vite preview"
   },
   "dependencies": {
-    "preact": "^10.5.9"
+    "preact": "^10.5.13"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.0.0",

--- a/packages/create-app/template-preact/vite.config.js
+++ b/packages/create-app/template-preact/vite.config.js
@@ -1,12 +1,7 @@
 import { defineConfig } from 'vite'
-import preactRefresh from '@prefresh/vite'
+import preact from '@preact/preset-vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  esbuild: {
-    jsxFactory: 'h',
-    jsxFragment: 'Fragment',
-    jsxInject: `import { h, Fragment } from 'preact'`
-  },
-  plugins: [preactRefresh()]
+  plugins: [preact()]
 })


### PR DESCRIPTION
We've just released a preset for vite so that it's even easier for Preact users to get started with vite. With this we want it to make easier for us to keep the templates up to date and make it less painful for users to upgrade when we add new features to our preset.

Before: 

```js
import { defineConfig } from 'vite'
import preactRefresh from '@prefresh/vite'

// https://vitejs.dev/config/
export default defineConfig({
  esbuild: {
    jsxFactory: 'h',
    jsxFragment: 'Fragment',
    jsxInject: `import { h, Fragment } from 'preact'`
  },
  plugins: [preactRefresh()]
})
```

After:

```js
import { defineConfig } from 'vite'
import preact from '@preact/preset-vite'

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [preact()]
})
```

See: https://github.com/preactjs/preset-vite

**EDIT:** Updated for the new preset version which returns an array of plugins now.