### PR TITLE
feat(ssr): support circular dependencies in ssr

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -136,6 +136,7 @@ async function instantiateModule(
       ssrExportAll
     )
   } catch (e) {
+    mod.ssrModule = null
     e.stack = ssrRewriteStacktrace(e.stack, moduleGraph)
     server.config.logger.error(
       `Error when evaluating SSR module ${url}:\n${e.stack}`,


### PR DESCRIPTION
This PR addresses #2258. 

Currently, whenever a circular dependency is encountered, `ssrLoadModule` returns an empty object, causing any code that requires circular dependencies to fail. 

The algorithm is inspired by [es-module-loader](https://github.com/ModuleLoader/es-module-loader/blob/v0.17.0/docs/circular-references-bindings.md#es6-circular-references--bindings). This PR changes `instantiateModule` to store the SSR Module exports object in the ModuleNode before its dependencies are loaded and before the code is executed. If `ssrLoadModule` detects that it is doing a circular import, then it returns that "live" `ssrModule` object (which hasn't yet been populated yet). Once all the dependencies are loaded, the `ssrModule` object is frozen. 

