### PR TITLE
feat: support `ignore` option for glob import

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -248,6 +248,21 @@ const modules = {
 }
 ```
 
+You can also pass the second argument to ignore some files:
+
+```js
+const modules = import.meta.glob('./dir/*.js', '**/b*.*')
+```
+
+That will ignore all files whose name starts with `b`, the file `./dir/bar.js` will be ignored, the above will be transformed into the following:
+
+```js
+// code produced by vite
+const modules = {
+  './dir/foo.js': () => import('./dir/foo.js')
+}
+```
+
 Note that:
 
 - This is a Vite-only feature and is not a web or ES standard.

--- a/packages/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/packages/playground/glob-import/__tests__/glob-import.spec.ts
@@ -44,10 +44,24 @@ const allResult = {
     msg: 'bar'
   }
 }
+const resultWithIgnoring = {
+  '/dir/foo.js': {
+    msg: 'foo'
+  },
+  '/dir/index.js': {
+    modules: filteredResult
+  }
+}
 
 test('should work', async () => {
   expect(await page.textContent('.result')).toBe(
     JSON.stringify(allResult, null, 2)
+  )
+})
+
+test('option `ignore` should work', async () => {
+  expect(await page.textContent('.result-option-ignore')).toBe(
+    JSON.stringify(resultWithIgnoring, null, 2)
   )
 })
 

--- a/packages/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/packages/playground/glob-import/__tests__/glob-import.spec.ts
@@ -3,7 +3,8 @@ import {
   editFile,
   isBuild,
   removeFile,
-  untilUpdated
+  untilUpdated,
+  sortObjectDeep
 } from '../../testUtils'
 
 const filteredResult = {
@@ -14,21 +15,14 @@ const filteredResult = {
 
 // json exports key order is altered during build, but it doesn't matter in
 // terms of behavior since module exports are not ordered anyway
-const json = isBuild
-  ? {
-      msg: 'baz',
-      default: {
-        msg: 'baz'
-      }
-    }
-  : {
-      default: {
-        msg: 'baz'
-      },
-      msg: 'baz'
-    }
+const json = {
+  msg: 'baz',
+  default: {
+    msg: 'baz'
+  }
+}
 
-const allResult = {
+const allResult = sortObjectDeep({
   '/dir/_ignored.js': {
     msg: 'ignored'
   },
@@ -46,7 +40,7 @@ const allResult = {
     },
     msg: 'bar'
   }
-}
+})
 
 test('should work', async () => {
   expect(await page.textContent('.result')).toBe(
@@ -60,10 +54,10 @@ if (!isBuild) {
     await untilUpdated(
       () => page.textContent('.result'),
       JSON.stringify(
-        {
+        sortObjectDeep({
           '/dir/+a.js': {},
           ...allResult
-        },
+        }),
         null,
         2
       )
@@ -74,12 +68,12 @@ if (!isBuild) {
     await untilUpdated(
       () => page.textContent('.result'),
       JSON.stringify(
-        {
+        sortObjectDeep({
           '/dir/+a.js': {
             msg: 'a'
           },
           ...allResult
-        },
+        }),
         null,
         2
       )
@@ -96,10 +90,10 @@ if (!isBuild) {
     await untilUpdated(
       () => page.textContent('.result'),
       JSON.stringify(
-        {
+        sortObjectDeep({
           '/dir/_a.js': {},
           ...allResult
-        },
+        }),
         null,
         2
       )
@@ -110,12 +104,12 @@ if (!isBuild) {
     await untilUpdated(
       () => page.textContent('.result'),
       JSON.stringify(
-        {
+        sortObjectDeep({
           '/dir/_a.js': {
             msg: 'a'
           },
           ...allResult
-        },
+        }),
         null,
         2
       )

--- a/packages/playground/glob-import/dir/_ignored.js
+++ b/packages/playground/glob-import/dir/_ignored.js
@@ -1,0 +1,1 @@
+export const msg = 'ignored'

--- a/packages/playground/glob-import/dir/index.js
+++ b/packages/playground/glob-import/dir/index.js
@@ -1,5 +1,3 @@
-import sortObjectDeep from '../sortObjectDeep'
-
-const modules = sortObjectDeep(import.meta.globEager('./*.js', './_*.js'))
+const modules = import.meta.globEager('./*.js', './_*.js')
 
 export { modules }

--- a/packages/playground/glob-import/dir/index.js
+++ b/packages/playground/glob-import/dir/index.js
@@ -1,3 +1,3 @@
-const modules = import.meta.globEager('./*.js')
+const modules = import.meta.globEager('./*.js', './_*.js')
 
 export { modules }

--- a/packages/playground/glob-import/dir/index.js
+++ b/packages/playground/glob-import/dir/index.js
@@ -1,3 +1,5 @@
-const modules = import.meta.globEager('./*.js', './_*.js')
+import sortObjectDeep from '../sortObjectDeep'
+
+const modules = sortObjectDeep(import.meta.globEager('./*.js', './_*.js'))
 
 export { modules }

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -1,21 +1,32 @@
 <pre class="result"></pre>
+<pre class="result-option-ignore"></pre>
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
   const modules = import.meta.glob('/dir/**')
+  const modulesWithOptionIgnore = import.meta.glob('/dir/**', '**/b*.*')
 
-  for (const path in modules) {
-    modules[path]().then((mod) => {
-      console.log(path, mod)
+  function outputContentToDom(modules, selector) {
+    for (const path in modules) {
+      modules[path]().then((mod) => {
+        console.log(path, mod)
+      })
+    }
+
+    const keys = Object.keys(modules)
+    Promise.all(keys.map((key) => modules[key]())).then((mods) => {
+      const res = {}
+      mods.forEach((m, i) => {
+        res[keys[i]] = m
+      })
+      document.querySelector(selector).textContent = JSON.stringify(
+        res,
+        null,
+        2
+      )
     })
   }
 
-  const keys = Object.keys(modules)
-  Promise.all(keys.map((key) => modules[key]())).then((mods) => {
-    const res = {}
-    mods.forEach((m, i) => {
-      res[keys[i]] = m
-    })
-    document.querySelector('.result').textContent = JSON.stringify(res, null, 2)
-  })
+  outputContentToDom(modules, '.result')
+  outputContentToDom(modulesWithOptionIgnore, '.result-option-ignore')
 </script>

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -2,7 +2,8 @@
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
-  const modules = import.meta.glob('/dir/**')
+  import sortObjectDeep from './sortObjectDeep'
+  const modules = sortObjectDeep(import.meta.glob('/dir/**'))
 
   for (const path in modules) {
     modules[path]().then((mod) => {

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -1,32 +1,21 @@
 <pre class="result"></pre>
-<pre class="result-option-ignore"></pre>
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
   const modules = import.meta.glob('/dir/**')
-  const modulesWithOptionIgnore = import.meta.glob('/dir/**', '**/b*.*')
 
-  function outputContentToDom(modules, selector) {
-    for (const path in modules) {
-      modules[path]().then((mod) => {
-        console.log(path, mod)
-      })
-    }
-
-    const keys = Object.keys(modules)
-    Promise.all(keys.map((key) => modules[key]())).then((mods) => {
-      const res = {}
-      mods.forEach((m, i) => {
-        res[keys[i]] = m
-      })
-      document.querySelector(selector).textContent = JSON.stringify(
-        res,
-        null,
-        2
-      )
+  for (const path in modules) {
+    modules[path]().then((mod) => {
+      console.log(path, mod)
     })
   }
 
-  outputContentToDom(modules, '.result')
-  outputContentToDom(modulesWithOptionIgnore, '.result-option-ignore')
+  const keys = Object.keys(modules)
+  Promise.all(keys.map((key) => modules[key]())).then((mods) => {
+    const res = {}
+    mods.forEach((m, i) => {
+      res[keys[i]] = m
+    })
+    document.querySelector('.result').textContent = JSON.stringify(res, null, 2)
+  })
 </script>

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -15,7 +15,7 @@
   Promise.all(keys.map((key) => modules[key]())).then((mods) => {
     const res = {}
     mods.forEach((m, i) => {
-      res[keys[i]] = m
+      res[keys[i]] = typeof m === 'object' ? sortObjectDeep(m) : m
     })
     document.querySelector('.result').textContent = JSON.stringify(res, null, 2)
   })

--- a/packages/playground/glob-import/sortObjectDeep.js
+++ b/packages/playground/glob-import/sortObjectDeep.js
@@ -1,0 +1,15 @@
+export default function sortObjectDeep(target) {
+  if (!target || typeof target !== 'object') return target
+  return Object.keys(target)
+    .sort()
+    .reduce(
+      (acc, item) => ({
+        ...acc,
+        [item]:
+          typeof target[item] === 'object'
+            ? sortObjectDeep(target[item])
+            : target[item]
+      }),
+      {}
+    )
+}

--- a/packages/playground/testUtils.ts
+++ b/packages/playground/testUtils.ts
@@ -114,3 +114,49 @@ export async function untilUpdated(
     }
   }
 }
+
+/**
+ * Sort an object by key, { c: 1, b: 3, a: 2, e: 4 } => { a: 2, b: 3, c: 1, e: 4 }
+ * @param target
+ */
+export function sortObjectDeep<T extends object = object>(target: T): T {
+  if (!target || typeof target !== 'object') return target
+  return Object.keys(target)
+    .sort()
+    .reduce<T>(
+      (acc, item) => ({
+        ...acc,
+        [item]:
+          typeof target[item] === 'object'
+            ? sortObjectDeep(target[item])
+            : target[item]
+      }),
+      {} as T
+    )
+}
+
+export function stringifyObjectWithSort(
+  value: any,
+  replacer?: (this: any, key: string, value: any) => any,
+  space?: string | number
+): string
+export function stringifyObjectWithSort(
+  value: any,
+  replacer?: (number | string)[] | null,
+  space?: string | number
+): string
+export function stringifyObjectWithSort(
+  value: any,
+  replacer?:
+    | ((this: any, key: string, value: any) => any)
+    | (number | string)[]
+    | null,
+  space?: string | number
+): string {
+  const finalValue = typeof value === 'object' ? sortObjectDeep(value) : value
+  // Must check to fix overload of JSON.stringify
+  if (typeof replacer === 'function') {
+    return JSON.stringify(finalValue, replacer, space)
+  }
+  return JSON.stringify(finalValue, replacer, space)
+}

--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -26,7 +26,8 @@ interface ImportMeta {
   readonly env: ImportMetaEnv
 
   glob(
-    pattern: string
+    pattern: string,
+    ignore?: string
   ): Record<
     string,
     () => Promise<{
@@ -35,7 +36,8 @@ interface ImportMeta {
   >
 
   globEager(
-    pattern: string
+    pattern: string,
+    ignore?: string
   ): Record<
     string,
     {

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -23,6 +23,7 @@ export async function transformImportGlob(
   endIndex: number
   isEager: boolean
   pattern: string
+  ignore?: string
   base: string
 }> {
   const isEager = source.slice(pos, pos + 21) === 'import.meta.globEager'
@@ -102,6 +103,7 @@ export async function transformImportGlob(
     endIndex,
     isEager,
     pattern,
+    ignore,
     base
   }
 }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -283,7 +283,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               exp,
               endIndex,
               base,
-              pattern
+              pattern,
+              ignore
             } = await transformImportGlob(
               source,
               start,
@@ -298,7 +299,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             server._globImporters[importerModule.file!] = {
               module: importerModule,
               base,
-              pattern
+              pattern,
+              ignore
             }
           }
           continue

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -167,9 +167,9 @@ export async function handleFileAddUnlink(
   } else {
     const modules = []
     for (const i in server._globImporters) {
-      const { module, base, pattern } = server._globImporters[i]
+      const { module, base, pattern, ignore } = server._globImporters[i]
       const relative = path.relative(base, file)
-      if (match(relative, pattern)) {
+      if (match(relative, pattern) && (!ignore || !match(relative, ignore))) {
         modules.push(module)
       }
     }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -240,6 +240,7 @@ export interface ViteDevServer {
     {
       base: string
       pattern: string
+      ignore?: string
       module: ModuleNode
     }
   >


### PR DESCRIPTION
### Motivation

Sometimes we need to ignore some files or directories when using `import.meta.glob`, such as ignoring `components` or `utils` directories, files beginning with `_` or `.`, etc.

A typical application scenario is:

In a file-based routing system, all files starting with lowercase letters and numbers in the pages directory will be automatically imported as routers by `src/pages/**/[a-z0-9]*.tsx`, and the following files or directory will be ignored:
* Directories or files beginning with a capital letter (this will be regarded as a component)
* `components` or `utils` directory
* Files or directories beginning with `.` or `_`
* Type definition files ending in `d.ts`
* Test files ending with `test.ts`, `spec.ts`, `e2e.ts`

That will be difficult to achieve if only one pattern can be specified (make duplicated multiple level path rule in `glob pattern` is very difficult, See https://github.com/mrmlnc/fast-glob/issues/306), but that can be easy if the `ignore` option of `fast-glob` can be specified.

### Document

You can also pass the second argument to ignore some files:

```js
const modules = import.meta.glob('./dir/*.js', '**/b*.*')
```

That will ignore all files whose name starts with `b`, the file `./dir/bar.js` will be ignored, the above will be transformed into the following:

```js
// code produced by vite
const modules = {
  './dir/foo.js': () => import('./dir/foo.js')
}
```