### PR TITLE
Mention `vue-tsc`

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -30,7 +30,7 @@ Note you don't need to manually set these up - when you [create an app via `@vit
 
 Vite supports importing `.ts` files out of the box.
 
-Vite only performs transpilation on `.ts` files and does **NOT** perform type checking. It assumes type checking is taken care of by your IDE and build process (you can run `tsc --noEmit` in the build script).
+Vite only performs transpilation on `.ts` files and does **NOT** perform type checking. It assumes type checking is taken care of by your IDE and build process (you can run `tsc --noEmit` in the build script or install `vue-tsc` and run `vue-tsc --noEmit` to also type check your `*.vue` files).
 
 Vite uses [esbuild](https://github.com/evanw/esbuild) to transpile TypeScript into JavaScript which is about 20~30x faster than vanilla `tsc`, and HMR updates can reflect in the browser in under 50ms.
 


### PR DESCRIPTION
I really struggled finding on how to perform TS type checking on SFC. At last I found a closed issue and this https://github.com/vitejs/vite/issues/749#issuecomment-785698509

Not sure how this lib behaves on large projects though, but I'd love the official docs would mention it.

If you agree to include it here then it probably also makes sense to mention it on official [Vue 3 docs](url).