### PR TITLE
Add `vue-tsc` to type check `.ts` and `.vue` files

### DIFF
--- a/packages/create-app/template-vue-ts/package.json
+++ b/packages/create-app/template-vue-ts/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview"
   },
   "dependencies": {
@@ -13,6 +13,7 @@
     "@vitejs/plugin-vue": "^1.1.5",
     "@vue/compiler-sfc": "^3.0.5",
     "typescript": "^4.1.3",
-    "vite": "^2.0.5"
+    "vite": "^2.0.5",
+    "vue-tsc": "^0.0.8"
   }
 }


### PR DESCRIPTION
Continuing from https://github.com/vitejs/vite/pull/2497

I'm not sure if this is ready for official TS template, but I like see this included :)