### PR TITLE
docs(create-app): fix newline omitted in the list

### DIFF
--- a/packages/create-app/template-vue-ts/README.md
+++ b/packages/create-app/template-vue-ts/README.md
@@ -23,4 +23,5 @@ Run `Volar: Switch TS Plugin on/off` from VSCode command palette.
 1. Install and add `@vuedx/typescript-plugin-vue` to the [plugins section](https://www.typescriptlang.org/tsconfig#plugins) in `tsconfig.json`
 2. Delete `src/shims-vue.d.ts` as it is no longer needed to provide module info to Typescript
 3. Open `src/main.ts` in VSCode
-4. Open the VSCode command palette 5. Search and run "Select TypeScript version" -> "Use workspace version"
+4. Open the VSCode command palette
+5. Search and run "Select TypeScript version" -> "Use workspace version"


### PR DESCRIPTION
At the end of [packages/create-app/template-vue-ts/README.md](../blob/master/packages/create-app/template-vue-ts/README.md), it misses a line break to separate bullet point 4 and bullet point 5. This PR adds a newline to fix it.