### PR TITLE
fix: keep process running when fail to load config in restarting server

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -7,6 +7,7 @@ import { ModuleNode } from './moduleGraph'
 import { Update } from 'types/hmrPayload'
 import { CLIENT_DIR } from '../constants'
 import { RollupError } from 'rollup'
+import { prepareError } from './middlewares/error'
 import match from 'minimatch'
 
 export const debugHmr = createDebugger('vite:hmr')
@@ -410,9 +411,20 @@ async function readModifiedFile(file: string): Promise<string> {
 }
 
 async function restartServer(server: ViteDevServer) {
+  // @ts-ignore
+  global.__vite_start_time = Date.now()
+  let newServer = null
+  try {
+    newServer = await createServer(server.config.inlineConfig)
+  } catch (err) {
+    server.ws.send({
+      type: 'error',
+      err: prepareError(err)
+    })
+    return
+  }
+
   await server.close()
-  ;(global as any).__vite_start_time = Date.now()
-  const newServer = await createServer(server.config.inlineConfig)
   for (const key in newServer) {
     if (key !== 'app') {
       // @ts-ignore


### PR DESCRIPTION
Close https://github.com/vitejs/vite/issues/2496