### PR TITLE
feat: support globbing from dependencies

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -251,7 +251,7 @@ const modules = {
 Note that:
 
 - This is a Vite-only feature and is not a web or ES standard.
-- The glob patterns are treated like import specifiers: they must be either relative (start with `./`) or absolute (start with `/`, resolved relative to project root). Globbing from dependencies is not supported.
+- The glob patterns are treated like import specifiers: they must be either relative (start with `./`) or absolute (start with `/`, resolved relative to project root).
 - The glob matching is done via `fast-glob` - check out its documentation for [supported glob patterns](https://github.com/mrmlnc/fast-glob#pattern-syntax).
 
 ## Web Assembly

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -96,7 +96,10 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer) {
-      if (importer.includes('node_modules')) {
+      if (
+        importer.includes('node_modules') &&
+        !source.includes('import.meta.glob')
+      ) {
         return
       }
 


### PR DESCRIPTION
Fixes #2390

The condition `source.includes('import.meta.glob')` won't catch source code like `import.meta['glob']` or new lines between `meta` and `glob`, but the subsequent `transform()` code won't either anyways.

```ts
        const { s: start, e: end, ss: expStart, d: dynamicIndex } = imports[
          index
        ]

        // This as well doesn't catch `import.meta['glob']` 
        const isGlob =
          source.slice(start, end) === 'import.meta' &&
          source.slice(end, end + 5) === '.glob'
```

The advantage of `source.includes('import.meta.glob')` is that we skip `es-module-lexer` parsing.