### PR TITLE
fix: chunks are analysed multiple times

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -218,6 +218,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           if (imports.length) {
             const s = new MagicString(code)
+            const analyzed: Set<string> = new Set<string>()
             for (let index = 0; index < imports.length; index++) {
               const { s: start, e: end, d: dynamicIndex } = imports[index]
               // if dynamic import polyfill is used, rewrite the import to
@@ -234,6 +235,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 // literal import - trace direct imports and add to deps
                 const addDeps = (filename: string) => {
                   if (filename === ownerFilename) return
+                  if (analyzed.has(filename)) return
+                  analyzed.add(filename)
                   const chunk = bundle[filename] as OutputChunk | undefined
                   if (chunk) {
                     deps.add(config.base + chunk.fileName)


### PR DESCRIPTION
In my special case, I have 1500 entry points which will result in every file being analyzed multiple times by the 'vite:import-analysis' plugin. I am still not 100% convinced, that there is no endless loop but I was not able to find it or reproduce it with a smaller example. 

You might ask: Why do you have 1500 entry points? That is, because I need to be able to still reference the source files in run-time, as I work on a platform with multiple plugins, that are only present during run-time. Therefore, we do not know, which files might be used by other plugins and therefore we provide any file as an entry point. 

You can find an excerpt of our config below: 

```
export default defineConfig({
  root: './src',
  build: {
    minify: 'esbuild',
    target: 'esnext',
    outDir: '../dist',
    emptyOutDir: true,
    polyfillDynamicImport: false,
    rollupOptions: {
      external: [
        '../../../oxguard/auth'
      ],
      input: { ... all files under src/ },
      output: {
        entryFileNames: '[name].js'
      }
    }
  },
  ...
})
```

We collect all the entry points with our own plugin. 

Some interesting side-notes: The problem is, that if (and only if) we set the minify option to either 'esbuild' or 'terser', it seems like the build process gets stuck after the "generateChunks" messages. We had it run for like 15 Minutes and then aborted it. I tried to debug, whether there is some kind of endless loop, but I was not able to find it. If we switch off minification, the build runs just fine. If we add this fix, minification works as well. 

I am not sure, whether this fix is applicable, but I would appreciate any help, that points me in the right direction. 