### PR TITLE
fix: update esbuild target to allow destructuring

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -44,7 +44,7 @@
   },
   "//": "READ .github/contributing.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
-    "esbuild": "^0.9.2",
+    "esbuild": "^0.9.3",
     "postcss": "^8.2.1",
     "resolve": "^1.19.0",
     "rollup": "^2.38.5"

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -447,7 +447,7 @@ async function doBuild(
       }
       return res
     } else {
-      return generate(outputs)
+      return await generate(outputs)
     }
   } catch (e) {
     config.logger.error(

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -220,7 +220,9 @@ export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
   // handle special build targets
   if (resolved.target === 'modules') {
     // https://caniuse.com/es6-module
-    resolved.target = ['es2019', 'edge16', 'firefox60', 'chrome61', 'safari11']
+    // edge18 according to js-table (destructuring is not supported in edge16)
+    // https://github.com/evanw/esbuild/blob/d943e89e50696647d6c89ae623ddfdf564ad3cfc/internal/compat/js_table.go#L84
+    resolved.target = ['es2019', 'edge18', 'firefox60', 'chrome61', 'safari11']
   } else if (resolved.target === 'esnext' && resolved.minify !== 'esbuild') {
     // esnext + terser: limit to es2019 so it can be minified by terser
     resolved.target = 'es2019'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2825,10 +2825,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.9.2:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.2.tgz#7e9fde247c913ed8ee059e2648b0c53f7d00abe5"
-  integrity sha512-xE3oOILjnmN8PSjkG3lT9NBbd1DbxNqolJ5qNyrLhDWsFef3yTp/KTQz1C/x7BYFKbtrr9foYtKA6KA1zuNAUQ==
+esbuild@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.3.tgz#09293a0b824159c6aa2488d1c6c22f57d8448f74"
+  integrity sha512-G8k0olucZp3LJ7I/p8y388t+IEyb2Y78nHrLeIxuqZqh6TYqDYP/B/7drAvYKfh83CGwKal9txVP+FTypsPJug==
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
Fixes #2564, Fixes #2562, Fixes #2560

Related to changes in esbuild 0.9.3 https://github.com/evanw/esbuild/commit/29b7c3fde35c31c4aa4abf775a952e6760ef44db