### PR TITLE
fix: skip inject of `jsxInject` option if the import has existed in this file (close #2369)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -271,6 +271,8 @@ export default ({ command, mode }) => {
   }
   ```
 
+  If a file has imported this module with the same name (e.g. `import React, { useState } from React` or `import * as React from React`), `jsxInject` will skip this file, so feel free to use it.
+
   Set to `false` to disable ESbuild transforms.
 
 ### assetsInclude

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -93,6 +93,8 @@ export default {
 }
 ```
 
+If a file has imported this module with the same name (e.g. `import React, { useState } from React` or `import * as React from React`), `jsxInject` will skip this file, so feel free to use it.
+
 ## CSS
 
 Importing `.css` files will inject its content to the page via a `<style>` tag with HMR support. You can also retrieve the processed CSS as a string as the module's default export.

--- a/packages/playground/react/App.jsx
+++ b/packages/playground/react/App.jsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import DefaultImport from './JSXInjectTest/DefaultImport'
+import NamespaceImport from './JSXInjectTest/NamespaceImport'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -7,7 +9,9 @@ function App() {
       <header className="App-header">
         <h1>Hello Vite + React</h1>
         <p>
-          <button onClick={() => setCount(count => count + 1)}>count is: {count}</button>
+          <button onClick={() => setCount((count) => count + 1)}>
+            count is: {count}
+          </button>
         </p>
         <p>
           Edit <code>App.jsx</code> and save to test HMR updates.
@@ -21,6 +25,8 @@ function App() {
           Learn React
         </a>
       </header>
+      <DefaultImport />
+      <NamespaceImport />
     </div>
   )
 }

--- a/packages/playground/react/JSXInjectTest/DefaultImport.jsx
+++ b/packages/playground/react/JSXInjectTest/DefaultImport.jsx
@@ -1,0 +1,11 @@
+import React, { useEffect, useState } from 'react'
+
+export default function DefaultImport() {
+  const [isReady, setReady] = useState(false)
+
+  useEffect(() => {
+    if (!isReady) setReady(true)
+  }, [isReady])
+
+  return <React.Fragment />
+}

--- a/packages/playground/react/JSXInjectTest/NamespaceImport.jsx
+++ b/packages/playground/react/JSXInjectTest/NamespaceImport.jsx
@@ -1,0 +1,5 @@
+import * as React from 'react'
+
+export default function NamespaceImport() {
+  return <React.Fragment />
+}

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -16,7 +16,8 @@ import {
   isObject,
   cleanUrl,
   externalRE,
-  dataUrlRE
+  dataUrlRE,
+  injectCode
 } from '../utils'
 import {
   createPluginContainer,
@@ -332,7 +333,7 @@ function esbuildScanPlugin(
 
         let contents = fs.readFileSync(id, 'utf-8')
         if (ext.endsWith('x') && config.esbuild && config.esbuild.jsxInject) {
-          contents = config.esbuild.jsxInject + `\n` + contents
+          contents = injectCode(contents, config.esbuild.jsxInject)
         }
 
         if (contents.includes('import.meta.glob')) {

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -8,7 +8,12 @@ import {
   TransformOptions,
   TransformResult
 } from 'esbuild'
-import { cleanUrl, createDebugger, generateCodeFrame } from '../utils'
+import {
+  cleanUrl,
+  createDebugger,
+  generateCodeFrame,
+  injectCode
+} from '../utils'
 import { RawSourceMap } from '@ampproject/remapping/dist/types/types'
 import { SourceMap } from 'rollup'
 import { ResolvedConfig } from '..'
@@ -105,7 +110,7 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
           })
         }
         if (options.jsxInject && /\.(?:j|t)sx\b/.test(id)) {
-          result.code = options.jsxInject + ';' + result.code
+          result.code = injectCode(result.code, options.jsxInject)
         }
         return {
           code: result.code,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -451,19 +451,21 @@ export function injectCode(
   const [, namespace] =
     injectedCode.match(/import\s*\*\s*as\s*([^*\s]+)\s/) || []
   const moduleName = defaultName || namespace
-  // Creat two RegExps to check if it has been imported.
-  // for example, the name `React` will try to find two pattern of import:
-  // `import React` and `import * as React`
-  const regExpOfDefaultImport = new RegExp(`import\\s*${moduleName}[,\\s]`)
-  const regExpOfNamespaceImport = new RegExp(
-    `import\\s*\\*\\s*as\\s*${moduleName}\\s`
-  )
-  // If the source content has imported this then skip it
-  if (
-    regExpOfDefaultImport.test(sourceContent) ||
-    regExpOfNamespaceImport.test(sourceContent)
-  ) {
-    return sourceContent
+  if (moduleName) {
+    // Creat two RegExps to check if it has been imported.
+    // for example, the name `React` will try to find two pattern of import:
+    // `import React` and `import * as React`
+    const regExpOfDefaultImport = new RegExp(`import\\s*${moduleName}[,\\s]`)
+    const regExpOfNamespaceImport = new RegExp(
+      `import\\s*\\*\\s*as\\s*${moduleName}\\s`
+    )
+    // If the source content has imported this then skip it
+    if (
+      regExpOfDefaultImport.test(sourceContent) ||
+      regExpOfNamespaceImport.test(sourceContent)
+    ) {
+      return sourceContent
+    }
   }
   return injectedCode + '\n' + sourceContent
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -440,3 +440,29 @@ export function combineSourcemaps(
 
   return map as RawSourceMap
 }
+
+export function injectCode(
+  sourceContent: string,
+  injectedCode: string
+): string {
+  // Match something like `import React`, extract `React`
+  const [, defaultName] = injectedCode.match(/import\s*([^*\s]+)/) || []
+  // Match something like `import * as React`, extract `React`
+  const [, namespace] = injectedCode.match(/import\s*\*\s*as\s*([^*\s]+)/) || []
+  const moduleName = defaultName || namespace
+  // Creat two RegExps to check if it has been imported.
+  // for example, the name `React` will try to find two pattern of import:
+  // `import React` and `import * as React`
+  const regExpOfDefaultImport = new RegExp(`import\\s*${moduleName}`)
+  const regExpOfNamespaceImport = new RegExp(
+    `import\\s*\\*\\s*as\\s*${moduleName}`
+  )
+  // If the source content has imported this then skip it
+  if (
+    regExpOfDefaultImport.test(sourceContent) ||
+    regExpOfNamespaceImport.test(sourceContent)
+  ) {
+    return sourceContent
+  }
+  return injectedCode + '\n' + sourceContent
+}

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -446,16 +446,17 @@ export function injectCode(
   injectedCode: string
 ): string {
   // Match something like `import React`, extract `React`
-  const [, defaultName] = injectedCode.match(/import\s*([^*\s]+)/) || []
+  const [, defaultName] = injectedCode.match(/import\s*([^*\s]+)[,\s]/) || []
   // Match something like `import * as React`, extract `React`
-  const [, namespace] = injectedCode.match(/import\s*\*\s*as\s*([^*\s]+)/) || []
+  const [, namespace] =
+    injectedCode.match(/import\s*\*\s*as\s*([^*\s]+)\s/) || []
   const moduleName = defaultName || namespace
   // Creat two RegExps to check if it has been imported.
   // for example, the name `React` will try to find two pattern of import:
   // `import React` and `import * as React`
-  const regExpOfDefaultImport = new RegExp(`import\\s*${moduleName}`)
+  const regExpOfDefaultImport = new RegExp(`import\\s*${moduleName}[,\\s]`)
   const regExpOfNamespaceImport = new RegExp(
-    `import\\s*\\*\\s*as\\s*${moduleName}`
+    `import\\s*\\*\\s*as\\s*${moduleName}\\s`
   )
   // If the source content has imported this then skip it
   if (


### PR DESCRIPTION
Closes #2369

## Motivation

According to [the document of Vite](https://vitejs.dev/guide/features.html#jsx), we can do an `auto-import` for JSX by:

```js
// vite.config.js
export default {
  esbuild: {
    jsxInject: `import React from 'react'`
  }
}
```

But it just places this snippet to the header of codes by simply concatenating string:

https://github.com/vitejs/vite/blob/a0d922e7d9790f998c246f8122bc339717b6088f/packages/vite/src/node/plugins/esbuild.ts#L125

If some codes have already import React for something like:

```js
import React from 'react';

export default function Button(props: React.ButtonHTMLAttributes<HTMLElement>) {
    return <div {...props} />
}
``` 

that will cause conflict and throw an error: `Uncaught SyntaxError: Identifier 'React' has already been declared`.

## Solution

This PR makes some checking before injecting it: if the file has imported as same as `jsxInject` option, `inject` will be skipped.

For example, for the config:
```js
// vite.config.js
export default {
  esbuild: {
    jsxInject: `import React from 'react'`
  }
}
```
Or this config:
```js
export default {
  esbuild: {
    jsxInject: `import * as React from 'react'`
  }
}
```
Following files will **skip** the injection of `import React from 'react'`
```jsx
import React, { useEffect, useState } from 'react'

export default function DefaultImport() {
  const [isReady, setReady] = useState(false)

  useEffect(() => {
    if (!isReady) setReady(true)
  }, [isReady])

  return <React.Fragment />
}
```
```jsx
import * as React from 'react'

export default function NamespaceImport() {
  return <React.Fragment />
}
```