### PR TITLE
fix: handle paths with special characters in injectQuery (fix #2585)

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,0 +1,42 @@
+import { injectQuery } from '../utils'
+
+const isWindows = process.platform === 'win32'
+
+if (isWindows) {
+  // this test will work incorrectly on unix systems
+  test('normalize windows path', () => {
+    expect(injectQuery('C:\\User\\Vite\\Project', 'direct')).toEqual(
+      'C:/User/Vite/Project?direct'
+    )
+  })
+}
+
+test('path with multiple spaces', () => {
+  expect(injectQuery('/usr/vite/path with space', 'direct')).toEqual(
+    '/usr/vite/path with space?direct'
+  )
+})
+
+test('path with multiple % characters', () => {
+  expect(injectQuery('/usr/vite/not%20a%20space', 'direct')).toEqual(
+    '/usr/vite/not%20a%20space?direct'
+  )
+})
+
+test('path with %25', () => {
+  expect(injectQuery('/usr/vite/%25hello%25', 'direct')).toEqual(
+    '/usr/vite/%25hello%25?direct'
+  )
+})
+
+test('path with unicode', () => {
+  expect(injectQuery('/usr/vite/東京', 'direct')).toEqual(
+    '/usr/vite/東京?direct'
+  )
+})
+
+test('path with unicode, space, and %', () => {
+  expect(injectQuery('/usr/vite/東京 %20 hello', 'direct')).toEqual(
+    '/usr/vite/東京 %20 hello?direct'
+  )
+})

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -124,7 +124,7 @@ export function removeImportQuery(url: string) {
 }
 
 export function injectQuery(url: string, queryToInject: string) {
-  let resolvedUrl = new URL(url, 'relative:///')
+  let resolvedUrl = new URL(url.replace(/%/g, '%25'), 'relative:///')
   if (resolvedUrl.protocol !== 'relative:') {
     resolvedUrl = pathToFileURL(url)
   }
@@ -132,6 +132,7 @@ export function injectQuery(url: string, queryToInject: string) {
   if (protocol === 'file:') {
     pathname = pathname.slice(1)
   }
+  pathname = decodeURIComponent(pathname)
   return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
     hash || ''
   }`

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -124,6 +124,8 @@ export function removeImportQuery(url: string) {
 }
 
 export function injectQuery(url: string, queryToInject: string) {
+  // encode percents for consistent behavior with pathToFileURL
+  // see #2614 for details
   let resolvedUrl = new URL(url.replace(/%/g, '%25'), 'relative:///')
   if (resolvedUrl.protocol !== 'relative:') {
     resolvedUrl = pathToFileURL(url)


### PR DESCRIPTION
Fixes regression introduced by #2435.

## Details

- Unlike the original code which uses `url.parse`, both `new URL()` and `pathToFileURL` will percent-encode path names.
- `new URL()` will not percent-encode the `%` character, whereas `pathToFileURL` will percent-encode the `%` character.
- In order to keep their behavior consistent, we manually replace `%` with `%25` before passing it to `new URL()`, but we pass the raw path to `pathToFileURL`.
- `String.prototype.replaceAll` is a relatively new API and only added to Node 15.0.0, so we're forced to use `String.prototype.replace` with a global regex modifier instead.
- To prevent future regressions, tests were added for a number of edge cases, including part of the original issue solved by #2435.

I'm super unhappy about the manual replace but I can't think of a better way to keep the behavior between `new URL()` and `pathToFileURL` consistent.