### PR TITLE
fix(dev): remove process listeners on server close, fix #2616

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -285,6 +285,8 @@ export async function createServer(
   const moduleGraph = new ModuleGraph(container)
   const closeHttpServer = createServerCloseFn(httpServer)
 
+  let exitProcess: () => void
+
   const server: ViteDevServer = {
     config: config,
     middlewares,
@@ -324,6 +326,12 @@ export async function createServer(
       return startServer(server, port, isRestart)
     },
     async close() {
+      process.off('SIGTERM', exitProcess)
+
+      if (!process.stdin.isTTY) {
+        process.stdin.off('end', exitProcess)
+      }
+
       await Promise.all([
         watcher.close(),
         ws.close(),
@@ -341,7 +349,7 @@ export async function createServer(
 
   server.transformIndexHtml = createDevHtmlTransformFn(server)
 
-  const exitProcess = async () => {
+  exitProcess = async () => {
     try {
       await server.close()
     } finally {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

---

### Description

See https://github.com/vitejs/vite/issues/2616
Signal event handlers are not removed during `server.close()`, causing a memory leak

This happens because the server is restarted (closed and recreated) any time there is a change in the config file.

### Additional context

This PR also removes the listener from `process.stdin` `'end'`, which could also cause a memory leak but was not reported in the original issue. 
