### PR TITLE
fix(create-app): change index.html templates' favicon.svg href to absolute URL

### DIFF
--- a/packages/create-app/template-lit-element-ts/index.html
+++ b/packages/create-app/template-lit-element-ts/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Lit-Element App</title>
     <script type="module" src="/src/my-element.ts"></script>

--- a/packages/create-app/template-lit-element/index.html
+++ b/packages/create-app/template-lit-element/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Lit-Element App</title>
     <script type="module" src="/src/my-element.js"></script>

--- a/packages/create-app/template-preact-ts/index.html
+++ b/packages/create-app/template-preact-ts/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
   </head>

--- a/packages/create-app/template-preact/index.html
+++ b/packages/create-app/template-preact/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
   </head>

--- a/packages/create-app/template-react-ts/index.html
+++ b/packages/create-app/template-react-ts/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
   </head>

--- a/packages/create-app/template-react/index.html
+++ b/packages/create-app/template-react/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="src/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite App</title>
   </head>


### PR DESCRIPTION
### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Change index.html templates' favicon.svg href to absolute URL `href="/src/favicon.svg"`.

When directly accessing the address of the non-root URL, the favicon cannot be found. (Microsoft Edge Version 89.0.774.57(Official build) (64-bit), but latest Chrome and Firefox are OK)
