### PR TITLE
fix: assets ?url import test for windows, fix #2625

### DIFF
--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -5,7 +5,8 @@ import {
   getColor,
   isBuild,
   listAssets,
-  readManifest
+  readManifest,
+  readFile
 } from '../../testUtils'
 
 const assetMatch = isBuild
@@ -179,17 +180,15 @@ test('?raw import', async () => {
   expect(await page.textContent('.raw')).toMatch('SVG')
 })
 
-function toBase64(src: string) {
-  return `data:application/javascript;base64,${Buffer.from(src).toString(
-    'base64'
-  )}`
-}
-
 test('?url import', async () => {
-  // Use startsWith instead of direct match because of Windows line break
-  const src = `console.log('hi')\n`
+  // Use startsWith regex to match because of line break diff in Windows
+  const src = readFile('foo.js')
   expect(await page.textContent('.url')).toMatch(
-    isBuild ? new RegExp(`^${toBase64(src)}`) : `/foo/foo.js`
+    isBuild
+      ? `data:application/javascript;base64,${Buffer.from(src).toString(
+          'base64'
+        )}`
+      : `/foo/foo.js`
   )
 })
 

--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -179,14 +179,17 @@ test('?raw import', async () => {
   expect(await page.textContent('.raw')).toMatch('SVG')
 })
 
+function toBase64(src: string) {
+  return `data:application/javascript;base64,${Buffer.from(src).toString(
+    'base64'
+  )}`
+}
+
 test('?url import', async () => {
+  // Use startsWith instead of direct match because of Windows line break
   const src = `console.log('hi')\n`
   expect(await page.textContent('.url')).toMatch(
-    isBuild
-      ? `data:application/javascript;base64,${Buffer.from(src).toString(
-          'base64'
-        )}`
-      : `/foo/foo.js`
+    isBuild ? new RegExp(`^${toBase64(src)}`) : `/foo/foo.js`
   )
 })
 

--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -181,7 +181,6 @@ test('?raw import', async () => {
 })
 
 test('?url import', async () => {
-  // Use startsWith regex to match because of line break diff in Windows
   const src = readFile('foo.js')
   expect(await page.textContent('.url')).toMatch(
     isBuild

--- a/packages/playground/testUtils.ts
+++ b/packages/playground/testUtils.ts
@@ -59,6 +59,10 @@ export async function getBg(el: string | ElementHandle) {
   return el.evaluate((el) => getComputedStyle(el as Element).backgroundImage)
 }
 
+export function readFile(filename: string) {
+  return fs.readFileSync(path.resolve(testDir, filename), 'utf-8')
+}
+
 export function editFile(filename: string, replacer: (str: string) => string) {
   if (isBuild) return
   filename = path.resolve(testDir, filename)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

---

### Description

Check #2625, looks like in windows the line end in `foo.js` was `\r\n`, and in the tests the line end was `\n`. This test then failed only in Windows. 

I initially thought of removing the line ends since they are not needed to test the `?url` feature, but the that is not possible because of prettier. This PR fixes the test in windows by matching with a `startsWidth` regex instead. I think it is enough for testing this feature.