### PR TITLE
feat(serve): support request carries .(DOT) character

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -403,6 +403,15 @@ export default ({ command, mode }) => {
 
   File system watcher options to pass on to [chokidar](https://github.com/paulmillr/chokidar#api).
 
+### server.disableDotRule
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+  Allow .(DOT) character in the request path.
+
+  Set to `true` to allow requests to carry .(DOT) character.
+
 ## Build Options
 
 ### build.target

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -120,6 +120,14 @@ export interface ServerOptions {
    * Should start and end with the `/` character
    */
   base?: string
+
+  /**
+   * uses https://github.com/bripkens/connect-history-api-fallback#disabledotrule
+   * Note: Allow  .(DOT) character in the request path.
+   * Set to `true` to allow requests to carry .(DOT) character
+   * default: false
+   */
+  disableDotRule?: boolean
 }
 
 /**
@@ -436,6 +444,7 @@ export async function createServer(
   if (!middlewareMode) {
     middlewares.use(
       history({
+        disableDotRule: !!serverConfig.disableDotRule,
         logger: createDebugger('vite:spa-fallback'),
         // support /dir/ without explicit index.html
         rewrites: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->
fix #2628 fix #2415
### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

---

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This issue is actually the same as https://github.com/bripkens/connect-history-api-fallback/issues/25. connect-history-api-fallback is configured by [disabledotrule](https://github.com/bripkens/connect-history-api-fallback#disabledotrule) to solve this problem.

I'm not sure if it is necessary to add an option to solve this problem, or it should be told not to use the request path with .(Dot) character

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
