### PR TITLE
feat: parameter settings when packaging the library

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -181,6 +181,7 @@ export interface BuildOptions {
 export interface LibraryOptions {
   entry: string
   name?: string
+  fileName?: string
   formats?: LibraryFormats[]
 }
 
@@ -386,7 +387,7 @@ async function doBuild(
         entryFileNames: ssr
           ? `[name].js`
           : libOptions
-          ? `${pkgName}.${output.format || `es`}.js`
+          ? `${libOptions.fileName || pkgName}.${output.format || `es`}.js`
           : path.posix.join(options.assetsDir, `[name].[hash].js`),
         chunkFileNames: libOptions
           ? `[name].js`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I'm using vite as a development build tool for lib projects. In vite, you can use lib to develop the file entry and the variable name or build type,but there is no fileName specified.
I read the source code and found that the field is a direct way to get the name field of package.json.I think a new fileName field should be added to specify the name of the output file after packaging,and the default value can be the name of package.json



### Additional context

Otherwise I would need to manually change the names of the different types of files after each build is completed. Because the nane of my package.json is not necessarily the name I need.I added a field for the lib configuration. 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

After improvement, it is configured like this
```
export default defineConfig({
  plugins: [reactRefresh()],
  build: {
    lib: {
      entry: path.resolve(__dirname, 'src/index.ts'),
      name: 'variablName,
      fileName:'MyFileName', // new add
      formats:['es','umd','cjs']
    }
  }
});


```