### PR TITLE
feat: Add `repository.directory` to `packages/**/package.json`

### DIFF
--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitejs/vite.git"
+    "url": "git+https://github.com/vitejs/vite.git",
+    "directory": "packages/create-app"
   },
   "bugs": {
     "url": "https://github.com/vitejs/vite/issues"

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitejs/vite.git"
+    "url": "git+https://github.com/vitejs/vite.git",
+    "directory": "packages/plugin-legacy"
   },
   "bugs": {
     "url": "https://github.com/vitejs/vite/issues"

--- a/packages/plugin-react-refresh/package.json
+++ b/packages/plugin-react-refresh/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitejs/vite.git"
+    "url": "git+https://github.com/vitejs/vite.git",
+    "directory": "packages/plugin-react-refresh"
   },
   "bugs": {
     "url": "https://github.com/vitejs/vite/issues"

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitejs/vite.git"
+    "url": "git+https://github.com/vitejs/vite.git",
+    "directory": "packages/plugin-vue-jsx"
   },
   "bugs": {
     "url": "https://github.com/vitejs/vite/issues"

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitejs/vite.git"
+    "url": "git+https://github.com/vitejs/vite.git",
+    "directory": "packages/plugin-vue"
   },
   "bugs": {
     "url": "https://github.com/vitejs/vite/issues"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitejs/vite.git"
+    "url": "git+https://github.com/vitejs/vite.git",
+    "directory": "packages/vite"
   },
   "bugs": {
     "url": "https://github.com/vitejs/vite/issues"


### PR DESCRIPTION
<!-- Thank you for contributing! -->
<!-- You're welcome. -->
### Description
According to the [recommendations of the npm](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository):

> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> {
>   "repository": {
>     "type": "git",
>     "url": "https://github.com/facebook/react.git",
>     "directory": "packages/react-dom"
>   }
> }
> ```

This should help various tools like dependabot or renovate to get more information about the package: package url, changelog etc. 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
