### PR TITLE
fix: support for firefox/safari worker output (fix #2029)

### DIFF
--- a/packages/playground/worker-code-split/__tests__/worker.spec.ts
+++ b/packages/playground/worker-code-split/__tests__/worker.spec.ts
@@ -1,0 +1,49 @@
+import fs from 'fs'
+import path from 'path'
+import { untilUpdated, isBuild, testDir } from '../../testUtils'
+
+test('normal', async () => {
+  await page.click('.ping')
+  await untilUpdated(() => page.textContent('.pong'), 'pong')
+  await untilUpdated(
+    () => page.textContent('.mode'),
+    isBuild ? 'production' : 'development'
+  )
+})
+
+test('legacy', async () => {
+  await page.click('.ping-inline')
+  await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
+})
+
+if (isBuild) {
+  // assert correct files
+  test('inlined code generation', async () => {
+    const assetsDir = path.resolve(testDir, 'dist/assets')
+    const files = fs.readdirSync(assetsDir)
+    // should have 1 worker chunk for module and legacy
+    expect(files.length).toBe(6)
+    expect(files[5]).toMatch('workerImport.')
+
+    const index = files.find((f) => f.includes('index'))
+    const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
+    // chunk
+    expect(content).toMatch(`new Worker("/assets`)
+    // not inlined
+    expect(content).not.toMatch(`new Worker("data:application/javascript`)
+
+    const workers = files.filter((f) => f.includes('my-worker-1'))
+    expect(workers.length).toBe(2)
+    const moduleContent = fs.readFileSync(
+      path.resolve(assetsDir, workers[0]),
+      'utf-8'
+    )
+    const scriptContent = fs.readFileSync(
+      path.resolve(assetsDir, workers[1]),
+      'utf-8'
+    )
+    // module worker
+    expect(moduleContent).toMatch(/import{.+}from".\/workerImport/)
+    expect(scriptContent).not.toMatch('import')
+  })
+}

--- a/packages/playground/worker-code-split/index.html
+++ b/packages/playground/worker-code-split/index.html
@@ -1,0 +1,31 @@
+<button class="ping">Ping</button>
+<div>
+  Response from worker: <span class="pong"></span><span class="mode"></span>
+</div>
+
+<button class="ping-inline">Ping Inline Worker</button>
+<div>Response from inline worker: <span class="pong-inline"></span></div>
+
+<script type="module">
+  import Worker1 from './my-worker-1?worker'
+  import Worker2 from './my-worker-2?worker'
+
+  const worker1 = new Worker1()
+  worker1.addEventListener('message', (e) => {
+    document.querySelector('.pong').textContent = e.data.msg
+    document.querySelector('.mode').textContent = e.data.mode
+  })
+
+  document.querySelector('.ping').addEventListener('click', () => {
+    worker1.postMessage('ping')
+  })
+
+  const worker2 = new Worker2()
+  worker2.addEventListener('message', (e) => {
+    document.querySelector('.pong-inline').textContent = e.data.msg
+  })
+
+  document.querySelector('.ping-inline').addEventListener('click', () => {
+    worker2.postMessage('ping')
+  })
+</script>

--- a/packages/playground/worker-code-split/my-worker-1.ts
+++ b/packages/playground/worker-code-split/my-worker-1.ts
@@ -1,0 +1,7 @@
+import { msg, mode } from './workerImport'
+
+self.onmessage = (e) => {
+  if (e.data === 'ping') {
+    self.postMessage({ msg, mode })
+  }
+}

--- a/packages/playground/worker-code-split/my-worker-2.ts
+++ b/packages/playground/worker-code-split/my-worker-2.ts
@@ -1,0 +1,7 @@
+import { msg, mode } from './workerImport'
+
+self.onmessage = (e) => {
+  if (e.data === 'ping') {
+    self.postMessage({ msg, mode })
+  }
+}

--- a/packages/playground/worker-code-split/package.json
+++ b/packages/playground/worker-code-split/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-worker-code-split",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "serve": "vite preview"
+  }
+}

--- a/packages/playground/worker-code-split/workerImport.js
+++ b/packages/playground/worker-code-split/workerImport.js
@@ -1,0 +1,2 @@
+export const msg = 'pong'
+export const mode = process.env.NODE_ENV

--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -47,7 +47,7 @@ if (isBuild) {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/assets')
     const files = fs.readdirSync(assetsDir)
-    // should have 2 worker chunk
+    // should have worker chunk for module and legacy
     expect(files.length).toBe(3)
     const index = files.find((f) => f.includes('index'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')

--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -55,6 +55,6 @@ if (isBuild) {
     expect(content).toMatch(`new Worker("/assets`)
     expect(content).toMatch(`new SharedWorker("/assets`)
     // inlined
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
+    expect(content).toMatch(`URL.createObjectURL`)
   })
 }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -254,7 +254,7 @@ async function fileToBuiltUrl(
   return url
 }
 
-function getAssetHash(content: Buffer) {
+export function getAssetHash(content: Buffer): string {
   return createHash('sha256').update(content).digest('hex').slice(0, 8)
 }
 

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -17,6 +17,41 @@ function parseWorkerRequest(id: string): ParsedUrlQuery | null {
 
 const WorkerFileId = 'worker_file'
 
+/**
+ * Create a factory for the worker constructor string.
+ * Can be combined with other strings to build an inline script.
+ *
+ * @param query Parsed worker request data
+ * @returns Factory function taking URL and worker options.
+ * Null is returned if the worker request is invalid.
+ */
+function buildWorkerConstructor(query: ParsedUrlQuery | null) {
+  if (!query) {
+    return null
+  }
+
+  let workerConstructor: string
+  if (query.sharedworker != null) {
+    workerConstructor = 'SharedWorker'
+  } else if (query.worker != null) {
+    workerConstructor = 'Worker'
+  } else {
+    return null
+  }
+
+  return (urlVariable: string, options?: object) => {
+    if (options) {
+      return `new ${workerConstructor}(${urlVariable}, ${JSON.stringify(
+        options,
+        null,
+        2
+      )})`
+    } else {
+      return `new ${workerConstructor}(${urlVariable})`
+    }
+  }
+}
+
 export function webWorkerPlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
 
@@ -26,10 +61,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
     load(id) {
       if (isBuild) {
         const parsedQuery = parseWorkerRequest(id)
-        if (
-          parsedQuery &&
-          (parsedQuery.worker ?? parsedQuery.sharedworker) != null
-        ) {
+        if (buildWorkerConstructor(parsedQuery) != null) {
           return ''
         }
       }
@@ -42,10 +74,9 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           code: `import '${ENV_PUBLIC_PATH}'\n` + _
         }
       }
-      if (
-        query == null ||
-        (query && (query.worker ?? query.sharedworker) == null)
-      ) {
+
+      const workerConstructor = buildWorkerConstructor(query)
+      if (query == null || workerConstructor == null) {
         return
       }
 
@@ -64,14 +95,19 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               format: 'es',
               sourcemap: config.build.sourcemap
             })
-            
-            return `const blob = new Blob([atob(\"${Buffer.from(output[0].code).toString('base64')}\")], { type: 'text/javascript;charset=utf-8' });
+
+            return `const blob = new Blob([atob(\"${Buffer.from(
+              output[0].code
+            ).toString(
+              'base64'
+            )}\")], { type: 'text/javascript;charset=utf-8' });
+            const URL = window.URL || window.webkitURL;
             export default function WorkerWrapper() {
-              const objURL = (window.URL || window.webkitURL).createObjectURL(blob);
+              const objURL = URL.createObjectURL(blob);
               try {
-                return new Worker(objURL);
+                return ${workerConstructor('objUrl')};
               } finally {
-                (window.URL || window.webkitURL).revokeObjectURL(objURL);
+                URL.revokeObjectURL(objURL);
               }
             }`
           } finally {
@@ -89,14 +125,11 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         url = injectQuery(url, WorkerFileId)
       }
 
-      const workerConstructor =
-        query.sharedworker != null ? 'SharedWorker' : 'Worker'
+      const workerUrl = JSON.stringify(url)
       const workerOptions = { type: 'module' }
 
       return `export default function WorkerWrapper() {
-        return new ${workerConstructor}(${JSON.stringify(
-        url
-      )}, ${JSON.stringify(workerOptions, null, 2)})
+        return ${workerConstructor(workerUrl, workerOptions)};
       }`
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

By default, Vite targets all browsers with ES module support. That criteria includes browsers that support modules but not module workers, notably Firefox & Safari.

This feature adds an alternate worker bundle output that can be used as a fallback if `{type:'module'}` workers aren't available. The bundle is equivalent to what would be outputted for inline scripts, but is a separate chunk so the data doesn't need to be loaded unless necessary. This double bundling is done only on build, not on serve.

### Additional context

Feature detection for module workers is [based on this WHATWG issue](https://github.com/whatwg/html/issues/5325).

This is a bug described in #2029, which was closed as I didn't have a reproduction. The new test case shows an example where imports can end up in the final worker build.

Would love support on reducing code duplication. It would be nice to extract the feature detection. Some of the plugin code is copied from `fileToBuiltUrl`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

Fixes #2029, fixes #2504