### PR TITLE
fix(optimizer): ensure the js files in deps won't mark as external

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -66,14 +66,18 @@ export function esbuildDepPlugin(
   return {
     name: 'vite:dep-pre-bundle',
     setup(build) {
+      const nonJsFileRE = new RegExp(
+        `\\.(` + externalTypes.join('|') + `)(\\?.*)?$`
+      )
       // externalize assets and commonly known non-js file types
       build.onResolve(
         {
-          filter: new RegExp(`\\.(` + externalTypes.join('|') + `)(\\?.*)?$`)
+          filter: nonJsFileRE
         },
         async ({ path: id, importer, kind }) => {
           const resolved = await resolve(id, importer, kind)
-          if (resolved) {
+          // ensure the files finally resolved as js won't be marked to external
+          if (resolved && nonJsFileRE.test(resolved)) {
             return {
               path: resolved,
               external: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The current behavior of prebundle (optimizer) will pack all deps in node_modules into chunks, whereas when it hit some js ending with assets ending, like `abc.scss.js` or `xyz.svg.js`, vite will treat the js file as external so it won't be correctly bundled.

For example, in [office-ui-fabric-react](https://www.npmjs.com/package/office-ui-fabric-react):

```js
// this is from node_modules/office-ui-fabric-react/lib/components/Dropdown/Dropdown.js

var stylesImport = require("./Dropdown.scss");
```

The `stylesImport` will be resolved to `'./Dropdown.scss.js'` with external marked, so it's generated like 

```js
var stylesImport = require(/* a full path of Dropdown.scss.js */);
```

We expect that it should be something like 

```js
var stylesImport = require_Dropdown_scss(); // this require_Dropdown_scss is the bundled module from ./Dropdown.scss.js
```

This PR fix this issue.

A similar issue described in #2492

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I'm not familiar with the testing infra here, and I'm still working with the test.... hopefully I can add a test for this soon.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
