### PR TITLE
fix: only provide npm package names to resolveSSRExternal

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -22,7 +22,7 @@ import { buildHtmlPlugin } from './plugins/html'
 import { buildEsbuildPlugin } from './plugins/esbuild'
 import { terserPlugin } from './plugins/terser'
 import { Terser } from 'types/terser'
-import { copyDir, emptyDir, lookupFile, normalizePath, unique } from './utils'
+import { copyDir, emptyDir, lookupFile, normalizePath } from './utils'
 import { manifestPlugin } from './plugins/manifest'
 import commonjsPlugin from '@rollup/plugin-commonjs'
 import { RollupCommonJSOptions } from 'types/commonjs'
@@ -353,9 +353,6 @@ async function doBuild(
         ) as DepOptimizationMetadata
         knownImports = Object.keys(data.optimized)
       } catch (e) {}
-      if (knownImports) {
-        knownImports = unique(knownImports.map(getNpmPackageName))
-      }
     }
     if (!knownImports) {
       // no dev deps optimization data, do a fresh scan
@@ -720,14 +717,5 @@ function wrapSsrHook(fn: Function | undefined) {
   if (!fn) return
   return function (this: any, ...args: any[]) {
     return fn.call(this, ...args, true)
-  }
-}
-
-function getNpmPackageName(importPath: string) {
-  const parts = importPath.split('/')
-  if (parts[0].startsWith('@')) {
-    return `${parts[0]}/${parts[1]}`
-  } else {
-    return parts[0]
   }
 }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -22,7 +22,7 @@ import { buildHtmlPlugin } from './plugins/html'
 import { buildEsbuildPlugin } from './plugins/esbuild'
 import { terserPlugin } from './plugins/terser'
 import { Terser } from 'types/terser'
-import { copyDir, emptyDir, lookupFile, normalizePath } from './utils'
+import { copyDir, emptyDir, lookupFile, normalizePath, unique } from './utils'
 import { manifestPlugin } from './plugins/manifest'
 import commonjsPlugin from '@rollup/plugin-commonjs'
 import { RollupCommonJSOptions } from 'types/commonjs'
@@ -353,6 +353,9 @@ async function doBuild(
         ) as DepOptimizationMetadata
         knownImports = Object.keys(data.optimized)
       } catch (e) {}
+      if (knownImports) {
+        knownImports = unique(knownImports.map(getNpmPackageName))
+      }
     }
     if (!knownImports) {
       // no dev deps optimization data, do a fresh scan
@@ -717,5 +720,14 @@ function wrapSsrHook(fn: Function | undefined) {
   if (!fn) return
   return function (this: any, ...args: any[]) {
     return fn.call(this, ...args, true)
+  }
+}
+
+function getNpmPackageName(importPath: string) {
+  const parts = importPath.split('/')
+  if (parts[0].startsWith('@')) {
+    return `${parts[0]}/${parts[1]}`
+  } else {
+    return parts[0]
   }
 }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { tryNodeResolve, InternalResolveOptions } from '../plugins/resolve'
-import { lookupFile, resolveFrom } from '../utils'
+import { isDefined, lookupFile, resolveFrom, unique } from '../utils'
 import { ResolvedConfig } from '..'
 
 /**
@@ -24,7 +24,10 @@ export function resolveSSRExternal(
   }
   const pkg = JSON.parse(pkgContent)
   const devDeps = Object.keys(pkg.devDependencies || {})
-  const deps = [...knownImports, ...Object.keys(pkg.dependencies || {})]
+  const importedDeps: string[] = unique(
+    knownImports.map(getNpmPackageName).filter(isDefined)
+  )
+  const deps = [...importedDeps, ...Object.keys(pkg.dependencies || {})]
 
   for (const id of devDeps) {
     ssrExternals.add(id)
@@ -120,4 +123,14 @@ export function shouldExternalizeForSSR(
     }
   })
   return should
+}
+
+function getNpmPackageName(importPath: string): string | null {
+  const parts = importPath.split('/')
+  if (parts[0].startsWith('@')) {
+    if (!parts[1]) return null
+    return `${parts[0]}/${parts[1]}`
+  } else {
+    return parts[0]
+  }
 }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -24,10 +24,8 @@ export function resolveSSRExternal(
   }
   const pkg = JSON.parse(pkgContent)
   const devDeps = Object.keys(pkg.devDependencies || {})
-  const importedDeps: string[] = unique(
-    knownImports.map(getNpmPackageName).filter(isDefined)
-  )
-  const deps = [...importedDeps, ...Object.keys(pkg.dependencies || {})]
+  const importedDeps = knownImports.map(getNpmPackageName).filter(isDefined)
+  const deps = unique([...importedDeps, ...Object.keys(pkg.dependencies || {})])
 
   for (const id of devDeps) {
     ssrExternals.add(id)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -204,6 +204,9 @@ export function prettifyUrl(url: string, root: string): string {
 export function isObject(value: unknown): value is Record<string, any> {
   return Object.prototype.toString.call(value) === '[object Object]'
 }
+export function isDefined<T>(value: T | undefined | null): value is T {
+  return value !== undefined && value !== null
+}
 
 export function lookupFile(
   dir: string,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -452,3 +452,7 @@ export function combineSourcemaps(
 
   return map as RawSourceMap
 }
+
+export function unique<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr))
+}


### PR DESCRIPTION
fix #2716

The root cause of #2716 seems to be that `resolveSSRExternal()` assumes its argument `knownImports` to be npm package names while `doBuild()` sets `knowImports` to `Object.keys(require('node_modules/.vite/_metadata.json').optimized)` which contains `vite-plugin-ssr/client/router`.