### PR TITLE
fix(resolve): fix resolver not following node resolve algorithm

### DIFF
--- a/packages/playground/resolve/__tests__/resolve.spec.ts
+++ b/packages/playground/resolve/__tests__/resolve.spec.ts
@@ -42,6 +42,14 @@ test('implicit dir/index.js vs explicit file', async () => {
   expect(await page.textContent('.dir-vs-file')).toMatch('[success]')
 })
 
+test('exact extension vs. duplicated (.js.js)', async () => {
+  expect(await page.textContent('.exact-extension')).toMatch('[success]')
+})
+
+test('dont add extension to directory name (./dir-with-ext.js/index.js)', async () => {
+  expect(await page.textContent('.dir-with-ext')).toMatch('[success]')
+})
+
 test('filename with dot', async () => {
   expect(await page.textContent('.dot')).toMatch('[success]')
 })

--- a/packages/playground/resolve/dir-with-ext/index.js
+++ b/packages/playground/resolve/dir-with-ext/index.js
@@ -1,0 +1,1 @@
+export const file = '[success] ./dir-with-ext/index.js'

--- a/packages/playground/resolve/exact-extension/file.js
+++ b/packages/playground/resolve/exact-extension/file.js
@@ -1,0 +1,1 @@
+export const file = '[success] file.js'

--- a/packages/playground/resolve/exact-extension/file.js.js
+++ b/packages/playground/resolve/exact-extension/file.js.js
@@ -1,0 +1,1 @@
+export const file = 'file.js.js'

--- a/packages/playground/resolve/index.html
+++ b/packages/playground/resolve/index.html
@@ -24,6 +24,12 @@
 <h2>Resolve dir and file of the same name (should prioritize file)</h2>
 <p class="dir-vs-file">fail</p>
 
+<h2>Resolve to non-duplicated file extension</h2>
+<p class="exact-extension">fail</p>
+
+<h2>Don't add extensions to directory names</h2>
+<p class="dir-with-ext">fail</p>
+
 <h2>Resolve file name containing dot</h2>
 <p class="dot">fail</p>
 
@@ -94,6 +100,14 @@
   // implicit dir index vs. file
   import { file } from './dir'
   text('.dir-vs-file', file)
+
+  // // exact extension vs. duplicated (.js.js)
+  import { file as exactExtMsg } from './exact-extension/file.js'
+  text('.exact-extension', exactExtMsg)
+
+  // don't add extensions to dir name (./dir-with-ext.js/index.js)
+  import { file as dirWithExtMsg } from './dir-with-ext'
+  text('.dir-with-ext', dirWithExtMsg)
 
   // filename with dot
   import { bar } from './util/bar.util'

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -240,6 +240,12 @@ function tryFsResolve(
   }
 
   let res: string | undefined
+  if (
+    (res = tryResolveFile(file, postfix, options, false, options.tryPrefix))
+  ) {
+    return res
+  }
+
   for (const ext of options.extensions || DEFAULT_EXTENSIONS) {
     if (
       (res = tryResolveFile(
@@ -288,8 +294,6 @@ function tryResolveFile(
       }
       const index = tryFsResolve(file + '/index', options)
       if (index) return index + postfix
-    } else {
-      return normalizePath(ensureVolumeInPath(file)) + postfix
     }
   }
   if (tryPrefix) {


### PR DESCRIPTION
(fix #2695)

<!-- Thank you for contributing! -->

### Description

Fixing resolver trying to postfix every file extension to path before trying to resolve to non-posfixed direct match.
Removed the ability to resolve to directory path while not in package.json and index resolution step.
Added 2 tests that previous implementation would fail.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
