### PR TITLE
chore: prefer-const

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,7 +51,13 @@ module.exports = {
     'node/no-unpublished-import': 'off',
     'node/no-unpublished-require': 'off',
     'node/no-unsupported-features/es-syntax': 'off',
-    'no-process-exit': 'off'
+    'no-process-exit': 'off',
+    'prefer-const': [
+      'warn',
+      {
+        destructuring: 'all'
+      }
+    ]
   },
   overrides: [
     {

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -127,7 +127,7 @@ export async function handleHotUpdate({
     }
   }
 
-  let updateType = []
+  const updateType = []
   if (needRerender) {
     updateType.push(`template`)
     // template is inlined into main, add main module instead

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -232,7 +232,7 @@ export function updateStyle(id: string, content: string) {
 }
 
 export function removeStyle(id: string) {
-  let style = sheetsMap.get(id)
+  const style = sheetsMap.get(id)
   if (style) {
     if (style instanceof CSSStyleSheet) {
       // @ts-ignore

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -42,7 +42,7 @@ export async function transformImportGlob(
   }
   let base
   let parentDepth = 0
-  let isAbsolute = pattern.startsWith('/')
+  const isAbsolute = pattern.startsWith('/')
   if (isAbsolute) {
     base = path.resolve(root)
     pattern = pattern.slice(1)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -751,7 +751,7 @@ function rewriteCssUrls(
   replacer: CssUrlReplacer
 ): Promise<string> {
   return asyncReplace(css, cssUrlRE, async (match) => {
-    let [matched, rawUrl] = match
+    const [matched, rawUrl] = match
     return await doUrlReplace(rawUrl, matched, replacer)
   })
 }
@@ -761,7 +761,7 @@ function rewriteCssImageSet(
   replacer: CssUrlReplacer
 ): Promise<string> {
   return asyncReplace(css, cssImageSetRE, async (match) => {
-    let [matched, rawUrl] = match
+    const [matched, rawUrl] = match
     const url = await processSrcSet(rawUrl, ({ url }) =>
       doUrlReplace(url, matched, replacer)
     )

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -121,7 +121,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
       // relative
       if (id.startsWith('.') || (preferRelative && /^\w/.test(id))) {
         const basedir = importer ? path.dirname(importer) : process.cwd()
-        let fsPath = path.resolve(basedir, id)
+        const fsPath = path.resolve(basedir, id)
         // handle browser field mapping for relative imports
 
         if ((res = tryResolveBrowserMapping(fsPath, importer, options, true))) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -285,6 +285,7 @@ export async function createServer(
   const moduleGraph = new ModuleGraph(container)
   const closeHttpServer = createServerCloseFn(httpServer)
 
+  // eslint-disable-next-line prefer-const
   let exitProcess: () => void
 
   const server: ViteDevServer = {

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -27,7 +27,7 @@ export function serveStaticMiddleware(
   const serve = sirv(dir, sirvOptions)
 
   return (req, res, next) => {
-    let url = req.url!
+    const url = req.url!
 
     // only serve the file if it's not an html request
     // so that html requests can fallthrough to our html middleware for

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -91,7 +91,7 @@ function startBrowserProcess(browser: string | undefined, url: string) {
   // Fallback to open
   // (It will always open new tab)
   try {
-    var options = { app: browser, url: true }
+    const options = { app: browser, url: true }
     open(url, options).catch(() => {}) // Prevent `unhandledRejection` error.
     return true
   } catch (err) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This turns the recommended `prefer-const` rule on but also set it to warning
Also we need to manipulate/configure it to our needs cause we have some usages of `let destructuring` calls
Example:

https://github.com/vitejs/vite/blob/2358dfcc49919331a8b488cbb58068bbeeaf6aa5/packages/vite/src/node/utils.ts#L133

### Additional context

https://eslint.org/docs/rules/prefer-const

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
