### PR TITLE
feat(dev): support keepNames option for optimizeDeps config

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -569,6 +569,15 @@ export default ({ command, mode }) => {
 
   By default, linked packages not inside `node_modules` are not pre-bundled. Use this option to force a linked package to be pre-bundled.
 
+### optimizeDeps.keepNames
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+  The bundler sometimes needs to rename symbols to avoid collisions.
+  Set this to `true` to keep the `name` property on functions and classes.
+  See [`keepNames`](https://esbuild.github.io/api/#keep-names).
+
 ## SSR Options
 
 :::warning Experimental

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -46,6 +46,12 @@ export interface DepOptimizationOptions {
    * cannot be globs).
    */
   exclude?: string[]
+  /**
+   * The bundler sometimes needs to rename symbols to avoid collisions.
+   * Set this to `true` to keep the `name` property on functions and classes.
+   * https://esbuild.github.io/api/#keep-names
+   */
+  keepNames?: boolean
 }
 
 export interface DepOptimizationMetadata {
@@ -229,7 +235,7 @@ export async function optimizeDeps(
   const result = await build({
     entryPoints: Object.keys(flatIdDeps),
     bundle: true,
-    keepNames: true,
+    keepNames: config.optimizeDeps?.keepNames,
     format: 'esm',
     external: config.optimizeDeps?.exclude,
     logLevel: 'error',


### PR DESCRIPTION
### Description

Fixes the undesired behavior detailed in [this comment](https://github.com/vitejs/vite/pull/2376#issuecomment-805285480) on #2376 by reverting to the original approach of using an option instead of forcing `keepNames` to `true`.

### Additional Context

This PR is practically identical to #2376 except that I added a default value to the docs as suggested by @patak-js [here](https://github.com/vitejs/vite/pull/2376#issuecomment-805294793).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
