### PR TITLE
docs: using plugins guide

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -82,6 +82,10 @@ module.exports = {
               link: '/guide/features'
             },
             {
+              text: 'Using Plugins',
+              link: '/guide/using-plugins'
+            },
+            {
               text: 'Dependency Pre-Bundling',
               link: '/guide/dep-pre-bundling'
             },

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -115,7 +115,7 @@ export default ({ command, mode }) => {
 
 - **Type:** ` (Plugin | Plugin[])[]`
 
-  Array of plugins to use. See [Plugin API](/guide/api-plugin) for more details on Vite plugins.
+  Array of plugins to use. Falsy plugins are ignored and arrays of plugins are flattened. See [Plugin API](/guide/api-plugin) for more details on Vite plugins.
 
 ### publicDir
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -25,6 +25,48 @@ If your plugin is only going to work for a particular framework, its name should
 - `vite-plugin-react-` prefix for React Plugins
 - `vite-plugin-svelte-` prefix for Svelte Plugins
 
+## Plugins config
+
+Users will add plugins to the project `devDependencies` and configure them using the `plugins` array option.
+
+```js
+// vite.config.js
+import vitePlugin from 'vite-plugin-feature'
+import rollupPlugin from 'rollup-plugin-feature'
+
+export default {
+  plugins: [ vitePlugin(), rollupPlugin() ]
+}
+```
+
+Falsy plugins will be ignored, which can be used to easily activate or deactivate plugins. 
+
+`plugins` also accept presets including several plugins as a single element. This is useful for complex features (like framework integration) that are implemented using several plugins. The array will be flattened internally.
+
+```js
+// framework-plugin
+import frameworkRefresh from "vite-plugin-framework-refresh";
+import frameworkDevtools from "vite-plugin-framework-devtools";
+
+export default function framework(config) {
+  return [ 
+    frameworkRefresh(config), 
+    frameworkDevTools(config)
+  ]
+}
+```
+
+```js
+// vite.config.js
+import framework from 'vite-plugin-framework'
+
+export default {
+  plugins: [
+    framework()
+  ]
+}
+```
+
 ## Simple Examples
 
 :::tip
@@ -365,13 +407,13 @@ A Vite plugin can additionally specify an `enforce` property (similar to webpack
 
 ## Conditional Application
 
-By default plugins are invoked for both serve and build. In cases where a plugin needs to be conditionally applied only during serve or build, use the `apply` property:
+By default plugins are invoked for both serve and build. In cases where a plugin needs to be conditionally applied only during serve or build, use the `apply` property to only invoke them during `'build'` or `'serve'`:
 
 ```js
 function myPlugin() {
   return {
     name: 'build-only',
-    apply: 'build'
+    apply: 'build' // or 'serve'
   }
 }
 ```

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -1,6 +1,6 @@
 # Plugin API
 
-Vite plugins extends Rollup's well-designed plugin interface with a few extra vite-specific options. As a result, you can write a Vite plugin once and have it work for both dev and build.
+Vite plugins extends Rollup's well-designed plugin interface with a few extra Vite-specific options. As a result, you can write a Vite plugin once and have it work for both dev and build.
 
 **It is recommended to go through [Rollup's plugin documentation](https://rollupjs.org/guide/en/#plugin-development) first before reading the sections below.**
 
@@ -422,7 +422,7 @@ function myPlugin() {
 
 A fair number of Rollup plugins will work directly as a Vite plugin (e.g. `@rollup/plugin-alias` or `@rollup/plugin-json`), but not all of them, since some plugin hooks do not make sense in an unbundled dev server context.
 
-In general, as long as a rollup plugin fits the following criterias then it should just work as a Vite plugin:
+In general, as long as a Rollup plugin fits the following criterias then it should just work as a Vite plugin:
 
 - It doesn't use the [`moduleParsed`](https://rollupjs.org/guide/en/#moduleparsed) hook.
 - It doesn't have strong coupling between bundle-phase hooks and output-phase hooks.
@@ -446,7 +446,7 @@ export default {
 }
 ```
 
-Check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official rollup plugins with usage instructions.
+Check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official Rollup plugins with usage instructions.
 
 ## Path normalization
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -45,12 +45,12 @@ Falsy plugins will be ignored, which can be used to easily activate or deactivat
 
 ```js
 // framework-plugin
-import frameworkRefresh from "vite-plugin-framework-refresh";
-import frameworkDevtools from "vite-plugin-framework-devtools";
+import frameworkRefresh from 'vite-plugin-framework-refresh'
+import frameworkDevtools from 'vite-plugin-framework-devtools'
 
 export default function framework(config) {
-  return [ 
-    frameworkRefresh(config), 
+  return [
+    frameworkRefresh(config),
     frameworkDevTools(config)
   ]
 }

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -1,0 +1,84 @@
+# Using Plugins
+
+Vite can be extended using plugins, which are based on Rollup's well-designed plugin interface with a few extra vite-specific options. This means that Vite users can rely on the mature ecosystem of rollup plugins, while also being able to extend the dev server and SSR functionality as needed.
+
+## Adding a Plugin
+
+To use a Plugin, it needs to be added to the `devDependencies` of the project and included in the `plugins` array in the `vite.config.js` config file. For example, to provide support for legacy browsers, the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) can be used:
+
+```
+$ npm i -D @vitejs/plugin-legacy
+```
+
+```js
+// vite.config.js
+import legacy from '@vitejs/plugin-legacy'
+
+export default {
+  plugins: [
+    legacy({
+      targets: ['defaults', 'not IE 11']
+    })
+  ]
+}
+```
+
+`plugins` also accept presets including several plugins as a single element. This is useful for complex features (like framework integration) that are implemented using several plugins. The array will be flattened internally.
+
+Falsy plugins will be ignored, which can be used to easily activate or deactivate plugins.
+
+## Finding Plugins
+
+:::tip NOTE
+Vite aims to provide out-of-the-box support for common web development patterns. Before searching for a Vite or Compatible Rollup plugin, check out the [Features Guide](../guide/features.md). A lot of the cases where a plugin would be needed in a Rollup project are already covered in Vite.
+:::
+
+Check out the [Plugins section](../plugins) for information about official plugins. Community Plugins are listed in [awesome-vite](https://github.com/vitejs/awesome-vite#plugins). For Compatible Rollup Plugins, check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official rollup plugins with usage instructions or the [Rollup Plugin Compatibility section](../guide/api-plugin#rollup-plugin-compatibility) in case it is not listed there.
+
+You can also find plugins that follow the [recommended conventions](./api-plugin.md#conventions) using a [npm search fro vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Vite Plugins or a [npm search for rollup-plugin](https://www.npmjs.com/search?q=rollup-plugin&ranking=popularity) or a [npm search fro vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Rollup Plugins.
+
+## Enforcing Plugin Ordering
+
+For compatibility with some Rollup Plugins, it may be needed to enforce the order of the plugin or only apply at build time. This should be an implementation detail for Vite Plugins. You can enforce the position of a Plugin with the `enforce` modifier:
+
+- `pre`: invoke plugin before Vite core plugins
+- default: invoke plugin after Vite core plugins
+- `post`: invoke plugin after Vite build plugins
+
+```js
+// vite.config.js
+import image from "@rollup/plugin-image"
+          
+export default {
+  plugins: [
+    {
+      ...image(),
+      enforce: 'pre',
+    },
+  ]
+}
+```
+
+Check out [Plugins API Guide](./api-plugin.md#plugin-ordering) for detailed information,  and look out for the `enforce` label and usage instructions for popular Plugins in the [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev/) compatibility listing.
+
+## Conditional Application
+
+By default, plugins are invoked for both serve and build. In cases where a plugin needs to be conditionally applied only during serve or build, use the `apply` property to only invoke them during `'build'` or `'serve'`:
+
+```js
+// vite.config.js
+import typescript2 from "rollup-plugin-typescript2"
+          
+export default {
+  plugins: [
+    {
+      ...typescript2(),
+      apply: 'build',
+    },
+  ]
+}
+```
+
+## Building Plugins
+
+Check out the [Plugins API Guide](./api-plugin.md) for documentation about creating plugins.

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -35,7 +35,7 @@ Vite aims to provide out-of-the-box support for common web development patterns.
 
 Check out the [Plugins section](../plugins) for information about official plugins. Community Plugins are listed in [awesome-vite](https://github.com/vitejs/awesome-vite#plugins). For Compatible Rollup Plugins, check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official rollup plugins with usage instructions or the [Rollup Plugin Compatibility section](../guide/api-plugin#rollup-plugin-compatibility) in case it is not listed there.
 
-You can also find plugins that follow the [recommended conventions](./api-plugin.md#conventions) using a [npm search fro vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Vite Plugins or a [npm search for rollup-plugin](https://www.npmjs.com/search?q=rollup-plugin&ranking=popularity) or a [npm search fro vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Rollup Plugins.
+You can also find plugins that follow the [recommended conventions](./api-plugin.md#conventions) using a [npm search for vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Vite Plugins or a [npm search for rollup-plugin](https://www.npmjs.com/search?q=rollup-plugin&ranking=popularity) or a [npm search fro vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Rollup Plugins.
 
 ## Enforcing Plugin Ordering
 
@@ -47,8 +47,8 @@ For compatibility with some Rollup Plugins, it may be needed to enforce the orde
 
 ```js
 // vite.config.js
-import image from "@rollup/plugin-image"
-          
+import image from '@rollup/plugin-image'
+
 export default {
   plugins: [
     {
@@ -59,7 +59,7 @@ export default {
 }
 ```
 
-Check out [Plugins API Guide](./api-plugin.md#plugin-ordering) for detailed information,  and look out for the `enforce` label and usage instructions for popular Plugins in the [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev/) compatibility listing.
+Check out [Plugins API Guide](./api-plugin.md#plugin-ordering) for detailed information,  and look out for the `enforce` label and usage instructions for popular Plugins in the [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) compatibility listing.
 
 ## Conditional Application
 
@@ -67,8 +67,8 @@ By default, plugins are invoked for both serve and build. In cases where a plugi
 
 ```js
 // vite.config.js
-import typescript2 from "rollup-plugin-typescript2"
-          
+import typescript2 from 'rollup-plugin-typescript2'
+
 export default {
   plugins: [
     {

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -1,10 +1,10 @@
 # Using Plugins
 
-Vite can be extended using plugins, which are based on Rollup's well-designed plugin interface with a few extra vite-specific options. This means that Vite users can rely on the mature ecosystem of rollup plugins, while also being able to extend the dev server and SSR functionality as needed.
+Vite can be extended using plugins, which are based on Rollup's well-designed plugin interface with a few extra Vite-specific options. This means that Vite users can rely on the mature ecosystem of Rollup plugins, while also being able to extend the dev server and SSR functionality as needed.
 
 ## Adding a Plugin
 
-To use a Plugin, it needs to be added to the `devDependencies` of the project and included in the `plugins` array in the `vite.config.js` config file. For example, to provide support for legacy browsers, the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) can be used:
+To use a plugin, it needs to be added to the `devDependencies` of the project and included in the `plugins` array in the `vite.config.js` config file. For example, to provide support for legacy browsers, the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) can be used:
 
 ```
 $ npm i -D @vitejs/plugin-legacy
@@ -30,16 +30,16 @@ Falsy plugins will be ignored, which can be used to easily activate or deactivat
 ## Finding Plugins
 
 :::tip NOTE
-Vite aims to provide out-of-the-box support for common web development patterns. Before searching for a Vite or Compatible Rollup plugin, check out the [Features Guide](../guide/features.md). A lot of the cases where a plugin would be needed in a Rollup project are already covered in Vite.
+Vite aims to provide out-of-the-box support for common web development patterns. Before searching for a Vite or compatible Rollup plugin, check out the [Features Guide](../guide/features.md). A lot of the cases where a plugin would be needed in a Rollup project are already covered in Vite.
 :::
 
-Check out the [Plugins section](../plugins) for information about official plugins. Community Plugins are listed in [awesome-vite](https://github.com/vitejs/awesome-vite#plugins). For Compatible Rollup Plugins, check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official rollup plugins with usage instructions or the [Rollup Plugin Compatibility section](../guide/api-plugin#rollup-plugin-compatibility) in case it is not listed there.
+Check out the [Plugins section](../plugins) for information about official plugins. Community plugins are listed in [awesome-vite](https://github.com/vitejs/awesome-vite#plugins). For compatible Rollup plugins, check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official Rollup plugins with usage instructions or the [Rollup Plugin Compatibility section](../guide/api-plugin#rollup-plugin-compatibility) in case it is not listed there.
 
-You can also find plugins that follow the [recommended conventions](./api-plugin.md#conventions) using a [npm search for vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Vite Plugins or a [npm search for rollup-plugin](https://www.npmjs.com/search?q=rollup-plugin&ranking=popularity) or a [npm search fro vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Rollup Plugins.
+You can also find plugins that follow the [recommended conventions](./api-plugin.md#conventions) using a [npm search for vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Vite plugins or a [npm search for rollup-plugin](https://www.npmjs.com/search?q=rollup-plugin&ranking=popularity) or a [npm search for vite-plugin](https://www.npmjs.com/search?q=vite-plugin&ranking=popularity) for Rollup plugins.
 
 ## Enforcing Plugin Ordering
 
-For compatibility with some Rollup Plugins, it may be needed to enforce the order of the plugin or only apply at build time. This should be an implementation detail for Vite Plugins. You can enforce the position of a Plugin with the `enforce` modifier:
+For compatibility with some Rollup plugins, it may be needed to enforce the order of the plugin or only apply at build time. This should be an implementation detail for Vite plugins. You can enforce the position of a plugin with the `enforce` modifier:
 
 - `pre`: invoke plugin before Vite core plugins
 - default: invoke plugin after Vite core plugins
@@ -59,7 +59,7 @@ export default {
 }
 ```
 
-Check out [Plugins API Guide](./api-plugin.md#plugin-ordering) for detailed information, and look out for the `enforce` label and usage instructions for popular Plugins in the [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) compatibility listing.
+Check out [Plugins API Guide](./api-plugin.md#plugin-ordering) for detailed information, and look out for the `enforce` label and usage instructions for popular plugins in the [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) compatibility listing.
 
 ## Conditional Application
 

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -59,7 +59,7 @@ export default {
 }
 ```
 
-Check out [Plugins API Guide](./api-plugin.md#plugin-ordering) for detailed information,  and look out for the `enforce` label and usage instructions for popular Plugins in the [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) compatibility listing.
+Check out [Plugins API Guide](./api-plugin.md#plugin-ordering) for detailed information, and look out for the `enforce` label and usage instructions for popular Plugins in the [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) compatibility listing.
 
 ## Conditional Application
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -24,7 +24,7 @@ Vite aims to provide out-of-the-box support for common web development patterns.
 
 ## Community Plugins
 
-Check out [awesome-vite](https://github.com/vitejs/awesome-vite) - you can also submit a PR to list your plugins there.
+Check out [awesome-vite](https://github.com/vitejs/awesome-vite#plugins) - you can also submit a PR to list your plugins there.
 
 ## Rollup Plugins
 


### PR DESCRIPTION
### Description

After the Features guide, this PR adds a Using Plugins guide from the user POV

Right now we have:
   a **Plugins section** on the top where official plugins and links to community plugins in awesome-vite are listed
   a **Plugin API** guide that is intended for plugin authors: conventions, hooks, links to rollup docs, etc

This Guide complements those two pages including only the information needed as a user, and links to them from the main Vite docs guides.

There are also small modifications to the other two plugin pages.

Rendered output
![using-plugins](https://user-images.githubusercontent.com/583075/112749554-48572f00-8fc3-11eb-9929-60b55013ab2b.png)
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
