### PR TITLE
fix(static): serve .js, .jsx, .ts, .tsx as application/javascript

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -1,12 +1,26 @@
 import os from 'os'
 import path from 'path'
-import sirv from 'sirv'
+import sirv, { Options } from 'sirv'
 import { Connect } from 'types/connect'
 import { ResolvedConfig } from '../..'
 import { FS_PREFIX } from '../../constants'
 import { cleanUrl, isImportRequest } from '../../utils'
 
-const sirvOptions = { dev: true, etag: true, extensions: [] }
+const sirvOptions: Options = {
+  dev: true,
+  etag: true,
+  extensions: [],
+  setHeaders(res, pathname) {
+    // Matches js, jsx, ts, tsx.
+    // The reason this is done, is that the .ts file extension is reserved
+    // for the MIME type video/mp2t. In almost all cases, we can expect
+    // these files to be TypeScript files, and for Vite to serve them with
+    // this Content-Type.
+    if (/\.[tj]sx?$/.test(pathname)) {
+      res.setHeader('Content-Type', 'application/javascript')
+    }
+  }
+}
 
 export function servePublicMiddleware(dir: string): Connect.NextHandleFunction {
   const serve = sirv(dir, sirvOptions)


### PR DESCRIPTION
This fixes #2642. (Well, I _believe_ it fixes it)
Thanks a lot to @lukeed, maintainer of Sirv, for the suggestion!
https://github.com/lukeed/sirv/pull/103#issuecomment-809633566

To be honest, I had a hard time finding a good way to test this fix - npm link didn't work for me, and I couldn't find any integration tests or documentation on how to develop locally using a forked version of Vite. Could somebody please point me in the right direction?