### PR TITLE
fix(create-app): improved package name validation

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -151,7 +151,7 @@ async function getValidPackageName(projectName) {
   if (packageNameRegExp.test(projectName)) {
     return projectName
   } else {
-    const suggestPkgName = projectName
+    const suggestedPackageName = projectName
       .trim()
       .toLowerCase()
       .replace(/\s+/g, '-')
@@ -165,7 +165,7 @@ async function getValidPackageName(projectName) {
       type: 'input',
       name: 'inputPackageName',
       message: `Package name:`,
-      initial: suggestPkgName,
+      initial: suggestedPackageName,
       validate: (input) =>
         packageNameRegExp.test(input) ? true : 'Invalid package.json name'
     })

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -66,7 +66,7 @@ async function init() {
      */
     const { inputPackageName } = await prompt({
       type: 'input',
-      name: 'packageName',
+      name: 'inputPackageName',
       message: `Name for package.json:`,
       initial: suggestPkgName,
       validate: (input) =>

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -49,34 +49,7 @@ async function init() {
     })
     targetDir = projectName
   }
-  let packageName
-  const packageNameRegExp = /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
-  if (packageNameRegExp.test(targetDir)) {
-    packageName = targetDir
-  } else {
-    const suggestPkgName = targetDir
-      .trim()
-      .toLowerCase()
-      .replace(/\s+/g, '-')
-      .replace(/^[._]/, '')
-      .replace(/[^a-z0-9-~]+/g, '-')
-
-    /**
-     * @type {{ inputPackageName: string }}
-     */
-    const { inputPackageName } = await prompt({
-      type: 'input',
-      name: 'inputPackageName',
-      message: `Name for package.json:`,
-      initial: suggestPkgName,
-      validate: (input) =>
-        packageNameRegExp.test(input)
-          ? true
-          : 'Name contains illegal characters'
-    })
-    packageName = inputPackageName
-  }
-
+  const packageName = await getValidPackageName(targetDir)
   const root = path.join(cwd, targetDir)
   console.log(`\nScaffolding project in ${root}...`)
 
@@ -170,6 +143,33 @@ function copy(src, dest) {
     copyDir(src, dest)
   } else {
     fs.copyFileSync(src, dest)
+  }
+}
+
+async function getValidPackageName(projectName) {
+  const packageNameRegExp = /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/
+  if (packageNameRegExp.test(projectName)) {
+    return projectName
+  } else {
+    const suggestPkgName = projectName
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, '-')
+      .replace(/^[._]/, '')
+      .replace(/[^a-z0-9-~]+/g, '-')
+
+    /**
+     * @type {{ inputPackageName: string }}
+     */
+    const { inputPackageName } = await prompt({
+      type: 'input',
+      name: 'inputPackageName',
+      message: `Package name:`,
+      initial: suggestPkgName,
+      validate: (input) =>
+        packageNameRegExp.test(input) ? true : 'Invalid package.json name'
+    })
+    return inputPackageName
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR fixes some cases where current validation of package name in package.json introduced in https://github.com/vitejs/vite/commit/1dbf24627d0fed4d6936f53fb84bc94b79372652 fails. Examples: names containing `&` , `$` and `@` not as part of scoped package name.
Silent package name substitution replaced with additional prompt that only appears if project name is cannot be used as legal package name. As such in most cases users won't be bothered with additional prompt but in edge cases they will be made immediately aware of possible issues with their choice of project name and given control over substitution, while maintaining the ease of using automated character substitution.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
Currently implied validation creates possibility of creating malformed package.json that would fail to initialize with `yarn` command with 
```
error package.json: Name contains illegal characters
```


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
