### PR TITLE
fix(scan): avoid crawling type only import

### DIFF
--- a/packages/playground/ssr-vue/dep-import-type/deep/index.d.ts
+++ b/packages/playground/ssr-vue/dep-import-type/deep/index.d.ts
@@ -1,0 +1,1 @@
+export interface Foo {}

--- a/packages/playground/ssr-vue/dep-import-type/package.json
+++ b/packages/playground/ssr-vue/dep-import-type/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep-import-type",
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/packages/playground/ssr-vue/package.json
+++ b/packages/playground/ssr-vue/package.json
@@ -20,6 +20,7 @@
     "@vitejs/plugin-vue-jsx": "^1.1.2",
     "@vue/compiler-sfc": "^3.0.8",
     "@vue/server-renderer": "^3.0.6",
+    "dep-import-type": "link:./dep-import-type",
     "compression": "^1.7.4",
     "cross-env": "^7.0.3",
     "express": "^4.17.1",

--- a/packages/playground/ssr-vue/src/components/ImportType.vue
+++ b/packages/playground/ssr-vue/src/components/ImportType.vue
@@ -1,0 +1,9 @@
+<template>
+  <p>import type should be removed without side-effect</p>
+</template>
+
+<script setup lang="ts">
+import type { Foo } from 'dep-import-type/deep'
+
+const msg: Foo = {}
+</script>

--- a/packages/playground/ssr-vue/src/pages/Home.vue
+++ b/packages/playground/ssr-vue/src/pages/Home.vue
@@ -6,11 +6,14 @@
   <button @click="state.count++">count is: {{ state.count }}</button>
   <Foo />
   <p class="virtual">msg from virtual module: {{ foo.msg }}</p>
+
+  <ImportType/>
 </template>
 
 <script setup>
 import foo from '@foo'
 import { reactive, defineAsyncComponent } from 'vue'
+import ImportType from '../components/ImportType.vue'
 const Foo = defineAsyncComponent(() =>
   import('../components/Foo').then((mod) => mod.Foo)
 )

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -38,7 +38,7 @@ const htmlTypesRE = /\.(html|vue|svelte)$/
 // use Acorn because it's slow. Luckily this doesn't have to be bullet proof
 // since even missed imports can be caught at runtime, and false positives will
 // simply be ignored.
-const importsRE = /\bimport(?:[\w*{}\n\r\t, ]+from\s*)?\s*("[^"]+"|'[^']+')/gm
+const importsRE = /\bimport(?!\s*type)(?:[\w*{}\n\r\t, ]+from\s*)?\s*("[^"]+"|'[^']+')/gm
 
 export async function scanImports(
   config: ResolvedConfig

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -38,7 +38,7 @@ const htmlTypesRE = /\.(html|vue|svelte)$/
 // use Acorn because it's slow. Luckily this doesn't have to be bullet proof
 // since even missed imports can be caught at runtime, and false positives will
 // simply be ignored.
-const importsRE = /\bimport(?!\s*type)(?:[\w*{}\n\r\t, ]+from\s*)?\s*("[^"]+"|'[^']+')/gm
+const importsRE = /\bimport(?!\s+type)(?:[\w*{}\n\r\t, ]+from\s*)?\s*("[^"]+"|'[^']+')/gm
 
 export async function scanImports(
   config: ResolvedConfig

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,6 +2652,10 @@ delegate@^3.1.2:
   version "0.0.0"
   uid ""
 
+"dep-import-type@link:./packages/playground/ssr-vue/dep-import-type":
+  version "0.0.0"
+  uid ""
+
 "dep-linked-include@link:./packages/playground/optimize-deps/dep-linked-include":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When I import something like `import type { Config } from 'windicss/types/interfaces'` I will got this error:
`
node_modules/.pnpm/vite@2.1.5/node_modules/vite/dist/node/chunks/dep-66eb515d.js:31609:7: error: [vite:dep-scan] Missing "./types/interfaces" export in "windicss" package
`
in vite build.

Then I found out in [this line](https://github.com/vitejs/vite/commit/8f527fd09c494fd23121aded0b836ff60a62835c#diff-00039b783552b3f2a608918986716e01b1a71996da1a8ad5493a102a1e969d7bR245) it generated a code to avoid unused import dropped in the esbuild build output, which will result to `import 'windicss/types/interfaces'`,  it's a type definition file, so I think we should simply ignore any type only import.


### Additional context

https://github.com/windicss/docs/actions/runs/705958534

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
