### PR TITLE
fix(build): properly handle alias key in config merge

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1,0 +1,44 @@
+import { mergeConfig, UserConfigExport } from '../config'
+
+test('merge configs with different alias schemas', () => {
+  const baseConfig: UserConfigExport = {
+    resolve: {
+      alias: [
+        {
+          find: 'foo',
+          replacement: 'foo-value'
+        }
+      ]
+    }
+  }
+
+  const newConfig: UserConfigExport = {
+    resolve: {
+      alias: {
+        bar: 'bar-value',
+        baz: 'baz-value'
+      }
+    }
+  }
+
+  const mergedConfig: UserConfigExport = {
+    resolve: {
+      alias: [
+        {
+          find: 'foo',
+          replacement: 'foo-value'
+        },
+        {
+          find: 'bar',
+          replacement: 'bar-value'
+        },
+        {
+          find: 'baz',
+          replacement: 'baz-value'
+        }
+      ]
+    }
+  }
+
+  expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+})

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1,44 +1,62 @@
 import { mergeConfig, UserConfigExport } from '../config'
 
-test('merge configs with different alias schemas', () => {
-  const baseConfig: UserConfigExport = {
-    resolve: {
-      alias: [
-        {
-          find: 'foo',
-          replacement: 'foo-value'
-        }
-      ]
-    }
-  }
-
-  const newConfig: UserConfigExport = {
-    resolve: {
-      alias: {
-        bar: 'bar-value',
-        baz: 'baz-value'
+describe('mergeConfig', () => {
+  test('handles configs with different alias schemas', () => {
+    const baseConfig: UserConfigExport = {
+      resolve: {
+        alias: [
+          {
+            find: 'foo',
+            replacement: 'foo-value'
+          }
+        ]
       }
     }
-  }
 
-  const mergedConfig: UserConfigExport = {
-    resolve: {
-      alias: [
-        {
-          find: 'foo',
-          replacement: 'foo-value'
-        },
-        {
-          find: 'bar',
-          replacement: 'bar-value'
-        },
-        {
-          find: 'baz',
-          replacement: 'baz-value'
+    const newConfig: UserConfigExport = {
+      resolve: {
+        alias: {
+          bar: 'bar-value',
+          baz: 'baz-value'
         }
-      ]
+      }
     }
-  }
 
-  expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+    const mergedConfig: UserConfigExport = {
+      resolve: {
+        alias: [
+          {
+            find: 'foo',
+            replacement: 'foo-value'
+          },
+          {
+            find: 'bar',
+            replacement: 'bar-value'
+          },
+          {
+            find: 'baz',
+            replacement: 'baz-value'
+          }
+        ]
+      }
+    }
+
+    expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+  })
+
+  test('handles assetsInclude', () => {
+    const baseConfig: UserConfigExport = {
+      assetsInclude: 'some-string'
+    }
+
+    const newConfig: UserConfigExport = {
+      assetsInclude: ['some-other-string', /regexp?/]
+    }
+
+    const mergedConfig: UserConfigExport = {
+      assetsInclude: ['some-string', 'some-other-string', /regexp?/]
+    }
+
+    expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+  })
 })

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -59,4 +59,36 @@ describe('mergeConfig', () => {
 
     expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
   })
+
+  test('not handles alias not under `resolve`', () => {
+    const baseConfig = {
+      custom: {
+        alias: {
+          bar: 'bar-value',
+          baz: 'baz-value'
+        }
+      }
+    }
+
+    const newConfig = {
+      custom: {
+        alias: {
+          bar: 'bar-value-2',
+          foo: 'foo-value'
+        }
+      }
+    }
+
+    const mergedConfig = {
+      custom: {
+        alias: {
+          bar: 'bar-value-2',
+          baz: 'baz-value',
+          foo: 'foo-value'
+        }
+      }
+    }
+
+    expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+  })
 })

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -527,12 +527,12 @@ export function mergeConfig(
       continue
     }
 
-    // root fields that require special handling
-    if (existing != null && isRoot) {
-      if (key === 'alias') {
+    // fields that require special handling
+    if (existing != null) {
+      if (key === 'alias' && !isRoot) {
         merged[key] = mergeAlias(existing, value)
         continue
-      } else if (key === 'assetsInclude') {
+      } else if (key === 'assetsInclude' && isRoot) {
         merged[key] = [].concat(existing, value)
         continue
       }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -505,11 +505,11 @@ function resolveBaseUrl(
   return base
 }
 
-export function mergeConfig(
+function mergeConfigRecursively(
   a: Record<string, any>,
   b: Record<string, any>,
-  isRoot = true
-): Record<string, any> {
+  rootPath: string
+) {
   const merged: Record<string, any> = { ...a }
   for (const key in b) {
     const value = b[key]
@@ -523,16 +523,20 @@ export function mergeConfig(
       continue
     }
     if (isObject(existing) && isObject(value)) {
-      merged[key] = mergeConfig(existing, value, false)
+      merged[key] = mergeConfigRecursively(
+        existing,
+        value,
+        rootPath ? `${rootPath}.${key}` : key
+      )
       continue
     }
 
     // fields that require special handling
     if (existing != null) {
-      if (key === 'alias' && !isRoot) {
+      if (key === 'alias' && (rootPath === 'resolve' || rootPath === '')) {
         merged[key] = mergeAlias(existing, value)
         continue
-      } else if (key === 'assetsInclude' && isRoot) {
+      } else if (key === 'assetsInclude' && rootPath === '') {
         merged[key] = [].concat(existing, value)
         continue
       }
@@ -541,6 +545,14 @@ export function mergeConfig(
     merged[key] = value
   }
   return merged
+}
+
+export function mergeConfig(
+  a: Record<string, any>,
+  b: Record<string, any>,
+  isRoot = true
+): Record<string, any> {
+  return mergeConfigRecursively(a, b, isRoot ? '' : '.')
 }
 
 function mergeAlias(a: AliasOptions = [], b: AliasOptions = []): Alias[] {


### PR DESCRIPTION
### Description

👋 small bug fix - there's some logic in `mergeConfig` to handle merging particular field types:

https://github.com/vitejs/vite/blob/fa8574921195dd03b539c150a2ae5f97121a0aea/packages/vite/src/node/config.ts#L520-L539

Note the custom handling of `alias` at the bottom. In some cases this isn't necessary (i.e. if `existing` and `value` are both objects / arrays) though it is if the configs use different alias schemas.

It looks like `mergeAlias` is never being run since `alias` is (afaik) never a root key. I tweaked the logic to only perform this check when checking a non-root key.

I added a failing test for this case as well as an additional test for the `assetsInclude` (already passes on main).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
