### PR TITLE
fix: babel preset execution order in legacy plugin

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -232,16 +232,6 @@ function viteLegacyPlugin(options = {}) {
         sourceMaps,
         inputSourceMap: sourceMaps && chunk.map,
         presets: [
-          // forcing our plugin to run before preset-env by wrapping it in a
-          // preset so we can catch the injected import statements...
-          [
-            () => ({
-              plugins: [
-                recordAndRemovePolyfillBabelPlugin(legacyPolyfills),
-                replaceLegacyEnvBabelPlugin()
-              ]
-            })
-          ],
           [
             'env',
             {
@@ -256,6 +246,16 @@ function viteLegacyPlugin(options = {}) {
               shippedProposals: true,
               ignoreBrowserslistConfig: options.ignoreBrowserslistConfig
             }
+          ],
+          // forcing our plugin to run first before preset-env by wrapping it in a
+          // preset so we can catch the injected import statements. Keep in mind that babel preset execution order is reversed-the last one always goes first.
+          [
+            () => ({
+              plugins: [
+                recordAndRemovePolyfillBabelPlugin(legacyPolyfills),
+                replaceLegacyEnvBabelPlugin()
+              ]
+            })
           ]
         ]
       })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix legacy plugin. With the current order it can happen that `import` keywords get into legacy builds

### Additional context

https://babeljs.io/docs/en/presets/#preset-ordering

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
