### PR TITLE
feat(esbuild): add user esbuild plugins support

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -34,7 +34,7 @@ import {
   PluginContainer
 } from './server/pluginContainer'
 import aliasPlugin from '@rollup/plugin-alias'
-import { build } from 'esbuild'
+import { Plugin as EsbuildPlugin, build } from 'esbuild'
 
 const debug = createDebugger('vite:config')
 
@@ -111,6 +111,10 @@ export interface UserConfig {
    */
   esbuild?: ESBuildOptions | false
   /**
+   * Array of esbuild plugins to use.
+   */
+  esbuildPlugins?: EsbuildPlugin[]
+  /**
    * Specify additional files to be treated as static assets.
    */
   assetsInclude?: string | RegExp | (string | RegExp)[]
@@ -178,6 +182,7 @@ export type ResolvedConfig = Readonly<
       alias: Alias[]
     }
     plugins: readonly Plugin[]
+    esbuildPlugins: readonly EsbuildPlugin[]
     server: ServerOptions
     build: ResolvedBuildOptions
     assetsInclude: (file: string) => boolean
@@ -352,6 +357,7 @@ export async function resolveConfig(
     isProduction,
     optimizeCacheDir,
     plugins: userPlugins,
+    esbuildPlugins: config.esbuildPlugins || [],
     server: config.server || {},
     build: resolvedBuildOptions,
     env: {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -245,7 +245,10 @@ export async function optimizeDeps(
     treeShaking: 'ignore-annotations',
     metafile: true,
     define,
-    plugins: [esbuildDepPlugin(flatIdDeps, flatIdToExports, config)]
+    plugins: [
+      esbuildDepPlugin(flatIdDeps, flatIdToExports, config),
+      ...config.esbuildPlugins
+    ]
   })
 
   const meta = result.metafile!

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -99,7 +99,7 @@ export async function scanImports(
         format: 'esm',
         logLevel: 'error',
         outdir: tempDir,
-        plugins: [plugin]
+        plugins: [plugin, ...config.esbuildPlugins]
       })
     )
   )


### PR DESCRIPTION
### Description

Quoting [esbuild-plugin-alias](https://github.com/igoradamenko/esbuild-plugin-alias):
> Sometimes it's useful to have dynamic imports that resolves into different files depending on some conditions (e.g. env variables).

In my case, I had to shim all internal Vuetify `VIcon` imports to replace it with a custom and improved component `ZIcon`. With vue-cli-3 and Webpack, all was fine. With **Vite**, I use this config:

```js
// vite.config.js
  resolve: {
    alias: {
      '../VIcon': path.resolve(__dirname, 'src/components/ZIcon'),
      '../../VIcon': path.resolve(__dirname, 'src/components/ZIcon'),
    },
  },
```

Aliases are properly handled by rollup at compilation. However, they are not matched by esbuild (the Vuetify component is imported).
I thought about adding internally to **Vite** an import to `esbuild-plugin-alias` and plug to it the config aliases, but not sure about side effects and the versatility of this solution – I guess it is an edge case, and more profitable to all if esbuid’s *plugin* system is exposed.

Hence, I propose to add an entry `esbuildPlugins` to Vite config as such:
```js
// vite.config.js
import alias from 'esbuild-plugin-alias';
export default {
  ...
  esbuildPlugins: [
    alias({
      '../VIcon': path.resolve(__dirname, 'src/components/ZIcon/index.js'),
      '../../VIcon': path.resolve(__dirname, 'src/components/ZIcon/index.js'),
    })
  ],
}
```

### Additional context

Do you think it is the correct way to tackle the above mentioned issue ?

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
