### PR TITLE
fix(build): augment chunked assets to hash calculation (#2804)

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -58,7 +58,23 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       const url = await fileToUrl(id, config, this)
       return `export default ${JSON.stringify(url)}`
     },
+    augmentChunkHash(info) {
+      const allIds = Array.from(this.getModuleIds())
+      const ids = Object.keys(info.modules).filter((moduleId) =>
+        allIds.includes(moduleId)
+      )
 
+      if (ids.length === 0) return
+
+      const modules = ids
+        .map((id) => this.getModuleInfo(id))
+        .filter((module) => assetUrlQuotedRE.test(module?.code ?? ''))
+      const codes = modules.map((m) =>
+        m?.id !== undefined ? fs.readFileSync(cleanUrl(m.id), 'utf-8') : ''
+      )
+
+      return codes.join('')
+    },
     renderChunk(code, chunk) {
       let match
       let s


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #2804.

Use Rollup's [augmentChunkHash](https://rollupjs.org/guide/en/#augmentchunkhash) hook to add chunked assets (for now, only worker files) into the hash calculation of the importer.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
