### PR TITLE
fix(plugin): avoid duplicate import (#2640)

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -143,10 +143,10 @@ export async function transformMain(
   // SSR module registration by wrapping user setup
   if (ssr) {
     output.push(
-      `import { useSSRContext } from 'vue'`,
+      `import { useSSRContext as _useSSRContext} from 'vue'`,
       `const _sfc_setup = _sfc_main.setup`,
       `_sfc_main.setup = (props, ctx) => {`,
-      `  const ssrContext = useSSRContext()`,
+      `  const ssrContext = _useSSRContext()`,
       `  ;(ssrContext.modules || (ssrContext.modules = new Set())).add(${JSON.stringify(
         filename
       )})`,

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -143,10 +143,10 @@ export async function transformMain(
   // SSR module registration by wrapping user setup
   if (ssr) {
     output.push(
-      `import { useSSRContext as _useSSRContext} from 'vue'`,
+      `import { useSSRContext as __vite_useSSRContext} from 'vue'`,
       `const _sfc_setup = _sfc_main.setup`,
       `_sfc_main.setup = (props, ctx) => {`,
-      `  const ssrContext = _useSSRContext()`,
+      `  const ssrContext = __vite_useSSRContext()`,
       `  ;(ssrContext.modules || (ssrContext.modules = new Set())).add(${JSON.stringify(
         filename
       )})`,

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -143,7 +143,7 @@ export async function transformMain(
   // SSR module registration by wrapping user setup
   if (ssr) {
     output.push(
-      `import { useSSRContext as __vite_useSSRContext} from 'vue'`,
+      `import { useSSRContext as __vite_useSSRContext } from 'vue'`,
       `const _sfc_setup = _sfc_main.setup`,
       `_sfc_main.setup = (props, ctx) => {`,
       `  const ssrContext = __vite_useSSRContext()`,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fixes #2640
The plugin-vue added a line:
```import { useSSRContext } from 'vue'```
which may duplicate with user's code

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
