### PR TITLE
fix(react-refresh): check FunctionDeclaration nodes properly

### DIFF
--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -200,22 +200,33 @@ function isRefreshBoundary(ast) {
       return true
     }
     const { declaration, specifiers } = node
-    if (declaration && declaration.type === 'VariableDeclaration') {
-      return declaration.declarations.every(
-        ({ id }) => id.type === 'Identifier' && isComponentishName(id.name)
-      )
+    if (declaration) {
+      if (declaration.type === 'VariableDeclaration') {
+        return declaration.declarations.every((variable) => {
+          return isComponentLikeIdentifier(variable.id)
+        })
+      }
+      if (declaration.type === 'FunctionDeclaration') {
+        return isComponentLikeIdentifier(declaration.id)
+      }
     }
-    return specifiers.every(
-      ({ exported }) =>
-        exported.type === 'Identifier' && isComponentishName(exported.name)
-    )
+    return specifiers.every((spec) => {
+      return isComponentLikeIdentifier(spec.exported)
+    })
   })
+}
+
+/**
+ * @param {import('@babel/types').Node} node
+ */
+function isComponentLikeIdentifier(node) {
+  return node.type === 'Identifier' && isComponentLikeName(node.name)
 }
 
 /**
  * @param {string} name
  */
-function isComponentishName(name) {
+function isComponentLikeName(name) {
   return typeof name === 'string' && name[0] >= 'A' && name[0] <= 'Z'
 }
 

--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -202,9 +202,9 @@ function isRefreshBoundary(ast) {
     const { declaration, specifiers } = node
     if (declaration) {
       if (declaration.type === 'VariableDeclaration') {
-        return declaration.declarations.every((variable) => {
-          return isComponentLikeIdentifier(variable.id)
-        })
+        return declaration.declarations.every(
+          (variable) => isComponentLikeIdentifier(variable.id)
+        )
       }
       if (declaration.type === 'FunctionDeclaration') {
         return isComponentLikeIdentifier(declaration.id)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The problem:
```ts
export const MyComponent = () => {...}

// This should prevent this module from being a Refresh boundary, but it doesn't.
export function useThing() {...}
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
