### PR TITLE
fix: ignore ENOENT in `injectSourcesContent`

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -20,7 +20,13 @@ export async function injectSourcesContent(
       if (!isVirtual) {
         sourcePath = path.resolve(sourceRoot, sourcePath)
       }
-      map.sourcesContent![i] = await fs.readFile(sourcePath, 'utf-8')
+      try {
+        map.sourcesContent![i] = await fs.readFile(sourcePath, 'utf-8')
+      } catch (e) {
+        throw new Error(
+          `Sourcemap for "${file}" has a non-existent source: "${sourcePath}"`
+        )
+      }
     })
   )
 }

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -10,21 +10,17 @@ export async function injectSourcesContent(
       path.resolve(path.dirname(file), map.sourceRoot || '')
     )
   } catch (e) {
-    if (e.code == 'ENOENT') return
-    throw e
+    if (e.code !== 'ENOENT') throw e
+    var isVirtual = true
   }
   map.sourcesContent = []
   await Promise.all(
     map.sources.filter(Boolean).map(async (sourcePath, i) => {
-      try {
-        map.sourcesContent![i] = await fs.readFile(
-          path.resolve(sourceRoot, decodeURI(sourcePath)),
-          'utf-8'
-        )
-      } catch (e) {
-        if (e.code == 'ENOENT') return
-        throw e
+      sourcePath = decodeURI(sourcePath)
+      if (!isVirtual) {
+        sourcePath = path.resolve(sourceRoot, sourcePath)
       }
+      map.sourcesContent![i] = await fs.readFile(sourcePath, 'utf-8')
     })
   )
 }

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -29,15 +29,18 @@ export async function injectSourcesContent(
 
   const missingSources: string[] = []
   map.sourcesContent = await Promise.all(
-    map.sources.filter(Boolean).map((sourcePath) => {
-      sourcePath = decodeURI(sourcePath)
-      if (sourceRoot) {
-        sourcePath = path.resolve(sourceRoot, sourcePath)
+    map.sources.map((sourcePath) => {
+      if (sourcePath) {
+        sourcePath = decodeURI(sourcePath)
+        if (sourceRoot) {
+          sourcePath = path.resolve(sourceRoot, sourcePath)
+        }
+        return fs.readFile(sourcePath, 'utf-8').catch(() => {
+          missingSources.push(sourcePath)
+          return null
+        })
       }
-      return fs.readFile(sourcePath, 'utf-8').catch(() => {
-        missingSources.push(sourcePath)
-        return null
-      })
+      return null
     })
   )
 

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -5,16 +5,26 @@ export async function injectSourcesContent(
   map: { sources: string[]; sourcesContent?: string[]; sourceRoot?: string },
   file: string
 ): Promise<void> {
-  const sourceRoot = await fs.realpath(
-    path.resolve(path.dirname(file), map.sourceRoot || '')
-  )
+  try {
+    var sourceRoot = await fs.realpath(
+      path.resolve(path.dirname(file), map.sourceRoot || '')
+    )
+  } catch (e) {
+    if (e.code == 'ENOENT') return
+    throw e
+  }
   map.sourcesContent = []
   await Promise.all(
     map.sources.filter(Boolean).map(async (sourcePath, i) => {
-      map.sourcesContent![i] = await fs.readFile(
-        path.resolve(sourceRoot, decodeURI(sourcePath)),
-        'utf-8'
-      )
+      try {
+        map.sourcesContent![i] = await fs.readFile(
+          path.resolve(sourceRoot, decodeURI(sourcePath)),
+          'utf-8'
+        )
+      } catch (e) {
+        if (e.code == 'ENOENT') return
+        throw e
+      }
     })
   )
 }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -147,7 +147,7 @@ export async function transformRequest(
   if (map && mod.file) {
     map = (typeof map === 'string' ? JSON.parse(map) : map) as SourceMap
     if (map.mappings && !map.sourcesContent) {
-      await injectSourcesContent(map, mod.file)
+      await injectSourcesContent(map, mod.file, logger)
     }
   }
 


### PR DESCRIPTION
### Description

This is important for virtual modules and malformed source maps, both of which can throw `ENOENT` errors when injecting `sourcesContent` into source maps.

### Solution

Expect sourcemaps for virtual modules to either contain a pre-populated `sourcesContent` array or have a `sources` array of **absolute paths only**. Otherwise, a warning will be printed (at most one time).

Expect sourcemaps for normal modules to either contain a pre-populated `sourcesContent` array or have a `sources` array that never points to non-existent files. Relative source paths are allowed, and they're resolved with `sourceRoot` (if defined) or the parent directory of the module. When a non-existent source is found, a warning will printed (at most once per sourcemap for the lifetime of the Vite server).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
