### PR TITLE
docs: add note about the .nojekyll file for static site deployment

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -96,6 +96,8 @@ Now the `preview` method will launch the server at http://localhost:8080.
 You can also run the above script in your CI setup to enable automatic deployment on each push.
 :::
 
+Note: Github Pages will use Jekyll to build your site by default. You may want to add a `.nojekyll` file at the root of the project to avoid any unexpected behaviour in case your files/folders match the Jekyll directory structure. See [Static site generators](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#static-site-generators).
+
 ### GitHub Pages and Travis CI
 
 1. Set the correct `base` in `vite.config.js`.


### PR DESCRIPTION
I wanted to keep the text short but I noticed the following as well:

Even if I picked the `docs/` subfolder as the "Source" in the repository's Github Pages settings, the .nojekyll file need to be at the root.

This isn't made very clear in Github docs, they say to add `.nojekyll` "in the root of your publishing source", so logically I would think that is the "Source" I selected (docs/).

Context: I have a small Vite app with a `gh-pages` branch to deploy. I simply added a new `docs/` folder into that branch only, and copy the contents of dist/ into it before pushing the branch.

So if I did this, it didn't work;:

```
index.html
docs/
   .nojekyll
   index.html
```

Somehow, Github Pages published the index.html at the root (the one that poins to `/src/main.ts`), even though I configured it to publish from docs/.

This worked:

```
.nojekyll
index.html
docs/
   index.html
```

So TLDR I guess what they mean is the file should always be at the root of the repo, regardless what "Source" you pick.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
