### PR TITLE
fix(plugin-vue): add newline character before class components

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -249,7 +249,7 @@ async function genScriptCode(
       const classMatch = script.content.match(exportDefaultClassRE)
       if (classMatch) {
         scriptCode =
-          script.content.replace(exportDefaultClassRE, `class $1`) +
+          script.content.replace(exportDefaultClassRE, `\nclass $1`) +
           `\nconst _sfc_main = ${classMatch[1]}`
         if (/export\s+default/.test(scriptCode)) {
           // fallback if there are still export default


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #2787 

This issue is caused by https://github.com/vitejs/vite/commit/2900a9a6a501628588b31f7453e2fe5a71fe45ce. 

```javascript
var str =  `import { Vue, Options } from "vue-class-component";

export default class ClassComponent extends Vue {
  counter = 0
}`;
```
After replace, it will become：
```javascript
import { Vue, Options } from "vue-class-component"class ClassComponent extends Vue {
  counter = 0
}
```

At first I plan to optimize  `exportDefaultClassRE ` expression: 
``` diff
-const exportDefaultClassRE = /(?:(?:^|\n|;)\s*)export\s+default\s+class\s+([\w$]+)/
+const exportDefaultClassRE = /(^|\n|;)\s*export\s+default\s+class\s+([\w$]+)/ 

-script.content.replace(exportDefaultClassRE, `class $1`)
+script.content.replace(exportDefaultClassRE, `$1 class $2`)
```

the above solution could solve both #2787 and #2277, but I am worried that there are other cases that have not been considered, so I think it is better to add `\n` before `class`:
```javascript
scriptCode = script.content.replace(exportDefaultClassRE, `\nclass $1`)
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
