### PR TITLE
fix(build): vendor chunk strategy uses static imports, fix #2672

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -557,14 +557,14 @@ function createMoveToVendorChunkFn(config: ResolvedConfig): GetManualChunk {
     if (
       id.includes('node_modules') &&
       !isCSSRequest(id) &&
-      !hasDynamicImporter(id, getModuleInfo, cache)
+      staticImportedByEntry(id, getModuleInfo, cache)
     ) {
       return 'vendor'
     }
   }
 }
 
-function hasDynamicImporter(
+function staticImportedByEntry(
   id: string,
   getModuleInfo: GetModuleInfo,
   cache: Map<string, boolean>,
@@ -583,15 +583,21 @@ function hasDynamicImporter(
     cache.set(id, false)
     return false
   }
-  if (mod.dynamicImporters.length) {
+
+  if (mod.isEntry) {
     cache.set(id, true)
     return true
   }
-  const someImporterHas = mod.importers.some((importer) =>
-    hasDynamicImporter(importer, getModuleInfo, cache, importStack.concat(id))
+  const someImporterIs = mod.importers.some((importer) =>
+    staticImportedByEntry(
+      importer,
+      getModuleInfo,
+      cache,
+      importStack.concat(id)
+    )
   )
-  cache.set(id, someImporterHas)
-  return someImporterHas
+  cache.set(id, someImporterIs)
+  return someImporterIs
 }
 
 function resolveBuildOutputs(


### PR DESCRIPTION
…2672)

<!-- Thank you for contributing! -->

### Description

Fixes #2672.

Vite put module which is in node_modules and not imported by any dynamic import recursively to the `vendor` chunk. But in #2672, `node_modules/prismjs/components/prism-json.js` is used in the initial chunk and also imported by dynamic import. So a runtime error threw when it used in the initial chunk.

![image](https://user-images.githubusercontent.com/12322740/114269396-68620600-9a39-11eb-9378-bd1cd7d5d5bc.png)

Maybe we should put modules which in node_modules and statically imported by any entry module recursively to the `vendor` chunk.

The diff of modules moved to `chunk` vendor (✅ - moved, ❌ - not moved)


before:

```txt
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/index.html
❌ vite/dynamic-import-polyfill
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/main.ts
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/prism.js
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/components/prism-json.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/themes/prism.css
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue/dist/vue.runtime.esm.js
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue-router/dist/vue-router.esm.js
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vuetify/dist/vuetify.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vuetify/dist/vuetify.min.css
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/MyView.vue
❌ vite/preload-helper
❌ commonjsHelpers.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/MyView.vue?vue&type=script&lang.ts
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/MyView.vue?vue&type=template&lang.js
❌ /vite/vueComponentNormalizer
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue?vue&type=script&lang.ts
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue?vue&type=template&lang.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue?vue&type=style&index=0&lang.css
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue-prism-component/dist/vue-prism-component.common.js
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue/dist/vue.runtime.esm.js?commonjs-proxy
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/prism.js?commonjs-proxy
```

after:

```txt
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/index.html
❌ vite/dynamic-import-polyfill
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/main.ts
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/prism.js
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/components/prism-json.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/themes/prism.css
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue/dist/vue.runtime.esm.js
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue-router/dist/vue-router.esm.js
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vuetify/dist/vuetify.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vuetify/dist/vuetify.min.css
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/MyView.vue
❌ vite/preload-helper
❌ commonjsHelpers.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue?vue&type=script&lang.ts
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue?vue&type=template&lang.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/App.vue?vue&type=style&index=0&lang.css
❌ /vite/vueComponentNormalizer
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/MyView.vue?vue&type=script&lang.ts
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/src/MyView.vue?vue&type=template&lang.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue-prism-component/dist/vue-prism-component.common.js
❌ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/prismjs/prism.js?commonjs-proxy
✅ /Users/fi3ework/Downloads/vite-repro-prism-is-not-defined-master/node_modules/vue/dist/vue.runtime.esm.js?commonjs-proxy
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
