### PR TITLE
docs: Added Multi-Page App example using 'root'

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -95,6 +95,41 @@ module.exports = {
 }
 ```
 
+If you use the ```root``` option, make sure that directory is included in the ```resolve``` arguments.
+
+If your directory structure looks like this:
+
+```
+├── package.json
+├── vite.config.js
+└── src
+    ├── index.html
+    ├── main.js
+    └── nested
+        ├── index.html
+        └── nested.js
+```
+
+You will need to make the following adjustments to your ```vite.config.js``` file:
+
+```js
+// vite.config.js
+const { resolve } = require('path')
+
+module.exports = {
+  root: 'src/',
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'src', 'index.html'),
+        nested: resolve(__dirname, 'src', 'nested/index.html')
+      }
+    }
+  }
+}
+```
+
+
 ## Library Mode
 
 When you are developing a browser-oriented library, you are likely spending most of the time on a test/demo page that imports your actual library. With Vite, you can use your `index.html` for that purpose to get the smooth development experience.

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -97,7 +97,6 @@ module.exports = {
 
 If you specify a different root, remember that `__dirname` will still be the folder of your vite.config.js file when resolving the input paths. Therfore, you will need to add your `root` entry to the arguments for `resolve`. 
 
-
 ## Library Mode
 
 When you are developing a browser-oriented library, you are likely spending most of the time on a test/demo page that imports your actual library. With Vite, you can use your `index.html` for that purpose to get the smooth development experience.

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -95,39 +95,7 @@ module.exports = {
 }
 ```
 
-If you use the `root` option, make sure that directory is included in the `resolve` arguments.
-
-If your directory structure looks like this:
-
-```
-├── package.json
-├── vite.config.js
-└── src
-    ├── index.html
-    ├── main.js
-    └── nested
-        ├── index.html
-        └── nested.js
-```
-
-You will need to make the following adjustments to your `vite.config.js` file:
-
-```js
-// vite.config.js
-const { resolve } = require('path')
-
-module.exports = {
-  root: 'src/',
-  build: {
-    rollupOptions: {
-      input: {
-        main: resolve(__dirname, 'src', 'index.html'),
-        nested: resolve(__dirname, 'src', 'nested/index.html')
-      }
-    }
-  }
-}
-```
+If you specify a different root, remember that `__dirname` will still be the folder of your vite.config.js file when resolving the input paths. Therfore, you will need to add your `root` entry to the arguments for `resolve`. 
 
 
 ## Library Mode

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -95,7 +95,7 @@ module.exports = {
 }
 ```
 
-If you use the ```root``` option, make sure that directory is included in the ```resolve``` arguments.
+If you use the `root` option, make sure that directory is included in the `resolve` arguments.
 
 If your directory structure looks like this:
 
@@ -110,7 +110,7 @@ If your directory structure looks like this:
         └── nested.js
 ```
 
-You will need to make the following adjustments to your ```vite.config.js``` file:
+You will need to make the following adjustments to your `vite.config.js` file:
 
 ```js
 // vite.config.js


### PR DESCRIPTION
### Description

Documentation change in the 'Building For Production' page, 'Multi-Page App' section:

When using the ```root``` option, it may not be clear to beginners that the root directory needs to be included within the ```resolve()``` function. Otherwise, running the build process will error out due to the HTML files not being found.

### What is the purpose of this pull request? 

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
