### PR TITLE
feat(create-app): two-level prompt for framework and variants

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -118,7 +118,7 @@ const FRAMEWORKS = [
 ]
 
 const TEMPLATES = FRAMEWORKS.map(
-  (i) => (i.variants && i.variants.map((v) => v.name)) || [i.name]
+  (f) => (f.variants && f.variants.map((v) => v.name)) || [f.name]
 ).reduce((a, b) => a.concat(b), [])
 
 const renameFiles = {

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -4,33 +4,122 @@
 const fs = require('fs')
 const path = require('path')
 const argv = require('minimist')(process.argv.slice(2))
+// eslint-disable-next-line node/no-restricted-require
 const { prompt } = require('enquirer')
 const {
   yellow,
   green,
   cyan,
+  blue,
   magenta,
   lightRed,
-  red,
-  stripColors
+  red
 } = require('kolorist')
 
 const cwd = process.cwd()
 
-const TEMPLATES = [
-  yellow('vanilla'),
-  yellow('vanilla-ts'),
-  green('vue'),
-  green('vue-ts'),
-  cyan('react'),
-  cyan('react-ts'),
-  magenta('preact'),
-  magenta('preact-ts'),
-  lightRed('lit-element'),
-  lightRed('lit-element-ts'),
-  red('svelte'),
-  red('svelte-ts')
+const FRAMEWORKS = [
+  {
+    name: 'vanilla',
+    color: yellow,
+    variants: [
+      {
+        name: 'vanilla',
+        display: 'JavaScript',
+        color: yellow
+      },
+      {
+        name: 'vanilla-ts',
+        display: 'TypeScript',
+        color: blue
+      }
+    ]
+  },
+  {
+    name: 'vue',
+    color: green,
+    variants: [
+      {
+        name: 'vue',
+        display: 'JavaScript',
+        color: yellow
+      },
+      {
+        name: 'vue-ts',
+        display: 'TypeScript',
+        color: blue
+      }
+    ]
+  },
+  {
+    name: 'react',
+    color: cyan,
+    variants: [
+      {
+        name: 'react',
+        display: 'JavaScript',
+        color: yellow
+      },
+      {
+        name: 'react-ts',
+        display: 'TypeScript',
+        color: blue
+      }
+    ]
+  },
+  {
+    name: 'preact',
+    color: magenta,
+    variants: [
+      {
+        name: 'preact',
+        display: 'JavaScript',
+        color: yellow
+      },
+      {
+        name: 'preact-ts',
+        display: 'TypeScript',
+        color: blue
+      }
+    ]
+  },
+  {
+    name: 'lit-element',
+    color: lightRed,
+    variants: [
+      {
+        name: 'lit-element',
+        display: 'JavaScript',
+        color: yellow
+      },
+      {
+        name: 'lit-element-ts',
+        display: 'TypeScript',
+        color: blue
+      }
+    ]
+  },
+  {
+    name: 'svelte',
+    color: red,
+    variants: [
+      {
+        name: 'svelte',
+        display: 'JavaScript',
+        color: yellow
+      },
+      {
+        name: 'svelte-ts',
+        display: 'TypeScript',
+        color: blue
+      }
+    ]
+  }
 ]
+
+const TEMPLATES = FRAMEWORKS.map(
+  (i) => (i.variants && i.variants.map((v) => v.name)) || [i.name]
+).reduce((a, b) => a.concat(b), [])
 
 const renameFiles = {
   _gitignore: '.gitignore'
@@ -52,7 +141,6 @@ async function init() {
   }
   const packageName = await getValidPackageName(targetDir)
   const root = path.join(cwd, targetDir)
-  console.log(`\nScaffolding project in ${root}...`)
 
   if (!fs.existsSync(root)) {
     fs.mkdirSync(root, { recursive: true })
@@ -80,28 +168,52 @@ async function init() {
 
   // determine template
   let template = argv.t || argv.template
-  let message = 'Select a template:'
+  let message = 'Select a framework:'
   let isValidTemplate = false
 
   // --template expects a value
   if (typeof template === 'string') {
-    const availableTemplates = TEMPLATES.map(stripColors)
-    isValidTemplate = availableTemplates.includes(template)
+    isValidTemplate = TEMPLATES.includes(template)
     message = `${template} isn't a valid template. Please choose from below:`
   }
 
   if (!template || !isValidTemplate) {
     /**
-     * @type {{ t: string }}
+     * @type {{ framework: string }}
      */
-    const { t } = await prompt({
+    const { framework } = await prompt({
       type: 'select',
-      name: 't',
+      name: 'framework',
       message,
-      choices: TEMPLATES
+      choices: FRAMEWORKS.map((f) => ({
+        name: f.name,
+        value: f.name,
+        message: f.color(f.display || f.name)
+      }))
     })
-    template = stripColors(t)
+    const frameworkInfo = FRAMEWORKS.find((f) => f.name === framework)
+
+    if (frameworkInfo.variants) {
+      /**
+       * @type {{ name: string }}
+       */
+      const { name } = await prompt({
+        type: 'select',
+        name: 'name',
+        message: 'Select a variant:',
+        choices: frameworkInfo.variants.map((v) => ({
+          name: v.name,
+          value: v.name,
+          message: v.color(v.display || v.name)
+        }))
+      })
+      template = name
+    } else {
+      template = frameworkInfo.name
+    }
   }
+
+  console.log(`\nScaffolding project in ${root}...`)
 
   const templateDir = path.join(__dirname, `template-${template}`)
 

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -185,6 +185,12 @@ async function init() {
       type: 'select',
       name: 'framework',
       message,
+      format(name) {
+        const framework = FRAMEWORKS.find((v) => v.name === name)
+        return framework
+          ? framework.color(framework.display || framework.name)
+          : name
+      },
       choices: FRAMEWORKS.map((f) => ({
         name: f.name,
         value: f.name,
@@ -200,6 +206,10 @@ async function init() {
       const { name } = await prompt({
         type: 'select',
         name: 'name',
+        format(name) {
+          const variant = frameworkInfo.variants.find((v) => v.name === name)
+          return variant ? variant.color(variant.display || variant.name) : name
+        },
         message: 'Select a variant:',
         choices: frameworkInfo.variants.map((v) => ({
           name: v.name,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

As we are growing rapidly, we are now having 12 templates for users to choose from. As half of them are TypeScript variants and we might have more in the future. This PR introduces two-level prompts to make it simpler and future-proofing - one for frameworks, and one for variants.

From

<img width="480" alt="Screen Shot 2021-04-11 at 6 00 11 AM" src="https://user-images.githubusercontent.com/11247099/114285633-4a24f600-9a8b-11eb-94b2-797d160abfd2.png">

To:

<img width="480" alt="Screen Shot 2021-04-11 at 6 00 44 AM" src="https://user-images.githubusercontent.com/11247099/114285630-485b3280-9a8b-11eb-8c83-c3875a14a5ef.png">
<img width="480" alt="Screen Shot 2021-04-11 at 6 00 52 AM" src="https://user-images.githubusercontent.com/11247099/114285634-4b562300-9a8b-11eb-9a9e-501b20781363.png">

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
