### PR TITLE
fix(ssr): fix ssrTransform catch clause error (fix #2667)

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -156,6 +156,21 @@ test('do not rewrite method definition', async () => {
   `)
 })
 
+test('do not rewrite catch clause', async () => {
+  expect(
+    (
+      await ssrTransform(
+        `import {error} from './dependency';try {} catch(error) {}`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    try {} catch(error) {}"
+  `)
+})
+
 // #2221
 test('should declare variable for imported super class', async () => {
   expect(

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -322,9 +322,10 @@ function walk(
 function isRefIdentifier(id: Identifier, parent: _Node, parentStack: _Node[]) {
   // declaration id
   if (
-    (parent.type === 'VariableDeclarator' ||
+    parent.type === 'CatchClause' ||
+    ((parent.type === 'VariableDeclarator' ||
       parent.type === 'ClassDeclaration') &&
-    parent.id === id
+      parent.id === id)
   ) {
     return false
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#2667 

vite ssrtransform can't work good with error catch
```js
import {error} from ''./actionTypes.js''

try {
// something
} cache(error) {
}
```
after transform
```js
const __vite_ssr_import_6__ = __vite_ssr_import__("/node_modules/xstate/es/actions.js")
try {
// something
} cache(__vite_ssr_import_6__.error) { //  SyntaxError: Unexpected token '.'

}
```
imp



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
