### PR TITLE
fix(plugin-legacy): wrap legacy chunks in IIFE (IE11)

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -260,7 +260,7 @@ function viteLegacyPlugin(options = {}) {
         ]
       })
 
-      return { code, map }
+      return { code: `;(function(){${code}})();`, map }
     },
 
     transformIndexHtml(html, { chunk }) {


### PR DESCRIPTION
### Description
template literals in our legacy chunks got randomly overwritten (gql mixed with emotion) in legacy build
the problem was that at the top of the file there were `var lit1, lit2, lit3` declarations and those were evaluated in global scope. this resolves the issue

### Additional context
I was surprised that systemjs does not wrap files in IIFE itself

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
