### PR TITLE
feat: add optimizeDeps.esbuildOptions

### DIFF
--- a/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -1,4 +1,4 @@
-import { getColor } from '../../testUtils'
+import { getColor, isBuild } from '../../testUtils'
 
 test('default + named imports from cjs dep (react)', async () => {
   expect(await page.textContent('.cjs button')).toBe('count is 0')
@@ -64,6 +64,6 @@ test('vue + vuex', async () => {
 
 test('esbuild-plugin', async () => {
   expect(await page.textContent('.esbuild-plugin')).toMatch(
-    `Hello from an esbuild plugin`
+    isBuild ? `Hello from a package` : `Hello from an esbuild plugin`
   )
 })

--- a/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -61,3 +61,9 @@ test('dep w/ non-js files handled via plugin', async () => {
 test('vue + vuex', async () => {
   expect(await page.textContent('.vue')).toMatch(`[success]`)
 })
+
+test('esbuild-plugin', async () => {
+  expect(await page.textContent('.esbuild-plugin')).toMatch(
+    `Hello from an esbuild plugin`
+  )
+})

--- a/packages/playground/optimize-deps/dep-esbuild-plugin-transform/index.js
+++ b/packages/playground/optimize-deps/dep-esbuild-plugin-transform/index.js
@@ -1,0 +1,3 @@
+// will be replaced by an esbuild plugin
+
+export const thisIsNotTheExportYoureLookingFor = 42

--- a/packages/playground/optimize-deps/dep-esbuild-plugin-transform/index.js
+++ b/packages/playground/optimize-deps/dep-esbuild-plugin-transform/index.js
@@ -1,3 +1,3 @@
 // will be replaced by an esbuild plugin
 
-export const thisIsNotTheExportYoureLookingFor = 42
+export const hello = () => `Hello from a package`

--- a/packages/playground/optimize-deps/dep-esbuild-plugin-transform/package.json
+++ b/packages/playground/optimize-deps/dep-esbuild-plugin-transform/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep-esbuild-plugin-transform",
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/packages/playground/optimize-deps/index.html
+++ b/packages/playground/optimize-deps/index.html
@@ -41,7 +41,7 @@
 <div class="vue"></div>
 
 <h2>Dep with changes from esbuild plugin</h2>
-<div>This should show a greeting: <span class="esbuild-options"></span></div>
+<div>This should show a greeting: <span class="esbuild-plugin"></span></div>
 
 <script type="module">
   // test dep detection in globbed files
@@ -69,5 +69,5 @@
   }
 
   import { hello } from 'dep-esbuild-plugin-transform'
-  document.querySelector('.esbuild-options').textContent = hello()
+  document.querySelector('.esbuild-plugin').textContent = hello()
 </script>

--- a/packages/playground/optimize-deps/index.html
+++ b/packages/playground/optimize-deps/index.html
@@ -40,6 +40,9 @@
 <h2>Vue & Vuex</h2>
 <div class="vue"></div>
 
+<h2>Dep with changes from esbuild plugin</h2>
+<div>This should show a greeting: <span class="esbuild-options"></span></div>
+
 <script type="module">
   // test dep detection in globbed files
   const globbed = import.meta.globEager('./glob/*.js')
@@ -64,4 +67,7 @@
   if (typeof createApp === 'function' && typeof createStore === 'function') {
     document.querySelector('.vue').textContent = '[success]'
   }
+
+  import { hello } from 'dep-esbuild-plugin-transform'
+  document.querySelector('.esbuild-options').textContent = hello()
 </script>

--- a/packages/playground/optimize-deps/package.json
+++ b/packages/playground/optimize-deps/package.json
@@ -14,6 +14,7 @@
     "dep-cjs-named-only": "link:./dep-cjs-named-only",
     "dep-linked": "link:./dep-linked",
     "dep-linked-include": "link:./dep-linked-include",
+    "dep-esbuild-plugin-transform": "link:./dep-esbuild-plugin-transform",
     "phoenix": "^1.5.7",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/packages/playground/optimize-deps/vite.config.js
+++ b/packages/playground/optimize-deps/vite.config.js
@@ -21,13 +21,10 @@ module.exports = {
           setup(build) {
             build.onLoad(
               { filter: /dep-esbuild-plugin-transform\/index\.js$/ },
-              (args) => {
-                console.log('onLoad', args)
-                return {
-                  contents: `export const hello = () => 'Hello from an esbuild plugin'`,
-                  loader: 'js'
-                }
-              }
+              () => ({
+                contents: `export const hello = () => 'Hello from an esbuild plugin'`,
+                loader: 'js'
+              })
             )
           }
         }

--- a/packages/playground/optimize-deps/vite.config.js
+++ b/packages/playground/optimize-deps/vite.config.js
@@ -9,8 +9,30 @@ module.exports = {
   },
 
   optimizeDeps: {
-    include: ['dep-linked-include'],
-    plugins: [vue()]
+    include: [
+      'dep-linked-include',
+      // required since it isn't in node_modules and is ignored by the optimizer otherwise
+      'dep-esbuild-plugin-transform'
+    ],
+    esbuildOptions: {
+      plugins: [
+        {
+          name: 'replace-a-file',
+          setup(build) {
+            build.onLoad(
+              { filter: /dep-esbuild-plugin-transform\/index\.js$/ },
+              (args) => {
+                console.log('onLoad', args)
+                return {
+                  contents: `export const hello = () => 'Hello from an esbuild plugin'`,
+                  loader: 'js'
+                }
+              }
+            )
+          }
+        }
+      ]
+    }
   },
 
   build: {

--- a/packages/playground/optimize-deps/vite.config.js
+++ b/packages/playground/optimize-deps/vite.config.js
@@ -20,7 +20,7 @@ module.exports = {
           name: 'replace-a-file',
           setup(build) {
             build.onLoad(
-              { filter: /dep-esbuild-plugin-transform\/index\.js$/ },
+              { filter: /dep-esbuild-plugin-transform(\\|\/)index\.js$/ },
               () => ({
                 contents: `export const hello = () => 'Hello from an esbuild plugin'`,
                 loader: 'js'

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -95,41 +95,6 @@ describe('mergeConfig', () => {
 })
 
 describe('resolveConfig', () => {
-  test('copies optimizeDeps.exclude to esbuildOptions.external', async () => {
-    const config: UserConfigExport = {
-      optimizeDeps: {
-        exclude: ['foo']
-      }
-    }
-
-    expect(await resolveConfig(config, 'serve')).toMatchObject({
-      optimizeDeps: {
-        esbuildOptions: {
-          external: ['foo']
-        }
-      }
-    })
-  })
-
-  test('uses esbuildOptions.external if set', async () => {
-    const config: InlineConfig = {
-      optimizeDeps: {
-        exclude: ['foo'],
-        esbuildOptions: {
-          external: ['bar']
-        }
-      }
-    }
-
-    expect(await resolveConfig(config, 'serve')).toMatchObject({
-      optimizeDeps: {
-        esbuildOptions: {
-          external: ['bar']
-        }
-      }
-    })
-  })
-
   test('copies optimizeDeps.keepNames to esbuildOptions.keepNames', async () => {
     const config: InlineConfig = {
       optimizeDeps: {

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -95,6 +95,15 @@ describe('mergeConfig', () => {
 })
 
 describe('resolveConfig', () => {
+  beforeAll(() => {
+    // silence deprecation warning
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    jest.clearAllMocks()
+  })
+
   test('copies optimizeDeps.keepNames to esbuildOptions.keepNames', async () => {
     const config: InlineConfig = {
       optimizeDeps: {

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1,4 +1,5 @@
-import { mergeConfig, UserConfigExport } from '../config'
+import { InlineConfig } from '..'
+import { mergeConfig, resolveConfig, UserConfigExport } from '../config'
 
 describe('mergeConfig', () => {
   test('handles configs with different alias schemas', () => {
@@ -90,5 +91,77 @@ describe('mergeConfig', () => {
     }
 
     expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+  })
+})
+
+describe('resolveConfig', () => {
+  test('copies optimizeDeps.exclude to esbuildOptions.external', async () => {
+    const config: UserConfigExport = {
+      optimizeDeps: {
+        exclude: ['foo']
+      }
+    }
+
+    expect(await resolveConfig(config, 'serve')).toMatchObject({
+      optimizeDeps: {
+        esbuildOptions: {
+          external: ['foo']
+        }
+      }
+    })
+  })
+
+  test('uses esbuildOptions.external if set', async () => {
+    const config: InlineConfig = {
+      optimizeDeps: {
+        exclude: ['foo'],
+        esbuildOptions: {
+          external: ['bar']
+        }
+      }
+    }
+
+    expect(await resolveConfig(config, 'serve')).toMatchObject({
+      optimizeDeps: {
+        esbuildOptions: {
+          external: ['bar']
+        }
+      }
+    })
+  })
+
+  test('copies optimizeDeps.keepNames to esbuildOptions.keepNames', async () => {
+    const config: InlineConfig = {
+      optimizeDeps: {
+        keepNames: false
+      }
+    }
+
+    expect(await resolveConfig(config, 'serve')).toMatchObject({
+      optimizeDeps: {
+        esbuildOptions: {
+          keepNames: false
+        }
+      }
+    })
+  })
+
+  test('uses esbuildOptions.keepNames if set', async () => {
+    const config: InlineConfig = {
+      optimizeDeps: {
+        keepNames: true,
+        esbuildOptions: {
+          keepNames: false
+        }
+      }
+    }
+
+    expect(await resolveConfig(config, 'serve')).toMatchObject({
+      optimizeDeps: {
+        esbuildOptions: {
+          keepNames: false
+        }
+      }
+    })
   })
 })

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -196,7 +196,7 @@ export type ResolvedConfig = Readonly<
     assetsInclude: (file: string) => boolean
     logger: Logger
     createResolver: (options?: Partial<InternalResolveOptions>) => ResolveFn
-    optimizeDeps: Omit<DepOptimizationOptions, 'external' | 'keepNames'>
+    optimizeDeps: Omit<DepOptimizationOptions, 'keepNames'>
   }
 >
 
@@ -390,7 +390,6 @@ export async function resolveConfig(
       ...config.optimizeDeps,
       esbuildOptions: {
         keepNames: config.optimizeDeps?.keepNames,
-        external: config.optimizeDeps?.exclude,
         ...config.optimizeDeps?.esbuildOptions
       }
     }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -173,7 +173,10 @@ export interface InlineConfig extends UserConfig {
 }
 
 export type ResolvedConfig = Readonly<
-  Omit<UserConfig, 'plugins' | 'alias' | 'dedupe' | 'assetsInclude'> & {
+  Omit<
+    UserConfig,
+    'plugins' | 'alias' | 'dedupe' | 'assetsInclude' | 'optimizeDeps'
+  > & {
     configFile: string | undefined
     configFileDependencies: string[]
     inlineConfig: InlineConfig
@@ -193,6 +196,7 @@ export type ResolvedConfig = Readonly<
     assetsInclude: (file: string) => boolean
     logger: Logger
     createResolver: (options?: Partial<InternalResolveOptions>) => ResolveFn
+    optimizeDeps: Omit<DepOptimizationOptions, 'external' | 'keepNames'>
   }
 >
 
@@ -381,10 +385,18 @@ export async function resolveConfig(
       return DEFAULT_ASSETS_RE.test(file) || assetsFilter(file)
     },
     logger,
-    createResolver
+    createResolver,
+    optimizeDeps: {
+      ...config.optimizeDeps,
+      esbuildOptions: {
+        keepNames: config.optimizeDeps?.keepNames,
+        external: config.optimizeDeps?.exclude,
+        ...config.optimizeDeps?.esbuildOptions
+      }
+    }
   }
 
-  ;(resolved as any).plugins = await resolvePlugins(
+  ;(resolved.plugins as Plugin[]) = await resolvePlugins(
     resolved,
     prePlugins,
     normalPlugins,
@@ -463,6 +475,24 @@ export async function resolveConfig(
         new Error()
       )
       return resolved.resolve.dedupe
+    }
+  })
+
+  if (config.optimizeDeps?.keepNames) {
+    logDeprecationWarning(
+      'optimizeDeps.keepNames',
+      'Use "optimizeDeps.esbuildOptions.keepNames" instead.'
+    )
+  }
+  Object.defineProperty(resolved.optimizeDeps, 'keepNames', {
+    enumerable: false,
+    get() {
+      logDeprecationWarning(
+        'optimizeDeps.keepNames',
+        'Use "optimizeDeps.esbuildOptions.keepNames" instead.',
+        new Error()
+      )
+      return resolved.optimizeDeps.esbuildOptions?.keepNames
     }
   })
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -49,9 +49,12 @@ export interface DepOptimizationOptions {
   /**
    * Options to pass to esbuild during the dep scanning and optimization
    *
+   * Certain options are omitted since changing them would not be compatible
+   * with Vite's dep optimization.
+   *
+   * - `external` is also omitted, use Vite's `optimizeDeps.exclude` option
    * - `plugins` are merged with Vite's dep plugin
    * - `keepNames` takes precedence over the deprecated `optimizeDeps.keepNames`
-   * - `external` is omitted, use Vite's `optimizeDeps.exclude` option
    *
    * https://esbuild.github.io/api
    */

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -69,7 +69,6 @@ export interface DepOptimizationOptions {
   >
   /**
    * @deprecated use esbuildOptions.keepNames
-   * @see DepOptimizationOptions.esbuildOptions
    */
   keepNames?: boolean
 }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -59,6 +59,7 @@ export interface DepOptimizationOptions {
   esbuildOptions?: Omit<
     EsbuildBuildOptions,
     | 'bundle'
+    | 'entryPoints'
     | 'write'
     | 'watch'
     | 'outdir'
@@ -252,11 +253,11 @@ export async function optimizeDeps(
 
   const start = Date.now()
 
-  const { entryPoints = [], plugins = [], ...esbuildOptions } =
+  const { plugins = [], ...esbuildOptions } =
     config.optimizeDeps?.esbuildOptions ?? {}
 
   const result = await build({
-    entryPoints: [...entryPoints, ...Object.keys(flatIdDeps)],
+    entryPoints: Object.keys(flatIdDeps),
     bundle: true,
     format: 'esm',
     logLevel: 'error',

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -49,10 +49,9 @@ export interface DepOptimizationOptions {
   /**
    * Options to pass to esbuild during the dep scanning and optimization
    *
-   * - `entryPoints` are merged
    * - `plugins` are merged with Vite's dep plugin
-   * - `external` takes precedence over `optimizeDeps.exclude`
    * - `keepNames` takes precedence over the deprecated `optimizeDeps.keepNames`
+   * - `external` is omitted, use Vite's optimizeDeps.exclude option
    *
    * https://esbuild.github.io/api
    */
@@ -60,6 +59,7 @@ export interface DepOptimizationOptions {
     EsbuildBuildOptions,
     | 'bundle'
     | 'entryPoints'
+    | 'external'
     | 'write'
     | 'watch'
     | 'outdir'
@@ -260,6 +260,7 @@ export async function optimizeDeps(
     entryPoints: Object.keys(flatIdDeps),
     bundle: true,
     format: 'esm',
+    external: config.optimizeDeps?.exclude,
     logLevel: 'error',
     splitting: true,
     sourcemap: true,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -51,7 +51,7 @@ export interface DepOptimizationOptions {
    *
    * - `plugins` are merged with Vite's dep plugin
    * - `keepNames` takes precedence over the deprecated `optimizeDeps.keepNames`
-   * - `external` is omitted, use Vite's optimizeDeps.exclude option
+   * - `external` is omitted, use Vite's `optimizeDeps.exclude` option
    *
    * https://esbuild.github.io/api
    */
@@ -69,7 +69,7 @@ export interface DepOptimizationOptions {
     | 'metafile'
   >
   /**
-   * @deprecated use esbuildOptions.keepNames
+   * @deprecated use `esbuildOptions.keepNames`
    */
   keepNames?: boolean
 }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -89,18 +89,18 @@ export async function scanImports(
   const container = await createPluginContainer(config)
   const plugin = esbuildScanPlugin(config, container, deps, missing, entries)
 
-  await Promise.all(
-    entries.map((entry) =>
-      build({
-        write: false,
-        entryPoints: [entry],
-        bundle: true,
-        format: 'esm',
-        logLevel: 'error',
-        plugins: [plugin]
-      })
-    )
-  )
+  const { entryPoints = [], plugins = [], ...esbuildOptions } =
+    config.optimizeDeps?.esbuildOptions ?? {}
+
+  await build({
+    write: false,
+    entryPoints: [...entryPoints, ...entries],
+    bundle: true,
+    format: 'esm',
+    logLevel: 'error',
+    plugins: [...plugins, plugin],
+    ...esbuildOptions
+  })
 
   debug(`Scan completed in ${Date.now() - s}ms:`, deps)
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -89,11 +89,11 @@ export async function scanImports(
   const container = await createPluginContainer(config)
   const plugin = esbuildScanPlugin(config, container, deps, missing, entries)
 
-  const { entryPoints = [], plugins = [], ...esbuildOptions } =
+  const { plugins = [], ...esbuildOptions } =
     config.optimizeDeps?.esbuildOptions ?? {}
 
   await Promise.all(
-    [...entryPoints, ...entries].map((entry) =>
+    entries.map((entry) =>
       build({
         write: false,
         entryPoints: [entry],

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -92,15 +92,19 @@ export async function scanImports(
   const { entryPoints = [], plugins = [], ...esbuildOptions } =
     config.optimizeDeps?.esbuildOptions ?? {}
 
-  await build({
-    write: false,
-    entryPoints: [...entryPoints, ...entries],
-    bundle: true,
-    format: 'esm',
-    logLevel: 'error',
-    plugins: [...plugins, plugin],
-    ...esbuildOptions
-  })
+  await Promise.all(
+    [...entryPoints, ...entries].map((entry) =>
+      build({
+        write: false,
+        entryPoints: [entry],
+        bundle: true,
+        format: 'esm',
+        logLevel: 'error',
+        plugins: [...plugins, plugin],
+        ...esbuildOptions
+      })
+    )
+  )
 
   debug(`Scan completed in ${Date.now() - s}ms:`, deps)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,6 +2707,10 @@ delegate@^3.1.2:
   version "0.0.0"
   uid ""
 
+"dep-esbuild-plugin-transform@link:./packages/playground/optimize-deps/dep-esbuild-plugin-transform":
+  version "0.0.0"
+  uid ""
+
 "dep-import-type@link:./packages/playground/ssr-vue/dep-import-type":
   version "0.0.0"
   uid ""


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds the ability to customise the esbuild options during the optimiser phase, including plugins.

There are some libraries that esbuild throws an error on, and I'd really like to have this functionality – we're stuck on a Vite conversion because of one or two packages – with plain esbuild, we're able to use plugins to work around small errors.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

See #3124

This is inspired by the conversation here: https://github.com/vitejs/vite/pull/2886#discussion_r608410494

The discussion is about where the build options should live. I feel like since `optimizeDeps` is an entirely different build phase than the esbuild transform options, the settings should go into `config.optimizeDeps`.

### Questions

- Other than `define` and `entryPoints`, should any other options be disallowed? For example, perhaps overriding `bundle`, `format`, or `outdir` shouldn't be allowed.
- Should the old fields be deprecated, or just left as additional options?

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

---

Closes #2886