### PR TITLE
fix: do not cache module while the file contains import.meta.glob

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -244,6 +244,8 @@ function invalidate(mod: ModuleNode, timestamp: number, seen: Set<ModuleNode>) {
   seen.add(mod)
   mod.lastHMRTimestamp = timestamp
   mod.transformResult = null
+  mod.ssrModule = null
+  mod.ssrTransformResult = null
   mod.importers.forEach((importer) => {
     if (!importer.acceptedHmrDeps.has(mod)) {
       invalidate(importer, timestamp, seen)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

in #2734 , while source file(`app.js`) use `import.glob.meta` to scan `/src/data/*.json`，while we add a json file such as `x.json`，the module will hit cache in urlToModuleMap because the source file(`app.js`) did not change.

fix #2734 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


