### PR TITLE
test: avoid favicon.ico 404

### DIFF
--- a/packages/playground/assets/index.html
+++ b/packages/playground/assets/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 
+<link rel="icon" href="data:," />
 <link rel="stylesheet" href="/raw.css" />
 
 <h1>Assets</h1>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

At least for Windows 10, a 404 was generated in the assets test because of the default request for `favicon.ico`. This PR adds a dummy inline favicon so no request is generated. This was the only test where we are explicitly checking for no 404 in the browser logs. We could choose to add the dummy icon to other tests in a subsequent PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
