### PR TITLE
fix(assets): preseve dir asset URL in build mode

### DIFF
--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -15,10 +15,11 @@ const assetMatch = isBuild
 
 const iconMatch = `/foo/icon.png`
 
-test('should have no 404s', () => {
-  browserLogs.forEach((msg) => {
-    expect(msg).not.toMatch('404')
-  })
+test('detect 404s', () => {
+  // Only got a 404 from `.preserve-invalid-dir` in build mode
+  expect(browserLogs.filter((msg) => msg.includes('404')).length).toBe(
+    isBuild ? 1 : 0
+  )
 })
 
 describe('injected scripts', () => {
@@ -143,6 +144,14 @@ describe('image', () => {
           : /\.\/nested\/asset\.png \d{1}x/
       )
     })
+  })
+
+  test('dir', async () => {
+    const img = await page.$('.preserve-invalid-dir')
+    const src = await img.getAttribute('src')
+    const srcset = await img.getAttribute('srcset')
+    expect(src).toBe('./nested')
+    expect(srcset).toBe('./nested 1x, ./nested/ 2x')
   })
 })
 

--- a/packages/playground/assets/index.html
+++ b/packages/playground/assets/index.html
@@ -78,6 +78,11 @@
     srcset="./nested/asset.png 1x, ./nested/asset.png 2x"
     alt=""
   />
+  <img
+    class="preserve-invalid-dir"
+    src="./nested"
+    srcset="./nested 1x, ./nested/ 2x"
+  />
 </div>
 
 <h2>SVG Fragments</h2>

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -260,6 +260,12 @@ export async function urlToBuiltUrl(
   const file = url.startsWith('/')
     ? path.join(config.root, url)
     : path.join(path.dirname(importer), url)
+
+  const stat = await fsp.stat(cleanUrl(file))
+  if (stat.isDirectory()) {
+    return url
+  }
+
   return fileToBuiltUrl(
     file,
     config,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For now, when there is an img tag in HTML like `<img src="./some_dir"` which points to a dir. In dev mode, everything works fine and the `src` remains the same. But it will throw in build mode.

![image](https://user-images.githubusercontent.com/12322740/115064542-9bb40180-9f1f-11eb-8bd5-bdf2359b1ad9.png)

This PR detects if the asset URL is a dir. It just returns the original URL, same as dev mode.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
