### PR TITLE
fix(plugin-legacy): Remove and record polyfills in plugin post (fix #2786, #2781)

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -533,17 +533,13 @@ function isLegacyOutput(options) {
 function recordAndRemovePolyfillBabelPlugin(polyfills) {
   return ({ types: t }) => ({
     name: 'vite-remove-polyfill-import',
-    visitor: {
-      Program: {
-        exit(path) {
-          path.get('body').forEach((p) => {
-            if (t.isImportDeclaration(p)) {
-              polyfills.add(p.node.source.value)
-              p.remove()
-            }
-          })
+    post({ path }) {
+      path.get('body').forEach((p) => {
+        if (t.isImportDeclaration(p)) {
+          polyfills.add(p.node.source.value)
+          p.remove()
         }
-      }
+      })
     }
   })
 }


### PR DESCRIPTION
Makes sure all polyfill ES imports are trimmed from legacy bundle by moving recording and removal from `Program:exit` to `post` in plugin. This seems to ensure that `@babel/preset-env` has found and added all polyfills from all nodes in chunk before `recordAndRemovePolyfillBabelPlugin` processes.  

Fixes #2786 and #2781.
 
### Additional context
I have not been able to create a test case for this. It's probably an api triggering `usage` polyfill import in a certain AST structure that causes the bug, but figuring out which seems hard. Instead the solution is tested by users experiencing the bug.

### What is the purpose of this pull request? 

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
