### PR TITLE
feat: watch the dependencies of config file

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -45,13 +45,16 @@ export async function handleHMRUpdate(
   const shortFile = getShortName(file, config.root)
 
   const isConfig = file === config.configFile
+  const isConfigDependency = config.configFileDependencies.some(
+    (name) => file === path.resolve(name)
+  )
   const isEnv = config.inlineConfig.envFile !== false && file.endsWith('.env')
-  if (isConfig || isEnv) {
+  if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
     debugHmr(`[config change] ${chalk.dim(shortFile)}`)
     config.logger.info(
       chalk.green(
-        `${isConfig ? 'config' : '.env'} file changed, restarting server...`
+        `${path.relative(process.cwd(), file)} changed, restarting server...`
       ),
       { clear: true, timestamp: true }
     )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Previously imported files in config file are not watched, cause the config file is bundled, this PR gets a list of imported files from esbuild metadata and restart the dev server when they're changed. 

Fixed #2832

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
