### PR TITLE
feat: call `resolveId` hooks for CSS urls

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -144,7 +144,9 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
         if (checkPublicFile(url, config)) {
           return config.base + url.slice(1)
         }
-        const resolved = await resolveUrl(url, importer)
+        const resolved =
+          (await resolveUrl(url, importer)) ||
+          (await this.resolve(url, importer))?.id
         if (resolved) {
           return fileToUrl(resolved, config, this)
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Allow for references to virtual modules in CSS `url(...)` expressions.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
