### PR TITLE
fix(emptyOutDir): never remove .git

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -323,11 +323,15 @@ export function writeFile(
   fs.writeFileSync(filename, content)
 }
 
-export function emptyDir(dir: string): void {
-  if (!fs.existsSync(dir)) {
-    return
-  }
+/**
+ * Delete every file and subdirectory. **The given directory must exist.**
+ * Pass an optional `skip` array to preserve files in the root directory.
+ */
+export function emptyDir(dir: string, skip?: string[]): void {
   for (const file of fs.readdirSync(dir)) {
+    if (skip?.includes(file)) {
+      continue
+    }
     const abs = path.resolve(dir, file)
     // baseline is Node 12 so can't use rmSync :(
     if (fs.lstatSync(abs).isDirectory()) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If `.git` exists in the root of `outDir`, assume the user doesn't want it removed. The rationale is that Vite never generates `.git` for the user, so it should leave it alone.

This PR also contains a fix related to `emptyOutDir` when the `--watch` flag is used in build mode. Previously, the `outDir` would not be emptied before Rollup rebuilds if `emptyOutDir` was null. Now it is emptied.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
