### PR TITLE
feat(optimizer): scan virtual modules if they opt-in

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -359,11 +359,26 @@ function esbuildScanPlugin(
       // for jsx/tsx, we need to access the content and check for
       // presence of import.meta.glob, since it results in import relationships
       // but isn't crawled by esbuild.
-      build.onLoad({ filter: JS_TYPES_RE }, ({ path: id }) => {
+      build.onLoad({ filter: JS_TYPES_RE }, async ({ path: id }) => {
         let ext = path.extname(id).slice(1)
         if (ext === 'mjs') ext = 'js'
 
-        let contents = fs.readFileSync(id, 'utf-8')
+        let contents: string
+        try {
+          contents = fs.readFileSync(id, 'utf-8')
+        } catch (e) {
+          if (e.code !== 'ENOENT') {
+            throw e
+          }
+          // assume this is a virtual module that wants to be scanned
+          // by the optimizer. any virtual module that doesn't want that
+          // should put \0 in its id or return itself in resolveId hook.
+          const loaded = await container.load(id)
+          if (!loaded) {
+            throw e
+          }
+          contents = typeof loaded === 'string' ? loaded : loaded.code
+        }
         if (ext.endsWith('x') && config.esbuild && config.esbuild.jsxInject) {
           contents = config.esbuild.jsxInject + `\n` + contents
         }


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

For a virtual module to "opt in" to be scanned by the optimizer, the plugin responsible for it must return a different id from the `resolveId` hook (eg: by appending a .js extension) and refrain from using a null byte "\0" in its id (eg: by using `/@my-plugin/` prefix instead). This is enforced on the following line:
https://github.com/vitejs/vite/blob/d5a3733a1c9062f15678b978aa644ba3015df9c6/packages/vite/src/node/optimizer/scan.ts#L429

When a virtual module sneaks past the `shouldExternalizeDep` function, it should be loaded with the `load` hook, but only if `readFileSync` fails. This PR implements that behavior.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
