### PR TITLE
fix(optimizer): depScan resolve with flatIdDeps

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -91,7 +91,7 @@ export function esbuildDepPlugin(
                 namespace: 'dep'
               }
             : {
-                path: require.resolve(flatId, {
+                path: require.resolve(qualified[flatId], {
                   paths: [resolveDir]
                 })
               }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

v2.2.0 broke my build (and other users in Vite Land) with hundreds of errors such as these:

```
 > node_modules/.pnpm/@material-ui+core@4.11.3_ba191c0052acfa37659f3ba04a2d9405/node_modules/@material-ui/core/es/styles/index.js:13:136: error: [vite:dep-pre-bundle] Cannot find module '@material-ui_styles'
Require stack:
- <redacted:repo-root>/node_modules/.pnpm/vite@2.2.0/node_modules/vite/dist/node/chunks/dep-8baf35b6.js
- <redacted:repo-root>/node_modules/.pnpm/vite@2.2.0/node_modules/vite/dist/node/cli.js
- <redacted:repo-root>/node_modules/.pnpm/vite@2.2.0/node_modules/vite/bin/vite.js
       13 │ export { createGenerateClassName, jssPreset, ServerStyleSheets, StylesProvider, ThemeProvider as MuiThemeProvider, ThemeProvider } from '@material-ui/styles';
          ╵                                                                                                                                         ~~~~~~~~~~~~~~~~~~~~~
   node_modules/.pnpm/vite@2.2.0/node_modules/vite/dist/node/chunks/dep-8baf35b6.js:65417:18: note: This error came from the "onResolve" callback registered here
    65417 │             build.onResolve({ filter: /^[\w@][^:]/ }, async ({ path: id, importer, kind, resolveDir }) => {
          ╵                   ~~~~~~~~~
    at setup (<redacted:repo-root>/node_modules/.pnpm/vite@2.2.0/node_modules/vite/dist/node/chunks/dep-8baf35b6.js:65417:19)
    at handlePlugins (<redacted:repo-root>/node_modules/.pnpm/esbuild@0.9.7/node_modules/esbuild/lib/main.js:686:7)
    at Object.buildOrServe (<redacted:repo-root>/node_modules/.pnpm/esbuild@0.9.7/node_modules/esbuild/lib/main.js:903:44)
    at <redacted:repo-root>/node_modules/.pnpm/esbuild@0.9.7/node_modules/esbuild/lib/main.js:1444:17
    at new Promise (<anonymous>)
    at Object.build (<redacted:repo-root>/node_modules/.pnpm/esbuild@0.9.7/node_modules/esbuild/lib/main.js:1443:14)
    at Object.build (<redacted:repo-root>/node_modules/.pnpm/esbuild@0.9.7/node_modules/esbuild/lib/main.js:1334:51)
    at optimizeDeps (<redacted:repo-root>/node_modules/.pnpm/vite@2.2.0/node_modules/vite/dist/node/chunks/dep-8baf35b6.js:65643:34)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
```

I looked at the diff and it seemed to be related to this change: https://github.com/vitejs/vite/pull/3003/files#diff-7657c7c3217417a1747348410996718b471f6f0cb9552752b47a411f8f010830R94-R96

Adding back `qualified[flatId]` fixed it for me.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- Where would be the best place to add a regression test?
- Nevertheless, this should probably be merged first since it has a big impact

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
