### PR TITLE
test(setup): fix server closure

### DIFF
--- a/packages/playground/ssr-react/__tests__/serve.js
+++ b/packages/playground/ssr-react/__tests__/serve.js
@@ -45,9 +45,13 @@ exports.serve = async function serve(root, isProd) {
       const server = app.listen(port, () => {
         resolve({
           // for test teardown
-          close() {
-            server.close()
-            return vite && vite.close()
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve)
+            })
+            if (vite) {
+              await vite.close()
+            }
           }
         })
       })

--- a/packages/playground/ssr-vue/__tests__/serve.js
+++ b/packages/playground/ssr-vue/__tests__/serve.js
@@ -45,9 +45,13 @@ exports.serve = async function serve(root, isProd) {
       const server = app.listen(port, () => {
         resolve({
           // for test teardown
-          close() {
-            server.close()
-            return vite && vite.close()
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve)
+            })
+            if (vite) {
+              await vite.close()
+            }
           }
         })
       })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Attempt to fix test teardown issues.

The current failures can be reliably reproduced using:

```sh
yarn test-serve packages/playground/ssr-vue/__tests__/ssr-vue.spec.ts --detectOpenHandles
```

This fixes that case.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Fixes [these](https://github.com/vitejs/vite/runs/2384193898) errors:

```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

Cannot log after tests are done. Did you forget to wait for something async in your test?
```


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
