### PR TITLE
fix: preload paths with different production base path breaks

### DIFF
--- a/packages/playground/base-path/__tests__/base-path.spec.ts
+++ b/packages/playground/base-path/__tests__/base-path.spec.ts
@@ -1,0 +1,14 @@
+import { readFile, untilUpdated, isBuild } from '../../testUtils'
+
+test('should work', async () => {
+  await page.click('.clickme')
+  await untilUpdated(() => page.textContent('.content'), '3', true)
+})
+
+if (isBuild) {
+  test('should have relative path', async () => {
+    expect(readFile('dist/foo/assets/index.js')).toMatch(
+      /.*\.\/assets\/preload\.js.*/
+    )
+  })
+}

--- a/packages/playground/base-path/dep.js
+++ b/packages/playground/base-path/dep.js
@@ -1,0 +1,5 @@
+import preload from './preload'
+
+export function test() {
+  return 1 + preload()
+}

--- a/packages/playground/base-path/index.html
+++ b/packages/playground/base-path/index.html
@@ -1,0 +1,4 @@
+<script type="module" src="./main.js"></script>
+
+<button class="clickme">Click me</button>
+<div class="content"></div>

--- a/packages/playground/base-path/main.js
+++ b/packages/playground/base-path/main.js
@@ -1,0 +1,4 @@
+document.querySelector('.clickme').addEventListener('click', async () => {
+  const { test } = await import('./dep.js')
+  document.querySelector('.content').textContent = test()
+})

--- a/packages/playground/base-path/package.json
+++ b/packages/playground/base-path/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "base-path",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "serve": "vite preview"
+  }
+}

--- a/packages/playground/base-path/preload.js
+++ b/packages/playground/base-path/preload.js
@@ -1,0 +1,3 @@
+export default function () {
+  return 2
+}

--- a/packages/playground/base-path/vite.config.js
+++ b/packages/playground/base-path/vite.config.js
@@ -1,0 +1,24 @@
+const { resolve } = require('path')
+
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = {
+  base: '/foo/',
+  build: {
+    // simulate production environment
+    outDir: 'dist/foo',
+    // prevent bundling of dep and preload to ensure that vite-preloading occurs
+    rollupOptions: {
+      input: [
+        resolve(__dirname, 'index.html'),
+        resolve(__dirname, 'preload.js'),
+        resolve(__dirname, 'dep.js')
+      ],
+      // use simple entry names for easier reference inside the tests
+      output: {
+        entryFileNames: 'assets/[name].js'
+      }
+    }
+  }
+}

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -267,7 +267,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   // the dep list includes the main chunk, so only need to
                   // preload when there are actual other deps.
                   deps.size > 1
-                    ? `[${[...deps].map((d) => JSON.stringify(d)).join(',')}]`
+                    ? `[${[...deps]
+                        .map((d) => JSON.stringify(d.replace(/^\//, './')))
+                        .join(',')}]`
                     : `void 0`
                 )
               }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -242,11 +242,13 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   analyzed.add(filename)
                   const chunk = bundle[filename] as OutputChunk | undefined
                   if (chunk) {
-                    deps.add(config.base + chunk.fileName)
+                    // use a relative path https://github.com/vitejs/vite/pull/3061
+                    deps.add('./' + chunk.fileName)
                     const cssFiles = chunkToEmittedCssFileMap.get(chunk)
                     if (cssFiles) {
                       cssFiles.forEach((file) => {
-                        deps.add(config.base + file)
+                        // use a relative path https://github.com/vitejs/vite/pull/3061
+                        deps.add('./' + file)
                       })
                     }
                     chunk.imports.forEach(addDeps)
@@ -267,10 +269,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   // the dep list includes the main chunk, so only need to
                   // preload when there are actual other deps.
                   deps.size > 1
-                    ? `[${[...deps]
-                        // replace leading slashes to ensure a relative path. See https://github.com/vitejs/vite/pull/3061
-                        .map((d) => JSON.stringify(d.replace(/^\//, './')))
-                        .join(',')}]`
+                    ? `[${[...deps].map((d) => JSON.stringify(d)).join(',')}]`
                     : `void 0`
                 )
               }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -268,6 +268,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   // preload when there are actual other deps.
                   deps.size > 1
                     ? `[${[...deps]
+                        // replace leading slashes to ensure a relative path. See https://github.com/vitejs/vite/pull/3061
                         .map((d) => JSON.stringify(d.replace(/^\//, './')))
                         .join(',')}]`
                     : `void 0`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If a module is imported dynamically, vite detects modules for preloading and replaces the code with the preload helper. This only affects production builds though. 

For example: 

```
await import('./test.js')
```

is replaced with 

```
await __vitePreload(() => import("./test.js"), true ? ["/path/to/other.js"] : void 0)
```

Modules are preloaded by injecting a link with rel="modulepreload" in the index.html. 

As the /path/to/other.js is absolute, this will only work, if the deployed application runs under "/". If the deployed application is under a different path, the preloading will not work. 

This fix just adds a dot in front of the preload url such that it will be load relative to the index.html. I don't see, why that should break anything, but I am not 100% sure. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
