### PR TITLE
fix: handle null/empty sources in source maps

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -10,8 +10,7 @@ export async function injectSourcesContent(
   )
   map.sourcesContent = []
   await Promise.all(
-    map.sources.map(async (sourcePath, i) => {
-      if (!sourcePath) return
+    map.sources.filter(Boolean).map(async (sourcePath, i) => {
       map.sourcesContent![i] = await fs.readFile(
         path.resolve(sourceRoot, decodeURI(sourcePath)),
         'utf-8'

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -2,7 +2,12 @@ import { promises as fs } from 'fs'
 import path from 'path'
 
 export async function injectSourcesContent(
-  map: { sources: string[]; sourcesContent?: string[]; sourceRoot?: string },
+  map: {
+    sources: string[]
+    sourcesContent?: string[]
+    sourceRoot?: string
+    file?: string
+  },
   file: string
 ): Promise<void> {
   const sourceRoot = await fs.realpath(
@@ -12,7 +17,7 @@ export async function injectSourcesContent(
   await Promise.all(
     map.sources.map(async (sourcePath, i) => {
       map.sourcesContent![i] = await fs.readFile(
-        path.resolve(sourceRoot, decodeURI(sourcePath || file)),
+        path.resolve(sourceRoot, decodeURI(sourcePath || map.file!)),
         'utf-8'
       )
     })

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -12,7 +12,7 @@ export async function injectSourcesContent(
   await Promise.all(
     map.sources.map(async (sourcePath, i) => {
       map.sourcesContent![i] = await fs.readFile(
-        path.resolve(sourceRoot, decodeURI(sourcePath)),
+        path.resolve(sourceRoot, decodeURI(sourcePath || file)),
         'utf-8'
       )
     })

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -2,12 +2,7 @@ import { promises as fs } from 'fs'
 import path from 'path'
 
 export async function injectSourcesContent(
-  map: {
-    sources: string[]
-    sourcesContent?: string[]
-    sourceRoot?: string
-    file?: string
-  },
+  map: { sources: string[]; sourcesContent?: string[]; sourceRoot?: string },
   file: string
 ): Promise<void> {
   const sourceRoot = await fs.realpath(
@@ -16,8 +11,9 @@ export async function injectSourcesContent(
   map.sourcesContent = []
   await Promise.all(
     map.sources.map(async (sourcePath, i) => {
+      if (!sourcePath) return
       map.sourcesContent![i] = await fs.readFile(
-        path.resolve(sourceRoot, decodeURI(sourcePath || map.file!)),
+        path.resolve(sourceRoot, decodeURI(sourcePath)),
         'utf-8'
       )
     })


### PR DESCRIPTION
**UPDATE**: issue was produced by `@nuxtjs/composition-api`-plugin incorrectly producing a sourcemap. Will address in there but it might be worth still handling an empty `source`.

---

### Description

This PR updates the sourcemap support in vite to handle empty strings.

The issue I'm facing is the following error:
```
[vite] Internal server error: EISDIR: illegal operation on a directory, read
```

It is produced by attempting to read a directory path: `sourceRoot` + an empty `sourcePath` (= `''`).

### Alternative solutions

We could just filter `sources` first for non-empty strings.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.