### PR TITLE
docs: more explicit defineComponent example

### DIFF
--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -32,17 +32,17 @@ This plugin supports HMR of Vue JSX components. The detection requirements are:
 import { defineComponent } from 'vue'
 
 // named exports w/ variable declaration: ok
-export const Foo = defineComponent(...)
+export const Foo = defineComponent({})
 
 // named exports referencing variable declaration: ok
-const Bar = defineComponent(...)
+const Bar = defineComponent({ render() { return <div>Test</div> }})
 export { Bar }
 
 // default export call: ok
-export default defineComponent(...)
+export default defineComponent({ render() { return <div>Test</div> }})
 
 // default export referencing variable declaration: ok
-const Baz = defineComponent(...)
+const Baz = defineComponent({ render() { return <div>Test</div> }})
 export default Baz
 ```
 


### PR DESCRIPTION
For people like me that are not familiar with defineComponent, I ran into an issue using this plugin and HMR not working. It would have been great if the docs were something I could copy and paste and still work.

https://github.com/vitejs/vite/issues/3002#issuecomment-822165159

- [x] Documentation update