### PR TITLE
test: increase jest test timeout

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@ const config: Config.InitialOptions = {
   testMatch: process.env.VITE_TEST_BUILD
     ? ['**/playground/**/*.spec.[jt]s?(x)']
     : ['**/*.spec.[jt]s?(x)'],
-  testTimeout: process.env.CI ? 30000 : 10000,
+  testTimeout: process.env.CI ? 40000 : 30000,
   globalSetup: './scripts/jestGlobalSetup.js',
   globalTeardown: './scripts/jestGlobalTeardown.js',
   testEnvironment: './scripts/jestEnv.js',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Testing CI after increasing jest test timeout from 30sec to 40sec. I also bumped the local timeout since in my Windows machine is required for tests to pass, so this may be also affecting other contributors.

This is what it took to run test-serve
```
Test Suites: 28 passed, 28 total
Tests:       228 passed, 228 total
Snapshots:   18 passed, 18 total
Time:        27.369 s
```

and test-build
```
Test Suites: 25 passed, 25 total
Tests:       200 passed, 200 total
Snapshots:   0 total
Time:        22.155 s
```

### Additional context

There may be another issue to fix here, but the timeout is generating a lot of noise in CI at this point.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
