### PR TITLE
feat: Allow overwrite `TerserOptions.safari10` from `UserConfig`

### DIFF
--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -21,11 +21,11 @@ export function terserPlugin(options: Terser.MinifyOptions): Plugin {
 
     async renderChunk(code, _chunk, outputOptions) {
       const res = await worker.run(__dirname, code, {
+        safari10: true,
         ...options,
         sourceMap: !!outputOptions.sourcemap,
         module: outputOptions.format.startsWith('es'),
-        toplevel: outputOptions.format === 'cjs',
-        safari10: true
+        toplevel: outputOptions.format === 'cjs'
       })
       return {
         code: res.code!,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
A simple patch that allows you to overwrite `TerserOptions.safari10` from `UserConfig`. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
