### PR TITLE
feat(hmr): #3093 add config.server.hmr.runtimePort option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -421,7 +421,7 @@ export default async ({ command, mode }) => {
 
   Set `server.hmr.overlay` to `false` to disable the server error overlay.
 
-  Set `server.hmr.runtimePort` to any runtime code which interpreted as a port. e.g. `'window.location.port'` and `(() => window.location.port)()`
+  Set `server.hmr.runtimePort` to any runtime code which interpreted as a port. e.g. `'window.location.port'` and `(() => window.location.port)()`. If this is set, `server.hmr.port` will be ignored.
 
 ### server.watch
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -415,11 +415,13 @@ export default async ({ command, mode }) => {
 
 ### server.hmr
 
-- **Type:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean }`
+- **Type:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean, runtimePort?: string }`
 
   Disable or configure HMR connection (in cases where the HMR websocket must use a different address from the http server).
 
   Set `server.hmr.overlay` to `false` to disable the server error overlay.
+
+  Set `server.hmr.runtimePort` to any runtime code which interpreted as a port. e.g. `'window.location.port'` and `(() => window.location.port)()`
 
 ### server.watch
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -421,8 +421,7 @@ export default async ({ command, mode }) => {
 
   Set `server.hmr.overlay` to `false` to disable the server error overlay.
 
-  Set `server.hmr.runtimePort` to any runtime code which interpreted as a port. e.g. `'window.location.port'` and `(() => window.location.port)()`. If this is set, `server.hmr.port` will be ignored.
-
+  Set `server.hmr.runtimePort` to a inline code string which will be interpreted as a port on runtime. e.g. `'window.location.port'` and `(() => window.location.port)()`. If this is set, `server.hmr.port` will be ignored.
 ### server.watch
 
 - **Type:** `object`

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -24,20 +24,23 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
         const timeout = options.timeout || 30000
         const overlay = options.overlay !== false
         let port
-        if (config.server.middlewareMode) {
-          port = String(
-            (typeof config.server.hmr === 'object' && config.server.hmr.port) ||
-              24678
-          )
-        } else {
-          port = String(options.port || config.server.port!)
-        }
-        let hmrBase = config.base
-        if (options.path) {
-          hmrBase = path.posix.join(hmrBase, options.path)
-        }
-        if (hmrBase !== '/') {
-          port = path.posix.normalize(`${port}${hmrBase}`)
+        if (!options.runtimePort) {
+          if (config.server.middlewareMode) {
+            port = String(
+              (typeof config.server.hmr === 'object' &&
+                config.server.hmr.port) ||
+                24678
+            )
+          } else {
+            port = String(options.port || config.server.port!)
+          }
+          let hmrBase = config.base
+          if (options.path) {
+            hmrBase = path.posix.join(hmrBase, options.path)
+          }
+          if (hmrBase !== '/') {
+            port = path.posix.normalize(`${port}${hmrBase}`)
+          }
         }
 
         return code
@@ -47,7 +50,10 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
           .replace(`__DEFINES__`, serializeDefine(config.define || {}))
           .replace(`__HMR_PROTOCOL__`, JSON.stringify(protocol))
           .replace(`__HMR_HOSTNAME__`, JSON.stringify(host))
-          .replace(`__HMR_PORT__`, JSON.stringify(port))
+          .replace(
+            `__HMR_PORT__`,
+            options.runtimePort ? options.runtimePort : JSON.stringify(port)
+          )
           .replace(`__HMR_TIMEOUT__`, JSON.stringify(timeout))
           .replace(`__HMR_ENABLE_OVERLAY__`, JSON.stringify(overlay))
       } else if (code.includes('process.env.NODE_ENV')) {

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -50,10 +50,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
           .replace(`__DEFINES__`, serializeDefine(config.define || {}))
           .replace(`__HMR_PROTOCOL__`, JSON.stringify(protocol))
           .replace(`__HMR_HOSTNAME__`, JSON.stringify(host))
-          .replace(
-            `__HMR_PORT__`,
-            options.runtimePort ? options.runtimePort : JSON.stringify(port)
-          )
+          .replace(`__HMR_PORT__`, options.runtimePort ?? JSON.stringify(port))
           .replace(`__HMR_TIMEOUT__`, JSON.stringify(timeout))
           .replace(`__HMR_ENABLE_OVERLAY__`, JSON.stringify(overlay))
       } else if (code.includes('process.env.NODE_ENV')) {

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -23,6 +23,7 @@ export interface HmrOptions {
   timeout?: number
   overlay?: boolean
   server?: Server
+  runtimePort?: string
 }
 
 export interface HmrContext {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #3093
add an option named `runtimePort` in `config.server.hmr` . The value of `runtimePort` will replace `__HMR_PORT__`  literal.

### Additional context

Is this a good option design ? Is a test case needed?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
