### PR TITLE
feat(create-app): improve non-empty message for current dir

### DIFF
--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -158,8 +158,8 @@ async function init() {
           (targetDir === '.'
             ? 'Current directory'
             : `Target directory ${targetDir}`) +
-          ` is not empty.\n` +
-          `Remove existing files and continue?`
+          ' is not empty.\n' +
+          'Remove existing files and continue?'
       })
       if (yes) {
         emptyDir(root)

--- a/packages/create-app/index.js
+++ b/packages/create-app/index.js
@@ -155,7 +155,10 @@ async function init() {
         name: 'yes',
         initial: 'Y',
         message:
-          `Target directory ${targetDir} is not empty.\n` +
+          (targetDir === '.'
+            ? 'Current directory'
+            : `Target directory ${targetDir}`) +
+          ` is not empty.\n` +
           `Remove existing files and continue?`
       })
       if (yes) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The user is greeted with the following message if he/she attempts to create a project in the current directory that is non-empty:-

```sh
Target directory . is not empty.
```

This PR aims at improving the message.

### Additional context
N/A

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature (Enhancement)
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
