### PR TITLE
feat(vite): prevent outputting empty js files

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -271,6 +271,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       return {
         code: modulesCode || `export default ${JSON.stringify(css)}`,
         map: { mappings: '' },
+        meta: { css: true },
         // avoid the css module from being tree-shaken so that we can retrieve
         // it in renderChunk()
         moduleSideEffects: 'no-treeshake'

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -344,22 +344,40 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
         // inject chunk asset links
         if (chunk) {
-          const assetTags = [
+          const assetTags = []
+
+          if (
+            chunk.imports.length ||
+            Object.entries(chunk.modules).some(
+              ([id, mod]) =>
+                id !== 'vite/dynamic-import-polyfill' &&
+                mod.renderedLength &&
+                !this.getModuleInfo(id)?.meta.css
+            )
+          ) {
             // js entry chunk for this page
-            {
+            assetTags.push({
               tag: 'script',
               attrs: {
                 type: 'module',
                 crossorigin: true,
                 src: toPublicPath(chunk.fileName, config)
               }
-            },
+            })
+          } else {
+            // entry js chunk was effectively empty, prevent rollup outputting it
+            delete bundle[chunk.fileName]
+          }
+
+          assetTags.push(
             // preload for imports
             ...getPreloadLinksForChunk(chunk),
             ...getCssTagsForChunk(chunk)
-          ]
+          )
 
-          result = injectToHead(result, assetTags)
+          if (assetTags.length) {
+            result = injectToHead(result, assetTags)
+          }
         }
 
         // inject css link when cssCodeSplit is false


### PR DESCRIPTION
### Description
This PR implements the suggestion from #3127 which is to prevent outputting empty js files in some cases.
It does this by analyzing the entry js chunk to determine if it contains any imports, any modules that have content (ignoring css files and vite/dynamic-import-polyfill). If there are no modules that have content, then the chunk is no longer written to disk, and the `<script>` for the entry file is no longer inlined.

### Additional context
~This is probably not in a mergeable state since I am having issues running the test suite on my development vm. It does however work when linked into the [marko/vite](https://github.com/marko-js/vite) project.~

~I will work on getting the tests running properly.~

I was able to get the tests working, and seems all existing tests pass, also the CI is happy. However I'm not sure where would make the most sense in this codebase to add a test for this. Would appreciate some pointers 😄 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ x Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
