### PR TITLE
fix: dymamic import polyfill path when base is a URL

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -5,14 +5,30 @@ import path from 'path'
 
 export const polyfillId = 'vite/dynamic-import-polyfill'
 
+/**
+ * fix #2918
+ * `path.posix.join` return a wrong path when config.base is a URL
+ * @param config
+ */
+function resolveModulePath(config: ResolvedConfig) {
+  const {
+    base,
+    command,
+    build: { assetsDir }
+  } = config
+  const isBuild = command === 'build'
+  if (isBuild && /^(https?:)?(\/\/)/i.test(base)) {
+    return `${base.replace(/\/$/, '')}/${assetsDir}/`
+  }
+  return path.posix.join(base, assetsDir, '/')
+}
+
 export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
   const skip = config.command === 'serve' || config.build.ssr
   let polyfillLoaded = false
   const polyfillString =
     `const p = ${polyfill.toString()};` +
-    `${isModernFlag}&&p(${JSON.stringify(
-      path.posix.join(config.base, config.build.assetsDir, '/')
-    )});`
+    `${isModernFlag}&&p(${JSON.stringify(resolveModulePath(config))});`
 
   return {
     name: 'vite:dynamic-import-polyfill',

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -5,16 +5,12 @@ import path from 'path'
 
 export const polyfillId = 'vite/dynamic-import-polyfill'
 
-/**
- * fix #2918
- * `path.posix.join` return a wrong path when config.base is a URL
- * @param config
- */
 function resolveModulePath(config: ResolvedConfig) {
   const {
     base,
     build: { assetsDir }
   } = config
+  // #2918 path.posix.join returns a wrong path when config.base is a URL
   if (/^(https?:)?(\/\/)/i.test(base)) {
     return `${base.replace(/\/$/, '')}/${assetsDir}/`
   }

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -13,11 +13,9 @@ export const polyfillId = 'vite/dynamic-import-polyfill'
 function resolveModulePath(config: ResolvedConfig) {
   const {
     base,
-    command,
     build: { assetsDir }
   } = config
-  const isBuild = command === 'build'
-  if (isBuild && /^(https?:)?(\/\/)/i.test(base)) {
+  if (/^(https?:)?(\/\/)/i.test(base)) {
     return `${base.replace(/\/$/, '')}/${assetsDir}/`
   }
   return path.posix.join(base, assetsDir, '/')


### PR DESCRIPTION
fix #2918

<!-- Thank you for contributing! -->

### Description

resolve module path parser in dynamicImportPolyfillPlugin

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
