### PR TITLE
chore(create-app): update svelte templates for JSON imports

### DIFF
--- a/packages/create-app/template-svelte-ts/README.md
+++ b/packages/create-app/template-svelte-ts/README.md
@@ -14,8 +14,6 @@ Check out [SvelteKit](https://github.com/sveltejs/kit#readme), which is also pow
 
 **Why use this over SvelteKit?**
 
-- SvelteKit is still a work-in-progress.
-- It currently does not support the pure-SPA use case.
 - It brings its own routing solution which might not be preferable for some users.
 - It is first and foremost a framework that just happens to use Vite under the hood, not a Vite app.
   `vite dev` and `vite build` wouldn't work in a SvelteKit environment, for example.

--- a/packages/create-app/template-svelte-ts/package.json
+++ b/packages/create-app/template-svelte-ts/package.json
@@ -7,10 +7,10 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "next",
-    "svelte": "^3.35.0",
-    "svelte-preprocess": "^4.6.9",
-    "typescript": "^4.2.3",
-    "vite": "^2.1.5"
+    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.7",
+    "svelte": "^3.37.0",
+    "svelte-preprocess": "^4.7.2",
+    "typescript": "^4.2.4",
+    "vite": "^2.2.2"
   }
 }

--- a/packages/create-app/template-svelte-ts/tsconfig.json
+++ b/packages/create-app/template-svelte-ts/tsconfig.json
@@ -10,6 +10,7 @@
      */
     "importsNotUsedAsValues": "error",
     "isolatedModules": true,
+    "resolveJsonModule": true,
     /**
      * To have warnings / errors of the Svelte compiler at the
      * correct position, enable source maps by default.

--- a/packages/create-app/template-svelte/README.md
+++ b/packages/create-app/template-svelte/README.md
@@ -14,8 +14,6 @@ Check out [SvelteKit](https://github.com/sveltejs/kit#readme), which is also pow
 
 **Why use this over SvelteKit?**
 
-- SvelteKit is still a work-in-progress.
-- It currently does not support the pure-SPA use case.
 - It brings its own routing solution which might not be preferable for some users.
 - It is first and foremost a framework that just happens to use Vite under the hood, not a Vite app.
   `vite dev` and `vite build` wouldn't work in a SvelteKit environment, for example.

--- a/packages/create-app/template-svelte/jsconfig.json
+++ b/packages/create-app/template-svelte/jsconfig.json
@@ -10,6 +10,7 @@
      */
     "importsNotUsedAsValues": "error",
     "isolatedModules": true,
+    "resolveJsonModule": true,
     /**
      * To have warnings / errors of the Svelte compiler at the
      * correct position, enable source maps by default.

--- a/packages/create-app/template-svelte/package.json
+++ b/packages/create-app/template-svelte/package.json
@@ -7,8 +7,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "next",
-    "svelte": "^3.35.0",
-    "vite": "^2.1.5"
+    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.7",
+    "svelte": "^3.37.0",
+    "vite": "^2.2.2"
   }
 }


### PR DESCRIPTION
### Description

- Remove outdated README lines
- Swapped `@sveltejs/vite-plugin-svelte` to `^1.0.0-next.7` which should cover every version pre-2.x
- Added `resolveJsonModule` to `jsconfig.json` and `tsconfig.json` since Vite supports JSON imports out of the box

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Other

