### PR TITLE
feat: webworker ssr target

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -628,3 +628,10 @@ SSR options may be adjusted in minor releases.
 - **Type:** `string[]`
 
   Prevent listed dependencies from being externalized for SSR.
+
+### ssr.target
+
+- **Type:** `'node' | 'webworker'`
+- **Default:** `node`
+
+  Build target for the SSR server.

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -240,3 +240,7 @@ export function mySSRPlugin() {
   }
 }
 ```
+
+## SSR Target
+
+The default target for the SSR build is a node environment, but you can also run the server in a Web Worker. Packages entry resolution is different for each platform. You can configure the target to be Web Worker using the `ssr.target` set to `'webworker'`.

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -162,9 +162,17 @@ export interface UserConfig {
   dedupe?: string[]
 }
 
+export type SSRTarget = 'node' | 'webworker'
+
 export interface SSROptions {
   external?: string[]
   noExternal?: string[]
+  /**
+   * Define the target for the ssr build. The browser field in package.json
+   * is ignored for node but used if webworker is the target
+   * Default: 'node'
+   */
+  target?: SSRTarget
 }
 
 export interface InlineConfig extends UserConfig {
@@ -342,6 +350,7 @@ export async function resolveConfig(
                 root: resolvedRoot,
                 isProduction,
                 isBuild: command === 'build',
+                ssrTarget: resolved.ssr?.target,
                 asSrc: true,
                 preferRelative: false,
                 tryIndex: true,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -39,6 +39,7 @@ export async function resolvePlugins(
       root: config.root,
       isProduction: config.isProduction,
       isBuild,
+      ssrTarget: config.ssr?.target,
       asSrc: true
     }),
     htmlInlineScriptProxyPlugin(),

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -30,6 +30,12 @@ import { createFilter } from '@rollup/pluginutils'
 import { PartialResolvedId } from 'rollup'
 import { resolve as _resolveExports } from 'resolve.exports'
 
+// Only Node.JS has a process variable that is of [[Class]] process, from https://github.com/iliakan/detect-node
+const isNode =
+  Object.prototype.toString.call(
+    typeof process !== 'undefined' ? process : 0
+  ) === '[object process]'
+
 // special id for paths marked with browser: false
 // https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module
 export const browserExternalId = '__vite-browser-external'
@@ -87,6 +93,8 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
         return
       }
 
+      const targetBrowser = !(isNode && ssr)
+
       // this is passed by @rollup/plugin-commonjs
       const isRequire =
         resolveOpts &&
@@ -125,7 +133,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
         // handle browser field mapping for relative imports
 
         if (
-          !ssr &&
+          targetBrowser &&
           (res = tryResolveBrowserMapping(fsPath, importer, options, true))
         ) {
           return res
@@ -177,13 +185,15 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
         }
 
         if (
-          !ssr &&
+          targetBrowser &&
           (res = tryResolveBrowserMapping(id, importer, options, false))
         ) {
           return res
         }
 
-        if ((res = tryNodeResolve(id, importer, options, ssr, server))) {
+        if (
+          (res = tryNodeResolve(id, importer, options, targetBrowser, server))
+        ) {
           return res
         }
 
@@ -232,7 +242,7 @@ function tryFsResolve(
   fsPath: string,
   options: InternalResolveOptions,
   tryIndex = true,
-  ssr?: boolean
+  targetBrowser = true
 ): string | undefined {
   let file = fsPath
   let postfix = ''
@@ -253,7 +263,7 @@ function tryFsResolve(
       postfix,
       options,
       false,
-      ssr,
+      targetBrowser,
       options.tryPrefix
     ))
   ) {
@@ -267,7 +277,7 @@ function tryFsResolve(
         postfix,
         options,
         false,
-        ssr,
+        targetBrowser,
         options.tryPrefix
       ))
     ) {
@@ -281,7 +291,7 @@ function tryFsResolve(
       postfix,
       options,
       tryIndex,
-      ssr,
+      targetBrowser,
       options.tryPrefix
     ))
   ) {
@@ -294,7 +304,7 @@ function tryResolveFile(
   postfix: string,
   options: InternalResolveOptions,
   tryIndex: boolean,
-  ssr?: boolean,
+  targetBrowser: boolean,
   tryPrefix?: string
 ): string | undefined {
   let isReadable = false
@@ -313,7 +323,7 @@ function tryResolveFile(
       if (fs.existsSync(pkgPath)) {
         // path points to a node package
         const pkg = loadPackageData(pkgPath)
-        return resolvePackageEntry(file, pkg, options, ssr)
+        return resolvePackageEntry(file, pkg, options, targetBrowser)
       }
       const index = tryFsResolve(file + '/index', options)
       if (index) return index + postfix
@@ -321,7 +331,7 @@ function tryResolveFile(
   }
   if (tryPrefix) {
     const prefixed = `${path.dirname(file)}/${tryPrefix}${path.basename(file)}`
-    return tryResolveFile(prefixed, postfix, options, tryIndex, ssr)
+    return tryResolveFile(prefixed, postfix, options, tryIndex, targetBrowser)
   }
 }
 
@@ -331,7 +341,7 @@ export function tryNodeResolve(
   id: string,
   importer: string | undefined,
   options: InternalResolveOptions,
-  ssr?: boolean,
+  targetBrowser: boolean,
   server?: ViteDevServer
 ): PartialResolvedId | undefined {
   const { root, dedupe, isBuild } = options
@@ -358,8 +368,8 @@ export function tryNodeResolve(
   }
 
   let resolved = deepMatch
-    ? resolveDeepImport(id, pkg, options, ssr)
-    : resolvePackageEntry(id, pkg, options, ssr)
+    ? resolveDeepImport(id, pkg, options, targetBrowser)
+    : resolvePackageEntry(id, pkg, options, targetBrowser)
   if (!resolved) {
     return
   }
@@ -431,10 +441,10 @@ export function tryOptimizedResolve(
 export interface PackageData {
   dir: string
   hasSideEffects: (id: string) => boolean
-  resolvedImports: Record<string, string | undefined>
-  ssrResolvedImports: Record<string, string | undefined>
-  setResolvedCache: (key: string, entry: string, ssr?: boolean) => void
-  getResolvedCache: (key: string, ssr?: boolean) => string | undefined
+  browserResolvedImports: Record<string, string | undefined>
+  nodeResolvedImports: Record<string, string | undefined>
+  setResolvedCache: (key: string, entry: string, targetBrowser: boolean) => void
+  getResolvedCache: (key: string, targetBrowser: boolean) => string | undefined
   data: {
     [field: string]: any
     version: string
@@ -481,20 +491,20 @@ function loadPackageData(pkgPath: string, cacheKey = pkgPath) {
     dir: pkgDir,
     data,
     hasSideEffects,
-    resolvedImports: {},
-    ssrResolvedImports: {},
-    setResolvedCache(key: string, entry: string, ssr?: boolean) {
-      if (ssr) {
-        pkg.ssrResolvedImports[key] = entry
+    browserResolvedImports: {},
+    nodeResolvedImports: {},
+    setResolvedCache(key: string, entry: string, targetBrowser: boolean) {
+      if (targetBrowser) {
+        pkg.browserResolvedImports[key] = entry
       } else {
-        pkg.resolvedImports[key] = entry
+        pkg.nodeResolvedImports[key] = entry
       }
     },
-    getResolvedCache(key: string, ssr?: boolean) {
-      if (ssr) {
-        return pkg.ssrResolvedImports[key]
+    getResolvedCache(key: string, targetBrowser: boolean) {
+      if (targetBrowser) {
+        return pkg.browserResolvedImports[key]
       } else {
-        return pkg.resolvedImports[key]
+        return pkg.nodeResolvedImports[key]
       }
     }
   }
@@ -506,9 +516,9 @@ export function resolvePackageEntry(
   id: string,
   { dir, data, setResolvedCache, getResolvedCache }: PackageData,
   options: InternalResolveOptions,
-  ssr?: boolean
+  targetBrowser: boolean
 ): string | undefined {
-  const cached = getResolvedCache('.', ssr)
+  const cached = getResolvedCache('.', targetBrowser)
   if (cached) {
     return cached
   }
@@ -524,7 +534,7 @@ export function resolvePackageEntry(
   // This is because .mjs files can technically import .cjs files which would
   // make them invalid for pure ESM environments - so if other module/browser
   // fields are present, prioritize those instead.
-  if (!ssr && (!entryPoint || entryPoint.endsWith('.mjs'))) {
+  if (targetBrowser && (!entryPoint || entryPoint.endsWith('.mjs'))) {
     // check browser field
     // https://github.com/defunctzombie/package-browser-field-spec
     const browserEntry =
@@ -574,7 +584,7 @@ export function resolvePackageEntry(
 
   // resolve object browser field in package.json
   const { browser: browserField } = data
-  if (!ssr && isObject(browserField)) {
+  if (targetBrowser && isObject(browserField)) {
     entryPoint = mapWithBrowserField(entryPoint, browserField) || entryPoint
   }
 
@@ -586,7 +596,7 @@ export function resolvePackageEntry(
       debug(
         `[package entry] ${chalk.cyan(id)} -> ${chalk.dim(resolvedEntryPoint)}`
       )
-    setResolvedCache('.', resolvedEntryPoint, ssr)
+    setResolvedCache('.', resolvedEntryPoint, targetBrowser)
     return resolvedEntryPoint
   } else {
     throw new Error(
@@ -618,17 +628,17 @@ function resolveExports(
 function resolveDeepImport(
   id: string,
   {
-    resolvedImports,
+    browserResolvedImports,
     setResolvedCache,
     getResolvedCache,
     dir,
     data
   }: PackageData,
   options: InternalResolveOptions,
-  ssr?: boolean
+  targetBrowser: boolean
 ): string | undefined {
   id = '.' + id.slice(data.name.length)
-  const cache = getResolvedCache(id, ssr)
+  const cache = getResolvedCache(id, targetBrowser)
   if (cache) {
     return cache
   }
@@ -650,12 +660,12 @@ function resolveDeepImport(
           `${path.join(dir, 'package.json')}.`
       )
     }
-  } else if (!ssr && isObject(browserField)) {
+  } else if (targetBrowser && isObject(browserField)) {
     const mapped = mapWithBrowserField(relativeId, browserField)
     if (mapped) {
       relativeId = mapped
     } else if (mapped === false) {
-      return (resolvedImports[id] = browserExternalId)
+      return (browserResolvedImports[id] = browserExternalId)
     }
   }
 
@@ -664,12 +674,12 @@ function resolveDeepImport(
       path.join(dir, relativeId),
       options,
       !exportsField, // try index only if no exports field
-      ssr
+      targetBrowser
     )
     if (resolved) {
       isDebug &&
         debug(`[node/deep-import] ${chalk.cyan(id)} -> ${chalk.dim(resolved)}`)
-      setResolvedCache(id, resolved, ssr)
+      setResolvedCache(id, resolved, targetBrowser)
       return resolved
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Reworked https://github.com/vitejs/vite/pull/3121 as a feat.

https://github.com/vitejs/vite/pull/2996 and https://github.com/vitejs/vite/pull/3039 reworked the package resolution to ignore the `browser` field if the plugin is running in ssr mode.

See @frandiox [comment](https://github.com/vitejs/vite/pull/3039#issuecomment-823818336), if the target is webworker (ie cloudflare workers) then the `browser` field should be respected even in ssr mode.

There is a new config option `ssr.target`:

> The default target for the SSR build is a node environment, but you can also run the server in a Web Worker. Packages entry resolution is different for each platform. You can configure the target to be Web Worker using the `ssr.target` set to `'webworker'`.

We already have a `build.target` but if we reuse it, the users will be forced to modify this option depending on building for the web or using `build --ssr`. I think it makes sense to be able to define both in the config file.

A `targetWeb` param to the resolve methods instead of the previous `ssr` one (I think that `targetWeb` is better here than `targetNode` to avoid the need to negate it when using it). In the resolve plugin:

```js
const targetWeb = !ssr || ssrTarget === 'webworker'
```

#2996 #3039 didn't introduce a regression for Web Workers, because the target was implicitly Node until this point. So they are both fixes for the Node ssr server.

This PR allows ecosystem solutions like vitedge to resolve the browser field as before. There may be other differences that we need to take into account when `ssr.target` is `webworker`, but for @frandiox Vite was working without issues before these changes. I think there is the need for extra configuration that may now be included as default when targeting webworkers. For example [the `resolve.mainFields` default](https://vitejs.dev/config/#resolve-mainfields). I think these could be added in future PRs. As the SSR feature is still labeled experimental, `ssr.target` should also be considered experimental.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other