### PR TITLE
fix: relative import from child of symlinked directory

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -120,10 +120,15 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
 
       // relative
       if (id.startsWith('.') || (preferRelative && /^\w/.test(id))) {
-        const realImporter =
-          importer && fs.realpathSync.native(importer.replace(/[*?#].*$/g, ''))
-        const basedir = realImporter
-          ? path.dirname(realImporter)
+        let realImporter: string | undefined
+        try {
+          // see #3165, ensure relative import resolves to intended file path
+          realImporter =
+            importer && fs.realpathSync.native(importer.replace(/[?#].*$/g, ''))
+        } catch {}
+
+        const basedir = importer
+          ? path.dirname(realImporter || importer)
           : process.cwd()
         const fsPath = path.resolve(basedir, id)
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -120,8 +120,10 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
 
       // relative
       if (id.startsWith('.') || (preferRelative && /^\w/.test(id))) {
-        const basedir = importer
-          ? path.dirname(fs.realpathSync.native(importer))
+        const realImporter =
+          importer && fs.realpathSync.native(importer.replace(/[*?#].*$/g, ''))
+        const basedir = realImporter
+          ? path.dirname(realImporter)
           : process.cwd()
         const fsPath = path.resolve(basedir, id)
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -120,9 +120,10 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
 
       // relative
       if (id.startsWith('.') || (preferRelative && /^\w/.test(id))) {
-        const basedir = importer ? path.dirname(importer) : process.cwd()
+        const basedir = importer
+          ? path.dirname(fs.realpathSync.native(importer))
+          : process.cwd()
         const fsPath = path.resolve(basedir, id)
-        // handle browser field mapping for relative imports
 
         if (
           !ssr &&


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For example, if `/a/b/main.js` imports `../foo` and `/a/b` is a symlinked directory pointing to `/g/b`, we want the import to resolve to `/g/foo` instead of `/a/foo` because the latter might not be equivalent.

```
realpath("/a/b/main.js")  => "/g/b/main.js"
resolve("/a/b", "../foo") => "/a/foo"
realpath("/a/foo")        => ENOENT
resolve("/g/b", "../foo") => "/g/foo"
realpath("/g/foo")        => "/g/foo"
```

I detailed my use case [in this comment](https://github.com/vitejs/vite/pull/3165#issuecomment-836788106).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
