### PR TITLE
test: fix timeout hiding runtime build error

### DIFF
--- a/packages/playground/ssr-react/__tests__/serve.js
+++ b/packages/playground/ssr-react/__tests__/serve.js
@@ -17,7 +17,7 @@ exports.serve = async function serve(root, isProd) {
     // client build
     await build({
       root,
-      logLevel: 'error',
+      logLevel: 'silent', // exceptions are logged by Jest
       build: {
         target: 'esnext',
         minify: false,
@@ -28,7 +28,7 @@ exports.serve = async function serve(root, isProd) {
     // server build
     await build({
       root,
-      logLevel: 'error',
+      logLevel: 'silent',
       build: {
         target: 'esnext',
         ssr: 'src/entry-server.jsx',

--- a/packages/playground/ssr-vue/__tests__/serve.js
+++ b/packages/playground/ssr-vue/__tests__/serve.js
@@ -17,7 +17,7 @@ exports.serve = async function serve(root, isProd) {
     // client build
     await build({
       root,
-      logLevel: 'error',
+      logLevel: 'silent', // exceptions are logged by Jest
       build: {
         target: 'esnext',
         minify: false,
@@ -28,7 +28,7 @@ exports.serve = async function serve(root, isProd) {
     // server build
     await build({
       root,
-      logLevel: 'error',
+      logLevel: 'silent',
       build: {
         target: 'esnext',
         ssr: 'src/entry-server.js',

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -458,7 +458,7 @@ async function buildPolyfillChunk(
     // so that everything is resolved from here
     root: __dirname,
     configFile: false,
-    logLevel: 'error',
+    logLevel: 'silent', // exceptions are logged by Jest
     plugins: [polyfillsPlugin(imports)],
     build: {
       write: false,

--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -124,7 +124,7 @@ function startStaticServer(): Promise<string> {
   let config: UserConfig
   try {
     config = require(configFile)
-  } catch (e) { }
+  } catch (e) {}
   const base = (config?.base || '/') === '/' ? '' : config.base
 
   // @ts-ignore

--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -66,7 +66,7 @@ beforeAll(async () => {
 
       const options: UserConfig = {
         root: tempDir,
-        logLevel: 'error',
+        logLevel: 'silent',
         server: {
           watch: {
             // During tests we edit the files too fast and sometimes chokidar
@@ -100,6 +100,12 @@ beforeAll(async () => {
     // jest doesn't exit if our setup has error here
     // https://github.com/facebook/jest/issues/2713
     err = e
+
+    // Closing the page since an error in the setup, for example a runtime error 
+    // when building the playground should skip further tests.
+    // If the page remains open, a command like `await page.click(...)` produces
+    // a timeout with an exception that hides the real error in the console.
+    await page.close()
   }
 }, 30000)
 
@@ -118,7 +124,7 @@ function startStaticServer(): Promise<string> {
   let config: UserConfig
   try {
     config = require(configFile)
-  } catch (e) {}
+  } catch (e) { }
   const base = (config?.base || '/') === '/' ? '' : config.base
 
   // @ts-ignore


### PR DESCRIPTION
### Description

Setup for the screenshots: I forced a runtime build error, by using `configResolved` to get the config in an internal plugin. This is ok according to the public API of vite, but internal plugins don't get this hook called (and you should directly get the config through params).

In the current test output for ssr-react, the build failed but the tests continued to run and trying to use `await page.click` caused a timeout that is reported and hides the real issue

![test-output-initial](https://user-images.githubusercontent.com/583075/116364430-79b25d00-a804-11eb-9b94-efdfa85ff1df.PNG)

<br><br>

This PR closes the page if there is an exception during the test setup, resolving the await and timeout issue. The real error gets properly reported but it is duplicated, as `logLevel: 'error'` is used to do the builds for the test suite so it is reported both by Vite and by Jest.

![test-output-error](https://user-images.githubusercontent.com/583075/116364487-8767e280-a804-11eb-8424-9691e8dafb91.PNG)

<br><br>

To avoid this, the logLevel is set as 'silent' so the only reported exception is logged by Jest

![test-output-final](https://user-images.githubusercontent.com/583075/116364501-8afb6980-a804-11eb-9ccf-b2eca6536011.PNG)

<br><br>

Note: I included both changes in the same PR because in the current test setup we don't have the duplicated log error.

### Additional context

The Jest log is a lot better than the one generated internally by Vite, it would be good to see if we could get the same output when the user uses the cli.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

