### PR TITLE
Feat: configurable known js source extensions

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,42 +1,91 @@
-import { injectQuery } from '../utils'
+import { injectQuery, isJSRequest } from '../utils'
 
 const isWindows = process.platform === 'win32'
 
-if (isWindows) {
-  // this test will work incorrectly on unix systems
-  test('normalize windows path', () => {
-    expect(injectQuery('C:\\User\\Vite\\Project', 'direct')).toEqual(
-      'C:/User/Vite/Project?direct'
+describe('injectQuery', () => {
+  if (isWindows) {
+    // this test will work incorrectly on unix systems
+    test('normalize windows path', () => {
+      expect(injectQuery('C:\\User\\Vite\\Project', 'direct')).toEqual(
+        'C:/User/Vite/Project?direct'
+      )
+    })
+  }
+
+  test('path with multiple spaces', () => {
+    expect(injectQuery('/usr/vite/path with space', 'direct')).toEqual(
+      '/usr/vite/path with space?direct'
     )
   })
-}
 
-test('path with multiple spaces', () => {
-  expect(injectQuery('/usr/vite/path with space', 'direct')).toEqual(
-    '/usr/vite/path with space?direct'
-  )
+  test('path with multiple % characters', () => {
+    expect(injectQuery('/usr/vite/not%20a%20space', 'direct')).toEqual(
+      '/usr/vite/not%20a%20space?direct'
+    )
+  })
+
+  test('path with %25', () => {
+    expect(injectQuery('/usr/vite/%25hello%25', 'direct')).toEqual(
+      '/usr/vite/%25hello%25?direct'
+    )
+  })
+
+  test('path with unicode', () => {
+    expect(injectQuery('/usr/vite/東京', 'direct')).toEqual(
+      '/usr/vite/東京?direct'
+    )
+  })
+
+  test('path with unicode, space, and %', () => {
+    expect(injectQuery('/usr/vite/東京 %20 hello', 'direct')).toEqual(
+      '/usr/vite/東京 %20 hello?direct'
+    )
+  })
 })
 
-test('path with multiple % characters', () => {
-  expect(injectQuery('/usr/vite/not%20a%20space', 'direct')).toEqual(
-    '/usr/vite/not%20a%20space?direct'
-  )
-})
+describe('isJSRequest', () => {
+  test('url', () => {
+    expect(isJSRequest('foo')).toBe(true)
+    expect(isJSRequest('foo.js')).toBe(true)
+    expect(isJSRequest('foo.x')).toBe(false)
+  })
 
-test('path with %25', () => {
-  expect(injectQuery('/usr/vite/%25hello%25', 'direct')).toEqual(
-    '/usr/vite/%25hello%25?direct'
-  )
-})
+  test('url with trailing slash', () => {
+    expect(isJSRequest('foo/')).toBe(false)
+    expect(isJSRequest('foo/?.js')).toBe(false)
+    expect(isJSRequest('foo/#.js')).toBe(false)
+    expect(isJSRequest('foo/?bar=.js#.js')).toBe(false)
+  })
 
-test('path with unicode', () => {
-  expect(injectQuery('/usr/vite/東京', 'direct')).toEqual(
-    '/usr/vite/東京?direct'
-  )
-})
+  test('url with querystring', () => {
+    expect(isJSRequest('foo.js?')).toBe(true)
+    expect(isJSRequest('foo.js?bar')).toBe(true)
+    expect(isJSRequest('foo.js?bar=baz')).toBe(true)
+    expect(isJSRequest('foo.js?bar=baz&oops=.x')).toBe(true)
+    expect(isJSRequest('foo.x?')).toBe(false)
+    expect(isJSRequest('foo.x?bar')).toBe(false)
+    expect(isJSRequest('foo.x?bar=baz')).toBe(false)
+    expect(isJSRequest('foo.x?bar=baz&oops=.js')).toBe(false)
+    expect(isJSRequest('foo.x?bar=baz&oops=.js')).toBe(false)
+  })
 
-test('path with unicode, space, and %', () => {
-  expect(injectQuery('/usr/vite/東京 %20 hello', 'direct')).toEqual(
-    '/usr/vite/東京 %20 hello?direct'
-  )
+  test('url with hash', () => {
+    expect(isJSRequest('foo.js#')).toBe(true)
+    expect(isJSRequest('foo.js#bar')).toBe(true)
+    expect(isJSRequest('foo.js#.x')).toBe(true)
+    expect(isJSRequest('foo.x#')).toBe(false)
+    expect(isJSRequest('foo.x#bar')).toBe(false)
+    expect(isJSRequest('foo.x#.js')).toBe(false)
+  })
+
+  test('url with querystring and hash', () => {
+    expect(isJSRequest('foo.js?#')).toBe(true)
+    expect(isJSRequest('foo.js?bar#')).toBe(true)
+    expect(isJSRequest('foo.js?bar=baz#blub')).toBe(true)
+    expect(isJSRequest('foo.js?bar=baz&oops=.x#.x')).toBe(true)
+    expect(isJSRequest('foo.x?#')).toBe(false)
+    expect(isJSRequest('foo.x?bar#baz')).toBe(false)
+    expect(isJSRequest('foo.x?bar=baz#.js')).toBe(false)
+    expect(isJSRequest('foo.x?bar=baz&oops=.js#.js')).toBe(false)
+  })
 })

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -128,7 +128,7 @@ export interface UserConfig {
    */
   assetsInclude?: string | RegExp | (string | RegExp)[]
   /**
-   * Specifiy additional extensions to be treated as sources of js modules
+   * Specify additional extensions to be treated as sources of js modules
    * requires plugins to be installed that transform the extensions!
    *
    * Plugin authors should set this with the config hook

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -17,7 +17,11 @@ import { ESBuildOptions } from './plugins/esbuild'
 import dotenv from 'dotenv'
 import dotenvExpand from 'dotenv-expand'
 import { Alias, AliasOptions } from 'types/alias'
-import { CLIENT_DIR, DEFAULT_ASSETS_RE } from './constants'
+import {
+  CLIENT_DIR,
+  DEFAULT_ASSETS_RE,
+  KNOWN_JS_SRC_EXTENSIONS
+} from './constants'
 import {
   InternalResolveOptions,
   ResolveOptions,
@@ -123,6 +127,13 @@ export interface UserConfig {
    * Specify additional files to be treated as static assets.
    */
   assetsInclude?: string | RegExp | (string | RegExp)[]
+  /**
+   * Specifiy additional extensions to be treated as sources of js modules
+   * requires plugins to be installed that transform the extensions!
+   *
+   * Plugin authors should set this with the config hook
+   */
+  knownJsSrcExtensions?: string[]
   /**
    * Server specific options, e.g. host, port, https...
    */
@@ -264,6 +275,11 @@ export async function resolveConfig(
       }
     }
   }
+
+  // update known js src extensions
+  config.knownJsSrcExtensions?.forEach((ext) =>
+    KNOWN_JS_SRC_EXTENSIONS.add(ext.startsWith('.') ? ext : `.${ext}`)
+  )
 
   // resolve root
   const resolvedRoot = normalizePath(

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -15,6 +15,18 @@ export const DEFAULT_EXTENSIONS = [
   '.json'
 ]
 
+// file extensions that will be transformed to js modules
+export const KNOWN_JS_SRC_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.mjs',
+  '.vue',
+  '.marko',
+  '.svelte'
+])
+
 export const JS_TYPES_RE = /\.(?:j|t)sx?$|\.mjs$/
 
 export const OPTIMIZABLE_ENTRY_RE = /\.(?:m?js|ts)$/

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -4,7 +4,12 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import { pathToFileURL, URL } from 'url'
-import { FS_PREFIX, DEFAULT_EXTENSIONS, VALID_ID_PREFIX } from './constants'
+import {
+  FS_PREFIX,
+  DEFAULT_EXTENSIONS,
+  VALID_ID_PREFIX,
+  KNOWN_JS_SRC_EXTENSIONS
+} from './constants'
 import resolve from 'resolve'
 import builtins from 'builtin-modules'
 import { FSWatcher } from 'chokidar'
@@ -106,16 +111,12 @@ export const isExternalUrl = (url: string): boolean => externalRE.test(url)
 export const dataUrlRE = /^\s*data:/i
 export const isDataUrl = (url: string): boolean => dataUrlRE.test(url)
 
-const knownJsSrcRE = /\.((j|t)sx?|mjs|vue|marko|svelte)($|\?)/
 export const isJSRequest = (url: string): boolean => {
-  if (knownJsSrcRE.test(url)) {
-    return true
-  }
   url = cleanUrl(url)
-  if (!path.extname(url) && !url.endsWith('/')) {
-    return true
-  }
-  return false
+  const ext = path.extname(url)
+  return (
+    (ext && KNOWN_JS_SRC_EXTENSIONS.has(ext)) || (!ext && !url.endsWith('/'))
+  )
 }
 
 const importQueryRE = /(\?|&)import(?:&|$)/


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Introduce a config option to allow plugins/users to contribute to the logic of vites `isJSRequest` util

see discussion here https://github.com/vitejs/vite/discussions/2829


As this option is primarily aimed at plugin authors i didn't add documentation to the user docs. Can be done if needed/wanted

This PR is also a first step in a series that would have to be taken to allow current and future SFC style plugins to configure vite without relying on the help of vite internals. The discussion linked above highlights other areas that are also in need of configurability

### Additional context

The current implementation of `isJSRequest` returns true for `foo.txt?bar=.js`  because it ended with `.js` and `cleanUrl` was called after the regex check. If that semantic was on purpose it could be added back by constructing a similar regex out of the Set

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
