### PR TITLE
refactor(scan): don’t write to disk during dep scan

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -11,7 +11,6 @@ import {
 } from '../constants'
 import {
   createDebugger,
-  emptyDir,
   normalizePath,
   isObject,
   cleanUrl,
@@ -85,7 +84,6 @@ export async function scanImports(
     debug(`Crawling dependencies using entries:\n  ${entries.join('\n  ')}`)
   }
 
-  const tempDir = path.join(config.cacheDir!, 'temp')
   const deps: Record<string, string> = {}
   const missing: Record<string, string> = {}
   const container = await createPluginContainer(config)
@@ -94,24 +92,15 @@ export async function scanImports(
   await Promise.all(
     entries.map((entry) =>
       build({
+        write: false,
         entryPoints: [entry],
         bundle: true,
         format: 'esm',
         logLevel: 'error',
-        outdir: tempDir,
         plugins: [plugin]
       })
     )
   )
-
-  try {
-    emptyDir(tempDir)
-    fs.rmdirSync(tempDir)
-  } catch (err) {
-    if (err.code !== 'ENOENT') {
-      throw err
-    }
-  }
 
   debug(`Scan completed in ${Date.now() - s}ms:`, deps)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Use `write: false` instead of a temp directory during dep scanning.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
