### PR TITLE
fix(plugin-legacy): correct log level to error

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -458,7 +458,7 @@ async function buildPolyfillChunk(
     // so that everything is resolved from here
     root: __dirname,
     configFile: false,
-    logLevel: 'silent', // exceptions are logged by Jest
+    logLevel: 'error',
     plugins: [polyfillsPlugin(imports)],
     build: {
       write: false,


### PR DESCRIPTION
### Description

As part of https://github.com/vitejs/vite/pull/3185, one of the log levels was wrongly modified as it is not part of a test: https://github.com/vitejs/vite/commit/978d991293f5b8e1a4197ac4e3aee4fa2e838a88#diff-e861d33a288ea61b3aee05203d1c43920c4326d904e3d41b4326adbd30a0127fR461

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other