### PR TITLE
refactor: vite middlewares as named functions

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -424,7 +424,9 @@ export async function createServer(
   middlewares.use('/__open-in-editor', launchEditorMiddleware())
 
   // hmr reconnect ping
-  middlewares.use('/__vite_ping', (_, res) => res.end('pong'))
+  middlewares.use('/__vite_ping', function viteHMRPingMiddleware(_, res) {
+    res.end('pong')
+  })
 
   //decode request url
   middlewares.use(decodeURIMiddleware())
@@ -473,7 +475,7 @@ export async function createServer(
     // transform index.html
     middlewares.use(indexHtmlMiddleware(server))
     // handle 404s
-    middlewares.use((_, res) => {
+    middlewares.use(function vite404Middleware(_, res) {
       res.statusCode = 404
       res.end()
     })

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -424,6 +424,7 @@ export async function createServer(
   middlewares.use('/__open-in-editor', launchEditorMiddleware())
 
   // hmr reconnect ping
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   middlewares.use('/__vite_ping', function viteHMRPingMiddleware(_, res) {
     res.end('pong')
   })
@@ -475,6 +476,7 @@ export async function createServer(
     // transform index.html
     middlewares.use(indexHtmlMiddleware(server))
     // handle 404s
+    // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
     middlewares.use(function vite404Middleware(_, res) {
       res.statusCode = 404
       res.end()

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -9,7 +9,7 @@ export function baseMiddleware({
 }: ViteDevServer): Connect.NextHandleFunction {
   const base = config.base
 
-  return (req, res, next) => {
+  return function viteBaseMiddleware(req, res, next) {
     const url = req.url!
     const parsed = parseUrl(url)
     const path = parsed.pathname || '/'

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -9,6 +9,7 @@ export function baseMiddleware({
 }: ViteDevServer): Connect.NextHandleFunction {
   const base = config.base
 
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteBaseMiddleware(req, res, next) {
     const url = req.url!
     const parsed = parseUrl(url)

--- a/packages/vite/src/node/server/middlewares/decodeURI.ts
+++ b/packages/vite/src/node/server/middlewares/decodeURI.ts
@@ -1,6 +1,7 @@
 import { Connect } from 'types/connect'
 
 export function decodeURIMiddleware(): Connect.NextHandleFunction {
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteDecoreURIMiddleware(req, _, next) {
     // #2195
     req.url = decodeURI(req.url!)

--- a/packages/vite/src/node/server/middlewares/decodeURI.ts
+++ b/packages/vite/src/node/server/middlewares/decodeURI.ts
@@ -1,7 +1,7 @@
 import { Connect } from 'types/connect'
 
 export function decodeURIMiddleware(): Connect.NextHandleFunction {
-  return (req, _, next) => {
+  return function viteDecoreURIMiddleware(req, _, next) {
     // #2195
     req.url = decodeURI(req.url!)
 

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -44,6 +44,7 @@ export function errorMiddleware(
   allowNext = false
 ): Connect.ErrorHandleFunction {
   // note the 4 args must be kept for connect to treat this as error middleware
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteErrorMiddleware(err: RollupError, _req, res, next) {
     const msg = buildErrorMessage(err, [
       chalk.red(`Internal server error: ${err.message}`)

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -44,7 +44,7 @@ export function errorMiddleware(
   allowNext = false
 ): Connect.ErrorHandleFunction {
   // note the 4 args must be kept for connect to treat this as error middleware
-  return (err: RollupError, _req, res, next) => {
+  return function viteErrorMiddleware(err: RollupError, _req, res, next) {
     const msg = buildErrorMessage(err, [
       chalk.red(`Internal server error: ${err.message}`)
     ])

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -130,7 +130,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 export function indexHtmlMiddleware(
   server: ViteDevServer
 ): Connect.NextHandleFunction {
-  return async (req, res, next) => {
+  return async function viteIndexHtmlMiddleware(req, res, next) {
     const url = req.url && cleanUrl(req.url)
     // spa-fallback always redirects to /index.html
     if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -130,6 +130,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 export function indexHtmlMiddleware(
   server: ViteDevServer
 ): Connect.NextHandleFunction {
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return async function viteIndexHtmlMiddleware(req, res, next) {
     const url = req.url && cleanUrl(req.url)
     // spa-fallback always redirects to /index.html

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -77,6 +77,7 @@ export function proxyMiddleware(
     })
   }
 
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteProxyMiddleware(req, res, next) {
     const url = req.url!
     for (const context in proxies) {

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -77,7 +77,7 @@ export function proxyMiddleware(
     })
   }
 
-  return (req, res, next) => {
+  return function viteProxyMiddleware(req, res, next) {
     const url = req.url!
     for (const context in proxies) {
       if (

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -25,7 +25,7 @@ const sirvOptions: Options = {
 export function servePublicMiddleware(dir: string): Connect.NextHandleFunction {
   const serve = sirv(dir, sirvOptions)
 
-  return (req, res, next) => {
+  return function viteServePublicMiddleware(req, res, next) {
     // skip import request
     if (isImportRequest(req.url!)) {
       return next()
@@ -40,7 +40,7 @@ export function serveStaticMiddleware(
 ): Connect.NextHandleFunction {
   const serve = sirv(dir, sirvOptions)
 
-  return (req, res, next) => {
+  return function viteServeStaticMiddleware(req, res, next) {
     const url = req.url!
 
     // only serve the file if it's not an html request
@@ -76,7 +76,7 @@ export function serveRawFsMiddleware(): Connect.NextHandleFunction {
   const isWin = os.platform() === 'win32'
   const serveFromRoot = sirv('/', sirvOptions)
 
-  return (req, res, next) => {
+  return function viteServeRawFsMiddleware(req, res, next) {
     let url = req.url!
     // In some cases (e.g. linked monorepos) files outside of root will
     // reference assets that are also out of served root. In such cases

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -25,6 +25,7 @@ const sirvOptions: Options = {
 export function servePublicMiddleware(dir: string): Connect.NextHandleFunction {
   const serve = sirv(dir, sirvOptions)
 
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteServePublicMiddleware(req, res, next) {
     // skip import request
     if (isImportRequest(req.url!)) {
@@ -40,6 +41,7 @@ export function serveStaticMiddleware(
 ): Connect.NextHandleFunction {
   const serve = sirv(dir, sirvOptions)
 
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteServeStaticMiddleware(req, res, next) {
     const url = req.url!
 
@@ -76,6 +78,7 @@ export function serveRawFsMiddleware(): Connect.NextHandleFunction {
   const isWin = os.platform() === 'win32'
   const serveFromRoot = sirv('/', sirvOptions)
 
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteServeRawFsMiddleware(req, res, next) {
     let url = req.url!
     // In some cases (e.g. linked monorepos) files outside of root will

--- a/packages/vite/src/node/server/middlewares/time.ts
+++ b/packages/vite/src/node/server/middlewares/time.ts
@@ -4,6 +4,7 @@ import { createDebugger, prettifyUrl, timeFrom } from '../../utils'
 const logTime = createDebugger('vite:time')
 
 export function timeMiddleware(root: string): Connect.NextHandleFunction {
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteTimeMiddleware(req, res, next) {
     const start = Date.now()
     const end = res.end

--- a/packages/vite/src/node/server/middlewares/time.ts
+++ b/packages/vite/src/node/server/middlewares/time.ts
@@ -4,7 +4,7 @@ import { createDebugger, prettifyUrl, timeFrom } from '../../utils'
 const logTime = createDebugger('vite:time')
 
 export function timeMiddleware(root: string): Connect.NextHandleFunction {
-  return (req, res, next) => {
+  return function viteTimeMiddleware(req, res, next) {
     const start = Date.now()
     const end = res.end
     res.end = (...args: any[]) => {

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -58,7 +58,7 @@ export function transformMiddleware(
     }
   }
 
-  return async (req, res, next) => {
+  return async function viteTransformMiddleware(req, res, next) {
     if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
       return next()
     }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -58,6 +58,7 @@ export function transformMiddleware(
     }
   }
 
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return async function viteTransformMiddleware(req, res, next) {
     if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
       return next()


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

This PR eases debugging of the middlewares by using named functions as middlewares.

### Additional context

`connect` uses the name of the middleware functions for debugging.
When debugging `vite` with `DEBUG=connect:dispatcher`, this PR replaces, _eg_, `connect:dispatcher <anonymous>  : /src/main.ts +0ms` with `connect:dispatcher viteTransformMiddleware  : /src/main.ts +0ms`, which is very useful to know which middleware a request goes through.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
