### PR TITLE
fix(middlewares): prefers originalUrl over url in middlewares

### DIFF
--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -10,7 +10,7 @@ export function baseMiddleware({
   const base = config.base
 
   return (req, res, next) => {
-    const url = req.url!
+    const url = req.originalUrl!
     const parsed = parseUrl(url)
     const path = parsed.pathname || '/'
 

--- a/packages/vite/src/node/server/middlewares/decodeURI.ts
+++ b/packages/vite/src/node/server/middlewares/decodeURI.ts
@@ -3,7 +3,7 @@ import { Connect } from 'types/connect'
 export function decodeURIMiddleware(): Connect.NextHandleFunction {
   return (req, _, next) => {
     // #2195
-    req.url = decodeURI(req.url!)
+    req.url = decodeURI(req.originalUrl!)
 
     // `sirv` middleware uses the req._parsedUrl values to find the file,
     // so decode it all together.

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -131,7 +131,7 @@ export function indexHtmlMiddleware(
   server: ViteDevServer
 ): Connect.NextHandleFunction {
   return async (req, res, next) => {
-    const url = req.url && cleanUrl(req.url)
+    const url = req.originalUrl && cleanUrl(req.originalUrl)
     // spa-fallback always redirects to /index.html
     if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {
       const filename = getHtmlFilename(url, server)

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -59,7 +59,7 @@ export function proxyMiddleware(
 
   if (httpServer) {
     httpServer.on('upgrade', (req, socket, head) => {
-      const url = req.url!
+      const url = req.originalUrl!
       for (const context in proxies) {
         if (url.startsWith(context)) {
           const [proxy, opts] = proxies[context]
@@ -78,7 +78,7 @@ export function proxyMiddleware(
   }
 
   return (req, res, next) => {
-    const url = req.url!
+    const url = req.originalUrl!
     for (const context in proxies) {
       if (
         (context.startsWith('^') && new RegExp(context).test(url)) ||
@@ -91,21 +91,21 @@ export function proxyMiddleware(
           const bypassResult = opts.bypass(req, res, opts)
           if (typeof bypassResult === 'string') {
             req.url = bypassResult
-            debug(`bypass: ${req.url} -> ${bypassResult}`)
+            debug(`bypass: ${url} -> ${bypassResult}`)
             return next()
           } else if (typeof bypassResult === 'object') {
             Object.assign(options, bypassResult)
-            debug(`bypass: ${req.url} use modified options: %O`, options)
+            debug(`bypass: ${url} use modified options: %O`, options)
             return next()
           } else if (bypassResult === false) {
-            debug(`bypass: ${req.url} -> 404`)
+            debug(`bypass: ${url} -> 404`)
             return res.end(404)
           }
         }
 
-        debug(`${req.url} -> ${opts.target || opts.forward}`)
+        debug(`${url} -> ${opts.target || opts.forward}`)
         if (opts.rewrite) {
-          req.url = opts.rewrite(req.url!)
+          req.url = opts.rewrite(url!)
         }
         proxy.web(req, res, options)
         return

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -27,7 +27,7 @@ export function servePublicMiddleware(dir: string): Connect.NextHandleFunction {
 
   return (req, res, next) => {
     // skip import request
-    if (isImportRequest(req.url!)) {
+    if (isImportRequest(req.originalUrl!)) {
       return next()
     }
     serve(req, res, next)
@@ -41,7 +41,7 @@ export function serveStaticMiddleware(
   const serve = sirv(dir, sirvOptions)
 
   return (req, res, next) => {
-    const url = req.url!
+    const url = req.originalUrl!
 
     // only serve the file if it's not an html request
     // so that html requests can fallthrough to our html middleware for
@@ -77,7 +77,7 @@ export function serveRawFsMiddleware(): Connect.NextHandleFunction {
   const serveFromRoot = sirv('/', sirvOptions)
 
   return (req, res, next) => {
-    let url = req.url!
+    let url = req.originalUrl!
     // In some cases (e.g. linked monorepos) files outside of root will
     // reference assets that are also out of served root. In such cases
     // the paths are rewritten to `/@fs/` prefixed paths and must be served by

--- a/packages/vite/src/node/server/middlewares/time.ts
+++ b/packages/vite/src/node/server/middlewares/time.ts
@@ -8,7 +8,7 @@ export function timeMiddleware(root: string): Connect.NextHandleFunction {
     const start = Date.now()
     const end = res.end
     res.end = (...args: any[]) => {
-      logTime(`${timeFrom(start)} ${prettifyUrl(req.url!, root)}`)
+      logTime(`${timeFrom(start)} ${prettifyUrl(req.originalUrl!, root)}`)
       // @ts-ignore
       return end.call(res, ...args)
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR refactors the middlewares to prefer `req.originalUrl` over `req.url`.

### Additional context

As per [Express' documentation](http://expressjs.com/en/api.html#req.originalUrl):
> `[req.originalUrl]` is much like `req.url`; however, it retains the original request URL, allowing you to rewrite `req.url` freely for internal routing purposes. For example, the “mounting” feature of `app.use()` will rewrite `req.url` to strip the mount point.

This PR is necessary to mount the SSR middlewares of Vite as a middleware of an existing app.

In my situation, I am mounting Vite as a middleware to a Nest.js API. Without this PR, HMR, assets and other features are failing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
