### PR TITLE
fix: disable dotfiles serving via /@fs/ by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -441,6 +441,14 @@ export default async ({ command, mode }) => {
   - contains one of the following file
     - `pnpm-workspace.yaml`
 
+### server.fsServe.dotfiles
+
+- **Type:** `string`
+- **Default:** `false`
+
+  Allow requests to dotfiles (files or directories beginning with a .).
+
+
 ## Build Options
 
 ### build.target

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -446,7 +446,7 @@ export default async ({ command, mode }) => {
 - **Type:** `string`
 - **Default:** `false`
 
-  Allow requests to dotfiles (files or directories beginning with a .).
+  Allow requests to dotfiles (files or directories beginning with a `.`).
 
 ## Build Options
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -448,7 +448,6 @@ export default async ({ command, mode }) => {
 
   Allow requests to dotfiles (files or directories beginning with a .).
 
-
 ## Build Options
 
 ### build.target

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -136,7 +136,7 @@ export interface FileSystemServeOptions {
   root?: string
 
   /**
-   * Allow requests to dotfiles (files or directories beginning with a .)
+   * Allow requests to dotfiles (files or directories beginning with a `.`)
    *
    * @default false
    */

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -134,6 +134,13 @@ export interface FileSystemServeOptions {
    * Will try to search up for workspace root by default.
    */
   root?: string
+
+  /**
+   * Allow requests to dotfiles (files or directories beginning with a .)
+   *
+   * @default false
+   */
+  dotfiles?: boolean
 }
 
 /**

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -98,8 +98,7 @@ export function serveRawFsMiddleware(
       // regex ported from sirv
       // https://github.com/lukeed/sirv/blob/ede9189b6c586cd4697e0ffb16671515fdefecde/packages/sirv/index.js#L145
       if (!dotfiles && /(^\.|[\\+|\/+]\.)/.test(url)) {
-        res.statusCode = 404
-        res.end()
+        next()
         return
       }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Continue from #2850, disable dotfiles serving by default to father enhance the security. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
