### PR TITLE
fix: warning for vite/dynamic-import-polyfill

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -3,6 +3,9 @@ import { Plugin } from '../plugin'
 
 export const polyfillId = 'vite/dynamic-import-polyfill'
 
+/**
+ * @deprecated 
+ */
 export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:dynamic-import-polyfill',

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -1,3 +1,23 @@
-throw new Error(
-  `Vite's dynamic import polyfill has been removed. Please install and import https://github.com/GoogleChromeLabs/dynamic-import-polyfill instead.`
-)
+import { ResolvedConfig } from '..'
+import { Plugin } from '../plugin'
+
+export const polyfillId = 'vite/dynamic-import-polyfill'
+
+export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
+  return {
+    name: 'vite:dynamic-import-polyfill',
+    resolveId(id) {
+      if (id === polyfillId) {
+        return id
+      }
+    },
+    load(id) {
+      if (id === polyfillId) {
+        config.logger.warn(
+          `\nVite's dynamic import polyfill has been removed, stop importing 'vite/dynamic-import-polyfill'`
+        )
+        return ''
+      }
+    }
+  }
+}

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -17,7 +17,7 @@ export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
     load(id) {
       if (id === polyfillId) {
         config.logger.warn(
-          `\nVite's dynamic import polyfill has been removed, stop importing 'vite/dynamic-import-polyfill'`
+          `\n'vite/dynamic-import-polyfill' is no longer needed, refer to https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md#230-2021-05-10`
         )
         return ''
       }

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -10,6 +10,7 @@ import { assetPlugin } from './asset'
 import { clientInjectionsPlugin } from './clientInjections'
 import { htmlInlineScriptProxyPlugin } from './html'
 import { wasmPlugin } from './wasm'
+import { dynamicImportPolyfillPlugin } from './dynamicImportPolyfill'
 import { webWorkerPlugin } from './worker'
 import { preAliasPlugin } from './preAlias'
 import { definePlugin } from './define'
@@ -30,6 +31,7 @@ export async function resolvePlugins(
     isBuild ? null : preAliasPlugin(),
     aliasPlugin({ entries: config.resolve.alias }),
     ...prePlugins,
+    dynamicImportPolyfillPlugin(config),
     resolvePlugin({
       ...config.resolve,
       root: config.root,


### PR DESCRIPTION
### Description

vite/dynamic-import-polyfill was removed in #2976. This PR re-instates the virtual file plugin with a warning and call to action to stop importing the polyfill. This avoids a hard error and fixes vitepress. The plugin can be removed in a few minors or in the next major.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other