### PR TITLE
fix(css): fix sass importer error

### DIFF
--- a/packages/playground/css/sass.scss
+++ b/packages/playground/css/sass.scss
@@ -1,6 +1,8 @@
 @import '@/nested'; // alias + custom index resolving -> /nested/_index.scss
 @import '@/nested/partial'; // sass convention: omitting leading _ for partials
 @import 'css-dep'; // package w/ sass entry points
+@import "virtual-dep"; // virtual file added through importer
+
 
 .sass {
   /* injected via vite.config.js */

--- a/packages/playground/css/sass.scss
+++ b/packages/playground/css/sass.scss
@@ -1,7 +1,7 @@
 @import '@/nested'; // alias + custom index resolving -> /nested/_index.scss
 @import '@/nested/partial'; // sass convention: omitting leading _ for partials
 @import 'css-dep'; // package w/ sass entry points
-@import "virtual-dep"; // virtual file added through importer
+@import 'virtual-dep'; // virtual file added through importer
 
 
 .sass {

--- a/packages/playground/css/vite.config.js
+++ b/packages/playground/css/vite.config.js
@@ -32,7 +32,10 @@ module.exports = {
     },
     preprocessorOptions: {
       scss: {
-        additionalData: `$injectedColor: orange;`
+        additionalData: `$injectedColor: orange;`,
+        importer(url) {
+          if (url === 'virtual-dep') return { contents: '' }
+        }
       },
       styl: {
         additionalData: `$injectedColor ?= orange`,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -166,13 +166,11 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       //       return urlToBuiltUrl(url, importer || id, config, this)
       //     }
 
-      const { code: css, modules, deps } = await compileCSS(
-        id,
-        raw,
-        config,
-        urlReplacer,
-        atImportResolvers
-      )
+      const {
+        code: css,
+        modules,
+        deps
+      } = await compileCSS(id, raw, config, urlReplacer, atImportResolvers)
       if (modules) {
         moduleCache.set(id, modules)
       }
@@ -906,20 +904,21 @@ function loadPreprocessor(lang: PreprocessLang, root: string): any {
 // .scss/.sass processor
 const scss: StylePreprocessor = async (source, root, options, resolvers) => {
   const render = loadPreprocessor(PreprocessLang.sass, root).render
+  const internalImporter: Sass.Importer = (url, importer, done) => {
+    resolvers.sass(url, importer).then((resolved) => {
+      if (resolved) {
+        rebaseUrls(resolved, options.filename, options.alias).then(done)
+      } else {
+        done(null)
+      }
+    })
+  }
   const finalOptions: Sass.Options = {
     ...options,
     data: await getSource(source, options.filename, options.additionalData),
     file: options.filename,
     outFile: options.filename,
-    importer(url, importer, done) {
-      resolvers.sass(url, importer).then((resolved) => {
-        if (resolved) {
-          rebaseUrls(resolved, options.filename, options.alias).then(done)
-        } else {
-          done(null)
-        }
-      })
-    }
+    importer: [internalImporter].concat(options.importer)
   }
 
   try {


### PR DESCRIPTION
close #3180

<!-- Thank you for contributing! -->

### Description

This PR Solves #3180, adding a simple mechanism to enable the usage of [importer](https://github.com/sass/node-sass#importer--v200---experimental) through `preprocessorOptions` in css configuration options.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
