### PR TITLE
feat: export internal utils

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -5,7 +5,7 @@ export { optimizeDeps } from './optimizer'
 export { send } from './server/send'
 export { createLogger } from './logger'
 export { resolvePackageData, resolvePackageEntry } from './plugins/resolve'
-export { normalizePath } from './utils'
+export * from './utils'
 
 // additional types
 export type {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Some internal utils of vite could be useful for tools that build on top of vite.

For example:

- we sometimes need to use `injectQuery` to handle url query manually
- since vite 2.3.0, we need to use `lookupFile` to determine the `fsServe.root`
- ...

Not sure if it's OK to export all the utils, or we should only export `injectQuery` & `lookupFile` as needed?

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
