### PR TITLE
fix: disable fsServe restrictions by default

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -432,6 +432,7 @@ export default async ({ command, mode }) => {
 
 ### server.fsServe.strict
 
+- **Experimental**
 - **Type:** `boolean`
 - **Default:** `false` (will change to `true` in future versions)
 
@@ -439,6 +440,7 @@ export default async ({ command, mode }) => {
 
 ### server.fsServe.root
 
+- **Experimental**
 - **Type:** `string`
 
   Restrict files that could be served via `/@fs/`. When `server.fsServe.strict` is set to `true`, accessing files outside this directory will result in a 403.

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -430,16 +430,36 @@ export default async ({ command, mode }) => {
 
   File system watcher options to pass on to [chokidar](https://github.com/paulmillr/chokidar#api).
 
+### server.fsServe.strict
+
+- **Type:** `boolean`
+- **Default:** `false` (will change to `true` in future versions)
+
+  Restrict serving files outside of workspace root.
+
 ### server.fsServe.root
 
 - **Type:** `string`
 
-  Restrict files that could be served via `/@fs/`. Accessing files outside this directory will result in a 403.
+  Restrict files that could be served via `/@fs/`. When `server.fsServe.strict` is set to `true`, accessing files outside this directory will result in a 403.
   
   Vite will search for the root of the potential workspace and use it as default. A valid workspace met the following conditions, otherwise will fallback to the [project root](/guide/#index-html-and-project-root).
   - contains `workspaces` field in `package.json`
   - contains one of the following file
     - `pnpm-workspace.yaml`
+
+  Accepts a path to specify the custom workspace root. Could be a absolute path or a path relative to [project root](/guide/#index-html-and-project-root). For example
+
+  ```js
+  export default {
+    server: {
+      fsServe: {
+        // Allow serving files from one level up to the project root 
+        root: '..' 
+      }
+    }
+  }
+  ```
 
 ## Build Options
 

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -9,6 +9,7 @@ export type LogLevel = LogType | 'silent'
 export interface Logger {
   info(msg: string, options?: LogOptions): void
   warn(msg: string, options?: LogOptions): void
+  warnOnce(msg: string, options?: LogOptions): void
   error(msg: string, options?: LogOptions): void
   clearScreen(type: LogType): void
   hasWarned: boolean
@@ -87,6 +88,8 @@ export function createLogger(
     }
   }
 
+  const warnedMessages = new Set<string>()
+
   const logger: Logger = {
     hasWarned: false,
     info(msg, opts) {
@@ -95,6 +98,12 @@ export function createLogger(
     warn(msg, opts) {
       logger.hasWarned = true
       output('warn', msg, opts)
+    },
+    warnOnce(msg, opts) {
+      if (warnedMessages.has(msg)) return
+      logger.hasWarned = true
+      output('warn', msg, opts)
+      warnedMessages.add(msg)
     },
     error(msg, opts) {
       logger.hasWarned = true

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -133,10 +133,21 @@ export interface ResolvedServerOptions extends ServerOptions {
 
 export interface FileSystemServeOptions {
   /**
+   * Strictly restrict file accessing outside of allowing paths.
+   *
+   * Default to false at this moment, will enabled by default in the future versions.
+   * @expiremental
+   * @default false
+   */
+  strict?: boolean
+
+  /**
    * Restrict accessing files outside this directory will result in a 403.
    *
    * Accepts absolute path or a path relative to project root.
    * Will try to search up for workspace root by default.
+   *
+   * @expiremental
    */
   root?: string
 }
@@ -692,9 +703,14 @@ export function resolveServerOptions(
   raw?: ServerOptions
 ): ResolvedServerOptions {
   const server = raw || {}
-  const serverRoot = normalizePath(
+  const fsServeRoot = normalizePath(
     path.resolve(root, server.fsServe?.root || searchForWorkspaceRoot(root))
   )
-  server.fsServe = { root: serverRoot }
+  // TODO: make strict by default
+  const fsServeStrict = server.fsServe?.strict ?? false
+  server.fsServe = {
+    root: fsServeRoot,
+    strict: fsServeStrict
+  }
   return server as ResolvedServerOptions
 }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -75,7 +75,7 @@ export async function transformRequest(
     // as string
     try {
       if (!options.ssr) {
-        ensureServingAccess(file, config.server.fsServe.root)
+        ensureServingAccess(file, config.server.fsServe, config.logger)
       }
       code = await fs.readFile(file, 'utf-8')
       isDebug && debugLoad(`${timeFrom(loadStart)} [fs] ${prettyUrl}`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

As discussions with the team, we decided to postpone the `fsServe` restrictions to `v2.4.0` or later when we find the solutions to solve a few issues and make the logic more robust and well tested.

This PR adding a new options `server.fsServe.strict` and set the default to `false`, and disabling the restrictions by default. In the future versions of Vite, we will change `server.fsServe.strict` to `true` when the restrictions issue are resolved.

You can still opt-in this security change by 

```ts
export default {
  server: {
    fsServe: {
      strict: true
    }
  }
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
