### PR TITLE
fix(server): hostname defaults to localhost, fix #3355

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -129,7 +129,7 @@ export function printServerUrls(
         const type = detail.address.includes('127.0.0.1')
           ? 'Local:   '
           : 'Network: '
-        const host = detail.address
+        const host = detail.address.replace('127.0.0.1', 'localhost')
         const url = `${protocol}://${host}:${chalk.bold(port)}${base}`
         return `  > ${type} ${chalk.cyan(url)}`
       })

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -10,6 +10,7 @@ import { openBrowser } from './server/openBrowser'
 import corsMiddleware from 'cors'
 import { proxyMiddleware } from './server/middlewares/proxy'
 import { printServerUrls } from './logger'
+import { defaultHostname } from './utils'
 
 export async function preview(
   config: ResolvedConfig,
@@ -69,7 +70,11 @@ export async function preview(
 
     if (options.open) {
       const path = typeof options.open === 'string' ? options.open : base
-      openBrowser(`${protocol}://${hostname}:${port}${path}`, true, logger)
+      openBrowser(
+        `${protocol}://${defaultHostname(hostname)}:${port}${path}`,
+        true,
+        logger
+      )
     }
   })
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -51,6 +51,7 @@ import { resolveSSRExternal } from '../ssr/ssrExternal'
 import { ssrRewriteStacktrace } from '../ssr/ssrStacktrace'
 import { createMissingImporterRegisterFn } from '../optimizer/registerMissing'
 import { printServerUrls } from '../logger'
+import { defaultHostname } from '../utils'
 import { searchForWorkspaceRoot } from './searchRoot'
 
 export interface ServerOptions {
@@ -640,7 +641,7 @@ async function startServer(
       if (options.open && !isRestart) {
         const path = typeof options.open === 'string' ? options.open : base
         openBrowser(
-          `${protocol}://${hostname}:${port}${path}`,
+          `${protocol}://${defaultHostname(hostname)}:${port}${path}`,
           true,
           server.config.logger
         )

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -465,7 +465,7 @@ export function unique<T>(arr: T[]): T[] {
   return Array.from(new Set(arr))
 }
 
-export function defaultHostname(host: string | undefined) {
+export function defaultHostname(host: string | undefined): string {
   if (
     host === '127.0.0.1' ||
     host === '0.0.0.0' ||

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -464,3 +464,16 @@ export function combineSourcemaps(
 export function unique<T>(arr: T[]): T[] {
   return Array.from(new Set(arr))
 }
+
+export function defaultHostname(host: string | undefined) {
+  if (
+    host === '127.0.0.1' ||
+    host === '0.0.0.0' ||
+    host === '::' ||
+    host === undefined
+  ) {
+    return 'localhost'
+  } else {
+    return host
+  }
+}


### PR DESCRIPTION
### Description

Fix #3355

After https://github.com/vitejs/vite/pull/2977, we lost the hostname defaulting to localhost for `'127.0.0.1'` and `'0.0.0.0'`
 https://github.com/vitejs/vite/blob/c374a5405050a6ed9013082027774fa275c2d324/packages/vite/src/node/server/index.ts#L536

This PR adds that logic back, also including `host === undefined` and `'::'` that should be treated equally to '0.0.0.0'

The reported URL in the console also replaces `'127.0.0.1'` by localhost now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
