### PR TITLE
fix(server): hostname defaults to localhost, fix #3355

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -3,6 +3,7 @@
 import chalk from 'chalk'
 import readline from 'readline'
 import os from 'os'
+import { Hostname } from './utils'
 
 export type LogType = 'error' | 'warn' | 'info'
 export type LogLevel = LogType | 'silent'
@@ -111,16 +112,18 @@ export function createLogger(
 }
 
 export function printServerUrls(
-  hostname: string | undefined,
+  hostname: Hostname,
   protocol: string,
   port: number,
   base: string,
   info: Logger['info']
 ): void {
-  if (hostname === '127.0.0.1') {
-    const url = `${protocol}://localhost:${chalk.bold(port)}${base}`
+  if (hostname.host === '127.0.0.1') {
+    const url = `${protocol}://${hostname.name}:${chalk.bold(port)}${base}`
     info(`  > Local: ${chalk.cyan(url)}`)
-    info(`  > Network: ${chalk.dim('use `--host` to expose')}`)
+    if (hostname.name !== '127.0.0.1') {
+      info(`  > Network: ${chalk.dim('use `--host` to expose')}`)
+    }
   } else {
     Object.values(os.networkInterfaces())
       .flatMap((nInterface) => nInterface ?? [])
@@ -129,7 +132,7 @@ export function printServerUrls(
         const type = detail.address.includes('127.0.0.1')
           ? 'Local:   '
           : 'Network: '
-        const host = detail.address.replace('127.0.0.1', 'localhost')
+        const host = detail.address.replace('127.0.0.1', hostname.name)
         const url = `${protocol}://${host}:${chalk.bold(port)}${base}`
         return `  > ${type} ${chalk.cyan(url)}`
       })

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -129,7 +129,7 @@ export function printServerUrls(
         const type = detail.address.includes('127.0.0.1')
           ? 'Local:   '
           : 'Network: '
-        const host = detail.address
+        const host = detail.address.replace('127.0.0.1', 'localhost')
         const url = `${protocol}://${host}:${chalk.bold(port)}${base}`
         return `  > ${type} ${chalk.cyan(url)}`
       })

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -10,7 +10,7 @@ import { openBrowser } from './server/openBrowser'
 import corsMiddleware from 'cors'
 import { proxyMiddleware } from './server/middlewares/proxy'
 import { printServerUrls } from './logger'
-import { defaultHostname } from './utils'
+import { resolveHostname } from './utils'
 
 export async function preview(
   config: ResolvedConfig,
@@ -46,21 +46,12 @@ export async function preview(
   )
 
   const options = config.server
-  let hostname: string | undefined
-  if (options.host === undefined || options.host === 'localhost') {
-    // Use a secure default
-    hostname = '127.0.0.1'
-  } else if (options.host === true) {
-    // The user probably passed --host in the CLI, without arguments
-    hostname = undefined // undefined typically means 0.0.0.0 or :: (listen on all IPs)
-  } else {
-    hostname = options.host as string
-  }
+  let hostname = resolveHostname(options.host)
   const protocol = options.https ? 'https' : 'http'
   const logger = config.logger
   const base = config.base
 
-  httpServer.listen(port, hostname, () => {
+  httpServer.listen(port, hostname.host, () => {
     logger.info(
       chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
         chalk.green(` build preview server running at:\n`)
@@ -70,11 +61,7 @@ export async function preview(
 
     if (options.open) {
       const path = typeof options.open === 'string' ? options.open : base
-      openBrowser(
-        `${protocol}://${defaultHostname(hostname)}:${port}${path}`,
-        true,
-        logger
-      )
+      openBrowser(`${protocol}://${hostname.name}:${port}${path}`, true, logger)
     }
   })
 }

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -10,6 +10,7 @@ import { openBrowser } from './server/openBrowser'
 import corsMiddleware from 'cors'
 import { proxyMiddleware } from './server/middlewares/proxy'
 import { printServerUrls } from './logger'
+import { defaultHostname } from './utils'
 
 export async function preview(
   config: ResolvedConfig,
@@ -69,7 +70,11 @@ export async function preview(
 
     if (options.open) {
       const path = typeof options.open === 'string' ? options.open : base
-      openBrowser(`${protocol}://${hostname}:${port}${path}`, true, logger)
+      openBrowser(
+        `${protocol}://${defaultHostname(hostname)}:${port}${path}`,
+        true,
+        logger
+      )
     }
   })
 }

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -46,7 +46,7 @@ export async function preview(
   )
 
   const options = config.server
-  let hostname = resolveHostname(options.host)
+  const hostname = resolveHostname(options.host)
   const protocol = options.https ? 'https' : 'http'
   const logger = config.logger
   const base = config.base

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -51,6 +51,7 @@ import { resolveSSRExternal } from '../ssr/ssrExternal'
 import { ssrRewriteStacktrace } from '../ssr/ssrStacktrace'
 import { createMissingImporterRegisterFn } from '../optimizer/registerMissing'
 import { printServerUrls } from '../logger'
+import { defaultHostname } from '../utils'
 import { searchForWorkspaceRoot } from './searchRoot'
 
 export interface ServerOptions {
@@ -640,7 +641,7 @@ async function startServer(
       if (options.open && !isRestart) {
         const path = typeof options.open === 'string' ? options.open : base
         openBrowser(
-          `${protocol}://${hostname}:${port}${path}`,
+          `${protocol}://${defaultHostname(hostname)}:${port}${path}`,
           true,
           server.config.logger
         )

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -490,7 +490,7 @@ export function resolveHostname(
     host = optionsHost as string
   }
 
-  // Set host name to localhost when possible if the user didn't explicitely asked for '127.0.0.1'
+  // Set host name to localhost when possible, unless the user explicitly asked for '127.0.0.1'
   const name =
     (optionsHost !== '127.0.0.1' && host === '127.0.0.1') ||
     host === '0.0.0.0' ||

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -477,3 +477,40 @@ export function defaultHostname(host: string | undefined) {
     return host
   }
 }
+
+export interface Hostname {
+  // undefined sets the default behaviour of server.listen
+  host: string | undefined
+  // resolve to localhost when possible
+  name: string
+}
+
+export function resolveHostname(
+  optionsHost: string | boolean | undefined
+): Hostname {
+  let host: string | undefined
+  if (
+    optionsHost === undefined ||
+    optionsHost === false ||
+    optionsHost === 'localhost'
+  ) {
+    // Use a secure default
+    host = '127.0.0.1'
+  } else if (optionsHost === true) {
+    // If passed --host in the CLI without arguments
+    host = undefined // undefined typically means 0.0.0.0 or :: (listen on all IPs)
+  } else {
+    host = optionsHost as string
+  }
+
+  // Set host name to localhost when possible if the user didn't explicitely asked for '127.0.0.1'
+  const name =
+    (optionsHost !== '127.0.0.1' && host === '127.0.0.1') ||
+    host === '0.0.0.0' ||
+    host === '::' ||
+    host === undefined
+      ? 'localhost'
+      : host
+
+  return { host, name }
+}

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -465,19 +465,6 @@ export function unique<T>(arr: T[]): T[] {
   return Array.from(new Set(arr))
 }
 
-export function defaultHostname(host: string | undefined) {
-  if (
-    host === '127.0.0.1' ||
-    host === '0.0.0.0' ||
-    host === '::' ||
-    host === undefined
-  ) {
-    return 'localhost'
-  } else {
-    return host
-  }
-}
-
 export interface Hostname {
   // undefined sets the default behaviour of server.listen
   host: string | undefined

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -487,7 +487,7 @@ export function resolveHostname(
     // If passed --host in the CLI without arguments
     host = undefined // undefined typically means 0.0.0.0 or :: (listen on all IPs)
   } else {
-    host = optionsHost as string
+    host = optionsHost
   }
 
   // Set host name to localhost when possible, unless the user explicitly asked for '127.0.0.1'

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -464,3 +464,16 @@ export function combineSourcemaps(
 export function unique<T>(arr: T[]): T[] {
   return Array.from(new Set(arr))
 }
+
+export function defaultHostname(host: string | undefined) {
+  if (
+    host === '127.0.0.1' ||
+    host === '0.0.0.0' ||
+    host === '::' ||
+    host === undefined
+  ) {
+    return 'localhost'
+  } else {
+    return host
+  }
+}


### PR DESCRIPTION
### Description

Rework of https://github.com/vitejs/vite/pull/3382, avoiding replacing `'127.0.0.1'` by `'localhost'` if this was defined by the user using `host`

It also fixes `options.host === false`.

The hint to use `host` in the console is not shown if the user sets `127.0.0.1` by hand.

---- 

Fix #3355

After https://github.com/vitejs/vite/pull/2977, we lost the hostname defaulting to localhost for `'127.0.0.1'` and `'0.0.0.0'`
 https://github.com/vitejs/vite/blob/c374a5405050a6ed9013082027774fa275c2d324/packages/vite/src/node/server/index.ts#L536

This PR adds that logic back, also including `host === undefined` and `'::'` that should be treated equally to '0.0.0.0'

The reported URL in the console also replaces `'127.0.0.1'` by localhost now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

--

Replaces + closes #3382
