### PR TITLE
fix: make dev file loader behavior same as rollup

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -232,6 +232,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:css-post',
 
+    load(id) {
+      if (isDirectCSSRequest(id)) {
+        return fs.readFileSync(cleanUrl(id), 'utf-8')
+      }
+    },
+
     transform(css, id, ssr) {
       if (!cssLangRE.test(id) || commonjsProxyRE.test(id)) {
         return

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -6,6 +6,7 @@ import { fileToUrl } from './asset'
 import { cleanUrl, injectQuery } from '../utils'
 import Rollup from 'rollup'
 import { ENV_PUBLIC_PATH } from '../constants'
+import fs from 'fs'
 
 function parseWorkerRequest(id: string): ParsedUrlQuery | null {
   const { search } = parseUrl(id)
@@ -24,8 +25,9 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:worker',
 
     load(id) {
-      if (isBuild && parseWorkerRequest(id)?.worker != null) {
-        return ''
+      const query = parseWorkerRequest(id)
+      if (query && (query.worker != null || query[WorkerFileId] != null)) {
+        return fs.readFileSync(cleanUrl(id), 'utf-8')
       }
     },
 

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -67,6 +67,7 @@ export function errorMiddleware(
         res.statusCode = 403
         res.write(renderErrorHTML(err.message))
         res.end()
+        return
       }
       res.statusCode = 500
       res.end()

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -148,6 +148,11 @@ export function removeTimestampQuery(url: string): string {
   return url.replace(timestampRE, '').replace(trailingSeparatorRE, '')
 }
 
+const versionRE = /\bv=\w{8}&?\b/
+export function removeVersionQuery(url: string): string {
+  return url.replace(versionRE, '').replace(trailingSeparatorRE, '')
+}
+
 export async function asyncReplace(
   input: string,
   re: RegExp,


### PR DESCRIPTION
related issue: #3255

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The rollup default file loader is not handle the query of id, if some importee has query, rollup will throw error. But vite dev server remove query and read file, so the id can be resolved by dev. It caused inconsistence of dev and build. So I open this pr to fix this. 

This maybe will break some users project which worked great before, but i think we should do it. Hope get some advice from you, thanks.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
