### PR TITLE
fix: avoid css leaking into emitted javascript

### DIFF
--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -30,11 +30,18 @@ test('linked css', async () => {
 })
 
 test('css import from js', async () => {
+  const importedNoVars = await page.$('.imported-no-vars')
   const imported = await page.$('.imported')
   const atImport = await page.$('.imported-at-import')
 
+  expect(await getColor(importedNoVars)).toBe('magenta')
   expect(await getColor(imported)).toBe('green')
   expect(await getColor(atImport)).toBe('purple')
+
+  editFile('imported-without-variable.css', (code) =>
+    code.replace('color: magenta', 'color: cyan')
+  )
+  await untilUpdated(() => getColor(imported), 'cyan')
 
   editFile('imported.css', (code) => code.replace('color: green', 'color: red'))
   await untilUpdated(() => getColor(imported), 'red')

--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -41,7 +41,7 @@ test('css import from js', async () => {
   editFile('imported-without-variable.css', (code) =>
     code.replace('color: magenta', 'color: cyan')
   )
-  await untilUpdated(() => getColor(imported), 'cyan')
+  await untilUpdated(() => getColor(importedNoVars), 'cyan')
 
   editFile('imported.css', (code) => code.replace('color: green', 'color: red'))
   await untilUpdated(() => getColor(imported), 'red')

--- a/packages/playground/css/imported-without-variable.css
+++ b/packages/playground/css/imported-without-variable.css
@@ -1,0 +1,3 @@
+.imported-no-vars {
+  color: magenta;
+}

--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -6,6 +6,10 @@
   <p class="linked">&lt;link&gt;: This should be blue</p>
   <p class="linked-at-import">@import in &lt;link&gt;: This should be red</p>
 
+  <p class="imported-no-vars">
+    import from js, no vars: This should be magenta
+  </p>
+
   <p class="imported">import from js: This should be green</p>
   <p class="imported-at-import">
     @import in import from js: This should be purple

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -1,3 +1,5 @@
+import './imported-without-variable.css'
+
 import css from './imported.css'
 text('.imported-css', css)
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -245,7 +245,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         } else {
           // server only
           if (ssr) {
-            return modulesCode || `export default ${JSON.stringify(null)}`
+            return modulesCode || `export default null`
           }
           return [
             `import { updateStyle, removeStyle } from ${JSON.stringify(
@@ -267,7 +267,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       styles.set(id, css)
 
       return {
-        code: modulesCode || `export default ${JSON.stringify(null)}`,
+        code: modulesCode || `export default null`,
         map: { mappings: '' },
         // avoid the css module from being tree-shaken so that we can retrieve
         // it in renderChunk()

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -245,7 +245,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         } else {
           // server only
           if (ssr) {
-            return modulesCode || `export default ${JSON.stringify(css)}`
+            return modulesCode || `export default ${JSON.stringify(null)}`
           }
           return [
             `import { updateStyle, removeStyle } from ${JSON.stringify(
@@ -267,7 +267,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       styles.set(id, css)
 
       return {
-        code: modulesCode || `export default ${JSON.stringify(css)}`,
+        code: modulesCode || `export default ${JSON.stringify(null)}`,
         map: { mappings: '' },
         // avoid the css module from being tree-shaken so that we can retrieve
         // it in renderChunk()

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -245,7 +245,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         } else {
           // server only
           if (ssr) {
-            return modulesCode || `export default null`
+            return modulesCode || `export default ''`
           }
           return [
             `import { updateStyle, removeStyle } from ${JSON.stringify(
@@ -267,7 +267,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       styles.set(id, css)
 
       return {
-        code: modulesCode || `export default null`,
+        code: modulesCode || `export default ''`,
         map: { mappings: '' },
         // avoid the css module from being tree-shaken so that we can retrieve
         // it in renderChunk()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Even with styles being emitted to their own .css files, their source code is present into the emitted .js files (both in regular and ssr modes) into a variable that is never used in the resulting source code.

It appears that this was added to prevent the css module from being "tree shaken" out of the compilation in this point of code so it can be used afterwards in the renderChunk hook. 

https://github.com/vitejs/vite/blob/4a955bcbdc3f2221f224dfd68d4fc1ecc4d9a90c/packages/vite/src/node/plugins/css.ts#L166-L175

Now, given that it doesn't appear to be used anywhere, it may not be necessary for the actual css code to be available in the variable, a simple "null" value would be enough.

### Additional context

Fixes #3397. 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
