### PR TITLE
fix(plugin-legacy): turn off babel loose mode

### DIFF
--- a/packages/playground/legacy/__tests__/legacy.spec.ts
+++ b/packages/playground/legacy/__tests__/legacy.spec.ts
@@ -7,3 +7,8 @@ test('should work', async () => {
 test('import.meta.env.LEGACY', async () => {
   expect(await page.textContent('#env')).toMatch(isBuild ? 'true' : 'false')
 })
+
+// https://github.com/vitejs/vite/issues/3400
+test('transpiles down iterators correctly', async () => {
+  expect(await page.textContent('#iterators')).toMatch('hello')
+})

--- a/packages/playground/legacy/index.html
+++ b/packages/playground/legacy/index.html
@@ -1,3 +1,4 @@
 <h1 id="app"></h1>
 <div id="env"></div>
+<div id="iterators"></div>
 <script type="module" src="./main.js"></script>

--- a/packages/playground/legacy/main.js
+++ b/packages/playground/legacy/main.js
@@ -15,3 +15,9 @@ if (import.meta.env.LEGACY) {
 }
 
 document.getElementById('env').textContent = `is legacy: ${isLegacy}`
+
+// Iterators
+
+document.getElementById('iterators').textContent = [...new Set(['hello'])].join(
+  ''
+)

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -248,7 +248,7 @@ function viteLegacyPlugin(options = {}) {
               targets,
               modules: false,
               bugfixes: true,
-              loose: true,
+              loose: false,
               useBuiltIns: needPolyfills ? 'usage' : false,
               corejs: needPolyfills
                 ? { version: 3, proposals: false }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #3400, fixes #3076

Babel's loose mode causes some issues with iterators, for example converting sets to arrays, or other spread operations.

Here's an example: [loose mode](https://babeljs.io/repl#?browsers=&build=&builtIns=false&corejs=3.6&spec=false&loose=true&code_lz=NoOjDsFMHcAIGVIBcAUBKAugKCA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=&version=7.14.2&externalPlugins=), [without loose mode](https://babeljs.io/repl#?browsers=&build=&builtIns=false&corejs=3.6&spec=false&loose=false&code_lz=NoOjDsFMHcAIGVIBcAUBKAugKCA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=&version=7.14.2&externalPlugins=)

Loose mode converts `[...new Set()]` to `[].concat(new Set())`, which is not the same thing. It does usually generate smaller, perhaps more performant bundles, but could break code in surprising ways. For example in the linked issue, which runs into this problem on [this Vue code](https://github.com/vuejs/vue-next/blob/f3d30363ec33ce6b620f67e4cb8dbf8b86cef583/packages/runtime-core/src/scheduler.ts#L154-L160)

I would propose adding this as an opt-in flag if users request it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Discussions: babel/babel#7958, babel/babel#6649


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
