### PR TITLE
fix: skip fs fallback for out of root urls, fix #3364

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -109,16 +109,24 @@ export function serveRawFsMiddleware(
   }
 }
 
+export function isFileAccessAllowed(
+  url: string,
+  { root, strict }: Required<FileSystemServeOptions>
+): boolean {
+  return !strict || normalizePath(url).startsWith(root + path.posix.sep)
+}
+
 export function ensureServingAccess(
   url: string,
-  { root, strict }: Required<FileSystemServeOptions>,
+  serveOptions: Required<FileSystemServeOptions>,
   logger: Logger
 ): void {
+  const { strict, root } = serveOptions
   // TODO: early return, should remove once we polished the restriction logic
   if (!strict) return
 
-  const normalizedUrl = normalizePath(url)
-  if (!normalizedUrl.startsWith(root + path.posix.sep)) {
+  if (!isFileAccessAllowed(url, serveOptions)) {
+    const normalizedUrl = normalizePath(url)
     if (strict) {
       throw new AccessRestrictedError(
         `The request url "${normalizedUrl}" is outside of vite dev server root "${root}". 


### PR DESCRIPTION
### Description

Fix #3364, and other issues reported that were trying to access `/service-worker.js`.

This PR reworks the fs fallback check and skips it instead of failing with a security error if the URL results in a file access that is not allowed (ie out of workspace root for the moment, but later it could mean that it is present in a blocklist).

This change only applies when the user sets `server.fsServe.strict` to `true`

### Additional context

The `isFileAccessAllowed` function may later contain more logic related to whitelist/blocklist so it is good that is already separated.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
