### PR TITLE
test: fsServe strict mode during serve

### DIFF
--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -75,7 +75,10 @@ beforeAll(async () => {
             usePolling: true,
             interval: 100
           },
-          host: true
+          host: true,
+          fsServe: {
+            strict: !isBuildTest
+          }
         },
         build: {
           // skip transpilation during tests to make it faster


### PR DESCRIPTION
### Description

Switch to fsServe strict mode during dev. I left build without strict mode to also get testing for non-strict mode. We could also switch everything to strict mode later.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
