### PR TITLE
fix: restore dynamic-import-polyfill

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -480,6 +480,23 @@ export default async ({ command, mode }) => {
 
   Note the build will fail if the code contains features that cannot be safely transpiled by esbuild. See [esbuild docs](https://esbuild.github.io/content-types/#javascript) for more details.
 
+### build.polyfillDynamicImport
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+  Whether to automatically inject [dynamic import polyfill](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
+
+  If set to true, the polyfill is auto injected into the proxy module of each `index.html` entry. If the build is configured to use a non-html custom entry via `build.rollupOptions.input`, then it is necessary to manually import the polyfill in your custom entry:
+
+  ```js
+  import 'vite/dynamic-import-polyfill'
+  ```
+
+  When using [`@vite-js/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy), the plugin sets this option to `true` automatically.
+
+  Note: the polyfill does **not** apply to [Library Mode](/guide/build#library-mode). If you need to support browsers without native dynamic import, you should probably avoid using it in your library.
+
 ### build.outDir
 
 - **Type:** `string`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -493,7 +493,7 @@ export default async ({ command, mode }) => {
   import 'vite/dynamic-import-polyfill'
   ```
 
-  When using [`@vite-js/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy), the plugin sets this option to `true` automatically.
+  When using [`@vitejs/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy), the plugin sets this option to `true` automatically.
 
   Note: the polyfill does **not** apply to [Library Mode](/guide/build#library-mode). If you need to support browsers without native dynamic import, you should probably avoid using it in your library.
 

--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -20,6 +20,13 @@ Or you can follow these steps to configure it manually:
    }
    ```
 
+   If you use [`@vite-js/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) or manually enable the [`build.dynamicImportPolyfill` option](/config/#build-polyfilldynamicimport), remember to add the [dynamic import polyfill](/config/#build-polyfilldynamicimport) to your entry, since it will no longer be auto-injected:
+
+   ```js
+   // add the beginning of your app entry
+   import 'vite/dynamic-import-polyfill'
+   ```
+
 2. For development, inject the following in your server's HTML template (substitute `http://localhost:3000` with the local URL Vite is running at):
 
    ```html

--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -20,7 +20,7 @@ Or you can follow these steps to configure it manually:
    }
    ```
 
-   If you use [`@vite-js/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) or manually enable the [`build.dynamicImportPolyfill` option](/config/#build-polyfilldynamicimport), remember to add the [dynamic import polyfill](/config/#build-polyfilldynamicimport) to your entry, since it will no longer be auto-injected:
+   If you use [`@vitejs/plugin-legacy`](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) or manually enable the [`build.dynamicImportPolyfill` option](/config/#build-polyfilldynamicimport), remember to add the [dynamic import polyfill](/config/#build-polyfilldynamicimport) to your entry, since it will no longer be auto-injected:
 
    ```js
    // add the beginning of your app entry

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -68,6 +68,20 @@ function viteLegacyPlugin(options = {}) {
   /**
    * @type {import('vite').Plugin}
    */
+  const legacyConfigPlugin = {
+    name: 'legacy-config',
+
+    config(config) {
+      if (!config.build) {
+        config.build = {}
+      }
+      config.build.polyfillDynamicImport = true
+    }
+  }
+
+  /**
+   * @type {import('vite').Plugin}
+   */
   const legacyGenerateBundlePlugin = {
     name: 'legacy-generate-polyfill-chunk',
     apply: 'build',
@@ -398,7 +412,12 @@ function viteLegacyPlugin(options = {}) {
     }
   }
 
-  return [legacyGenerateBundlePlugin, legacyPostPlugin, legacyEnvPlugin]
+  return [
+    legacyConfigPlugin,
+    legacyGenerateBundlePlugin,
+    legacyPostPlugin,
+    legacyEnvPlugin
+  ]
 }
 
 /**

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -71,6 +71,7 @@ function viteLegacyPlugin(options = {}) {
   const legacyConfigPlugin = {
     name: 'legacy-config',
 
+    apply: 'build',
     config(config) {
       if (!config.build) {
         config.build = {}

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -64,7 +64,7 @@ export interface BuildOptions {
   /**
    * whether to inject dynamic import polyfill.
    * Note: does not apply to library mode.
-   * @deprecated the dynamic import polyfill has been removed
+   * @default false
    */
   polyfillDynamicImport?: boolean
   /**
@@ -194,13 +194,12 @@ export interface LibraryOptions {
 
 export type LibraryFormats = 'es' | 'cjs' | 'umd' | 'iife'
 
-export type ResolvedBuildOptions = Required<
-  Omit<BuildOptions, 'base' | 'polyfillDynamicImport'>
->
+export type ResolvedBuildOptions = Required<Omit<BuildOptions, 'base'>>
 
 export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
   const resolved: ResolvedBuildOptions = {
     target: 'modules',
+    polyfillDynamicImport: false,
     outDir: 'dist',
     assetsDir: 'assets',
     assetsInlineLimit: 4096,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -470,25 +470,6 @@ export async function resolveConfig(
     }
   })
 
-  if (config.build?.polyfillDynamicImport) {
-    logDeprecationWarning(
-      'build.polyfillDynamicImport',
-      '"polyfillDynamicImport" has been removed. Please use @vitejs/plugin-legacy if your target browsers do not support dynamic imports.'
-    )
-  }
-
-  Object.defineProperty(resolvedBuildOptions, 'polyfillDynamicImport', {
-    enumerable: false,
-    get() {
-      logDeprecationWarning(
-        'build.polyfillDynamicImport',
-        '"polyfillDynamicImport" has been removed. Please use @vitejs/plugin-legacy if your target browsers do not support dynamic imports.',
-        new Error()
-      )
-      return false
-    }
-  })
-
   if (config.alias) {
     logDeprecationWarning('alias', 'Use "resolve.alias" instead.')
   }

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -1,12 +1,27 @@
 import { ResolvedConfig } from '..'
 import { Plugin } from '../plugin'
+import { isModernFlag } from './importAnalysisBuild'
+import path from 'path'
 
 export const polyfillId = 'vite/dynamic-import-polyfill'
 
-/**
- * @deprecated
- */
+function resolveModulePath(config: ResolvedConfig) {
+  const {
+    base,
+    build: { assetsDir }
+  } = config
+  // #2918 path.posix.join returns a wrong path when config.base is a URL
+  if (/^(https?:)?(\/\/)/i.test(base)) {
+    return `${base.replace(/\/$/, '')}/${assetsDir}/`
+  }
+  return path.posix.join(base, assetsDir, '/')
+}
+
 export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
+  const enabled = config.build.polyfillDynamicImport
+  const skip = !enabled || config.command === 'serve' || config.build.ssr
+  let polyfillString: string | undefined
+
   return {
     name: 'vite:dynamic-import-polyfill',
     resolveId(id) {
@@ -16,11 +31,114 @@ export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
     },
     load(id) {
       if (id === polyfillId) {
-        config.logger.warn(
-          `\n'vite/dynamic-import-polyfill' is no longer needed, refer to https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md#230-2021-05-10`
-        )
-        return ''
+        if (!enabled) {
+          config.logger.warnOnce(
+            `\n'vite/dynamic-import-polyfill' is no longer if you only target modern browsers`
+          )
+        }
+        if (skip) {
+          return ''
+        }
+        // return a placeholder here and defer the injection to renderChunk
+        // so that we can selectively skip the injection based on output format
+        if (!polyfillString) {
+          polyfillString =
+            `const p = ${polyfill.toString()};` +
+            `${isModernFlag}&&p(${JSON.stringify(resolveModulePath(config))});`
+        }
+        return polyfillString
       }
+    },
+
+    renderDynamicImport({ format }) {
+      if (skip || format !== 'es') {
+        return null
+      }
+      if (!polyfillString) {
+        throw new Error(
+          `Vite's dynamic import polyfill is enabled but was never imported. This ` +
+            `should only happen when using custom non-html rollup inputs. Make ` +
+            `sure to add \`import "${polyfillId}"\` as the first statement in ` +
+            `your custom entry.`
+        )
+      }
+      // we do not actually return anything here because rewriting here would
+      // make it impossible to use es-module-lexer on the rendered chunks, which
+      // we need for import graph optimization in ./importAnalysisBuild.
     }
+  }
+}
+
+/**
+The following polyfill function is meant to run in the browser and adapted from
+https://github.com/GoogleChromeLabs/dynamic-import-polyfill
+MIT License
+Copyright (c) 2018 uupaa and 2019 Google LLC
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*/
+
+declare const self: any
+declare const location: any
+declare const document: any
+declare const URL: any
+declare const Blob: any
+
+function polyfill(modulePath = '.', importFunctionName = '__import__') {
+  try {
+    self[importFunctionName] = new Function('u', `return import(u)`)
+  } catch (error) {
+    const baseURL = new URL(modulePath, location)
+    const cleanup = (script: any) => {
+      URL.revokeObjectURL(script.src)
+      script.remove()
+    }
+
+    self[importFunctionName] = (url: string) =>
+      new Promise((resolve, reject) => {
+        const absURL = new URL(url, baseURL)
+
+        // If the module has already been imported, resolve immediately.
+        if (self[importFunctionName].moduleMap[absURL]) {
+          return resolve(self[importFunctionName].moduleMap[absURL])
+        }
+
+        const moduleBlob = new Blob(
+          [
+            `import * as m from '${absURL}';`,
+            `${importFunctionName}.moduleMap['${absURL}']=m;`
+          ],
+          { type: 'text/javascript' }
+        )
+
+        const script = Object.assign(document.createElement('script'), {
+          type: 'module',
+          src: URL.createObjectURL(moduleBlob),
+          onerror() {
+            reject(new Error(`Failed to import: ${url}`))
+            cleanup(script)
+          },
+          onload() {
+            resolve(self[importFunctionName].moduleMap[absURL])
+            cleanup(script)
+          }
+        })
+
+        document.head.appendChild(script)
+      })
+
+    self[importFunctionName].moduleMap = {}
   }
 }

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -33,7 +33,7 @@ export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
       if (id === polyfillId) {
         if (!enabled) {
           config.logger.warnOnce(
-            `\n'vite/dynamic-import-polyfill' is no longer if you only target modern browsers`
+            `\n'vite/dynamic-import-polyfill' is no longer needed if you target modern browsers`
           )
         }
         if (skip) {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -20,6 +20,7 @@ import {
   getAssetFilename
 } from './asset'
 import { isCSSRequest, chunkToEmittedCssFileMap } from './css'
+import { polyfillId } from './dynamicImportPolyfill'
 import {
   AttributeNode,
   NodeTransform,
@@ -262,6 +263,12 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         }
 
         processedHtml.set(id, s.toString())
+
+        // inject dynamic import polyfill
+        if (config.build.polyfillDynamicImport) {
+          js = `import "${polyfillId}";\n${js}`
+        }
+
         return js
       }
     },

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -204,6 +204,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
         return
       }
 
+      const isPolyfillEnabled = config.build.polyfillDynamicImport
       for (const file in bundle) {
         const chunk = bundle[file]
         // can't use chunk.dynamicImports.length here since some modules e.g.
@@ -220,7 +221,12 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           if (imports.length) {
             const s = new MagicString(code)
             for (let index = 0; index < imports.length; index++) {
-              const { s: start, e: end } = imports[index]
+              const { s: start, e: end, d: dynamicIndex } = imports[index]
+              // if dynamic import polyfill is used, rewrite the import to
+              // use the polyfilled function.
+              if (isPolyfillEnabled) {
+                s.overwrite(dynamicIndex, dynamicIndex + 6, `__import__`)
+              }
               // check the chunk being imported
               const url = code.slice(start, end)
               const deps: Set<string> = new Set()


### PR DESCRIPTION
### Description

This PR restores the dynamic import polyfill plugin that was removed in https://github.com/vitejs/vite/pull/2976 with `build.polyfillDynamicImport` disabled by default.

`@vitejs/legacy-plugin` will use this plugin setting `build.polyfillDynamicImport` to `true`.

There are two changes compared to the old plugin code: https://github.com/vitejs/vite/blob/02ba4ba32cd40f1cc3943781022c05f9df3b57e6/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
1. The plugin is always included so we can use it to issue a warning when the user imports `vite/dynamic-import-polyfill` but the polyfill feature is disabled.
2. Computing the polyfill string has now been moved inside load, as with the new default it is no generally needed. This move also replaced the need for the extra boolean loaded flag.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
