### PR TITLE
fix(create-app): lit-element templates package.json

### DIFF
--- a/packages/create-app/template-lit-element-ts/package.json
+++ b/packages/create-app/template-lit-element-ts/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "my-vite-element",
+  "name": "vite-lit-element-ts-starter",
   "version": "0.0.0",
-  "main": "dist/my-vite-element.es.js",
+  "main": "dist/my-element.es.js",
   "exports": {
-    ".": "./dist/my-vite-element.es.js"
+    ".": "./dist/my-element.es.js"
   },
   "types": "types/my-element.d.ts",
   "files": [

--- a/packages/create-app/template-lit-element/package.json
+++ b/packages/create-app/template-lit-element/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "my-vite-element",
+  "name": "vite-lit-element-starter",
   "version": "0.0.0",
-  "main": "dist/my-vite-element.es.js",
+  "main": "dist/my-element.es.js",
   "exports": {
-    ".": "./dist/my-vite-element.es.js"
+    ".": "./dist/my-element.es.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
### Description

Modify names in package.json of lit templates so they are unique and Jest stop issuing a warning.

Correct main and exports fields that were pointing to the wrong file, check vite.config.js of templates.

I don't know why we are generating a lib and not an app for lit templates. I imagine that the Lit team will switch these templates to an app when they update them to Lit 2.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
