### PR TITLE
fix: ignore ids that start with \0 in plugin asset, fix #3424

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -41,6 +41,12 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     },
 
     async load(id) {
+      if (id.startsWith('\0')) {
+        // Rollup convention, this id should be handled by the
+        // plugin that marked it with \0
+        return
+      }
+
       // raw requests, read from disk
       if (rawRE.test(id)) {
         const file = checkPublicFile(id, config) || cleanUrl(id)


### PR DESCRIPTION
### Description

It is a convention in rollup that some plugins will mark an id with a `'\0'` prefix. These ids should be then handled by the same plugin. In the case of #3424, an id of the form `'\0/root/node_modules/quill/assets/icons/align-left.svg'` was processed by Vite's asset plugin resulting in an error when trying to load the file. This same file was also present without the initial `'\0'` and loaded correctly. I don't fully understand why the extra prefixed id is being generated (probably by the commonjs plugin) but these ids should be handled by the plugin that generated them and AFAIU ignored by our internal plugins.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
