### PR TITLE
changed behaviour to enable customization for env prefixes

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -113,6 +113,10 @@ export interface UserConfig {
    */
   resolve?: ResolveOptions & { alias?: AliasOptions }
   /**
+   * Change variable prefix for env keys
+   */
+  envPrefix?: string | boolean
+  /**
    * CSS related options (preprocessors and CSS modules)
    */
   css?: CSSOptions
@@ -201,6 +205,7 @@ export type ResolvedConfig = Readonly<
     mode: string
     isProduction: boolean
     env: Record<string, any>
+	envPrefix: string
     resolve: ResolveOptions & {
       alias: Alias[]
     }
@@ -304,7 +309,8 @@ export async function resolveConfig(
   }
 
   // load .env files
-  const userEnv = inlineConfig.envFile !== false && loadEnv(mode, resolvedRoot)
+  const prefix = typeof config.envPrefix === "boolean" ? (config.envPrefix ? "VITE_":""):(config.envPrefix || "VITE_");
+  const userEnv = inlineConfig.envFile !== false && loadEnv(mode, resolvedRoot, prefix)
 
   // Note it is possible for user to have a custom mode, e.g. `staging` where
   // production-like behavior is expected. This is indicated by NODE_ENV=production


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Forcing users into the env prefix "VITE_" is not what I would call ideal. Since not all the developers are satisfied with this solution. We should provide a way for them to work the prefix they wish (or no prefix at all). Didn't have time to do the tests since I need this asap. But I will be working on it.

Solves the issue: https://github.com/vitejs/vite/issues/1095

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
