### PR TITLE
fix: warn about dynamic import polyfill only during build

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -31,11 +31,6 @@ export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
     },
     load(id) {
       if (id === polyfillId) {
-        if (!enabled) {
-          config.logger.warnOnce(
-            `\n'vite/dynamic-import-polyfill' is no longer needed if you target modern browsers`
-          )
-        }
         if (skip) {
           return ''
         }

--- a/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
+++ b/packages/vite/src/node/plugins/dynamicImportPolyfill.ts
@@ -31,6 +31,11 @@ export function dynamicImportPolyfillPlugin(config: ResolvedConfig): Plugin {
     },
     load(id) {
       if (id === polyfillId) {
+        if (!enabled && config.command === 'build') {
+          config.logger.warnOnce(
+            `\n'vite/dynamic-import-polyfill' is no longer needed if you target modern browsers`
+          )
+        }
         if (skip) {
           return ''
         }


### PR DESCRIPTION
### Description

Since we are enabling the dynamic import polyfill only during build, we can not reliably warn about an unneeded import 'vite/dynamic-import-polyfill'. We can also not detect the legacy plugin, since the user may want to enable this plugin only without the full legacy build. This PR removes this warning. See related discussion in #3434

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
