### PR TITLE
Hide warning about explicit /public/ paths for .html files

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -119,7 +119,7 @@ export function transformMiddleware(
       }
 
       // warn explicit /public/ paths
-      if (url.startsWith('/public/')) {
+      if (url.startsWith('/public/') && !url.includes('.html')) {
         logger.warn(
           chalk.yellow(
             `files in the public directory are served at the root path.\n` +


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It's possible to serve html files from public directory, with simple middleware that transfroms /page.html (or /page) to /public/page.html so HMR works correctly. But when someone does this, warnings keep popping out in console.

So with this change warnings keep popping out for all files from public dir, expect .html files. Is this change ok?

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
