### PR TITLE
docs: Add vanilla-ts in the Getting Started guide

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -52,6 +52,7 @@ yarn create @vitejs/app my-vue-app --template vue
 Supported template presets include:
 
 - `vanilla`
+- `vanilla-ts`
 - `vue`
 - `vue-ts`
 - `react`


### PR DESCRIPTION
### Description

This PR adds `vanilla-ts` to the list of the available templates in the Getting Started guide

### Additional context

I was looking into the available templates and was confused for a second about the missing `ts` variant, which does exist in https://github.com/vitejs/vite/tree/main/packages/create-app

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
