### PR TITLE
docs: note about Vite's native SSR API being a low-level API

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -11,7 +11,7 @@ The following guide also assumes prior experience working with SSR in your frame
 :::
 
 :::warning Low-level API
-This is a low-level API meant for library and framework authors. If your goal is to create an application, you may want to have a look at these higher-level SSR tools at [Awesome Vite SSR](https://github.com/vitejs/awesome-vite#ssr) first. That said, many applications are successfully built directly on top of Vite's native low-level API &mdash; just make sure to check out these higher-level tools first.
+This is a low-level API meant for library and framework authors. If your goal is to create an application, make sure to check out the higher-level SSR plugins and tools at [Awesome Vite SSR section](https://github.com/vitejs/awesome-vite#ssr) first. That said, many applications are successfully built directly on top of Vite's native low-level API.
 :::
 
 :::tip Help

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -10,6 +10,10 @@ SSR specifically refers to front-end frameworks (for example React, Preact, Vue,
 The following guide also assumes prior experience working with SSR in your framework of choice, and will only focus on Vite-specific integration details.
 :::
 
+:::warning Low-level API
+This is a low-level API meant for library and framework authors. If your goal is to create an application, you may want to have a look at these higher-level SSR tools at [Awesome Vite SSR](https://github.com/vitejs/awesome-vite#ssr) first. That said, many applications are successfully built directly on top of Vite's native low-level API &mdash; just make sure to check out these higher-level tools first.
+:::
+
 :::tip Help
 If you have questions, the community is usually helpful at [Vite Discord's #ssr channel](https://discord.gg/PkbxgzPhJv).
 :::


### PR DESCRIPTION
Follow up of:
 - https://discord.com/channels/804011606160703521/804061937029218334/844266963244941348
 - https://github.com/vitejs/awesome-vite/pull/166

I reason I chose `:::warning` is because I'm regularly seeing people on Discord's #ssr channel using the Vite's native API directly and, after telling them about e.g. vite-ssr or vite-plugin-ssr, they are grateful and tell me they chose the native API because they weren't aware of these higher-level tools. We may want to make sure that people read that note/warning first.