### PR TITLE
fix: inline webworker safari support

### DIFF
--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -28,6 +28,6 @@ if (isBuild) {
     // chunk
     expect(content).toMatch(`new Worker("/assets`)
     // inlined
-    expect(content).toMatch(`new Worker("data:application/javascript`)
+    expect(content).toMatch(`new Worker((window.URL||window.webkitURL)`)
   })
 }

--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -28,6 +28,6 @@ if (isBuild) {
     // chunk
     expect(content).toMatch(`new Worker("/assets`)
     // inlined
-    expect(content).toMatch(`new Worker(objURL`)
+    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
   })
 }

--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -28,6 +28,6 @@ if (isBuild) {
     // chunk
     expect(content).toMatch(`new Worker("/assets`)
     // inlined
-    expect(content).toMatch(`new Worker((window.URL||window.webkitURL)`)
+    expect(content).toMatch(`new Worker(objURL`)
   })
 }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -43,7 +43,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       let url: string
       if (isBuild) {
         if (query.inline != null) {
-          // bundle the file as entry to support imports and inline as base64
+          // bundle the file as entry to support imports and inline as blob
           // data url
           const rollup = require('rollup') as typeof Rollup
           const bundle = await rollup.rollup({
@@ -55,9 +55,11 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               format: 'es',
               sourcemap: config.build.sourcemap
             })
-            url = `data:application/javascript;base64,${Buffer.from(
-              output[0].code
-            ).toString('base64')}`
+            
+            return `export default function WorkerWrapper() {
+              const blob = new Blob([atob(\"${Buffer.from(output[0].code).toString('base64')}\")], { type: 'text/javascript;charset=utf-8' });
+              return new Worker((window.URL || window.webkitURL).createObjectURL(blob));
+            }`
           } finally {
             await bundle.close()
           }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -56,9 +56,14 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               sourcemap: config.build.sourcemap
             })
             
-            return `export default function WorkerWrapper() {
-              const blob = new Blob([atob(\"${Buffer.from(output[0].code).toString('base64')}\")], { type: 'text/javascript;charset=utf-8' });
-              return new Worker((window.URL || window.webkitURL).createObjectURL(blob));
+            return `const blob = new Blob([atob(\"${Buffer.from(output[0].code).toString('base64')}\")], { type: 'text/javascript;charset=utf-8' });
+            export default function WorkerWrapper() {
+              const objURL = (window.URL || window.webkitURL).createObjectURL(blob);
+              try {
+                return new Worker(objURL);
+              } finally {
+                (window.URL || window.webkitURL).revokeObjectURL(objURL);
+              }
             }`
           } finally {
             await bundle.close()


### PR DESCRIPTION
### Description

Issue related to this https://github.com/vitejs/vite/issues/2504

Safari doesn't play by the rules, so we have to adapt.

Base64 isn't accepted for inline webworkers on Safari, yet blobs are fine. This very simple change adapted from my own custom plugin solves this issue. Tested on multiple Tim Apple's devices and non-Tim Apple devices, works perfectly so far and it is currently used in production.

I'm aware that there's https://github.com/vitejs/vite/pull/2689 but this change is slimmer and frankly very simple compared to what the hell is going on in that thread.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
