### PR TITLE
fix: use react-jsx in tsconfig.json

### DIFF
--- a/packages/create-app/template-react-ts/tsconfig.json
+++ b/packages/create-app/template-react-ts/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react"
   },
   "include": ["./src"]
 }

--- a/packages/create-app/template-react-ts/tsconfig.json
+++ b/packages/create-app/template-react-ts/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
   "include": ["./src"]
 }

--- a/packages/create-app/template-react-ts/vite.config.ts
+++ b/packages/create-app/template-react-ts/vite.config.ts
@@ -5,7 +5,7 @@ import reactRefresh from '@vitejs/plugin-react-refresh'
 export default defineConfig({
   plugins: [reactRefresh()]
   // To automatically inject React you can uncomment the following lines
-  // (you also have to set "jsx" to true in tsconfig.json):
+  // (you also have to set "jsx" to "react-jsx" in tsconfig.json):
   // esbuild: {
   //   jsxInject: "import React from 'react';",
   // }

--- a/packages/create-app/template-react-ts/vite.config.ts
+++ b/packages/create-app/template-react-ts/vite.config.ts
@@ -4,4 +4,9 @@ import reactRefresh from '@vitejs/plugin-react-refresh'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [reactRefresh()]
+  // To automatically inject React you can uncomment the following lines
+  // (you also have to set "jsx" to true in tsconfig.json):
+  // esbuild: {
+  //   jsxInject: "import React from 'react';",
+  // }
 })

--- a/packages/create-app/template-react/vite.config.js
+++ b/packages/create-app/template-react/vite.config.js
@@ -4,4 +4,8 @@ import reactRefresh from '@vitejs/plugin-react-refresh'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [reactRefresh()]
+  // To automatically inject React you can uncomment the following lines:
+  // esbuild: {
+  //   jsxInject: "import React from 'react';",
+  // }
 })


### PR DESCRIPTION
### Description

Changed `jsx: react` to `jsx: react-jsx`, because the example uses React 17 and TypeScript 4.1.

### Additional context

With `jsx: react`, users will still be forced to import React even though it's not required anymore.
They would get the following error:
![jsx-react-err](https://user-images.githubusercontent.com/53915302/118914120-f67bb700-b92a-11eb-9809-8396e4ed33db.png)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
