### PR TITLE
fix: handle HMR for files with more than one glob import

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -300,11 +300,16 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             str().prepend(importsString)
             str().overwrite(expStart, endIndex, exp)
             imports.forEach((url) => importedUrls.add(url.replace(base, '/')))
-            server._globImporters[importerModule.file!] = {
-              module: importerModule,
+            if (!(importerModule.file! in server._globImporters)) {
+              server._globImporters[importerModule.file!] = {
+                module: importerModule,
+                importGlobs: []
+              }
+            }
+            server._globImporters[importerModule.file!].importGlobs.push({
               base,
               pattern
-            }
+            })
           }
           continue
         }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -177,13 +177,16 @@ export async function handleFileAddUnlink(
     delete server._globImporters[file]
   } else {
     for (const i in server._globImporters) {
-      const { module, base, pattern } = server._globImporters[i]
-      const relative = path.relative(base, file)
-      if (match(relative, pattern)) {
-        modules.push(module)
-        // We use `onFileChange` to invalidate `module.file` so that subsequent `ssrLoadModule()`
-        // calls get fresh glob import results with(out) the newly added(/removed) `file`.
-        server.moduleGraph.onFileChange(module.file!)
+      const { module, importGlobs } = server._globImporters[i]
+      for (const { base, pattern } of importGlobs) {
+        const relative = path.relative(base, file)
+        if (match(relative, pattern)) {
+          modules.push(module)
+          // We use `onFileChange` to invalidate `module.file` so that subsequent `ssrLoadModule()`
+          // calls get fresh glob import results with(out) the newly added(/removed) `file`.
+          server.moduleGraph.onFileChange(module.file!)
+          break
+        }
       }
     }
   }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -273,9 +273,11 @@ export interface ViteDevServer {
   _globImporters: Record<
     string,
     {
-      base: string
-      pattern: string
       module: ModuleNode
+      importGlobs: {
+        base: string
+        pattern: string
+      }[]
     }
   >
   /**


### PR DESCRIPTION
This PR fixes HMR when a file has more than one glob import.

This is the case for vite-plugin-ssr and is a root cause for https://github.com/brillout/vite-plugin-ssr/issues/66.

This fixes https://github.com/vitejs/vite/issues/3496.