### PR TITLE
fix: invalidate import globs upon new/removed files (fix #3499)

### DIFF
--- a/packages/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/packages/playground/glob-import/__tests__/glob-import.spec.ts
@@ -59,7 +59,13 @@ if (!isBuild) {
       JSON.stringify(
         {
           '/dir/a.js': {},
-          ...allResult
+          ...allResult,
+          '/dir/index.js': {
+            modules: {
+              './a.js': {},
+              ...allResult['/dir/index.js'].modules
+            }
+          }
         },
         null,
         2
@@ -75,7 +81,15 @@ if (!isBuild) {
           '/dir/a.js': {
             msg: 'a'
           },
-          ...allResult
+          ...allResult,
+          '/dir/index.js': {
+            modules: {
+              './a.js': {
+                msg: 'a'
+              },
+              ...allResult['/dir/index.js'].modules
+            }
+          }
         },
         null,
         2

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -181,6 +181,9 @@ export async function handleFileAddUnlink(
       const relative = path.relative(base, file)
       if (match(relative, pattern)) {
         modules.push(module)
+        // We use `onFileChange` to invalidate `module.file` so that subsequent `ssrLoadModule()`
+        // calls get fresh glob import results with(out) the newly added(/removed) `file`.
+        server.moduleGraph.onFileChange(module.file!)
       }
     }
   }


### PR DESCRIPTION
Fixes #3499.

See comment in the commit for an explanation of what's going on.

This and https://github.com/vitejs/vite/pull/3497 will fix https://github.com/brillout/vite-plugin-ssr/issues/66.