### PR TITLE
fix(preview): support custom hostname

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -186,12 +186,17 @@ cli
 
 cli
   .command('preview [root]')
+  .option('--host [host]', `[string] specify hostname`)
   .option('--port <port>', `[number] specify port`)
   .option('--open [path]', `[boolean | string] open browser on startup`)
   .action(
     async (
       root: string,
-      options: { port?: number; open?: boolean | string } & GlobalCLIOptions
+      options: {
+        host?: string
+        port?: number
+        open?: boolean | string
+      } & GlobalCLIOptions
     ) => {
       try {
         const config = await resolveConfig(
@@ -207,7 +212,7 @@ cli
           'serve',
           'development'
         )
-        await preview(config, options.port)
+        await preview(config, { host: options.host, port: options.port })
       } catch (e) {
         createLogger(options.logLevel).error(
           chalk.red(`error when starting preview server:\n${e.stack}`)

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -14,7 +14,7 @@ import { resolveHostname } from './utils'
 
 export async function preview(
   config: ResolvedConfig,
-  port = 5000
+  serverOptions: { host?: string; port?: number }
 ): Promise<void> {
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
@@ -46,7 +46,8 @@ export async function preview(
   )
 
   const options = config.server
-  const hostname = resolveHostname(options.host)
+  const hostname = resolveHostname(serverOptions.host ?? options.host)
+  const port = serverOptions.port ?? 5000
   const protocol = options.https ? 'https' : 'http'
   const logger = config.logger
   const base = config.base


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes the `preview` command doesn't support custom hostname.

### Additional context

I treat this PR as a fix instead of a feature, because its behavior should keep align with the default `serve` command. Also, when we use `preview` command without any CLI arguments, Vite tells us:

![图片](https://user-images.githubusercontent.com/17216317/119221664-f7773900-bb22-11eb-8d2b-b9a5a1d4a017.png)

However, if we pass `--host` argument to Vite, it will throw an error and say `--host` option is unknown, which should be a bug.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
