### PR TITLE
fix: ensure new assets cache at build start, fix #3271

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -21,12 +21,24 @@ const urlRE = /(\?|&)url(?:&|$)/
 
 export const chunkToEmittedAssetsMap = new WeakMap<RenderedChunk, Set<string>>()
 
+const assetCache = new WeakMap<ResolvedConfig, Map<string, string>>()
+
+const assetHashToFilenameMap = new WeakMap<
+  ResolvedConfig,
+  Map<string, string>
+>()
+
 /**
  * Also supports loading plain strings with import text from './foo.txt?raw'
  */
 export function assetPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:asset',
+
+    buildStart() {
+      assetCache.set(config, new Map())
+      assetHashToFilenameMap.set(config, new Map())
+    },
 
     resolveId(id) {
       if (!config.assetsInclude(cleanUrl(id))) {
@@ -162,13 +174,6 @@ function fileToDevUrl(id: string, config: ResolvedConfig) {
   return config.base + rtn.replace(/^\//, '')
 }
 
-const assetCache = new WeakMap<ResolvedConfig, Map<string, string>>()
-
-const assetHashToFilenameMap = new WeakMap<
-  ResolvedConfig,
-  Map<string, string>
->()
-
 export function getAssetFilename(
   hash: string,
   config: ResolvedConfig
@@ -190,11 +195,7 @@ async function fileToBuiltUrl(
     return config.base + id.slice(1)
   }
 
-  let cache = assetCache.get(config)
-  if (!cache) {
-    cache = new Map()
-    assetCache.set(config, cache)
-  }
+  const cache = assetCache.get(config)!
   const cached = cache.get(id)
   if (cached) {
     return cached
@@ -221,11 +222,7 @@ async function fileToBuiltUrl(
     // into the chunk's hash, so we have to do our own content hashing here.
     // https://bundlers.tooling.report/hashing/asset-cascade/
     // https://github.com/rollup/rollup/issues/3415
-    let map = assetHashToFilenameMap.get(config)
-    if (!map) {
-      map = new Map()
-      assetHashToFilenameMap.set(config, map)
-    }
+    const map = assetHashToFilenameMap.get(config)!
 
     const contentHash = getAssetHash(content)
     if (!map.has(contentHash)) {


### PR DESCRIPTION
### Description

See #3271 and previous work by @CHOYSEN https://github.com/vitejs/vite/pull/3480

Moved the cache definitions before the plugin as they are now referenced by the hooks (following the style of the caches for the CSS plugin)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
