### PR TITLE
fix(preview): allow to disable HTTPS

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -188,6 +188,7 @@ cli
   .command('preview [root]')
   .option('--host [host]', `[string] specify hostname`)
   .option('--port <port>', `[number] specify port`)
+  .option('--https', `[boolean] use TLS + HTTP/2`)
   .option('--open [path]', `[boolean | string] open browser on startup`)
   .action(
     async (
@@ -195,6 +196,7 @@ cli
       options: {
         host?: string
         port?: number
+        https?: boolean
         open?: boolean | string
       } & GlobalCLIOptions
     ) => {
@@ -212,7 +214,14 @@ cli
           'serve',
           'development'
         )
-        await preview(config, { host: options.host, port: options.port })
+        await preview(
+          config,
+          cleanOptions(options) as {
+            host?: string
+            port?: number
+            https?: boolean
+          }
+        )
       } catch (e) {
         createLogger(options.logLevel).error(
           chalk.red(`error when starting preview server:\n${e.stack}`)

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -14,13 +14,13 @@ import { resolveHostname } from './utils'
 
 export async function preview(
   config: ResolvedConfig,
-  serverOptions: { host?: string; port?: number }
+  serverOptions: { host?: string; port?: number; https?: boolean }
 ): Promise<void> {
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.server,
     app,
-    await resolveHttpsConfig(config)
+    serverOptions.https === false ? undefined : await resolveHttpsConfig(config)
   )
 
   // cors


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes missing `--https` CLI argument of `preview` command which allows to enable or disable HTTPS.

### Additional context

I treat this PR as a fix instead of a feature because its behavior should keep align with the default `serve` command.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
