### PR TITLE
chore: fixing sort in rollup config

### DIFF
--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -273,7 +273,7 @@ function licensePlugin() {
       )
       const licenses = new Set()
       const dependencyLicenseTexts = dependencies
-        .sort(({ name: nameA }, { name: nameB }) => (nameA > nameB) ? 1 : ((nameB>nameA) ? -1 : 0))
+        .sort(({ name: nameA }, { name: nameB }) => (nameA > nameB) ? 1 : ((nameB > nameA) ? -1 : 0))
         .map(
           ({
             name,

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -273,7 +273,7 @@ function licensePlugin() {
       )
       const licenses = new Set()
       const dependencyLicenseTexts = dependencies
-        .sort(({ name: nameA }, { name: nameB }) => (nameA > nameB ? 1 : -1))
+        .sort(({ name: nameA }, { name: nameB }) => (nameA > nameB) ? 1 : ((nameB>nameA) ? -1 : 0))
         .map(
           ({
             name,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The callback provided to sort should return 0 if the compared values are equal.
We return 0 when both values are equal to preserve the original order. Otherwise, while both values would be next to each other in the sorted array, their order might change on every function call

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
