### PR TITLE
fix: allow passing an array as sass / scss importer

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -936,12 +936,7 @@ const scss: SassStylePreprocessor = async (
       }
     })
   }
-  const importer = [internalImporter]
-  if (options.importer) {
-    Array.isArray(options.importer)
-      ? importer.concat(options.importer)
-      : importer.push(options.importer)
-  }
+  const importer = [internalImporter].concat(options.importer!)
 
   const finalOptions: Sass.Options = {
     ...options,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -936,7 +936,12 @@ const scss: SassStylePreprocessor = async (
       }
     })
   }
-  const importer = [internalImporter].concat(options.importer!)
+  const importer = [internalImporter]
+  if (options.importer) {
+    Array.isArray(options.importer)
+      ? importer.push(...options.importer)
+      : importer.push(options.importer)
+  }
 
   const finalOptions: Sass.Options = {
     ...options,


### PR DESCRIPTION
### Description

This change allows passing an array with multiple custom importers. Fixes #3526.

### Additional context

JavaScript does not mind passing `undefined` to concat, so additional checks are not needed. In that case shallow copy is created, but it does not matter here.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
