### PR TITLE
fix: the return value of resolve by adding a namespace when processing a '@' in filter

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -288,9 +288,11 @@ function esbuildScanPlugin(
               }
               return externalUnlessEntry({ path: id })
             } else {
+              const namespace = htmlTypesRE.test(resolved) ? 'html' : undefined
               // linked package, keep crawling
               return {
-                path: path.resolve(resolved)
+                path: path.resolve(resolved),
+                namespace
               }
             }
           } else {


### PR DESCRIPTION
fixes #3532

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When the alias is equal to "@", the program will match "filter: / ^ [\ w @] [^:] /" and enter "build.onResolve". However, the return value of build.onResolve does not include the namespace, which causes the vue file to not be processed into HTML format.
After adding `namespace` in the return value of `build.onResolve`, the project work properly.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
