### PR TITLE
fix: data-uri, build-html plugins caches at buildStart

### DIFF
--- a/packages/vite/src/node/plugins/dataUri.ts
+++ b/packages/vite/src/node/plugins/dataUri.ts
@@ -12,12 +12,17 @@ const dataUriPrefix = `/@data-uri/`
  * Build only, since importing from a data URI works natively.
  */
 export function dataURIPlugin(): Plugin {
-  const resolved: {
+  let resolved: {
     [key: string]: string
-  } = {}
+  }
 
   return {
     name: 'vite:data-uri',
+
+    buildStart() {
+      resolved = {}
+    },
+
     resolveId(id) {
       if (!dataUriRE.test(id)) {
         return null

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -139,7 +139,7 @@ function formatParseError(e: any, id: string, html: string): Error {
  */
 export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   const [preHooks, postHooks] = resolveHtmlTransforms(config.plugins)
-  const processedHtml = new Map<string, string>()
+  let processedHtml: Map<string, string>
   const isExcludedUrl = (url: string) =>
     url.startsWith('#') ||
     isExternalUrl(url) ||
@@ -148,6 +148,10 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
   return {
     name: 'vite:build-html',
+
+    buildStart() {
+      processedHtml = new Map<string, string>()
+    },
 
     async transform(html, id) {
       if (id.endsWith('.html')) {


### PR DESCRIPTION
### Description

See also #3516, #3512 and #3530

This PR generate new caches at buildStart for vite:data-uri and vite:build-html. These are the last two plugins that had caches that weren't regenerated for each build.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
