### PR TITLE
fix: cannot recognize JS url correctly(#3568)

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -108,7 +108,7 @@ export const isDataUrl = (url: string): boolean => dataUrlRE.test(url)
 
 const knownJsSrcRE = /\.((j|t)sx?|mjs|vue|marko|svelte)($|\?)/
 export const isJSRequest = (url: string): boolean => {
-  if (knownJsSrcRE.test(url)) {
+  if (!url.includes('?') && knownJsSrcRE.test(url)) {
     return true
   }
   url = cleanUrl(url)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -108,10 +108,10 @@ export const isDataUrl = (url: string): boolean => dataUrlRE.test(url)
 
 const knownJsSrcRE = /\.((j|t)sx?|mjs|vue|marko|svelte)($|\?)/
 export const isJSRequest = (url: string): boolean => {
-  if (!url.includes('?') && knownJsSrcRE.test(url)) {
+  url = cleanUrl(url)
+  if (knownJsSrcRE.test(url)) {
     return true
   }
-  url = cleanUrl(url)
   if (!path.extname(url) && !url.endsWith('/')) {
     return true
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix util-isJSRequest function cannot recognize JS url correctly(#3568). That will lead to internal error when visit devserver url with query string ending with '.js'. see [issue3568](https://github.com/vitejs/vite/issues/3568).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other


