### PR TITLE
fix: include/exclude options for vue-jsx .d.ts

### DIFF
--- a/packages/plugin-vue-jsx/index.d.ts
+++ b/packages/plugin-vue-jsx/index.d.ts
@@ -1,6 +1,12 @@
 import { Plugin } from 'vite'
 import { VueJSXPluginOptions } from '@vue/babel-plugin-jsx'
+import { FilterPattern } from '@rollup/pluginutils'
 
-declare function createPlugin(options?: VueJSXPluginOptions): Plugin
+declare interface CommonOptions{
+    include?: FilterPattern;
+    exclude?: FilterPattern;
+}
+
+declare function createPlugin(options?: VueJSXPluginOptions & CommonOptions): Plugin
 
 export default createPlugin

--- a/packages/plugin-vue-jsx/index.d.ts
+++ b/packages/plugin-vue-jsx/index.d.ts
@@ -2,7 +2,7 @@ import { Plugin } from 'vite'
 import { VueJSXPluginOptions } from '@vue/babel-plugin-jsx'
 import { FilterPattern } from '@rollup/pluginutils'
 
-declare interface CommonOptions{
+declare interface CommonOptions {
     include?: FilterPattern;
     exclude?: FilterPattern;
 }

--- a/packages/plugin-vue-jsx/index.d.ts
+++ b/packages/plugin-vue-jsx/index.d.ts
@@ -2,11 +2,13 @@ import { Plugin } from 'vite'
 import { VueJSXPluginOptions } from '@vue/babel-plugin-jsx'
 import { FilterPattern } from '@rollup/pluginutils'
 
-declare interface CommonOptions {
+declare interface FilterOptions {
   include?: FilterPattern
   exclude?: FilterPattern
 }
 
-declare function createPlugin(options?: VueJSXPluginOptions & CommonOptions): Plugin
+declare function createPlugin(
+  options?: VueJSXPluginOptions & FilterOptions
+): Plugin
 
 export default createPlugin

--- a/packages/plugin-vue-jsx/index.d.ts
+++ b/packages/plugin-vue-jsx/index.d.ts
@@ -3,8 +3,8 @@ import { VueJSXPluginOptions } from '@vue/babel-plugin-jsx'
 import { FilterPattern } from '@rollup/pluginutils'
 
 declare interface CommonOptions {
-    include?: FilterPattern;
-    exclude?: FilterPattern;
+  include?: FilterPattern
+  exclude?: FilterPattern
 }
 
 declare function createPlugin(options?: VueJSXPluginOptions & CommonOptions): Plugin


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix use vue-jsx config `include` / `exclude` has warn "Object literal may only specify known properties, and 'include' does not exist in type 'VueJSXPluginOptions'."

```ts
// vite.config.ts
import { defineConfig } from 'vite'
import vue from '@vitejs/plugin-vue'
import vueJsx from '@vitejs/plugin-vue-jsx'

// https://vitejs.dev/config/
export default defineConfig({
  plugins: [
    vue(),
    vueJsx({
      include: /\.([jt]sx|xxx)$/
    }),
  ]
})

```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
