### PR TITLE
feat: added clientPort to HmrOptions

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -424,10 +424,7 @@ export default async ({ command, mode }) => {
 
   Set `server.hmr.overlay` to `false` to disable the server error overlay.
 
-  `clientPort` is an advanced option that overrides the port only on the client
-  side, allowing you to serve the websocket on a different port than the client
-  code looks for it on. Useful if you're using an SSL proxy in front of your dev
-  server.
+  `clientPort` is an advanced option that overrides the port only on the client side, allowing you to serve the websocket on a different port than the client code looks for it on. Useful if you're using an SSL proxy in front of your dev server.
 
 ### server.watch
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -418,11 +418,16 @@ export default async ({ command, mode }) => {
 
 ### server.hmr
 
-- **Type:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean }`
+- **Type:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean, clientPort?: number }`
 
   Disable or configure HMR connection (in cases where the HMR websocket must use a different address from the http server).
 
   Set `server.hmr.overlay` to `false` to disable the server error overlay.
+
+  `clientPort` is an advanced option that overrides the port only on the client
+  side, allowing you to serve the websocket on a different port than the client
+  code looks for it on. Useful if you're using an SSL proxy in front of your dev
+  server.
 
 ### server.watch
 

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -25,10 +25,10 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
         const overlay = options.overlay !== false
         let port
         if (config.server.middlewareMode) {
-          port = String(
-            (typeof config.server.hmr === 'object' && config.server.hmr.port) ||
-              24678
-          )
+          if (typeof config.server.hmr === 'object') {
+            port = config.server.hmr.clientPort || config.server.hmr.port
+          }
+          port = port || 24678
         } else {
           port = String(options.port || config.server.port!)
         }

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -28,7 +28,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
           if (typeof config.server.hmr === 'object') {
             port = config.server.hmr.clientPort || config.server.hmr.port
           }
-          port = port || 24678
+          port = String(port || 24678)
         } else {
           port = String(options.port || config.server.port!)
         }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -19,6 +19,7 @@ export interface HmrOptions {
   protocol?: string
   host?: string
   port?: number
+  clientPort?: number
   path?: string
   timeout?: number
   overlay?: boolean


### PR DESCRIPTION
### Description

There are times when it's useful to mismatch the HMR ports, meaning you run the websocket server on a different port than the client code looks for. The prime example is if you have SSL in front of your dev server using an SSL-terminating proxy, you'll also need to add SSL termination in front of your HMR websocket to avoid "mixed security" issues in the browser. But you can't have TLS and non TLS all on the same port.

So with this change, you'd be able let the websocket run on its default of 24678, but have the client code try to connect to ws://host:24679 for example, then use something like `stunnel` or any kind of SSL terminating proxy to route from 24679 => 24678.

### Additional context

Nothing in particular, it's a minor change.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

I was unable to get the tests to run, kept getting

```
portersi-macbookpro:hmr portersi$ pwd
/Users/portersi/projects/vite/packages/playground/hmr
portersi-macbookpro:hmr portersi$ yarn test
yarn run v1.22.10
error Command "test" not found. Did you mean "jest"?
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

If you help me out there I can run them.

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
