### PR TITLE
test(worker): only check result when all worker ran

### DIFF
--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -27,6 +27,7 @@ const waitSharedWorkerTick = (
     // test.concurrent sequential is not guaranteed
     // force page to wait to ensure two pages overlap in time
     resolvedSharedWorkerCount++
+    if (resolvedSharedWorkerCount < 2) return
 
     await untilUpdated(() => {
       return resolvedSharedWorkerCount === 2 ? 'all pages loaded' : ''


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix CI breaks due to Jest v27. Should early return when not all pages are ready.

### Additional context

https://github.com/vitejs/vite/pull/2505#issuecomment-850760890

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
