### PR TITLE
fix(playground): fix an eslint error in testUtils

### DIFF
--- a/packages/playground/testUtils.ts
+++ b/packages/playground/testUtils.ts
@@ -20,7 +20,7 @@ Object.keys(colors).forEach((color) => {
 })
 
 function componentToHex(c: number): string {
-  var hex = c.toString(16)
+  const hex = c.toString(16)
   return hex.length == 1 ? '0' + hex : hex
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

the following code in testUtils.ts 

```
function componentToHex(c: number): string {
  var hex = c.toString(16)
  return hex.length == 1 ? '0' + hex : hex
}
```

caused an eslint error :

```
× eslint:
   26:3  error    Unexpected var, use let or const instead  no-var
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
