### PR TITLE
feat: make the timeout to optimise new dependencies configurable

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -118,6 +118,10 @@ export interface ServerOptions {
    */
   middlewareMode?: boolean | 'html' | 'ssr'
   /**
+   * Time (ms) Vite has to optimise new dependencies before timing out.
+   */
+  pendingReloadTimeout?: number
+  /**
    * Prepend this folder to http requests, for use when proxying vite as a subfolder
    * Should start and end with the `/` character
    */

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -24,12 +24,6 @@ import {
 } from '../../constants'
 import { isCSSRequest, isDirectCSSRequest } from '../../plugins/css'
 
-/**
- * Time (ms) Vite has to full-reload the page before returning
- * an empty response.
- */
-const NEW_DEPENDENCY_BUILD_TIMEOUT = 1000
-
 const debugCache = createDebugger('vite:cache')
 const isDebug = !!process.env.DEBUG
 
@@ -82,7 +76,7 @@ export function transformMiddleware(
             `<h1>[vite] Something unexpected happened while optimizing "${req.url}"<h1>` +
               `<p>The current page should have reloaded by now</p>`
           )
-        }, NEW_DEPENDENCY_BUILD_TIMEOUT)
+        }, server.config.server.pendingReloadTimeout || 1000)
       )
       return
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This allows configuring the timeout for a new dependency to be optimised, making it easier to avoid timeouts in low-performance environments where consistency is more important than speed.

### Additional context

I run tests with Puppeteer and Vite on GitHub Actions. I noticed that I frequently see 408 errors, which isn't particularly surprising given the limited computing power available. I need my tests to be reproducible, so I will want to increase the timeout to account for GitHub Actions' slowness.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
