### PR TITLE
fix: revert avoid css leaking into emitted javascript (#3402)

### DIFF
--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -30,18 +30,11 @@ test('linked css', async () => {
 })
 
 test('css import from js', async () => {
-  const importedNoVars = await page.$('.imported-no-vars')
   const imported = await page.$('.imported')
   const atImport = await page.$('.imported-at-import')
 
-  expect(await getColor(importedNoVars)).toBe('magenta')
   expect(await getColor(imported)).toBe('green')
   expect(await getColor(atImport)).toBe('purple')
-
-  editFile('imported-without-variable.css', (code) =>
-    code.replace('color: magenta', 'color: cyan')
-  )
-  await untilUpdated(() => getColor(importedNoVars), 'cyan')
 
   editFile('imported.css', (code) => code.replace('color: green', 'color: red'))
   await untilUpdated(() => getColor(imported), 'red')

--- a/packages/playground/css/imported-without-variable.css
+++ b/packages/playground/css/imported-without-variable.css
@@ -1,3 +1,0 @@
-.imported-no-vars {
-  color: magenta;
-}

--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -6,10 +6,6 @@
   <p class="linked">&lt;link&gt;: This should be blue</p>
   <p class="linked-at-import">@import in &lt;link&gt;: This should be red</p>
 
-  <p class="imported-no-vars">
-    import from js, no vars: This should be magenta
-  </p>
-
   <p class="imported">import from js: This should be green</p>
   <p class="imported-at-import">
     @import in import from js: This should be purple

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -1,5 +1,3 @@
-import './imported-without-variable.css'
-
 import css from './imported.css'
 text('.imported-css', css)
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -263,7 +263,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         } else {
           // server only
           if (ssr) {
-            return modulesCode || `export default ''`
+            return modulesCode || `export default ${JSON.stringify(css)}`
           }
           return [
             `import { updateStyle, removeStyle } from ${JSON.stringify(
@@ -285,7 +285,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       styles.set(id, css)
 
       return {
-        code: modulesCode || `export default ''`,
+        code: modulesCode || `export default ${JSON.stringify(css)}`,
         map: { mappings: '' },
         // avoid the css module from being tree-shaken so that we can retrieve
         // it in renderChunk()


### PR DESCRIPTION
…fix for #3610 and partial fix for #2282

This reverts commit 65d333d8

<!-- Thank you for contributing! -->

### Description

The PR #3402 changed the content of css modules to empty string which causes failures for sveltekit testsuite: https://github.com/sveltejs/kit/pull/1622  and also other issues, see #3610 and #2282

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
