### PR TITLE
feat: cache certificate

### DIFF
--- a/packages/vite/src/node/server/http.ts
+++ b/packages/vite/src/node/server/http.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs, { promises as fsp } from 'fs'
 import path from 'path'
 import { Server as HttpServer } from 'http'
 import { ServerOptions as HttpsServerOptions } from 'https'
@@ -44,7 +44,7 @@ export async function resolveHttpsConfig(
     pfx: readFileIfExists(pfx)
   })
   if (!httpsOption.key || !httpsOption.cert) {
-    httpsOption.cert = httpsOption.key = await createCertificate()
+    httpsOption.cert = httpsOption.key = await getCertificate(config)
   }
   return httpsOption
 }
@@ -132,4 +132,27 @@ async function createCertificate() {
     ]
   })
   return pems.private + pems.cert
+}
+
+async function getCertificate(config: ResolvedConfig) {
+  if (!config.cacheDir) return await createCertificate()
+
+  const cachePath = path.join(config.cacheDir, '_cert.pem')
+
+  try {
+    const [stat, content] = await Promise.all([
+      fsp.stat(cachePath),
+      fsp.readFile(cachePath, 'utf8')
+    ])
+
+    if (Date.now() - stat.ctime.valueOf() > 30 * 24 * 60 * 60 * 1000) {
+      throw new Error('cache is outdated.')
+    }
+
+    return content
+  } catch (e) {
+    const content = await createCertificate()
+    fsp.writeFile(cachePath, content).catch(() => {})
+    return content
+  }
 }

--- a/packages/vite/src/node/server/http.ts
+++ b/packages/vite/src/node/server/http.ts
@@ -152,7 +152,10 @@ async function getCertificate(config: ResolvedConfig) {
     return content
   } catch (e) {
     const content = await createCertificate()
-    fsp.writeFile(cachePath, content).catch(() => {})
+    fsp
+      .mkdir(config.cacheDir, { recursive: true })
+      .then(() => fsp.writeFile(cachePath, content))
+      .catch(() => {})
     return content
   }
 }

--- a/packages/vite/src/node/server/http.ts
+++ b/packages/vite/src/node/server/http.ts
@@ -150,7 +150,7 @@ async function getCertificate(config: ResolvedConfig) {
     }
 
     return content
-  } catch (e) {
+  } catch {
     const content = await createCertificate()
     fsp
       .mkdir(config.cacheDir, { recursive: true })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
If we enable https with the config below:

```ts
export default defineConfig({
  server: {
     https: true,
  },
});
```

Browser will throw the `NET::ERR_CERT_AUTHORITY_INVALID` error ervery time vite restart.

This PR cache the certificate to file system to avoid the boring error.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I do not know if I can use the `config.cacheDir` directory to cache this.
It seem that it only use for build data and maybe clean by `--force` option.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
