### PR TITLE
fix: do not end server process in CI

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -401,8 +401,9 @@ export async function createServer(
 
   process.once('SIGTERM', exitProcess)
 
-  if (!process.stdin.isTTY) {
+  if (process.env.CI !== 'true') {
     process.stdin.on('end', exitProcess)
+    process.stdin.resume()
   }
 
   watcher.on('change', async (file) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes a problem running the vite server in docker and github actions (ci) as documented in https://github.com/betaboon/vite-web-test-runner-plugin/issues/6.  It took me a long time to figure out why my tests were completing just fine locally but exiting early with a `0` exit code in CI without running any tests.  I eventually traced it down to the `process.exit(0)` added in https://github.com/vitejs/vite/pull/1857.  

With the changes here, I am able to run tests successfully both locally, as well as in CI.

I would love if @nullpilot, @jonathanstiansen, and @1player could take a look and try this out to see if it meets their needs as well.

### Additional context

Docker (and by extension github ci) do not always run as an interactive tty.  Create-react-app had an issue when they tried to add a shutdown based on detecting an interactive terminal, and addressed it by only checking for a CI environment variable instead (see https://github.com/facebook/create-react-app/pull/8845 and the referenced issue, https://github.com/facebook/create-react-app/issues/8688).

As an aside, note that webpack-dev-server listens to both `SIGINT` and `SIGTERM` for docker support (https://github.com/webpack/webpack-dev-server/pull/787), but `SIGINT` was factored out of vite and I'm not quite sure why based on the [commit](https://github.com/vitejs/vite/commit/a04db16f0329cfa7ef97d0f58f36189b391494a0#diff-abb3345b6e3b2ec6d297c2ebc54cca85ae4487a31bac3cc9e78457f5114adb26).

I'm also not sure how to write a test for this particular feature, but I did check that the server is still torn down when I run `vite` locally and then kill it with `ctrl+c`.  I think it will also be interesting to see if CI completes successfully, since that was a problem the last time that `process.stdin.resume()` was added, which I've added here to match CRA and to allow the stream to drain correctly.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
