### PR TITLE
fix: tolerant fs error in formatError

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -292,7 +292,9 @@ export async function createPluginContainer(
           let code = ctx._activeCode
           if (err.loc.file) {
             err.id = normalizePath(err.loc.file)
-            code = fs.readFileSync(err.loc.file, 'utf-8')
+            try {
+              code = fs.readFileSync(err.loc.file, 'utf-8')
+            } catch {}
           }
           err.frame = generateCodeFrame(code, err.loc)
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When plugins failed to process content served by virtual modules, the `formatError` will try to read the file from fs, which does not exist, causes the real error message being overwritten.

Before:
![image](https://user-images.githubusercontent.com/11247099/120614475-d9e29180-c489-11eb-85f1-3268cd95a48d.png)

After:
![image](https://user-images.githubusercontent.com/11247099/120614500-e2d36300-c489-11eb-86cd-84b299ce71c8.png)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
