### PR TITLE
fix: show error message above the stack when HMR overlay is disabled

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -124,7 +124,9 @@ async function handleMessage(payload: HMRPayload) {
       if (enableOverlay) {
         createErrorOverlay(err)
       } else {
-        console.error(`[vite] Internal Server Error\n${err.stack}`)
+        console.error(
+          `[vite] Internal Server Error\n${err.message}\n${err.stack}`
+        )
       }
       break
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The error stack in `ErrorPayload` doesn't contain the original error message, as it's stripped out by the call to `cleanStack` ([source](https://github.com/vitejs/vite/blob/4d2e68b96394c22b55dab205ecbdf4cbd47cc883/packages/vite/src/node/server/middlewares/error.ts#L14)). As a result, if the HMR overlay is disabled, the error message does not appear in console logs.

Therefore, the error message needs to be explicitly prepended.

**Before**

<img width="700" alt="Screen Shot 2021-06-05 at 9 07 40 am" src="https://user-images.githubusercontent.com/772570/120870994-d3fdc500-c5dd-11eb-8d22-6ae1338a0237.png">

**After**

<img width="700" alt="Screen Shot 2021-06-05 at 9 07 07 am" src="https://user-images.githubusercontent.com/772570/120871005-dc560000-c5dd-11eb-8378-4f3ae4e63a86.png">

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
