### PR TITLE
feat: allow 'hidden' sourcemap to remove //# sourceMappingURL from generated maps

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -583,7 +583,7 @@ createServer()
 
 ### build.sourcemap
 
-- **Type:** `boolean | 'inline'`
+- **Type:** `boolean | 'inline' | 'hidden'`
 - **Default:** `false`
 
   Generate production source maps.

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -93,9 +93,9 @@ export interface BuildOptions {
    */
   cssCodeSplit?: boolean
   /**
-   * If true, a separate sourcemap file will be created. If "inline", the
+   * If `true`, a separate sourcemap file will be created. If 'inline', the
    * sourcemap will be appended to the resulting output file as data URI.
-   * "hidden" works like true except that the corresponding sourcemap
+   * 'hidden' works like `true` except that the corresponding sourcemap
    * comments in the bundled files are suppressed.
    * @default false
    */

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -93,10 +93,13 @@ export interface BuildOptions {
    */
   cssCodeSplit?: boolean
   /**
-   * Whether to generate sourcemap
+   * If true, a separate sourcemap file will be created. If "inline", the
+   * sourcemap will be appended to the resulting output file as data URI.
+   * "hidden" works like true except that the corresponding sourcemap
+   * comments in the bundled files are suppressed.
    * @default false
    */
-  sourcemap?: boolean | 'inline'
+  sourcemap?: boolean | 'inline' | 'hidden'
   /**
    * Set to `false` to disable minification, or specify the minifier to use.
    * Available options are 'terser' or 'esbuild'.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Rollup supports hidden sourcemap where `//# sourceMappingURL` is not included in the generated sourcemap.

### Additional context

This fixes #3683 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
