### PR TITLE
fix: don't replace `process.env` if `process` not global variable

### DIFF
--- a/packages/playground/define/__tests__/define.spec.ts
+++ b/packages/playground/define/__tests__/define.spec.ts
@@ -11,4 +11,7 @@ test('string', async () => {
   expect(await page.textContent('.env-var')).toBe(
     JSON.parse(defines['process.env.SOMEVAR'])
   )
+  expect(await page.textContent('.process-as-property')).toBe(
+    defines.__OBJ__.process.env.SOMEVAR
+  )
 })

--- a/packages/playground/define/index.html
+++ b/packages/playground/define/index.html
@@ -6,6 +6,7 @@
 <p>Boolean <code class="boolean"></code></p>
 <p>Object <span class="pre object"></span></p>
 <p>Env Var <code class="env-var"></code></p>
+<p>process as property: <code class="process-as-property"></code></p>
 
 <script type="module">
   text('.exp', __EXP__)
@@ -14,6 +15,7 @@
   text('.boolean', __BOOLEAN__)
   text('.object', JSON.stringify(__OBJ__, null, 2))
   text('.env-var', process.env.SOMEVAR)
+  text('.process-as-property', __OBJ__.process.env.SOMEVAR)
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/packages/playground/define/vite.config.js
+++ b/packages/playground/define/vite.config.js
@@ -8,6 +8,11 @@ module.exports = {
       foo: 1,
       bar: {
         baz: 2
+      },
+      process: {
+        env: {
+          SOMEVAR: '"PROCESS MAY BE PROPERTY"'
+        }
       }
     },
     'process.env.SOMEVAR': '"SOMEVAR"'

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -32,15 +32,21 @@ export function definePlugin(config: ResolvedConfig): Plugin {
 
   const replacements: Record<string, string | undefined> = {
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || config.mode),
+    'global.process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || config.mode
+    ),
+    'globalThis.process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || config.mode
+    ),
     ...userDefine,
     ...importMetaKeys,
     'process.env.': `({}).`,
     'global.process.env.': `({}).`,
-    'globalThis.process.env.': `({}).`,
+    'globalThis.process.env.': `({}).`
   }
 
   const pattern = new RegExp(
-    '(?<!\.)\\b(' +
+    '(?<!.)\\b(' +
       Object.keys(replacements)
         .map((str) => {
           return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -46,7 +46,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
   }
 
   const pattern = new RegExp(
-    '(?<!.)\\b(' +
+    '(?<!\\.)\\b(' +
       Object.keys(replacements)
         .map((str) => {
           return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -34,11 +34,13 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || config.mode),
     ...userDefine,
     ...importMetaKeys,
-    'process.env.': `({}).`
+    'process.env.': `({}).`,
+    'global.process.env.': `({}).`,
+    'globalThis.process.env.': `({}).`,
   }
 
   const pattern = new RegExp(
-    '\\b(' +
+    '(?<!\.)\\b(' +
       Object.keys(replacements)
         .map((str) => {
           return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Try to fix https://github.com/vitejs/vite/issues/3701

### Additional context

- The string from `replacements` will not be replaced if the `.` (dot) goes before it.
- Also added a few additional synonyms rules to replace the `process.env` if in is in `global` or `globalThis`

The following strings should be replaced
```js
process.env.foo // ({}).foo
global.process.env.foo // ({}).foo
globalThis.process.env.foo // ({}).foo
```

The following strings should NOT be replaced
```js
someVar.process.env.foo
someVar.global.process.env.foo
someVar.globalThis.process.env.foo
```
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
