### PR TITLE
test(css): update dir-dependency test to include js file

### DIFF
--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -220,9 +220,11 @@ test('treeshaken async chunk', async () => {
 test('PostCSS dir-dependency', async () => {
   const el1 = await page.$('.dir-dep')
   const el2 = await page.$('.dir-dep-2')
+  const el3 = await page.$('.dir-dep-3')
 
   expect(await getColor(el1)).toBe('grey')
   expect(await getColor(el2)).toBe('grey')
+  expect(await getColor(el3)).toBe('grey')
 
   if (!isBuild) {
     editFile('glob-dep/foo.css', (code) =>
@@ -230,12 +232,21 @@ test('PostCSS dir-dependency', async () => {
     )
     await untilUpdated(() => getColor(el1), 'blue')
     expect(await getColor(el2)).toBe('grey')
+    expect(await getColor(el3)).toBe('grey')
 
     editFile('glob-dep/bar.css', (code) =>
       code.replace('color: grey', 'color: red')
     )
     await untilUpdated(() => getColor(el2), 'red')
     expect(await getColor(el1)).toBe('blue')
+    expect(await getColor(el3)).toBe('grey')
+
+    editFile('glob-dep/foo.js', (code) =>
+      code.replace('color: grey', 'color: green')
+    )
+    await untilUpdated(() => getColor(el3), 'green')
+    expect(await getColor(el1)).toBe('blue')
+    expect(await getColor(el2)).toBe('red')
 
     // test add/remove
     removeFile('glob-dep/bar.css')

--- a/packages/playground/css/glob-dep/foo.js
+++ b/packages/playground/css/glob-dep/foo.js
@@ -1,0 +1,5 @@
+module.exports = `
+  .dir-dep-3 {
+    color: grey;
+  }
+`

--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -82,6 +82,9 @@
   <p class="dir-dep-2">
     PostCSS dir-dependency (file 2): this should be grey too
   </p>
+  <p class="dir-dep-3">
+    PostCSS dir-dependency (file 3): this should also be grey
+  </p>
 </div>
 
 <script type="module" src="./main.js"></script>

--- a/packages/playground/css/postcss.config.js
+++ b/packages/playground/css/postcss.config.js
@@ -16,10 +16,17 @@ function testDirDep() {
     AtRule(atRule, { result, Comment }) {
       if (atRule.name === 'test') {
         const pattern = normalizePath(
-          path.resolve(path.dirname(result.opts.from), './glob-dep/*.css')
+          path.resolve(path.dirname(result.opts.from), './glob-dep/*.{css,js}')
         )
         const files = glob.sync(pattern)
-        const text = files.map((f) => fs.readFileSync(f, 'utf-8')).join('\n')
+        const text = files
+          .map((f) => {
+            if (f.endsWith('.css')) {
+              return fs.readFileSync(f, 'utf-8')
+            }
+            return require(f)
+          })
+          .join('\n')
         atRule.parent.insertAfter(atRule, text)
         atRule.remove()
 
@@ -27,7 +34,7 @@ function testDirDep() {
           type: 'dir-dependency',
           plugin: 'dir-dep',
           dir: './glob-dep',
-          glob: '*.css',
+          glob: '*.{css,js}',
           parent: result.opts.from
         })
       }


### PR DESCRIPTION
### Description

This PR updates the PostCSS `dir-dependency` test to include a JavaScript file in the glob.

### Additional context

This test is now failing when run in `serve` mode. It seems that the CSS is not rebuilt when `.js` dependencies are updated. You can see this behaviour in this "real world" example: https://github.com/bradlc/vite-postcss-dependencies – this example uses the latest `canary` release of `tailwindcss`. The plugin registers `main.js` as a dependency, but the CSS is not rebuilt when this file changes.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other