### PR TITLE
fix(css): file or contents missing error in build watch (#3742)

### DIFF
--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -6,7 +6,9 @@ import {
   isBuild,
   listAssets,
   readManifest,
-  readFile
+  readFile,
+  editFile,
+  notifyRebuildComplete
 } from '../../testUtils'
 
 const assetMatch = isBuild
@@ -83,14 +85,14 @@ describe('css url() references', () => {
   })
 
   test('image-set relative', async () => {
-    let imageSet = await getBg('.css-image-set-relative')
+    const imageSet = await getBg('.css-image-set-relative')
     imageSet.split(', ').forEach((s) => {
       expect(s).toMatch(assetMatch)
     })
   })
 
   test('image-set without the url() call', async () => {
-    let imageSet = await getBg('.css-image-set-without-url-call')
+    const imageSet = await getBg('.css-image-set-without-url-call')
     imageSet.split(', ').forEach((s) => {
       expect(s).toMatch(assetMatch)
     })
@@ -195,3 +197,15 @@ if (isBuild) {
     }
   })
 }
+describe('css and assets in css in build watch', () => {
+  if (isBuild) {
+    test('css will not be lost and css does not contain undefined', async () => {
+      editFile('index.html', (code) => code.replace('Assets', 'assets'), true)
+      await notifyRebuildComplete(watcher)
+      const cssFile = findAssetFile(/index\.\w+\.css$/, 'foo')
+      expect(cssFile).not.toBe('')
+      expect(cssFile).not.toMatch(/undefined/)
+      watcher?.close()
+    })
+  }
+})

--- a/packages/playground/assets/vite.config.js
+++ b/packages/playground/assets/vite.config.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   build: {
     outDir: 'dist/foo',
-    manifest: true
+    manifest: true,
+    watch: {}
   }
 }

--- a/packages/playground/testEnv.d.ts
+++ b/packages/playground/testEnv.d.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright-chromium'
+import { RollupWatcher } from 'rollup'
 
 declare global {
   // injected by the custom jest env in scripts/jestEnv.js
@@ -7,4 +8,5 @@ declare global {
   // injected in scripts/jestPerTestSetup.ts
   const browserLogs: string[]
   const viteTestUrl: string
+  const watcher: RollupWatcher
 }

--- a/packages/playground/testUtils.ts
+++ b/packages/playground/testUtils.ts
@@ -70,7 +70,7 @@ export function editFile(
   filename: string,
   replacer: (str: string) => string,
   runInBuild: boolean = false
-) {
+): void {
   if (isBuild && !runInBuild) return
   filename = path.resolve(testDir, filename)
   const content = fs.readFileSync(filename, 'utf-8')

--- a/packages/playground/testUtils.ts
+++ b/packages/playground/testUtils.ts
@@ -66,8 +66,12 @@ export function readFile(filename: string) {
   return fs.readFileSync(path.resolve(testDir, filename), 'utf-8')
 }
 
-export function editFile(filename: string, replacer: (str: string) => string) {
-  if (isBuild) return
+export function editFile(
+  filename: string,
+  replacer: (str: string) => string,
+  runInBuild: boolean = false
+) {
+  if (isBuild && !runInBuild) return
   filename = path.resolve(testDir, filename)
   const content = fs.readFileSync(filename, 'utf-8')
   const modified = replacer(content)
@@ -122,3 +126,8 @@ export async function untilUpdated(
     }
   }
 }
+
+/**
+ * Send the rebuild complete message in build watch
+ */
+export { notifyRebuildComplete } from '../../scripts/jestPerTestSetup'

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -28,7 +28,7 @@ const assetHashToFilenameMap = new WeakMap<
   Map<string, string>
 >()
 // save hashes of the files that has been emitted in build watch
-const emittedHashesSet: Set<string> = new Set()
+const emittedHashMap = new WeakMap<ResolvedConfig, Set<string>>()
 
 /**
  * Also supports loading plain strings with import text from './foo.txt?raw'
@@ -41,7 +41,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
 
     buildStart() {
       assetCache.set(config, new Map())
-      emittedHashesSet.clear()
+      emittedHashMap.set(config, new Set())
     },
 
     resolveId(id) {
@@ -237,13 +237,14 @@ async function fileToBuiltUrl(
     if (!map.has(contentHash)) {
       map.set(contentHash, fileName)
     }
-    if (!emittedHashesSet.has(contentHash)) {
+    const emittedSet = emittedHashMap.get(config)!
+    if (!emittedSet.has(contentHash)) {
       pluginContext.emitFile({
         fileName,
         type: 'asset',
         source: content
       })
-      emittedHashesSet.add(contentHash)
+      emittedSet.add(contentHash)
     }
 
     url = `__VITE_ASSET__${contentHash}__${postfix ? `$_${postfix}__` : ``}`

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -223,7 +223,8 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
  * Plugin applied after user plugins
  */
 export function cssPostPlugin(config: ResolvedConfig): Plugin {
-  let styles: Map<string, string>
+  // styles initialization in buildStart causes a styling loss in watch
+  const styles: Map<string, string> = new Map<string, string>()
   let pureCssChunks: Set<string>
 
   // when there are multiple rollup outputs and extracting CSS, only emit once,
@@ -236,7 +237,6 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
     buildStart() {
       // Ensure new caches for every build (i.e. rebuilding in watch mode)
-      styles = new Map<string, string>()
       pureCssChunks = new Set<string>()
       outputToExtractedCSSMap = new Map<NormalizedOutputOptions, string>()
     },

--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -2,10 +2,16 @@ import fs from 'fs-extra'
 import * as http from 'http'
 import { resolve, dirname } from 'path'
 import sirv from 'sirv'
-import { createServer, build, ViteDevServer, UserConfig } from 'vite'
+import {
+  createServer,
+  build,
+  ViteDevServer,
+  UserConfig,
+  PluginOption
+} from 'vite'
 import { Page } from 'playwright-chromium'
 // eslint-disable-next-line node/no-extraneous-import
-import { RollupWatcher } from 'rollup'
+import { RollupWatcher, RollupWatcherEvent } from 'rollup'
 
 const isBuildTest = !!process.env.VITE_TEST_BUILD
 
@@ -104,10 +110,10 @@ beforeAll(async () => {
         process.env.VITE_INLINE = 'inline-build'
         // determine build watch
         let isWatch = false
-        const resolvedPlugin = () => ({
+        const resolvedPlugin: () => PluginOption = () => ({
           name: 'vite-plugin-watcher',
           configResolved(resolvedConfig) {
-            isWatch = resolvedConfig.build?.watch
+            isWatch = !!resolvedConfig.build?.watch
           }
         })
         options.plugins = [resolvedPlugin()]
@@ -191,8 +197,8 @@ function startStaticServer(): Promise<string> {
  */
 export async function notifyRebuildComplete(
   watcher: RollupWatcher
-): Promise<any> {
-  let callback
+): Promise<RollupWatcher> {
+  let callback: (event: RollupWatcherEvent) => void
   await new Promise((resolve, reject) => {
     callback = (event) => {
       if (event.code === 'END') {

--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -7,7 +7,8 @@ import {
   build,
   ViteDevServer,
   UserConfig,
-  PluginOption
+  PluginOption,
+  ResolvedConfig
 } from 'vite'
 import { Page } from 'playwright-chromium'
 // eslint-disable-next-line node/no-extraneous-import
@@ -109,15 +110,16 @@ beforeAll(async () => {
       } else {
         process.env.VITE_INLINE = 'inline-build'
         // determine build watch
-        let isWatch = false
+        let resolvedConfig: ResolvedConfig
         const resolvedPlugin: () => PluginOption = () => ({
           name: 'vite-plugin-watcher',
-          configResolved(resolvedConfig) {
-            isWatch = !!resolvedConfig.build?.watch
+          configResolved(config) {
+            resolvedConfig = config
           }
         })
         options.plugins = [resolvedPlugin()]
         const rollupOutput = await build(options)
+        const isWatch = !!resolvedConfig!.build.watch
         // in build watch,call startStaticServer after the build is complete
         if (isWatch) {
           global.watcher = rollupOutput as RollupWatcher


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix #3742, `styles` will be incomplete，because `styles` is initialized in `buildStart`.
https://github.com/vitejs/vite/blob/5979d0e3b2c071ee15408aa67974af04f7bb1c3d/packages/vite/src/node/plugins/css.ts#L290
In `asset.ts`, `assetHashToFilenameMap` initialization in `buildStart` causes `getAssetFilename` called in `css.ts` to return `undefined`.
https://github.com/vitejs/vite/blob/5979d0e3b2c071ee15408aa67974af04f7bb1c3d/packages/vite/src/node/plugins/css.ts#L314
 I add another variable `emittedHashesSet` to determine whether to emit a file.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
