### PR TITLE
fix(css): #3729 filter out function name suffixes with url

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -24,4 +24,20 @@ describe('search css url function', () => {
     }`)
     ).toBe(false)
   })
+
+  test('after parenthesis', () => {
+    expect(
+      cssUrlRE.test(
+        'mask-image: image(url(mask.png), skyblue, linear-gradient(rgba(0, 0, 0, 1.0), transparent));'
+      )
+    ).toBe(true)
+  })
+
+  test('after comma', () => {
+    expect(
+      cssUrlRE.test(
+        'mask-image: image(skyblue,url(mask.png), linear-gradient(rgba(0, 0, 0, 1.0), transparent));'
+      )
+    ).toBe(true)
+  })
 })

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -1,0 +1,27 @@
+import { cssUrlRE } from '../../plugins/css'
+
+describe('search css url function', () => {
+  test('some spaces before it', () => {
+    expect(
+      cssUrlRE.test("list-style-image: url('../images/bullet.jpg');")
+    ).toBe(true)
+  })
+
+  test('no space after colon', () => {
+    expect(cssUrlRE.test("list-style-image:url('../images/bullet.jpg');")).toBe(
+      true
+    )
+  })
+
+  test('at the beginning of line', () => {
+    expect(cssUrlRE.test("url('../images/bullet.jpg');")).toBe(true)
+  })
+
+  test('as suffix of a function name', () => {
+    expect(
+      cssUrlRE.test(`@function svg-url($string) {
+      @return "";
+    }`)
+    ).toBe(false)
+  })
+})

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -757,7 +757,9 @@ type CssUrlReplacer = (
   url: string,
   importer?: string
 ) => string | Promise<string>
-export const cssUrlRE = /(?:^|\:|\s)url\(\s*('[^']+'|"[^"]+"|[^'")]+)\s*\)/
+// https://drafts.csswg.org/css-syntax-3/#identifier-code-point
+export const cssUrlRE =
+  /(?:^|[^\w\-\u0080-\uffff])url\(\s*('[^']+'|"[^"]+"|[^'")]+)\s*\)/
 const cssImageSetRE = /image-set\(([^)]+)\)/
 
 const UrlRewritePostcssPlugin: Postcss.PluginCreator<{

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -757,7 +757,7 @@ type CssUrlReplacer = (
   url: string,
   importer?: string
 ) => string | Promise<string>
-const cssUrlRE = /url\(\s*('[^']+'|"[^"]+"|[^'")]+)\s*\)/
+export const cssUrlRE = /(?:^|\:|\s)url\(\s*('[^']+'|"[^"]+"|[^'")]+)\s*\)/
 const cssImageSetRE = /image-set\(([^)]+)\)/
 
 const UrlRewritePostcssPlugin: Postcss.PluginCreator<{


### PR DESCRIPTION
### Description

fix #3729

 https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/css.ts#L800-L808

old regExp would rewrite this
```scss
 @function svg-url($string) { 
 @return ""; 
 } 
```
to something like due to the rebase process on importing file
```scss
 @function svg-url(@a/a/svg/$string) { 
 @return ""; 
 } 
```

### Additional context

Is there any case the new regExp hasn't covered ?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
