### PR TITLE
fix(create-app): update svelte templates to use named export of vite-…

### DIFF
--- a/packages/create-app/template-svelte-ts/package.json
+++ b/packages/create-app/template-svelte-ts/package.json
@@ -8,7 +8,7 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.7",
+    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
     "@tsconfig/svelte": "^2.0.1",
     "svelte": "^3.37.0",
     "svelte-check": "^2.1.0",

--- a/packages/create-app/template-svelte-ts/svelte.config.js
+++ b/packages/create-app/template-svelte-ts/svelte.config.js
@@ -1,6 +1,6 @@
-const sveltePreprocess = require('svelte-preprocess')
+import sveltePreprocess from 'svelte-preprocess'
 
-module.exports = {
+export default {
   // Consult https://github.com/sveltejs/svelte-preprocess
   // for more information about preprocessors
   preprocess: sveltePreprocess()

--- a/packages/create-app/template-svelte-ts/vite.config.js
+++ b/packages/create-app/template-svelte-ts/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import svelte from '@sveltejs/vite-plugin-svelte'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/packages/create-app/template-svelte/package.json
+++ b/packages/create-app/template-svelte/package.json
@@ -7,7 +7,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.7",
+    "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",
     "svelte": "^3.37.0",
     "vite": "^2.3.7"
   }

--- a/packages/create-app/template-svelte/vite.config.js
+++ b/packages/create-app/template-svelte/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import svelte from '@sveltejs/vite-plugin-svelte'
+import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
…plugin-svelte

<!-- Thank you for contributing! -->

### Description

Starting with version 1.0.0-next.11,  @sveltejs/vite-plugin-svelte is going to use a named export 'svelte' instead of a default export for the plugin function. ~~This PR is in preparation for that and should be merged **after** 1.0.0-next.11 has been released~~

update: vite-plugin-svelte@1.0.0-next.11 has been released this PR is ready to be merged

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
