### PR TITLE
fix(utils): add dot-all flag to match all characters, fix #3761

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -94,8 +94,8 @@ export function ensureVolumeInPath(file: string): string {
   return isWindows ? path.resolve(file) : file
 }
 
-export const queryRE = /\?.*$/
-export const hashRE = /#.*$/
+export const queryRE = /\?.*$/s
+export const hashRE = /#.*$/s
 
 export const cleanUrl = (url: string): string =>
   url.replace(hashRE, '').replace(queryRE, '')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #3761 

### Additional context

We can make a assumption that every url pass to `clearUrl` is valid. As long as url is valid, we don't care about what character appears in query or hash.This is how `node` does in [`URL` module](https://github.com/nodejs/node/blob/2bb0c20/lib/url.js#L453-L470). So here we can simply add `dot-all` flag to match all characters after the question mark and also the number sign.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
