### PR TITLE
fix: ?import with trailing = added by some servers

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -300,7 +300,7 @@ async function fetchUpdate({ path, acceptedPath, timestamp }: Update) {
           /* @vite-ignore */
           base +
             path.slice(1) +
-            `?import=&t=${timestamp}${query ? `&${query}` : ''}`
+            `?import&t=${timestamp}${query ? `&${query}` : ''}`
         )
         moduleMap.set(dep, newMod)
       } catch (e) {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -300,7 +300,7 @@ async function fetchUpdate({ path, acceptedPath, timestamp }: Update) {
           /* @vite-ignore */
           base +
             path.slice(1) +
-            `?import&t=${timestamp}${query ? `&${query}` : ''}`
+            `?import=vitedev&t=${timestamp}${query ? `&${query}` : ''}`
         )
         moduleMap.set(dep, newMod)
       } catch (e) {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -300,7 +300,7 @@ async function fetchUpdate({ path, acceptedPath, timestamp }: Update) {
           /* @vite-ignore */
           base +
             path.slice(1) +
-            `?import=vitedev&t=${timestamp}${query ? `&${query}` : ''}`
+            `?import=&t=${timestamp}${query ? `&${query}` : ''}`
         )
         moduleMap.set(dep, newMod)
       } catch (e) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -54,7 +54,7 @@ function isExplicitImportRequired(url: string) {
 
 function markExplicitImport(url: string) {
   if (isExplicitImportRequired(url)) {
-    return injectQuery(url, 'import=')
+    return injectQuery(url, 'import')
   }
   return url
 }
@@ -222,7 +222,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // for relative js/css imports, inherit importer's version query
           // do not do this for unknown type imports, otherwise the appended
           // query can break 3rd party plugin's extension checks.
-          if (isRelative && !/[\?&]import=\b/.test(url)) {
+          if (isRelative && !/[\?&]import=?\b/.test(url)) {
             const versionMatch = importer.match(DEP_VERSION_RE)
             if (versionMatch) {
               url = injectQuery(url, versionMatch[1])
@@ -419,11 +419,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             isExplicitImportRequired(url.slice(1, -1))
           ) {
             needQueryInjectHelper = true
-            str().overwrite(
-              start,
-              end,
-              `__vite__injectQuery(${url}, 'import=')`
-            )
+            str().overwrite(start, end, `__vite__injectQuery(${url}, 'import')`)
           }
         }
       }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -54,7 +54,7 @@ function isExplicitImportRequired(url: string) {
 
 function markExplicitImport(url: string) {
   if (isExplicitImportRequired(url)) {
-    return injectQuery(url, 'import=vitedev')
+    return injectQuery(url, 'import=')
   }
   return url
 }
@@ -222,7 +222,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // for relative js/css imports, inherit importer's version query
           // do not do this for unknown type imports, otherwise the appended
           // query can break 3rd party plugin's extension checks.
-          if (isRelative && !/[\?&]import=vitedev\b/.test(url)) {
+          if (isRelative && !/[\?&]import=\b/.test(url)) {
             const versionMatch = importer.match(DEP_VERSION_RE)
             if (versionMatch) {
               url = injectQuery(url, versionMatch[1])
@@ -422,7 +422,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             str().overwrite(
               start,
               end,
-              `__vite__injectQuery(${url}, 'import=vitedev')`
+              `__vite__injectQuery(${url}, 'import=')`
             )
           }
         }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -54,7 +54,7 @@ function isExplicitImportRequired(url: string) {
 
 function markExplicitImport(url: string) {
   if (isExplicitImportRequired(url)) {
-    return injectQuery(url, 'import')
+    return injectQuery(url, 'import=vitedev')
   }
   return url
 }
@@ -222,7 +222,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // for relative js/css imports, inherit importer's version query
           // do not do this for unknown type imports, otherwise the appended
           // query can break 3rd party plugin's extension checks.
-          if (isRelative && !/[\?&]import\b/.test(url)) {
+          if (isRelative && !/[\?&]import=vitedev\b/.test(url)) {
             const versionMatch = importer.match(DEP_VERSION_RE)
             if (versionMatch) {
               url = injectQuery(url, versionMatch[1])
@@ -419,7 +419,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             isExplicitImportRequired(url.slice(1, -1))
           ) {
             needQueryInjectHelper = true
-            str().overwrite(start, end, `__vite__injectQuery(${url}, 'import')`)
+            str().overwrite(
+              start,
+              end,
+              `__vite__injectQuery(${url}, 'import=vitedev')`
+            )
           }
         }
       }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -118,7 +118,7 @@ export const isJSRequest = (url: string): boolean => {
   return false
 }
 
-const importQueryRE = /(\?|&)import=vitedev(?:&|$)/
+const importQueryRE = /(\?|&)import=(?:&|$)/
 const trailingSeparatorRE = /[\?&]$/
 export const isImportRequest = (url: string): boolean => importQueryRE.test(url)
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -118,7 +118,7 @@ export const isJSRequest = (url: string): boolean => {
   return false
 }
 
-const importQueryRE = /(\?|&)import(?:&|$)/
+const importQueryRE = /(\?|&)import=vitedev(?:&|$)/
 const trailingSeparatorRE = /[\?&]$/
 export const isImportRequest = (url: string): boolean => importQueryRE.test(url)
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -118,7 +118,7 @@ export const isJSRequest = (url: string): boolean => {
   return false
 }
 
-const importQueryRE = /(\?|&)import=(?:&|$)/
+const importQueryRE = /(\?|&)import=?(?:&|$)/
 const trailingSeparatorRE = /[\?&]$/
 export const isImportRequest = (url: string): boolean => importQueryRE.test(url)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vercel's cli tries to resolve all paths before passing them to the frontend dev server. During these checks, it parses query strings. During this parse, it modifies `?import` to be `?import=`, which the vite dev server fails to resolve :(

To prevent this from breaking in Vercel and other dev servers, I've modified the `?import` query param to include a value: `?import=vitedev`

Most servers and URL parsers assume that querystrings are key:value pairs, bound with `=`, and I think it is reasonable to encode that assumption. At the very least, a trailing `=` should be supported (as most parsers assume this is the case).

That said, I'm more than happy to investigate another solution - let me know if you would prefer an alternative :)

### Additional context

Issue:
https://github.com/vitejs/vite/issues/3781

Attempt to fix on Vercel CLI side, includes good discussion on why this should be fixed here:
https://github.com/vercel/vercel/pull/6359

Example of `=` being appended by standard browser URL interface
```js
> u = new URL('http://a.com/p?import')

// good
> u.href
'http://a.com/p?import'

// modify
> u.searchParams.set('a', 'b')

// bad
> u.href
'http://a.com/p?import=&a=b'
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
