### PR TITLE
chore: set stabilityDays for renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,7 @@
   "pin": false,
   "rangeStrategy": "bump",
   "node": false,
+  "stabilityDays": 7,
   "ignoreDeps": [
     // manually bumping
     "esbuild",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://docs.renovatebot.com/configuration-options/#stabilitydays

Make the stabilityDays to **7 days** for bumping the deps.