### PR TITLE
feat: support for regex for ssr.noExternal

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -718,7 +718,7 @@ SSR options may be adjusted in minor releases.
 
 ### ssr.noExternal
 
-- **Type:** `string[]`
+- **Type:** `string | RegExp | (string | RegExp)[]`
 
   Prevent listed dependencies from being externalized for SSR.
 

--- a/packages/playground/ssr-vue/package.json
+++ b/packages/playground/ssr-vue/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "dev": "node server",
     "build": "yarn build:client && yarn build:server",
+    "build:noExternal": "yarn build:client && yarn build:server:noExternal",
     "build:client": "vite build --ssrManifest --outDir dist/client",
     "build:server": "vite build --ssr src/entry-server.js --outDir dist/server",
+    "build:server:noExternal": "vite build --config vite.config.noexternal.js --ssr src/entry-server.js --outDir dist/server",
     "generate": "vite build --ssrManifest --outDir dist/static && yarn build:server && node prerender",
     "serve": "cross-env NODE_ENV=production node server",
     "debug": "node --inspect-brk server"

--- a/packages/playground/ssr-vue/vite.config.noexternal.js
+++ b/packages/playground/ssr-vue/vite.config.noexternal.js
@@ -1,0 +1,22 @@
+const config = require('./vite.config.js')
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = Object.assign(config, {
+  ssr: {
+    noExternal: /./
+  },
+  resolve: {
+    // necessary because vue.ssrUtils is only exported on cjs modules
+    alias: [
+      {
+        find: '@vue/runtime-dom',
+        replacement: '@vue/runtime-dom/dist/runtime-dom.cjs.js'
+      },
+      {
+        find: '@vue/runtime-core',
+        replacement: '@vue/runtime-core/dist/runtime-core.cjs.js'
+      }
+    ]
+  }
+})

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -178,7 +178,7 @@ export type SSRTarget = 'node' | 'webworker'
 
 export interface SSROptions {
   external?: string[]
-  noExternal?: string[]
+  noExternal?: string | RegExp | (string | RegExp)[]
   /**
    * Define the target for the ssr build. The browser field in package.json
    * is ignored for node but used if webworker is the target

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { tryNodeResolve, InternalResolveOptions } from '../plugins/resolve'
 import { isDefined, lookupFile, resolveFrom, unique } from '../utils'
 import { ResolvedConfig } from '..'
-
+import { createFilter } from '@rollup/pluginutils'
 /**
  * Heuristics for determining whether a dependency should be externalized for
  * server-side rendering.
@@ -101,7 +101,10 @@ export function resolveSSRExternal(
   }
   let externals = [...ssrExternals]
   if (config.ssr?.noExternal) {
-    externals = externals.filter((id) => !config.ssr!.noExternal!.includes(id))
+    const filter = createFilter(undefined, config.ssr.noExternal, {
+      resolve: false
+    })
+    externals = externals.filter((id) => filter(id))
   }
   return externals.filter((id) => id !== 'vite')
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds support for regex for ssr.noExternal, implementing what is described at #3818. 

Closes #3818

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
A test was added to the playground to exemplify the use of noExternal with a regex. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

Enhancing an existing feature

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
