### PR TITLE
fix: incorrect transform of imports in object destructure default (fix #3803)

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -208,6 +208,35 @@ test('should declare variable for imported super class', async () => {
   `)
 })
 
+// #3803
+test('should transform object destructure default in function param', async () => {
+  expect(
+    (
+      await ssrTransform(
+        `import { foo } from './dependency';function bar({a=foo()}){}`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    function bar({a=__vite_ssr_import_0__.foo()}){}"
+  `)
+
+  expect(
+    (
+      await ssrTransform(
+        `import { foo } from './dependency';function bar({a=foo}){}`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    function bar({a=__vite_ssr_import_0__.foo}){}"
+  `)
+})
+
 test('sourcemap source', async () => {
   expect(
     (await ssrTransform(`export const a = 1`, null, 'input.js')).map.sources

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -263,9 +263,14 @@ function walk(
       } else if (isFunction(node)) {
         // walk function expressions and add its arguments to known identifiers
         // so that we don't prefix them
-        node.params.forEach((p) =>
-          (eswalk as any)(p, {
+        node.params.forEach((p) => {
+          const paramParentStack: Node[] = []
+
+          ;(eswalk as any)(p, {
             enter(child: Node, parent: Node) {
+              parent && paramParentStack.push(parent)
+
+              const grandparent = paramParentStack[paramParentStack.length - 2]
               if (
                 child.type === 'Identifier' &&
                 // do not record as scope variable if is a destructuring key
@@ -274,15 +279,23 @@ function walk(
                 // assignment of a destructuring variable
                 !(
                   parent &&
-                  parent.type === 'AssignmentPattern' &&
-                  parent.right === child
+                  ((parent.type === 'AssignmentPattern' &&
+                    parent.right === child) ||
+                    (parent.type === 'CallExpression' &&
+                      grandparent?.type === 'AssignmentPattern' &&
+                      grandparent?.right === parent &&
+                      parent.callee === child))
                 )
               ) {
                 setScope(node, child.name)
               }
+            },
+
+            leave(node: Node, parent: Node | null) {
+              parent && paramParentStack.pop()
             }
           })
-        )
+        })
       } else if (node.type === 'Property' && parent!.type === 'ObjectPattern') {
         // mark property in destructuring pattern
         ;(node as any).inPattern = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix: #3803

Fixes an incorrect transform of imports when they are used as the default value of an object destructuring in a function parameter, specifically when the import is a function being called.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
In the case of a function call, there is an additional CallExpression node between the AssignmentPattern and the Identifier, so I had to detect that situation specifically.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
