### PR TITLE
fix(hmr/css): fix infinite recursion on hmr

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -593,7 +593,7 @@ async function compileCSS(
     if (preprocessResult.deps) {
       preprocessResult.deps.forEach((dep) => {
         // sometimes sass registers the file itself as a dep
-        if (dep !== opts.filename) {
+        if (normalizePath(dep) !== normalizePath(opts.filename)) {
           deps.add(dep)
         }
       })

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -227,7 +227,7 @@ function propagateUpdate(
     // additionally check for CSS importers, since a PostCSS plugin like
     // Tailwind JIT may register any file as a dependency to a CSS file.
     for (const importer of node.importers) {
-      if (isCSSRequest(importer.url)) {
+      if (isCSSRequest(importer.url) && !currentChain.includes(importer)) {
         propagateUpdate(
           importer,
           timestamp,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #3864. Description of the problem and reproduction steps are at that bug.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Currently existing tests caught the error (on Windows only, for some reason), no additional tests needed.

The added check, `&& !currentChain.includes(importer)`, is the same as the check a couple of lines below (to prevent an importer already in the chain to be added back again).

https://github.com/vitejs/vite/blob/6eaec3ab74d126310d93f8a93f8577bed1c3f474/packages/vite/src/node/server/hmr.ts#L257-L260



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
