### PR TITLE
fix(plugin-legacy): legacy fallback for dynamic import

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -122,6 +122,13 @@ export default {
   }
   ```
 
+## Dynamic Import
+
+The legacy plugin offers a way to use native `import()` in the modern build while falling back to the legacy build in browsers with native ESM but without dynamic import support (e.g. Legacy Edge). This feature works by injecting a runtime check and loading the legacy bundle with SystemJs runtime if needed. There are the following drawbacks:
+
+- Modern bundle is downloaded in all ESM browsers
+- Modern bundle throws `SyntaxError` in browsers without dynamic import
+
 ## Polyfill Specifiers
 
 Polyfill specifier strings for `polyfills` and `modernPolyfills` can be either of the following:
@@ -147,12 +154,13 @@ export default {
 
 ## Content Security Policy
 
-The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc) and SystemJS initialization. If you have a strict CSP policy requirement, you will need to [add the corresponding hashes to your `script-src` list](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script):
+The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc), SystemJS initialization, and dynamic import fallback. If you have a strict CSP policy requirement, you will need to [add the corresponding hashes to your `script-src` list](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script):
 
 - `MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=`
 - `tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=`
+- `T9h4ixy0FtNsCwAyTfBtIY6uV5ZhMeNQIlL42GAKEME=`
 
-These values can also be retrived via
+These values can also be retrieved via
 
 ```js
 const { cspHashes } = require('@vitejs/plugin-legacy')


### PR DESCRIPTION
Closes #3469

<!-- Thank you for contributing! -->

### Implementation checklist:
- [x] Add a new option to the plugin `fallbackToLegacyIfNoDynamicImport` (disabled by default)
- [x] Write a fallback script that loads SystemJs runtime and legacy bundle
- [x] Do not polyfill dynamic import if option is enabled
- [x] Inject dynamic import banner to ensure that modern bundle errors out as soon as possible
- [x] ~~Investigate if it's possible to filter out syntax error from the modern bundle. (We don't want users or tools like Sentry to see this)~~ Even if it's possible, there's no sure way to distinguish between `import()` syntax error and a regular `SyntaxError`, and we don't want to miss the later
- [x] Document new option, mention drawbacks and alternatives
- [x] Add CSP hash for the fallback script, add a note to the CSP section in the readme

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This is my attempt (or rather PoC) to implement the feature described in #3469.
I'm not quite happy with the current solution, but it's the best I could think of for now.

The problem is that I wanted for the dynamic fallback check to only influence the legacy bundle and not the main one, so proposed solution (check then load correct bundle) wouldn't work, since it requires code execution before even starting to download the correct bundle, while module/nomodule thing works at parse-time.

To not slow down the main bundle, I opted for this approach:
- let tha main bundle download and execute (hoping that most of the targets actually have dynamic import)
- in a separate module script check for dynamic import support and import polyfills and legacy chunk if there's none

The downsides are that main bundle would error-out if dynamic import syntax is not supported, which would produce error, which is not really desirable. Another potential problem is if the main bundle had no dynamic imports, it would fully execute and legacy bundle would load another copy of the app, which sounds like really bad news

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
