### PR TITLE
fix(plugin-legacy): chunk may not exist

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -303,6 +303,7 @@ function viteLegacyPlugin(options = {}) {
     },
 
     transformIndexHtml(html, { chunk }) {
+      if (!chunk) return
       if (chunk.fileName.includes('-legacy')) {
         // The legacy bundle is built first, and its index.html isn't actually
         // emitted. Here we simply record its corresponding legacy chunk.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #3670 

### Additional context
```javascript
import xxx from './xxx?worker&inline'
```
`worker&inline` will cause rollup to compile the web worker script.

https://github.com/vitejs/vite/blob/6e3653fe62bc381deb86d28921e1ae7375456d0b/packages/vite/src/node/plugins/worker.ts#L58-L63

The option plugins contains `vite:build-html` plugin. `chunk.facadeModuleId === id` makes an undefined chunk.

https://github.com/vitejs/vite/blob/6e3653fe62bc381deb86d28921e1ae7375456d0b/packages/vite/src/node/plugins/html.ts#L340-L345

I think that the worker plugin's rollup compile should not use `vite:build-html` as a plugin, but considering that chunk may not exist under other conditions. I added a judgment in plugin-legacy's transformIndexHtml.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
