### PR TITLE
fix(scan): 'for await' support in script setup for dev server

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -217,12 +217,6 @@ function esbuildScanPlugin(
             }
           }
 
-          // <script setup> may contain TLA which is not true TLA but esbuild
-          // will error on it, so replace it with another operator.
-          if (js.includes('await')) {
-            js = js.replace(/\bawait(\s)/g, 'void$1')
-          }
-
           if (
             loader.startsWith('ts') &&
             (path.endsWith('.svelte') ||


### PR DESCRIPTION
### Description

Fixes issue mentioned in https://github.com/vitejs/vite/issues/2528#issuecomment-848697717. Specifically, when using `script setup` and having `for await` loops (non-`TLA`), the dev server fails to start, e.g.:

```typescript
<script lang="ts" setup>
// type Subscription = AsyncIterable<{value: number}>;
const readSubscription = async (subscription: Subscription): Promise<void> => {
    for await (const { value } of subscription) {
       //
    }
};

readSubscription(subscription).catch(() => {});
```

```bash
> yarn dev
> html:...: error: Expected "(" but found "void"
    for void (const { value } of subscription) {
```

This PR removes workaround that was replacing most `await`s with `void`s in `script setup`.

### Additional context

The workaround introduced in https://github.com/vitejs/vite/commit/24ed098eedf9e90da69c328bb4d2749fec957fb3 to tackle `esbuild` not supporting `TLA` (https://github.com/vitejs/vite/issues/2044) in no longer (https://github.com/evanw/esbuild/issues/253#issuecomment-806500846) relevant.

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
