### PR TITLE
fix: don't run import analysis on build in lib

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -97,8 +97,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
     async transform(source, importer) {
       if (
-        importer.includes('node_modules') &&
-        !source.includes('import.meta.glob')
+        config.build.lib ||
+        (importer.includes('node_modules') &&
+          !source.includes('import.meta.glob'))
       ) {
         return
       }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -96,10 +96,12 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer) {
+      // skip on lib mode, #3662
+      if (config.build.lib) return
+
       if (
-        config.build.lib ||
-        (importer.includes('node_modules') &&
-          !source.includes('import.meta.glob'))
+        importer.includes('node_modules') &&
+        !source.includes('import.meta.glob')
       ) {
         return
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When running in library mode, import analysis returns strings that aren't analyzable by future bundlers, which prevents assets from being loaded and throws errors in final bundles. The solution is to not run this process at all, and instead require users of a library to import the css directly (which is what must be done currently, this just gets rid of the errors)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Fixes https://github.com/vitejs/vite/issues/3662
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
