### PR TITLE
feat(plugin-react-refresh): add include / exclude options

### DIFF
--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -27,18 +27,20 @@ export default {
 
 [Full list of Babel parser plugins](https://babeljs.io/docs/en/babel-parser#ecmascript-proposalshttpsgithubcombabelproposals).
 
-## Specifying files to exclude from refreshing
+## Specifying files to include or exclude from refreshing
 
-In some situations you may not want a file to act as an HMR boundary, instead preferring that the changes propigate higher in the stack before being handled. In these cases, you can provide an `exclude` function that receives filenames and should return true if that file should not accept hot module replacement.
+By default, @vite/plugin-react-refresh will process files ending with `.js`, `.jsx`, and `.tsx`, and excludes all files in `node_modules`.
+
+In some situations you may not want a file to act as an HMR boundary, instead preferring that the changes propigate higher in the stack before being handled. In these cases, you can provide an `include` and/or `exclude` option, which can be regex or a [picomatch](https://github.com/micromatch/picomatch#globbing-features) pattern, or array of either. Files must match include and not exclude in order to be processed. Note, when using either `include`, or `exclude`, the defaults will not be merged in, so re-apply them if necessary.
 
 ```js
 export default {
   plugins: [
     reactRefresh({
-      exclude(filename) {
-        // Exclude storybook stories
-        return /\.stories\.(t|j)sx?$/.test(filename)
-      }
+      // Exclude storybook stories and node_modules
+      exclude: [/\.stories\.(t|j)sx?$/, /node_modules/]
+      // Only .tsx files
+      include: '**/*.tsx',
     })
   ]
 }

--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -29,7 +29,7 @@ export default {
 
 ## Specifying files to include or exclude from refreshing
 
-By default, @vite/plugin-react-refresh will process files ending with `.js`, `.jsx`, and `.tsx`, and excludes all files in `node_modules`.
+By default, @vite/plugin-react-refresh will process files ending with `.js`, `.jsx`, `.ts`, and `.tsx`, and excludes all files in `node_modules`.
 
 In some situations you may not want a file to act as an HMR boundary, instead preferring that the changes propagate higher in the stack before being handled. In these cases, you can provide an `include` and/or `exclude` option, which can be regex or a [picomatch](https://github.com/micromatch/picomatch#globbing-features) pattern, or array of either. Files must match include and not exclude to be processed. Note, when using either `include`, or `exclude`, the defaults will not be merged in, so re-apply them if necessary.
 

--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -27,6 +27,23 @@ export default {
 
 [Full list of Babel parser plugins](https://babeljs.io/docs/en/babel-parser#ecmascript-proposalshttpsgithubcombabelproposals).
 
+## Specifying files to exclude from refreshing
+
+In some situations you may not want a file to act as an HMR boundary, instead preferring that the changes propigate higher in the stack before being handled. In these cases, you can provide an `exclude` function that receives filenames and should return true if that file should not accept hot module replacement.
+
+```js
+export default {
+  plugins: [
+    reactRefresh({
+      exclude(filename) {
+        // Exclude storybook stories
+        return /\.stories\.(t|j)sx?$/.test(filename)
+      }
+    })
+  ]
+}
+```
+
 ### Notes
 
 - If using TSX, any TS-supported syntax will already be transpiled away so you won't need to specify them here.

--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -38,9 +38,9 @@ export default {
   plugins: [
     reactRefresh({
       // Exclude storybook stories and node_modules
-      exclude: [/\.stories\.(t|j)sx?$/, /node_modules/]
+      exclude: [/\.stories\.(t|j)sx?$/, /node_modules/],
       // Only .tsx files
-      include: '**/*.tsx',
+      include: '**/*.tsx'
     })
   ]
 }

--- a/packages/plugin-react-refresh/README.md
+++ b/packages/plugin-react-refresh/README.md
@@ -31,7 +31,7 @@ export default {
 
 By default, @vite/plugin-react-refresh will process files ending with `.js`, `.jsx`, and `.tsx`, and excludes all files in `node_modules`.
 
-In some situations you may not want a file to act as an HMR boundary, instead preferring that the changes propigate higher in the stack before being handled. In these cases, you can provide an `include` and/or `exclude` option, which can be regex or a [picomatch](https://github.com/micromatch/picomatch#globbing-features) pattern, or array of either. Files must match include and not exclude in order to be processed. Note, when using either `include`, or `exclude`, the defaults will not be merged in, so re-apply them if necessary.
+In some situations you may not want a file to act as an HMR boundary, instead preferring that the changes propagate higher in the stack before being handled. In these cases, you can provide an `include` and/or `exclude` option, which can be regex or a [picomatch](https://github.com/micromatch/picomatch#globbing-features) pattern, or array of either. Files must match include and not exclude to be processed. Note, when using either `include`, or `exclude`, the defaults will not be merged in, so re-apply them if necessary.
 
 ```js
 export default {

--- a/packages/plugin-react-refresh/index.d.ts
+++ b/packages/plugin-react-refresh/index.d.ts
@@ -7,7 +7,8 @@ declare const createPlugin: PluginFactory & { preambleCode: string }
 
 export interface Options {
   parserPlugins?: ParserOptions['plugins']
-  exclude?: (filename: string) => boolean
+  include?: string | RegExp | Array<string | RegExp>
+  exclude?: string | RegExp | Array<string | RegExp>
 }
 
 export default createPlugin

--- a/packages/plugin-react-refresh/index.d.ts
+++ b/packages/plugin-react-refresh/index.d.ts
@@ -6,7 +6,8 @@ type PluginFactory = (options?: Options) => Plugin
 declare const createPlugin: PluginFactory & { preambleCode: string }
 
 export interface Options {
-  parserPlugins: ParserOptions['plugins']
+  parserPlugins?: ParserOptions['plugins']
+  exclude?: (filename: string) => boolean
 }
 
 export default createPlugin

--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 const fs = require('fs')
 const { transformSync, ParserOptions } = require('@babel/core')
-
+import { createFilter } from '@rollup/pluginutils'
 const runtimePublicPath = '/@react-refresh'
 const runtimeFilePath = require.resolve(
   'react-refresh/cjs/react-refresh-runtime.development.js'
@@ -37,6 +37,10 @@ window.__vite_plugin_react_preamble_installed__ = true
 function reactRefreshPlugin(opts) {
   let shouldSkip = false
   let base = '/'
+  const filter = createFilter(
+    (opts && opts.include) || /\.(?:tsx|jsx|js)$/,
+    (opts && opts.exclude) || /node_modules/
+  )
 
   return {
     name: 'react-refresh',
@@ -65,17 +69,13 @@ function reactRefreshPlugin(opts) {
         return
       }
 
-      if (!/\.(t|j)sx?$/.test(id) || id.includes('node_modules')) {
+      if (!filter(id)) {
         return
       }
 
       // plain js/ts files can't use React without importing it, so skip
       // them whenever possible
       if (!id.endsWith('x') && !code.includes('react')) {
-        return
-      }
-
-      if (typeof opts?.exclude === 'function' && opts.exclude(id)) {
         return
       }
 

--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -1,7 +1,7 @@
 // @ts-check
 const fs = require('fs')
 const { transformSync, ParserOptions } = require('@babel/core')
-import { createFilter } from '@rollup/pluginutils'
+const { createFilter } = require('@rollup/pluginutils')
 const runtimePublicPath = '/@react-refresh'
 const runtimeFilePath = require.resolve(
   'react-refresh/cjs/react-refresh-runtime.development.js'

--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -75,6 +75,10 @@ function reactRefreshPlugin(opts) {
         return
       }
 
+      if (typeof opts?.exclude === 'function' && opts.exclude(id)) {
+        return
+      }
+
       /**
        * @type ParserOptions["plugins"]
        */

--- a/packages/plugin-react-refresh/index.js
+++ b/packages/plugin-react-refresh/index.js
@@ -38,7 +38,7 @@ function reactRefreshPlugin(opts) {
   let shouldSkip = false
   let base = '/'
   const filter = createFilter(
-    (opts && opts.include) || /\.(?:tsx|jsx|js)$/,
+    (opts && opts.include) || /\.(t|j)sx?$/,
     (opts && opts.exclude) || /node_modules/
   )
 

--- a/packages/plugin-react-refresh/package.json
+++ b/packages/plugin-react-refresh/package.json
@@ -29,6 +29,7 @@
     "@babel/core": "^7.14.6",
     "@babel/plugin-transform-react-jsx-self": "^7.14.5",
     "@babel/plugin-transform-react-jsx-source": "^7.14.5",
+    "@rollup/pluginutils": "^4.1.0",
     "react-refresh": "^0.9.0"
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR unblocks a problem in storybook-builder-vite by allowing us to specify an `exclude` filter option to the plugin which prevents it from treating story files as HMR boundaries, as discussed in https://github.com/vitejs/vite/issues/3778.

I've tested this locally in my own storybook vite project, and it does what we want, allowing the change to storybook story files to propagate into storybook itself.

### Additional context

I'd love to hear from anyone who is knowledgable about HMR and in particular getting vite HMR and webpack HMR to play nicely together.  🙏  But this PR is pretty straightforward and I think it could be generally useful in other situations as well, outside of storybook.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
