### PR TITLE
feat(ssr): support commonjs in `ssrTransform`

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -6,7 +6,7 @@ const transform = (code: string, url?: string) =>
 test('default import', async () => {
   expect(await transform(`import foo from 'vue';console.log(foo.bar)`))
     .toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     console.log(__vite_ssr_import_0__.default.bar)"
   `)
@@ -18,7 +18,7 @@ test('named import', async () => {
       `import { ref } from 'vue';function foo() { return ref(0) }`
     )
   ).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
@@ -30,7 +30,7 @@ test('namespace import', async () => {
       `import * as vue from 'vue';function foo() { return vue.ref(0) }`
     )
   ).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
@@ -38,7 +38,7 @@ test('namespace import', async () => {
 
 test('export function declaration', async () => {
   expect(await transform(`export function foo() {}`)).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     function foo() {}
     Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
   `)
@@ -46,7 +46,7 @@ test('export function declaration', async () => {
 
 test('export class declaration', async () => {
   expect(await transform(`export class foo {}`)).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     class foo {}
     Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
   `)
@@ -54,7 +54,7 @@ test('export class declaration', async () => {
 
 test('export var declaration', async () => {
   expect(await transform(`export const a = 1, b = 2`)).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const a = 1, b = 2
     Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
     Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }})"
@@ -64,7 +64,7 @@ test('export var declaration', async () => {
 test('export named', async () => {
   expect(await transform(`const a = 1, b = 2; export { a, b as c }`))
     .toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const a = 1, b = 2; 
     Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
     Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }})"
@@ -74,7 +74,7 @@ test('export named', async () => {
 test('export named from', async () => {
   expect(await transform(`export { ref, computed as c } from 'vue'`))
     .toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
     Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.ref }})
@@ -85,7 +85,7 @@ test('export named from', async () => {
 test('named exports of imported binding', async () => {
   expect(await transform(`import {createApp} from 'vue';export {createApp}`))
     .toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
     Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.createApp }})"
@@ -94,7 +94,7 @@ test('named exports of imported binding', async () => {
 
 test('export * from', async () => {
   expect(await transform(`export * from 'vue'`)).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
     __vite_ssr_exportAll__(__vite_ssr_import_0__)"
@@ -103,7 +103,7 @@ test('export * from', async () => {
 
 test('export default', async () => {
   expect(await transform(`export default {}`)).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     __vite_ssr_exports__.default = {}"
   `)
 })
@@ -111,7 +111,7 @@ test('export default', async () => {
 test('import.meta', async () => {
   expect(await transform(`console.log(import.meta.url)`))
     .toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     console.log(__vite_ssr_import_meta__.url)"
   `)
 })
@@ -119,7 +119,7 @@ test('import.meta', async () => {
 test('dynamic import', async () => {
   expect(await transform(`export const i = () => import('./foo')`))
     .toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const i = () => __vite_ssr_dynamic_import__('./foo')
     Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, configurable: true, get(){ return i }})"
   `)
@@ -128,7 +128,7 @@ test('dynamic import', async () => {
 test('do not rewrite method definition', async () => {
   expect(await transform(`import { fn } from 'vue';class A { fn() { fn() } }`))
     .toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     class A { fn() { __vite_ssr_import_0__.fn() } }"
   `)
@@ -138,7 +138,7 @@ test('do not rewrite catch clause', async () => {
   expect(
     await transform(`import {error} from './dependency';try {} catch(error) {}`)
   ).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
     try {} catch(error) {}"
   `)
@@ -151,7 +151,7 @@ test('should declare variable for imported super class', async () => {
       `import { Foo } from './dependency';` + `class A extends Foo {}`
     )
   ).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
     const Foo = __vite_ssr_import_0__.Foo;
     class A extends Foo {}"
@@ -166,7 +166,7 @@ test('should declare variable for imported super class', async () => {
         `export class B extends Foo {}`
     )
   ).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
     const Foo = __vite_ssr_import_0__.Foo;
     __vite_ssr_exports__.default = class A extends Foo {}
@@ -193,7 +193,7 @@ test('overwrite bindings', async () => {
         `function e() { const { inject } = { inject: true } }\n`
     )
   ).toMatchInlineSnapshot(`
-    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
     const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     const a = { inject: __vite_ssr_import_0__.inject }
     const b = { test: __vite_ssr_import_0__.inject }

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -1,93 +1,81 @@
-import { traverseHtml } from '../../plugins/html'
 import { ssrTransform } from '../ssrTransform'
 
+const transform = (code: string, url?: string) =>
+  ssrTransform(code, null, url).then((res) => res.code)
+
 test('default import', async () => {
-  expect(
-    (
-      await ssrTransform(
-        `import foo from 'vue';console.log(foo.bar)`,
-        null,
-        null
-      )
-    ).code
-  ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+  expect(await transform(`import foo from 'vue';console.log(foo.bar)`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     console.log(__vite_ssr_import_0__.default.bar)"
   `)
 })
 
 test('named import', async () => {
   expect(
-    (
-      await ssrTransform(
-        `import { ref } from 'vue';function foo() { return ref(0) }`,
-        null,
-        null
-      )
-    ).code
+    await transform(
+      `import { ref } from 'vue';function foo() { return ref(0) }`
+    )
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
 })
 
 test('namespace import', async () => {
   expect(
-    (
-      await ssrTransform(
-        `import * as vue from 'vue';function foo() { return vue.ref(0) }`,
-        null,
-        null
-      )
-    ).code
+    await transform(
+      `import * as vue from 'vue';function foo() { return vue.ref(0) }`
+    )
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
 })
 
 test('export function declaration', async () => {
-  expect((await ssrTransform(`export function foo() {}`, null, null)).code)
-    .toMatchInlineSnapshot(`
-    "function foo() {}
+  expect(await transform(`export function foo() {}`)).toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    function foo() {}
     Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
   `)
 })
 
 test('export class declaration', async () => {
-  expect((await ssrTransform(`export class foo {}`, null, null)).code)
-    .toMatchInlineSnapshot(`
-    "class foo {}
+  expect(await transform(`export class foo {}`)).toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    class foo {}
     Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
   `)
 })
 
 test('export var declaration', async () => {
-  expect((await ssrTransform(`export const a = 1, b = 2`, null, null)).code)
-    .toMatchInlineSnapshot(`
-    "const a = 1, b = 2
+  expect(await transform(`export const a = 1, b = 2`)).toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const a = 1, b = 2
     Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
     Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }})"
   `)
 })
 
 test('export named', async () => {
-  expect(
-    (await ssrTransform(`const a = 1, b = 2; export { a, b as c }`, null, null))
-      .code
-  ).toMatchInlineSnapshot(`
-    "const a = 1, b = 2; 
+  expect(await transform(`const a = 1, b = 2; export { a, b as c }`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const a = 1, b = 2; 
     Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
     Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }})"
   `)
 })
 
 test('export named from', async () => {
-  expect(
-    (await ssrTransform(`export { ref, computed as c } from 'vue'`, null, null))
-      .code
-  ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+  expect(await transform(`export { ref, computed as c } from 'vue'`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
     Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.ref }})
     Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.computed }})"
@@ -95,78 +83,63 @@ test('export named from', async () => {
 })
 
 test('named exports of imported binding', async () => {
-  expect(
-    (
-      await ssrTransform(
-        `import {createApp} from 'vue';export {createApp}`,
-        null,
-        null
-      )
-    ).code
-  ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+  expect(await transform(`import {createApp} from 'vue';export {createApp}`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
     Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.createApp }})"
   `)
 })
 
 test('export * from', async () => {
-  expect((await ssrTransform(`export * from 'vue'`, null, null)).code)
-    .toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+  expect(await transform(`export * from 'vue'`)).toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
 
     __vite_ssr_exportAll__(__vite_ssr_import_0__)"
   `)
 })
 
 test('export default', async () => {
-  expect(
-    (await ssrTransform(`export default {}`, null, null)).code
-  ).toMatchInlineSnapshot(`"__vite_ssr_exports__.default = {}"`)
+  expect(await transform(`export default {}`)).toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    __vite_ssr_exports__.default = {}"
+  `)
 })
 
 test('import.meta', async () => {
-  expect(
-    (await ssrTransform(`console.log(import.meta.url)`, null, null)).code
-  ).toMatchInlineSnapshot(`"console.log(__vite_ssr_import_meta__.url)"`)
+  expect(await transform(`console.log(import.meta.url)`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    console.log(__vite_ssr_import_meta__.url)"
+  `)
 })
 
 test('dynamic import', async () => {
-  expect(
-    (await ssrTransform(`export const i = () => import('./foo')`, null, null))
-      .code
-  ).toMatchInlineSnapshot(`
-    "const i = () => __vite_ssr_dynamic_import__('./foo')
+  expect(await transform(`export const i = () => import('./foo')`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const i = () => __vite_ssr_dynamic_import__('./foo')
     Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, configurable: true, get(){ return i }})"
   `)
 })
 
 test('do not rewrite method definition', async () => {
-  expect(
-    (
-      await ssrTransform(
-        `import { fn } from 'vue';class A { fn() { fn() } }`,
-        null,
-        null
-      )
-    ).code
-  ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+  expect(await transform(`import { fn } from 'vue';class A { fn() { fn() } }`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     class A { fn() { __vite_ssr_import_0__.fn() } }"
   `)
 })
 
 test('do not rewrite catch clause', async () => {
   expect(
-    (
-      await ssrTransform(
-        `import {error} from './dependency';try {} catch(error) {}`,
-        null,
-        null
-      )
-    ).code
+    await transform(`import {error} from './dependency';try {} catch(error) {}`)
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
     try {} catch(error) {}"
   `)
 })
@@ -174,15 +147,12 @@ test('do not rewrite catch clause', async () => {
 // #2221
 test('should declare variable for imported super class', async () => {
   expect(
-    (
-      await ssrTransform(
-        `import { Foo } from './dependency';` + `class A extends Foo {}`,
-        null,
-        null
-      )
-    ).code
+    await transform(
+      `import { Foo } from './dependency';` + `class A extends Foo {}`
+    )
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
     const Foo = __vite_ssr_import_0__.Foo;
     class A extends Foo {}"
   `)
@@ -190,17 +160,14 @@ test('should declare variable for imported super class', async () => {
   // exported classes: should prepend the declaration at root level, before the
   // first class that uses the binding
   expect(
-    (
-      await ssrTransform(
-        `import { Foo } from './dependency';` +
-          `export default class A extends Foo {}\n` +
-          `export class B extends Foo {}`,
-        null,
-        null
-      )
-    ).code
+    await transform(
+      `import { Foo } from './dependency';` +
+        `export default class A extends Foo {}\n` +
+        `export class B extends Foo {}`
+    )
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
     const Foo = __vite_ssr_import_0__.Foo;
     __vite_ssr_exports__.default = class A extends Foo {}
     class B extends Foo {}
@@ -216,21 +183,18 @@ test('sourcemap source', async () => {
 
 test('overwrite bindings', async () => {
   expect(
-    (
-      await ssrTransform(
-        `import { inject } from 'vue';` +
-          `const a = { inject }\n` +
-          `const b = { test: inject }\n` +
-          `function c() { const { test: inject } = { test: true }; console.log(inject) }\n` +
-          `const d = inject \n` +
-          `function f() {  console.log(inject) }\n` +
-          `function e() { const { inject } = { inject: true } }\n`,
-        null,
-        null
-      )
-    ).code
+    await transform(
+      `import { inject } from 'vue';` +
+        `const a = { inject }\n` +
+        `const b = { test: inject }\n` +
+        `function c() { const { test: inject } = { test: true }; console.log(inject) }\n` +
+        `const d = inject \n` +
+        `function f() {  console.log(inject) }\n` +
+        `function e() { const { inject } = { inject: true } }\n`
+    )
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true})
+    const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
     const a = { inject: __vite_ssr_import_0__.inject }
     const b = { test: __vite_ssr_import_0__.inject }
     function c() { const { test: inject } = { test: true }; console.log(inject) }
@@ -239,4 +203,48 @@ test('overwrite bindings', async () => {
     function e() { const { inject } = { inject: true } }
     "
   `)
+})
+
+describe('commonjs', () => {
+  test('require call', async () => {
+    expect(await transform(`const foo = require("foo")`)).toMatchInlineSnapshot(
+      `"const foo = __vite_ssr_import__(\\"foo\\")"`
+    )
+  })
+
+  test('module.exports assignment', async () => {
+    expect(await transform(`module.exports = 1`)).toMatchInlineSnapshot(
+      `"__vite_ssr_exports__.default = 1"`
+    )
+  })
+
+  test('module.exports property assignment', async () => {
+    expect(await transform(`module.exports.foo = 1`)).toMatchInlineSnapshot(
+      `"__vite_ssr_exports__.foo = 1"`
+    )
+  })
+
+  test('module.exports reference', async () => {
+    expect(await transform(`foo(module.exports)`)).toMatchInlineSnapshot(
+      `"foo(__vite_ssr_exports__)"`
+    )
+  })
+
+  test('module.exports property reference', async () => {
+    expect(await transform(`foo(module.exports.foo)`)).toMatchInlineSnapshot(
+      `"foo(__vite_ssr_exports__.foo)"`
+    )
+  })
+
+  test('exports property assignment', async () => {
+    expect(await transform(`exports.foo = 1`)).toMatchInlineSnapshot(
+      `"__vite_ssr_exports__.foo = 1"`
+    )
+  })
+
+  test('exports property reference', async () => {
+    expect(await transform(`foo(exports.foo)`)).toMatchInlineSnapshot(
+      `"foo(__vite_ssr_exports__.foo)"`
+    )
+  })
 })

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -205,6 +205,15 @@ test('overwrite bindings', async () => {
   `)
 })
 
+test('commonjs false positive', async () => {
+  expect(await transform(`export const exports = require("foo")`))
+    .toMatchInlineSnapshot(`
+    "Object.defineProperty(__vite_ssr_exports__, \\"__esModule\\", {value: true});
+    const exports = require(\\"foo\\")
+    Object.defineProperty(__vite_ssr_exports__, \\"exports\\", { enumerable: true, configurable: true, get(){ return exports }})"
+  `)
+})
+
 describe('commonjs', () => {
   test('require call', async () => {
     expect(await transform(`const foo = require("foo")`)).toMatchInlineSnapshot(

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -71,10 +71,9 @@ async function instantiateModule(
     throw new Error(`failed to load module for ssr: ${url}`)
   }
 
-  const ssrModule = {
+  const ssrModule: any = {
     [Symbol.toStringTag]: 'Module'
   }
-  Object.defineProperty(ssrModule, '__esModule', { value: true })
 
   const isExternal = (dep: string) => dep[0] !== '.' && dep[0] !== '/'
 
@@ -150,6 +149,13 @@ async function instantiateModule(
       }
     )
     throw e
+  }
+
+  if (!ssrModule.__esModule) {
+    Object.defineProperty(ssrModule, '__esModule', { value: true })
+    if (!Object.getOwnPropertyDescriptor(ssrModule, 'default')) {
+      Object.defineProperty(ssrModule, 'default', { value: ssrModule })
+    }
   }
 
   mod.ssrModule = Object.freeze(ssrModule)

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -60,17 +60,21 @@ export async function ssrTransform(
     isCommonJS = true
     if (match[1]) {
       const moduleExportsEnd = match.index + 'module.exports'.length
+      // rewrite `module.exports` to `__vite_ssr_exports__`
       s.overwrite(match.index, moduleExportsEnd, ssrModuleExportsKey)
       if (!match[3] && match[4]) {
+        // rewrite `module.exports =` to `__vite_ssr_exports__.default =`
         s.appendLeft(moduleExportsEnd, '.default')
       }
     } else if (match[2]) {
+      // rewrite `exports` to `__vite_ssr_exports__`
       s.overwrite(
         match.index,
         match.index + 'exports'.length,
         ssrModuleExportsKey
       )
     } else if (match[5]) {
+      // rewrite `require(` to `__vite_ssr_import__(`
       s.overwrite(match.index, match.index + 'require'.length, ssrImportKey)
     }
   }

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -82,6 +82,11 @@ export async function ssrTransform(
       locations: true
     }) as any
 
+    // mark this as a module
+    s.prepend(
+      `Object.defineProperty(${ssrModuleExportsKey}, "__esModule", {value: true})\n`
+    )
+
     // 1. check all import statements and record id -> importName map
     for (const node of ast.body as Node[]) {
       // import foo from 'foo' --> foo -> __import_foo__.default


### PR DESCRIPTION
### Description

When a dependency is (1) cloned within the Vite root and (2) is listed in `optimizeDeps.exclude`, it will pass through `ssrTransform` and might be using `require` and `module.exports`, so we need to check for that and do some basic replacements. Dependencies in `ssr.noExternal` are also affected.

Once we know a URL isn't a module (eg: it doesn't use `import`, `export`, `import.meta` or dynamic `import(...)`), we can do the following replacements:
- replace `require` calls with `__vite_ssr_import__`
- replace `module.exports` and `exports` references with `__vite_ssr_exports__`
- replace `module.exports` assignments with `__vite_ssr_exports__.default = xxx`

This PR also moves `__esModule` declaration into `ssrTransform` so CJS modules can be made compatible with ESM import by automatically assigning `exports.default = exports` within `ssrModuleLoader` if it's undefined. This allows `import foo from 'cjs'` to work as expected.

### Additional context

Fixes #2579

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.