### PR TITLE
fix(hmr): entry mod's importers contains css mod invalidate hmr

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -244,7 +244,15 @@ function propagateUpdate(
     return true
   }
 
+  const isNotCSSMod = !isCSSRequest(node.url)
+  let noImporter = true
+
   for (const importer of node.importers) {
+    if (isCSSRequest(importer.url) && isNotCSSMod) {
+      continue
+    }
+    noImporter = false
+
     const subChain = currentChain.concat(importer)
     if (importer.acceptedHmrDeps.has(node)) {
       boundaries.add({
@@ -263,7 +271,7 @@ function propagateUpdate(
       return true
     }
   }
-  return false
+  return noImporter
 }
 
 function invalidate(mod: ModuleNode, timestamp: number, seen: Set<ModuleNode>) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #3913 #3716 

HMR is not working as change entry javascript file or index.html

### Additional context
entry file `main.js`:
```js
import './index.css';
```
``index.css``:
```css
@tailwind base;
```
hmr is not working as change the`main.js`, the client receive the error update message - `hmr update index.css`

PostCSS plugin Tailwind JIT register any file as a dependency to a CSS file. Although `main.js` is an entry file, `main.js` module's importers includes `index.css` module. Through the `propagateUpdate` function,   get the wrong result that `index.css` needs to be updated.
https://github.com/vitejs/vite/blob/f623ba37dbc517656a7ffb10bc1b3cb221a4bc72/packages/vite/src/node/server/hmr.ts#L212


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
