### PR TITLE
docs: proxy 'configure' option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -411,7 +411,7 @@ export default async ({ command, mode }) => {
         '/api': {
           target: 'http://jsonplaceholder.typicode.com',
           changeOrigin: true,
-          configure: (proxy) => {
+          configure: (proxy, options) => {
             // proxy will be an instance of 'http-proxy'
           }),
         }

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -383,7 +383,7 @@ export default async ({ command, mode }) => {
 
 - **Type:** `Record<string, string | ProxyOptions>`
 
-  Configure custom proxy rules for the dev server. Expects an object of `{ key: options }` pairs. If the key starts with `^`, it will be interpreted as a `RegExp`.
+  Configure custom proxy rules for the dev server. Expects an object of `{ key: options }` pairs. If the key starts with `^`, it will be interpreted as a `RegExp`. The `configure` option can be used to access the proxy instance.
 
   Uses [`http-proxy`](https://github.com/http-party/node-http-proxy). Full options [here](https://github.com/http-party/node-http-proxy#options).
 
@@ -406,6 +406,14 @@ export default async ({ command, mode }) => {
           target: 'http://jsonplaceholder.typicode.com',
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/fallback/, '')
+        }
+        // Using the proxy instance
+        '/api': {
+          target: 'http://jsonplaceholder.typicode.com',
+          changeOrigin: true,
+          configure: (proxy) => {
+            // proxy will be an instance of 'http-proxy'
+          }),
         }
       }
     }


### PR DESCRIPTION
### Description

There is an undocumented `configure` option for `proxy` that allows you to work with the current instance of `http-proxy`. This PR adds some documentation for that option.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Documentation update

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

Closes #2711