### PR TITLE
feat(plugins/worker): Support shared inline worker

### DIFF
--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -64,6 +64,6 @@ if (isBuild) {
     expect(content).toMatch(`new Worker("/assets`)
     expect(content).toMatch(`new SharedWorker("/assets`)
     // inlined
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
+    expect(content).toMatch(`.createObjectURL(`)
   })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR simplifies some of the worker plugin logic by moving duplicate code into a shared function. The new function checks if a URL includes either `?worker` or `?sharedworker`, then returns a function to build the relevant `new Worker(...)` function call string.

This also fixes an issue with the plugin where `?sharedworker` is ignored for blob URLs.

### Additional context

I'm also going to build off this for my rebase in #2494

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
