### PR TITLE
feat: generate inline sourcemaps for bundled vite.config.js files

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -830,6 +830,7 @@ async function bundleConfigFile(
     platform: 'node',
     bundle: true,
     format: mjs ? 'esm' : 'cjs',
+    sourcemap: 'inline',
     metafile: true,
     plugins: [
       {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When a `vite.config.[tj]s` file needs to be bundled, we should append an inline sourcemap to make debugging easier.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
