### PR TITLE
feat(ssr): tolerate circular imports

### DIFF
--- a/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -1,4 +1,4 @@
-import { editFile, getColor, isBuild, untilUpdated } from '../../testUtils'
+import { editFile, untilUpdated } from '../../testUtils'
 import { port } from './serve'
 import fetch from 'node-fetch'
 
@@ -45,4 +45,11 @@ test('client navigation', async () => {
     code.replace('<h1>About', '<h1>changed')
   )
   await untilUpdated(() => page.textContent('h1'), 'changed')
+})
+
+test(`circular dependecies modules doesn't throw`, async () => {
+  await page.goto(url)
+  expect(await page.textContent('.circ-dep-init')).toMatch(
+    'circ-dep-init-a circ-dep-init-b'
+  )
 })

--- a/packages/playground/ssr-react/src/add.js
+++ b/packages/playground/ssr-react/src/add.js
@@ -1,0 +1,9 @@
+import { multiply } from './multiply'
+
+export function add(a, b) {
+  return a + b
+}
+
+export function addAndMultiply(a, b, c) {
+  return multiply(add(a, b), c)
+}

--- a/packages/playground/ssr-react/src/circular-dep-init/README.md
+++ b/packages/playground/ssr-react/src/circular-dep-init/README.md
@@ -1,0 +1,1 @@
+This test aim to find out wherever the modules with circular dependencies are correctly initialized

--- a/packages/playground/ssr-react/src/circular-dep-init/circular-dep-init.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/circular-dep-init.js
@@ -1,0 +1,2 @@
+export * from './module-a'
+export { getValueAB } from './module-b'

--- a/packages/playground/ssr-react/src/circular-dep-init/module-a.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/module-a.js
@@ -1,0 +1,1 @@
+export const valueA = 'circ-dep-init-a'

--- a/packages/playground/ssr-react/src/circular-dep-init/module-b.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/module-b.js
@@ -1,0 +1,8 @@
+import { valueA } from './circular-dep-init'
+
+export const valueB = 'circ-dep-init-b'
+export const valueAB = valueA.concat(` ${valueB}`)
+
+export function getValueAB() {
+  return valueAB
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/README.md
+++ b/packages/playground/ssr-react/src/forked-deadlock/README.md
@@ -1,0 +1,45 @@
+This test aim to check for a particular type of circular dependency that causes tricky deadlocks, **deadlocks with forked imports stack**
+
+```
+A -> B means: B is imported by A and B has A in its stack
+A ... B means: A is waiting for B to ssrLoadModule()
+
+H -> X ... Y
+H -> X -> Y ... B
+H -> A ... B
+H -> A -> B ... X
+```
+
+### Forked deadlock description:
+```
+[X] is waiting for [Y] to resolve
+ ↑                  ↳ is waiting for [A] to resolve
+ │                                    ↳ is waiting for [B] to resolve
+ │                                                      ↳ is waiting for [X] to resolve
+ └────────────────────────────────────────────────────────────────────────┘
+```
+
+This may seems a traditional deadlock, but the thing that makes this special is the import stack of each module:
+```
+[X] stack:
+	[H]
+```
+```
+[Y] stack:
+	[X]
+	[H]
+```
+```
+[A] stack:
+	[H]
+```
+```
+[B] stack:
+	[A]
+	[H]
+```
+Even if `[X]` is imported by `[B]`, `[B]` is not in `[X]`'s stack because it's imported by `[H]` in first place then it's stack is only composed by `[H]`. `[H]` **forks** the imports **stack** and this make hard to be found.
+
+### Fix description
+Vite, when imports `[X]`, should check whether `[X]` is already pending and if it is, it must check that, when it was imported in first place, the stack of `[X]` doesn't have any module in common with the current module; in this case `[B]` has the module `[H]` is common with `[X]` and i can assume that a deadlock is going to happen.
+

--- a/packages/playground/ssr-react/src/forked-deadlock/common-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/common-module.js
@@ -1,0 +1,10 @@
+import { stuckModuleExport } from './stuck-module'
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module H
+ */
+export function commonModuleExport() {
+  stuckModuleExport()
+  deadlockfuseModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/deadlock-fuse-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/deadlock-fuse-module.js
@@ -1,0 +1,8 @@
+import { fuseStuckBridgeModuleExport } from './fuse-stuck-bridge-module'
+
+/**
+ * module A
+ */
+export function deadlockfuseModuleExport() {
+  fuseStuckBridgeModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/fuse-stuck-bridge-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/fuse-stuck-bridge-module.js
@@ -1,0 +1,8 @@
+import { stuckModuleExport } from './stuck-module'
+
+/**
+ * module C
+ */
+export function fuseStuckBridgeModuleExport() {
+  stuckModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/middle-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/middle-module.js
@@ -1,0 +1,8 @@
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module Y
+ */
+export function middleModuleExport() {
+  void deadlockfuseModuleExport
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/stuck-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/stuck-module.js
@@ -1,0 +1,8 @@
+import { middleModuleExport } from './middle-module'
+
+/**
+ * module X
+ */
+export function stuckModuleExport() {
+  middleModuleExport()
+}

--- a/packages/playground/ssr-react/src/multiply.js
+++ b/packages/playground/ssr-react/src/multiply.js
@@ -1,0 +1,9 @@
+import { add } from './add'
+
+export function multiply(a, b) {
+  return a * b
+}
+
+export function multiplyAndAdd(a, b, c) {
+  return add(multiply(a, b), c)
+}

--- a/packages/playground/ssr-react/src/pages/About.jsx
+++ b/packages/playground/ssr-react/src/pages/About.jsx
@@ -1,3 +1,12 @@
+import { addAndMultiply } from '../add'
+import { multiplyAndAdd } from '../multiply'
+
 export default function About() {
-  return <h1>About</h1>
+  return (
+    <>
+      <h1>About</h1>
+      <div>{addAndMultiply(1, 2, 3)}</div>
+      <div>{multiplyAndAdd(1, 2, 3)}</div>
+    </>
+  )
 }

--- a/packages/playground/ssr-react/src/pages/Home.jsx
+++ b/packages/playground/ssr-react/src/pages/Home.jsx
@@ -1,3 +1,12 @@
+import { addAndMultiply } from '../add'
+import { multiplyAndAdd } from '../multiply'
+
 export default function Home() {
-  return <h1>Home</h1>
+  return (
+    <>
+      <h1>Home</h1>
+      <div>{addAndMultiply(1, 2, 3)}</div>
+      <div>{multiplyAndAdd(1, 2, 3)}</div>
+    </>
+  )
 }

--- a/packages/playground/ssr-react/src/pages/Home.jsx
+++ b/packages/playground/ssr-react/src/pages/Home.jsx
@@ -1,12 +1,17 @@
 import { addAndMultiply } from '../add'
 import { multiplyAndAdd } from '../multiply'
+import { commonModuleExport } from '../forked-deadlock/common-module'
+import { getValueAB } from '../circular-dep-init/circular-dep-init'
 
 export default function Home() {
+  commonModuleExport()
+
   return (
     <>
       <h1>Home</h1>
       <div>{addAndMultiply(1, 2, 3)}</div>
       <div>{multiplyAndAdd(1, 2, 3)}</div>
+      <div className="circ-dep-init">{getValueAB()}</div>
     </>
   )
 }

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -11,7 +11,7 @@ test('default import', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     console.log(__vite_ssr_import_0__.default.bar)"
   `)
 })
@@ -26,7 +26,7 @@ test('named import', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
 })
@@ -41,7 +41,7 @@ test('namespace import', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
 })
@@ -50,7 +50,7 @@ test('export function declaration', async () => {
   expect((await ssrTransform(`export function foo() {}`, null, null)).code)
     .toMatchInlineSnapshot(`
     "function foo() {}
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }});"
   `)
 })
 
@@ -58,7 +58,7 @@ test('export class declaration', async () => {
   expect((await ssrTransform(`export class foo {}`, null, null)).code)
     .toMatchInlineSnapshot(`
     "class foo {}
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }});"
   `)
 })
 
@@ -66,8 +66,8 @@ test('export var declaration', async () => {
   expect((await ssrTransform(`export const a = 1, b = 2`, null, null)).code)
     .toMatchInlineSnapshot(`
     "const a = 1, b = 2
-    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
-    Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }});
+    Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }});"
   `)
 })
 
@@ -77,8 +77,8 @@ test('export named', async () => {
       .code
   ).toMatchInlineSnapshot(`
     "const a = 1, b = 2; 
-    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
-    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }});
+    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }});"
   `)
 })
 
@@ -87,10 +87,10 @@ test('export named from', async () => {
     (await ssrTransform(`export { ref, computed as c } from 'vue'`, null, null))
       .code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
 
-    Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.ref }})
-    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.computed }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.ref }});
+    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.computed }});"
   `)
 })
 
@@ -104,27 +104,35 @@ test('named exports of imported binding', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
 
-    Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.createApp }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.createApp }});"
   `)
 })
 
 test('export * from', async () => {
-  expect((await ssrTransform(`export * from 'vue'`, null, null)).code)
-    .toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
-
-    __vite_ssr_exportAll__(__vite_ssr_import_0__)"
+  expect(
+    (
+      await ssrTransform(
+        `export * from 'vue'\n` + `export * from 'react'`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    __vite_ssr_exportAll__(__vite_ssr_import_0__);
+    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"react\\");
+    __vite_ssr_exportAll__(__vite_ssr_import_1__);"
   `)
 })
 
 test('export * as from', async () => {
   expect((await ssrTransform(`export * as foo from 'vue'`, null, null)).code)
     .toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
 
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__ }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__ }});"
   `)
 })
 
@@ -146,7 +154,7 @@ test('dynamic import', async () => {
       .code
   ).toMatchInlineSnapshot(`
     "const i = () => __vite_ssr_dynamic_import__('./foo')
-    Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, configurable: true, get(){ return i }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, configurable: true, get(){ return i }});"
   `)
 })
 
@@ -160,7 +168,7 @@ test('do not rewrite method definition', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     class A { fn() { __vite_ssr_import_0__.fn() } }"
   `)
 })
@@ -175,7 +183,7 @@ test('do not rewrite catch clause', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./dependency\\");
     try {} catch(error) {}"
   `)
 })
@@ -191,7 +199,7 @@ test('should declare variable for imported super class', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./dependency\\");
     const Foo = __vite_ssr_import_0__.Foo;
     class A extends Foo {}"
   `)
@@ -209,12 +217,12 @@ test('should declare variable for imported super class', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./dependency\\");
     const Foo = __vite_ssr_import_0__.Foo;
     class A extends Foo {}
     class B extends Foo {}
-    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A })
-    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A });
+    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }});"
   `)
 })
 
@@ -246,7 +254,7 @@ test('should handle default export variants', async () => {
   ).toMatchInlineSnapshot(`
     "function foo() {}
     foo.prototype = Object.prototype;
-    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: foo })"
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: foo });"
   `)
   // default named classes
   expect(
@@ -260,8 +268,8 @@ test('should handle default export variants', async () => {
   ).toMatchInlineSnapshot(`
     "class A {}
     class B extends A {}
-    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A })
-    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A });
+    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }});"
   `)
 })
 
@@ -288,7 +296,7 @@ test('overwrite bindings', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     const a = { inject: __vite_ssr_import_0__.inject }
     const b = { test: __vite_ssr_import_0__.inject }
     function c() { const { test: inject } = { test: true }; console.log(inject) }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -94,7 +94,7 @@ async function instantiateModule(
       return nodeRequire(dep, mod.file, server.config.root)
     }
     dep = unwrapId(dep)
-    if (!pendingImports.get(dep)?.some(isCircular)) {
+    if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
       pendingDeps.push(dep)
       if (pendingDeps.length == 1) {
         pendingImports.set(url, pendingDeps)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -10,7 +10,8 @@ import {
   ssrImportMetaKey,
   ssrDynamicImportKey
 } from './ssrTransform'
-import { transformRequest } from '../server/transformRequest'
+import { transformRequest, TransformResult } from '../server/transformRequest'
+import { ModuleNode } from '../server/moduleGraph'
 
 interface SSRContext {
   global: NodeJS.Global
@@ -42,6 +43,14 @@ export async function ssrLoadModule(
   // request to that module are simply waiting on the same promise.
   const pending = pendingModules.get(url)
   if (pending) {
+    const { moduleGraph } = server
+    const mod = await moduleGraph.ensureEntryFromUrl(url)
+    const transformResult = await transformModule(mod, server)
+    const deps = (transformResult.deps || []).map((d) => unwrapId(d))
+    const circularDep = urlStack.find((u) => deps.includes(u))
+    if (circularDep) {
+      return {}
+    }
     return pending
   }
 
@@ -69,13 +78,7 @@ async function instantiateModule(
     return mod.ssrModule
   }
 
-  const result =
-    mod.ssrTransformResult ||
-    (await transformRequest(url, server, { ssr: true }))
-  if (!result) {
-    // TODO more info? is this even necessary?
-    throw new Error(`failed to load module for ssr: ${url}`)
-  }
+  const result = await transformModule(mod, server)
 
   urlStack = urlStack.concat(url)
 
@@ -83,6 +86,8 @@ async function instantiateModule(
     [Symbol.toStringTag]: 'Module'
   }
   Object.defineProperty(ssrModule, '__esModule', { value: true })
+  // Set immediately so the module is available in case of circular dependencies.
+  mod.ssrModule = ssrModule
 
   // Tolerate circular imports by ensuring the module can be
   // referenced before it's been instantiated.
@@ -208,4 +213,25 @@ function resolve(id: string, importer: string | null, root: string) {
   const resolved = resolveFrom(id, resolveDir, true)
   resolveCache.set(key, resolved)
   return resolved
+}
+
+const pendingTransforms = new Map<string, Promise<TransformResult | null>>()
+
+async function transformModule(mod: ModuleNode, server: ViteDevServer) {
+  const url = mod.url
+  let transformResult = mod.ssrTransformResult
+  if (!transformResult) {
+    let transformPromise = pendingTransforms.get(url)
+    if (!transformPromise) {
+      transformPromise = transformRequest(url, server, { ssr: true })
+      pendingTransforms.set(url, transformPromise)
+      transformPromise.catch(() => {}).then(() => pendingTransforms.delete(url))
+    }
+    transformResult = await transformPromise
+  }
+  if (!transformResult) {
+    // TODO more info? is this even necessary?
+    throw new Error(`failed to load module for ssr: ${url}`)
+  }
+  return transformResult
 }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -96,11 +96,11 @@ async function instantiateModule(
     dep = unwrapId(dep)
     if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
       pendingDeps.push(dep)
-      if (pendingDeps.length == 1) {
+      if (pendingDeps.length === 1) {
         pendingImports.set(url, pendingDeps)
       }
       await ssrLoadModule(dep, server, context, urlStack)
-      if (pendingDeps.length == 1) {
+      if (pendingDeps.length === 1) {
         pendingImports.delete(url)
       } else {
         pendingDeps.splice(pendingDeps.indexOf(dep), 1)
@@ -133,6 +133,7 @@ async function instantiateModule(
   }
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
     const AsyncFunction = async function () {}.constructor as typeof Function
     const initModule = new AsyncFunction(
       `global`,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -82,12 +82,10 @@ async function instantiateModule(
   // referenced before it's been instantiated.
   mod.ssrModule = ssrModule
 
-  const isExternal = (dep: string) => dep[0] !== '.' && dep[0] !== '/'
-
   const ssrImportMeta = { url }
 
   const ssrImport = async (dep: string) => {
-    if (isExternal(dep)) {
+    if (dep[0] !== '.' && dep[0] !== '/') {
       return nodeRequire(dep, mod.file, server.config.root)
     }
     dep = unwrapId(dep)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -19,7 +19,7 @@ interface SSRContext {
 type SSRModule = Record<string, any>
 
 const pendingModules = new Map<string, Promise<SSRModule>>()
-const pendingImports = new Map<string, Set<string>>()
+const pendingImports = new Map<string, string>()
 
 export async function ssrLoadModule(
   url: string,
@@ -28,13 +28,6 @@ export async function ssrLoadModule(
   urlStack: string[] = []
 ): Promise<SSRModule> {
   url = unwrapId(url)
-
-  if (urlStack.includes(url)) {
-    server.config.logger.warn(
-      `Circular dependency: ${urlStack.join(' -> ')} -> ${url}`
-    )
-    return {}
-  }
 
   // when we instantiate multiple dependency modules in parallel, they may
   // point to shared modules. We need to avoid duplicate instantiation attempts
@@ -48,10 +41,11 @@ export async function ssrLoadModule(
   const modulePromise = instantiateModule(url, server, context, urlStack)
   pendingModules.set(url, modulePromise)
   modulePromise
-    .catch(() => {})
+    .catch(() => {
+      pendingImports.delete(url)
+    })
     .then(() => {
       pendingModules.delete(url)
-      pendingImports.delete(url)
     })
   return modulePromise
 }
@@ -90,48 +84,29 @@ async function instantiateModule(
 
   const isExternal = (dep: string) => dep[0] !== '.' && dep[0] !== '/'
 
-  if (result.deps?.length) {
-    // Store the parsed dependencies while this module is loading,
-    // so dependent modules can avoid waiting on a circular import.
-    pendingImports.set(url, new Set(result.deps))
-
-    // Load dependencies one at a time to ensure modules are
-    // instantiated in a predictable order.
-    await result.deps.reduce(
-      (queue, dep) =>
-        isExternal(dep)
-          ? queue
-          : queue.then(async () => {
-              const deps = pendingImports.get(dep)
-              if (!deps || !urlStack.some((url) => deps.has(url))) {
-                await ssrLoadModule(dep, server, context, urlStack)
-              }
-            }),
-      Promise.resolve()
-    )
-  }
-
   const ssrImportMeta = { url }
 
-  const ssrImport = (dep: string) => {
+  const ssrImport = async (dep: string) => {
     if (isExternal(dep)) {
       return nodeRequire(dep, mod.file, server.config.root)
-    } else {
-      return moduleGraph.urlToModuleMap.get(unwrapId(dep))?.ssrModule
     }
+    dep = unwrapId(dep)
+    const pendingImport = pendingImports.get(dep)
+    if (!pendingImport || !urlStack.includes(pendingImport)) {
+      pendingImports.set(url, dep)
+      await ssrLoadModule(dep, server, context, urlStack)
+      pendingImports.delete(url)
+    }
+    return moduleGraph.urlToModuleMap.get(dep)?.ssrModule
   }
 
   const ssrDynamicImport = (dep: string) => {
-    if (isExternal(dep)) {
-      return Promise.resolve(nodeRequire(dep, mod.file, server.config.root))
-    } else {
-      // #3087 dynamic import vars is ignored at rewrite import path,
-      // so here need process relative path
-      if (dep.startsWith('.')) {
-        dep = path.posix.resolve(path.dirname(url), dep)
-      }
-      return ssrLoadModule(dep, server, context, urlStack)
+    // #3087 dynamic import vars is ignored at rewrite import path,
+    // so here need process relative path
+    if (!isExternal(dep) && dep.startsWith('.')) {
+      dep = path.posix.resolve(path.dirname(url), dep)
     }
+    return ssrImport(dep)
   }
 
   function ssrExportAll(sourceModule: any) {
@@ -149,7 +124,8 @@ async function instantiateModule(
   }
 
   try {
-    new Function(
+    const AsyncFunction = async function () {}.constructor as typeof Function
+    const initModule = new AsyncFunction(
       `global`,
       ssrModuleExportsKey,
       ssrImportMetaKey,
@@ -157,7 +133,8 @@ async function instantiateModule(
       ssrDynamicImportKey,
       ssrExportAllKey,
       result.code + `\n//# sourceURL=${mod.url}`
-    )(
+    )
+    await initModule(
       context.global,
       ssrModule,
       ssrImportMeta,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -103,7 +103,7 @@ async function instantiateModule(
   const ssrDynamicImport = (dep: string) => {
     // #3087 dynamic import vars is ignored at rewrite import path,
     // so here need process relative path
-    if (!isExternal(dep) && dep.startsWith('.')) {
+    if (dep[0] === '.') {
       dep = path.posix.resolve(path.dirname(url), dep)
     }
     return ssrImport(dep)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -44,7 +44,7 @@ export async function ssrLoadModule(
     .catch(() => {
       pendingImports.delete(url)
     })
-    .then(() => {
+    .finally(() => {
       pendingModules.delete(url)
     })
   return modulePromise


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR makes SSR imports work like Node.js in the following way:

Modules that depend on each other will never receive an undefined exports. Instead, the module that is first to import the other module will wait for the other module to be instantiated. When the other module imports the first module, it receives the incomplete exports object, which will be completed when the first module is done being instantiated.

To accomplish this behavior, we need to load SSR dependencies **one at a time**. This ensures a predictable import order. Before this PR, the import order is non-deterministic, as it depends on the depth of the dependency tree plus the transformation time per module.

This PR also avoids infinite hangs caused by a dependency having its `ssrLoadModule` promise awaited without first checking if one of its dependencies is within the `urlStack`.

As of 0333312, this PR also allows the "other module" to access the partial exports of the "first module". For example, if `export { foo } from "./foo"` comes before `export { bar } from "./bar"` in the `./index.js` module, then `./bar.js` will still be able to `import { foo } from "./index"` and use it before `./index.js` has finished being instantiated.

### Todo

- [ ] Split out the `playground/ssr-react` changes into a new playground `ssr-circular-import`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Fixes #2258
Fixes #2491 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
