### PR TITLE
fix(ssr): not flatten export * as (fix #3934)

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -119,6 +119,15 @@ test('export * from', async () => {
   `)
 })
 
+test('export * as from', async () => {
+  expect((await ssrTransform(`export * as foo from 'vue'`, null, null)).code)
+    .toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__ }})"
+  `)
+})
+
 test('export default', async () => {
   expect(
     (await ssrTransform(`export default {}`, null, null)).code

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -133,9 +133,15 @@ export async function ssrTransform(
 
     // export * from './foo'
     if (node.type === 'ExportAllDeclaration') {
-      const importId = defineImport(node, node.source.value as string)
-      s.remove(node.start, node.end)
-      s.append(`\n${ssrExportAllKey}(${importId})`)
+      if (!node.exported) {
+        const importId = defineImport(node, node.source.value as string)
+        s.remove(node.start, node.end)
+        s.append(`\n${ssrExportAllKey}(${importId})`)
+      } else {
+        const importId = defineImport(node, node.source.value as string)
+        defineExport(node.exported.name, `${importId}`)
+        s.remove(node.start, node.end)
+      }
     }
   }
 

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -133,14 +133,14 @@ export async function ssrTransform(
 
     // export * from './foo'
     if (node.type === 'ExportAllDeclaration') {
-      if (!node.exported) {
+      if ((node as any).exported) {
+        const importId = defineImport(node, node.source.value as string)
+        defineExport((node as any).exported.name, `${importId}`)
+        s.remove(node.start, node.end)
+      } else {
         const importId = defineImport(node, node.source.value as string)
         s.remove(node.start, node.end)
         s.append(`\n${ssrExportAllKey}(${importId})`)
-      } else {
-        const importId = defineImport(node, node.source.value as string)
-        defineExport(node.exported.name, `${importId}`)
-        s.remove(node.start, node.end)
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix for #3934. This PR relies on a typescript definition PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/54060

### Additional context

A tangential question, why the `default` export doesn't use `Object.defineProperty`?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
