### PR TITLE
docs: clarify CommonJS with `optimizeDeps.exclude`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -691,7 +691,7 @@ createServer()
   Dependencies to exclude from pre-bundling.
 
   :::warning CommonJS
-  CommonJS dependencies cannot be excluded from optimization. If an ESM dependency has a CommonJS dependency, it also cannot be excluded.
+  CommonJS dependencies should not be excluded from optimization. If an ESM dependency has a nested CommonJS dependency, it should not be excluded as well.
   :::
 
 ### optimizeDeps.include

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -690,6 +690,10 @@ createServer()
 
   Dependencies to exclude from pre-bundling.
 
+  :::warning CommonJS
+  CommonJS dependencies cannot be excluded from optimization. If an ESM dependency has a CommonJS dependency, it also cannot be excluded.
+  :::
+
 ### optimizeDeps.include
 
 - **Type:** `string[]`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

As a follow-up to #3927, let's clarify that CJS dependencies cannot be added to `optimizeDeps.exclude`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
