### PR TITLE
refactor: deprecated `server.fs.root` in favor of `server.fs.allow`

### DIFF
--- a/packages/playground/fs-serve/root/vite.config.js
+++ b/packages/playground/fs-serve/root/vite.config.js
@@ -6,8 +6,8 @@ const path = require('path')
 module.exports = {
   server: {
     fs: {
-      root: __dirname,
-      strict: true
+      strict: true,
+      allow: [__dirname]
     },
     hmr: {
       overlay: false

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -713,16 +713,16 @@ export function resolveServerOptions(
   let allowDirs = server.fs?.allow
 
   if (!allowDirs) {
-    allowDirs = [resolvedAllowDir(root, searchForWorkspaceRoot(root))]
-
-    // only push client dir when vite itself is outside-of-root
-    const resolvedClientDir = resolvedAllowDir(root, CLIENT_DIR)
-    if (!allowDirs.some((i) => resolvedClientDir.startsWith(i))) {
-      allowDirs.push(resolvedClientDir)
-    }
+    allowDirs = [searchForWorkspaceRoot(root)]
   }
 
   allowDirs = allowDirs.map((i) => resolvedAllowDir(root, i))
+
+  // only push client dir when vite itself is outside-of-root
+  const resolvedClientDir = resolvedAllowDir(root, CLIENT_DIR)
+  if (!allowDirs.some((i) => resolvedClientDir.startsWith(i))) {
+    allowDirs.push(resolvedClientDir)
+  }
 
   server.fs = {
     // TODO: make strict by default

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -130,7 +130,7 @@ export interface ServerOptions {
 }
 
 export interface ResolvedServerOptions extends ServerOptions {
-  fs: Required<Omit<FileSystemServeOptions, 'root'>>
+  fs: Required<FileSystemServeOptions>
 }
 
 export interface FileSystemServeOptions {
@@ -144,13 +144,6 @@ export interface FileSystemServeOptions {
    * @default undefined
    */
   strict?: boolean | undefined
-
-  /**
-   *
-   * @expiremental
-   * @deprecated use `fs.allow` instead
-   */
-  root?: string
 
   /**
    * Restrict accessing files outside the allowed directories.
@@ -720,15 +713,16 @@ export function resolveServerOptions(
   let allowDirs = server.fs?.allow
 
   if (!allowDirs) {
-    allowDirs = [server.fs?.root || searchForWorkspaceRoot(root)]
-  }
-  allowDirs = allowDirs.map((i) => resolvedAllowDir(root, i))
+    allowDirs = [resolvedAllowDir(root, searchForWorkspaceRoot(root))]
 
-  // only push client dir when vite itself is outside-of-root
-  const resolvedClientDir = resolvedAllowDir(root, CLIENT_DIR)
-  if (!allowDirs.some((i) => resolvedClientDir.startsWith(i))) {
-    allowDirs.push(resolvedClientDir)
+    // only push client dir when vite itself is outside-of-root
+    const resolvedClientDir = resolvedAllowDir(root, CLIENT_DIR)
+    if (!allowDirs.some((i) => resolvedClientDir.startsWith(i))) {
+      allowDirs.push(resolvedClientDir)
+    }
   }
+
+  allowDirs = allowDirs.map((i) => resolvedAllowDir(root, i))
 
   server.fs = {
     // TODO: make strict by default

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -94,7 +94,7 @@ export function serveRawFsMiddleware(
     // the paths are rewritten to `/@fs/` prefixed paths and must be served by
     // searching based from fs root.
     if (url.startsWith(FS_PREFIX)) {
-      // restrict files outside of `fs.root`
+      // restrict files outside of `fs.allow`
       ensureServingAccess(slash(path.resolve(fsPathFromId(url))), server)
       url = url.slice(FS_PREFIX.length)
       if (isWindows) url = url.replace(/^[A-Z]:/i, '')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
