### PR TITLE
docs: add note about opening in a specific browser

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -367,7 +367,7 @@ export default async ({ command, mode }) => {
 
 - **Type:** `boolean | string`
 
-  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can add it to `process.env.BROWSER` (for ex: firefox). For more info, have a look at [the open package](https://www.npmjs.com/package/open) and [openBrowser.ts](https://github.com/vitejs/vite/blob/11de3c226940a9eaf1ba998f037bfbd1e7aaf3ec/packages/vite/src/node/server/openBrowser.ts#L32)
+  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can add it to `process.env.BROWSER` (for ex: firefox). For more info, have a look at [the open package](https://github.com/sindresorhus/open#app) and [openBrowser.ts](https://github.com/vitejs/vite/blob/11de3c226940a9eaf1ba998f037bfbd1e7aaf3ec/packages/vite/src/node/server/openBrowser.ts#L32)
 
   **Example:**
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -367,7 +367,7 @@ export default async ({ command, mode }) => {
 
 - **Type:** `boolean | string`
 
-  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname.
+  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can add it to `process.env.BROWSER` (for ex: firefox). For more info, have a look at [the open package](https://www.npmjs.com/package/open) and [openBrowser.ts](https://github.com/vitejs/vite/blob/11de3c226940a9eaf1ba998f037bfbd1e7aaf3ec/packages/vite/src/node/server/openBrowser.ts#L32)
 
   **Example:**
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -367,7 +367,7 @@ export default async ({ command, mode }) => {
 
 - **Type:** `boolean | string`
 
-  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can add it to `process.env.BROWSER` (for ex: firefox). For more info, have a look at [the open package](https://github.com/sindresorhus/open#app) and [openBrowser.ts](https://github.com/vitejs/vite/blob/11de3c226940a9eaf1ba998f037bfbd1e7aaf3ec/packages/vite/src/node/server/openBrowser.ts#L32)
+  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can set the env `process.env.BROWSER` (e.g. `firefox`). See [the `open` package](https://github.com/sindresorhus/open#app) for more details.
 
   **Example:**
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add small note about how to open your server in a specific browser (not the the dafault)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
