### PR TITLE
fix: Use a separate cached PostCSS config for each CSS plugin instantiation

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -744,7 +744,7 @@ async function resolvePostcssConfig(
     const searchPath =
       typeof inlineOptions === 'string' ? inlineOptions : config.root
     // @ts-ignore
-    return (cachedPostcssConfig = await postcssrc({}, searchPath))
+    return await postcssrc({}, searchPath)
   } catch (e) {
     if (!/No PostCSS Config found/.test(e.message)) {
       throw e

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -140,7 +140,6 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       // Ensure a new cache for every build (i.e. rebuilding in watch mode)
       moduleCache = new Map<string, Record<string, string>>()
       cssModulesCache.set(config, moduleCache)
-      cachedPostcssConfig = undefined
     },
 
     async transform(raw, id) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -139,6 +139,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       // Ensure a new cache for every build (i.e. rebuilding in watch mode)
       moduleCache = new Map<string, Record<string, string>>()
       cssModulesCache.set(config, moduleCache)
+      cachedPostcssConfig = undefined
     },
 
     async transform(raw, id) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The PostCSS config is currently cached once for the entire lifetime of the Node process. This assumes that, for a given Node process, Vite only runs on a single project. That assumption breaks for example when using Vite's API to preview different projects, each with their own PostCSS config.

This PR moves the `cachedPostcssConfig` variable to the `cssPlugin` function scope, so that each Vite server has its own independently cached value (enabling multiple projects to run in parallel).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
