### PR TITLE
fix: insufficient check for postcssConfig plugins

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -604,7 +604,9 @@ async function compileCSS(
   // 3. postcss
   const postcssOptions = (postcssConfig && postcssConfig.options) || {}
   const postcssPlugins =
-    postcssConfig && postcssConfig.plugins ? postcssConfig.plugins.slice() : []
+    postcssConfig && Array.isArray(postcssConfig.plugins)
+      ? postcssConfig.plugins.slice()
+      : []
 
   if (needInlineImport) {
     postcssPlugins.unshift(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The description of `css-postcss` in the [doc](https://vitejs.dev/config/#css-postcss) is
> Inline PostCSS config (expects the same format as postcss.config.js), or a custom path to search PostCSS config from (default is project root).

It’s easy for users not to notice the `css.postcss`'s type(``string | (postcss.ProcessOptions & { plugins?: postcss.Plugin[] })``), give a config that the same format as `postcss.config.js`(plugins is object).
```js
{
  css: {
    postcss: {
      plugins: {...},
    },
  },
}
```
error output:
```
error during build:
TypeError: postcssConfig.plugins.slice is not a function
......
```

### Additional context
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
