### PR TITLE
fix: ensure that esbuild uses the same working directory as Vite

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -825,6 +825,7 @@ async function bundleConfigFile(
   mjs = false
 ): Promise<{ code: string; dependencies: string[] }> {
   const result = await build({
+    absWorkingDir: process.cwd(),
     entryPoints: [fileName],
     outfile: 'out.js',
     write: false,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -261,6 +261,7 @@ export async function optimizeDeps(
     config.optimizeDeps?.esbuildOptions ?? {}
 
   const result = await build({
+    absWorkingDir: process.cwd(),
     entryPoints: Object.keys(flatIdDeps),
     bundle: true,
     format: 'esm',

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -94,6 +94,7 @@ export async function scanImports(config: ResolvedConfig): Promise<{
   await Promise.all(
     entries.map((entry) =>
       build({
+        absWorkingDir: process.cwd(),
         write: false,
         entryPoints: [entry],
         bundle: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

There are a few places where the assumption is made that Vite and esbuild have the same working directory, for example here: https://github.com/vitejs/vite/blob/f3643d8e74db07a0c3014987e8c87d4fec31f5a9/packages/vite/src/node/optimizer/index.ts#L284

This leads to unexpected behaviour when the process invoking Vite has called `process.chdir()`, as that assumption is no longer valid. This can lead to `needsInterop()` returning `true` incorrectly, as exhibited in the example of https://github.com/vitejs/vite/issues/4000#issuecomment-869672160.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
