### PR TITLE
fix(css): skip comma when matching css url

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -760,7 +760,7 @@ type CssUrlReplacer = (
 ) => string | Promise<string>
 // https://drafts.csswg.org/css-syntax-3/#identifier-code-point
 export const cssUrlRE =
-  /(?:^|[^\w\-\u0080-\uffff])url\(\s*('[^']+'|"[^"]+"|[^'")]+)\s*\)/
+  /(?<=^|[^\w\-\u0080-\uffff])url\(\s*('[^']+'|"[^"]+"|[^'")]+)\s*\)/
 const cssImageSetRE = /image-set\(([^)]+)\)/
 
 const UrlRewritePostcssPlugin: Postcss.PluginCreator<{
@@ -837,9 +837,7 @@ async function doUrlReplace(
     return matched
   }
 
-  // #3926
-  const initialComma = matched[0] === ',' ? ',' : ''
-  return `${initialComma}url(${wrap}${await replacer(rawUrl)}${wrap})`
+  return `url(${wrap}${await replacer(rawUrl)}${wrap})`
 }
 
 let CleanCSS: any


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I think it would be better to fix the multiple css url issue by correcting the regex, original issue  #3922.

#### Issue review:

The comma is removed when there are multiple `url()`.

```css
.test {
  background-image: url(foo.png),url(bar.png);
}
```

resulting in

```css
.test {
  background-image: url(foo.png)url(bar.png);
}
```
#### Debugging

![vite-debug](https://user-images.githubusercontent.com/9206414/123658163-0d83c200-d864-11eb-8b52-b63aeb104ae2.png)

Issue fixed after correcting the regex:

![vite-debug-fix](https://user-images.githubusercontent.com/9206414/123660509-50469980-d866-11eb-9f16-1620d2c92274.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
