### PR TITLE
fix(commonjs): `ignoreDynamicRequires` should default to `false`

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -272,10 +272,7 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
   return {
     pre: [
       buildHtmlPlugin(config),
-      commonjsPlugin({
-        ignoreDynamicRequires: true,
-        ...options.commonjsOptions
-      }),
+      commonjsPlugin(options.commonjsOptions),
       dataURIPlugin(),
       dynamicImportVars(options.dynamicImportVarsOptions),
       assetImportMetaUrlPlugin(config),

--- a/packages/vite/types/commonjs.d.ts
+++ b/packages/vite/types/commonjs.d.ts
@@ -42,6 +42,18 @@ export interface RollupCommonJSOptions {
    */
   sourceMap?: boolean
   /**
+   * Some `require` calls cannot be resolved statically to be translated to
+   * imports.
+   * When this option is set to `false`, the generated code will either
+   * directly throw an error when such a call is encountered or, when
+   * `dynamicRequireTargets` is used, when such a call cannot be resolved with a
+   * configured dynamic require target.
+   * Setting this option to `true` will instead leave the `require` call in the
+   * code or use it as a fallback for `dynamicRequireTargets`.
+   * @default false
+   */
+  ignoreDynamicRequires?: boolean
+  /**
    * Instructs the plugin whether to enable mixed module transformations. This
    * is useful in scenarios with modules that contain a mix of ES `import`
    * statements and CommonJS `require` expressions. Set to `true` if `require`


### PR DESCRIPTION
### Description

See https://github.com/vitejs/vite/pull/3353#issuecomment-851520683

Comparing to the behavior before v2.3.1, the new default now throws a *runtime* error in the following case:
- `require(/* a dynamic expression */)`, where `dynamicRequireTargets` is specified, but the expression in the `require` call cannot be resolved via the targets.

Comparing to the behavior since v2.3.1, the new default fixes the following use case:
- `typeof require ==== 'function'`

It is used in many legacy UMD bundles for CommonJS environment detection.

Fixes #3426
Fixes #3997

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
