### PR TITLE
fix: revert resolve nested dependencies #3753

### DIFF
--- a/packages/playground/nested-deps/__tests__/nested-deps.spec.ts
+++ b/packages/playground/nested-deps/__tests__/nested-deps.spec.ts
@@ -1,4 +1,5 @@
-test('handle nested package', async () => {
+// TODO: Rework #3753, taking into account issues with #4005, #4012, #4014
+test.skip('handle nested package', async () => {
   expect(await page.textContent('.a')).toBe('A@2.0.0')
   expect(await page.textContent('.b')).toBe('B@1.0.0')
   expect(await page.textContent('.nested-a')).toBe('A@1.0.0')

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -94,7 +94,7 @@ export function esbuildDepPlugin(
                 namespace: 'dep'
               }
             : {
-                path: require.resolve(id, {
+                path: require.resolve(qualified[flatId], {
                   paths: [resolveDir]
                 })
               }


### PR DESCRIPTION
Fixes #4005

### Description

Revert #3753, [as discussed](https://github.com/vitejs/vite/pull/3753#issuecomment-870503460) with @Yelmor.

I only reverted the code change in packages/vite/src/node/optimizer/esbuildDepPlugin.ts, and left the test suite with a TODO: until #3573 is reworked to fix #3254 again.

### Additional context

Tested that #4005 is working correctly after this PR
Probably also fixes #4012 and #4014, I'll ask them to test once this is merged

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other