### PR TITLE
fix: use path type import, fix #4028

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,6 +107,12 @@ module.exports = defineConfig({
       rules: {
         '@typescript-eslint/explicit-module-boundary-types': 'off'
       }
+    },
+    {
+      files: ['*.d.ts'],
+      rules: {
+        '@typescript-eslint/triple-slash-reference': 'off'
+      }
     }
   ]
 })

--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-/// <reference types="vite/types/importMeta" />
+/// <reference path="./types/importMeta" />
 
 // CSS modules
 type CSSModuleClasses = { readonly [key: string]: string }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Replaces https://github.com/vitejs/vite/pull/4029.

This seems to be a simpler way to fix the issue, and I've verified that it does in fact pass CI in linux in my own project.

### Additional context

I believe that the `type` directive is for pointing to the name of a types package, and it just-so-happened to work in case-insensitive OSes.  But from what we are trying to do, after reading https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-, the `path` directive seems more appropriate, and does not suffer from being made lowercase.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
