### PR TITLE
fix: Avoid importing in source that __vitePreload has declared (close #4016)

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -164,7 +164,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (
         needPreloadHelper &&
         !ssr &&
-        source.indexOf(`const ${preloadMethod} =`) < 0
+        !source.includes(`const ${preloadMethod} =`)
       ) {
         str().prepend(`import { ${preloadMethod} } from "${preloadHelperId}";`)
       }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -161,7 +161,11 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
       }
 
-      if (needPreloadHelper && !ssr) {
+      if (
+        needPreloadHelper &&
+        !ssr &&
+        source.indexOf(`const ${preloadMethod} =`) < 0
+      ) {
         str().prepend(`import { ${preloadMethod} } from "${preloadHelperId}";`)
       }
 


### PR DESCRIPTION
fix: Avoid importing in source that __vitePreload has declared (close #4016)

<!-- Thank you for contributing! -->

### Description

this pull request fix  #4016 (Error: Identifier '__vitePreload' has already been declared)


### Additional context

If the Identifier '__vitePreload' has already been declared, there is no need to repeat the import

Use this simple project to verify: https://github.com/xingxiuyi/test-vite-async-import

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
