### PR TITLE
fix(ssr): Transform named default exports without altering scope

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -211,8 +211,56 @@ test('should declare variable for imported super class', async () => {
   ).toMatchInlineSnapshot(`
     "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
     const Foo = __vite_ssr_import_0__.Foo;
-    __vite_ssr_exports__.default = class A extends Foo {}
+    class A extends Foo {}
     class B extends Foo {}
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A })
+    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }})"
+  `)
+})
+
+// #4049
+test('should handle default export variants', async () => {
+  // default anonymous functions
+  expect(
+    (await ssrTransform(`export default function() {}\n`, null, null)).code
+  ).toMatchInlineSnapshot(`
+    "__vite_ssr_exports__.default = function() {}
+    "
+  `)
+  // default anonymous class
+  expect((await ssrTransform(`export default class {}\n`, null, null)).code)
+    .toMatchInlineSnapshot(`
+    "__vite_ssr_exports__.default = class {}
+    "
+  `)
+  // default named functions
+  expect(
+    (
+      await ssrTransform(
+        `export default function foo() {}\n` +
+          `foo.prototype = Object.prototype;`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "function foo() {}
+    foo.prototype = Object.prototype;
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: foo })"
+  `)
+  // default named classes
+  expect(
+    (
+      await ssrTransform(
+        `export default class A {}\n` + `export class B extends A {}`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "class A {}
+    class B extends A {}
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A })
     Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }})"
   `)
 })

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -124,11 +124,24 @@ export async function ssrTransform(
 
     // default export
     if (node.type === 'ExportDefaultDeclaration') {
-      s.overwrite(
-        node.start,
-        node.start + 14,
-        `${ssrModuleExportsKey}.default =`
-      )
+      if ('id' in node.declaration && node.declaration.id) {
+        // named hoistable/class exports
+        // export default function foo() {}
+        // export default class A {}
+        const { name } = node.declaration.id
+        s.remove(node.start, node.start + `export default `.length)
+        s.append(
+          `\nObject.defineProperty(${ssrModuleExportsKey}, "default", ` +
+            `{ enumerable: true, value: ${name} })`
+        )
+      } else {
+        // anonymous default exports
+        s.overwrite(
+          node.start,
+          node.start + `export default`.length,
+          `${ssrModuleExportsKey}.default =`
+        )
+      }
     }
 
     // export * from './foo'

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -129,7 +129,7 @@ export async function ssrTransform(
         // export default function foo() {}
         // export default class A {}
         const { name } = node.declaration.id
-        s.remove(node.start, node.start + `export default `.length)
+        s.remove(node.start, node.start + 15 /* 'export default '.length */)
         s.append(
           `\nObject.defineProperty(${ssrModuleExportsKey}, "default", ` +
             `{ enumerable: true, value: ${name} })`
@@ -138,7 +138,7 @@ export async function ssrTransform(
         // anonymous default exports
         s.overwrite(
           node.start,
-          node.start + `export default`.length,
+          node.start + 14 /* 'export default'.length */,
           `${ssrModuleExportsKey}.default =`
         )
       }


### PR DESCRIPTION
Fixes #4049.

### Existing Behavior

Previously, given the following source files:
```js
export default function() {}
```
```js
export default class {}
```
```js
export default function hello() {}
hello.test = 1234;
```
```js
export default class A {}
export class B extends A {}
```

The SSR Transformer would indiscriminately replace the `export default` with `__vite_ssr_exports__.default =` as follows:
```js
__vite_ssr_exports__.default = function() {}
```
```js
__vite_ssr_exports__.default = class {}
```
```js
__vite_ssr_exports__.default = function hello() {}
hello.test = 1234;
```
```js
__vite_ssr_exports__.default = class A {}
class B extends A {}
Object.defineProperty(__vite_ssr_exports__, "B", { enumerable: true, configurable: true, get(){ return B }})
```

Which works for the anonymous cases, but alters the scope of named functions and classes, producing erroneous code that references undefined bindings.

### Proposed Behavior

This PR instead reuses the `Object.defineProperty` technique already used for named exports:
```js
__vite_ssr_exports__.default = function() {}
```
```js
__vite_ssr_exports__.default = class {}
```
```js
function hello() {}
hello.test = 1234;
Object.defineProperty(__vite_ssr_exports__, "default", { enumerable: true, value: hello })
```
```js
class A {}
class B extends A {}
Object.defineProperty(__vite_ssr_exports__, "default", { enumerable: true, value: A })
Object.defineProperty(__vite_ssr_exports__, "B", { enumerable: true, configurable: true, get(){ return B }})
```

The options passed to `Object.defineProperty` are the same ones performed by [TypeScript's `esModuleInterop`](https://www.typescriptlang.org/tsconfig#esModuleInterop). The anonymous case is still handled in the same manner as the previous algorithm.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
