### PR TITLE
Fix conflict between VSCode import and Rollup import in template

### DIFF
--- a/packages/create-app/template-svelte-ts/vite.config.js
+++ b/packages/create-app/template-svelte-ts/vite.config.js
@@ -3,5 +3,11 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  resolve: {
+    alias: [
+      // Allow imports to specify, e.g. import 'src/example'
+      { find: /^src\/(.*)/, replacement: '/src/$1' }
+    ]
+  },
   plugins: [svelte()]
 })


### PR DESCRIPTION
### Description

Currently, VSCode inserts something like the following when using the automatic import option (when directory nesting necessitates it):

```ts
import { Foo } from 'src/mydir/foo.ts'
```

This immediately fails to compile, because Rollup seems to want `/src/mydir/foo.ts`. Correcting the import to this then breaks VSCode intellisense (it searches from `/`/root on the filesystem).

Replacing "src/" (strictly starts-with) with "/src/" provides the best of both worlds: VSCode is happy with the source, and Rollup is happy with the transformed code.

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
