### PR TITLE
fix: skip redirect and error fallback on middleware mode

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -463,7 +463,8 @@ export async function createServer(
   }
 
   // base
-  if (config.base !== '/') {
+  // skip base middleware on middleware mode, #4057
+  if (config.base !== '/' && !server.middlewares) {
     middlewares.use(baseMiddleware(server))
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -463,8 +463,7 @@ export async function createServer(
   }
 
   // base
-  // skip base middleware on middleware mode, #4057
-  if (config.base !== '/' && config.server.middlewareMode) {
+  if (config.base !== '/') {
     middlewares.use(baseMiddleware(server))
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -464,7 +464,7 @@ export async function createServer(
 
   // base
   // skip base middleware on middleware mode, #4057
-  if (config.base !== '/' && !server.middlewares) {
+  if (config.base !== '/' && config.server.middlewareMode) {
     middlewares.use(baseMiddleware(server))
   }
 

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -23,10 +23,7 @@ export function baseMiddleware({
     }
 
     // skip redirect and error fallback on middleware mode, #4057
-    if (
-      config.server.middlewareMode === true ||
-      config.server.middlewareMode === 'html'
-    ) {
+    if (config.server.middlewareMode) {
       return next()
     }
 

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -19,7 +19,18 @@ export function baseMiddleware({
       // rewrite url to remove base.. this ensures that other middleware does
       // not need to consider base being prepended or not
       req.url = url.replace(base, '/')
-    } else if (path === '/' || path === '/index.html') {
+      return next()
+    }
+
+    // skip redirect and error fallback on middleware mode, #4057
+    if (
+      config.server.middlewareMode === true ||
+      config.server.middlewareMode === 'html'
+    ) {
+      return next()
+    }
+
+    if (path === '/' || path === '/index.html') {
       // redirect root visit to based url
       res.writeHead(302, {
         Location: base


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When serving vite server as middleware mode with base, it can't be used with sub routes as the base middleware will always redirect `/` to the base. 

Consider `base` is set to `/admin/` in the following examples.

```ts
// the default handle is been override with vite's fallback
// a.k.a only vite server work, but not the server original handlers
app.use(server.middlewares)
```

```ts
// the original handlers works, but as the base in `req.url` passed to vite is striped off by `connect`
// which cause the middleware resolve to `/admin/admin/` 
app.use('/admin/', server.middlewares)
```

Neither of these usages work. I think the `baseMiddware` is more like a friendly guide and warning for standalone vite server but not actually for middleware mode. Skipped the middleware in this PR.

### Additional context

Current workaround:

```ts
  const middlewares = server.middlewares

  // remove Vite's base middleware since it's already handled by connect route
  // it's right before '/__open-in-editor' middleware
  const viteBaseMiddlewareIndex = middlewares.stack.findIndex(i => i.route === '/__open-in-editor') - 1
  if (viteBaseMiddlewareIndex >= 0) {
    middlewares.stack.splice(viteBaseMiddlewareIndex, 1)
  }

  app.use('/admin/', middlewares)
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
