### PR TITLE
fix: use `.mjs` extension for injected client modules

### DIFF
--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -26,7 +26,7 @@ const envConfig = {
     })
   ],
   output: {
-    dir: path.resolve(__dirname, 'dist/client'),
+    file: path.resolve(__dirname, 'dist/client', 'env.mjs'),
     sourcemap: true
   }
 }
@@ -48,7 +48,7 @@ const clientConfig = {
     })
   ],
   output: {
-    dir: path.resolve(__dirname, 'dist/client'),
+    file: path.resolve(__dirname, 'dist/client', 'client.mjs'),
     sourcemap: true
   }
 }

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -41,9 +41,9 @@ export const NULL_BYTE_PLACEHOLDER = `__x00__`
 export const CLIENT_PUBLIC_PATH = `/@vite/client`
 export const ENV_PUBLIC_PATH = `/@vite/env`
 // eslint-disable-next-line node/no-missing-require
-export const CLIENT_ENTRY = require.resolve('vite/dist/client/client.js')
+export const CLIENT_ENTRY = require.resolve('vite/dist/client/client.mjs')
 // eslint-disable-next-line node/no-missing-require
-export const ENV_ENTRY = require.resolve('vite/dist/client/env.js')
+export const ENV_ENTRY = require.resolve('vite/dist/client/env.mjs')
 export const CLIENT_DIR = path.dirname(CLIENT_ENTRY)
 
 export const KNOWN_ASSET_TYPES = [


### PR DESCRIPTION
### Description

Otherwise, they will not be recognized by Node.js as ES modules.

Usually, it doesn't matter, as they're intended to be run in browsers.

I only encountered this problem in `vite-jest`, which tries to run vite-transpiled code in Node.js environments.
After this PR, the following workaround would no longer be necessary:
https://github.com/sodatea/vite-jest/blob/1e05b4c62df714b1537c76052d5fec761a46c619/packages/vite-jest/bin/vite-jest.js#L11-L12

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
