### PR TITLE
fix: use `.mjs` extension for cached optimized deps

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -270,6 +270,9 @@ export async function optimizeDeps(
     splitting: true,
     sourcemap: true,
     outdir: cacheDir,
+    outExtension: {
+      '.js': '.mjs'
+    },
     treeShaking: 'ignore-annotations',
     metafile: true,
     define,
@@ -288,7 +291,7 @@ export async function optimizeDeps(
   for (const id in deps) {
     const entry = deps[id]
     data.optimized[id] = {
-      file: normalizePath(path.resolve(cacheDir, flattenId(id) + '.js')),
+      file: normalizePath(path.resolve(cacheDir, flattenId(id) + '.mjs')),
       src: entry,
       needsInterop: needsInterop(
         id,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -331,7 +331,7 @@ function needsInterop(
   // if a peer dependency used require() on a ESM dependency, esbuild turns the
   // ESM dependency's entry chunk into a single default export... detect
   // such cases by checking exports mismatch, and force interop.
-  const flatId = flattenId(id) + '.js'
+  const flatId = flattenId(id) + '.mjs'
   let generatedExports: string[] | undefined
   for (const output in outputs) {
     if (


### PR DESCRIPTION
### Description

Solves the same problem as https://github.com/vitejs/vite/pull/4063 but it's more explict.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
