### PR TITLE
chore(deps): update react-refresh to 0.10.0

### DIFF
--- a/packages/plugin-react-refresh/package.json
+++ b/packages/plugin-react-refresh/package.json
@@ -30,6 +30,6 @@
     "@babel/plugin-transform-react-jsx-self": "^7.14.5",
     "@babel/plugin-transform-react-jsx-source": "^7.14.5",
     "@rollup/pluginutils": "^4.1.0",
-    "react-refresh": "^0.9.0"
+    "react-refresh": "^0.10.0"
   }
 }


### PR DESCRIPTION
### Description

This PR updates react-refresh to 0.10.0, to fix an issue where react-refresh 0.9.0 [does not handle changing hook usage inside MobX observer-wrapped components well.](https://github.com/facebook/react/issues/20417) Essentially, in this scenario, adding / removing a hook during development errors out the whole app, requiring a manual refresh. Updating react-refresh to 0.10.0 fixes the issue, so this does just that for @vitejs/plugin-react-refresh.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
