### PR TITLE
fix: nested dependencies from sub node_modules, fix #3254

### DIFF
--- a/packages/playground/nested-deps/__tests__/nested-deps.spec.ts
+++ b/packages/playground/nested-deps/__tests__/nested-deps.spec.ts
@@ -1,6 +1,8 @@
-// TODO: Rework #3753, taking into account issues with #4005, #4012, #4014
-test.skip('handle nested package', async () => {
+test('handle nested package', async () => {
   expect(await page.textContent('.a')).toBe('A@2.0.0')
   expect(await page.textContent('.b')).toBe('B@1.0.0')
   expect(await page.textContent('.nested-a')).toBe('A@1.0.0')
+  const c = await page.textContent('.c')
+  expect(c).toBe('es-C@1.0.0')
+  expect(await page.textContent('.side-c')).toBe(c)
 })

--- a/packages/playground/nested-deps/index.html
+++ b/packages/playground/nested-deps/index.html
@@ -7,13 +7,24 @@
 <h2>nested dependency A</h2>
 <pre class="nested-a"></pre>
 
+<h2>direct dependency C</h2>
+<pre class="c"></pre>
+
+<h2>side dependency C</h2>
+<pre class="side-c"></pre>
+
 <script type="module">
   import A from 'test-package-a'
   import B, { A as nestedA } from 'test-package-b'
+  import C from 'test-package-c'
+  import { C as sideC } from 'test-package-c/side'
 
   text('.a', A)
   text('.b', B)
   text('.nested-a', nestedA)
+
+  text('.c', C)
+  text('.side-c', sideC)
 
   function text(sel, text) {
     document.querySelector(sel).textContent = text

--- a/packages/playground/nested-deps/package.json
+++ b/packages/playground/nested-deps/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "test-package-a": "link:./test-package-a",
-    "test-package-b": "link:./test-package-b"
+    "test-package-b": "link:./test-package-b",
+    "test-package-c": "link:./test-package-c"
   }
 }

--- a/packages/playground/nested-deps/test-package-c/index-es.js
+++ b/packages/playground/nested-deps/test-package-c/index-es.js
@@ -1,0 +1,1 @@
+export default 'es-C@1.0.0'

--- a/packages/playground/nested-deps/test-package-c/index.js
+++ b/packages/playground/nested-deps/test-package-c/index.js
@@ -1,0 +1,2 @@
+// this module should not be resolved
+export default 'C@1.0.0'

--- a/packages/playground/nested-deps/test-package-c/package.json
+++ b/packages/playground/nested-deps/test-package-c/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-package-c",
+  "version": "1.0.0",
+  "main": "index.js",
+  "module": "index-es.js"
+}

--- a/packages/playground/nested-deps/test-package-c/side.js
+++ b/packages/playground/nested-deps/test-package-c/side.js
@@ -1,0 +1,1 @@
+export { default as C } from 'test-package-c'

--- a/packages/playground/nested-deps/vite.config.js
+++ b/packages/playground/nested-deps/vite.config.js
@@ -3,6 +3,11 @@
  */
 module.exports = {
   optimizeDeps: {
-    include: ['test-package-a', 'test-package-b']
+    include: [
+      'test-package-a',
+      'test-package-b',
+      'test-package-c',
+      'test-package-c/side'
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6962,6 +6962,10 @@ test-exclude@^6.0.0:
   version "0.0.0"
   uid ""
 
+"test-package-c@link:./packages/playground/nested-deps/test-package-c":
+  version "0.0.0"
+  uid ""
+
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

Fix #3254.

Correct fixes in #3753 which caused #4005, #4014.

It's still a "easy fix". I think it's not necessary to use another `esbuildScanPlugin` to fix this. For non-entry import, it's ok to just leave it to "vite's own resolver".

I added a test case to fit the circumstance in #4005, and I also checked the reproduction of #4005 and #4014, they worked fine in the new fix.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

As I didn't read through the whole code base of vite, there may still be unconsidered circumstances causing error.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
