### PR TITLE
feat: library mode does not include preload

### DIFF
--- a/packages/playground/lib/__tests__/lib.spec.ts
+++ b/packages/playground/lib/__tests__/lib.spec.ts
@@ -1,4 +1,6 @@
-import { isBuild } from 'testUtils'
+import { isBuild, findAssetFile, testDir } from 'testUtils'
+import path from 'path'
+import fs from 'fs'
 
 if (isBuild) {
   test('es', async () => {
@@ -7,6 +9,15 @@ if (isBuild) {
 
   test('umd', async () => {
     expect(await page.textContent('.umd')).toBe('It works')
+  })
+
+  test('Library mode does not include `preload`', async () => {
+    expect(await page.textContent('.dynamic-import-message')).toBe('hello vite')
+    const code = fs.readFileSync(
+      path.join(testDir, 'dist/lib/dynamic-import-message.js'),
+      'utf-8'
+    )
+    expect(code).not.toMatch('__vitePreload')
   })
 } else {
   test('dev', async () => {

--- a/packages/playground/lib/__tests__/serve.js
+++ b/packages/playground/lib/__tests__/serve.js
@@ -1,0 +1,90 @@
+// @ts-check
+// this is automtically detected by scripts/jestPerTestSetup.ts and will replace
+// the default e2e test serve behavior
+
+const path = require('path')
+const http = require('http')
+const sirv = require('sirv')
+
+const port = (exports.port = 9527)
+
+/**
+ * @param {string} root
+ * @param {boolean} isBuildTest
+ */
+exports.serve = async function serve(root, isBuildTest) {
+  // build first
+
+  if (!isBuildTest) {
+    const { createServer } = require('vite')
+    process.env.VITE_INLINE = 'inline-serve'
+    let viteServer = await (
+      await createServer({
+        root: root,
+        logLevel: 'silent',
+        server: {
+          watch: {
+            usePolling: true,
+            interval: 100
+          },
+          host: true,
+          fs: {
+            strict: !isBuildTest
+          }
+        },
+        build: {
+          target: 'esnext'
+        }
+      })
+    ).listen()
+    // use resolved port/base from server
+    const base = viteServer.config.base === '/' ? '' : viteServer.config.base
+    const url =
+      (global.viteTestUrl = `http://localhost:${viteServer.config.server.port}${base}`)
+    await page.goto(url)
+
+    return viteServer
+  } else {
+    const { build } = require('vite')
+    await build({
+      root,
+      logLevel: 'silent',
+      configFile: path.resolve(__dirname, '../vite.config.js')
+    })
+
+    await build({
+      root,
+      logLevel: 'silent',
+      configFile: path.resolve(__dirname, '../vite.dyimport.config.js')
+    })
+
+    // start static file server
+    const serve = sirv(path.resolve(root, 'dist'))
+    const httpServer = http.createServer((req, res) => {
+      if (req.url === '/ping') {
+        res.statusCode = 200
+        res.end('pong')
+      } else {
+        serve(req, res)
+      }
+    })
+
+    return new Promise((resolve, reject) => {
+      try {
+        const server = httpServer.listen(port, async () => {
+          await page.goto(`http://localhost:${port}`)
+          resolve({
+            // for test teardown
+            async close() {
+              await new Promise((resolve) => {
+                server.close(resolve)
+              })
+            }
+          })
+        })
+      } catch (e) {
+        reject(e)
+      }
+    })
+  }
+}

--- a/packages/playground/lib/index.dist.html
+++ b/packages/playground/lib/index.dist.html
@@ -1,11 +1,18 @@
 <!-- the production demo page, copied into dist/ -->
 <div class="es"></div>
 <div class="umd"></div>
+<div class="dynamic-import-message"></div>
 
 <script type="module">
   import myLib from './my-lib-custom-filename.es.js'
 
   myLib('.es')
+</script>
+
+<script type="module">
+  import message from './lib/dynamic-import-message.js'
+
+  message('.dynamic-import-message')
 </script>
 
 <script src="./my-lib-custom-filename.umd.js"></script>

--- a/packages/playground/lib/src/main2.js
+++ b/packages/playground/lib/src/main2.js
@@ -1,0 +1,4 @@
+export default async function message(sel) {
+  const message = await import('./message.js')
+  document.querySelector(sel).textContent = message.default
+}

--- a/packages/playground/lib/src/message.js
+++ b/packages/playground/lib/src/message.js
@@ -1,0 +1,1 @@
+export default 'hello vite'

--- a/packages/playground/lib/vite.dyimport.config.js
+++ b/packages/playground/lib/vite.dyimport.config.js
@@ -1,0 +1,18 @@
+const fs = require('fs')
+const path = require('path')
+
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = {
+  build: {
+    minify: false,
+    lib: {
+      entry: path.resolve(__dirname, 'src/main2.js'),
+      formats: ['es'],
+      name: 'message',
+      fileName: () => 'dynamic-import-message.js'
+    },
+    outDir: 'dist/lib'
+  }
+}

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -15,7 +15,7 @@ export async function transformImportGlob(
   importIndex: number,
   root: string,
   normalizeUrl?: (url: string, pos: number) => Promise<[string, string]>,
-  ssr = false
+  preload = true
 ): Promise<{
   importsString: string
   imports: string[]
@@ -87,7 +87,7 @@ export async function transformImportGlob(
       entries += ` ${JSON.stringify(file)}: ${identifier},`
     } else {
       let imp = `import(${JSON.stringify(importee)})`
-      if (!normalizeUrl && !ssr) {
+      if (!normalizeUrl && preload) {
         imp =
           `(${isModernFlag}` +
           `? ${preloadMethod}(()=>${imp},"${preloadMarker}")` +

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -82,6 +82,7 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
  */
 export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
   const ssr = !!config.build.ssr
+  const insertPreload = !(ssr || !!config.build.lib)
 
   return {
     name: 'vite:import-analysis',
@@ -145,7 +146,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               index,
               config.root,
               undefined,
-              ssr
+              insertPreload
             )
           str().prepend(importsString)
           str().overwrite(expStart, endIndex, exp)
@@ -155,7 +156,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           continue
         }
 
-        if (dynamicIndex > -1 && !ssr) {
+        if (dynamicIndex > -1 && insertPreload) {
           needPreloadHelper = true
           const dynamicEnd = source.indexOf(`)`, end) + 1
           const original = source.slice(dynamicIndex, dynamicEnd)
@@ -166,7 +167,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
       if (
         needPreloadHelper &&
-        !ssr &&
+        insertPreload &&
         !source.includes(`const ${preloadMethod} =`)
       ) {
         str().prepend(`import { ${preloadMethod} } from "${preloadHelperId}";`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Related issues https://github.com/vitejs/vite/issues/3133 https://github.com/vitejs/vite/issues/3662
~Add `build.autoPreload` switch configuration. When set to false, `__vitePreload` helper method will not be inserted.~
Support library mode does not include preload
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
