### PR TITLE
feat: expose pendingReload to consumers

### DIFF
--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -71,7 +71,7 @@ export function createMissingImporterRegisterFn(
     } finally {
       server._isRunningOptimizer = false
       pendingResolve && pendingResolve()
-      server._pendingReload = pendingResolve = null
+      server.pendingReload = pendingResolve = null
     }
 
     // Cached transform results have stale imports (resolved to
@@ -94,7 +94,7 @@ export function createMissingImporterRegisterFn(
       currentMissing[id] = resolved
       if (handle) clearTimeout(handle)
       handle = setTimeout(() => rerun(ssr), debounceMs)
-      server._pendingReload = new Promise((r) => {
+      server.pendingReload = new Promise((r) => {
         pendingResolve = r
       })
     }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -220,6 +220,13 @@ export interface ViteDevServer {
    */
   moduleGraph: ModuleGraph
   /**
+   * A promise which will resolve once a reload is complete. A reload is
+   * pending as a result of optimizing missing dependencies.
+   * 
+   * When no reload is pending it will be null.
+   */
+  pendingReload: Promise<void> | null
+  /**
    * Programmatically resolve, load and transform a URL and get the result
    * without going through the http request pipeline.
    */
@@ -293,10 +300,6 @@ export interface ViteDevServer {
   _registerMissingImport:
     | ((id: string, resolved: string, ssr: boolean | undefined) => void)
     | null
-  /**
-   * @internal
-   */
-  _pendingReload: Promise<void> | null
 }
 
 export async function createServer(
@@ -348,6 +351,7 @@ export async function createServer(
     pluginContainer: container,
     ws,
     moduleGraph,
+    pendingReload: null,
     transformWithEsbuild,
     transformRequest(url, options) {
       return transformRequest(url, server, options)
@@ -390,8 +394,7 @@ export async function createServer(
     _ssrExternals: null,
     _globImporters: {},
     _isRunningOptimizer: false,
-    _registerMissingImport: null,
-    _pendingReload: null
+    _registerMissingImport: null
   }
 
   server.transformIndexHtml = createDevHtmlTransformFn(server)

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -65,13 +65,13 @@ export function transformMiddleware(
     }
 
     if (
-      server._pendingReload &&
+      server.pendingReload &&
       // always allow vite client requests so that it can trigger page reload
       !req.url?.startsWith(CLIENT_PUBLIC_PATH) &&
       !req.url?.includes('vite/dist/client')
     ) {
       // missing dep pending reload, hold request until reload happens
-      server._pendingReload.then(() =>
+      server.pendingReload.then(() =>
         // If the refresh has not happened after timeout, Vite considers
         // something unexpected has happened. In this case, Vite
         // returns an empty response that will error.


### PR DESCRIPTION
### Description
Implements #4100 

Expose pendingReload to consumers

At the moment, when I run a Jest test for the first time, when unoptimized dependencies are discovered the server gets flagged to do a "reload", where it optimize the dependencies and re-bundles the cache.

This results in tests failing, because they are unable to resolve dependencies in the cache while things are reloading.

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
