### PR TITLE
fix(hmr): html registered as a PostCSS dependency, fix #3716

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -81,7 +81,7 @@ export interface CSSModulesOptions {
 }
 
 const cssLangs = `\\.(css|less|sass|scss|styl|stylus|pcss|postcss)($|\\?)`
-const cssLangRE = new RegExp(cssLangs)
+export const cssLangRE = new RegExp(cssLangs)
 const cssModuleRE = new RegExp(`\\.module${cssLangs}`)
 const directRequestRE = /(\?|&)direct\b/
 const commonjsProxyRE = /\?commonjs-proxy/

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -10,7 +10,7 @@ import { RollupError } from 'rollup'
 import { prepareError } from './middlewares/error'
 import match from 'minimatch'
 import { Server } from 'http'
-import { isCSSRequest } from '../plugins/css'
+import { cssLangRE } from '../plugins/css'
 
 export const debugHmr = createDebugger('vite:hmr')
 
@@ -227,7 +227,7 @@ function propagateUpdate(
     // additionally check for CSS importers, since a PostCSS plugin like
     // Tailwind JIT may register any file as a dependency to a CSS file.
     for (const importer of node.importers) {
-      if (isCSSRequest(importer.url) && !currentChain.includes(importer)) {
+      if (cssLangRE.test(importer.url) && !currentChain.includes(importer)) {
         propagateUpdate(
           importer,
           timestamp,
@@ -243,13 +243,13 @@ function propagateUpdate(
   if (!node.importers.size) {
     return true
   }
-  
+
   // #3716, #3913
   // For a non-CSS file, if all of its importers are CSS files (registered via
   // PostCSS plugins) it should be considered a dead end and force full reload.
   if (
-    !isCSSRequest(node.url) &&
-    [...node.importers].every((i) => isCSSRequest(i.url))
+    !cssLangRE.test(node.url) &&
+    [...node.importers].every((i) => cssLangRE.test(i.url))
   ) {
     return true
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #3716 

### Additional context
PostCSS plugin Tailwind JIT register any file as a dependency to a CSS file. When using `<link rel="stylesheet">`, `index.html` module's importers includes style.css module, the browser does not automatically refresh as index.html is changed.
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <title>Vite App</title>
    <link rel="stylesheet" href="/style.css" />
  </head>
  <body>
    <div id="app">
      <h1>Hello Vite!</h1>
    </div>
  </body>
</html>
```
The current solution does not include the processing of direct import css:
https://github.com/vitejs/vite/blob/e30ce56861a154389a47e679c46a93680aae1325/packages/vite/src/node/server/hmr.ts#L252

https://github.com/vitejs/vite/blob/e30ce56861a154389a47e679c46a93680aae1325/packages/vite/src/node/plugins/css.ts#L101-L102

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
