### PR TITLE
fix: specify full filepath to importMeta.d.ts, fix #4125

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-/// <reference path="./types/importMeta" />
+/// <reference path="./types/importMeta.d.ts" />
 
 // CSS modules
 type CSSModuleClasses = { readonly [key: string]: string }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #4125 

The [docs](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-) don't specify that a full filepath with extension is required, but it does seem to be.  

### Additional context

These triple-slash directives seem to be pretty fiddly.  There has been https://github.com/vitejs/vite/pull/4031 and https://github.com/vitejs/vite/pull/4003 trying to get this working.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
