### PR TITLE
fix: __VITE_PRELOAD__ replacement error, fix #3051

### DIFF
--- a/packages/playground/preload/__tests__/preload.spec.ts
+++ b/packages/playground/preload/__tests__/preload.spec.ts
@@ -1,0 +1,14 @@
+import { isBuild } from '../../testUtils'
+
+test('should have no 404s', () => {
+  browserLogs.forEach((msg) => {
+    expect(msg).not.toMatch('404')
+  })
+})
+
+if (isBuild) {
+  test('dynamic import', async () => {
+    let appHtml = await page.content()
+    expect(appHtml).toMatch('This is <b>home</b> page.')
+  })
+}

--- a/packages/playground/preload/index.html
+++ b/packages/playground/preload/index.html
@@ -1,0 +1,8 @@
+<div id="app"></div>
+<script type="module">
+  import { createApp } from 'vue'
+  import router from './router.js'
+  import App from './src/App.vue'
+
+  createApp(App).use(router).mount('#app')
+</script>

--- a/packages/playground/preload/package.json
+++ b/packages/playground/preload/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-preload",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.0.8",
+    "vue-router": "^4.0.6"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^1.0.0",
+    "@vue/compiler-sfc": "^3.0.8"
+  }
+}

--- a/packages/playground/preload/router.js
+++ b/packages/playground/preload/router.js
@@ -1,0 +1,16 @@
+import { createRouter, createWebHashHistory } from 'vue-router'
+import Home from './src/components/Home.vue'
+
+const routes = [
+  { path: '/', name: 'Home', component: Home },
+  {
+    path: '/about',
+    name: 'About',
+    component: () => import('./src/components/About.vue')
+  } // Lazy load route component
+]
+
+export default createRouter({
+  routes,
+  history: createWebHashHistory()
+})

--- a/packages/playground/preload/src/App.vue
+++ b/packages/playground/preload/src/App.vue
@@ -1,0 +1,6 @@
+<template>
+  <router-view></router-view>
+</template>
+
+<script setup>
+</script>

--- a/packages/playground/preload/src/components/About.vue
+++ b/packages/playground/preload/src/components/About.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    This is <b>about</b> page.
+    <br>
+    Go to <router-link to="/">Home</router-link> page
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/packages/playground/preload/src/components/Home.vue
+++ b/packages/playground/preload/src/components/Home.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    This is <b>home</b> page.
+    <br>
+    Go to <router-link to="/about">About</router-link> page
+  </div>
+</template>
+
+<script setup>
+</script>

--- a/packages/playground/preload/vite.config.js
+++ b/packages/playground/preload/vite.config.js
@@ -1,0 +1,15 @@
+const vuePlugin = require('@vitejs/plugin-vue')
+
+module.exports = {
+  plugins: [vuePlugin()],
+  build: {
+    terserOptions: {
+      format: {
+        beautify: true
+      },
+      compress: {
+        passes: 3
+      }
+    }
+  }
+}

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -26,7 +26,7 @@ const preloadMarkerRE = new RegExp(`"${preloadMarker}"`, 'g')
  */
 function preload(baseModule: () => Promise<{}>, deps?: string[]) {
   // @ts-ignore
-  if (!__VITE_IS_MODERN__ || !deps) {
+  if (!__VITE_IS_MODERN__ || !deps || deps.length === 0) {
     return baseModule()
   }
 
@@ -262,7 +262,12 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 addDeps(normalizedFile)
               }
 
-              const markPos = code.indexOf(preloadMarker, end)
+              let markPos = code.indexOf(preloadMarker, end)
+              // fix issue #3051
+              if (markPos == -1 && imports.length == 1) {
+                markPos = code.indexOf(preloadMarker)
+              }
+
               if (markPos > 0) {
                 s.overwrite(
                   markPos - 1,
@@ -271,7 +276,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   // preload when there are actual other deps.
                   deps.size > 1
                     ? `[${[...deps].map((d) => JSON.stringify(d)).join(',')}]`
-                    : `void 0`
+                    : `[]`
                 )
               }
             }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -26,7 +26,7 @@ const preloadMarkerRE = new RegExp(`"${preloadMarker}"`, 'g')
  */
 function preload(baseModule: () => Promise<{}>, deps?: string[]) {
   // @ts-ignore
-  if (!__VITE_IS_MODERN__ || deps.length === 0) {
+  if (!__VITE_IS_MODERN__ || !deps || deps.length === 0) {
     return baseModule()
   }
 

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -26,7 +26,7 @@ const preloadMarkerRE = new RegExp(`"${preloadMarker}"`, 'g')
  */
 function preload(baseModule: () => Promise<{}>, deps?: string[]) {
   // @ts-ignore
-  if (!__VITE_IS_MODERN__ || !deps || deps.length === 0) {
+  if (!__VITE_IS_MODERN__ || deps.length === 0) {
     return baseModule()
   }
 

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -264,7 +264,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
               let markPos = code.indexOf(preloadMarker, end)
               // fix issue #3051
-              if (markPos == -1 && imports.length == 1) {
+              if (markPos === -1 && imports.length === 1) {
                 markPos = code.indexOf(preloadMarker)
               }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #3051

When there is only one dynamic import, the input parameter `deps` of the `preload` function,
https://github.com/vitejs/vite/blob/98d95e3e11bbc43e410b213b682e315b9344d2d7/packages/vite/src/node/plugins/importAnalysisBuild.ts#L23-L28
when `terser` compresses for the third time, it will think that `deps` is a constant string, move directly to the place of call and delete the input parameters.

Before `terser minify`,[complete file,before.txt](https://github.com/vitejs/vite/files/6775466/Before.txt):
```javascript
import { o as openBlock, c as createBlock, a as createVNode, w as withCtx, b as createTextVNode, r as resolveComponent, d as createRouter, e as createWebHashHistory, f as createApp } from "./vendor.30acece7.js";
let scriptRel;
const seen = {};
const __vitePreload = function preload(baseModule, deps) {
  if (!deps) {
    return baseModule();
  }
  if (scriptRel === void 0) {
    const relList = document.createElement("link").relList;
    scriptRel = relList && relList.supports && relList.supports("modulepreload") ? "modulepreload" : "preload";
  }
  return Promise.all(deps.map((dep) => {
    ......
  })).then(() => baseModule());
};
......
const routes = [
  { path: "/", name: "Home", component: _sfc_main$1 },
  {
    path: "/about",
    name: "About",
    component: () => __vitePreload(() => import("./About.d4daf36e.js"), true ? "__VITE_PRELOAD__" : void 0)
  }
];
......
```
After `terser minify`,[complete file,after.txt](https://github.com/vitejs/vite/files/6775459/After.txt):
```javascript
......
var E = a({
    routes: [ {
    ......
    }, {
        path: "/about",
        name: "About",
        component: () => function(e, t) {
           ......
            return Promise.all("__VITE_PRELOAD__".map((e => {
               ......
            }))).then((() => import("./About.d4daf36e.js")));
        }()
    } ],
    history: u()
});
......
```
The above behavior will cause the `__VITE_PRELOAD__` marker to move from the back of the `import` statement to the front, causing the `code.indexOf(preloadMarker, end)` to not find the mark,resulting in no replacement of the `__VITE_PRELOAD__`

https://github.com/vitejs/vite/blob/98d95e3e11bbc43e410b213b682e315b9344d2d7/packages/vite/src/node/plugins/importAnalysisBuild.ts#L265-L275

Finally, `__VITE_PRELOAD__` was incorrectly replaced with `void 0` by the following code
https://github.com/vitejs/vite/blob/98d95e3e11bbc43e410b213b682e315b9344d2d7/packages/vite/src/node/plugins/importAnalysisBuild.ts#L282-L284

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
