### PR TITLE
fix(client): infer socket host from script location (fix: #3093)

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -22,9 +22,10 @@ declare const __HMR_ENABLE_OVERLAY__: boolean
 console.log('[vite] connecting...')
 
 // use server configuration, then fallback to inference
+const scriptLocation = new URL((document.currentScript as HTMLScriptElement).src)
 const socketProtocol =
-  __HMR_PROTOCOL__ || (location.protocol === 'https:' ? 'wss' : 'ws')
-const socketHost = `${__HMR_HOSTNAME__ || location.hostname}:${__HMR_PORT__}`
+  __HMR_PROTOCOL__ || (scriptLocation.protocol === 'https:' ? 'wss' : 'ws')
+const socketHost = `${__HMR_HOSTNAME__ || scriptLocation.hostname}:${__HMR_PORT__ || scriptLocation.port}`
 const socket = new WebSocket(`${socketProtocol}://${socketHost}`, 'vite-hmr')
 const base = __BASE__ || '/'
 


### PR DESCRIPTION
### Description

Currently, the socket hostname is inferred from the current page location. This PR changes the inference logic to be based on the location of the client script, and adds support for inferring the socket port in addition to the socket hostname.

### Additional context

Inferring socket location from client script location is more robust than assuming the current page is hosted by the vite dev server. For example, consider a web component being developed on a vite dev server, routed through a reverse proxy, and loaded into a web page on a different origin—by inferring socket host from client script location, this scenario "just works". 

In addition, port number inference should make it easier to rely on default configuration settings when switching between localhost and/or reverse proxy configurations, or reverse proxies with random port numbers (e.g. #3093) . 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
