### PR TITLE
build: use `rollup -w` for dev bundling

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -31,9 +31,7 @@
   "homepage": "https://github.com/vitejs/vite/tree/main/#readme",
   "scripts": {
     "predev": "rimraf dist",
-    "dev": "run-p dev-client dev-node",
-    "dev-client": "tsc -w --incremental --p src/client",
-    "dev-node": "tsc -w --incremental --p src/node",
+    "dev": "rollup -c -w",
     "prebuild": "rimraf dist && yarn lint",
     "build": "run-s build-bundle build-types",
     "build-bundle": "rollup -c",


### PR DESCRIPTION
### Description

`tsc` does not support custom file extensions, which is used for the
emitted client files.

It does not understand the `exports` field of other packages,
making it impossible to use pure-ESM dependencies (#4059),

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
