### PR TITLE
docs: dependency resolution warning, closes #4089

### DIFF
--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -38,6 +38,11 @@ After the server has already started, if a new dependency import is encountered 
 
 In a monorepo setup, a dependency may be a linked package from the same repo. Vite automatically detects dependencies that are not resolved from `node_modules` and treats the linked dep as source code. It will not attempt to bundle the linked dep, and instead will analyze the linked dep's dependency list instead.
 
+::: warning Note
+Linked dependencies might not work properly in the final build due to differences in dependency resolution.
+Use `npm package` instead for all local dependencies to avoid issues in the final bundle.
+:::
+
 ## Customizing the Behavior
 
 The default dependency discovery heuristics may not always be desirable. In cases where you want to explicitly include/exclude dependencies from the list, use the [`optimizeDeps` config options](/config/#dep-optimization-options).


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Added a warning about the differences in vite's and rollup's dependency resolution that caused confusion in #4089.

### Additional context

This was the only relevant page I found to put this warning on, I'm not sure if there is a better place for it.

**I haven't built and ran the docs site, just edited the page**, the note syntax was copied from an another page, I'm not sure if it works and looks correct.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
