### PR TITLE
feat: `vite preview` port is used automatically `+1`

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -190,6 +190,7 @@ cli
   .option('--port <port>', `[number] specify port`)
   .option('--https', `[boolean] use TLS + HTTP/2`)
   .option('--open [path]', `[boolean | string] open browser on startup`)
+  .option('--strictPort', `[boolean] exit if specified port is already in use`)
   .action(
     async (
       root: string,
@@ -198,6 +199,7 @@ cli
         port?: number
         https?: boolean
         open?: boolean | string
+        strictPort?: boolean
       } & GlobalCLIOptions
     ) => {
       try {
@@ -208,7 +210,8 @@ cli
             configFile: options.config,
             logLevel: options.logLevel,
             server: {
-              open: options.open
+              open: options.open,
+              strictPort: options.strictPort
             }
           },
           'serve',

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -59,7 +59,7 @@ export async function preview(
 
   const serverPort = await httpServerStart(httpServer, {
     port,
-    strict: !!serverOptions.port,
+    strictPort: options.strictPort,
     host: hostname.host,
     logger
   })

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -57,30 +57,26 @@ export async function preview(
   const logger = config.logger
   const base = config.base
 
-  await httpServerStart(httpServer, {
+  const serverPort = await httpServerStart(httpServer, {
     port,
     strict: !!serverOptions.port,
     host: hostname.host,
     logger
   })
-    .then((serverPort) => {
-      logger.info(
-        chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-          chalk.green(` build preview server running at:\n`)
-      )
 
-      printServerUrls(hostname, protocol, serverPort, base, logger.info)
+  logger.info(
+    chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
+      chalk.green(` build preview server running at:\n`)
+  )
 
-      if (options.open) {
-        const path = typeof options.open === 'string' ? options.open : base
-        openBrowser(
-          `${protocol}://${hostname.name}:${serverPort}${path}`,
-          true,
-          logger
-        )
-      }
-    })
-    .catch((e) => {
-      throw e
-    })
+  printServerUrls(hostname, protocol, serverPort, base, logger.info)
+
+  if (options.open) {
+    const path = typeof options.open === 'string' ? options.open : base
+    openBrowser(
+      `${protocol}://${hostname.name}:${serverPort}${path}`,
+      true,
+      logger
+    )
+  }
 }

--- a/packages/vite/src/node/server/http.ts
+++ b/packages/vite/src/node/server/http.ts
@@ -4,6 +4,7 @@ import { Server as HttpServer } from 'http'
 import { ServerOptions as HttpsServerOptions } from 'https'
 import { ResolvedConfig, ServerOptions } from '..'
 import { Connect } from 'types/connect'
+import { Logger } from '../logger'
 
 export async function resolveHttpServer(
   { proxy }: ServerOptions,
@@ -158,4 +159,40 @@ async function getCertificate(config: ResolvedConfig) {
       .catch(() => {})
     return content
   }
+}
+
+export async function httpServerStart(
+  httpServer: HttpServer,
+  serverOptions: {
+    port: number
+    strict: boolean | undefined
+    host: string | undefined
+    logger: Logger
+  }
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let { port, strict, host, logger } = serverOptions
+
+    const onError = (e: Error & { code?: string }) => {
+      if (e.code === 'EADDRINUSE') {
+        if (strict) {
+          httpServer.removeListener('error', onError)
+          reject(new Error(`Port ${port} is already in use`))
+        } else {
+          logger.info(`Port ${port} is in use, trying another one...`)
+          httpServer.listen(++port, host)
+        }
+      } else {
+        httpServer.removeListener('error', onError)
+        reject(e)
+      }
+    }
+
+    httpServer.on('error', onError)
+
+    httpServer.listen(port, host, () => {
+      httpServer.removeListener('error', onError)
+      resolve(port)
+    })
+  })
 }

--- a/packages/vite/src/node/server/http.ts
+++ b/packages/vite/src/node/server/http.ts
@@ -165,17 +165,17 @@ export async function httpServerStart(
   httpServer: HttpServer,
   serverOptions: {
     port: number
-    strict: boolean | undefined
+    strictPort: boolean | undefined
     host: string | undefined
     logger: Logger
   }
 ): Promise<number> {
   return new Promise((resolve, reject) => {
-    let { port, strict, host, logger } = serverOptions
+    let { port, strictPort, host, logger } = serverOptions
 
     const onError = (e: Error & { code?: string }) => {
       if (e.code === 'EADDRINUSE') {
-        if (strict) {
+        if (strictPort) {
           httpServer.removeListener('error', onError)
           reject(new Error(`Port ${port} is already in use`))
         } else {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -8,7 +8,7 @@ import corsMiddleware from 'cors'
 import chalk from 'chalk'
 import { AddressInfo } from 'net'
 import chokidar from 'chokidar'
-import { resolveHttpsConfig, resolveHttpServer } from './http'
+import { resolveHttpsConfig, resolveHttpServer, httpServerStart } from './http'
 import { resolveConfig, InlineConfig, ResolvedConfig } from '../config'
 import {
   createPluginContainer,
@@ -583,7 +583,7 @@ async function startServer(
   }
 
   const options = server.config.server
-  let port = inlinePort || options.port || 3000
+  const port = inlinePort || options.port || 3000
   const hostname = resolveHostname(options.host)
 
   const protocol = options.https ? 'https' : 'http'
@@ -591,76 +591,65 @@ async function startServer(
   const base = server.config.base
 
   return new Promise((resolve, reject) => {
-    const onError = (e: Error & { code?: string }) => {
-      if (e.code === 'EADDRINUSE') {
-        if (options.strictPort) {
-          httpServer.removeListener('error', onError)
-          reject(new Error(`Port ${port} is already in use`))
-        } else {
-          info(`Port ${port} is in use, trying another one...`)
-          httpServer.listen(++port, hostname.host)
-        }
-      } else {
-        httpServer.removeListener('error', onError)
-        reject(e)
-      }
-    }
-
-    httpServer.on('error', onError)
-
-    httpServer.listen(port, hostname.host, () => {
-      httpServer.removeListener('error', onError)
-
-      info(
-        chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-          chalk.green(` dev server running at:\n`),
-        {
-          clear: !server.config.logger.hasWarned
-        }
-      )
-
-      printServerUrls(hostname, protocol, port, base, info)
-
-      // @ts-ignore
-      if (global.__vite_start_time) {
-        info(
-          chalk.cyan(
-            // @ts-ignore
-            `\n  ready in ${Date.now() - global.__vite_start_time}ms.\n`
-          )
-        )
-      }
-
-      // @ts-ignore
-      const profileSession = global.__vite_profile_session
-      if (profileSession) {
-        profileSession.post('Profiler.stop', (err: any, { profile }: any) => {
-          // Write profile to disk, upload, etc.
-          if (!err) {
-            const outPath = path.resolve('./vite-profile.cpuprofile')
-            fs.writeFileSync(outPath, JSON.stringify(profile))
-            info(
-              chalk.yellow(
-                `  CPU profile written to ${chalk.white.dim(outPath)}\n`
-              )
-            )
-          } else {
-            throw err
-          }
-        })
-      }
-
-      if (options.open && !isRestart) {
-        const path = typeof options.open === 'string' ? options.open : base
-        openBrowser(
-          `${protocol}://${hostname.name}:${port}${path}`,
-          true,
-          server.config.logger
-        )
-      }
-
-      resolve(server)
+    httpServerStart(httpServer, {
+      port,
+      strict: options.strictPort,
+      host: hostname.host,
+      logger: server.config.logger
     })
+      .then((serverPort) => {
+        info(
+          chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
+            chalk.green(` dev server running at:\n`),
+          {
+            clear: !server.config.logger.hasWarned
+          }
+        )
+
+        printServerUrls(hostname, protocol, serverPort, base, info)
+
+        // @ts-ignore
+        if (global.__vite_start_time) {
+          info(
+            chalk.cyan(
+              // @ts-ignore
+              `\n  ready in ${Date.now() - global.__vite_start_time}ms.\n`
+            )
+          )
+        }
+
+        // @ts-ignore
+        const profileSession = global.__vite_profile_session
+        if (profileSession) {
+          profileSession.post('Profiler.stop', (err: any, { profile }: any) => {
+            // Write profile to disk, upload, etc.
+            if (!err) {
+              const outPath = path.resolve('./vite-profile.cpuprofile')
+              fs.writeFileSync(outPath, JSON.stringify(profile))
+              info(
+                chalk.yellow(
+                  `  CPU profile written to ${chalk.white.dim(outPath)}\n`
+                )
+              )
+            } else {
+              throw err
+            }
+          })
+        }
+
+        if (options.open && !isRestart) {
+          const path = typeof options.open === 'string' ? options.open : base
+          openBrowser(
+            `${protocol}://${hostname.name}:${serverPort}${path}`,
+            true,
+            server.config.logger
+          )
+        }
+        resolve(server)
+      })
+      .catch((e) => {
+        reject(e)
+      })
   })
 }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -590,67 +590,60 @@ async function startServer(
   const info = server.config.logger.info
   const base = server.config.base
 
-  return new Promise((resolve, reject) => {
-    httpServerStart(httpServer, {
-      port,
-      strict: options.strictPort,
-      host: hostname.host,
-      logger: server.config.logger
-    })
-      .then((serverPort) => {
-        info(
-          chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-            chalk.green(` dev server running at:\n`),
-          {
-            clear: !server.config.logger.hasWarned
-          }
-        )
-
-        printServerUrls(hostname, protocol, serverPort, base, info)
-
-        // @ts-ignore
-        if (global.__vite_start_time) {
-          info(
-            chalk.cyan(
-              // @ts-ignore
-              `\n  ready in ${Date.now() - global.__vite_start_time}ms.\n`
-            )
-          )
-        }
-
-        // @ts-ignore
-        const profileSession = global.__vite_profile_session
-        if (profileSession) {
-          profileSession.post('Profiler.stop', (err: any, { profile }: any) => {
-            // Write profile to disk, upload, etc.
-            if (!err) {
-              const outPath = path.resolve('./vite-profile.cpuprofile')
-              fs.writeFileSync(outPath, JSON.stringify(profile))
-              info(
-                chalk.yellow(
-                  `  CPU profile written to ${chalk.white.dim(outPath)}\n`
-                )
-              )
-            } else {
-              throw err
-            }
-          })
-        }
-
-        if (options.open && !isRestart) {
-          const path = typeof options.open === 'string' ? options.open : base
-          openBrowser(
-            `${protocol}://${hostname.name}:${serverPort}${path}`,
-            true,
-            server.config.logger
-          )
-        }
-        resolve(server)
-      })
-      .catch((e) => {
-        reject(e)
-      })
+  const serverPort = await httpServerStart(httpServer, {
+    port,
+    strictPort: options.strictPort,
+    host: hostname.host,
+    logger: server.config.logger
   })
+
+  info(
+    chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
+      chalk.green(` dev server running at:\n`),
+    {
+      clear: !server.config.logger.hasWarned
+    }
+  )
+
+  printServerUrls(hostname, protocol, serverPort, base, info)
+
+  // @ts-ignore
+  if (global.__vite_start_time) {
+    info(
+      chalk.cyan(
+        // @ts-ignore
+        `\n  ready in ${Date.now() - global.__vite_start_time}ms.\n`
+      )
+    )
+  }
+
+  // @ts-ignore
+  const profileSession = global.__vite_profile_session
+  if (profileSession) {
+    profileSession.post('Profiler.stop', (err: any, { profile }: any) => {
+      // Write profile to disk, upload, etc.
+      if (!err) {
+        const outPath = path.resolve('./vite-profile.cpuprofile')
+        fs.writeFileSync(outPath, JSON.stringify(profile))
+        info(
+          chalk.yellow(`  CPU profile written to ${chalk.white.dim(outPath)}\n`)
+        )
+      } else {
+        throw err
+      }
+    })
+  }
+
+  if (options.open && !isRestart) {
+    const path = typeof options.open === 'string' ? options.open : base
+    openBrowser(
+      `${protocol}://${hostname.name}:${serverPort}${path}`,
+      true,
+      server.config.logger
+    )
+  }
+
+  return server
 }
 
 function createServerCloseFn(server: http.Server | null) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
### Description
related #4185 
`vite preview` port is used automatically `+1`.

If the port is specified, it will not `+1`
```javascript
{
  "scripts": {
    "preview": "vite preview --port 8080"
  }
}
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
