### PR TITLE
fix: correctly ignore optional deps when bundling vite deps

### DIFF
--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -161,14 +161,10 @@ const createNodeConfig = (isProduction) => {
             replacement: `: eval('require'),`
           }
         }),
-      // Optional peer deps of ws. Native deps that are mostly for performance.
-      // Since ws is not that perf critical for us, just ignore these deps.
-      ignoreDepPlugin({
-        bufferutil: 1,
-        'utf-8-validate': 1
-      }),
       commonjs({
         extensions: ['.js'],
+        // Optional peer deps of ws. Native deps that are mostly for performance.
+        // Since ws is not that perf critical for us, just ignore these deps.
         ignore: ['bufferutil', 'utf-8-validate']
       }),
       json(),
@@ -256,26 +252,6 @@ function shimDepsPlugin(deps) {
             )
           }
         }
-      }
-    }
-  }
-}
-
-/**
- * @type { (deps: Record<string, any>) => import('rollup').Plugin }
- */
-function ignoreDepPlugin(ignoredDeps) {
-  return {
-    name: 'ignore-deps',
-    resolveId(id) {
-      if (id in ignoredDeps) {
-        return id
-      }
-    },
-    load(id) {
-      if (id in ignoredDeps) {
-        console.log(`ignored: ${id}`)
-        return ''
       }
     }
   }


### PR DESCRIPTION
### Description

Fixes #3977
Fixes #3850

😅 I've accidentally committed the actual fix in https://github.com/vitejs/vite/commit/25d86eb4ba6f2c5094932bd86870265f4d2319ce#diff-d17472499351c5bf75d44c67aaa203337dcce321fb578ff05302c61b2b2a3a8aR172

So this PR just removes the erroneous `ingoreDepPlugin`, and moves
the comments to the `ignore` option of the commonjs plugin.

The cause of the issues is this line: https://github.com/websockets/ws/blob/4c1849a61e773fe0ce016f6eb59bc3877f09aeee/lib/buffer-util.js#L105

When we ignore the optional deps when bundling, we expect
`require('bufferutil')` to throw an error.

However, with the previous `ignoreDepPlugin` implementation, the
`require` expression is turned into:
```js
var bufferutil = {
	__proto__: null
};

var require$$1 = /*@__PURE__*/getAugmentedNamespace(bufferutil);

// ...

const bufferUtil = require$$1;
```
No error is thrown, so the code executes into the wrong branch.

After the fix, the `require` expression is left as-is. As `bufferutil`
is not installed in the user project, the error is thrown as expected.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
