### PR TITLE
fix: improve indent of built html file

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -545,7 +545,7 @@ function injectToHead(
   } else {
     // inject before head close
     if (headInjectRE.test(html)) {
-      return html.replace(headInjectRE, `${tagsHtml}\n$&`)
+      return html.replace(headInjectRE, `${tagsHtml}\n  $&`)
     }
   }
   // if no <head> tag is present, just prepend
@@ -592,7 +592,7 @@ function serializeTags(tags: HtmlTagDescriptor['children']): string {
   if (typeof tags === 'string') {
     return tags
   } else if (tags) {
-    return tags.map(serializeTag).join(`\n  `)
+    return `  ${tags.map(serializeTag).join('\n    ')}`
   }
   return ''
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Improve the indent in final built html file.

### Additional context

Not sure if it is too picky or not, when build a project, injecting processed links/scripts into **head** with proper indent looks slightly better.

**Before:**
![image](https://user-images.githubusercontent.com/5228723/125424689-471623ae-b771-4af8-af05-56c653420842.png)

**After:**
![image](https://user-images.githubusercontent.com/5228723/125424899-700c454a-71cb-44f3-b259-720efe91bb11.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
