### PR TITLE
feat: adding support for input source maps

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -14,6 +14,7 @@ import { SourceMap } from 'rollup'
 import { ResolvedConfig } from '..'
 import { createFilter } from '@rollup/pluginutils'
 import { combineSourcemaps } from '../utils'
+import * as convertSourceMap from 'convert-source-map'
 
 const debug = createDebugger('vite:esbuild')
 
@@ -130,10 +131,18 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
       if ((!target || target === 'esnext') && !minify) {
         return null
       }
-      return transformWithEsbuild(code, chunk.fileName, {
-        target: target || undefined,
-        minify
-      })
+      return transformWithEsbuild(
+        code,
+        chunk.fileName,
+        {
+          target: target || undefined,
+          minify
+        },
+        convertSourceMap.fromSource(code) ||
+          convertSourceMap
+            .fromMapFileSource(code, path.dirname(chunk.fileName))
+            ?.toObject()
+      )
     }
   }
 }


### PR DESCRIPTION
### Description

Adding support for input source maps on `vite build`.

### Additional context

If you have compile-to-JS language (such as TypeScript) and then use `vite build` the minified output doesn't have a way to give you the original source files to debug, as it didn't traverse the source map tree.

This fix will add that to the build output.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
