### PR TITLE
fix: do not end process in middleware mode, fix #4196

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -375,7 +375,7 @@ export async function createServer(
     async close() {
       process.off('SIGTERM', exitProcess)
 
-      if (process.env.CI !== 'true') {
+      if (!middlewareMode && process.env.CI !== 'true') {
         process.stdin.off('end', exitProcess)
       }
 
@@ -406,7 +406,7 @@ export async function createServer(
 
   process.once('SIGTERM', exitProcess)
 
-  if (process.env.CI !== 'true') {
+  if (!middlewareMode && process.env.CI !== 'true') {
     process.stdin.on('end', exitProcess)
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #4196.

It doesn't make much sense to end the vite process based on stdin when vite is running in middleware mode, as pointed out in https://github.com/vitejs/vite/issues/4196.

### Additional context

I based the original check for CI off of what create-react-app does, but that project does not have a specific "middleware mode".  I think it makes sense to include both of these checks, until/unless we can find a good way to detect running in docker/CI/container/non-interactive terminal (which is harder than it seems like it should be).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
