### PR TITLE
fix: create-vite when targetDir is a valid packageName

### DIFF
--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -250,7 +250,7 @@ async function init() {
 
   const pkg = require(path.join(templateDir, `package.json`))
 
-  pkg.name = packageName
+  pkg.name = packageName || targetDir
 
   write('package.json', JSON.stringify(pkg, null, 2))
 

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -164,7 +164,7 @@ async function init() {
           name: 'overwriteChecker'
         },
         {
-          type: () => (isValidPackageName(targetDir) ? null : 'text'),
+          type: () => (isValidPackageName(targetDir) ? 'text' : null),
           name: 'packageName',
           message: 'Package name:',
           initial: () => toValidPackageName(targetDir),

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -164,7 +164,7 @@ async function init() {
           name: 'overwriteChecker'
         },
         {
-          type: () => (isValidPackageName(targetDir) ? 'text' : null),
+          type: () => (isValidPackageName(targetDir) ? null : 'text'),
           name: 'packageName',
           message: 'Package name:',
           initial: () => toValidPackageName(targetDir),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix create-vite without packageName

### Additional context

isValidPackageName judgment

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
