### PR TITLE
fix(dev): only rewrite SSR stacktrace when possible

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -366,7 +366,21 @@ export async function createServer(
     },
     ssrFixStacktrace(e) {
       if (e.stack) {
-        e.stack = ssrRewriteStacktrace(e.stack, moduleGraph)
+        const stacktrace = ssrRewriteStacktrace(e.stack, moduleGraph)
+        const { configurable, writable } = Object.getOwnPropertyDescriptor(
+          e,
+          'stack'
+        )!
+        if (configurable) {
+          Object.defineProperty(e, 'stack', {
+            value: stacktrace,
+            enumerable: true,
+            configurable: true,
+            writable: true
+          })
+        } else if (writable) {
+          e.stack = stacktrace
+        }
       }
     },
     listen(port?: number, isRestart?: boolean) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -48,7 +48,10 @@ import { TransformOptions as EsbuildTransformOptions } from 'esbuild'
 import { DepOptimizationMetadata, optimizeDeps } from '../optimizer'
 import { ssrLoadModule } from '../ssr/ssrModuleLoader'
 import { resolveSSRExternal } from '../ssr/ssrExternal'
-import { ssrRewriteStacktrace } from '../ssr/ssrStacktrace'
+import {
+  rebindErrorStacktrace,
+  ssrRewriteStacktrace
+} from '../ssr/ssrStacktrace'
 import { createMissingImporterRegisterFn } from '../optimizer/registerMissing'
 import { printServerUrls } from '../logger'
 import { resolveHostname } from '../utils'
@@ -367,20 +370,7 @@ export async function createServer(
     ssrFixStacktrace(e) {
       if (e.stack) {
         const stacktrace = ssrRewriteStacktrace(e.stack, moduleGraph)
-        const { configurable, writable } = Object.getOwnPropertyDescriptor(
-          e,
-          'stack'
-        )!
-        if (configurable) {
-          Object.defineProperty(e, 'stack', {
-            value: stacktrace,
-            enumerable: true,
-            configurable: true,
-            writable: true
-          })
-        } else if (writable) {
-          e.stack = stacktrace
-        }
+        rebindErrorStacktrace(e, stacktrace)
       }
     },
     listen(port?: number, isRestart?: boolean) {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -141,9 +141,23 @@ async function instantiateModule(
       ssrExportAll
     )
   } catch (e) {
-    e.stack = ssrRewriteStacktrace(e.stack, moduleGraph)
+    const stacktrace = ssrRewriteStacktrace(e.stack, moduleGraph)
+    const { configurable, writable } = Object.getOwnPropertyDescriptor(
+      e,
+      'stack'
+    )!
+    if (configurable) {
+      Object.defineProperty(e, 'stack', {
+        value: stacktrace,
+        enumerable: true,
+        configurable: true,
+        writable: true
+      })
+    } else if (writable) {
+      e.stack = stacktrace
+    }
     server.config.logger.error(
-      `Error when evaluating SSR module ${url}:\n${e.stack}`,
+      `Error when evaluating SSR module ${url}:\n${stacktrace}`,
       {
         timestamp: true,
         clear: server.config.clearScreen

--- a/packages/vite/src/node/ssr/ssrStacktrace.ts
+++ b/packages/vite/src/node/ssr/ssrStacktrace.ts
@@ -56,3 +56,20 @@ export function ssrRewriteStacktrace(
     })
     .join('\n')
 }
+
+export function rebindErrorStacktrace(e: Error, stacktrace: string): void {
+  const { configurable, writable } = Object.getOwnPropertyDescriptor(
+    e,
+    'stack'
+  )!
+  if (configurable) {
+    Object.defineProperty(e, 'stack', {
+      value: stacktrace,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    })
+  } else if (writable) {
+    e.stack = stacktrace
+  }
+}


### PR DESCRIPTION
### Current Behavior

https://github.com/vitejs/vite/blob/772b2f73b0da08181a7cc29e0eb50073ff3cc464/packages/vite/src/node/server/index.ts#L367-L371

https://github.com/vitejs/vite/blob/772b2f73b0da08181a7cc29e0eb50073ff3cc464/packages/vite/src/node/ssr/ssrModuleLoader.ts#L144-L146

Currently, Vite assumes that the `stack` property of an error will always be writable. Unfortunately, this is not always the case, as seen [here](https://github.com/reboxer/discord-oauth2/blob/037dcaa2a20c1e08709daa219b995259eee3f764/lib/eris/errors/DiscordHTTPError.js#L63-L66) in the `discord-oauth2` module:

```js
Object.defineProperty(this, "stack", {
    value: this.message + "\n" + stack,
    writable: false,
});
```

This leads to errors *inside* `ssrFixStacktrace`:
```
TypeError: Cannot assign to read only property 'stack' of object 'DiscordHTTPError: 400 Bad Request on POST /api/v7/oauth2/token'
```

### Proposed Behavior

1. Check if the property is `configurable` (i.e. redefinable with `Object.defineProperty`). If so, redefine the property.
2. Otherwise, check if the property is `writable`. If so, perform assignment to the property.
3. If all else fails, leave the stacktrace untouched.

As `ssrFixStacktrace` is an in-place operation, we cannot return a new error object with the redefined stack-trace. I am unsure if there's a better way to handle this.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
