### PR TITLE
fix(ssr): avoid preload of loading="lazy" img

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/html.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/html.spec.ts
@@ -1,0 +1,9 @@
+describe('img emit correctly into different manifests depending on loading attribute', () => {
+  test('manifest.json', () => {
+    // TODO
+  })
+
+  test('ssr-manifest.json', () => {
+    // TODO
+  })
+})

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -97,10 +97,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
 
         const assetFilesWithLoadPreference = chunkToEmittedAssetsMap.get(chunk)
         if (assetFilesWithLoadPreference) {
-          const assets = Array.from(assetFilesWithLoadPreference).map(
-            ({ file }) => file
-          )
-          manifestChunk.assets = assets
+          manifestChunk.assets = [...assetFilesWithLoadPreference].map(({ file }) => file)
         }
 
         return manifestChunk

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -97,9 +97,9 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
 
         const assetFilesWithLoadPreference = chunkToEmittedAssetsMap.get(chunk)
         if (assetFilesWithLoadPreference) {
-          const assets = Array.from(assetFilesWithLoadPreference)
-            .filter(({ lazy }) => !lazy)
-            .map(({ file }) => file)
+          const assets = Array.from(assetFilesWithLoadPreference).map(
+            ({ file }) => file
+          )
           manifestChunk.assets = assets
         }
 

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -95,8 +95,13 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
           manifestChunk.css = [...cssFiles]
         }
 
-        const assets = chunkToEmittedAssetsMap.get(chunk)
-        if (assets) [(manifestChunk.assets = [...assets])]
+        const assetFilesWithLoadPreference = chunkToEmittedAssetsMap.get(chunk)
+        if (assetFilesWithLoadPreference) {
+          const assets = Array.from(assetFilesWithLoadPreference)
+            .filter(({ lazy }) => !lazy)
+            .map(({ file }) => file)
+          manifestChunk.assets = assets
+        }
 
         return manifestChunk
       }

--- a/packages/vite/src/node/ssr/ssrManifestPlugin.ts
+++ b/packages/vite/src/node/ssr/ssrManifestPlugin.ts
@@ -21,7 +21,8 @@ export function ssrManifestPlugin(config: ResolvedConfig): Plugin {
           const cssFiles = chunk.isEntry
             ? null
             : chunkToEmittedCssFileMap.get(chunk)
-          const assetFiles = chunkToEmittedAssetsMap.get(chunk)
+          const assetFilesWithLoadPreference =
+            chunkToEmittedAssetsMap.get(chunk)
           for (const id in chunk.modules) {
             const normalizedId = normalizePath(relative(config.root, id))
             const mappedChunks =
@@ -34,9 +35,11 @@ export function ssrManifestPlugin(config: ResolvedConfig): Plugin {
                 mappedChunks.push(base + file)
               })
             }
-            if (assetFiles) {
-              assetFiles.forEach((file) => {
-                mappedChunks.push(base + file)
+            if (assetFilesWithLoadPreference) {
+              assetFilesWithLoadPreference.forEach(({ file, lazy }) => {
+                if (!lazy) {
+                  mappedChunks.push(base + file)
+                }
               })
             }
           }


### PR DESCRIPTION
See update in comment below.

### Description

Noticed that during SSR would preload (inject into ssr-manifest) images even marked as `loading="lazy"`

### Additional context

- this is a rough draft... could be doing this extremely incorrectly so looking for feedback
- needs testing!

---

### What is the purpose of this pull request?

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
