### PR TITLE
fix(plugin-vue): properly select the main module during hot update (fix #4150)

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -38,7 +38,7 @@ export async function handleHotUpdate({
   let needRerender = false
   const affectedModules = new Set<ModuleNode | undefined>()
   const mainModule = modules.find(
-    (m) => !/type=/.test(m.url) || /type=script/.test(m.url)
+    (m) => m.id && (!/type=/.test(m.url) || /type=script/.test(m.url))
   )
   const templateModule = modules.find((m) => /type=template/.test(m.url))
 


### PR DESCRIPTION
fix #4150 

### Description

`moduleGraph` contains 2 entries for the SFC being updated :

* One with index.css as the only importer (because Tailwind JIT tells that every purgeable files are a deps of the generated css (index.css)).
* Another one with the "right" importer (the parent component or the js file where the component is imported).

This fix tries to better select the "main module" being selected during `handleHotUpdate` by selecting one with an `id` set.

### Additional context

I'm not super familiar with the code and so, i'm not 100% if there are legit cases where `id` property is missing

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
