### PR TITLE
fix(playground/ssr-vue): remove crossorigin from image preloads

### DIFF
--- a/packages/playground/ssr-vue/src/App.vue
+++ b/packages/playground/ssr-vue/src/App.vue
@@ -16,7 +16,7 @@
   font-style: italic;
   font-weight: 400;
   font-display: swap;
-  src: url('./assets/fonts/Inter-Italic.woff2?#iefix') format('woff2'),
+  src: url('./assets/fonts/Inter-Italic.woff2#iefix') format('woff2'),
     url('./assets/fonts/Inter-Italic.woff') format('woff');
 }
 .inter {

--- a/packages/playground/ssr-vue/src/entry-server.js
+++ b/packages/playground/ssr-vue/src/entry-server.js
@@ -49,13 +49,11 @@ function renderPreloadLink(file) {
   } else if (file.endsWith('.woff2')) {
     return ` <link rel="preload" href="${file}" as="font" type="font/woff2" crossorigin>`
   } else if (file.endsWith('.gif')) {
-    return ` <link rel="preload" href="${file}" as="image" type="image/gif" crossorigin>`
-  } else if (file.endsWith('.jpg')) {
-    return ` <link rel="preload" href="${file}" as="image" type="image/jpeg" crossorigin>`
-  } else if (file.endsWith('.jpeg')) {
-    return ` <link rel="preload" href="${file}" as="image" type="image/jpeg" crossorigin>`
+    return ` <link rel="preload" href="${file}" as="image" type="image/gif">`
+  } else if (file.endsWith('.jpg') || file.endsWith('.jpeg')) {
+    return ` <link rel="preload" href="${file}" as="image" type="image/jpeg">`
   } else if (file.endsWith('.png')) {
-    return ` <link rel="preload" href="${file}" as="image" type="image/png" crossorigin>`
+    return ` <link rel="preload" href="${file}" as="image" type="image/png">`
   } else {
     // TODO
     return ''


### PR DESCRIPTION
### Description

> Warnings: A preload <link> was found for "..." but was not used by the browser.

[CORS can be used with images with canvas](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-crossorigin) in which case you'd want a preload directive using the `crossorigin` attribute (instead or as well), but that seems like more of an edge case. 

For more complexity, I think vite could (1) avoid inserting preload for images that are only used with `"lazy"` / `"auto"` `loading` attribute to save on HTML output (see https://github.com/vitejs/vite/pull/4249), and (2) determine if images are used with `crossorigin` attribute to come up with more appropriate `preload` directives.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
