### PR TITLE
feat(build): watch vite.config.js in --watch mode

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -40,6 +40,7 @@ import { isCSSRequest } from './plugins/css'
 import { DepOptimizationMetadata } from './optimizer'
 import { scanImports } from './optimizer/scan'
 import { assetImportMetaUrlPlugin } from './plugins/assetImportMetaUrl'
+import * as chokidar from 'chokidar'
 
 export interface BuildOptions {
   /**
@@ -502,8 +503,48 @@ async function doBuild(
         }
       })
 
-      // stop watching
-      watcher.close()
+      if (config.configFile) {
+        const configWatcher = chokidar.watch(config.configFile, {
+          ignoreInitial: true
+        })
+        type Watcher = RollupWatcher & {
+          firstWatcher?: RollupWatcher
+        }
+        const lastWatcher = watcher as Watcher
+        lastWatcher.once('close', () => {
+          configWatcher.close()
+        })
+        configWatcher.once('change', () => {
+          lastWatcher.close()
+
+          // Let the last watcher close this watcher before
+          // it's been initialized.
+          let closed = false
+          lastWatcher.close = () => {
+            closed = true
+          }
+
+          // Reload the config and create another watcher.
+          const watcherPromise = doBuild(inlineConfig) as Promise<Watcher>
+
+          watcherPromise.then((watcher) => {
+            if (closed) {
+              return watcher.close()
+            }
+
+            // Let the first watcher close this watcher.
+            const { firstWatcher = lastWatcher } = lastWatcher
+            firstWatcher.close = () => watcher.close()
+
+            // Ensure the last watcher always has a reference to the first watcher.
+            watcher.firstWatcher = firstWatcher
+          })
+
+          watcherPromise.catch((error) => {
+            process.emit('uncaughtException', error)
+          })
+        })
+      }
 
       return watcher
     }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -505,3 +505,9 @@ export function resolveHostname(
 
   return { host, name }
 }
+
+export function getLastModified(path: string): number | undefined {
+  try {
+    return fs.statSync(path).mtimeMs
+  } catch {}
+}


### PR DESCRIPTION

### Description

With this PR, the Vite config is reloaded and the Rollup watcher is recreated whenever the Vite config is changed while the `build.watch` option is true. 

The watcher returned by the original `build` call is able to `.close()` the current watcher at any time.

```js
import * as vite from 'vite'

const watcher = await vite.build({ watch: true })

// Later on... after changes to the config file

watcher.close() // this still works
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
