### PR TITLE
fix: enable failing dependencies to be optimised by pre-processing them with esbuild

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -247,7 +247,7 @@ export async function optimizeDeps(
     try {
       exportsData = parse(entryContent) as ExportsData
     } catch {
-      config.logger.warn(
+      debug(
         `Unable to parse dependency: ${id}. Trying again with an esbuild transform.`
       )
       const transformed = await transform(entryContent, config.esbuild || {})

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -238,7 +238,7 @@ export async function optimizeDeps(
   const idToExports: Record<string, ExportsData> = {}
   const flatIdToExports: Record<string, ExportsData> = {}
 
-  let { plugins = [], ...esbuildOptions } =
+  const { plugins = [], ...esbuildOptions } =
     config.optimizeDeps?.esbuildOptions ?? {}
 
   await init
@@ -258,12 +258,9 @@ export async function optimizeDeps(
       })
       // Ensure that optimization won't fail by defaulting '.js' to the JSX parser.
       // This is useful for packages such as Gatsby.
-      esbuildOptions = {
-        ...esbuildOptions,
-        loader: {
-          '.js': 'jsx',
-          ...esbuildOptions.loader
-        }
+      esbuildOptions.loader = {
+        '.js': 'jsx',
+        ...esbuildOptions.loader
       }
       exportsData = parse(transformed.code) as ExportsData
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Some packages such as Gatsby [ship with JSX](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/gatsby-browser-entry.js) which is expected to be compiled by the library users' bundler.

While there are workarounds to force Vite to interpret `.js` files as JSX ([see discussion](https://github.com/vitejs/vite/discussions/3448)), these are not sufficient when the JSX is inside `node_modules/`. In particular, `es-module-lexer` doesn't support JSX (this was considered infeasible as per https://github.com/guybedford/es-module-lexer/issues/47). This means that the `parse()` call at: https://github.com/vitejs/vite/blob/887c247984abc0f80d8b19a1d681855944f6d01a/packages/vite/src/node/optimizer/index.ts#L245 fails when it encounters JSX.

While the best approach is certainly to ensure that packages don't ship as JSX, it's possible to improve the situation by adding a fallback mechanism which transforms the code with esbuild prior to re-trying.

This fix enables Gatsby to work when passing Vite the following options:
```js
        esbuild: {
          loader: "jsx",
        },
        optimizeDeps: {
          esbuildOptions: {
            loader: {
              ".js": "jsx",
            },
          },
        },
```

Since it's only a fallback mechanism, it shouldn't affect performance adversely.

### Additional context

This was originally surfaced as a bug report for the Viteshot project, see https://github.com/zenclabs/viteshot/issues/53.

Example project: https://github.com/fwouts/vite-gatsby-sample-app

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
