### PR TITLE
chore: temporarily shorten the time between locks

### DIFF
--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -2,7 +2,7 @@ name: Lock Closed Issues
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "*/5 * * * *"
 
 permissions:
   issues: write

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -2,7 +2,7 @@ name: Lock Closed Issues
 
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/10 * * * *"
 
 permissions:
   issues: write

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-lock-inactive-days: "14"
-          issue-lock-comment: |
-            This issue has been locked since it has been closed for more than 14 days.
-
-            If you have found a concrete bug or regression related to it, please open a new [bug report](https://github.com/vitejs/vite/issues/new/choose) with a reproduction against the latest Vite version. If you have any other comments you should join the chat at [Vite Land](https://chat.vitejs.dev) or create a new [discussion](https://github.com/vitejs/vite/discussions).
+          #issue-lock-comment: |
+          #  This issue has been locked since it has been closed for more than 14 days.
+          #
+          #  If you have found a concrete bug or regression related to it, please open a new [bug report](https://github.com/vitejs/vite/issues/new/choose) with a reproduction against the latest Vite version. If you have any other comments you should join the chat at [Vite Land](https://chat.vitejs.dev) or create a new [discussion](https://github.com/vitejs/vite/discussions).
           issue-lock-reason: ""
           process-only: "issues"


### PR DESCRIPTION
https://github.com/dessant/lock-threads#why-are-only-some-issues-and-pull-requests-processed

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This will set temporarily shorten the time to every 5min for the locks, so the ~1.8k closed issues get processed today instead of the next 40 days

After that we will set it to every week or bi-weekly: [0 0 */14 * *](https://crontab.guru/#0_0_*/14_*_*)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Discord internal communication https://discord.com/channels/804011606160703521/822526054316113941/865477165550010368

It may be possible to mute the bot for yourself: https://webapps.stackexchange.com/questions/119494/disable-notifications-from-github-bots

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
