### PR TITLE
feat: explicit set `useDefineForClassFields` in ts templates

### DIFF
--- a/packages/create-vite/template-lit-element-ts/tsconfig.json
+++ b/packages/create-vite/template-lit-element-ts/tsconfig.json
@@ -14,7 +14,8 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": false
   },
   "include": ["src/**/*.ts"],
   "exclude": []

--- a/packages/create-vite/template-preact-ts/tsconfig.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": false,

--- a/packages/create-vite/template-react-ts/tsconfig.json
+++ b/packages/create-vite/template-react-ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
     "skipLibCheck": false,

--- a/packages/create-vite/template-svelte-ts/tsconfig.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
     "target": "esnext",
+    "useDefineForClassFields": true,
     "module": "esnext",
     "resolveJsonModule": true,
     "baseUrl": ".",

--- a/packages/create-vite/template-vanilla-ts/tsconfig.json
+++ b/packages/create-vite/template-vanilla-ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "useDefineForClassFields": true,
     "module": "ESNext",
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",

--- a/packages/create-vite/template-vue-ts/tsconfig.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
+    "useDefineForClassFields": true,
     "module": "esnext",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
### Description

Since TypeScript 4.3, `target: "esnext"` indicates that
`useDefineForClassFields: true` as the new default.
See <https://github.com/microsoft/TypeScript/pull/42663>

So I'm explicitly adding this field to the tsconfigs to avoid any
confusions.

Note that `lit-element` projects must use
`useDefineForClassFields: false` because of <https://github.com/lit/lit/issues/3278>

Vue projects must use `useDefineForClassFields: true` so as to support
class style `prop` definition in `vue-class-component`:
<https://github.com/vuejs/vue-class-component/issues/465>

Popular React state management library MobX requires it to be `true`:
<https://mobx.js.org/installation.html#use-spec-compliant-transpilation-for-class-properties>

Other frameworks seem to have no particular opinion on this.

So I turned it on in all templates except for the `lit-element` one.

### Additional context

#4279 needs to be resolved before this PR to avoid confusing users.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes lit/lit-element#123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
