### PR TITLE
docs: add a workaround to `isolatedModules: true`

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -36,6 +36,8 @@ Vite uses [esbuild](https://github.com/evanw/esbuild) to transpile TypeScript in
 
 Note that because `esbuild` only performs transpilation without type information, it doesn't support certain features like const enum and implicit type-only imports. You must set `"isolatedModules": true` in your `tsconfig.json` under `compilerOptions` so that TS will warn you against the features that do not work with isolated transpilation.
 
+If migrating your codebase to `"isolatedModules": true` is an unsurmountable effort, you may be able to get around it with a third-party plugin such as [rollup-plugin-friendly-type-imports](https://www.npmjs.com/package/rollup-plugin-friendly-type-imports). However, this approach is not officially supported by Vite.
+
 ### Client Types
 
 Vite's default types are for its Node.js API. To shim the environment of client side code in a Vite application, add a `d.ts` declaration file:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I recently published a Rollup plugin designed for TypeScript projects that aren't ready to transition to `isolatedModules: true` (this is used in [React Preview](https://reactpreview.com), for example). This PR points to it from the documentation, in the hope that it will help projects move to Vite more easily.

Feel free to close this PR—I'd understand if we prefer not to point to barely known third-party plugins from the official docs!

### Additional context

See https://github.com/evanw/esbuild/issues/1398 for some prior discussion about integrating this directly into esbuild.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
