### PR TITLE
fix(templates): enable ESM in all templates

### DIFF
--- a/packages/create-vite/template-lit-element-ts/package.json
+++ b/packages/create-vite/template-lit-element-ts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-lit-element-ts-starter",
   "version": "0.0.0",
+  "type": "module",
   "main": "dist/my-element.es.js",
   "exports": {
     ".": "./dist/my-element.es.js"

--- a/packages/create-vite/template-lit-element/package.json
+++ b/packages/create-vite/template-lit-element/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-lit-element-starter",
   "version": "0.0.0",
+  "type": "module",
   "main": "dist/my-element.es.js",
   "exports": {
     ".": "./dist/my-element.es.js"

--- a/packages/create-vite/template-preact-ts/package.json
+++ b/packages/create-vite/template-preact-ts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-preact-ts-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/packages/create-vite/template-preact/package.json
+++ b/packages/create-vite/template-preact/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-preact-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-react-typescript-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/packages/create-vite/template-react/package.json
+++ b/packages/create-vite/template-react/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-react-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/create-vite/template-vanilla-ts/package.json
+++ b/packages/create-vite/template-vanilla-ts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-typescript-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/packages/create-vite/template-vanilla/package.json
+++ b/packages/create-vite/template-vanilla/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-vue-typescript-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/packages/create-vite/template-vue/package.json
+++ b/packages/create-vite/template-vue/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-vue-starter",
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

ESM is not enabled in most templates, which causes an error when the project is started (except for Svelte, fixed by https://github.com/vitejs/vite/pull/3835).

```js
import { defineConfig } from 'vite'
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1025:15)
    at Module._compile (node:internal/modules/cjs/loader:1059:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1124:10)
    at Object.require.extensions.<computed> [as .js] (...\node_modules\vite\dist\node\chunks\dep-11db14da.js:75452:13)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:816:12)
    at Module.require (node:internal/modules/cjs/loader:999:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at loadConfigFromBundledFile (...\node_modules\vite\dist\node\chunks\dep-11db14da.js:75457:17)14da.js:75457:17)
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
