### PR TITLE
chore: no implicit any for local vars

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -7,7 +7,7 @@ import {
   getPrevDescriptor,
   setDescriptor
 } from './utils/descriptorCache'
-import { PluginContext, TransformPluginContext } from 'rollup'
+import { PluginContext, SourceMap, TransformPluginContext } from 'rollup'
 import { normalizePath } from '@rollup/pluginutils'
 import { resolveScript } from './script'
 import { transformTemplateInMain } from './template'
@@ -63,7 +63,7 @@ export async function transformMain(
   const hasTemplateImport = descriptor.template && !useInlineTemplate
 
   let templateCode = ''
-  let templateMap
+  let templateMap: RawSourceMap | undefined
   if (hasTemplateImport) {
     ;({ code: templateCode, map: templateMap } = await genTemplateCode(
       descriptor,
@@ -239,7 +239,8 @@ async function genScriptCode(
   map: RawSourceMap
 }> {
   let scriptCode = `const _sfc_main = {}`
-  let map
+  let map: RawSourceMap | SourceMap | undefined
+
   const script = resolveScript(descriptor, options, ssr)
   if (script) {
     // If the script is js/ts and has no external src, it can be directly placed

--- a/packages/plugin-vue/src/template.ts
+++ b/packages/plugin-vue/src/template.ts
@@ -109,7 +109,8 @@ export function resolveTemplateCompilerOptions(
   const { id, filename, cssVars } = descriptor
 
   let transformAssetUrls = options.template?.transformAssetUrls
-  let assetUrlOptions
+  // @vue/compiler-sfc/dist/compiler-sfc.d.ts should export `AssetURLOptions`
+  let assetUrlOptions //: AssetURLOptions | undefined
   if (options.devServer) {
     // during dev, inject vite base so that @vue/compiler-sfc can transform
     // relative paths directly to absolute paths without incurring an extra import

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -157,7 +157,7 @@ export class ErrorOverlay extends HTMLElement {
       el.textContent = text
     } else {
       let curIndex = 0
-      let match
+      let match: RegExpExecArray | null
       while ((match = fileRE.exec(text))) {
         const { 0: file, index } = match
         if (index != null) {

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -42,7 +42,7 @@ export async function transformImportGlob(
   if (!pattern.startsWith('.') && !pattern.startsWith('/')) {
     throw err(`pattern must start with "." or "/" (relative to project root)`)
   }
-  let base
+  let base: string
   let parentDepth = 0
   const isAbsolute = pattern.startsWith('/')
   if (isAbsolute) {

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -53,7 +53,7 @@ export function esbuildDepPlugin(
     kind: ImportKind,
     resolveDir?: string
   ): Promise<string | undefined> => {
-    let _importer
+    let _importer: string
     // explicit resolveDir - this is passed only during yarn pnp resolve for
     // entries
     if (resolveDir) {
@@ -99,7 +99,7 @@ export function esbuildDepPlugin(
         { filter: /^[\w@][^:]/ },
         async ({ path: id, importer, kind }) => {
           // ensure esbuild uses our resolved entries
-          let entry
+          let entry: { path: string; namespace: string } | undefined
           // if this is an entry, return entry namespace resolve result
           if (!importer) {
             if ((entry = resolveEntry(id))) return entry

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -128,7 +128,7 @@ export async function optimizeDeps(
   }
 
   if (!force) {
-    let prevData
+    let prevData: DepOptimizationMetadata | undefined
     try {
       prevData = JSON.parse(fs.readFileSync(dataPath, 'utf-8'))
     } catch (e) {}

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -199,7 +199,7 @@ function esbuildScanPlugin(
           regex.lastIndex = 0
           let js = ''
           let loader: Loader = 'js'
-          let match
+          let match: RegExpExecArray | null
           while ((match = regex.exec(raw))) {
             const [, openTag, content] = match
             const srcMatch = openTag.match(srcRE)
@@ -227,7 +227,7 @@ function esbuildScanPlugin(
             // esbuild from crawling further.
             // the solution is to add `import 'x'` for every source to force
             // esbuild to keep crawling due to potential side effects.
-            let m
+            let m: RegExpExecArray | null
             const original = js
             while ((m = importsRE.exec(original)) != null) {
               // This is necessary to avoid infinite loops with zero-width matches

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -82,8 +82,8 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     },
 
     renderChunk(code, chunk) {
-      let match
-      let s
+      let match: RegExpExecArray | null
+      let s: MagicString | undefined
       while ((match = assetUrlQuotedRE.exec(code))) {
         s = s || (s = new MagicString(code))
         const [full, hash, postfix = ''] = match
@@ -208,7 +208,7 @@ async function fileToBuiltUrl(
   const file = cleanUrl(id)
   const content = await fsp.readFile(file)
 
-  let url
+  let url: string
   if (
     config.build.lib ||
     (!file.endsWith('.svg') &&

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -23,7 +23,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
         const protocol = options.protocol || null
         const timeout = options.timeout || 30000
         const overlay = options.overlay !== false
-        let port
+        let port: number | string | undefined
         if (config.server.middlewareMode) {
           if (typeof config.server.hmr === 'object') {
             port = config.server.hmr.clientPort || config.server.hmr.port

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1142,7 +1142,7 @@ function createViteLessPlugin(
         )
         if (resolved) {
           const result = await rebaseUrls(resolved, this.rootFile, this.alias)
-          let contents
+          let contents: string
           if (result && 'contents' in result) {
             contents = result.contents
           } else {

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -82,7 +82,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
 
       const s = new MagicString(code)
       let hasReplaced = false
-      let match
+      let match: RegExpExecArray | null
 
       while ((match = pattern.exec(code))) {
         hasReplaced = true

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -51,7 +51,7 @@ export function htmlInlineScriptProxyPlugin(): Plugin {
         const index = Number(proxyMatch[1])
         const file = cleanUrl(id)
         const html = fs.readFileSync(file, 'utf-8').replace(htmlCommentRE, '')
-        let match
+        let match: RegExpExecArray | null | undefined
         scriptModuleRE.lastIndex = 0
         for (let i = 0; i <= index; i++) {
           match = scriptModuleRE.exec(html)
@@ -485,7 +485,7 @@ export async function applyHtmlTransforms(
     if (typeof res === 'string') {
       html = res
     } else {
-      let tags
+      let tags: HtmlTagDescriptor[]
       if (Array.isArray(res)) {
         tags = res
       } else {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -187,7 +187,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
         const isModern = String(format === 'es')
         if (config.build.sourcemap) {
           const s = new MagicString(code)
-          let match
+          let match: RegExpExecArray | null
           while ((match = re.exec(code))) {
             s.overwrite(
               match.index,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -105,7 +105,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
 
       const options = isRequire ? requireOptions : baseOptions
 
-      let res
+      let res: string | PartialResolvedId | undefined
 
       // explicit fs paths that starts with /@fs/*
       if (asSrc && id.startsWith(FS_PREFIX)) {
@@ -371,7 +371,7 @@ export function tryNodeResolve(
   const deepMatch = id.match(deepImportRE)
   const pkgId = deepMatch ? deepMatch[1] || deepMatch[2] : id
 
-  let basedir
+  let basedir: string
   if (dedupe && dedupe.includes(pkgId)) {
     basedir = root
   } else if (
@@ -501,7 +501,7 @@ function loadPackageData(pkgPath: string, cacheKey = pkgPath) {
   const data = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
   const pkgDir = path.dirname(pkgPath)
   const { sideEffects } = data
-  let hasSideEffects
+  let hasSideEffects: (id: string) => boolean
   if (typeof sideEffects === 'boolean') {
     hasSideEffects = () => sideEffects
   } else if (Array.isArray(sideEffects)) {

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -87,13 +87,13 @@ export function transformMiddleware(
       return
     }
 
-    let url
+    let url: string
     try {
       url = removeTimestampQuery(req.url!).replace(NULL_BYTE_PLACEHOLDER, '\0')
     } catch (err) {
       // if it starts with %PUBLIC%, someone's migrating from something
       // like create-react-app
-      let errorMessage
+      let errorMessage: string
       if (req.url?.startsWith('/%PUBLIC')) {
         errorMessage = `index.html shouldn't include environment variables like %PUBLIC_URL%, see https://vitejs.dev/guide/#index-html-and-project-root for more information`
       } else {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -46,7 +46,8 @@ import {
   SourceDescription,
   EmittedFile,
   SourceMap,
-  RollupError
+  RollupError,
+  TransformResult
 } from 'rollup'
 import * as acorn from 'acorn'
 import acornClassFields from 'acorn-class-fields'
@@ -492,7 +493,7 @@ export async function createPluginContainer(
         ctx._activeId = id
         ctx._activeCode = code
         const start = isDebug ? Date.now() : 0
-        let result
+        let result: TransformResult | string | undefined
         try {
           result = await plugin.transform.call(ctx as any, code, id, ssr)
         } catch (e) {

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -4,6 +4,7 @@ import { tryNodeResolve, InternalResolveOptions } from '../plugins/resolve'
 import { isDefined, lookupFile, resolveFrom, unique } from '../utils'
 import { ResolvedConfig } from '..'
 import { createFilter } from '@rollup/pluginutils'
+
 /**
  * Heuristics for determining whether a dependency should be externalized for
  * server-side rendering.
@@ -46,8 +47,8 @@ export function resolveSSRExternal(
     }
     seen.add(id)
 
-    let entry
-    let requireEntry
+    let entry: string | undefined
+    let requireEntry: string
     try {
       entry = tryNodeResolve(
         id,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -442,7 +442,8 @@ export function combineSourcemaps(
     return { ...nullSourceMap }
   }
 
-  let map
+  // We don't declare type here so we can convert/fake/map as RawSourceMap
+  let map //: SourceMap
   let mapIndex = 1
   const useArrayInterface =
     sourcemapList.slice(0, -1).find((m) => m.sources.length !== 1) === undefined


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR adds typedefs to local vars that are not typed yet and therefor implicit `any`
TS code analysis can handle some of the if else cases but it's unsafe and if someone just reassign with something different then it's not safe anymore
This prevents potential bugs

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
