### PR TITLE
fix: --https is invalid in preview

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -211,7 +211,8 @@ cli
             logLevel: options.logLevel,
             server: {
               open: options.open,
-              strictPort: options.strictPort
+              strictPort: options.strictPort,
+              https: options.https
             }
           },
           'serve',
@@ -222,7 +223,6 @@ cli
           cleanOptions(options) as {
             host?: string
             port?: number
-            https?: boolean
           }
         )
       } catch (e) {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -18,13 +18,13 @@ import { resolveHostname } from './utils'
 
 export async function preview(
   config: ResolvedConfig,
-  serverOptions: { host?: string; port?: number; https?: boolean }
+  serverOptions: { host?: string; port?: number }
 ): Promise<void> {
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.server,
     app,
-    serverOptions.https === false ? undefined : await resolveHttpsConfig(config)
+    await resolveHttpsConfig(config)
   )
 
   // cors


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #4169
`--https` is invalid in `vite preview`.

```
>  vite preview --https
```
console: 
```
> Local: http://localhost:5000/
```
The protocol of the url is `http`, and the url with https  `https://localhost:5000` cannot be opened.

### Additional context
`options.https` is not passed into `resolveConfig`
https://github.com/vitejs/vite/blob/decc7d885d108a3e96ffc82abcb4057f54aa6db5/packages/vite/src/node/cli.ts#L206-L215

but subsequent execution depends on `config.server.https`
https://github.com/vitejs/vite/blob/decc7d885d108a3e96ffc82abcb4057f54aa6db5/packages/vite/src/node/preview.ts#L56
https://github.com/vitejs/vite/blob/decc7d885d108a3e96ffc82abcb4057f54aa6db5/packages/vite/src/node/server/http.ts#L32-L35

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
