### PR TITLE
fix:  handle non-existing files in sourcemap

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -14,7 +14,7 @@ export async function injectSourcesContent(
       map.sourcesContent![i] = await fs.readFile(
         path.resolve(sourceRoot, decodeURI(sourcePath)),
         'utf-8'
-      )
+      ).catch(() => '')
     })
   )
 }

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -14,7 +14,7 @@ export async function injectSourcesContent(
       map.sourcesContent![i] = await fs.readFile(
         path.resolve(sourceRoot, decodeURI(sourcePath)),
         'utf-8'
-      ).catch(() => '')
+      ).catch(() => '/* Vite fails to read source because it is missing or a virtual module.*/')
     })
   )
 }


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

If a source map contains a file in `source` section without uploading the referenced file, Vite will complain about ENOENT.
This fix makes Vite more lenient with npm ecosystem's misdemeanor.

### Additional context
When a npm package's source map has a source field, Vite will resolve the referenced file. However, not all packages will upload the source to npm registry, which makes such error. For example, the package `compute-scroll-into-view` does have such sources field.

<img width="787" alt="image" src="https://user-images.githubusercontent.com/2883231/126337412-8defc445-c874-494b-aacb-c0b4ba634070.png">

And vite throws an error.

<img width="721" alt="image" src="https://user-images.githubusercontent.com/2883231/126337106-3eb2e15a-5325-4756-815d-d09c8be525b1.png">

Instead of throwing an error, this fix makes Vite ignore the missing source file. 
To make the output less noisy and make the build successful, a comment is added for possible suggestion in the emitted source map. This supersedes #2904. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
