### PR TITLE
refactor: use utils.isObject insteads of typeof

### DIFF
--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { Plugin } from '../plugin'
 import { ResolvedConfig } from '../config'
 import { CLIENT_ENTRY, ENV_ENTRY } from '../constants'
-import { normalizePath } from '../utils'
+import { normalizePath, isObject } from '../utils'
 
 // ids in transform are normalized to unix style
 const normalizedClientEntry = normalizePath(CLIENT_ENTRY)
@@ -25,7 +25,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
         const overlay = options.overlay !== false
         let port: number | string | undefined
         if (config.server.middlewareMode) {
-          if (typeof config.server.hmr === 'object') {
+          if (isObject(config.server.hmr)) {
             port = config.server.hmr.clientPort || config.server.hmr.port
           }
           port = String(port || 24678)

--- a/packages/vite/src/node/server/http.ts
+++ b/packages/vite/src/node/server/http.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { Server as HttpServer } from 'http'
 import { ServerOptions as HttpsServerOptions } from 'https'
 import { ResolvedConfig, ServerOptions } from '..'
+import { isObject } from '../utils'
 import { Connect } from 'types/connect'
 import { Logger } from '../logger'
 
@@ -34,8 +35,7 @@ export async function resolveHttpsConfig(
 ): Promise<HttpsServerOptions | undefined> {
   if (!config.server.https) return undefined
 
-  const httpsOption =
-    typeof config.server.https === 'object' ? config.server.https : {}
+  const httpsOption = isObject(config.server.https) ? config.server.https : {}
 
   const { ca, cert, key, pfx } = httpsOption
   Object.assign(httpsOption, {

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -1,5 +1,5 @@
 import * as http from 'http'
-import { createDebugger } from '../../utils'
+import { createDebugger, isObject } from '../../utils'
 import httpProxy from 'http-proxy'
 import { HMR_HEADER } from '../ws'
 import { Connect } from 'types/connect'
@@ -94,7 +94,7 @@ export function proxyMiddleware(
             req.url = bypassResult
             debug(`bypass: ${req.url} -> ${bypassResult}`)
             return next()
-          } else if (typeof bypassResult === 'object') {
+          } else if (isObject(bypassResult)) {
             Object.assign(options, bypassResult)
             debug(`bypass: ${req.url} use modified options: %O`, options)
             return next()

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -61,6 +61,7 @@ import {
   createDebugger,
   ensureWatchedFile,
   generateCodeFrame,
+  isObject,
   isExternalUrl,
   normalizePath,
   numberToPos,
@@ -506,7 +507,7 @@ export async function createPluginContainer(
             plugin.name,
             prettifyUrl(id, root)
           )
-        if (typeof result === 'object') {
+        if (isObject(result)) {
           code = result.code || ''
           if (result.map) ctx.sourcemapChain.push(result.map)
         } else {

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -11,7 +11,8 @@ import {
   prettifyUrl,
   removeTimestampQuery,
   timeFrom,
-  ensureWatchedFile
+  ensureWatchedFile,
+  isObject
 } from '../utils'
 import { checkPublicFile } from '../plugins/asset'
 import { ssrTransform } from '../ssr/ssrTransform'
@@ -101,7 +102,7 @@ export async function transformRequest(
     }
   } else {
     isDebug && debugLoad(`${timeFrom(loadStart)} [plugin] ${prettyUrl}`)
-    if (typeof loadResult === 'object') {
+    if (isObject(loadResult)) {
       code = loadResult.code
       map = loadResult.map
     } else {
@@ -130,7 +131,7 @@ export async function transformRequest(
   const transformResult = await pluginContainer.transform(code, id, map, ssr)
   if (
     transformResult == null ||
-    (typeof transformResult === 'object' && transformResult.code == null)
+    (isObject(transformResult) && transformResult.code == null)
   ) {
     // no transform applied, keep code as-is
     isDebug &&

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -7,7 +7,7 @@ import {
 import WebSocket from 'ws'
 import { ErrorPayload, HMRPayload } from 'types/hmrPayload'
 import { ResolvedConfig } from '..'
-
+import { isObject } from '../utils'
 export const HMR_HEADER = 'vite-hmr'
 
 export interface WebSocketServer {
@@ -23,7 +23,7 @@ export function createWebSocketServer(
   let wss: WebSocket.Server
   let httpsServer: Server | undefined = undefined
 
-  const hmr = typeof config.server.hmr === 'object' && config.server.hmr
+  const hmr = isObject(config.server.hmr) && config.server.hmr
   const wsServer = (hmr && hmr.server) || server
 
   if (wsServer) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

refactor(vite-node): use utils.isObject insteads of typeof

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
