### PR TITLE
fix: transform without `sourcesContent`

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -341,13 +341,17 @@ export async function createPluginContainer(
         if (!combinedMap) {
           combinedMap = m as SourceMap
         } else {
-          combinedMap = combineSourcemaps(this.filename, [
-            {
-              ...(m as RawSourceMap),
-              sourcesContent: combinedMap.sourcesContent
-            },
-            combinedMap as RawSourceMap
-          ]) as SourceMap
+          combinedMap = combineSourcemaps(
+            this.filename,
+            [
+              {
+                ...(m as RawSourceMap),
+                sourcesContent: combinedMap.sourcesContent
+              },
+              combinedMap as RawSourceMap
+            ],
+            true
+          ) as SourceMap
         }
       }
       if (!combinedMap) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -433,7 +433,8 @@ const nullSourceMap: RawSourceMap = {
 }
 export function combineSourcemaps(
   filename: string,
-  sourcemapList: Array<DecodedSourceMap | RawSourceMap>
+  sourcemapList: Array<DecodedSourceMap | RawSourceMap>,
+  excludeContent = true
 ): RawSourceMap {
   if (
     sourcemapList.length === 0 ||
@@ -448,7 +449,7 @@ export function combineSourcemaps(
   const useArrayInterface =
     sourcemapList.slice(0, -1).find((m) => m.sources.length !== 1) === undefined
   if (useArrayInterface) {
-    map = remapping(sourcemapList, () => null, true)
+    map = remapping(sourcemapList, () => null, excludeContent)
   } else {
     map = remapping(
       sourcemapList[0],
@@ -459,7 +460,7 @@ export function combineSourcemaps(
           return { ...nullSourceMap }
         }
       },
-      true
+      excludeContent
     )
   }
   if (!map.file) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
If we use a plugin with transform like:
```ts
import MagicString from 'magic-string';
import type { Plugin } from 'vite';

export default function testTransformPlugin(): Plugin {
  return {
    name: 'testTransform',
    async transform(code, id) {
      const magicString = new MagicString(code);
      magicString.prepend('/* todo */');

      return {
        code: magicString.toString(),
        map: magicString.generateMap(),
      };
    },
  };
}
```
The vite will be crashed when browser load a script like:
```ts
import 'react';
```

This is because the sourcemap of react has a virtual path: 
```json
{
  "version": 3,
  "sources": ["../object-assign/index.js", "../react/cjs/react.development.js", "../react/index.js", "dep:react"],
...
}
```
[This PR](https://github.com/vitejs/vite/pull/2904) has fixed the crash. But there is also a warn log.

### Solution

I found that  the `pluginContainer.transform` has not lost the `sourcesContent` which causes the `injectSourcesContent` to be called. And I fixed this.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
