### PR TITLE
fix: don't interact with res if refresh has happened

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -76,6 +76,8 @@ export function transformMiddleware(
         // something unexpected has happened. In this case, Vite
         // returns an empty response that will error.
         setTimeout(() => {
+          // Don't do anything if refresh has happened before timeout
+          if (!server._pendingReload) return
           // status code request timeout
           res.statusCode = 408
           res.end(

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -76,8 +76,8 @@ export function transformMiddleware(
         // something unexpected has happened. In this case, Vite
         // returns an empty response that will error.
         setTimeout(() => {
-          // Don't do anything if refresh has happened before timeout
-          if (!server._pendingReload) return
+          // Don't do anything if response has already been sent
+          if (!res.writableEnded) return
           // status code request timeout
           res.statusCode = 408
           res.end(

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -77,7 +77,7 @@ export function transformMiddleware(
         // returns an empty response that will error.
         setTimeout(() => {
           // Don't do anything if response has already been sent
-          if (!res.writableEnded) return
+          if (res.writableEnded) return
           // status code request timeout
           res.statusCode = 408
           res.end(


### PR DESCRIPTION
### Description

In a server context we're getting this error:

```
Error [ERR_STREAM_WRITE_AFTER_END]: write after end
    at writeAfterEnd (_http_outgoing.js:694:15)
    at ServerResponse.end (_http_outgoing.js:815:7)
    at Timeout._onTimeout (/myproject/node_modules/vite/dist/node/chunks/dep-f2b4ca46.js:66784:21)
    at listOnTimeout (internal/timers.js:557:17)
    at processTimers (internal/timers.js:500:7) {
  code: 'ERR_STREAM_WRITE_AFTER_END'
}
```

It occurs when making a first SSR request when the vite cache dir is empty.

It seems the issue stems from this timeout getting called and trying to interact with a consumed node response. It seems that it would be possible simply to check whether a response has already been sent before responding.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
