### PR TITLE
docs: clarify sourcemap options

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -599,7 +599,7 @@ createServer()
 - **Type:** `boolean | 'inline' | 'hidden'`
 - **Default:** `false`
 
-  Generate production source maps. If true, a separate sourcemap file will be created. If "inline", the sourcemap will be appended to the resulting output file as a data URI. "hidden" works like true except that the corresponding sourcemap comments in the bundled files are suppressed.
+  Generate production source maps. If `true`, a separate sourcemap file will be created. If `'inline'`, the sourcemap will be appended to the resulting output file as a data URI. `'hidden'` works like `true` except that the corresponding sourcemap comments in the bundled files are suppressed.
 
 ### build.rollupOptions
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -599,7 +599,7 @@ createServer()
 - **Type:** `boolean | 'inline' | 'hidden'`
 - **Default:** `false`
 
-  Generate production source maps.
+  Generate production source maps. If true, a separate sourcemap file will be created. If "inline", the sourcemap will be appended to the resulting output file as a data URI. "hidden" works like true except that the corresponding sourcemap comments in the bundled files are suppressed.
 
 ### build.rollupOptions
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I was confused what the `"hidden"` option for sourcemaps meant, until I found the description in the [Rollup docs](https://rollupjs.org/guide/en/#outputsourcemap).  This PR copies the language from rollup to show in the Vite docs.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
