### PR TITLE
docs: link to ja translation

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -71,6 +71,10 @@ module.exports = {
           {
             text: '简体中文',
             link: 'https://cn.vitejs.dev'
+          },
+          {
+            text: '日本語',
+            link: 'https://ja.vitejs.dev'
           }
         ]
       }


### PR DESCRIPTION
### Description

https://ja.vitejs.dev/ is now live. This PR adds the link in the core english docs to it. I'm using 日本語, the same translation used in https://v3.vuejs.org/ for the Japanese docs link.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other