### PR TITLE
fix(build): fix define plugin spread operations

### DIFF
--- a/packages/playground/define/__tests__/define.spec.ts
+++ b/packages/playground/define/__tests__/define.spec.ts
@@ -14,4 +14,10 @@ test('string', async () => {
   expect(await page.textContent('.process-as-property')).toBe(
     defines.__OBJ__.process.env.SOMEVAR
   )
+  expect(await page.textContent('.spread-object')).toBe(
+    JSON.stringify({ SOMEVAR: defines['process.env.SOMEVAR'] })
+  )
+  expect(await page.textContent('.spread-array')).toBe(
+    JSON.stringify([...defines.__STRING__])
+  )
 })

--- a/packages/playground/define/index.html
+++ b/packages/playground/define/index.html
@@ -7,6 +7,8 @@
 <p>Object <span class="pre object"></span></p>
 <p>Env Var <code class="env-var"></code></p>
 <p>process as property: <code class="process-as-property"></code></p>
+<p>spread object: <code class="spread-object"></code></p>
+<p>spread array: <code class="spread-array"></code></p>
 
 <script type="module">
   text('.exp', __EXP__)
@@ -16,6 +18,13 @@
   text('.object', JSON.stringify(__OBJ__, null, 2))
   text('.env-var', process.env.SOMEVAR)
   text('.process-as-property', __OBJ__.process.env.SOMEVAR)
+  text(
+    '.spread-object',
+    JSON.stringify({
+      ...(process.env.SOMEVAR ? { SOMEVAR: `"${process.env.SOMEVAR}"` } : {})
+    })
+  )
+  text('.spread-array', JSON.stringify([...`"${__STRING__}"`]))
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -46,7 +46,8 @@ export function definePlugin(config: ResolvedConfig): Plugin {
   }
 
   const pattern = new RegExp(
-    '(?<!\\.)\\b(' +
+    // Do not allow preceding '.', but do allow preceding '...' for spread operations
+    '(?<!(?<!\\.\\.)\\.)\\b(' +
       Object.keys(replacements)
         .map((str) => {
           return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed a bug in the define plugin where the RegExp would not match when using spread operations. For instance, this would not get replaced:

```js
const myObj = {
   ...import.meta.env.VITE_ENV === 'dev' ? { a: 1 } : {}
}
```

By adding another negative look-behind inside, it will accept `...` but still reject `.`.

### Additional context

n/a

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
