### PR TITLE
fix: preserve base in HMR for CSS referenced in link tags

### DIFF
--- a/packages/playground/backend-integration/frontend/entrypoints/global.css
+++ b/packages/playground/backend-integration/frontend/entrypoints/global.css
@@ -8,6 +8,7 @@ body {
 }
 
 body {
+  color: black;
   margin: 4vh auto;
   max-width: 800px;
   padding: 0 4vw;

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -84,9 +84,9 @@ async function handleMessage(payload: HMRPayload) {
             ) as HTMLLinkElement[]
           ).find((e) => e.href.includes(path))
           if (el) {
-            const newPath =
-              base +
-              `${path.slice(1)}${path.includes('?') ? '&' : '?'}t=${timestamp}`
+            const newPath = `${base}${path.slice(1)}${
+              path.includes('?') ? '&' : '?'
+            }t=${timestamp}`
             el.href = new URL(newPath, el.href).href
           }
           console.log(`[vite] css hot updated: ${path}`)

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -84,9 +84,9 @@ async function handleMessage(payload: HMRPayload) {
             ) as HTMLLinkElement[]
           ).find((e) => e.href.includes(path))
           if (el) {
-            const newPath = `${path}${
-              path.includes('?') ? '&' : '?'
-            }t=${timestamp}`
+            const newPath =
+              base +
+              `${path.slice(1)}${path.includes('?') ? '&' : '?'}t=${timestamp}`
             el.href = new URL(newPath, el.href).href
           }
           console.log(`[vite] css hot updated: ${path}`)


### PR DESCRIPTION
### Description 📖 

This pull request ensures the `base` is also used for HMR updates when a CSS file was included using a `link` tag.

### Additional context

`base` is [already being used](https://github.com/ElMassimo/vite/blob/57cae10159e063c0ac671bbd4587fbe4a6670fee/packages/vite/src/client/client.ts#L332) to prefix the URLs when a `js-update` occurs.

Since the `base` is removed from the `url` when registering a CSS file in the module graph, the `path` sent in the `css-update` message is not prefixed with `base`.

As a result, the updated `href` targets the origin root (`/`), which is not consistent with how JS updates are fetched, and [requires special handling if proxying requests to the Vite dev server](https://github.com/ElMassimo/vite_ruby/blob/main/vite_ruby/lib/vite_ruby/dev_server_proxy.rb#L55).

### What is the purpose of this pull request?

- [x] Bug fix