### PR TITLE
fix(types): remove boolean from ImportMetaEnv index signature

### DIFF
--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -59,8 +59,14 @@ interface ImportMeta {
   >
 }
 
-interface ImportMetaEnv {
+// The index signature is for user-defined variables, which are always strings. Some
+// predefined properties are boolean, and TypeScript doesn't allow them to have types
+// that don't match the index signature. However, in this case properties are always
+// accessed statically (.PROP, not [PROP]), so the limitation doesn't matter.
+// The intersection type is a workaround.
+type ImportMetaEnv = {
   [key: string]: string | undefined
+} & {
   BASE_URL: string
   MODE: string
   DEV: boolean

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -60,7 +60,7 @@ interface ImportMeta {
 }
 
 interface ImportMetaEnv {
-  [key: string]: string | boolean | undefined
+  [key: string]: string | undefined
   BASE_URL: string
   MODE: string
   DEV: boolean

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -59,14 +59,7 @@ interface ImportMeta {
   >
 }
 
-// The index signature is for user-defined variables, which are always strings. Some
-// predefined properties are boolean, and TypeScript doesn't allow them to have types
-// that don't match the index signature. However, in this case properties are always
-// accessed statically (.PROP, not [PROP]), so the limitation doesn't matter.
-// The intersection type is a workaround.
-type ImportMetaEnv = {
-  [key: string]: string | undefined
-} & {
+type ImportMetaEnv = Record<string, string | undefined> & {
   BASE_URL: string
   MODE: string
   DEV: boolean


### PR DESCRIPTION
### Description

The current index signature of `ImportMetaEnv` (the type for `import.meta.env`) includes `boolean`:  

```ts
interface ImportMetaEnv {
  [key: string]: string | boolean | undefined
  BASE_URL: string
  MODE: string
  DEV: boolean
  PROD: boolean
  SSR: boolean
}
```

However, the only possible boolean values are the three special properties provided by Vite itself: `DEV`, `PROD` and `SSR`. These properties are typed explicitly in the interface and don't use the index signature. Actual user-defined environment variables are [always](https://github.com/motdotla/dotenv#rules) read as strings.

The extra `boolean` type makes it impossible to use environment variables as is where a `string | undefined` value is expected. The user either has to type-cast the value or override the interface.

This PR removes `boolean` from the index signature.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
