### PR TITLE
docs: update `commit-convention.md` to align with GitHub bot

### DIFF
--- a/.github/commit-convention.md
+++ b/.github/commit-convention.md
@@ -1,6 +1,6 @@
 ## Git Commit Message Convention
 
-> This is adapted from [Angular's commit convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
+> Vite expects [semantic pull requests](https://github.com/zeke/semantic-pull-requests).
 
 #### TL;DR:
 
@@ -8,7 +8,7 @@ Messages must be matched by the following regex:
 
 <!-- prettier-ignore -->
 ```js
-/^(revert: )?(feat|fix|docs|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(\(.+\))?: .{1,50}/
+/^(revert: )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .{1,50}/
 ```
 
 #### Examples


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Align list of acceptable prefixes with Github bot that this repo uses

### Additional context

I tried submitting a PR prefixed with `deps:` and it was rejected by a Github bot https://github.com/vitejs/vite/pull/4418

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
