### PR TITLE
chore: configure PR prefixes accepted by GitHub bot

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,1 +1,18 @@
 titleOnly: true
+types:
+  - feat
+  - fix
+  - docs
+  - dx
+  - refactor
+  - perf
+  - test
+  - workflow
+  - build
+  - ci
+  - chore
+  - types
+  - wip
+  - release
+  - deps
+  


### PR DESCRIPTION
Makes them match what's listed in `commit-convention.md`. See https://github.com/vitejs/vite/pull/4419 for more details