### PR TITLE
fix: overwrite configEnv.mode if the user explicitly set mode option (fix #4441)

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -49,9 +49,7 @@ export interface ConfigEnv {
   mode: string
 }
 
-export type UserConfigFn = (
-  env: Readonly<ConfigEnv>
-) => UserConfig | Promise<UserConfig>
+export type UserConfigFn = (env: ConfigEnv) => UserConfig | Promise<UserConfig>
 export type UserConfigExport = UserConfig | Promise<UserConfig> | UserConfigFn
 
 /**

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -268,8 +268,8 @@ export async function resolveConfig(
     allowClearScreen: config.clearScreen
   })
 
-  // user config may provide an alternative mode
-  mode = config.mode || mode
+  // user config may provide an alternative mode. But --mode has a higher prority
+  mode = inlineConfig.mode || config.mode || mode
   configEnv.mode = mode
 
   // resolve plugins

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -49,7 +49,9 @@ export interface ConfigEnv {
   mode: string
 }
 
-export type UserConfigFn = (env: ConfigEnv) => UserConfig | Promise<UserConfig>
+export type UserConfigFn = (
+  env: Readonly<ConfigEnv>
+) => UserConfig | Promise<UserConfig>
 export type UserConfigExport = UserConfig | Promise<UserConfig> | UserConfigFn
 
 /**
@@ -270,6 +272,7 @@ export async function resolveConfig(
 
   // user config may provide an alternative mode
   mode = config.mode || mode
+  configEnv.mode = mode
 
   // resolve plugins
   const rawUserPlugins = (config.plugins || []).flat().filter((p) => {

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -63,7 +63,7 @@ export interface Plugin extends RollupPlugin {
    */
   config?: (
     config: UserConfig,
-    env: Readonly<ConfigEnv>
+    env: ConfigEnv
   ) => UserConfig | null | void | Promise<UserConfig | null | void>
   /**
    * Use this hook to read and store the final resolved vite config.

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -63,7 +63,7 @@ export interface Plugin extends RollupPlugin {
    */
   config?: (
     config: UserConfig,
-    env: ConfigEnv
+    env: Readonly<ConfigEnv>
   ) => UserConfig | null | void | Promise<UserConfig | null | void>
   /**
    * Use this hook to read and store the final resolved vite config.


### PR DESCRIPTION
Fix #4441 .
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

without this PR. the `mode` and `configEnv.mode` variables will be inconsistent in some cases.

### Additional context

I don't quite understand how to add a test for such case.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
