### PR TITLE
fix(plugin-legacy): bake-in Promise polyfill, fix #4414

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -44,7 +44,12 @@ function viteLegacyPlugin(options = {}) {
   const facadeToLegacyPolyfillMap = new Map()
   const facadeToModernPolyfillMap = new Map()
   const modernPolyfills = new Set()
-  const legacyPolyfills = new Set()
+  // System JS relies on the Promise interface. It needs to be polyfilled for IE 11. (array.iterator is mandatory for supporting Promise.all)
+  const DEFAULT_LEGACY_POLYFILL = [
+    'core-js/modules/es.promise',
+    'core-js/modules/es.array.iterator'
+  ]
+  const legacyPolyfills = new Set(DEFAULT_LEGACY_POLYFILL)
 
   if (Array.isArray(options.modernPolyfills)) {
     options.modernPolyfills.forEach((i) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This fixes support for ie11 with legacy plugin.
see #4414 for the reasoning
This adds 2 polyfills per default, which can maybe improved by only injecting them when required (ie: only for ie11 and below) and not add to the bundle size for those that supports Promise

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
