### PR TITLE
feat(ssr): support ESM-only dependencies

### DIFF
--- a/packages/playground/ssr-esm/app/entry-server.jsx
+++ b/packages/playground/ssr-esm/app/entry-server.jsx
@@ -1,0 +1,4 @@
+import cjs from 'cjs-package'
+import { esm, cjsFromEsm } from 'esm-package'
+
+export default { cjs, esm, cjsFromEsm }

--- a/packages/playground/ssr-esm/cjs-package/index.dev.js
+++ b/packages/playground/ssr-esm/cjs-package/index.dev.js
@@ -1,0 +1,1 @@
+module.exports = 'cjs-dev'

--- a/packages/playground/ssr-esm/cjs-package/index.js
+++ b/packages/playground/ssr-esm/cjs-package/index.js
@@ -1,0 +1,1 @@
+module.exports = 'cjs-prod'

--- a/packages/playground/ssr-esm/cjs-package/package.json
+++ b/packages/playground/ssr-esm/cjs-package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cjs-package",
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "development": "./index.dev.js",
+      "default": "./index.js"
+    }
+  }
+}

--- a/packages/playground/ssr-esm/esm-package/index.dev.mjs
+++ b/packages/playground/ssr-esm/esm-package/index.dev.mjs
@@ -1,0 +1,4 @@
+import cjs from 'cjs-package'
+
+export const esm = 'esm-dev'
+export const cjsFromEsm = cjs

--- a/packages/playground/ssr-esm/esm-package/index.mjs
+++ b/packages/playground/ssr-esm/esm-package/index.mjs
@@ -1,0 +1,4 @@
+import cjs from 'cjs-package'
+
+export const esm = 'esm-prod'
+export const cjsFromEsm = cjs

--- a/packages/playground/ssr-esm/esm-package/package.json
+++ b/packages/playground/ssr-esm/esm-package/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "esm-package",
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "development": "./index.dev.mjs",
+      "default": "./index.mjs"
+    }
+  }
+}

--- a/packages/playground/ssr-esm/package.json
+++ b/packages/playground/ssr-esm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-ssr-esm",
+  "private": true,
+  "version": "0.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "cjs-package": "link:./cjs-package",
+    "esm-package": "link:./esm-package",
+    "vite": "link:../../vite"
+  },
+  "scripts": {
+    "serve": "node server.mjs"
+  }
+}

--- a/packages/playground/ssr-esm/server.mjs
+++ b/packages/playground/ssr-esm/server.mjs
@@ -1,0 +1,22 @@
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+import { install } from 'source-map-support'
+install()
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const vite = await import('vite')
+const server = await vite.createServer({
+  root: path.join(__dirname, 'app'),
+  // mode: 'production',
+  ssr: {
+    external: ['cjs-package', 'esm-package']
+  },
+  server: {
+    middlewareMode: 'ssr'
+  }
+})
+
+const entryModule = await server.ssrLoadModule('/entry-server.jsx')
+console.log(entryModule.default)

--- a/packages/playground/ssr-esm/vite.config.js
+++ b/packages/playground/ssr-esm/vite.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = {
+  build: {
+    minify: false
+  }
+}

--- a/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -1,4 +1,4 @@
-import { editFile, getColor, isBuild, untilUpdated } from '../../testUtils'
+import { editFile, untilUpdated } from '../../testUtils'
 import { port } from './serve'
 import fetch from 'node-fetch'
 
@@ -45,4 +45,11 @@ test('client navigation', async () => {
     code.replace('<h1>About', '<h1>changed')
   )
   await untilUpdated(() => page.textContent('h1'), 'changed')
+})
+
+test(`circular dependecies modules doesn't throw`, async () => {
+  await page.goto(url)
+  expect(await page.textContent('.circ-dep-init')).toMatch(
+    'circ-dep-init-a circ-dep-init-b'
+  )
 })

--- a/packages/playground/ssr-react/src/add.js
+++ b/packages/playground/ssr-react/src/add.js
@@ -1,0 +1,9 @@
+import { multiply } from './multiply'
+
+export function add(a, b) {
+  return a + b
+}
+
+export function addAndMultiply(a, b, c) {
+  return multiply(add(a, b), c)
+}

--- a/packages/playground/ssr-react/src/circular-dep-init/README.md
+++ b/packages/playground/ssr-react/src/circular-dep-init/README.md
@@ -1,0 +1,1 @@
+This test aim to find out wherever the modules with circular dependencies are correctly initialized

--- a/packages/playground/ssr-react/src/circular-dep-init/circular-dep-init.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/circular-dep-init.js
@@ -1,0 +1,2 @@
+export * from './module-a'
+export { getValueAB } from './module-b'

--- a/packages/playground/ssr-react/src/circular-dep-init/module-a.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/module-a.js
@@ -1,0 +1,1 @@
+export const valueA = 'circ-dep-init-a'

--- a/packages/playground/ssr-react/src/circular-dep-init/module-b.js
+++ b/packages/playground/ssr-react/src/circular-dep-init/module-b.js
@@ -1,0 +1,8 @@
+import { valueA } from './circular-dep-init'
+
+export const valueB = 'circ-dep-init-b'
+export const valueAB = valueA.concat(` ${valueB}`)
+
+export function getValueAB() {
+  return valueAB
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/README.md
+++ b/packages/playground/ssr-react/src/forked-deadlock/README.md
@@ -1,0 +1,51 @@
+This test aim to check for a particular type of circular dependency that causes tricky deadlocks, **deadlocks with forked imports stack**
+
+```
+A -> B means: B is imported by A and B has A in its stack
+A ... B means: A is waiting for B to ssrLoadModule()
+
+H -> X ... Y
+H -> X -> Y ... B
+H -> A ... B
+H -> A -> B ... X
+```
+
+### Forked deadlock description:
+
+```
+[X] is waiting for [Y] to resolve
+ ↑                  ↳ is waiting for [A] to resolve
+ │                                    ↳ is waiting for [B] to resolve
+ │                                                      ↳ is waiting for [X] to resolve
+ └────────────────────────────────────────────────────────────────────────┘
+```
+
+This may seems a traditional deadlock, but the thing that makes this special is the import stack of each module:
+
+```
+[X] stack:
+	[H]
+```
+
+```
+[Y] stack:
+	[X]
+	[H]
+```
+
+```
+[A] stack:
+	[H]
+```
+
+```
+[B] stack:
+	[A]
+	[H]
+```
+
+Even if `[X]` is imported by `[B]`, `[B]` is not in `[X]`'s stack because it's imported by `[H]` in first place then it's stack is only composed by `[H]`. `[H]` **forks** the imports **stack** and this make hard to be found.
+
+### Fix description
+
+Vite, when imports `[X]`, should check whether `[X]` is already pending and if it is, it must check that, when it was imported in first place, the stack of `[X]` doesn't have any module in common with the current module; in this case `[B]` has the module `[H]` is common with `[X]` and i can assume that a deadlock is going to happen.

--- a/packages/playground/ssr-react/src/forked-deadlock/common-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/common-module.js
@@ -1,0 +1,10 @@
+import { stuckModuleExport } from './stuck-module'
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module H
+ */
+export function commonModuleExport() {
+  stuckModuleExport()
+  deadlockfuseModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/deadlock-fuse-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/deadlock-fuse-module.js
@@ -1,0 +1,8 @@
+import { fuseStuckBridgeModuleExport } from './fuse-stuck-bridge-module'
+
+/**
+ * module A
+ */
+export function deadlockfuseModuleExport() {
+  fuseStuckBridgeModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/fuse-stuck-bridge-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/fuse-stuck-bridge-module.js
@@ -1,0 +1,8 @@
+import { stuckModuleExport } from './stuck-module'
+
+/**
+ * module C
+ */
+export function fuseStuckBridgeModuleExport() {
+  stuckModuleExport()
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/middle-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/middle-module.js
@@ -1,0 +1,8 @@
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module Y
+ */
+export function middleModuleExport() {
+  void deadlockfuseModuleExport
+}

--- a/packages/playground/ssr-react/src/forked-deadlock/stuck-module.js
+++ b/packages/playground/ssr-react/src/forked-deadlock/stuck-module.js
@@ -1,0 +1,8 @@
+import { middleModuleExport } from './middle-module'
+
+/**
+ * module X
+ */
+export function stuckModuleExport() {
+  middleModuleExport()
+}

--- a/packages/playground/ssr-react/src/multiply.js
+++ b/packages/playground/ssr-react/src/multiply.js
@@ -1,0 +1,9 @@
+import { add } from './add'
+
+export function multiply(a, b) {
+  return a * b
+}
+
+export function multiplyAndAdd(a, b, c) {
+  return add(multiply(a, b), c)
+}

--- a/packages/playground/ssr-react/src/pages/About.jsx
+++ b/packages/playground/ssr-react/src/pages/About.jsx
@@ -1,3 +1,12 @@
+import { addAndMultiply } from '../add'
+import { multiplyAndAdd } from '../multiply'
+
 export default function About() {
-  return <h1>About</h1>
+  return (
+    <>
+      <h1>About</h1>
+      <div>{addAndMultiply(1, 2, 3)}</div>
+      <div>{multiplyAndAdd(1, 2, 3)}</div>
+    </>
+  )
 }

--- a/packages/playground/ssr-react/src/pages/Home.jsx
+++ b/packages/playground/ssr-react/src/pages/Home.jsx
@@ -1,3 +1,17 @@
+import { addAndMultiply } from '../add'
+import { multiplyAndAdd } from '../multiply'
+import { commonModuleExport } from '../forked-deadlock/common-module'
+import { getValueAB } from '../circular-dep-init/circular-dep-init'
+
 export default function Home() {
-  return <h1>Home</h1>
+  commonModuleExport()
+
+  return (
+    <>
+      <h1>Home</h1>
+      <div>{addAndMultiply(1, 2, 3)}</div>
+      <div>{multiplyAndAdd(1, 2, 3)}</div>
+      <div className="circ-dep-init">{getValueAB()}</div>
+    </>
+  )
 }

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -14,6 +14,7 @@ import { modulePreloadPolyfillPlugin } from './modulePreloadPolyfill'
 import { webWorkerPlugin } from './worker'
 import { preAliasPlugin } from './preAlias'
 import { definePlugin } from './define'
+import { ssrRequireHookPlugin } from './ssrRequireHook'
 
 export async function resolvePlugins(
   config: ResolvedConfig,
@@ -42,6 +43,7 @@ export async function resolvePlugins(
       ssrTarget: config.ssr?.target,
       asSrc: true
     }),
+    config.build.ssr ? ssrRequireHookPlugin(config) : null,
     htmlInlineScriptProxyPlugin(),
     cssPlugin(config),
     config.esbuild !== false ? esbuildPlugin(config.esbuild) : null,

--- a/packages/vite/src/node/plugins/ssrRequireHook.ts
+++ b/packages/vite/src/node/plugins/ssrRequireHook.ts
@@ -1,0 +1,64 @@
+import MagicString from 'magic-string'
+import { ResolvedConfig } from '..'
+import { Plugin } from '../plugin'
+
+export function ssrRequireHookPlugin(config: ResolvedConfig): Plugin | null {
+  if (config.command !== 'build' || !config.resolve.dedupe?.length) {
+    return null
+  }
+  return {
+    name: 'vite:ssr-require-hook',
+    transform(code, id) {
+      const moduleInfo = this.getModuleInfo(id)
+      if (moduleInfo?.isEntry) {
+        const s = new MagicString(code)
+        s.prepend(
+          `;(${dedupeRequire.toString()})(${JSON.stringify(
+            config.resolve.dedupe
+          )});\n`
+        )
+        return {
+          code: s.toString(),
+          map: s.generateMap({
+            source: id
+          })
+        }
+      }
+    }
+  }
+}
+
+type NodeResolveFilename = (
+  request: string,
+  parent: NodeModule,
+  isMain: boolean,
+  options?: Record<string, any>
+) => string
+
+/** Respect the `resolve.dedupe` option in production SSR. */
+function dedupeRequire(dedupe: string[]) {
+  const Module = require('module') as { _resolveFilename: NodeResolveFilename }
+  const resolveFilename = Module._resolveFilename
+  Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request[0] !== '.' && request[0] !== '/') {
+      const parts = request.split('/')
+      const pkgName = parts[0][0] === '@' ? parts[0] + '/' + parts[1] : parts[0]
+      if (dedupe.includes(pkgName)) {
+        // Use this module as the parent.
+        parent = module
+      }
+    }
+    return resolveFilename!(request, parent, isMain, options)
+  }
+}
+
+export function hookNodeResolve(
+  getResolver: (resolveFilename: NodeResolveFilename) => NodeResolveFilename
+): () => void {
+  const Module = require('module') as { _resolveFilename: NodeResolveFilename }
+  const prevResolver = Module._resolveFilename
+  Module._resolveFilename = getResolver(prevResolver)
+  return () => {
+    Module._resolveFilename = prevResolver
+  }
+}

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -11,7 +11,7 @@ test('default import', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     console.log(__vite_ssr_import_0__.default.bar)"
   `)
 })
@@ -26,7 +26,7 @@ test('named import', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
 })
@@ -41,7 +41,7 @@ test('namespace import', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     function foo() { return __vite_ssr_import_0__.ref(0) }"
   `)
 })
@@ -50,7 +50,7 @@ test('export function declaration', async () => {
   expect((await ssrTransform(`export function foo() {}`, null, null)).code)
     .toMatchInlineSnapshot(`
     "function foo() {}
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }});"
   `)
 })
 
@@ -58,7 +58,7 @@ test('export class declaration', async () => {
   expect((await ssrTransform(`export class foo {}`, null, null)).code)
     .toMatchInlineSnapshot(`
     "class foo {}
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return foo }});"
   `)
 })
 
@@ -66,8 +66,8 @@ test('export var declaration', async () => {
   expect((await ssrTransform(`export const a = 1, b = 2`, null, null)).code)
     .toMatchInlineSnapshot(`
     "const a = 1, b = 2
-    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
-    Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }});
+    Object.defineProperty(__vite_ssr_exports__, \\"b\\", { enumerable: true, configurable: true, get(){ return b }});"
   `)
 })
 
@@ -77,8 +77,8 @@ test('export named', async () => {
       .code
   ).toMatchInlineSnapshot(`
     "const a = 1, b = 2; 
-    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }})
-    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"a\\", { enumerable: true, configurable: true, get(){ return a }});
+    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return b }});"
   `)
 })
 
@@ -87,10 +87,10 @@ test('export named from', async () => {
     (await ssrTransform(`export { ref, computed as c } from 'vue'`, null, null))
       .code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
 
-    Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.ref }})
-    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.computed }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"ref\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.ref }});
+    Object.defineProperty(__vite_ssr_exports__, \\"c\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.computed }});"
   `)
 })
 
@@ -104,27 +104,35 @@ test('named exports of imported binding', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
 
-    Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.createApp }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"createApp\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__.createApp }});"
   `)
 })
 
 test('export * from', async () => {
-  expect((await ssrTransform(`export * from 'vue'`, null, null)).code)
-    .toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
-
-    __vite_ssr_exportAll__(__vite_ssr_import_0__)"
+  expect(
+    (
+      await ssrTransform(
+        `export * from 'vue'\n` + `export * from 'react'`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    __vite_ssr_exportAll__(__vite_ssr_import_0__);
+    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"react\\");
+    __vite_ssr_exportAll__(__vite_ssr_import_1__);"
   `)
 })
 
 test('export * as from', async () => {
   expect((await ssrTransform(`export * as foo from 'vue'`, null, null)).code)
     .toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
 
-    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__ }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__ }});"
   `)
 })
 
@@ -146,7 +154,7 @@ test('dynamic import', async () => {
       .code
   ).toMatchInlineSnapshot(`
     "const i = () => __vite_ssr_dynamic_import__('./foo')
-    Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, configurable: true, get(){ return i }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"i\\", { enumerable: true, configurable: true, get(){ return i }});"
   `)
 })
 
@@ -160,7 +168,7 @@ test('do not rewrite method definition', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     class A { fn() { __vite_ssr_import_0__.fn() } }"
   `)
 })
@@ -175,7 +183,7 @@ test('do not rewrite catch clause', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./dependency\\");
     try {} catch(error) {}"
   `)
 })
@@ -191,7 +199,7 @@ test('should declare variable for imported super class', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./dependency\\");
     const Foo = __vite_ssr_import_0__.Foo;
     class A extends Foo {}"
   `)
@@ -209,12 +217,12 @@ test('should declare variable for imported super class', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"./dependency\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./dependency\\");
     const Foo = __vite_ssr_import_0__.Foo;
     class A extends Foo {}
     class B extends Foo {}
-    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A })
-    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A });
+    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }});"
   `)
 })
 
@@ -246,7 +254,7 @@ test('should handle default export variants', async () => {
   ).toMatchInlineSnapshot(`
     "function foo() {}
     foo.prototype = Object.prototype;
-    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: foo })"
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: foo });"
   `)
   // default named classes
   expect(
@@ -260,8 +268,8 @@ test('should handle default export variants', async () => {
   ).toMatchInlineSnapshot(`
     "class A {}
     class B extends A {}
-    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A })
-    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }})"
+    Object.defineProperty(__vite_ssr_exports__, \\"default\\", { enumerable: true, value: A });
+    Object.defineProperty(__vite_ssr_exports__, \\"B\\", { enumerable: true, configurable: true, get(){ return B }});"
   `)
 })
 
@@ -288,7 +296,7 @@ test('overwrite bindings', async () => {
       )
     ).code
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = __vite_ssr_import__(\\"vue\\")
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     const a = { inject: __vite_ssr_import_0__.inject }
     const b = { test: __vite_ssr_import_0__.inject }
     function c() { const { test: inject } = { test: true }; console.log(inject) }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -35,6 +35,7 @@ export function resolveSSRExternal(
 
   const resolveOptions: InternalResolveOptions = {
     root,
+    preserveSymlinks: true,
     isProduction: false,
     isBuild: true
   }


### PR DESCRIPTION
### Description

This is a proof-of-concept for compatibility with **ESM-only** dependencies in Vite SSR.

It needs #3950 and #3951 to be merged first. Therefore, I've squashed those two branches and included them in this PR, so you'll want to look at [6a279e80](https://github.com/vitejs/vite/commit/6a279e80) to avoid all the git-diff noise.

**Caveats:**
- The temporary override of `require` resolution being done in #3951 is incompatible with Node's ESM loader, so ESM-only dependencies are unaware of `resolve.dedupe` and `mode` options. The only way around this is to inject an experimental ESM loader through a CLI flag (see [here](https://nodejs.org/api/esm.html#esm_loaders)), which is *not* ideal, since we really only want to affect module resolution while loading an SSR module, rather than all the time, but maybe that issue can be fixed via temporary injection of the Vite config into the ESM loader.

Other than that, this approach seems to be bullet-proof.

**Playground**

I've also included an `ssr-esm` playground, but no automated tests yet. To test it out, do the following:
```
cd packages/playground/ssr-esm
pnpm install
pnpm serve
```

Try setting `mode: "production"` in the Vite config to see the ESM-only package load the incorrect module for its `cjs-package` dependency, resulting in duplicate instances of `cjs-package` (one from `./index.js`, the other from `./index.dev.js`).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
