### PR TITLE
fix(server): keep port when modifying the config file

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
 import { createServer, ViteDevServer } from '..'
-import { createDebugger, isObject, normalizePath } from '../utils'
+import { createDebugger, normalizePath } from '../utils'
 import { ModuleNode } from './moduleGraph'
 import { Update } from 'types/hmrPayload'
 import { CLIENT_DIR } from '../constants'
@@ -467,7 +467,7 @@ async function readModifiedFile(file: string): Promise<string> {
 async function restartServer(server: ViteDevServer) {
   // @ts-ignore
   global.__vite_start_time = Date.now()
-  const prevAddress = server.httpServer ? server.httpServer.address() : null
+  const { port } = server.config.server
   let newServer = null
   try {
     newServer = await createServer(server.config.inlineConfig)
@@ -487,10 +487,7 @@ async function restartServer(server: ViteDevServer) {
     }
   }
   if (!server.config.server.middlewareMode) {
-    await server.listen(
-      isObject(prevAddress) ? prevAddress.port : undefined,
-      true
-    )
+    await server.listen(port, true)
   } else {
     server.config.logger.info('server restarted.', { timestamp: true })
   }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
 import { createServer, ViteDevServer } from '..'
-import { createDebugger, normalizePath } from '../utils'
+import { createDebugger, isObject, normalizePath } from '../utils'
 import { ModuleNode } from './moduleGraph'
 import { Update } from 'types/hmrPayload'
 import { CLIENT_DIR } from '../constants'
@@ -467,6 +467,7 @@ async function readModifiedFile(file: string): Promise<string> {
 async function restartServer(server: ViteDevServer) {
   // @ts-ignore
   global.__vite_start_time = Date.now()
+  const prevAddress = server.httpServer ? server.httpServer.address() : null
   let newServer = null
   try {
     newServer = await createServer(server.config.inlineConfig)
@@ -486,7 +487,10 @@ async function restartServer(server: ViteDevServer) {
     }
   }
   if (!server.config.server.middlewareMode) {
-    await server.listen(undefined, true)
+    await server.listen(
+      isObject(prevAddress) ? prevAddress.port : undefined,
+      true
+    )
   } else {
     server.config.logger.info('server restarted.', { timestamp: true })
   }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -371,6 +371,12 @@ export async function createServer(
       }
     },
     listen(port?: number, isRestart?: boolean) {
+      if (port !== undefined) {
+        server.config.inlineConfig.server = {
+          ...(config.inlineConfig.server || {}),
+          port,
+        };
+      }
       return startServer(server, port, isRestart)
     },
     async close() {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -371,12 +371,6 @@ export async function createServer(
       }
     },
     listen(port?: number, isRestart?: boolean) {
-      if (port !== undefined) {
-        server.config.inlineConfig.server = {
-          ...(config.inlineConfig.server || {}),
-          port,
-        };
-      }
       return startServer(server, port, isRestart)
     },
     async close() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

```js
console.log('start vite server');
const server = await vite.createServer({
  root: process.cwd(),
});
server.listen(8000);
```

I use createServer directly like above, when I modify vite.config.js file, the port is no longer 8000 but the default 3000. 

> Or make `listen` not support the `port` param.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
