### PR TITLE
feat(server): invalidate module when watch files change

### DIFF
--- a/packages/playground/transform-plugin/__tests__/transform-plugin.spec.ts
+++ b/packages/playground/transform-plugin/__tests__/transform-plugin.spec.ts
@@ -1,0 +1,8 @@
+import { editFile, untilUpdated } from '../../testUtils'
+
+test('should re-run transform when plugin-dep file is edited', async () => {
+  expect(await page.textContent('#transform-count')).toBe('1')
+
+  await editFile('plugin-dep.js', (str) => str)
+  await untilUpdated(() => page.textContent('#transform-count'), '2')
+})

--- a/packages/playground/transform-plugin/index.html
+++ b/packages/playground/transform-plugin/index.html
@@ -1,0 +1,3 @@
+<div id="transform-count"></div>
+
+<script type="module" src="./index.js"></script>

--- a/packages/playground/transform-plugin/index.js
+++ b/packages/playground/transform-plugin/index.js
@@ -1,0 +1,3 @@
+// 'TRANSFORM_COUNT' is injected by the transform plugin
+// eslint-disable-next-line no-undef
+document.getElementById('transform-count').innerHTML = TRANSFORM_COUNT

--- a/packages/playground/transform-plugin/package.json
+++ b/packages/playground/transform-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-transform-plugin",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "serve": "vite preview"
+  }
+}

--- a/packages/playground/transform-plugin/plugin-dep.js
+++ b/packages/playground/transform-plugin/plugin-dep.js
@@ -1,0 +1,1 @@
+// Empty file for detecting changes in tests

--- a/packages/playground/transform-plugin/vite.config.js
+++ b/packages/playground/transform-plugin/vite.config.js
@@ -1,0 +1,22 @@
+let transformCount = 1
+
+const transformPlugin = {
+  name: 'transform',
+  transform(code, id) {
+    if (id === require.resolve('./index.js')) {
+      // Ensure `index.js` is reevaluated if 'plugin-dep.js' is changed
+      this.addWatchFile(require.resolve('./plugin-dep.js'))
+
+      return `
+        // Inject TRANSFORM_COUNT
+        let TRANSFORM_COUNT = ${transformCount++};
+
+        ${code}
+      `
+    }
+  }
+}
+
+module.exports = {
+  plugins: [transformPlugin]
+}

--- a/packages/playground/transform-plugin/vite.config.js
+++ b/packages/playground/transform-plugin/vite.config.js
@@ -1,9 +1,10 @@
+const { normalizePath } = require('vite')
 let transformCount = 1
 
 const transformPlugin = {
   name: 'transform',
   transform(code, id) {
-    if (id === require.resolve('./index.js')) {
+    if (id === normalizePath(require.resolve('./index.js'))) {
       // Ensure `index.js` is reevaluated if 'plugin-dep.js' is changed
       this.addWatchFile(require.resolve('./plugin-dep.js'))
 

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -70,6 +70,19 @@ export class ModuleGraph {
     return this.fileToModulesMap.get(file)
   }
 
+  addWatchModuleToFile(file: string, id: string): void {
+    let fileMappedModules = this.fileToModulesMap.get(file)
+    if (!fileMappedModules) {
+      fileMappedModules = new Set()
+      this.fileToModulesMap.set(file, fileMappedModules)
+    }
+
+    const moduleNode = this.idToModuleMap.get(id)
+    if (moduleNode) {
+      fileMappedModules!.add(moduleNode)
+    }
+  }
+
   onFileChange(file: string): void {
     const mods = this.getModulesByFile(file)
     if (mods) {

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -71,6 +71,7 @@ export class ModuleGraph {
   }
 
   addWatchModuleToFile(file: string, id: string): void {
+    file = normalizePath(file)
     let fileMappedModules = this.fileToModulesMap.get(file)
     if (!fileMappedModules) {
       fileMappedModules = new Set()

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -79,7 +79,7 @@ export class ModuleGraph {
 
     const moduleNode = this.idToModuleMap.get(id)
     if (moduleNode) {
-      fileMappedModules!.add(moduleNode)
+      fileMappedModules.add(moduleNode)
     }
   }
 

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -95,7 +95,7 @@ export interface PluginContainer {
     id: string,
     inMap?: SourceDescription['map'],
     ssr?: boolean
-  ): Promise<(SourceDescription & { watchFiles: Array<string> }) | null>
+  ): Promise<(SourceDescription & { watchFiles: string[] }) | null>
   load(id: string, ssr?: boolean): Promise<LoadResult | null>
   close(): Promise<void>
 }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -142,6 +142,10 @@ export async function transformRequest(
     isDebug && debugTransform(`${timeFrom(transformStart)} ${prettyUrl}`)
     code = transformResult.code!
     map = transformResult.map
+
+    transformResult.watchFiles.forEach((file) => {
+      moduleGraph.addWatchModuleToFile(file, mod.id!)
+    })
   }
 
   if (map && mod.file) {

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -144,7 +144,9 @@ export async function transformRequest(
     map = transformResult.map
 
     transformResult.watchFiles.forEach((file) => {
-      moduleGraph.addWatchModuleToFile(file, mod.id!)
+      if (mod.id) {
+        moduleGraph.addWatchModuleToFile(file, mod.id)
+      }
     })
   }
 

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -143,11 +143,11 @@ export async function transformRequest(
     code = transformResult.code!
     map = transformResult.map
 
-    transformResult.watchFiles.forEach((file) => {
-      if (mod.id) {
-        moduleGraph.addWatchModuleToFile(file, mod.id)
-      }
-    })
+    if (mod.id) {
+      transformResult.watchFiles.forEach((file) => {
+        moduleGraph.addWatchModuleToFile(file, mod.id!)
+      })
+    }
   }
 
   if (map && mod.file) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

As specified in the [rollup `addWatchFile` docs](https://rollupjs.org/guide/en/#thisaddwatchfileid-string--void).

> Using this.addWatchFile from within the transform hook will make sure the transform hook is also reevaluated for this module if the watched file changes.

This change will invalidate the current module if any changes are detected from the files passed to `this.addWatchFile` during the `transform` hook.

Resolves #3216 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
