### PR TITLE
feat(util): no need to delete url's hash

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -98,10 +98,9 @@ export function ensureVolumeInPath(file: string): string {
 }
 
 export const queryRE = /\?.*$/s
-export const hashRE = /#.*$/s
 
 export const cleanUrl = (url: string): string =>
-  url.replace(hashRE, '').replace(queryRE, '')
+  url.replace(queryRE, '')
 
 export const externalRE = /^(https?:)?\/\//
 export const isExternalUrl = (url: string): boolean => externalRE.test(url)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
There is no need to delete url's hash.
`#`  is used to guide the browser action and is completely useless to the server. 
Therefore, the HTTP request does not include `#`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] feat

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/.github/contributing.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.


> Is this a bugfix or a feat? One of these are wrong? (name or checkbox)

