### PR TITLE
fix(html): cover more cases in bodyPrependInjectRE

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -553,7 +553,7 @@ function injectToHead(
 }
 
 const bodyInjectRE = /<\/body>/
-const bodyPrependInjectRE = /<body>/
+const bodyPrependInjectRE = /<body[^>]*>/
 function injectToBody(
   html: string,
   tags: HtmlTagDescriptor[],


### PR DESCRIPTION
### Description
`/<body>/`  only captures bare body tag. This fix allow body with attributes.

### Additional context

<img width="331" alt="image" src="https://user-images.githubusercontent.com/2883231/127825342-29afffcc-077e-4a7a-acc1-5dc6e3f5f8c2.png">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

I didn't find a good place to add test for the fix while I think having one is more ideal.
