### PR TITLE
deps: update esbuild to 12.17

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -47,7 +47,7 @@
   },
   "//": "READ .github/contributing.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
-    "esbuild": "^0.12.8",
+    "esbuild": "^0.12.17",
     "postcss": "^8.3.6",
     "resolve": "^1.20.0",
     "rollup": "^2.38.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3059,10 +3059,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.12.8:
-  version "0.12.9"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.9.tgz#bed4e7087c286cd81d975631f77d47feb1660070"
-  integrity sha512-MWRhAbMOJ9RJygCrt778rz/qNYgA4ZVj6aXnNPxFjs7PmIpb0fuB9Gmg5uWrr6n++XKwwm/RmSz6RR5JL2Ocsw==
+esbuild@^0.12.17:
+  version "0.12.17"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.12.17.tgz#5816f905c2905de0ebbc658860df7b5b48afbcd3"
+  integrity sha512-GshKJyVYUnlSXIZj/NheC2O0Kblh42CS7P1wJyTbbIHevTG4jYMS9NNw8EOd8dDWD0dzydYHS01MpZoUcQXB4g==
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
### Description

We are currently in esbuild 12.8, there have quite a bit of fixes (some for CSS minification for example)
https://github.com/evanw/esbuild/blob/master/CHANGELOG.md#01217

Checking if CI is happy with the update, it would be good to use the 2.5 beta period to test this update

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Other