### PR TITLE
docs: Fix the confusing example of `server.proxy`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -396,7 +396,7 @@ export default defineConfig(async ({ command, mode }) => {
     server: {
       proxy: {
         // string shorthand
-        '/foo': 'http://localhost:4567/foo',
+        '/foo': 'http://localhost:4567',
         // with options
         '/api': {
           target: 'http://jsonplaceholder.typicode.com',


### PR DESCRIPTION
If you write the actual requested url like this, you will spell `/foo` again. For example, the actual mapped url of `/foo/get` is `http://localhost:4567/foo/foo/get`, which will lead to 404 unless the user Reuse `rewrite` configuration

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
