### PR TITLE
fix: PFX certs not working (closes #4495)

### DIFF
--- a/packages/vite/src/node/server/http.ts
+++ b/packages/vite/src/node/server/http.ts
@@ -6,6 +6,7 @@ import { ResolvedConfig, ServerOptions } from '..'
 import { isObject } from '../utils'
 import { Connect } from 'types/connect'
 import { Logger } from '../logger'
+import { Buffer } from 'buffer'
 
 export async function resolveHttpServer(
   { proxy }: ServerOptions,
@@ -44,9 +45,19 @@ export async function resolveHttpsConfig(
     key: readFileIfExists(key),
     pfx: readFileIfExists(pfx)
   })
-  if (!httpsOption.key || !httpsOption.cert) {
+
+  if (!httpsOption.pfx && (!httpsOption.key || !httpsOption.cert)) {
     httpsOption.cert = httpsOption.key = await getCertificate(config)
   }
+
+  if (httpsOption.pfx && httpsOption.passphrase) {
+    const buf = Buffer.from(new String(httpsOption.passphrase))
+    // type definition is incorrect; Buffer should be allowed per Node docs
+    // will not work if passphrase is left a string - throws error: Pass phrase must be a buffer
+    // @ts-ignore
+    httpsOption.passphrase = buf
+  }
+
   return httpsOption
 }
 


### PR DESCRIPTION
### Description

When using PFX files, localhost certs were still being generated.

In addition, Node wanted the passphrase as a buffer.

Fixes #4495 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
