### PR TITLE
fix: prevent crash when a file imported from SCSS does not exist

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -998,7 +998,9 @@ const scss: SassStylePreprocessor = async (
   const internalImporter: Sass.Importer = (url, importer, done) => {
     resolvers.sass(url, importer).then((resolved) => {
       if (resolved) {
-        rebaseUrls(resolved, options.filename, options.alias).then(done)
+        rebaseUrls(resolved, options.filename, options.alias)
+          .then(done)
+          .catch(done)
       } else {
         done(null)
       }


### PR DESCRIPTION
### Description

This pull request fixes an issue where importing a non-existing file within Sass causes the Vite process to crash.

```scss
@import '~/non-existing';
```

Crash:

```
node:fs:582
  handleErrorFromBinding(ctx);
  ^

Error: ENOENT: no such file or directory, open 'frontend/non-existing'
    at Object.openSync (node:fs:582:3)
    at Object.readFileSync (node:fs:450:35)
    at rebaseUrls (node_modules/.pnpm/vite@2.5.0-beta.0/node_modules/vite/dist/node/chunks/dep-1a88e67d.js:28855:33)
    at node_modules/.pnpm/vite@2.5.0-beta.0/node_modules/vite/dist/node/chunks/dep-1a88e67d.js:28793:17 {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: 'frontend/non-existing'
}
```

### Additional context

The error will be reported to the user instead.

```
11:55:20 AM [vite] Internal server error: ENOENT: no such file or directory, open 'frontend/non-existing'
  ╷
8 │ @import "~/non-existing";
  │         ^^^^^^^^^^^^^^^^^
  ╵
  frontend/styles.scss 8:9  root stylesheet
  Plugin: vite:css
```

### What is the purpose of this pull request?

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [ ] Include relevant tests that fail without this PR but pass with it.

Would it make sense to add a case where a file is edited to add a missing import in `packages/playground/css/__tests__/css.spec.ts`?