### PR TITLE
feat: import `.webmanifest` assets as URL

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -72,7 +72,8 @@ export const KNOWN_ASSET_TYPES = [
   'otf',
 
   // other
-  'wasm'
+  'wasm',
+  'webmanifest'
 ]
 
 export const DEFAULT_ASSETS_RE = new RegExp(


### PR DESCRIPTION
Leading to a slightly better DX.

```js
/* Before this PR:
import manifest from './path/to/app.webmanifest?url'
*/
// After this PR:
import manifest from './path/to/app.webmanifest'

const manifestMetaTag = ` <link rel="manifest" href=${manifest} crossorigin="use-credentials">`
```
