### PR TITLE
docs: make link to existing integrations more prominent

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -1,8 +1,10 @@
 # Backend Integration
 
+:::tip Note
 If you want to serve the HTML using a traditional backend (e.g. Rails, Laravel) but use Vite for serving assets, check for existing integrations listed in [Awesome Vite](https://github.com/vitejs/awesome-vite#integrations-with-backends).
 
-Or you can follow these steps to configure it manually:
+If you need a custom integration, you can follow the steps in this guide to configure it manually
+:::
 
 1. In your Vite config, configure the entry and enable build manifest:
 


### PR DESCRIPTION
### Description

Trying to push more people to use laravel-vite, vite-ruby and other existing integrations by making the first paragraph of the guide more prominent. Context, discussion in Vite Land from the creator of laravel-vite
> I never actually read that first paragraph
> The first code block caught my eye first

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other