### PR TITLE
fix(plugin-legacy): skip in SSR build

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -97,7 +97,7 @@ function viteLegacyPlugin(options = {}) {
     apply: 'build',
 
     configResolved(config) {
-      if (config.build.minify === 'esbuild') {
+      if (!config.build.ssr && config.build.minify === 'esbuild') {
         throw new Error(
           `Can't use esbuild as the minifier when targeting legacy browsers ` +
             `because esbuild minification is not legacy safe.`
@@ -106,6 +106,10 @@ function viteLegacyPlugin(options = {}) {
     },
 
     async generateBundle(opts, bundle) {
+      if (config.build.ssr) {
+        return
+      }
+
       if (!isLegacyBundle(bundle, opts)) {
         if (!modernPolyfills.size) {
           return
@@ -170,7 +174,7 @@ function viteLegacyPlugin(options = {}) {
       }
       config = _config
 
-      if (!genLegacy) {
+      if (!genLegacy || config.build.ssr) {
         return
       }
 
@@ -226,6 +230,10 @@ function viteLegacyPlugin(options = {}) {
     },
 
     renderChunk(raw, chunk, opts) {
+      if (config.build.ssr) {
+        return
+      }
+
       if (!isLegacyChunk(chunk, opts)) {
         if (
           options.modernPolyfills &&
@@ -315,6 +323,7 @@ function viteLegacyPlugin(options = {}) {
     },
 
     transformIndexHtml(html, { chunk }) {
+      if (config.build.ssr) return
       if (!chunk) return
       if (chunk.fileName.includes('-legacy')) {
         // The legacy bundle is built first, and its index.html isn't actually
@@ -420,6 +429,10 @@ function viteLegacyPlugin(options = {}) {
     },
 
     generateBundle(opts, bundle) {
+      if (config.build.ssr) {
+        return
+      }
+
       if (isLegacyBundle(bundle, opts)) {
         // avoid emitting duplicate assets
         for (const name in bundle) {


### PR DESCRIPTION
### Description

Disable `plugin-legacy` in SSR build, since it's obviously not needed, and the output won't be used in html files anyway.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
