### PR TITLE
fix: hmr doesn't work when modifying the code of jsx in sfc

### DIFF
--- a/packages/playground/vue-jsx/Script.vue
+++ b/packages/playground/vue-jsx/Script.vue
@@ -1,0 +1,14 @@
+<script lang="jsx">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent(() => {
+  const count = ref(4)
+  const inc = () => count.value++
+
+  return () => (
+    <button class="script" onClick={inc}>
+      script {count.value}
+    </button>
+  )
+})
+</script>

--- a/packages/playground/vue-jsx/SrcImport.jsx
+++ b/packages/playground/vue-jsx/SrcImport.jsx
@@ -1,0 +1,12 @@
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent(() => {
+  const count = ref(5)
+  const inc = () => count.value++
+
+  return () => (
+    <button class="src-import" onClick={inc}>
+      src import {count.value}
+    </button>
+  )
+})

--- a/packages/playground/vue-jsx/SrcImport.vue
+++ b/packages/playground/vue-jsx/SrcImport.vue
@@ -1,0 +1,1 @@
+<script src="./SrcImport.jsx"></script>

--- a/packages/playground/vue-jsx/__tests__/vue-jsx.spec.ts
+++ b/packages/playground/vue-jsx/__tests__/vue-jsx.spec.ts
@@ -5,6 +5,8 @@ test('should render', async () => {
   expect(await page.textContent('.named-specifier')).toMatch('1')
   expect(await page.textContent('.default')).toMatch('2')
   expect(await page.textContent('.default-tsx')).toMatch('3')
+  expect(await page.textContent('.script')).toMatch('4')
+  expect(await page.textContent('.src-import')).toMatch('5')
   expect(await page.textContent('.other-ext')).toMatch('Other Ext')
 })
 
@@ -17,6 +19,10 @@ test('should update', async () => {
   expect(await page.textContent('.default')).toMatch('3')
   await page.click('.default-tsx')
   expect(await page.textContent('.default-tsx')).toMatch('4')
+  await page.click('.script')
+  expect(await page.textContent('.script')).toMatch('5')
+  await page.click('.src-import')
+  expect(await page.textContent('.src-import')).toMatch('6')
 })
 
 if (!isBuild) {
@@ -73,5 +79,27 @@ if (!isBuild) {
 
     // should not affect other components on the page
     expect(await page.textContent('.named')).toMatch('1')
+  })
+
+  test('hmr: script in .vue', async () => {
+    editFile('Script.vue', (code) =>
+      code.replace('script {count', 'script updated {count')
+    )
+    await untilUpdated(() => page.textContent('.script'), 'script updated 4')
+
+    expect(await page.textContent('.src-import')).toMatch('6')
+  })
+
+  test('hmr: src import in .vue', async () => {
+    await page.click('.script')
+    editFile('SrcImport.jsx', (code) =>
+      code.replace('src import {count', 'src import updated {count')
+    )
+    await untilUpdated(
+      () => page.textContent('.src-import'),
+      'src import updated 5'
+    )
+
+    expect(await page.textContent('.script')).toMatch('5')
   })
 }

--- a/packages/playground/vue-jsx/main.jsx
+++ b/packages/playground/vue-jsx/main.jsx
@@ -2,6 +2,8 @@ import { createApp } from 'vue'
 import { Named, NamedSpec, default as Default } from './Comps'
 import { default as TsxDefault } from './Comp'
 import OtherExt from './OtherExt.tesx'
+import JsxScript from './Script.vue'
+import JsxSrcImport from './SrcImport.vue'
 
 function App() {
   return (
@@ -11,6 +13,8 @@ function App() {
       <Default />
       <TsxDefault />
       <OtherExt />
+      <JsxScript />
+      <JsxSrcImport />
     </>
   )
 }

--- a/packages/playground/vue-jsx/package.json
+++ b/packages/playground/vue-jsx/package.json
@@ -9,6 +9,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue-jsx": "^1.0.0"
+    "@vitejs/plugin-vue-jsx": "^1.0.0",
+    "@vitejs/plugin-vue": "^1.3.0"
   }
 }

--- a/packages/playground/vue-jsx/vite.config.js
+++ b/packages/playground/vue-jsx/vite.config.js
@@ -1,4 +1,5 @@
 const vueJsxPlugin = require('@vitejs/plugin-vue-jsx')
+const vuePlugin = require('@vitejs/plugin-vue')
 
 /**
  * @type {import('vite').UserConfig}
@@ -7,7 +8,8 @@ module.exports = {
   plugins: [
     vueJsxPlugin({
       include: [/\.tesx$/, /\.[jt]sx$/]
-    })
+    }),
+    vuePlugin()
   ],
   build: {
     // to make tests faster

--- a/packages/plugin-vue-jsx/index.js
+++ b/packages/plugin-vue-jsx/index.js
@@ -207,7 +207,7 @@ function vueJsxPlugin(options = {}) {
               ) + `\nexport default __default__`
           }
 
-          if (needHmr && !ssr) {
+          if (needHmr && !ssr && !/\?vue&type=script/.test(id)) {
             let code = result.code
             let callbackCode = ``
             for (const { local, exported, id } of hotComponents) {

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -46,7 +46,14 @@ export async function handleHotUpdate({
     !isEqualBlock(descriptor.script, prevDescriptor.script) ||
     !isEqualBlock(descriptor.scriptSetup, prevDescriptor.scriptSetup)
   ) {
-    affectedModules.add(mainModule)
+    let scriptModule
+    if (descriptor.script?.lang && !descriptor.script.src) {
+      const scriptModuleRE = new RegExp(
+        `type=script.*&lang\.${descriptor.script.lang}$`
+      )
+      scriptModule = modules.find((m) => scriptModuleRE.test(m.url))
+    }
+    affectedModules.add(scriptModule || mainModule)
   }
 
   if (!isEqualBlock(descriptor.template, prevDescriptor.template)) {

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -46,7 +46,7 @@ export async function handleHotUpdate({
     !isEqualBlock(descriptor.script, prevDescriptor.script) ||
     !isEqualBlock(descriptor.scriptSetup, prevDescriptor.scriptSetup)
   ) {
-    let scriptModule
+    let scriptModule: ModuleNode | undefined
     if (descriptor.script?.lang && !descriptor.script.src) {
       const scriptModuleRE = new RegExp(
         `type=script.*&lang\.${descriptor.script.lang}$`


### PR DESCRIPTION
### Description
fix #3008
When modifying the jsx code in the sfc file or modifying the code in the jsx file through script import, hmr does not work.
```html
<script lang="jsx">
import { defineComponent } from "vue";

export default defineComponent({
  render() {
    return <div>change it</div>
  },
});
</script>
```
or change code in `test.jsx`.
```html
<script src="./test.jsx"></script>
```

### Additional context
#### The case of <script src="./test.jsx"></script>:

When the `jsx` file is imported through src in the `.vue`, the `jsx` file will be processed by `plugin-vue-jsx` to add hot related code.
https://github.com/vitejs/vite/blob/5c0f0a362f669e3d38ddc51bfdd9d424a7c08feb/packages/plugin-vue-jsx/index.js#L220
The `importAnalysis` plugin will make the `isSelfAccepting ` of the `jsx` module `true`.
https://github.com/vitejs/vite/blob/5c0f0a362f669e3d38ddc51bfdd9d424a7c08feb/packages/vite/src/node/plugins/importAnalysis.ts#L283
So when modifying the code in the `jsx` file, only a request will be sent to get the updated `jsx` file. Because the `__hmrId` of the instance corresponding to `.vue` is `descriptor.id`:
https://github.com/vitejs/vite/blob/ed16488591b7dfac7e54d96f67c6f3674368b0cc/packages/plugin-vue/src/main.ts#L129
and the `__hmrId` of `jsx` is newly generated and different, so the instance cannot be re-rendered only by loading `jsx`.
https://github.com/vitejs/vite/blob/ed16488591b7dfac7e54d96f67c6f3674368b0cc/packages/plugin-vue-jsx/index.js#L215

The solution of this pr is to make the `jsx` file requested in the `.vue` have no hot related code,  the `isSelfAccepting` of the module is false, so that when the `jsx` code is changed, the `.vue` file will be requested again.

#### The case of <script lang="jsx">:

But the `jsx` code used by `<script lang='jsx'>` will request a file of `.vue?vue&type=script&lang.jsx`, and the file's module will be excluded by the `handleHotUpdate` of `plugin-vue`.
https://github.com/vitejs/vite/blob/5c0f0a362f669e3d38ddc51bfdd9d424a7c08feb/packages/plugin-vue/src/handleHotUpdate.ts#L49
In this way, the corresponding module will not be processed by `invalidate` and add `lastHMRTimestamp `.
https://github.com/vitejs/vite/blob/5c0f0a362f669e3d38ddc51bfdd9d424a7c08feb/packages/vite/src/node/server/hmr.ts#L132
Because there is no query parameter `t` in the `jsx` import in `.vue` file, after obtaining the `.vue` file, the `jsx` file will not be requested again
https://github.com/vitejs/vite/blob/5c0f0a362f669e3d38ddc51bfdd9d424a7c08feb/packages/vite/src/node/plugins/importAnalysis.ts#L238
The solution of this pr is to filter out the module corresponding to `jsx` file in the `handleHotUpdate` method of `plugin-vue`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.