### PR TITLE
fix: skip optimizer run on non-JS script tags

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -135,6 +135,7 @@ const scriptModuleRE =
 export const scriptRE = /(<script\b(?:\s[^>]*>|>))(.*?)<\/script>/gims
 export const commentRE = /<!--(.|[\r\n])*?-->/
 const srcRE = /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im
+const typeRE = /\btype\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im
 const langRE = /\blang\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im
 
 function esbuildScanPlugin(
@@ -207,9 +208,23 @@ function esbuildScanPlugin(
           while ((match = regex.exec(raw))) {
             const [, openTag, content] = match
             const srcMatch = openTag.match(srcRE)
+            const typeMatch = openTag.match(typeRE)
             const langMatch = openTag.match(langRE)
+            const type =
+              typeMatch && (typeMatch[1] || typeMatch[2] || typeMatch[3])
             const lang =
               langMatch && (langMatch[1] || langMatch[2] || langMatch[3])
+            // skip type="application/ld+json" and other non-JS types
+            if (
+              type &&
+              !(
+                type.includes('javascript') ||
+                type.includes('ecmascript') ||
+                type === 'module'
+              )
+            ) {
+              continue
+            }
             if (lang === 'ts' || lang === 'tsx' || lang === 'jsx') {
               loader = lang
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Skip `<script type="application/ld+json">` and other non-JS script types

Fixes https://github.com/vitejs/vite/issues/4564

### Additional context

This is commonly included on webpages for SEO purposes:
https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
