### PR TITLE
fix: support dangling comma and throw on circular dependency in tsconfig

### DIFF
--- a/packages/playground/tsconfig-json/nested/tsconfig.json
+++ b/packages/playground/tsconfig-json/nested/tsconfig.json
@@ -1,3 +1,4 @@
+// prettier-ignore
 {
   "include": ["./"],
   "compilerOptions": {

--- a/packages/playground/tsconfig-json/nested/tsconfig.json
+++ b/packages/playground/tsconfig-json/nested/tsconfig.json
@@ -14,6 +14,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
 
+    /* tsconfig.json should support comments and trailing comma */
     "useDefineForClassFields": false
   }
 }

--- a/packages/playground/tsconfig-json/nested/tsconfig.json
+++ b/packages/playground/tsconfig-json/nested/tsconfig.json
@@ -15,6 +15,6 @@
     "noImplicitReturns": true,
 
     /* tsconfig.json should support comments and trailing comma */
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
   }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -117,6 +117,8 @@
     "source-map": "^0.6.1",
     "source-map-support": "^0.5.19",
     "strip-ansi": "^6.0.0",
+    "strip-bom": "^4.0.0",
+    "strip-json-comments": "^3.1.1",
     "terser": "^5.7.1",
     "tsconfig": "^7.0.0",
     "tslib": "^2.3.0",

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import path from 'path'
 import chalk from 'chalk'
 import { Plugin } from '../plugin'
@@ -14,7 +15,8 @@ import { SourceMap } from 'rollup'
 import { ResolvedConfig } from '..'
 import { createFilter } from '@rollup/pluginutils'
 import { combineSourcemaps } from '../utils'
-import { find as findTSConfig, readFile as readTSConfig } from 'tsconfig'
+import stripBom from 'strip-bom'
+import stripComments from 'strip-json-comments'
 import { createRequire } from 'module'
 
 const debug = createDebugger('vite:esbuild')
@@ -41,43 +43,6 @@ type TSConfigJSON = {
   [key: string]: any
 }
 type TSCompilerOptions = NonNullable<TSConfigJSON['compilerOptions']>
-
-const tsconfigCache = new Map<string, TSConfigJSON>()
-async function loadTsconfigJsonForFile(
-  filename: string
-): Promise<TSConfigJSON> {
-  const directory = path.dirname(filename)
-
-  const cached = tsconfigCache.get(directory)
-  if (cached) {
-    return cached
-  }
-
-  let configPath = await findTSConfig(directory)
-  let tsconfig: TSConfigJSON = {}
-
-  if (configPath) {
-    tsconfig = (await readTSConfig(configPath)) as TSConfigJSON
-    while (tsconfig.extends) {
-      const configRequire = createRequire(configPath)
-
-      const extendsPath = configRequire.resolve(tsconfig.extends)
-      const extendedConfig = (await readTSConfig(extendsPath)) as TSConfigJSON
-
-      tsconfig = {
-        extends: extendedConfig.extends,
-        compilerOptions: {
-          ...extendedConfig.compilerOptions,
-          ...tsconfig.compilerOptions
-        }
-      }
-      configPath = extendsPath
-    }
-  }
-
-  tsconfigCache.set(directory, tsconfig)
-  return tsconfig
-}
 
 export async function transformWithEsbuild(
   code: string,
@@ -233,4 +198,196 @@ function prettifyMessage(m: Message, code: string): string {
     res += `\n` + generateCodeFrame(code, offset, offset + 1)
   }
   return res + `\n`
+}
+
+// modified from <https://github.com/TypeStrong/tsconfig/blob/v7.0.0/src/tsconfig.ts#L75-L95>
+
+/**
+ * Copyright (c) 2015 TypeStrong
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+async function findTSConfig(dir: string): Promise<string | void> {
+  const configFile = path.resolve(dir, 'tsconfig.json')
+
+  return stat(configFile).then((stats) => {
+    if (isFile(stats)) {
+      return configFile
+    }
+
+    const parentDir = path.dirname(dir)
+
+    if (dir === parentDir) {
+      return
+    }
+
+    return findTSConfig(parentDir)
+  })
+}
+
+/**
+ * Check if a file exists.
+ */
+function stat(filename: string): Promise<fs.Stats | void> {
+  return new Promise<fs.Stats | void>((resolve, reject) => {
+    fs.stat(filename, (err, stats) => {
+      return err ? resolve(undefined) : resolve(stats)
+    })
+  })
+}
+
+/**
+ * Check filesystem stat is a directory.
+ */
+function isFile(stats: fs.Stats | void) {
+  return stats
+    ? (stats as fs.Stats).isFile() || (stats as fs.Stats).isFIFO()
+    : false
+}
+
+// from <https://github.com/TypeStrong/tsconfig/pull/31>
+// by @dominikg
+
+/**
+ * replace dangling commas from pseudo-json string with single space
+ *
+ * limitations:
+ * - pseudo-json must not contain comments, use strip-json-comments before
+ * - only a single dangling comma before } or ] is removed
+ *   stripDanglingComma('[1,2,]') === '[1,2 ]
+ *   stripDanglingComma('[1,2,,]') === '[1,2, ]
+ *
+ * implementation heavily inspired by strip-json-comments
+ */
+function stripDanglingComma(jsonString: string) {
+  /**
+   * Check if char at qoutePosition is escaped by an odd number of backslashes preceding it
+   */
+  function isEscaped(jsonString: string, quotePosition: number) {
+    let index = quotePosition - 1
+    let backslashCount = 0
+
+    while (jsonString[index] === '\\') {
+      index -= 1
+      backslashCount += 1
+    }
+
+    return Boolean(backslashCount % 2)
+  }
+  let insideString = false
+  let offset = 0
+  let result = ''
+  let danglingCommaPos = null
+  for (let i = 0; i < jsonString.length; i++) {
+    const currentCharacter = jsonString[i]
+
+    if (currentCharacter === '"') {
+      const escaped = isEscaped(jsonString, i)
+      if (!escaped) {
+        insideString = !insideString
+      }
+    }
+
+    if (insideString) {
+      danglingCommaPos = null
+      continue
+    }
+    if (currentCharacter === ',') {
+      danglingCommaPos = i
+      continue
+    }
+    if (danglingCommaPos) {
+      if (currentCharacter === '}' || currentCharacter === ']') {
+        result += jsonString.slice(offset, danglingCommaPos) + ' '
+        offset = danglingCommaPos + 1
+        danglingCommaPos = null
+      } else if (!currentCharacter.match(/\s/)) {
+        danglingCommaPos = null
+      }
+    }
+  }
+
+  return result + jsonString.substring(offset)
+}
+
+async function readTSConfig(configPath: string): Promise<TSConfigJSON> {
+  const content: string = await new Promise((resolve, reject) => {
+    fs.readFile(configPath, 'utf-8', (err, data) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(stripComments(stripBom(data)))
+    })
+  })
+
+  // tsconfig.json can be empty
+  if (/^\s*$/.test(content)) {
+    return {}
+  }
+
+  return JSON.parse(stripDanglingComma(content)) as TSConfigJSON
+}
+
+const tsconfigCache = new Map<string, TSConfigJSON>()
+async function loadTsconfigJsonForFile(
+  filename: string
+): Promise<TSConfigJSON> {
+  const directory = path.dirname(filename)
+
+  const cached = tsconfigCache.get(directory)
+  if (cached) {
+    return cached
+  }
+
+  let configPath = await findTSConfig(directory)
+  let tsconfig: TSConfigJSON = {}
+
+  if (configPath) {
+    const visited = new Set()
+    visited.add(configPath)
+
+    tsconfig = await readTSConfig(configPath)
+    while (tsconfig.extends) {
+      const configRequire = createRequire(configPath)
+
+      const extendsPath = configRequire.resolve(tsconfig.extends)
+      const extendedConfig = await readTSConfig(extendsPath)
+
+      if (visited.has(extendsPath)) {
+        throw new Error(
+          `Circular dependency detected in the "extends" field of ${configPath}`
+        )
+      }
+      visited.add(extendsPath)
+
+      tsconfig = {
+        extends: extendedConfig.extends,
+        compilerOptions: {
+          ...extendedConfig.compilerOptions,
+          ...tsconfig.compilerOptions
+        }
+      }
+      configPath = extendsPath
+    }
+  }
+
+  tsconfigCache.set(directory, tsconfig)
+  return tsconfig
 }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -226,19 +226,18 @@ function prettifyMessage(m: Message, code: string): string {
 async function findTSConfig(dir: string): Promise<string | void> {
   const configFile = path.resolve(dir, 'tsconfig.json')
 
-  return stat(configFile).then((stats) => {
-    if (isFile(stats)) {
-      return configFile
-    }
+  const stats = await stat(configFile)
+  if (isFile(stats)) {
+    return configFile
+  }
 
-    const parentDir = path.dirname(dir)
+  const parentDir = path.dirname(dir)
 
-    if (dir === parentDir) {
-      return
-    }
+  if (dir === parentDir) {
+    return
+  }
 
-    return findTSConfig(parentDir)
-  })
+  return findTSConfig(parentDir)
 }
 
 /**

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -245,9 +245,9 @@ async function findTSConfig(dir: string): Promise<string | void> {
  * Check if a file exists.
  */
 function stat(filename: string): Promise<fs.Stats | void> {
-  return new Promise<fs.Stats | void>((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     fs.stat(filename, (err, stats) => {
-      return err ? resolve(undefined) : resolve(stats)
+      return err ? resolve() : resolve(stats)
     })
   })
 }
@@ -256,9 +256,7 @@ function stat(filename: string): Promise<fs.Stats | void> {
  * Check filesystem stat is a directory.
  */
 function isFile(stats: fs.Stats | void) {
-  return stats
-    ? (stats as fs.Stats).isFile() || (stats as fs.Stats).isFIFO()
-    : false
+  return stats ? stats.isFile() || stats.isFIFO() : false
 }
 
 // from <https://github.com/TypeStrong/tsconfig/pull/31>
@@ -288,8 +286,9 @@ function stripDanglingComma(jsonString: string) {
       backslashCount += 1
     }
 
-    return Boolean(backslashCount % 2)
+    return backslashCount % 2 === 1
   }
+
   let insideString = false
   let offset = 0
   let result = ''


### PR DESCRIPTION
### Description

By implementing tsconfig resolve/parse/load logic in vite.
Much of the code is from the `tsconfig` package and thanks to @dominikg

Fixes #4481
Fixes #4512

### Additional context

`strip-bom` v4 is used instead of v5, because v5 is a native ES module, causing jest tests to fail.

No tests are added for the circular dependency issue because I don't yet know how to test it.

If we need better error messages, `json5` can be used.
I've considered using `jsonc-parser`, but it outputs error messages for trailing commas despite successfully parsing it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
