### PR TITLE
fix: CSS dependencies are tracked incorrectly when base is set

### DIFF
--- a/packages/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/packages/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -32,15 +32,33 @@ if (isBuild) {
     expect(htmlEntry.assets.length).toEqual(1)
   })
 } else {
-  test('preserve the base in CSS HMR', async () => {
-    await untilUpdated(() => getColor('body'), 'black') // sanity check
-    editFile('frontend/entrypoints/global.css', (code) =>
-      code.replace('black', 'red')
-    )
-    await untilUpdated(() => getColor('body'), 'red') // successful HMR
+  describe('CSS HMR', () => {
+    test('preserve the base in CSS HMR', async () => {
+      await untilUpdated(() => getColor('body'), 'black') // sanity check
+      editFile('frontend/entrypoints/global.css', (code) =>
+        code.replace('black', 'red')
+      )
+      await untilUpdated(() => getColor('body'), 'red') // successful HMR
 
-    // Verify that the base (/dev/) was added during the css-update
-    const link = await page.$('link[rel="stylesheet"]')
-    expect(await link.getAttribute('href')).toContain('/dev/global.css?t=')
+      // Verify that the base (/dev/) was added during the css-update
+      const link = await page.$('link[rel="stylesheet"]')
+      expect(await link.getAttribute('href')).toContain('/dev/global.css?t=')
+    })
+
+    test('CSS dependencies are tracked for HMR', async () => {
+      const el = await page.$('h1')
+      browserLogs.length = 0
+
+      editFile('frontend/entrypoints/main.ts', (code) =>
+        code.replace('text-black', 'text-[rgb(204,0,0)]')
+      )
+      await untilUpdated(() => getColor(el), 'rgb(204, 0, 0)')
+      expect(browserLogs).toMatchObject([
+        '[vite] css hot updated: /global.css',
+        '[vite] css hot updated: /global.css',
+        '[vite] hot updated: /main.ts',
+        '[vite] hot updated: /global.css'
+      ])
+    })
   })
 }

--- a/packages/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/packages/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -53,12 +53,7 @@ if (isBuild) {
         code.replace('text-black', 'text-[rgb(204,0,0)]')
       )
       await untilUpdated(() => getColor(el), 'rgb(204, 0, 0)')
-      expect(browserLogs).toMatchObject([
-        '[vite] css hot updated: /global.css',
-        '[vite] css hot updated: /global.css',
-        '[vite] hot updated: /main.ts',
-        '[vite] hot updated: /global.css'
-      ])
+      expect(browserLogs).toContain('[vite] css hot updated: /global.css')
     })
   })
 }

--- a/packages/playground/backend-integration/frontend/entrypoints/global.css
+++ b/packages/playground/backend-integration/frontend/entrypoints/global.css
@@ -1,4 +1,5 @@
 @import '~/styles/background.css';
+@import '~/styles/tailwind.css';
 @import '../../references.css';
 
 html,

--- a/packages/playground/backend-integration/frontend/entrypoints/index.html
+++ b/packages/playground/backend-integration/frontend/entrypoints/index.html
@@ -2,7 +2,7 @@
 
 <link rel="stylesheet" href="/global.css" />
 
-<h1>Backend Integration</h1>
+<h1 class="text-black">Backend Integration</h1>
 
 <p>
   This test configures the <code>root</code> to simulate a Laravel/Rails setup.
@@ -27,6 +27,7 @@
   </li>
 </ul>
 
+<script type="module" src="./main.ts"></script>
 <script type="module">
   import './global.css'
 

--- a/packages/playground/backend-integration/frontend/entrypoints/main.ts
+++ b/packages/playground/backend-integration/frontend/entrypoints/main.ts
@@ -1,0 +1,11 @@
+export const colorClass = 'text-black'
+
+export function colorHeading() {
+  document.querySelector('h1').className = colorClass
+}
+
+colorHeading()
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}

--- a/packages/playground/backend-integration/frontend/styles/tailwind.css
+++ b/packages/playground/backend-integration/frontend/styles/tailwind.css
@@ -1,0 +1,1 @@
+@tailwind utilities;

--- a/packages/playground/backend-integration/package.json
+++ b/packages/playground/backend-integration/package.json
@@ -7,5 +7,8 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
     "serve": "vite preview"
+  },
+  "dependencies": {
+    "tailwindcss": "^2.2.4"
   }
 }

--- a/packages/playground/backend-integration/postcss.config.js
+++ b/packages/playground/backend-integration/postcss.config.js
@@ -1,0 +1,6 @@
+// postcss.config.js
+module.exports = {
+  plugins: {
+    tailwindcss: { config: __dirname + '/tailwind.config.js' }
+  }
+}

--- a/packages/playground/backend-integration/tailwind.config.js
+++ b/packages/playground/backend-integration/tailwind.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  mode: 'jit',
+  purge: [__dirname + '/frontend/**/*.{css,html,ts,js}'],
+  darkMode: false, // or 'media' or 'class'
+  theme: {
+    extend: {}
+  },
+  variants: {
+    extend: {}
+  },
+  plugins: []
+}

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -208,7 +208,9 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
                 isCSSRequest(file)
                   ? moduleGraph.createFileOnlyEntry(file)
                   : await moduleGraph.ensureEntryFromUrl(
-                      await fileToUrl(file, config, this)
+                      (
+                        await fileToUrl(file, config, this)
+                      ).replace(config.base, '/')
                     )
               )
             }


### PR DESCRIPTION
### Description

CSS file dependencies are being tracked incorrectly when the [`base`](https://vitejs.dev/config/#base) configuration option is set—URLs are being prefixed with `base` in some scenarios.

URLs in the module graph are normalized and are never prefixed with `base`, and as a result changes to those files are not causing the CSS module to be invalidated.

This pull request ensures the base is removed before passing it to `ensureEntryFromUrl` which is not base-aware.

### Additional context

The bug was introduced in https://github.com/vitejs/vite/pull/4267, released in `2.4.3`.

Among other potential bugs, this causes Tailwind CSS in JIT mode to stop working as expected when `base` is specified, because changes to HTML or JS files do not match the module graph file names, and as a result CSS is not invalidated when a change occurs.

See https://github.com/tailwindlabs/tailwindcss/issues/4978#issuecomment-897620776 for more context.

### What is the purpose of this pull request?

- [x] Bug fix
