### PR TITLE
fix(scan): do not match 'export default' in comments

### DIFF
--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -3,7 +3,7 @@ import {
   commentRE,
   importsRE,
   multilineCommentsRE,
-  singleCommentsRE
+  singlelineCommentsRE
 } from '../optimizer/scan'
 
 describe('optimizer-scan:script-test', () => {
@@ -116,8 +116,8 @@ describe('optimizer-scan:script-test', () => {
       */`.replace(multilineCommentsRE, '')
     expect(ret).not.toContain('export default')
 
-    singleCommentsRE.lastIndex = 0
-    ret = `//export default { }`.replace(singleCommentsRE, '')
+    singlelineCommentsRE.lastIndex = 0
+    ret = `//export default { }`.replace(singlelineCommentsRE, '')
     expect(ret).not.toContain('export default')
   })
 })

--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -1,4 +1,10 @@
-import { scriptRE, commentRE, importsRE } from '../optimizer/scan'
+import {
+  scriptRE,
+  commentRE,
+  importsRE,
+  multilineCommentsRE,
+  singleCommentsRE
+} from '../optimizer/scan'
 
 describe('optimizer-scan:script-test', () => {
   const scriptContent = `import { defineComponent } from 'vue'
@@ -101,5 +107,17 @@ describe('optimizer-scan:script-test', () => {
     shouldFailArray.forEach((str) => {
       expect(importsRE.test(str)).toBe(false)
     })
+  })
+
+  test('script comments test', () => {
+    multilineCommentsRE.lastIndex = 0
+    let ret = `/*
+      export default { }
+      */`.replace(multilineCommentsRE, '')
+    expect(ret).not.toContain('export default')
+
+    singleCommentsRE.lastIndex = 0
+    ret = `//export default { }`.replace(singleCommentsRE, '')
+    expect(ret).not.toContain('export default')
   })
 })

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -41,7 +41,7 @@ export const importsRE =
   /(?<!\/\/.*)(?<=^|;|\*\/)\s*import(?!\s+type)(?:[\w*{}\n\r\t, ]+from\s*)?\s*("[^"]+"|'[^']+')\s*(?=$|;|\/\/|\/\*)/gm
 
 export const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
-export const singleCommentsRE = /\/\/.*/g
+export const singlelineCommentsRE = /\/\/.*/g
 
 export async function scanImports(config: ResolvedConfig): Promise<{
   deps: Record<string, string>
@@ -239,7 +239,7 @@ function esbuildScanPlugin(
           // empty singleline & multiline comments to avoid matching comments
           const code = js
             .replace(multilineCommentsRE, '/* */')
-            .replace(singleCommentsRE, '')
+            .replace(singlelineCommentsRE, '')
 
           if (
             loader.startsWith('ts') &&

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -41,6 +41,7 @@ export const importsRE =
   /(?<!\/\/.*)(?<=^|;|\*\/)\s*import(?!\s+type)(?:[\w*{}\n\r\t, ]+from\s*)?\s*("[^"]+"|'[^']+')\s*(?=$|;|\/\/|\/\*)/gm
 
 const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
+const singleCommentsRegex = /\/\/.*/g
 
 export async function scanImports(config: ResolvedConfig): Promise<{
   deps: Record<string, string>
@@ -235,6 +236,10 @@ function esbuildScanPlugin(
               js += content + '\n'
             }
           }
+          // empty singleline & multiline comments to avoid matching comments
+          const code = js
+            .replace(multilineCommentsRE, '/* */')
+            .replace(singleCommentsRegex, '')
 
           if (
             loader.startsWith('ts') &&
@@ -247,8 +252,6 @@ function esbuildScanPlugin(
             // the solution is to add `import 'x'` for every source to force
             // esbuild to keep crawling due to potential side effects.
             let m
-            // empty multiline comments to avoid matching commented out imports
-            const code = js.replace(multilineCommentsRE, '/* */')
             while ((m = importsRE.exec(code)) != null) {
               // This is necessary to avoid infinite loops with zero-width matches
               if (m.index === importsRE.lastIndex) {
@@ -258,11 +261,11 @@ function esbuildScanPlugin(
             }
           }
 
-          if (!js.includes(`export default`)) {
+          if (!code.includes(`export default`)) {
             js += `\nexport default {}`
           }
 
-          if (js.includes('import.meta.glob')) {
+          if (code.includes('import.meta.glob')) {
             return {
               // transformGlob already transforms to js
               loader: 'js',

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -40,8 +40,8 @@ const htmlTypesRE = /\.(html|vue|svelte)$/
 export const importsRE =
   /(?<!\/\/.*)(?<=^|;|\*\/)\s*import(?!\s+type)(?:[\w*{}\n\r\t, ]+from\s*)?\s*("[^"]+"|'[^']+')\s*(?=$|;|\/\/|\/\*)/gm
 
-const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
-const singleCommentsRegex = /\/\/.*/g
+export const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
+export const singleCommentsRE = /\/\/.*/g
 
 export async function scanImports(config: ResolvedConfig): Promise<{
   deps: Record<string, string>
@@ -239,7 +239,7 @@ function esbuildScanPlugin(
           // empty singleline & multiline comments to avoid matching comments
           const code = js
             .replace(multilineCommentsRE, '/* */')
-            .replace(singleCommentsRegex, '')
+            .replace(singleCommentsRE, '')
 
           if (
             loader.startsWith('ts') &&


### PR DESCRIPTION
fix #4598

<!-- Thank you for contributing! -->

### Description
If the script code happens to contain `export default` in comments, then `export default {}` will not be added at the end of line.
Just like the issue #4598 :
```js
<script setup>
import { provide } from 'vue'

// const count = ref(1)
// const plusOne = computed(() => count.value + 1)
// export default {
//     computed: {
//         notification_width: function () {
//             return Math.min(600, Math.max(document.documentElement.clientWidth, window.innerWidth || 0)) || 'px' //fit on mobile
//         }
//     },

</script>
```
https://github.com/vitejs/vite/blob/eb2e41b098fb3d5f367c1f4fdfcad12f7538ac16/packages/vite/src/node/optimizer/scan.ts#L241-L243

My current solution refers to PR: #4088 . Empty the singleline & multiline comments first, using the `code` without comments to match.

### Additional context

I have considered adding test cases, but meanwhile I noticed that current unit tests are only for regular expressions, so I don't add them at the moment.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
