### PR TITLE
fix(create-vite): project name with only numbers as an argument

### DIFF
--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -3,7 +3,7 @@
 // @ts-check
 const fs = require('fs')
 const path = require('path')
-const argv = require('minimist')(process.argv.slice(2))
+const argv = require('minimist')(process.argv.slice(2), { string: ['_'] })
 // eslint-disable-next-line node/no-restricted-require
 const prompts = require('prompts')
 const {

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -3,6 +3,8 @@
 // @ts-check
 const fs = require('fs')
 const path = require('path')
+// For solving the problem failed to create a project with number-only argument,
+// the second argument of "minimist" is added to convert it to string type.
 const argv = require('minimist')(process.argv.slice(2), { string: ['_'] })
 // eslint-disable-next-line node/no-restricted-require
 const prompts = require('prompts')

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -3,8 +3,8 @@
 // @ts-check
 const fs = require('fs')
 const path = require('path')
-// For solving the problem failed to create a project with number-only argument,
-// the second argument of "minimist" is added to convert it to string type.
+// Avoids autoconversion to number of the project name by defining that the args 
+// non associated with an option ( _ ) needs to be parsed as a string. See #4606
 const argv = require('minimist')(process.argv.slice(2), { string: ['_'] })
 // eslint-disable-next-line node/no-restricted-require
 const prompts = require('prompts')


### PR DESCRIPTION
### Description
If an argument for the project name is set only with numbers, [path.join](https://github.com/vitejs/vite/blob/c0a3dbfa66266378f6f329f1981d5827b781fdbb/packages/create-vite/index.js#L220) will be failed because the argument is retained in "number" type.

On entering the project name interactively, the type conversion to "string" type is implicitly performed because ["trim" method is called in the middle](https://github.com/vitejs/vite/blob/c0a3dbfa66266378f6f329f1981d5827b781fdbb/packages/create-vite/index.js#L145).

I think it is strange that `create-vite` can generate a project with numbers on setting interactively, but not on setting it with arguments.

### Additional context
The reason why happened that, it is automatically converted to "number" type, on not setting an option for "minimist", which is a library for managing arguments.
ref: https://github.com/substack/minimist/blob/aeb3e27dae0412de5c0494e9563a5f10c82cc7a9/index.js#L59-L61

I would like to attach the failed log for an reference.

```bash
$ yarn create vite 1234 --template react-ts
yarn create v1.22.11
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Installed "create-vite@2.5.4" with binaries:
      - create-vite
      - cva
[#########] 9/9TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type number (1234)
    at new NodeError (node:internal/errors:329:5)
    at validateString (node:internal/validators:129:11)
    at Object.join (node:path:1081:7)
    at init (/Users/task4233/.config/yarn/global/node_modules/create-vite/index.js:220:21) {
  code: 'ERR_INVALID_ARG_TYPE'
}
✨  Done in 0.66s.
```

Moreover, I would like to attach the succeeded log for an reference.
(2021-08-15 added)

```
$ yarn create vite --template react-ts
yarn create v1.22.11
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Installed "create-vite@2.5.4" with binaries:
      - create-vite
      - cva
✔ Project name: … 1234

Scaffolding project in /Users/task4233/work/1234...

Done. Now run:

  cd 1234
  yarn
  yarn dev

✨  Done in 4.18s.
```

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
