### PR TITLE
docs: align package.json serve script (fix #4609)

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -40,7 +40,7 @@ $ npm run build
 $ npm run serve
 ```
 
-The `preview` command will boot up local static web server that serves the files from `dist` at http://localhost:5000. It's an easy way to check if the production build looks OK in your local environment.
+The `vite preview` command will boot up local static web server that serves the files from `dist` at http://localhost:5000. It's an easy way to check if the production build looks OK in your local environment.
 
 You may configure the port of the server py passing `--port` flag as an argument.
 

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -10,12 +10,12 @@ The following guides are based on some shared assumptions:
 {
   "scripts": {
     "build": "vite build",
-    "preview": "vite preview"
+    "serve": "vite preview"
   }
 }
 ```
 
-It is important to note that `vite preview` is intended for previewing the build locally and not meant as a production server.
+It is important to note that `vite serve` is intended for previewing the build locally and not meant as a production server.
 
 ::: tip NOTE
 These guides provide instructions for performing a static deployment of your Vite site. Vite also has experimental support for Server Side Rendering. SSR refers to front-end frameworks that support running the same application in Node.js, pre-rendering it to HTML, and finally hydrating it on the client. Check out the [SSR Guide](./ssr) to learn about this feature. On the other hand, if you are looking for integration with traditional server-side frameworks, check out the [Backend Integration guide](./backend-integration) instead.
@@ -33,11 +33,11 @@ By default, the build output will be placed at `dist`. You may deploy this `dist
 
 ### Testing The App Locally
 
-Once you've built the app, you may test it locally by running `npm run preview` command.
+Once you've built the app, you may test it locally by running `npm run serve` command.
 
 ```bash
 $ npm run build
-$ npm run preview
+$ npm run serve 
 ```
 
 The `preview` command will boot up local static web server that serves the files from `dist` at http://localhost:5000. It's an easy way to check if the production build looks OK in your local environment.
@@ -47,7 +47,7 @@ You may configure the port of the server py passing `--port` flag as an argument
 ```json
 {
   "scripts": {
-    "preview": "vite preview --port 8080"
+    "serve": "vite preview --port 8080"
   }
 }
 ```

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -54,6 +54,10 @@ You may configure the port of the server py passing `--port` flag as an argument
 
 Now the `preview` method will launch the server at http://localhost:8080.
 
+::: tip NOTE
+If you are using `npm` as your package manager, you may run into issues with changing the `serve` command to `preview` due to npm's usage of `pre` and `post` commands. For more info checkout the [npm docs](https://docs.npmjs.com/cli/v7/using-npm/scripts#pre--post-scripts) regarding Pre & Post scripts.
+:::
+
 ## GitHub Pages
 
 1. Set the correct `base` in `vite.config.js`.

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -37,7 +37,7 @@ Once you've built the app, you may test it locally by running `npm run serve` co
 
 ```bash
 $ npm run build
-$ npm run serve 
+$ npm run serve
 ```
 
 The `preview` command will boot up local static web server that serves the files from `dist` at http://localhost:5000. It's an easy way to check if the production build looks OK in your local environment.

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -15,7 +15,7 @@ The following guides are based on some shared assumptions:
 }
 ```
 
-It is important to note that `vite serve` is intended for previewing the build locally and not meant as a production server.
+It is important to note that `vite preview` is intended for previewing the build locally and not meant as a production server.
 
 ::: tip NOTE
 These guides provide instructions for performing a static deployment of your Vite site. Vite also has experimental support for Server Side Rendering. SSR refers to front-end frameworks that support running the same application in Node.js, pre-rendering it to HTML, and finally hydrating it on the client. Check out the [SSR Guide](./ssr) to learn about this feature. On the other hand, if you are looking for integration with traditional server-side frameworks, check out the [Backend Integration guide](./backend-integration) instead.

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -55,7 +55,7 @@ You may configure the port of the server py passing `--port` flag as an argument
 Now the `preview` method will launch the server at http://localhost:8080.
 
 ::: tip NOTE
-If you are using `npm` as your package manager, you may run into issues with changing the `serve` command to `preview` due to npm's usage of `pre` and `post` commands. For more info checkout the [npm docs](https://docs.npmjs.com/cli/v7/using-npm/scripts#pre--post-scripts) regarding Pre & Post scripts.
+If you change the script name from `serve` to `preview`, you may run into issues with some package managers due to the way they handle [Pre & Post scripts](https://docs.npmjs.com/cli/v7/using-npm/scripts#pre--post-scripts).
 :::
 
 ## GitHub Pages


### PR DESCRIPTION
Modified the template package.json files for preact, react, svelte, vanilla, and vue javascript and typescript projects.

<!-- Thank you for contributing! -->

### Description

Modified the template package.json files for preact, react, svelte, vanilla, and vue javascript and typescript projects. Based on the documentation for deploying a static site. The npm/yarn commands show `preview` to run `vite preview` when the template files have `serve` for `vite preview`. Added the command `preview` to the scripts section in the various `package.json` template files.

I wasn't sure if the lit-element templates needed a `preview` command as they were the two templates with out a `vite preview` command. I am unfamiliar with the framework to know if its needed or not.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
