### PR TITLE
fix(css): minify css will transform rgba to #rrggbbaa

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -898,9 +898,11 @@ async function doUrlReplace(
 }
 
 async function minifyCSS(css: string, config: ResolvedConfig) {
+  const target = config.build.target
   const { code, warnings } = await transform(css, {
     loader: 'css',
-    minify: true
+    minify: true,
+    target: target || undefined
   })
   if (warnings.length) {
     const msgs = await formatMessages(warnings, { kind: 'warning' })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -898,11 +898,10 @@ async function doUrlReplace(
 }
 
 async function minifyCSS(css: string, config: ResolvedConfig) {
-  const target = config.build.target
   const { code, warnings } = await transform(css, {
     loader: 'css',
     minify: true,
-    target: target || undefined
+    target: config.build.target || undefined
   })
   if (warnings.length) {
     const msgs = await formatMessages(warnings, { kind: 'warning' })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #4650 

### Additional context
`esbuild` will decide whether to convert `rgba` to [`#rrggbbaa`](https://caniuse.com/?search=%23rrggbbaa) according to the target, related [issue](https://github.com/evanw/esbuild/issues/1419)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
