### PR TITLE
 feat: add css.isModuleFile config used to customize xxx.module.xxx rule

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -51,6 +51,14 @@ export interface CSSOptions {
    * https://github.com/css-modules/postcss-modules
    */
   modules?: CSSModulesOptions | false
+  isModuleFile?: (arg: {
+    id: string
+    code: string
+    config: ResolvedConfig
+    urlReplacer: CssUrlReplacer
+    atImportResolvers: CSSAtImportResolvers
+    server?: ViteDevServer
+  }) => boolean
   preprocessorOptions?: Record<string, any>
   postcss?:
     | string
@@ -572,8 +580,23 @@ async function compileCSS(
   modules?: Record<string, string>
   deps?: Set<string>
 }> {
-  const { modules: modulesOptions, preprocessorOptions } = config.css || {}
-  const isModule = modulesOptions !== false && cssModuleRE.test(id)
+  const {
+    modules: modulesOptions,
+    preprocessorOptions,
+    isModuleFile
+  } = config.css || {}
+  const isModule =
+    modulesOptions !== false &&
+    (isModuleFile
+      ? isModuleFile({
+          id,
+          code,
+          config,
+          urlReplacer,
+          atImportResolvers,
+          server
+        })
+      : cssModuleRE.test(id))
   // although at serve time it can work without processing, we do need to
   // crawl them in order to register watch dependencies.
   const needInlineImport = code.includes('@import')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Hi, this is just a small feature. In some projects, there may be no.module.less or.module. CSS rules to use the CSS module, so to solve this problem, you can add a function configuration in the configuration item. It gets complicated without this configuration (I'm not sure if there's an easy way to fix this?).

The configuration will look like this:

```
export default defineConfig({
  css: {
    isModuleFile: (arg) => {
	  const { id } = arg;
	  const cssLangs = `\\.(css|less)($|\\?)`;
	  const isModuleRE = new RegExp(cssLangs);
	  return isModuleRE.test(id);
    }
  }
});
```


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
