### PR TITLE
fix: check for Blob before creating worker URL (close #4462)

### DIFF
--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -65,5 +65,6 @@ if (isBuild) {
     expect(content).toMatch(`new SharedWorker("/assets`)
     // inlined
     expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
+    expect(content).toMatch(`window.Blob`)
   })
 }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -71,15 +71,14 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         const content = Buffer.from(code)
         if (query.inline != null) {
           // inline as blob data url
-          return `const blob = new Blob([atob(\"${content.toString(
-            'base64'
-          )}\")], { type: 'text/javascript;charset=utf-8' });
+          return `const encodedJs = "${content.toString('base64')}";
+            const blob = typeof window !== "undefined" && window.Blob && new Blob([atob(encodedJs)], { type: "text/javascript;charset=utf-8" });
             export default function WorkerWrapper() {
-              const objURL = (window.URL || window.webkitURL).createObjectURL(blob);
+              const objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);
               try {
-                return new Worker(objURL);
+                return objURL ? new Worker(objURL) : new Worker("data:application/javascript;base64," + encodedJs, {type: "module"});
               } finally {
-                (window.URL || window.webkitURL).revokeObjectURL(objURL);
+                objURL && (window.URL || window.webkitURL).revokeObjectURL(objURL);
               }
             }`
         } else {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #4462

With server-side rendering, in my case Next.js, `Blob` isn't defined in Node.js. That causes the generated output for web workers to fail. This adds a check for the availability of `Blob` to the generated code. In its absence, the previous approach is being used. The concatenation of a long string introduces a slight inefficiency. However, I'm happy that things work again and the function `WorkerWrapper` may not even be called.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.

I'm not really sure how to test this but I'm open to suggestions.