### PR TITLE
feat(vite/css): add config.css.postcssImportOptions

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -49,7 +49,11 @@ export type {
   IndexHtmlTransformResult,
   HtmlTagDescriptor
 } from './plugins/html'
-export type { CSSOptions, CSSModulesOptions } from './plugins/css'
+export type {
+  CSSOptions,
+  CSSModulesOptions,
+  PostcssImportOptions
+} from './plugins/css'
 export type { JsonOptions } from './plugins/json'
 export type { ESBuildOptions, ESBuildTransformResult } from './plugins/esbuild'
 export type { Manifest, ManifestChunk } from './plugins/manifest'

--- a/packages/vite/types/shims.d.ts
+++ b/packages/vite/types/shims.d.ts
@@ -59,14 +59,29 @@ declare module 'postcss-load-config' {
 }
 
 declare module 'postcss-import' {
-  import { Plugin } from 'postcss'
-  const plugin: (options: {
-    resolve: (
-      id: string,
-      basedir: string,
-      importOptions: any
-    ) => string | string[] | Promise<string | string[]>
-  }) => Plugin
+  import { Plugin, AcceptedPlugin } from 'postcss'
+  interface PostcssImportOptions {
+    filter?: (path: string) => boolean | undefined
+    root?: string | undefined
+    path?: string | string[] | undefined
+    plugins?: AcceptedPlugin[] | undefined
+    resolve?:
+      | ((
+          id: string,
+          basedir: string,
+          importOptions?: PostcssImportOptions
+        ) => string | string[] | Promise<string | string[]>)
+      | undefined
+    load?:
+      | ((
+          filename: string,
+          importOptions: PostcssImportOptions
+        ) => string | Promise<string>)
+      | undefined
+    skipDuplicates?: boolean | undefined
+    addModulesDirectories?: string[] | undefined
+  }
+  const plugin: (options: PostcssImportOptions) => Plugin
   export = plugin
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Following the following PR : https://github.com/vitejs/vite/pull/2440
This one add  the `css.postcssImportOptions` config which is passed to `postcss-import` in order to customize its behavior.

If that sounds good to you, I can provide docs and tests for it!

Thanks !
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
