### PR TITLE
fix: apply SSR externalization heuristic to devDependencies

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -28,14 +28,12 @@ export function resolveSSRExternal(
     return []
   }
   const pkg = JSON.parse(pkgContent)
-  const devDeps = Object.keys(pkg.devDependencies || {})
   const importedDeps = knownImports.map(getNpmPackageName).filter(isDefined)
-  const deps = unique([...importedDeps, ...Object.keys(pkg.dependencies || {})])
-
-  for (const id of devDeps) {
-    ssrExternals.add(id)
-    seen.add(id)
-  }
+  const deps = unique([
+    ...importedDeps,
+    ...Object.keys(pkg.devDependencies || {}),
+    ...Object.keys(pkg.dependencies || {})
+  ])
 
   const resolveOptions: InternalResolveOptions = {
     root,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Use the SSR externalization heuristic for `devDependencies` just like we do for `dependencies`. Whether something is in `dependencies` vs `devDependencies` doesn't say anything about whether it might be written in CJS or ESM. It's also an undocumented behavior to treat `dependencies` vs `devDependencies` differently so is a bit confusing in that regard

### Additional context

SvelteKit's helper libraries don't work because they're distributed as ESM (https://github.com/sveltejs/kit/issues/2237). Since Vite assumes they can always be externalized and loaded with `require` Vite fails to import them

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
