### PR TITLE
fix(template): update HelloWorld.vue: remove defineProps  import

### DIFF
--- a/packages/create-vite/template-vue/src/components/HelloWorld.vue
+++ b/packages/create-vite/template-vue/src/components/HelloWorld.vue
@@ -19,7 +19,7 @@
 </template>
 
 <script setup>
-import { defineProps, reactive } from 'vue'
+import { reactive } from 'vue'
 
 defineProps({
   msg: String


### PR DESCRIPTION
defineProps is a compiler macro and no longer needs to be imported

### Description

[@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported

```sh
$ npm init vite@latest
$ cd vite-project
$ npm run dev            
> vite-project@0.0.0 dev
> vite
Pre-bundling dependencies:
  vue
(this will be run only when your dependencies or config have changed)
  vite v2.5.0 dev server running at:
  > Local: http://localhost:3000/
  > Network: use `--host` to expose
  ready in 1140ms.

[@vue/compiler-sfc] `defineProps` is a compiler macro and no longer needs to be imported.
```
 
### What is the purpose of this pull request? 

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
