### PR TITLE
fix: leading double slash in dynamic CSS import

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -44,8 +44,9 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
   return Promise.all(
     deps.map((dep) => {
       // @ts-ignore
-      const baseNoTrailingSlash = base.endsWith('/') ? base.slice(0, -1) : base
-      dep = baseNoTrailingSlash + dep
+      const safeBase =
+        base.endsWith('/') && dep.startsWith('/') ? base.slice(0, -1) : base
+      dep = safeBase + dep
       // @ts-ignore
       if (dep in seen) return
       // @ts-ignore

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -44,8 +44,10 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
   return Promise.all(
     deps.map((dep) => {
       // @ts-ignore
-      const safeBase =
-        base.endsWith('/') && dep.startsWith('/') ? base.slice(0, -1) : base
+      const hasDoubleSlash = base.endsWith('/') && dep.startsWith('/')
+      // @ts-ignore
+      const safeBase = hasDoubleSlash ? base.slice(0, -1) : base
+      // @ts-ignore
       dep = safeBase + dep
       // @ts-ignore
       if (dep in seen) return

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -44,7 +44,8 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
   return Promise.all(
     deps.map((dep) => {
       // @ts-ignore
-      dep = `${base}${dep}`
+      const baseNoTrailingSlash = base.endsWith('/') ? base.slice(0, -1) : base
+      dep = baseNoTrailingSlash + dep
       // @ts-ignore
       if (dep in seen) return
       // @ts-ignore


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #4731.

This removes the trailing slash from the base if it has a trailing slash *and* dep also has a leading slash. This should prevent a double slash when concatenating, yet preserve a single slash.

I'm not sure about this. It feels like a hacky solution. Maybe there should be a project-wide method for safely concatenating paths like that. I have no clue what values `base` and `dep` they can assume. Please test this very carefully!

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
