### PR TITLE
fix: the base is duplicated in `importAnalysisBuild.ts`

### DIFF
--- a/packages/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/packages/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -50,8 +50,8 @@ test('should load dynamic import with vars', async () => {
 test('should load dynamic import with css', async () => {
   await page.click('.css')
   await untilUpdated(
-    () => page.$eval('.css', (node) => window.getComputedStyle(node).boxSizing),
-    'border-box',
+    () => page.$eval('.view', (node) => window.getComputedStyle(node).color),
+    'rgb(255, 0, 0)',
     true
   )
 })

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -264,7 +264,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                       const cssFiles = chunkToEmittedCssFileMap.get(chunk)
                       if (cssFiles && cssFiles.size > 0) {
                         cssFiles.forEach((file) => {
-                          deps.add(config.base + file)
+                          deps.add(file)
                         })
                         hasRemovedPureCssChunk = true
                       }


### PR DESCRIPTION
### Description

Fix a problem that the base is duplicated when importing css files dynamically.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
