### PR TITLE
feat: add `.pdf` to list of known asset types

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -161,6 +161,10 @@ declare module '*.webmanifest' {
   const src: string
   export default src
 }
+declare module '*.pdf' {
+  const src: string
+  export default src
+}
 
 // web worker
 declare module '*?worker' {

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -76,7 +76,8 @@ export const KNOWN_ASSET_TYPES = [
 
   // other
   'wasm',
-  'webmanifest'
+  'webmanifest',
+  'pdf'
 ]
 
 export const DEFAULT_ASSETS_RE = new RegExp(


### PR DESCRIPTION

### Description

Add `.pdf` files to know asset types, so that Vite users can simply `import myDocUrl from './path/to/myDoc.pdf'` instead of having to append `?url`.

### Additional context

NA.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
