### PR TITLE
fix: jest module naming collision

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,7 @@ const config: Config.InitialOptions = {
   testEnvironment: './scripts/jestEnv.js',
   setupFilesAfterEnv: ['./scripts/jestPerTestSetup.ts'],
   watchPathIgnorePatterns: ['<rootDir>/temp'],
+  modulePathIgnorePatterns: ['<rootDir>/temp'],
   moduleNameMapper: {
     testUtils: '<rootDir>/packages/playground/testUtils.ts'
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
some time when I run test it will show something like:
```
jest-haste-map: Haste module naming collision: dep-esbuild-plugin-transform
```
that is because we have the same package name inside `temp` folder.

reference: https://github.com/facebook/jest/issues/8114

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
