### PR TITLE
fix: special handling for ssr.noExternal in mergeConfig

### DIFF
--- a/packages/playground/ssr-webworker/vite.config.js
+++ b/packages/playground/ssr-webworker/vite.config.js
@@ -8,5 +8,16 @@ module.exports = {
   ssr: {
     target: 'webworker',
     noExternal: true
-  }
+  },
+  plugins: [
+    {
+      config() {
+        return {
+          ssr: {
+            noExternal: ['this-should-not-replace-the-boolean']
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -649,6 +649,8 @@ function mergeConfigRecursively(
       } else if (key === 'assetsInclude' && rootPath === '') {
         merged[key] = [].concat(existing, value)
         continue
+      } else if (key === 'noExternal' && existing === true) {
+        continue
       }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The new `ssr.noExternal: true` feature [added recently](https://github.com/vitejs/vite/pull/4490) offers a way to bundle all the dependencies. However, if a plugin also adds `ssr.noExternal: ['one-dependency']` in its own config, Vite will give priority to the latter over the boolean because it has an object type.

This PR adds a special handling for `noExternal` key to avoid overriding the boolean value since it's actually a superset of any object value.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
