### PR TITLE
fix(ssr): resolve .cjs file extensions

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -44,7 +44,7 @@ try {
   isRunningWithYarnPnp = Boolean(require('pnpapi'))
 } catch {}
 
-const ssrExtensions = ['.js', '.json', '.node']
+const ssrExtensions = ['.js', '.cjs', '.json', '.node']
 
 export function resolveFrom(id: string, basedir: string, ssr = false): string {
   return resolve.sync(id, {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
fix #4452
### Description
Currently vite uses `require()` to import module in `ssr` mode.
https://github.com/vitejs/vite/blob/fb406ce4c0fe6da3333c9d1c00477b2880d46352/packages/vite/src/node/ssr/ssrModuleLoader.ts#L173
According to nodejs' [doc](https://nodejs.org/dist/latest-v14.x/docs/api/modules.html#modules_addenda_the_mjs_extension), It is not possible to require() files that have the `.mjs` extension. Attempting to do so will throw an error. 
So we can only include the `.cjs` file extension here.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
