### PR TITLE
fix: devtools does not show the setup section of a component for vite build --mode development

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -58,7 +58,7 @@ export async function transformMain(
   // inside <script setup>. This can only be done for build because
   // inlined template cannot be individually hot updated.
   const useInlineTemplate =
-    !devServer &&
+    isProduction &&
     descriptor.scriptSetup &&
     !(descriptor.template && descriptor.template.src)
   const hasTemplateImport = descriptor.template && !useInlineTemplate
@@ -114,7 +114,7 @@ export async function transformMain(
       `_sfc_main.__scopeId = ${JSON.stringify(`data-v-${descriptor.id}`)}`
     )
   }
-  if (devServer && !isProduction) {
+  if (!isProduction) {
     // expose filename during serve for devtools to pickup
     output.push(`_sfc_main.__file = ${JSON.stringify(filename)}`)
   }

--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -42,7 +42,7 @@ export function resolveScript(
     ...options.script,
     id: descriptor.id,
     isProd: options.isProduction,
-    inlineTemplate: !options.devServer,
+    inlineTemplate: options.isProduction,
     refTransform: options.refTransform !== false,
     templateOptions: resolveTemplateCompilerOptions(descriptor, options, ssr)
   })


### PR DESCRIPTION
### Description

Steps to reproduce
How to create a project by vite (documentation)

Run npm init vite@latest
Enter name
Select Vue (not vue-ts)
Run npm install
Devtools shows "setup" section for dev-server:

Run npm run dev (It starts dev-server for development)
Open http://localhost:3000/
Open devtools
Component "HelloWorld" contains "setup" section in devtools
Devtools doesn't show "setup" section for my build (And component displayed as `Anonymous Component"):

Replace vite build by vite build --mode development inside package.json
Run npm run build. "Dist" folder will be created
Serve the folder using instrument what you prefer. (npm run serve doesn't work for me. I used Golang with http.FileServer for static files and http.ServeFile for index.html)
Open url of your server
Open devtools
Component "HelloWorld" has name Anonymous Component and doesn't contain "setup" section in devtools
What is expected?
Devtools shows "setup" section for my result build (not only for dev-server)

What is actually happening?
Devtools doesn't show "setup" section for my result build


### Additional context

See also https://github.com/vuejs/devtools/issues/1544

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
