### PR TITLE
fix: some file are not generated while using plugin legacy (fix #4358)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -403,6 +403,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           )
         } else if (!config.build.ssr) {
           // legacy build, inline css
+          pureCssChunks.delete(chunk.fileName)
           chunkCSS = await processChunkCSS(chunkCSS, {
             inlined: true,
             minify: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
project use vant lib and @vitejs/plugin-legacy plugin build.   some file are not generated.
![image](https://user-images.githubusercontent.com/14368755/131337694-b1e74b36-5e32-4d50-bfc4-a9ffc43f2742.png)
![image](https://user-images.githubusercontent.com/14368755/131337745-c1e63fb5-3656-4554-b279-8b40cf2823cc.png)
`dist/assets` not has file `./index-legacy.62d61901.js`
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
