### PR TITLE
fix: globEntries should not ignore node_modules outside the root

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -122,7 +122,7 @@ function globEntries(pattern: string | string[], config: ResolvedConfig) {
   return glob(pattern, {
     cwd: config.root,
     ignore: [
-      '**/node_modules/**',
+      `${config.root}/**/node_modules/**`,
       `**/${config.build.outDir}/**`,
       `**/__tests__/**`
     ],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I have a global CLI program that uses vite internally. Because it is in the global node_modules, the entry file cannot be matched.


e.g.
`../npm/node_modules/global-cli/vite-project/index.html`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
