### PR TITLE
fix(dev): fix import failure on filenames with hashes

### DIFF
--- a/packages/playground/resolve/#/sub/index.js
+++ b/packages/playground/resolve/#/sub/index.js
@@ -1,0 +1,1 @@
+export const msg = '[success] from nested index.js under hash directory'

--- a/packages/playground/resolve/__tests__/resolve.spec.ts
+++ b/packages/playground/resolve/__tests__/resolve.spec.ts
@@ -38,6 +38,10 @@ test('Respect production/development conditionals', async () => {
   )
 })
 
+test('filename with hash', async () => {
+  expect(await page.textContent('.hash')).toMatch('[success]')
+})
+
 test('implicit dir/index.js', async () => {
   expect(await page.textContent('.index')).toMatch('[success]')
 })

--- a/packages/playground/resolve/__tests__/resolve.spec.ts
+++ b/packages/playground/resolve/__tests__/resolve.spec.ts
@@ -42,6 +42,10 @@ test('filename with hash', async () => {
   expect(await page.textContent('.hash')).toMatch('[success]')
 })
 
+test('dir/index with hash', async () => {
+  expect(await page.textContent('.hash-dir')).toMatch('[success]')
+})
+
 test('implicit dir/index.js', async () => {
   expect(await page.textContent('.index')).toMatch('[success]')
 })

--- a/packages/playground/resolve/exports-path/hash#.js
+++ b/packages/playground/resolve/exports-path/hash#.js
@@ -1,0 +1,1 @@
+export const msg = '[success] from filename with hash'

--- a/packages/playground/resolve/exports-path/package.json
+++ b/packages/playground/resolve/exports-path/package.json
@@ -6,6 +6,7 @@
       "import": "./main.js",
       "require": "./cjs.js"
     },
+    "./hash#.js": "./hash#.js",
     "./deep.js": "./deep.js",
     "./dir/": "./dir/",
     "./dir-mapped/*": {

--- a/packages/playground/resolve/index.html
+++ b/packages/playground/resolve/index.html
@@ -24,6 +24,9 @@
 <h2>Resolve /index.*</h2>
 <p class="index">fail</p>
 
+<h2>Resolve filename with hash</h2>
+<p class="hash">fail</p>
+
 <h2>Resolve dir and file of the same name (should prioritize file)</h2>
 <p class="dir-vs-file">fail</p>
 
@@ -103,6 +106,10 @@
   // implicit index resolving
   import { foo } from './util'
   text('.index', foo())
+
+  // resolving filenames with hashes
+  import { msg as hashMsg } from 'resolve-exports-path/hash#.js'
+  text('.hash', hashMsg)
 
   // implicit dir index vs. file
   import { file } from './dir'

--- a/packages/playground/resolve/index.html
+++ b/packages/playground/resolve/index.html
@@ -27,6 +27,9 @@
 <h2>Resolve filename with hash</h2>
 <p class="hash">fail</p>
 
+<h2>Resolve dir/index with hash</h2>
+<p class="hash-dir">fail</p>
+
 <h2>Resolve dir and file of the same name (should prioritize file)</h2>
 <p class="dir-vs-file">fail</p>
 
@@ -110,6 +113,10 @@
   // resolving filenames with hashes
   import { msg as hashMsg } from 'resolve-exports-path/hash#.js'
   text('.hash', hashMsg)
+
+  // resolving dir/index with hash
+  import { msg as hashDirMsg } from './#/sub'
+  text('.hash-dir', hashDirMsg)
 
   // implicit dir index vs. file
   import { file } from './dir'

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -38,6 +38,12 @@ export const VALID_ID_PREFIX = `/@id/`
  */
 export const NULL_BYTE_PLACEHOLDER = `__x00__`
 
+/**
+ * Some node packages use the '#' character in their import paths, which
+ * is invalid in URLs, so we have to replace them.
+ */
+export const HASH_PLACEHOLDER = `__x2F__`
+
 export const CLIENT_PUBLIC_PATH = `/@vite/client`
 export const ENV_PUBLIC_PATH = `/@vite/env`
 // eslint-disable-next-line node/no-missing-require

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -17,7 +17,8 @@ import {
   externalRE,
   dataUrlRE,
   multilineCommentsRE,
-  singlelineCommentsRE
+  singlelineCommentsRE,
+  hashPlaceholderRE
 } from '../utils'
 import {
   createPluginContainer,
@@ -380,6 +381,7 @@ function esbuildScanPlugin(
       // presence of import.meta.glob, since it results in import relationships
       // but isn't crawled by esbuild.
       build.onLoad({ filter: JS_TYPES_RE }, ({ path: id }) => {
+        id = id.replace(hashPlaceholderRE, '#')
         let ext = path.extname(id).slice(1)
         if (ext === 'mjs') ext = 'js'
 

--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -7,9 +7,9 @@ export function loadFallbackPlugin(): Plugin {
     name: 'load-fallback',
     async load(id) {
       try {
-        return fs.readFile(cleanUrl(id), 'utf-8')
+        return await fs.readFile(cleanUrl(id), 'utf-8')
       } catch (e) {
-        return fs.readFile(id, 'utf-8')
+        return await fs.readFile(id, 'utf-8')
       }
     }
   }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -4,6 +4,7 @@ import { Connect } from 'types/connect'
 import {
   cleanUrl,
   createDebugger,
+  hashPlaceholderRE,
   injectQuery,
   isImportRequest,
   isJSRequest,
@@ -141,6 +142,8 @@ export function transformMiddleware(
         // Strip valid id prefix. This is prepended to resolved Ids that are
         // not valid browser import specifiers by the importAnalysis plugin.
         url = unwrapId(url)
+
+        url = url.replace(hashPlaceholderRE, '#')
 
         // for CSS, we need to differentiate between normal CSS requests and
         // imports

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -9,7 +9,8 @@ import {
   DEFAULT_EXTENSIONS,
   VALID_ID_PREFIX,
   CLIENT_PUBLIC_PATH,
-  ENV_PUBLIC_PATH
+  ENV_PUBLIC_PATH,
+  HASH_PLACEHOLDER
 } from './constants'
 import resolve from 'resolve'
 import builtins from 'builtin-modules'
@@ -123,6 +124,8 @@ export function ensureVolumeInPath(file: string): string {
 
 export const queryRE = /\?.*$/s
 export const hashRE = /#.*$/s
+
+export const hashPlaceholderRE = new RegExp(HASH_PLACEHOLDER, 'g')
 
 export const cleanUrl = (url: string): string =>
   url.replace(hashRE, '').replace(queryRE, '')
@@ -291,7 +294,9 @@ export function numberToPos(
 ): { line: number; column: number } {
   if (typeof offset !== 'number') return offset
   if (offset > source.length) {
-    throw new Error(`offset is longer than source length! offset ${offset} > length ${source.length}`);
+    throw new Error(
+      `offset is longer than source length! offset ${offset} > length ${source.length}`
+    )
   }
   const lines = source.split(splitRE)
   let counted = 0


### PR DESCRIPTION
close #2346

<!-- Thank you for contributing! -->

### Description

Credit to @iheyunfei, who took a crack at this first in #4703 -- I started with their work. If it'd be more appropriate to merge this into that PR somehow, just let me know!

Right now, all imports of files with a # character in their path fail because the hash is interpreted as a denoting a postfix. To support hashes in file paths without breaking support for postfix hashes, I'm just trying both -- postfix interpretation first, then file path interpretation. This still won't work for hash postfixes on files that **also** have hashes in their names, but I'm not sure how common that is.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
