### PR TITLE
feat(css): allow for custom css container

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -237,11 +237,16 @@ const supportsConstructedSheet = (() => {
 
 const sheetsMap = new Map()
 
-export function updateStyle(id: string, content: string): void {
+export function updateStyle(
+  id: string,
+  content: string,
+  inject?: (style: HTMLStyleElement) => void,
+  remove?: (style: HTMLStyleElement) => void
+): void {
   let style = sheetsMap.get(id)
   if (supportsConstructedSheet && !content.includes('@import')) {
     if (style && !(style instanceof CSSStyleSheet)) {
-      removeStyle(id)
+      removeStyle(id, remove)
       style = undefined
     }
 
@@ -255,7 +260,7 @@ export function updateStyle(id: string, content: string): void {
     }
   } else {
     if (style && !(style instanceof HTMLStyleElement)) {
-      removeStyle(id)
+      removeStyle(id, remove)
       style = undefined
     }
 
@@ -263,7 +268,11 @@ export function updateStyle(id: string, content: string): void {
       style = document.createElement('style')
       style.setAttribute('type', 'text/css')
       style.innerHTML = content
-      document.head.appendChild(style)
+      if (inject) {
+        inject(style)
+      } else {
+        document.head.appendChild(style)
+      }
     } else {
       style.innerHTML = content
     }
@@ -271,7 +280,10 @@ export function updateStyle(id: string, content: string): void {
   sheetsMap.set(id, style)
 }
 
-export function removeStyle(id: string): void {
+export function removeStyle(
+  id: string,
+  remove?: (style: HTMLStyleElement) => void
+): void {
   const style = sheetsMap.get(id)
   if (style) {
     if (style instanceof CSSStyleSheet) {
@@ -282,7 +294,11 @@ export function removeStyle(id: string): void {
         (s: CSSStyleSheet) => s !== style
       )
     } else {
-      document.head.removeChild(style)
+      if (remove) {
+        remove(style)
+      } else {
+        document.head.removeChild(style)
+      }
     }
     sheetsMap.delete(id)
   }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -57,6 +57,8 @@ export interface CSSOptions {
     | (Postcss.ProcessOptions & {
         plugins?: Postcss.Plugin[]
       })
+  inject?: string
+  remove?: string
 }
 
 export interface CSSModulesOptions {
@@ -295,12 +297,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             `import { updateStyle, removeStyle } from ${JSON.stringify(
               path.posix.join(config.base, CLIENT_PUBLIC_PATH)
             )}`,
+            `const inject = ${config.css?.inject}`,
+            `const remove = ${config.css?.remove}`,
             `const id = ${JSON.stringify(id)}`,
             `const css = ${JSON.stringify(css)}`,
-            `updateStyle(id, css)`,
+            `updateStyle(id, css, inject, remove)`,
             // css modules exports change on edit so it can't self accept
             `${modulesCode || `import.meta.hot.accept()\nexport default css`}`,
-            `import.meta.hot.prune(() => removeStyle(id))`
+            `import.meta.hot.prune(() => removeStyle(id, remove))`
           ].join('\n')
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds a way for Vite users to customise where CSS gets injected during dev. 

Currently CSS is automatically injected into the head of the document. I have a use case where I would like the styles to be injected into a shadow root instead. My use case involves Vue SFC styles, so I don't have direct access to the CSS import to do this manually myself.

### Additional context

I'm unsure as to which tests need updating or adding. Happy to add any the reviewers deem necessary. 

Example config snippet:
```js
css: {
	inject: '(styleElement) => window.myShadowRoot.appendChild(styleElement)',
	remove: '(styleElement) => window.myShadowRoot.removeChild(styleElement)',
},
```

An alternative approach I thought of was to just specify a single function for resolving the element itself. This is easier for the simple use cases of simply changing which element the styles get injected into. But could be less useful for other use cases I haven't thought of. Hence my more flexible approach. Happy to change to a single config option for resolving the CSS container if this is preferred.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
