### PR TITLE
fix: plugin-react-refresh   libraries  sourcemaps

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -192,7 +192,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             decoratorsBeforeExport: true
           },
           plugins,
-          sourceMaps: true
+          sourceMaps: true,
+          // Vite handles sourcemap flattening
+          inputSourceMap: false as any
         }
 
         const result = ast


### PR DESCRIPTION
prevent babel from loading and merging source maps in plugin-react-refresh. fix libraries source maps in developpement server when using plugin-react-refresh.

(fix #4055)

<!-- Thank you for contributing! -->

### Description

In developpement mode (vite dev server) with @vitejs/plugin-react-refresh, the source maps didn't work for some libraries. With this fix, you can debug code from the libraries.

babel should not load source maps from '/# sourceMappingURL=...'
because the source maps generated by babel should  map the babel input code to the babel output code and not be relative to initial code.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
