### PR TITLE
chore: recommend volar vscode extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ explorations
 *.local
 /packages/vite/LICENSE
 *.cpuprofile
-.vscode/
+/.vscode/

--- a/packages/create-vite/template-vue-ts/.vscode/extensions.json
+++ b/packages/create-vite/template-vue-ts/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["johnsoncodehk.volar"]
+}

--- a/packages/create-vite/template-vue-ts/README.md
+++ b/packages/create-vite/template-vue-ts/README.md
@@ -1,6 +1,6 @@
 # Vue 3 + Typescript + Vite
 
-This template should help get you started developing with Vue 3 and Typescript in Vite.
+This template should help get you started developing with Vue 3 and Typescript in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
 
 ## Recommended IDE Setup
 

--- a/packages/create-vite/template-vue/.vscode/extensions.json
+++ b/packages/create-vite/template-vue/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["johnsoncodehk.volar"]
+}

--- a/packages/create-vite/template-vue/README.md
+++ b/packages/create-vite/template-vue/README.md
@@ -1,0 +1,7 @@
+# Vue 3 + Vite
+
+This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+
+## Recommended IDE Setup
+
+- [VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)


### PR DESCRIPTION
### Description

Adds `.vscode/extensions.json` to recommend volar automatically to users once they create their template. For reference, we have been doing the same for the svelte extension in their starters.
I added some more info in the readme of both projects, already present in the code.

### Additional context

I had to change `.vscode` to `/.vscode` in the root gitignore to allow these files to be tracked.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other