### PR TITLE
fix: sometimes THIS_IS_UNDEFINED warnings were still shown

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -7,6 +7,7 @@ import { cleanUrl, injectQuery } from '../utils'
 import Rollup from 'rollup'
 import { ENV_PUBLIC_PATH } from '../constants'
 import path from 'path'
+import { onRollupWarning } from '../build'
 
 function parseWorkerRequest(id: string): Record<string, string> | null {
   const { search } = parseUrl(id)
@@ -56,7 +57,10 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         const rollup = require('rollup') as typeof Rollup
         const bundle = await rollup.rollup({
           input: cleanUrl(id),
-          plugins: await resolvePlugins({ ...config }, [], [], [])
+          plugins: await resolvePlugins({ ...config }, [], [], []),
+          onwarn(warning, warn) {
+            onRollupWarning(warning, warn, config)
+          },
         })
         let code: string
         try {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Using current latest (`v.2.5.3`) `vite` for building our project i was getting lot of `The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten` errors in console. 

I've dived into sources, and found that [here](https://github.com/vitejs/vite/blob/46ecda4df229e4cf3e9e364cb6271198f9fdfc40/packages/vite/src/node/build.ts#L676) we have logic for filtering out such warnings, but [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/worker.ts#L57-L60) no `onwarn` provided at all.

So I've fixed situation by reusage at [node/plugins/worker](https://github.com/vitejs/vite/pull/4844/files#diff-3b7bb11b5633d82f82c069037789e105005d657667b1da1e96c18fcf3eb622adR61) function `onRollupWarning` exported from [./node/build](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/build.ts#L682). 

Using `npm pack` I've tried it on my side already, and having no more `THIS_IS_UNDEFINED` warnings at console during building, as expected

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
