### PR TITLE
fix(overlay): handle missing customElements

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -182,4 +182,6 @@ export class ErrorOverlay extends HTMLElement {
 }
 
 export const overlayId = 'vite-error-overlay'
-!customElements.get(overlayId) && customElements.define(overlayId, ErrorOverlay)
+if (customElements && !customElements.get(overlayId)) {
+  customElements.define(overlayId, ErrorOverlay)
+}


### PR DESCRIPTION
### Description

My environment doesn't have `customElements`. I set `server.hmr.overlay` to `false`, but importing `overlay` immediately triggers this error, making the configuration moot for this case.

### Additional context

In theory a better fix might be to use an `async import` for `overlay`. `async imports` potentially have other issues depending on the build/env so I avoided using that approach.

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
