### PR TITLE
feat: allow `apply` condition to be a function

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -414,6 +414,14 @@ function myPlugin() {
 }
 ```
 
+A function can also be used for more precise control:
+
+```js
+apply(config, { command }) {
+  return command === 'build' && !config.build.ssr
+}
+```
+
 ## Rollup Plugin Compatibility
 
 A fair number of Rollup plugins will work directly as a Vite plugin (e.g. `@rollup/plugin-alias` or `@rollup/plugin-json`), but not all of them, since some plugin hooks do not make sense in an unbundled dev server context.

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -418,6 +418,7 @@ A function can also be used for more precise control:
 
 ```js
 apply(config, { command }) {
+  // apply only on build but not for SSR
   return command === 'build' && !config.build.ssr
 }
 ```

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -82,6 +82,14 @@ export default defineConfig({
 })
 ```
 
+A function can also be used for more precise control:
+
+```js
+apply(config, { command }) {
+  return command === 'build' && !config.build.ssr
+}
+```
+
 ## Building Plugins
 
 Check out the [Plugins API Guide](./api-plugin.md) for documentation about creating plugins.

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -82,14 +82,6 @@ export default defineConfig({
 })
 ```
 
-A function can also be used for more precise control:
-
-```js
-apply(config, { command }) {
-  return command === 'build' && !config.build.ssr
-}
-```
-
 ## Building Plugins
 
 Check out the [Plugins API Guide](./api-plugin.md) for documentation about creating plugins.

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -285,7 +285,15 @@ export async function resolveConfig(
 
   // resolve plugins
   const rawUserPlugins = (config.plugins || []).flat().filter((p) => {
-    return p && (!p.apply || p.apply === command)
+    if (!p) {
+      return false
+    } else if (!p.apply) {
+      return true
+    } else if (typeof p.apply === 'function') {
+      return p.apply({ ...config, mode }, configEnv)
+    } else {
+      return p.apply === command
+    }
   }) as Plugin[]
   const [prePlugins, normalPlugins, postPlugins] =
     sortUserPlugins(rawUserPlugins)

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -50,9 +50,9 @@ export interface Plugin extends RollupPlugin {
    */
   enforce?: 'pre' | 'post'
   /**
-   * Apply the plugin only for serve or for build.
+   * Apply the plugin only for serve or build, or on certain conditions.
    */
-  apply?: 'serve' | 'build'
+  apply?: 'serve' | 'build' | ((config: UserConfig, env: ConfigEnv) => boolean)
   /**
    * Modify vite config before it's resolved. The hook can either mutate the
    * passed-in config directly, or return a partial config object that will be


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`apply` can now be a function. Please see https://github.com/vitejs/vite/pull/4536#pullrequestreview-746997416 for the original motivation.

```js
function myPlugin() {
  return {
    name: 'client-build-only',
    apply(config, { command }) {
      return command === 'build' && !config.build.ssr
    }
  }
}
```

### Additional context

Unfortunately we won't have `ResolvedConfig` ready when we check for `apply` and that's not easy to change (we don't want to call `config` hook on a plugin if it's ultimately not going to `apply`, for example). I eventually decided that `UserConfig` and `ConfigEnv` should probably be enough for most use cases, and those can always fallback to `if (...) return` pattern if necessary.

It felt a bit awkward trying to write documentation for this (not a native English speaker), any wording suggestions are welcome :D

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
