### PR TITLE
fix: exclude ?commonjs-external when building in JSON plugin

### DIFF
--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -25,7 +25,7 @@ export interface JsonOptions {
 }
 
 // Custom json filter for vite
-const jsonExtRE = /\.json($|\?)(?!commonjs-proxy)/
+const jsonExtRE = /\.json($|\?)(?!commonjs-(proxy|external))/
 
 export function jsonPlugin(
   options: JsonOptions = {},


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/4866

Cannot replicate independently, thus cannot create a test to fail on this. I have tested this locally in our repository and this fixes the problem.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
