### PR TITLE
fix: use debugger for package resolution warnings

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -1,9 +1,17 @@
 import fs from 'fs'
 import path from 'path'
 import { tryNodeResolve, InternalResolveOptions } from '../plugins/resolve'
-import { isDefined, lookupFile, resolveFrom, unique } from '../utils'
+import {
+  createDebugger,
+  isDefined,
+  lookupFile,
+  resolveFrom,
+  unique
+} from '../utils'
 import { ResolvedConfig } from '..'
 import { createFilter } from '@rollup/pluginutils'
+
+const debug = createDebugger('vite:ssr-external')
 
 /**
  * Heuristics for determining whether a dependency should be externalized for
@@ -63,6 +71,7 @@ export function resolveSSRExternal(
       requireEntry = require.resolve(id, { paths: [root] })
     } catch (e) {
       // resolve failed, assume include
+      debug(`Failed to resolve entries for package "${id}"\n`, e)
       continue
     }
     if (!entry) {

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -63,9 +63,6 @@ export function resolveSSRExternal(
       requireEntry = require.resolve(id, { paths: [root] })
     } catch (e) {
       // resolve failed, assume include
-      config.logger.warn(
-        `Bundling package for SSR due to resolve failure. ${e.message}`
-      )
       continue
     }
     if (!entry) {


### PR DESCRIPTION
Reverts vitejs/vite#4822

I think the original behavior (trying to get submodule paths) is expected.

The log creates too much noise that ppl usually don't need to care about. For the debugging purpose stated in #4822, I think it's better to modify local `node_modules` when debugging.

![image](https://user-images.githubusercontent.com/11247099/132414043-a717d0c9-ce2e-4763-ba43-05a1d1bb0e04.png)
