### PR TITLE
feat: export transformWithEsbuild

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -88,16 +88,6 @@ interface ViteDevServer {
    */
   transformIndexHtml(url: string, html: string): Promise<string>
   /**
-   * Util for transforming a file with esbuild.
-   * Can be useful for certain plugins.
-   */
-  transformWithEsbuild(
-    code: string,
-    filename: string,
-    options?: EsbuildTransformOptions,
-    inMap?: object
-  ): Promise<ESBuildTransformResult>
-  /**
    * Load a given URL as an instantiated module for SSR.
    */
   ssrLoadModule(

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -149,3 +149,16 @@ async function resolveConfig(
   defaultMode?: string
 ): Promise<ResolvedConfig>
 ```
+
+## `transformWithEsbuild`
+
+**Type Signature:**
+
+```ts
+async function transformWithEsbuild(
+  code: string,
+  filename: string,
+  options?: EsbuildTransformOptions,
+  inMap?: object
+): Promise<ESBuildTransformResult>
+```

--- a/packages/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
+++ b/packages/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
@@ -19,7 +19,7 @@ test('should respected each `tsconfig.json`s compilerOptions', () => {
   expect(browserLogs).toContain('data setter in NestedWithExtendsBase')
 })
 
-describe.only('transformWithEsbuild', () => {
+describe('transformWithEsbuild', () => {
   test('merge tsconfigRaw object', async () => {
     const main = path.resolve(__dirname, '../src/main.ts')
     const mainContent = fs.readFileSync(main, 'utf-8')

--- a/packages/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
+++ b/packages/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
@@ -1,3 +1,7 @@
+import path from 'path'
+import fs from 'fs'
+import { transformWithEsbuild } from 'vite'
+
 test('should respected each `tsconfig.json`s compilerOptions', () => {
   // main side effect should be called (because of `"importsNotUsedAsValues": "preserve"`)
   expect(browserLogs).toContain('main side effect')
@@ -13,4 +17,39 @@ test('should respected each `tsconfig.json`s compilerOptions', () => {
   expect(browserLogs).toContain('nested-with-extends side effect')
   // nested-with-extends base setter should be called (because of `"useDefineForClassFields": false"`)
   expect(browserLogs).toContain('data setter in NestedWithExtendsBase')
+})
+
+describe.only('transformWithEsbuild', () => {
+  test('merge tsconfigRaw object', async () => {
+    const main = path.resolve(__dirname, '../src/main.ts')
+    const mainContent = fs.readFileSync(main, 'utf-8')
+    const result = await transformWithEsbuild(mainContent, main, {
+      tsconfigRaw: {
+        compilerOptions: {
+          useDefineForClassFields: false
+        }
+      }
+    })
+    // "importsNotUsedAsValues": "preserve" from tsconfig.json should still work
+    expect(result.code).toContain(
+      'import { MainTypeOnlyClass } from "./not-used-type";'
+    )
+  })
+
+  test('overwrite tsconfigRaw string', async () => {
+    const main = path.resolve(__dirname, '../src/main.ts')
+    const mainContent = fs.readFileSync(main, 'utf-8')
+    const result = await transformWithEsbuild(mainContent, main, {
+      tsconfigRaw: `{
+        "compilerOptions": {
+          "useDefineForClassFields": false
+        }
+      }`
+    })
+    // "importsNotUsedAsValues": "preserve" from tsconfig.json should not be read
+    // and defaults to "remove"
+    expect(result.code).not.toContain(
+      'import { MainTypeOnlyClass } from "./not-used-type";'
+    )
+  })
 })

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -4,6 +4,7 @@ export { build } from './build'
 export { optimizeDeps } from './optimizer'
 export { send } from './server/send'
 export { createLogger } from './logger'
+export { transformWithEsbuild } from './plugins/esbuild'
 export { resolvePackageData, resolvePackageEntry } from './plugins/resolve'
 export { normalizePath } from './utils'
 

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -52,6 +52,7 @@ export type {
 } from './plugins/html'
 export type { CSSOptions, CSSModulesOptions } from './plugins/css'
 export type { JsonOptions } from './plugins/json'
+export type { TransformOptions as EsbuildTransformOptions } from 'esbuild'
 export type { ESBuildOptions, ESBuildTransformResult } from './plugins/esbuild'
 export type { Manifest, ManifestChunk } from './plugins/manifest'
 export type {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -237,6 +237,8 @@ export interface ViteDevServer {
   /**
    * Util for transforming a file with esbuild.
    * Can be useful for certain plugins.
+   *
+   * @deprecated import `transformWithEsbuild` from `vite` instead
    */
   transformWithEsbuild(
     code: string,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Expose `transformWithEsbuild` from the `vite` package. Also fixes `tsconfigRaw` merging for `transformWithEsbuild` and perf improvements.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- `transformWithEsbuild` is currently already exposed under [server](https://vitejs.dev/guide/api-javascript.html#vitedevserver), but I don't see it coupled to the server. It could be used as a standalone.
- This also allows `vite-plugin-svelte` to use it for preprocessing a Svelte file script tag with `lang="ts"`
- Do we want to deprecate `server.transformWithEsbuild`?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
