### PR TITLE
fix: websocket proxies not the same as http

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -62,7 +62,7 @@ export function proxyMiddleware(
     httpServer.on('upgrade', (req, socket, head) => {
       const url = req.url!
       for (const context in proxies) {
-        if (url.startsWith(context)) {
+        if (testUrl(url, context)) {
           const [proxy, opts] = proxies[context]
           if (
             (opts.ws || opts.target?.toString().startsWith('ws:')) &&
@@ -82,10 +82,7 @@ export function proxyMiddleware(
   return function viteProxyMiddleware(req, res, next) {
     const url = req.url!
     for (const context in proxies) {
-      if (
-        (context.startsWith('^') && new RegExp(context).test(url)) ||
-        url.startsWith(context)
-      ) {
+      if (testUrl(url, context)) {
         const [proxy, opts] = proxies[context]
         const options: HttpProxy.ServerOptions = {}
 
@@ -115,4 +112,11 @@ export function proxyMiddleware(
     }
     next()
   }
+}
+
+function testUrl(url: string, target: string) {
+  return (
+    (target.startsWith('^') && new RegExp(target).test(url)) ||
+    url.startsWith(target)
+  )
 }

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -62,7 +62,7 @@ export function proxyMiddleware(
     httpServer.on('upgrade', (req, socket, head) => {
       const url = req.url!
       for (const context in proxies) {
-        if (testUrl(url, context)) {
+        if (doesProxyContextMatchUrl(context, url)) {
           const [proxy, opts] = proxies[context]
           if (
             (opts.ws || opts.target?.toString().startsWith('ws:')) &&
@@ -84,7 +84,7 @@ export function proxyMiddleware(
   return function viteProxyMiddleware(req, res, next) {
     const url = req.url!
     for (const context in proxies) {
-      if (testUrl(url, context)) {
+      if (doesProxyContextMatchUrl(context, url)) {
         const [proxy, opts] = proxies[context]
         const options: HttpProxy.ServerOptions = {}
 
@@ -116,9 +116,9 @@ export function proxyMiddleware(
   }
 }
 
-function testUrl(url: string, target: string) {
+function doesProxyContextMatchUrl(context: string, url: string): boolean {
   return (
-    (target.startsWith('^') && new RegExp(target).test(url)) ||
-    url.startsWith(target)
+    (context.startsWith('^') && new RegExp(context).test(url)) ||
+    url.startsWith(context)
   )
 }

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -71,7 +71,9 @@ export function proxyMiddleware(
             if (opts.rewrite) {
               req.url = opts.rewrite(url)
             }
+            debug(`${req.url} -> ws ${opts.target}`)
             proxy.ws(req, socket, head)
+            return
           }
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently WebSocket proxies cannot use a regex like with HTTP ones -- this PR makes WS and HTTP have the same behaviour for matching URLs. Seems like just something that was missed when initially adding regex support for proxies.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
