### PR TITLE
fix(esbuildDepPlugin): externalize built-in module during SSR

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -6,7 +6,8 @@ import {
   isRunningWithYarnPnp,
   flattenId,
   normalizePath,
-  isExternalUrl
+  isExternalUrl,
+  isBuiltin
 } from '../utils'
 import { browserExternalId } from '../plugins/resolve'
 import { ExportsData } from '.'
@@ -119,7 +120,7 @@ export function esbuildDepPlugin(
                 namespace: 'browser-external'
               }
             }
-            if (isExternalUrl(resolved)) {
+            if (isExternalUrl(resolved) || (ssr && isBuiltin(id))) {
               return {
                 path: resolved,
                 external: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->
fix #4700 

### Description
`esbuildDepPlugin` use `path.resolve` to resolve built-in module during SSR cause error, it should externalize built-in module during SSR

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
