### PR TITLE
chore: give history middleware a name

### DIFF
--- a/packages/vite/src/node/server/middlewares/spaFallback.ts
+++ b/packages/vite/src/node/server/middlewares/spaFallback.ts
@@ -7,24 +7,26 @@ import { createDebugger } from '../../utils'
 export function spaFallbackMiddleware(
   root: string
 ): Connect.NextHandleFunction {
-  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return function viteSpaFallbackMiddleware(req, res, next) {
-    return history({
-      logger: createDebugger('vite:spa-fallback'),
-      // support /dir/ without explicit index.html
-      rewrites: [
-        {
-          from: /\/$/,
-          to({ parsedUrl }: any) {
-            const rewritten = parsedUrl.pathname + 'index.html'
-            if (fs.existsSync(path.join(root, rewritten))) {
-              return rewritten
-            } else {
-              return `/index.html`
-            }
+  const spaFallbackMiddleware = return history({
+    logger: createDebugger('vite:spa-fallback'),
+    // support /dir/ without explicit index.html
+    rewrites: [
+      {
+        from: /\/$/,
+        to({ parsedUrl }: any) {
+          const rewritten = parsedUrl.pathname + 'index.html'
+          if (fs.existsSync(path.join(root, rewritten))) {
+            return rewritten
+          } else {
+            return `/index.html`
           }
         }
-      ]
-    })(req, res, next)
+      }
+    ]
+  })
+  
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
+  return function viteSpaFallbackMiddleware(req, res, next) {
+    return spaFallbackMiddleware(req, res, next)
   }
 }

--- a/packages/vite/src/node/server/middlewares/spaFallback.ts
+++ b/packages/vite/src/node/server/middlewares/spaFallback.ts
@@ -7,7 +7,7 @@ import { createDebugger } from '../../utils'
 export function spaFallbackMiddleware(
   root: string
 ): Connect.NextHandleFunction {
-  const spaFallbackMiddleware = history({
+  const historySpaFallbackMiddleware = history({
     logger: createDebugger('vite:spa-fallback'),
     // support /dir/ without explicit index.html
     rewrites: [
@@ -27,6 +27,6 @@ export function spaFallbackMiddleware(
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteSpaFallbackMiddleware(req, res, next) {
-    return spaFallbackMiddleware(req, res, next)
+    return historySpaFallbackMiddleware(req, res, next)
   }
 }

--- a/packages/vite/src/node/server/middlewares/spaFallback.ts
+++ b/packages/vite/src/node/server/middlewares/spaFallback.ts
@@ -7,7 +7,7 @@ import { createDebugger } from '../../utils'
 export function spaFallbackMiddleware(
   root: string
 ): Connect.NextHandleFunction {
-  const spaFallbackMiddleware = return history({
+  const spaFallbackMiddleware = history({
     logger: createDebugger('vite:spa-fallback'),
     // support /dir/ without explicit index.html
     rewrites: [
@@ -24,7 +24,7 @@ export function spaFallbackMiddleware(
       }
     ]
   })
-  
+
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteSpaFallbackMiddleware(req, res, next) {
     return spaFallbackMiddleware(req, res, next)

--- a/packages/vite/src/node/server/middlewares/spaFallback.ts
+++ b/packages/vite/src/node/server/middlewares/spaFallback.ts
@@ -1,0 +1,30 @@
+import fs from 'fs'
+import history from 'connect-history-api-fallback'
+import path from 'path'
+import { Connect } from 'types/connect'
+import { createDebugger } from '../../utils'
+
+export function spaFallbackMiddleware(
+  root: string
+): Connect.NextHandleFunction {
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
+  return function viteSpaFallbackMiddleware(req, res, next) {
+    return history({
+      logger: createDebugger('vite:spa-fallback'),
+      // support /dir/ without explicit index.html
+      rewrites: [
+        {
+          from: /\/$/,
+          to({ parsedUrl }: any) {
+            const rewritten = parsedUrl.pathname + 'index.html'
+            if (fs.existsSync(path.join(root, rewritten))) {
+              return rewritten
+            } else {
+              return `/index.html`
+            }
+          }
+        }
+      ]
+    })(req, res, next)
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This history middleware is the single anonymous middleware in Vite right now. Give it a name can be printed during debugging

### Additional context

I'd like it to have a name so that I can search for it and remove it in SvelteKit. This is an alternative to adding an option to avoid adding it in the first place (https://github.com/vitejs/vite/pull/4640)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.