### PR TITLE
fix: avoid wrong warning of explicit public paths

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -114,20 +114,22 @@ export function transformMiddleware(
         }
       }
 
-      const publicPath =
-        normalizePath(server.config.publicDir).slice(
-          server.config.root.length
-        ) + '/'
-      // warn explicit public paths
-      if (url.startsWith(publicPath)) {
-        logger.warn(
-          chalk.yellow(
-            `files in the public directory are served at the root path.\n` +
-              `Instead of ${chalk.cyan(url)}, use ${chalk.cyan(
-                url.replace(publicPath, '/')
-              )}.`
+      // check if public dir is inside root dir
+      const publicDir = normalizePath(server.config.publicDir)
+      const rootDir = normalizePath(server.config.root)
+      if (publicDir.startsWith(rootDir)) {
+        const publicPath = `${publicDir.slice(rootDir.length)}/`
+        // warn explicit public paths
+        if (url.startsWith(publicPath)) {
+          logger.warn(
+            chalk.yellow(
+              `files in the public directory are served at the root path.\n` +
+                `Instead of ${chalk.cyan(url)}, use ${chalk.cyan(
+                  url.replace(publicPath, '/')
+                )}.`
+            )
           )
-        )
+        }
       }
 
       if (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This issue is caused by #4631, reported here https://github.com/vitejs/vite/pull/4631/files#r707910410.

We should not simply determine `publicPath` by slicing the string, because the custom public dir can be outside the root dir.

It's OK to use `startsWith` to check if `publicDir` is inside `root` or not, because they are all resolved as absoluted path. An alternative way is to use `path.relative()`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
