### PR TITLE
docs: update env-and-mode.md to fix default modes

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -68,7 +68,7 @@ interface ImportMetaEnv {
 
 ## Modes
 
-By default, the dev server (`serve` command) runs in `development` mode, and the `build` command runs in `production` mode.
+By default, the dev server (`dev` command) runs in `development` mode and the `build` and `serve` commands run in `production` mode.
 
 This means when running `vite build`, it will load the env variables from `.env.production` if there is one:
 


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

As per this pull request https://github.com/vitejs/vite/pull/4483, the default mode for `preview` is now `production`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
