### PR TITLE
fix: force overlay LTR

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -34,6 +34,8 @@ const template = /*html*/ `
   box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
   overflow: hidden;
   border-top: 8px solid var(--red);
+  direction: ltr;
+  text-align: left;
 }
 
 pre {


### PR DESCRIPTION
Make overlay window readable(Force it in LTR) in RTL development environment.

<!-- Thank you for contributing! -->

### Description

In RTL develop environment the whole overlay direction and text-align is in RTL and right to left. which make it har to read!
