### PR TITLE
fix(css): revert return sourcemap in vite:css transform (#4880)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -179,8 +179,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       const {
         code: css,
         modules,
-        deps,
-        map
+        deps
       } = await compileCSS(
         id,
         raw,
@@ -242,7 +241,8 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
 
       return {
         code: css,
-        map
+        // TODO CSS source map
+        map: { mappings: '' }
       }
     }
   }


### PR DESCRIPTION
This reverts commit 015290a169d5ca3806aa0b2eb417426d61df9b7d.

(fixes #4939)

alternative to #4950 

<!-- Thank you for contributing! -->

### Description

as mentioned in #4950, adding proper css sourcemap support is a lot more work, so revert this to avoid #4939 until we got there.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
