### PR TITLE
fix: fixed dynamic import lose vue style after build cjs (fix #4277)

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -80,7 +80,7 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
     })
   ).then(() => baseModule())
 }
-function ParseCjsDynamicImports(code: string) {
+function parseCjsDynamicImports(code: string) {
   /**
    * cjs
    * https://rollupjs.org/guide/en/#outputinlinedynamicimports
@@ -284,7 +284,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           let imports: ImportSpecifier[]
           try {
             if (format === 'cjs') {
-              imports = ParseCjsDynamicImports(code)
+              imports = parseCjsDynamicImports(code)
             } else {
               imports = parseImports(code)[0].filter((i) => i.d > -1)
             }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -86,28 +86,28 @@ function parseCjsDynamicImports(code: string) {
    * https://rollupjs.org/guide/en/#outputinlinedynamicimports
    * import('a.vue') => Promise.resolve().then(function(){ return require('a.vue') })
    */
-  const Imports: ImportSpecifier[] = []
+  const imports: ImportSpecifier[] = []
   let start = 0
-  const CodeArray = code.split(preloadMethod)
-  for (let i = 1; i < CodeArray.length; i++) {
-    const CurrentCode = CodeArray[i]
-    start += CodeArray[i - 1].length + preloadMethod.length
-    const CodeEndIndex = CurrentCode.indexOf(preloadMarker)
-    if (CodeEndIndex > -1) {
-      const DynamicImportMatch = CurrentCode.slice(0, CodeEndIndex).match(
-        /require\(["|'](.+)["|']\)/
-      )
-      if (DynamicImportMatch) {
+  const codeArray = code.split(preloadMethod)
+  for (let i = 1; i < codeArray.length; i++) {
+    const currentCode = codeArray[i]
+    start += codeArray[i - 1].length + preloadMethod.length
+    const codeEndIndex = currentCode.indexOf(preloadMarker)
+    if (codeEndIndex > -1) {
+      const dynamicImportMatch = currentCode
+        .slice(0, codeEndIndex)
+        .match(/require\(["|'](.+)["|']\)/)
+      if (dynamicImportMatch) {
         // Dynamic imports are indicated by imports[2].d > -1
         // In this case the "d" index is the start of the dynamic import
         const startIndex =
           start +
-          DynamicImportMatch.index! +
-          DynamicImportMatch[0].indexOf(DynamicImportMatch[1]) -
+          dynamicImportMatch.index! +
+          dynamicImportMatch[0].indexOf(dynamicImportMatch[1]) -
           1
-        const endIndex = startIndex + DynamicImportMatch[1].length + 2
-        Imports.push({
-          n: DynamicImportMatch[1],
+        const endIndex = startIndex + dynamicImportMatch[1].length + 2
+        imports.push({
+          n: dynamicImportMatch[1],
           s: startIndex,
           e: endIndex,
           ss: startIndex,
@@ -118,7 +118,7 @@ function parseCjsDynamicImports(code: string) {
       }
     }
   }
-  return Imports
+  return imports
 }
 /**
  * Build only. During serve this is performed as part of ./importAnalysis.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fixed vitejs/vite-plugin-vue#27
when dynamic import vue file 
before vite 2.1.5 build format cjs ,vite create style label to import css 
but after vite 2.1.5 build format cjs ,vite create css file but nowhere to import it 

use https://github.com/Veiintc/vite-cjs-csslose Recurrence problem
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
