### PR TITLE
feat: expose `searchForWorkspaceRoot` util

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -1,5 +1,5 @@
 export * from './config'
-export { createServer } from './server'
+export { createServer, searchForWorkspaceRoot } from './server'
 export { build } from './build'
 export { optimizeDeps } from './optimizer'
 export { send } from './server/send'

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -54,6 +54,8 @@ import { resolveHostname } from '../utils'
 import { searchForWorkspaceRoot } from './searchRoot'
 import { CLIENT_DIR } from '../constants'
 
+export { searchForWorkspaceRoot } from './searchRoot'
+
 export interface ServerOptions {
   host?: string | boolean
   port?: number


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When users set `server.fs.strict` along with custom `server.fs.allow`, the original behavior of searching for workspace root is overwritten. Giving this logic still having some complexity, I think it would be better to expose it for users to reuse the logic.

### Additional context

In Slidev, we currently vendor the `searchRoot.ts` for that.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
