### PR TITLE
fix: docs for ssr manifest plugin and dedupe name

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -664,6 +664,14 @@ createServer()
 
   When set to `true`, the build will also generate a `manifest.json` file that contains a mapping of non-hashed asset filenames to their hashed versions, which can then be used by a server framework to render the correct asset links.
 
+### build.ssrManifest
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Related:** [Server-Side Rendering](/guide/ssr)
+
+  When set to `true`, the build will also generate a SSR manifest for determining style links and asset preload directives in production.
+
 ### build.minify
 
 - **Type:** `boolean | 'terser' | 'esbuild'`

--- a/packages/vite/src/node/ssr/ssrManifestPlugin.ts
+++ b/packages/vite/src/node/ssr/ssrManifestPlugin.ts
@@ -11,7 +11,7 @@ export function ssrManifestPlugin(config: ResolvedConfig): Plugin {
   const base = config.base
 
   return {
-    name: 'vite:manifest',
+    name: 'vite:ssr-manifest',
     generateBundle(_options, bundle) {
       for (const file in bundle) {
         const chunk = bundle[file]


### PR DESCRIPTION
### Description

Both `manifestPlugin` and `ssrManifestPlugin` were named `'vite:manifest'`. This PR renames the ssr manifest plugin. This is a breaking change but I don't think that no one in the ecosystem is relying on this, or we have seen this fix long ago. We can merge this one and have the beta period to test it just in case.

### Additional context

Also adds `build.ssrManifest` config option to the docs.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other