### PR TITLE
fix: normalize internal plugin names

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -79,7 +79,7 @@ function viteLegacyPlugin(options = {}) {
    * @type {import('vite').Plugin}
    */
   const legacyConfigPlugin = {
-    name: 'legacy-config',
+    name: 'vite:legacy-config',
 
     apply: 'build',
     config(config) {
@@ -93,7 +93,7 @@ function viteLegacyPlugin(options = {}) {
    * @type {import('vite').Plugin}
    */
   const legacyGenerateBundlePlugin = {
-    name: 'legacy-generate-polyfill-chunk',
+    name: 'vite:legacy-generate-polyfill-chunk',
     apply: 'build',
 
     configResolved(config) {
@@ -164,7 +164,7 @@ function viteLegacyPlugin(options = {}) {
    * @type {import('vite').Plugin}
    */
   const legacyPostPlugin = {
-    name: 'legacy-post-process',
+    name: 'vite:legacy-post-process',
     enforce: 'post',
     apply: 'build',
 
@@ -449,7 +449,7 @@ function viteLegacyPlugin(options = {}) {
    * @type {import('vite').Plugin}
    */
   const legacyEnvPlugin = {
-    name: 'legacy-env',
+    name: 'vite:legacy-env',
 
     config(config, env) {
       if (env) {
@@ -582,7 +582,7 @@ const polyfillId = 'vite/legacy-polyfills'
  */
 function polyfillsPlugin(imports) {
   return {
-    name: 'polyfills',
+    name: 'vite:legacy-polyfills',
     resolveId(id) {
       if (id === polyfillId) {
         return id

--- a/packages/plugin-vue-jsx/index.js
+++ b/packages/plugin-vue-jsx/index.js
@@ -45,7 +45,7 @@ function vueJsxPlugin(options = {}) {
   let needSourceMap = true
 
   return {
-    name: 'vue-jsx',
+    name: 'vite:vue-jsx',
 
     config(config) {
       return {

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -17,7 +17,7 @@ import { multilineCommentsRE, singlelineCommentsRE } from '../utils'
  */
 export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   return {
-    name: 'asset-import-meta-url',
+    name: 'vite:asset-import-meta-url',
     async transform(code, id, ssr) {
       if (code.includes('new URL') && code.includes(`import.meta.url`)) {
         const importMetaUrlRE =

--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -2,9 +2,13 @@ import { promises as fs } from 'fs'
 import { Plugin } from '..'
 import { cleanUrl } from '../utils'
 
+/**
+ * A plugin to provide build load fallback for arbitrary request with queries
+ */
+
 export function loadFallbackPlugin(): Plugin {
   return {
-    name: 'load-fallback',
+    name: 'vite:load-fallback',
     async load(id) {
       try {
         return fs.readFile(cleanUrl(id), 'utf-8')

--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -3,9 +3,8 @@ import { Plugin } from '..'
 import { cleanUrl } from '../utils'
 
 /**
- * A plugin to provide build load fallback for arbitrary request with queries
+ * A plugin to provide build load fallback for arbitrary request with queries.
  */
-
 export function loadFallbackPlugin(): Plugin {
   return {
     name: 'vite:load-fallback',


### PR DESCRIPTION
### Description

Ensure that all internal and official plugins names follow the `'vite:{name}'` format.
Plugin React and Vue were already using this format, but legacy and vue-jsx were not. There were several internal plugins that weren't following either.

Since we are now recommending the use of @antfu's https://github.com/antfu/vite-plugin-inspect, people will start to see and maybe rely on these names. This is a breaking change but I think it can safely be applied as part of the 2.6 beta

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
