### PR TITLE
fix(ssr): add normalizePath to require.resolve, fix #2393

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -5,6 +5,7 @@ import {
   createDebugger,
   isDefined,
   lookupFile,
+  normalizePath,
   resolveFrom,
   unique
 } from '../utils'
@@ -68,7 +69,9 @@ export function resolveSSRExternal(
         undefined,
         true
       )?.id
-      requireEntry = require.resolve(id, { paths: [root] })
+      // normalizePath required for windows. tryNodeResolve uses normalizePath
+      // which returns with '/', require.resolve returns with '\\'
+      requireEntry = normalizePath(require.resolve(id, { paths: [root] }))
     } catch (e) {
       // resolve failed, assume include
       debug(`Failed to resolve entries for package "${id}"\n`, e)


### PR DESCRIPTION
### Description
Solves #2393

### Additional context
On windows, `entry` is a string with `/` and `requireEntry` is a string with `\`. When `requireEntry` passed to `normalizePath`, it becomes a string with `/`.
```
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/solid-js/dist/solid.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\solid-js\dist\static.cjs
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/solid-js/dist/static.cjs
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/jiti/lib/index.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\jiti\lib\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/jiti/lib/index.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/rollup-route-manifest/dist/index.mjs
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\rollup-route-manifest\dist\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/rollup-route-manifest/dist/index.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/vite/dist/node/index.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\vite\dist\node\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/vite/dist/node/index.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/vite-plugin-solid/dist/esm/index.mjs
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\vite-plugin-solid\dist\cjs\index.cjs
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/vite-plugin-solid/dist/cjs/index.cjs
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/compression/index.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\compression\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/compression/index.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/express/index.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\express\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/express/index.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/fastify/fastify.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\fastify\fastify.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/fastify/fastify.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/node-fetch/lib/index.mjs
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\node-fetch\lib\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/node-fetch/lib/index.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/serve-static/index.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\serve-static\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/serve-static/index.js
                          entry: C:/Users/U/Desktop/solid-hackernews/node_modules/solid-app-router/dist/index.js
                   requireEntry: C:\Users\U\Desktop\solid-hackernews\node_modules\solid-app-router\dist\index.js
requireEntry with normalizePath: C:/Users/U/Desktop/solid-hackernews/node_modules/solid-app-router/dist/index.js
```

Also in #2393 @rturnq said
> Simply using Vite's path normalization utility on `requireEntry` also doesn't quite work as, at least in my case, the paths end up with slightly different casing: `"C:\..."` vs `"c:\..."`

but I can't reproduce it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
