### PR TITLE
chore: correct async modules test cases

### DIFF
--- a/packages/playground/html/scriptAsync.html
+++ b/packages/playground/html/scriptAsync.html
@@ -1,14 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>scriptAsync</title>
-    <script async type="module" src="/main.js"></script>
-    <script async type="module" src="/nested/nested.js"></script>
-  </head>
-  <body>
-    <h1>scriptAsync.html</h1>
-  </body>
-</html>
+<link rel="stylesheet" href="/main.css" />
+
+<h1>scriptAsync.html</h1>
+
+<script async type="module" src="/main.js"></script>
+<script async type="module" src="/nested/nested.js"></script>

--- a/packages/playground/html/scriptMixed.html
+++ b/packages/playground/html/scriptMixed.html
@@ -1,14 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>scriptMixed</title>
-    <script async type="module" src="/main.js"></script>
-    <script type="module" src="/nested/nested.js"></script>
-  </head>
-  <body>
-    <h1>scriptMixed.html</h1>
-  </body>
-</html>
+<link rel="stylesheet" href="/main.css" />
+
+<h1>scriptMixed.html</h1>
+
+<script async type="module" src="/main.js"></script>
+<script type="module" src="/nested/nested.js"></script>


### PR DESCRIPTION
### Description

The html playground has an inline plugin that I failed to account when added these test cases. As with other .html in this playground, there shouldn't be a doctype, head, etc. This doesn't change the validity of the test cases.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
