### PR TITLE
fix: avoid module preload polyfill for zero js html

### DIFF
--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -104,6 +104,7 @@ if (isBuild) {
 
     test('script is async', async () => {
       expect(await page.$('head script[type=module][async]')).toBeTruthy()
+      expect(await page.$('head script[type=module]:not([async])')).toBeNull()
     })
   })
 
@@ -115,6 +116,20 @@ if (isBuild) {
 
     test('script is mixed', async () => {
       expect(await page.$('head script[type=module][async]')).toBeNull()
+      expect(await page.$('head script[type=module]:not([async])')).toBeTruthy()
+    })
+  })
+
+  describe('zeroJS', () => {
+    // Ensure that the modulePreload polyfill is discarded in this case
+
+    beforeAll(async () => {
+      // viteTestUrl is globally injected in scripts/jestPerTestSetup.ts
+      await page.goto(viteTestUrl + '/zeroJS.html')
+    })
+
+    test('zeroJS', async () => {
+      expect(await page.$('head script[type=module]')).toBeNull()
     })
   })
 

--- a/packages/playground/html/vite.config.js
+++ b/packages/playground/html/vite.config.js
@@ -11,6 +11,7 @@ module.exports = {
         nested: resolve(__dirname, 'nested/index.html'),
         scriptAsync: resolve(__dirname, 'scriptAsync.html'),
         scriptMixed: resolve(__dirname, 'scriptMixed.html'),
+        zeroJS: resolve(__dirname, 'zeroJS.html'),
         inline1: resolve(__dirname, 'inline/shared-1.html'),
         inline2: resolve(__dirname, 'inline/shared-2.html'),
         inline3: resolve(__dirname, 'inline/unique.html')

--- a/packages/playground/html/zeroJS.html
+++ b/packages/playground/html/zeroJS.html
@@ -1,0 +1,9 @@
+<link rel="stylesheet" href="/main.css" />
+
+<h1>zeroJS.html</h1>
+
+<style>
+  body {
+    background-color: linen;
+  }
+</style>

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -293,8 +293,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
         processedHtml.set(id, s.toString())
 
-        // inject module preload polyfill
-        if (config.build.polyfillModulePreload) {
+        // inject module preload polyfill only when configured and needed
+        if (
+          config.build.polyfillModulePreload &&
+          (someScriptsAreAsync || someScriptsAreDefer)
+        ) {
           js = `import "${modulePreloadPolyfillId}";\n${js}`
         }
 
@@ -391,6 +394,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             chunk.isEntry &&
             chunk.facadeModuleId === id
         ) as OutputChunk | undefined
+
         let canInlineEntry = false
 
         // inject chunk asset links
@@ -405,6 +409,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           // when not inlined, inject <script> for entry and modulepreload its dependencies
           // when inlined, discard entry chunk and inject <script> for everything in post-order
           const imports = getImportedChunks(chunk)
+
           const assetTags = canInlineEntry
             ? imports.map((chunk) => toScriptTag(chunk, isAsync))
             : [toScriptTag(chunk, isAsync), ...imports.map(toPreloadTag)]

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -409,7 +409,6 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           // when not inlined, inject <script> for entry and modulepreload its dependencies
           // when inlined, discard entry chunk and inject <script> for everything in post-order
           const imports = getImportedChunks(chunk)
-
           const assetTags = canInlineEntry
             ? imports.map((chunk) => toScriptTag(chunk, isAsync))
             : [toScriptTag(chunk, isAsync), ...imports.map(toPreloadTag)]


### PR DESCRIPTION
### Description

After #4555, we closed #3127 but @DylanPiercey found out that the module preload polyfill is still loaded when there isn't any JS.

This PR adds a guard avoiding adding the polyfill in html entries that don't have any script module (for example, a simple 404 page).
The user may add modules in pre plugins, but these are executed before the guard. If the user adds a module in a post plugin, they are executed after the preloads are inserted so these tags will still not need the polyfill internally.

The only case would be if the user is adding a tag + preload by hand in a post plugin, but I can't see why someone would want to avoid these scripts be processed by Vite. In the worst case scenario, this will only mean a that some browsers will not take into account that preload. We could document this gotcha if someone thinks this is something users will end up hitting.

### Additional context

An alternative is to always add the polyfill and remove it when analyzing the generated chunk. I tried to do so and it isn't straightforward. And the same caveat would apply here, the user may still add something by hand as a post plugin transforming the html.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other