### PR TITLE
fix: injected tags indentation

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -658,9 +658,9 @@ function serializeTag(
   indent: string = ''
 ): string {
   if (unaryTags.has(tag)) {
-    return `${indent}<${tag}${serializeAttrs(attrs)}>`
+    return `<${tag}${serializeAttrs(attrs)}>`
   } else {
-    return `${indent}<${tag}${serializeAttrs(attrs)}>${serializeTags(
+    return `<${tag}${serializeAttrs(attrs)}>${serializeTags(
       children,
       incrementIndent(indent)
     )}</${tag}>`
@@ -674,7 +674,7 @@ function serializeTags(
   if (typeof tags === 'string') {
     return tags
   } else if (tags && tags.length) {
-    return `${tags.map((tag) => serializeTag(tag, indent)).join('\n')}\n`
+    return tags.map((tag) => `${indent}${serializeTag(tag, indent)}\n`).join('')
   }
   return ''
 }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -590,33 +590,39 @@ function toPublicPath(filename: string, config: ResolvedConfig) {
   return isExternalUrl(filename) ? filename : config.base + filename
 }
 
-const headInjectRE = /<\/head>/
-const headPrependInjectRE = [/<head>/, /<!doctype html>/i]
+const headInjectRE = /([ \t]*)<\/head>/
+const headPrependInjectRE = [/([ \t]*)<head>/, /<!doctype html>/i]
 function injectToHead(
   html: string,
   tags: HtmlTagDescriptor[],
   prepend = false
 ) {
-  const tagsHtml = serializeTags(tags)
   if (prepend) {
     // inject after head or doctype
     for (const re of headPrependInjectRE) {
       if (re.test(html)) {
-        return html.replace(re, `$&\n${tagsHtml}`)
+        return html.replace(
+          re,
+          (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`
+        )
       }
     }
   } else {
     // inject before head close
     if (headInjectRE.test(html)) {
-      return html.replace(headInjectRE, `${tagsHtml}\n  $&`)
+      // respect indentation of head tag
+      return html.replace(
+        headInjectRE,
+        (match, p1) => `${serializeTags(tags, incrementIndent(p1))}${match}`
+      )
     }
   }
   // if no <head> tag is present, just prepend
-  return tagsHtml + `\n` + html
+  return serializeTags(tags) + html
 }
 
-const bodyInjectRE = /<\/body>/
-const bodyPrependInjectRE = /<body[^>]*>/
+const bodyInjectRE = /([ \t]*)<\/body>/
+const bodyPrependInjectRE = /([ \t]*)<body[^>]*>/
 function injectToBody(
   html: string,
   tags: HtmlTagDescriptor[],
@@ -624,38 +630,51 @@ function injectToBody(
 ) {
   if (prepend) {
     // inject after body open
-    const tagsHtml = `\n` + serializeTags(tags)
     if (bodyPrependInjectRE.test(html)) {
-      return html.replace(bodyPrependInjectRE, `$&\n${tagsHtml}`)
+      return html.replace(
+        bodyPrependInjectRE,
+        (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`
+      )
     }
     // if no body, prepend
-    return tagsHtml + `\n` + html
+    return serializeTags(tags) + html
   } else {
     // inject before body close
-    const tagsHtml = `\n` + serializeTags(tags)
     if (bodyInjectRE.test(html)) {
-      return html.replace(bodyInjectRE, `${tagsHtml}\n$&`)
+      return html.replace(
+        bodyInjectRE,
+        (match, p1) => `${serializeTags(tags, incrementIndent(p1))}${match}`
+      )
     }
     // if no body, append
-    return html + `\n` + tagsHtml
+    return html + `\n` + serializeTags(tags)
   }
 }
 
 const unaryTags = new Set(['link', 'meta', 'base'])
 
-function serializeTag({ tag, attrs, children }: HtmlTagDescriptor): string {
+function serializeTag(
+  { tag, attrs, children }: HtmlTagDescriptor,
+  indent: string = ''
+): string {
   if (unaryTags.has(tag)) {
-    return `<${tag}${serializeAttrs(attrs)}>`
+    return `${indent}<${tag}${serializeAttrs(attrs)}>`
   } else {
-    return `<${tag}${serializeAttrs(attrs)}>${serializeTags(children)}</${tag}>`
+    return `${indent}<${tag}${serializeAttrs(attrs)}>${serializeTags(
+      children,
+      incrementIndent(indent)
+    )}</${tag}>`
   }
 }
 
-function serializeTags(tags: HtmlTagDescriptor['children']): string {
+function serializeTags(
+  tags: HtmlTagDescriptor['children'],
+  indent: string = ''
+): string {
   if (typeof tags === 'string') {
     return tags
-  } else if (tags) {
-    return `  ${tags.map(serializeTag).join('\n    ')}`
+  } else if (tags && tags.length) {
+    return `${tags.map((tag) => serializeTag(tag, indent)).join('\n')}\n`
   }
   return ''
 }
@@ -670,4 +689,8 @@ function serializeAttrs(attrs: HtmlTagDescriptor['attrs']): string {
     }
   }
   return res
+}
+
+function incrementIndent(indent: string = '') {
+  return `${indent}${indent[0] === '\t' ? '\t' : '  '}`
 }


### PR DESCRIPTION
### Description

We merged #4227 to improve indentation of injected tags, but that PR assumes that the head is indented with two spaces. The approach in this PR is similar to #1068, but also takes into account the case when the head isn't indented.

The only caveat is that if the head isn't indented, it assumes two spaces for indentation. If it is indented, then it will properly respect tabs. We could improve this further by detecting the indentation with another regex, but I think that would be already too complex and fragile. We may need to provide a config option for this, but I prefer to avoid proposing something without a request from users. I think this approach is enough for the moment.

Current indentation and spacing when `<head>` and `<body>` start at the beginning of the line (real example from playground/html):
```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta name="description" content="a vite app">
  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Test HTML transforms</title>
  <script type="module" crossorigin src="/assets/modulepreload-polyfill.0d94a2e8.js"></script>
    <script type="module" crossorigin src="/assets/common.fde954c5.js"></script>
    <script type="module" crossorigin src="/assets/main.48436d11.js"></script>
    <link rel="stylesheet" href="/assets/common.e7d02c8e.css">
    <link rel="stylesheet" href="/assets/main.ebd1b3ad.css">
    <meta name="keywords" content="es modules">
  </head>
<body>

  <noscript><!-- this is prepended to body --></noscript>
  
  ...

  <p class="inject">This is injected</p>
    <p class="build">This is injected only during build</p>
    <noscript><!-- this is appended to body --></noscript>
</body>
</html>
```

After this PR:
```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta name="description" content="a vite app">

  <meta charset="UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1.0">
  <title>Test HTML transforms</title>
  <script type="module" crossorigin src="/assets/modulepreload-polyfill.0d94a2e8.js"></script>
  <script type="module" crossorigin src="/assets/common.fde954c5.js"></script>
  <script type="module" crossorigin src="/assets/main.48436d11.js"></script>
  <link rel="stylesheet" href="/assets/common.e7d02c8e.css">
  <link rel="stylesheet" href="/assets/main.ebd1b3ad.css">
  <meta name="keywords" content="es modules">
</head>
<body>
  <noscript><!-- this is prepended to body --></noscript>

  ...

  <p class="inject">This is injected</p>
  <p class="build">This is injected only during build</p>
  <noscript><!-- this is appended to body --></noscript>
</body>
</html>
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other