### PR TITLE
refactor: change location of server start log messages

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -1,10 +1,13 @@
 /* eslint no-console: 0 */
 
 import chalk from 'chalk'
-import readline from 'readline'
+import { AddressInfo, Server } from 'net'
 import os from 'os'
+import readline from 'readline'
 import { RollupError } from 'rollup'
-import { Hostname } from './utils'
+import { ResolvedConfig } from '.'
+import { ServerOptions } from './server'
+import { Hostname, resolveHostname } from './utils'
 
 export type LogType = 'error' | 'warn' | 'info'
 export type LogLevel = LogType | 'silent'
@@ -135,6 +138,26 @@ export function createLogger(
   }
 
   return logger
+}
+
+export function printHttpServerUrls(
+  server: Server,
+  config: ResolvedConfig,
+  options: ServerOptions
+): void {
+  const address = server.address()
+  const isAddressInfo = (x: any): x is AddressInfo => x.address
+  if (isAddressInfo(address)) {
+    const hostname = resolveHostname(options.host)
+    const protocol = config.server.https ? 'https' : 'http'
+    printServerUrls(
+      hostname,
+      protocol,
+      address.port,
+      config.base,
+      config.logger.info
+    )
+  }
 }
 
 export function printServerUrls(

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,8 +1,8 @@
 import path from 'path'
 import sirv from 'sirv'
-import chalk from 'chalk'
 import connect from 'connect'
 import compression from 'compression'
+import { Server } from 'http'
 import { ResolvedConfig, ServerOptions } from '.'
 import { Connect } from 'types/connect'
 import {
@@ -13,7 +13,6 @@ import {
 import { openBrowser } from './server/openBrowser'
 import corsMiddleware from 'cors'
 import { proxyMiddleware } from './server/middlewares/proxy'
-import { printServerUrls } from './logger'
 import { resolveHostname } from './utils'
 
 /**
@@ -25,7 +24,7 @@ import { resolveHostname } from './utils'
 export async function preview(
   config: ResolvedConfig,
   serverOptions: Pick<ServerOptions, 'port' | 'host'>
-): Promise<void> {
+): Promise<Server> {
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.server,
@@ -70,13 +69,6 @@ export async function preview(
     logger
   })
 
-  logger.info(
-    chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-      chalk.green(` build preview server running at:\n`)
-  )
-
-  printServerUrls(hostname, protocol, serverPort, base, logger.info)
-
   if (options.open) {
     const path = typeof options.open === 'string' ? options.open : base
     openBrowser(
@@ -85,4 +77,6 @@ export async function preview(
       logger
     )
   }
+
+  return httpServer
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -52,11 +52,9 @@ import {
   ssrRewriteStacktrace
 } from '../ssr/ssrStacktrace'
 import { createMissingImporterRegisterFn } from '../optimizer/registerMissing'
-import { printServerUrls } from '../logger'
 import { resolveHostname } from '../utils'
 import { searchForWorkspaceRoot } from './searchRoot'
 import { CLIENT_DIR } from '../constants'
-import { performance } from 'perf_hooks'
 
 export { searchForWorkspaceRoot } from './searchRoot'
 
@@ -598,28 +596,6 @@ async function startServer(
     host: hostname.host,
     logger: server.config.logger
   })
-
-  info(
-    chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-      chalk.green(` dev server running at:\n`),
-    {
-      clear: !server.config.logger.hasWarned
-    }
-  )
-
-  printServerUrls(hostname, protocol, serverPort, base, info)
-
-  // @ts-ignore
-  if (global.__vite_start_time) {
-    info(
-      chalk.cyan(
-        `\n  ready in ${Math.round(
-          // @ts-ignore
-          performance.now() - global.__vite_start_time
-        )}ms.\n`
-      )
-    )
-  }
 
   // @ts-ignore
   const profileSession = global.__vite_profile_session


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Print the server startup messages in the CLI rather than the methods which start the server

### Additional context

SvelteKit has started calling `createServer` to start the Vite server. However, this has created some log messages that duplicate / conflict with SvelteKit's. Moving these log messages will allow Vite to function exactly as it does today while fixing the log messages for SvelteKit

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
