### PR TITLE
fix: exclude missing dependencies from optimization during SSR

### DIFF
--- a/packages/playground/optimize-missing-deps/__test__/optimize-missing-deps.spec.ts
+++ b/packages/playground/optimize-missing-deps/__test__/optimize-missing-deps.spec.ts
@@ -1,0 +1,16 @@
+import { port } from './serve'
+import fetch from 'node-fetch'
+import { untilUpdated } from '../../testUtils'
+
+const url = `http://localhost:${port}`
+
+test('*', async () => {
+  await page.goto(url)
+  // reload page to get optimized missing deps
+  await page.reload()
+  await untilUpdated(() => page.textContent('div'), 'Client')
+
+  // raw http request
+  const aboutHtml = await (await fetch(url)).text()
+  expect(aboutHtml).toMatch('Server')
+})

--- a/packages/playground/optimize-missing-deps/__test__/serve.js
+++ b/packages/playground/optimize-missing-deps/__test__/serve.js
@@ -1,0 +1,36 @@
+// @ts-check
+// this is automtically detected by scripts/jestPerTestSetup.ts and will replace
+// the default e2e test serve behavior
+
+const path = require('path')
+
+const port = (exports.port = 9529)
+
+/**
+ * @param {string} root
+ * @param {boolean} isProd
+ */
+exports.serve = async function serve(root, isProd) {
+  const { createServer } = require(path.resolve(root, 'server.js'))
+  const { app, vite } = await createServer(root, isProd)
+
+  return new Promise((resolve, reject) => {
+    try {
+      const server = app.listen(port, () => {
+        resolve({
+          // for test teardown
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve)
+            })
+            if (vite) {
+              await vite.close()
+            }
+          }
+        })
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}

--- a/packages/playground/optimize-missing-deps/index.html
+++ b/packages/playground/optimize-missing-deps/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+  </head>
+  <body>
+    <!--app-html-->
+  </body>
+</html>

--- a/packages/playground/optimize-missing-deps/main.js
+++ b/packages/playground/optimize-missing-deps/main.js
@@ -1,0 +1,3 @@
+import { sayName } from 'missing-dep'
+
+export const name = sayName()

--- a/packages/playground/optimize-missing-deps/missing-dep/index.js
+++ b/packages/playground/optimize-missing-deps/missing-dep/index.js
@@ -1,0 +1,5 @@
+import { name } from 'multi-entry-dep'
+
+export function sayName() {
+  return name
+}

--- a/packages/playground/optimize-missing-deps/missing-dep/package.json
+++ b/packages/playground/optimize-missing-deps/missing-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "missing-dep",
+  "version": "0.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "multi-entry-dep": "file:../multi-entry-dep"
+  }
+}

--- a/packages/playground/optimize-missing-deps/multi-entry-dep/index.browser.js
+++ b/packages/playground/optimize-missing-deps/multi-entry-dep/index.browser.js
@@ -1,0 +1,1 @@
+exports.name = 'Client'

--- a/packages/playground/optimize-missing-deps/multi-entry-dep/index.js
+++ b/packages/playground/optimize-missing-deps/multi-entry-dep/index.js
@@ -1,0 +1,3 @@
+const path = require('path')
+
+exports.name = path.normalize('./Server')

--- a/packages/playground/optimize-missing-deps/multi-entry-dep/package.json
+++ b/packages/playground/optimize-missing-deps/multi-entry-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "multi-entry-dep",
+  "version": "0.0.0",
+  "main": "index.js",
+  "browser": {
+    "./index.js": "./index.browser.js"
+  }
+}

--- a/packages/playground/optimize-missing-deps/package.json
+++ b/packages/playground/optimize-missing-deps/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "optimize-missing-deps",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "node server"
+  },
+  "workspaces": {
+    "packages": [
+      "./*"
+    ]
+  },
+  "dependencies": {
+    "missing-dep": "file:./missing-dep",
+    "multi-entry-dep": "file:./multi-entry-dep"
+  }
+}

--- a/packages/playground/optimize-missing-deps/server.js
+++ b/packages/playground/optimize-missing-deps/server.js
@@ -1,0 +1,60 @@
+// @ts-check
+const fs = require('fs')
+const path = require('path')
+const express = require('express')
+
+const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+
+async function createServer(root = process.cwd()) {
+  const resolve = (p) => path.resolve(__dirname, p)
+
+  const app = express()
+
+  /**
+   * @type {import('vite').ViteDevServer}
+   */
+  const vite = await require('vite').createServer({
+    root,
+    logLevel: isTest ? 'error' : 'info',
+    server: { middlewareMode: 'ssr' }
+  })
+  app.use(vite.middlewares)
+
+  app.use('*', async (req, res) => {
+    try {
+      let template = fs.readFileSync(resolve('index.html'), 'utf-8')
+      template = await vite.transformIndexHtml(req.originalUrl, template)
+
+      // this will import missing deps nest built-in deps that should not be optimized
+      const { name } = await vite.ssrLoadModule('./main.js')
+
+      // this will import missing deps that should be optimized correctly
+      const appHtml = `<div id="app">${name}</div>
+<script type='module'>
+  import { name } from './main.js'
+  document.getElementById('app').innerText = name
+</script>`
+
+      const html = template.replace(`<!--app-html-->`, appHtml)
+
+      res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+    } catch (e) {
+      vite.ssrFixStacktrace(e)
+      console.log(e.stack)
+      res.status(500).end(e.stack)
+    }
+  })
+
+  return { app, vite }
+}
+
+if (!isTest) {
+  createServer().then(({ app }) =>
+    app.listen(3000, () => {
+      console.log('http://localhost:3000')
+    })
+  )
+}
+
+// for test use
+exports.createServer = createServer

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -6,8 +6,7 @@ import {
   isRunningWithYarnPnp,
   flattenId,
   normalizePath,
-  isExternalUrl,
-  isBuiltin
+  isExternalUrl
 } from '../utils'
 import { browserExternalId } from '../plugins/resolve'
 import { ExportsData } from '.'
@@ -120,7 +119,7 @@ export function esbuildDepPlugin(
                 namespace: 'browser-external'
               }
             }
-            if (isExternalUrl(resolved) || (ssr && isBuiltin(id))) {
+            if (isExternalUrl(resolved)) {
               return {
                 path: resolved,
                 external: true

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -507,7 +507,8 @@ export function tryNodeResolve(
       importer?.includes('node_modules') ||
       exclude?.includes(pkgId) ||
       exclude?.includes(id) ||
-      SPECIAL_QUERY_RE.test(resolved)
+      SPECIAL_QUERY_RE.test(resolved) ||
+      ssr
     ) {
       // excluded from optimization
       // Inject a version query to npm deps so that the browser

--- a/yarn.lock
+++ b/yarn.lock
@@ -5552,6 +5552,11 @@ minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
+"missing-dep@file:./packages/playground/optimize-missing-deps/missing-dep":
+  version "0.0.0"
+  dependencies:
+    multi-entry-dep "file:../../../Library/Caches/Yarn/v6/npm-missing-dep-0.0.0-c3d33c60-1540-4e68-9410-6849e432ed4c-1632279325025/node_modules/multi-entry-dep"
+
 mkdirp@1.0.4, mkdirp@~1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
@@ -5591,6 +5596,9 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+"multi-entry-dep@file:./packages/playground/optimize-missing-deps/multi-entry-dep", "multi-entry-dep@file:packages/playground/optimize-missing-deps/multi-entry-dep":
+  version "0.0.0"
 
 mustache@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Optimized based on #4904 , fixed #4700 , and added test cases.

After I submitted the RP #4904 , I am going to add test cases according to the comment of @patak-js .
 
In the process of building test cases, I found a problem.

For testing, I did not add the script entry point in the `index.html`, it will be dynamically added during SSR.

First, if you import a missing dependency that contains multiple entries during SSR, it will execute `server._registerMissingImport` and build a server-based output.

Then, when the client imports the same missing dependency that contains multiple entries, it will directly consume the build result of the SSR stage. The build result is only applicable to the server, and importing on the client will cause an error.

In my opinion, there is no need to execute `server._registerMissingImport` during the SSR, because the build result is based on the server, and the optimized dependencies are for the client.

If there is anything missing, please remind me.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
