### PR TITLE
fix: dedupe import analysis public name

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -94,7 +94,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
   const preloadCode = `const scriptRel = ${scriptRel};const seen = {};const base = '${preloadBaseMarker}';export const ${preloadMethod} = ${preload.toString()}`
 
   return {
-    name: 'vite:import-analysis',
+    name: 'vite:build-import-analysis',
 
     resolveId(id) {
       if (id === preloadHelperId) {


### PR DESCRIPTION
### Description

Same as with #4974, this PR dedupes the `'vite:import-analysis'` name that is currently shared between the dev and build plugins. This one is a bit different because, in the case of the manifests plugins, both plugins could be used together but here it is always one or the other. I still think that it is better to dedupe the names so people can go from the inspect tool to the code by name to the correct plugin.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other