### PR TITLE
feat(plugin-react): pre-optimize jsx-dev-runtime

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -251,6 +251,13 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   const viteReactJsx: Plugin = {
     name: 'vite:react-jsx',
     enforce: 'pre',
+    config() {
+      return {
+        optimizeDeps: {
+          include: ['react/jsx-dev-runtime']
+        }
+      }
+    },
     resolveId(id: string) {
       return id === runtimeId ? id : null
     },


### PR DESCRIPTION
This avoids late discovery of `react/jsx-dev-runtime` since it only appears after transforms:

<img width="572" alt="Screen_Shot_2021-09-22_at_1 45 09_PM" src="https://user-images.githubusercontent.com/499550/134396264-0d41331a-a071-45fd-8872-da078cd145fa.png">

/cc @aleclarson 