### PR TITLE
feat: pre transform direct imports before requests hit the server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - release/*
+      - feat/*
   pull_request:
   workflow_dispatch:
 

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -17,7 +17,9 @@ import {
   isJSRequest,
   prettifyUrl,
   timeFrom,
-  normalizePath
+  normalizePath,
+  removeImportQuery,
+  unwrapId
 } from '../utils'
 import {
   debugHmr,
@@ -40,6 +42,7 @@ import { transformImportGlob } from '../importGlob'
 import { makeLegalIdentifier } from '@rollup/pluginutils'
 import { shouldExternalizeForSSR } from '../ssr/ssrExternal'
 import { performance } from 'perf_hooks'
+import { transformRequest } from '../server/transformRequest'
 
 const isDebug = !!process.env.DEBUG
 const debug = createDebugger('vite:import-analysis')
@@ -159,6 +162,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // have been loaded so its entry is guaranteed in the module graph.
       const importerModule = moduleGraph.getModuleById(importer)!
       const importedUrls = new Set<string>()
+      const staticImportedUrls = new Set<string>()
       const acceptedUrls = new Set<{
         url: string
         start: number
@@ -289,18 +293,28 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           } else if (prop === '.glo' && source[end + 4] === 'b') {
             // transform import.meta.glob()
             // e.g. `import.meta.glob('glob:./dir/*.js')`
-            const { imports, importsString, exp, endIndex, base, pattern } =
-              await transformImportGlob(
-                source,
-                start,
-                importer,
-                index,
-                root,
-                normalizeUrl
-              )
+            const {
+              imports,
+              importsString,
+              exp,
+              endIndex,
+              base,
+              pattern,
+              isEager
+            } = await transformImportGlob(
+              source,
+              start,
+              importer,
+              index,
+              root,
+              normalizeUrl
+            )
             str().prepend(importsString)
             str().overwrite(expStart, endIndex, exp)
-            imports.forEach((url) => importedUrls.add(url.replace(base, '/')))
+            imports.forEach((url) => {
+              importedUrls.add(url)
+              if (isEager) staticImportedUrls.add(url)
+            })
             if (!(importerModule.file! in server._globImporters)) {
               server._globImporters[importerModule.file!] = {
                 module: importerModule,
@@ -397,7 +411,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           // record for HMR import chain analysis
           // make sure to normalize away base
-          importedUrls.add(url.replace(base, '/'))
+          importedUrls.add(url)
+          if (!isDynamicImport) {
+            // for pre-transforming
+            staticImportedUrls.add(url)
+          }
         } else if (!importer.startsWith(clientDir) && !ssr) {
           // check @vite-ignore which suppresses dynamic import warning
           const hasViteIgnore = /\/\*\s*@vite-ignore\s*\*\//.test(rawUrl)
@@ -515,6 +533,13 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             `[${importedUrls.size} imports rewritten] ${prettyImporter}`
           )}`
         )
+
+      // pre-transform known direct imports
+      if (staticImportedUrls.size) {
+        staticImportedUrls.forEach((url) => {
+          transformRequest(unwrapId(removeImportQuery(url)), server, { ssr })
+        })
+      }
 
       if (s) {
         return s.toString()

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -34,8 +34,11 @@ import { errorMiddleware, prepareError } from './middlewares/error'
 import { handleHMRUpdate, HmrOptions, handleFileAddUnlink } from './hmr'
 import { openBrowser } from './openBrowser'
 import launchEditorMiddleware from 'launch-editor-middleware'
-import { TransformResult } from 'rollup'
-import { TransformOptions, transformRequest } from './transformRequest'
+import {
+  TransformOptions,
+  TransformResult,
+  transformRequest
+} from './transformRequest'
 import {
   transformWithEsbuild,
   ESBuildTransformResult
@@ -299,6 +302,10 @@ export interface ViteDevServer {
    * @internal
    */
   _pendingReload: Promise<void> | null
+  /**
+   * @internal
+   */
+  _pendingRequests: Record<string, Promise<TransformResult | null> | null>
 }
 
 export async function createServer(
@@ -395,10 +402,11 @@ export async function createServer(
     },
     _optimizeDepsMetadata: null,
     _ssrExternals: null,
-    _globImporters: {},
+    _globImporters: Object.create(null),
     _isRunningOptimizer: false,
     _registerMissingImport: null,
-    _pendingReload: null
+    _pendingReload: null,
+    _pendingRequests: Object.create(null)
   }
 
   server.transformIndexHtml = createDevHtmlTransformFn(server)


### PR DESCRIPTION
Currently Vite only transforms a file (i.e. go through the plugin pipeline) when the file is requested. This ensures only files actually used on the current page are transformed, however it also creates a problem with deeply nested import chains:

```
A --> B --> C
```

`B` is only requested when `A` is evaluated in the browser (triggering the import request to `B`). Similarly `C` is only requested after `B` is evaluated in the browser. The problem becomes more obvious when there are many modules being loaded in parallel - since the browser typically can only handle 6 parallel requests so it will hold off some requests until previously pending requests have resolved (HTTP/2 requires HTTPS which in fact make things slower). This causes requests to hit the server at a delayed rate so the server is in fact under-utilized and waiting for the browser. The deeper the import chain and the more modules are loaded in parallel, the more obvious the problem is.

Since Vite already performs import analysis when transforming each module, we can in fact start transforming all direct imports of a module before even sending back the response. This essentially means Vite will be eagerly compiling the non-lazy-imported sub graph of the application without waiting on network requests. When the requests come in, they can pick up the already initiated transform Promise (can be pending or already resolved).

I did some synthetic benchmarking [here](https://github.com/yyx990803/vite-pre-transform-test):

|                   | D2/C5/T31     | D3/C7/T400    | D4/C4/T341  | C1/C100/T101  | D4/C8/T4681    |
|-------------------|--------------|--------------|------------|--------------|---------------|
| Base              | 157ms          | 778ms          | 727ms        | 282ms          | 8092ms          |
| Post Optimization | 112ms (-28.6%) | 321ms (-58.7%) | 305ms (-58%) | 142ms (-49.6%) | 2414ms (-70.2%) |

> D = layers of nested imports / C = parallel imports per file / T = total number of modules loaded

---

Tests are passing but this may have subtle implications in real world cases, so we should put it in a beta and test it in some projects to make sure it doesn't break anything.
