### PR TITLE
fix(ssr): handle default arguments properly in `ssrTransform`

### DIFF
--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -294,7 +294,7 @@ function walk(
         // walk function expressions and add its arguments to known identifiers
         // so that we don't prefix them
         node.params.forEach((p) =>
-          (eswalk as any)(p, {
+          (eswalk as any)(p.type === 'AssignmentPattern' ? p.left : p, {
             enter(child: Node, parent: Node) {
               if (
                 child.type === 'Identifier' &&


### PR DESCRIPTION
Previously, any Identifier nodes that were both (1) used in a default argument expression and (2) referenced an import binding would not be rewritten to point to the transformed import binding.

For example:

```ts
import Foo from './foo'

export function hello(arg = Foo.foo) {}
```

…would be transformed into something like:

```ts
const __vite_ssr_import_0__ = __vite_ssr_import__('./foo')

function hello(arg = Foo.foo) {}

Object.defineProperty(__vite_ssr_exports__, "hello", { enumerable: true, value: hello })
```

…so the `Foo.foo` reference would result in a runtime error.
