### PR TITLE
feat(plugin-react): add `decorators` option

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -32,7 +32,11 @@ export interface Options {
    * @default "react"
    */
   jsxImportSource?: string
-
+  /**
+   * Enable decorator syntax proposal.
+   * @see https://babeljs.io/docs/en/babel-plugin-proposal-decorators
+   */
+  decorators?: { legacy: true } | { beforeExport: boolean }
   /**
    * Babel configuration applied in both dev and prod.
    */
@@ -57,6 +61,18 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   const userPlugins = opts.babel?.plugins || []
   const userParserPlugins =
     opts.parserPlugins || opts.babel?.parserOpts?.plugins || []
+
+  // Shortcut for enabling decorator syntax.
+  if (opts.decorators) {
+    userParserPlugins.push(
+      'legacy' in opts.decorators
+        ? 'decorators-legacy'
+        : [
+            'decorators',
+            { decoratorsBeforeExport: opts.decorators.beforeExport }
+          ]
+    )
+  }
 
   const importReactRE = /(^|\n)import\s+(\*\s+as\s+)?React\s+/
 


### PR DESCRIPTION
Using decorator syntax is common enough to warrant an easier way to enable it.

**Before:**

```js
react({
  babel: {
    parserOpts: { plugins: ['decorators-legacy'] }
  }
})
```

…or by using https://babeljs.io/docs/en/babel-plugin-syntax-decorators

**After:**

```js
react({
  decorators: { legacy: true },
  // or
  decorators: { beforeExport: true || false },
})
```
