### PR TITLE
chore: fix eslint invalid ecmaVersion value

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = defineConfig({
   parser: '@typescript-eslint/parser',
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 'latest'
+    ecmaVersion: 2021
   },
   rules: {
     eqeqeq: ['warn', 'always', { null: 'never' }],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The configured `parserOptions.ecmaVersion` value is not known / invalid.
This results in false-positive reports.

### Additional context

<img src="https://user-images.githubusercontent.com/7195563/134527526-c2b634b5-1080-4582-ae80-1d62004fc538.jpg" width="500px"/>

https://github.com/vitejs/vite/pull/5021
https://github.com/eslint/eslint/issues/15022#issuecomment-925812331

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
