### PR TITLE
fix: esbuild minification and renderLegacyChunks false

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -97,7 +97,7 @@ function viteLegacyPlugin(options = {}) {
     apply: 'build',
 
     configResolved(config) {
-      if (!config.build.ssr && config.build.minify === 'esbuild') {
+      if (!config.build.ssr && genLegacy && config.build.minify === 'esbuild') {
         throw new Error(
           `Can't use esbuild as the minifier when targeting legacy browsers ` +
             `because esbuild minification is not legacy safe.`


### PR DESCRIPTION
### Description

When using vite 2.6.0-beta.2 together with plugin-legacy and `renderLegacyChunks` set to `false` the build fails with

```
Error: Can't use esbuild as the minifier when targeting legacy browsers because esbuild minification is not legacy safe.
```

even though no legacy code is generated that might be incompatible with esbuild.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
