### PR TITLE
feat(plugin-react): respect `experimentalDecorators` compiler option

### DIFF
--- a/packages/plugin-react/src/fs.ts
+++ b/packages/plugin-react/src/fs.ts
@@ -1,0 +1,12 @@
+import fs from 'fs'
+
+export function readJsonFile(file: string, throwError?: boolean) {
+  let content: string
+  try {
+    content = fs.readFileSync(file, 'utf8')
+  } catch (e) {
+    if (throwError) throw e
+    return
+  }
+  return JSON.parse(content)
+}

--- a/packages/plugin-react/src/fs.ts
+++ b/packages/plugin-react/src/fs.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 
-export function readJsonFile(file: string, throwError?: boolean) {
+export function readJsonFile(file: string, throwError?: boolean): any {
   let content: string
   try {
     content = fs.readFileSync(file, 'utf8')

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from './fast-refresh'
 import { babelImportToRequire } from './jsx-runtime/babel-import-to-require'
 import { restoreJSX } from './jsx-runtime/restore-jsx'
+import { findCompilerOption } from './tsconfig'
 
 export interface Options {
   include?: string | RegExp | Array<string | RegExp>
@@ -111,6 +112,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         const isTypeScript = /\.tsx?$/.test(id)
         if (isTypeScript) {
           parserPlugins.push('typescript')
+          if (findCompilerOption(id, 'experimentalDecorators')) {
+            parserPlugins.push('decorators-legacy')
+          }
         }
 
         const isNodeModules = id.includes('node_modules')

--- a/packages/plugin-react/src/tsconfig.spec.ts
+++ b/packages/plugin-react/src/tsconfig.spec.ts
@@ -1,0 +1,56 @@
+import { findCompilerOption } from './tsconfig'
+import * as fs from './fs'
+
+jest.mock('./fs')
+
+const readJsonFile = fs.readJsonFile as jest.Mock
+
+describe('findCompilerOption', () => {
+  afterEach(() => {
+    readJsonFile.mockReset()
+  })
+
+  it('finds the nearest tsconfig.json', () => {
+    findCompilerOption('/a/b/c.ts', 'foo')
+    expect(readJsonFile.mock.calls).toEqual([
+      ['/a/b/tsconfig.json'],
+      ['/a/tsconfig.json'],
+      ['/tsconfig.json']
+    ])
+  })
+
+  it('searches the "extends" chain', () => {
+    const files = {
+      '/a/b/tsconfig.json': { extends: '../../tsconfig.json' },
+      '/tsconfig.json': { compilerOptions: { foo: 1 } }
+    }
+    readJsonFile.mockImplementation((file) => files[file])
+    expect(findCompilerOption('/a/b/c.ts', 'foo')).toBe(1)
+  })
+
+  it('stops looking on first defined value', () => {
+    const files = {
+      '/a/b/tsconfig.json': {
+        extends: '../tsconfig.json'
+      },
+      '/a/tsconfig.json': {
+        extends: '../tsconfig.json',
+        compilerOptions: { foo: 1 }
+      },
+      '/tsconfig.json': {
+        compilerOptions: { foo: 2 }
+      }
+    }
+    readJsonFile.mockImplementation((file) => files[file])
+    expect(findCompilerOption('/a/b/c.ts', 'foo')).toBe(1)
+  })
+
+  it('works with Windows paths', () => {
+    findCompilerOption('C:\\a\\b\\c.ts', 'foo')
+    expect(readJsonFile.mock.calls).toEqual([
+      ['C:\\a\\b\\tsconfig.json'],
+      ['C:\\a\\tsconfig.json'],
+      ['C:\\tsconfig.json']
+    ])
+  })
+})

--- a/packages/plugin-react/src/tsconfig.ts
+++ b/packages/plugin-react/src/tsconfig.ts
@@ -1,0 +1,29 @@
+import path from 'path'
+import { readJsonFile } from './fs'
+
+export function findCompilerOption(fileName: string, optionKey: string): any {
+  const { dirname, join, resolve } = path.posix.isAbsolute(fileName)
+    ? path.posix
+    : path.win32
+
+  let parentDir = dirname(fileName)
+  while (true) {
+    let config = readJsonFile(join(parentDir, 'tsconfig.json'))
+    while (config) {
+      if (config.compilerOptions?.[optionKey] !== undefined) {
+        return config.compilerOptions[optionKey]
+      }
+      if (!config.extends) {
+        return
+      }
+      if (!config.extends.endsWith('.json')) {
+        config.extends += '.json'
+      }
+      config = readJsonFile(resolve(parentDir, config.extends), true)
+    }
+    const grandParentDir = dirname(parentDir)
+    if (grandParentDir !== parentDir) {
+      parentDir = grandParentDir
+    } else return
+  }
+}

--- a/packages/plugin-react/src/tsconfig.ts
+++ b/packages/plugin-react/src/tsconfig.ts
@@ -6,8 +6,7 @@ export function findCompilerOption(fileName: string, optionKey: string): any {
     ? path.posix
     : path.win32
 
-  let parentDir = dirname(fileName)
-  while (true) {
+  for (let parentDir = dirname(fileName); ; ) {
     let config = readJsonFile(join(parentDir, 'tsconfig.json'))
     while (config) {
       if (config.compilerOptions?.[optionKey] !== undefined) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Respect `experimentalDecorators` compiler option (in `tsconfig.json`) by enabling `decorators-legacy` Babel syntax plugin, which avoids compilation issues like this one 👇 

<img width="820" alt="image" src="https://user-images.githubusercontent.com/1925840/134546695-b427997c-33b8-4c68-a786-714112124bac.png">

⚠️  This only affects TypeScript projects using `@vitejs/plugin-react`.

### Additional context

Tests included for `tsconfig.json` lookup.

Follow-up to #5050

I used [this repo](https://github.com/aleclarson/repro/blob/vite-react-ts-decorators) to test the feature.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
