### PR TITLE
fix: server.address before listen, chdir in test, basic cli test

### DIFF
--- a/packages/playground/cli/__tests__/cli.spec.ts
+++ b/packages/playground/cli/__tests__/cli.spec.ts
@@ -1,0 +1,18 @@
+import { port } from './serve'
+
+test('cli should work', async () => {
+  // this test uses a custom serve implementation, so regular helpers for browserLogs and goto don't work
+  // do the same thing manually
+  const logs = []
+  const onConsole = (msg) => {
+    logs.push(msg.text())
+  }
+  try {
+    page.on('console', onConsole)
+    await page.goto(`http://localhost:${port}/`)
+    expect(await page.textContent('.app')).toBe('vite cli works!')
+    expect(logs.some((msg) => msg.match('vite cli works!'))).toBe(true)
+  } finally {
+    page.off('console', onConsole)
+  }
+})

--- a/packages/playground/cli/__tests__/serve.js
+++ b/packages/playground/cli/__tests__/serve.js
@@ -64,7 +64,7 @@ exports.serve = async function serve(root, isProd) {
       detached: true, // force a new process group so we can kill it with all subprocesses later
       preferLocal: true,
       cwd: root,
-      stdio: 'pipe'
+      stdio: ['pipe', 'pipe', 'pipe', 'ipc']
     }
   )
   collectStreams('server', serverProcess)
@@ -82,6 +82,9 @@ exports.serve = async function serve(root, isProd) {
           console.error('failed to end vite cli process:', e)
           await printStreamsToConsole('server')
         }
+      } finally {
+        serverProcess.disconnect()
+        serverProcess.unref()
       }
     }
   }

--- a/packages/playground/cli/__tests__/serve.js
+++ b/packages/playground/cli/__tests__/serve.js
@@ -70,7 +70,7 @@ exports.serve = async function serve(root, isProd) {
   if (isProd) {
     viteServerArgs.unshift('preview')
   }
-  const serverProcess = execa('vite', viteServerArgs, {
+  const serverProcess = execa(viteBin, viteServerArgs, {
     cwd: root,
     stdio: 'pipe'
   })

--- a/packages/playground/cli/__tests__/serve.js
+++ b/packages/playground/cli/__tests__/serve.js
@@ -87,7 +87,7 @@ exports.serve = async function serve(root, isProd) {
   }
 
   try {
-    await startedOnPort(serverProcess, port, 3000)
+    await startedOnPort(serverProcess, port)
     return { close }
   } catch (e) {
     console.error('failed to start server:', e)
@@ -102,7 +102,7 @@ exports.serve = async function serve(root, isProd) {
 }
 
 // helper to validate that server was started on the correct port
-async function startedOnPort(serverProcess, port, timeout) {
+async function startedOnPort(serverProcess, port) {
   let checkPort
   const startedPromise = new Promise((resolve, reject) => {
     checkPort = (data) => {
@@ -124,8 +124,8 @@ async function startedOnPort(serverProcess, port, timeout) {
   })
   return resolvedOrTimoutError(
     startedPromise,
-    3000,
-    'test server failed to start within 3s'
+    5000,
+    `test server failed to start within 5s`
   ).finally(() => {
     serverProcess.stdout.off('data', checkPort)
   })

--- a/packages/playground/cli/__tests__/serve.js
+++ b/packages/playground/cli/__tests__/serve.js
@@ -1,0 +1,148 @@
+// @ts-check
+// this is automtically detected by scripts/jestPerTestSetup.ts and will replace
+// the default e2e test serve behavior
+
+// eslint-disable-next-line node/no-restricted-require
+const execa = require('execa')
+
+// make sure this port is unique
+const port = (exports.port = 9510)
+
+/**
+ * @param {string} root
+ * @param {boolean} isProd
+ */
+exports.serve = async function serve(root, isProd) {
+  // collect stdout and stderr streams from child processes here to avoid interfering with regular jest output
+  const streams = {
+    build: { out: [], err: [] },
+    server: { out: [], err: [] }
+  }
+  // helpers to collect streams
+  const collectStreams = (name, process) => {
+    process.stdout.on('data', (d) => streams[name].out.push(d.toString()))
+    process.stderr.on('data', (d) => streams[name].err.push(d.toString()))
+  }
+  const collectErrorStreams = (name, e) => {
+    e.stdout && streams[name].out.push(e.stdout)
+    e.stderr && streams[name].err.push(e.stderr)
+  }
+
+  // helper to output stream content on error
+  const printStreamsToConsole = async (name) => {
+    const std = streams[name]
+    if (std.out && std.out.length > 0) {
+      console.log(`stdout of ${name}\n${std.out.join('\n')}\n`)
+    }
+    if (std.err && std.err.length > 0) {
+      console.log(`stderr of ${name}\n${std.err.join('\n')}\n`)
+    }
+  }
+
+  // only run `vite build` when needed
+  if (isProd) {
+    try {
+      const buildProcess = execa('vite', ['build'], {
+        preferLocal: true,
+        cwd: root,
+        stdio: 'pipe'
+      })
+      collectStreams('build', buildProcess)
+      await buildProcess
+    } catch (e) {
+      collectErrorStreams('build', e)
+      await printStreamsToConsole('build')
+      throw e
+    }
+  }
+
+  // run `vite --port x` or `vite preview --port x` to start server
+  const serverProcess = execa(
+    'vite',
+    [isProd ? 'preview' : '', '--port', `${port}`],
+    {
+      preferLocal: true,
+      cwd: root,
+      stdio: 'pipe'
+    }
+  )
+  collectStreams('server', serverProcess)
+
+  // close server helper, send SIGTERM followed by SIGKILL if needed, give up after 3sec
+  const close = async () => {
+    if (serverProcess) {
+      let timer
+      const timerPromise = new Promise(
+        (_, reject) =>
+          (timer = setTimeout(() => {
+            reject(`server process still alive after 3s`)
+          }, 3000))
+      )
+
+      serverProcess.kill('SIGTERM', { forceKillAfterTimeout: 2000 })
+
+      try {
+        await Promise.race([serverProcess, timerPromise]).finally(() => {
+          clearTimeout(timer)
+        })
+      } catch (e) {
+        if (!e.killed) {
+          collectErrorStreams('server', e)
+          console.error('failed to end vite cli process', e)
+          await printStreamsToConsole('server')
+        }
+      }
+    }
+  }
+
+  try {
+    await startedOnPort(serverProcess, port, 3000)
+    return {
+      close
+    }
+  } catch (e) {
+    console.error('failed to start server', e)
+    try {
+      await close()
+    } catch (e1) {
+      console.error('failed to close server process', e1)
+    }
+  }
+}
+
+// helper to validate that server was started on the correct port
+async function startedOnPort(serverProcess, port, timeout) {
+  let id
+  let checkPort
+  const timerPromise = new Promise(
+    (_, reject) =>
+      (id = setTimeout(() => {
+        reject(`timeout for server start after ${timeout}`)
+      }, timeout))
+  )
+  const startedPromise = new Promise((resolve, reject) => {
+    checkPort = (data) => {
+      const str = data.toString()
+      // hack, console output may contain color code gibberish
+      // skip gibberish between localhost: and port number
+      const match = str.match(/(http:\/\/localhost:)(?:.*)(\d{4})/)
+      if (match) {
+        const startedPort = parseInt(match[2], 10)
+        if (startedPort === port) {
+          resolve()
+        } else {
+          const msg = `test server started on ${startedPort} instead of ${port}`
+          console.log(msg)
+          reject(msg)
+        }
+      }
+    }
+
+    serverProcess.stdout.on('data', checkPort)
+  })
+
+  return Promise.race([timerPromise, startedPromise]).finally(() => {
+    serverProcess.stdout.off('data', checkPort)
+    clearTimeout(id)
+  })
+}

--- a/packages/playground/cli/index.html
+++ b/packages/playground/cli/index.html
@@ -1,0 +1,3 @@
+<script type="module" src="./index.js"></script>
+
+<div class="app">vite cli works!</div>

--- a/packages/playground/cli/index.js
+++ b/packages/playground/cli/index.js
@@ -1,0 +1,1 @@
+console.log('vite cli works!')

--- a/packages/playground/cli/package.json
+++ b/packages/playground/cli/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-cli",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "serve": "vite preview"
+  }
+}

--- a/packages/playground/cli/vite.config.js
+++ b/packages/playground/cli/vite.config.js
@@ -1,0 +1,9 @@
+const { defineConfig } = require('vite')
+
+module.exports = defineConfig({
+  build: {
+    //speed up build
+    minify: false,
+    target: 'esnext'
+  }
+})

--- a/packages/playground/cli/vite.config.js
+++ b/packages/playground/cli/vite.config.js
@@ -1,6 +1,9 @@
 const { defineConfig } = require('vite')
 
 module.exports = defineConfig({
+  server: {
+    host: 'localhost'
+  },
   build: {
     //speed up build
     minify: false,

--- a/packages/playground/css/postcss-caching/css.spec.ts
+++ b/packages/playground/css/postcss-caching/css.spec.ts
@@ -4,26 +4,51 @@ import path from 'path'
 
 test('postcss config', async () => {
   const port = 5005
+  const startServer = async (root) => {
+    const server = await createServer({
+      root,
+      logLevel: 'silent',
+      server: {
+        port,
+        strictPort: true
+      },
+      build: {
+        // skip transpilation during tests to make it faster
+        target: 'esnext'
+      }
+    })
+    await server.listen()
+    return server
+  }
   const blueAppDir = path.join(__dirname, 'blue-app')
   const greenAppDir = path.join(__dirname, 'green-app')
+  let blueApp
+  let greenApp
+  try {
+    blueApp = await startServer(blueAppDir)
 
-  process.chdir(blueAppDir)
-  const blueApp = await createServer()
-  await blueApp.listen(port)
-  await page.goto(`http://localhost:${port}`)
-  const blueA = await page.$('.postcss-a')
-  expect(await getColor(blueA)).toBe('blue')
-  const blueB = await page.$('.postcss-b')
-  expect(await getColor(blueB)).toBe('black')
-  await blueApp.close()
+    await page.goto(`http://localhost:${port}`)
+    const blueA = await page.$('.postcss-a')
+    expect(await getColor(blueA)).toBe('blue')
+    const blueB = await page.$('.postcss-b')
+    expect(await getColor(blueB)).toBe('black')
+    await blueApp.close()
+    blueApp = null
 
-  process.chdir(greenAppDir)
-  const greenApp = await createServer()
-  await greenApp.listen(port)
-  await page.goto(`http://localhost:${port}`)
-  const greenA = await page.$('.postcss-a')
-  expect(await getColor(greenA)).toBe('black')
-  const greenB = await page.$('.postcss-b')
-  expect(await getColor(greenB)).toBe('green')
-  await greenApp.close()
+    greenApp = await startServer(greenAppDir)
+    await page.goto(`http://localhost:${port}`)
+    const greenA = await page.$('.postcss-a')
+    expect(await getColor(greenA)).toBe('black')
+    const greenB = await page.$('.postcss-b')
+    expect(await getColor(greenB)).toBe('green')
+    await greenApp.close()
+    greenApp = null
+  } finally {
+    if (blueApp) {
+      await blueApp.close()
+    }
+    if (greenApp) {
+      await greenApp.close()
+    }
+  }
 })

--- a/packages/playground/testUtils.ts
+++ b/packages/playground/testUtils.ts
@@ -17,6 +17,7 @@ export const isBuild = !!process.env.VITE_TEST_BUILD
 const testPath = expect.getState().testPath
 const testName = slash(testPath).match(/playground\/([\w-]+)\//)?.[1]
 export const testDir = path.resolve(__dirname, '../../packages/temp', testName)
+export const workspaceRoot = path.resolve(__dirname, '../../')
 
 const hexToNameMap: Record<string, string> = {}
 Object.keys(colors).forEach((color) => {

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -106,19 +106,16 @@ cli
         throw new Error('HTTP server not available')
       }
 
+      await server.listen()
+
       printHttpServerUrls(server.httpServer, server.config, options)
 
       // @ts-ignore
       if (global.__vite_start_time) {
-        info(
-          chalk.cyan(
-            // @ts-ignore
-            performance.now() - global.__vite_start_time
-          )
-        )
+        // @ts-ignore
+        const startupDuration = performance.now() - global.__vite_start_time
+        info(`\n  ${chalk.cyan(`ready in ${Math.ceil(startupDuration)}ms.`)}\n`)
       }
-
-      await server.listen()
     } catch (e) {
       createLogger(options.logLevel).error(
         chalk.red(`error when starting dev server:\n${e.stack}`),

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -160,7 +160,7 @@ export function printHttpServerUrls(
   }
 }
 
-export function printServerUrls(
+function printServerUrls(
   hostname: Hostname,
   protocol: string,
   port: number,

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -176,7 +176,7 @@ export function printServerUrls(
   } else {
     Object.values(os.networkInterfaces())
       .flatMap((nInterface) => nInterface ?? [])
-      .filter((detail) => detail.family === 'IPv4')
+      .filter((detail) => detail && detail.address && detail.family === 'IPv4')
       .map((detail) => {
         const type = detail.address.includes('127.0.0.1')
           ? 'Local:   '

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
     dependencies:
       tailwindcss: 2.2.15_ts-node@10.2.1
 
+  packages/playground/cli:
+    specifiers: {}
+
   packages/playground/css:
     specifiers:
       css-dep: link:./css-dep


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

today vite-2.6.0-beta.1 release broke cli  on node < 16 and it went unnoticed because the current tests never use the cli

This PR adds a new cli playground that uses a custom `serve.js` implementation that runs `vite`, `vite build` and `vite preview` in a subprocess.

The tests themsselves are very basic, just checking that the page comes up with expected content. No tests for arguments or anything. 

### Additional context

killing of the subprocess is a pain, in vite-plugin-svelte i used tree-kill for that because there's another indirection. Here it relies on execa's kill.
There are relatively short timeouts on process handling to avoid running out of the 10s jest limit, hopefully this works on CI too, otherwise it might need a larger timeout.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
