### PR TITLE
fix: normalize away `base` in imported URLs

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -312,7 +312,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             str().prepend(importsString)
             str().overwrite(expStart, endIndex, exp)
             imports.forEach((url) => {
-              importedUrls.add(url.replace(base, '/'))
+              url = url.replace(base, '/')
+              importedUrls.add(url)
               if (isEager) staticImportedUrls.add(url)
             })
             if (!(importerModule.file! in server._globImporters)) {
@@ -411,10 +412,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           // record for HMR import chain analysis
           // make sure to normalize away base
-          importedUrls.add(url.replace(base, '/'))
+          const urlWithoutBase = url.replace(base, '/')
+          importedUrls.add(urlWithoutBase)
           if (!isDynamicImport) {
             // for pre-transforming
-            staticImportedUrls.add(url)
+            staticImportedUrls.add(urlWithoutBase)
           }
         } else if (!importer.startsWith(clientDir) && !ssr) {
           // check @vite-ignore which suppresses dynamic import warning

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -312,7 +312,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             str().prepend(importsString)
             str().overwrite(expStart, endIndex, exp)
             imports.forEach((url) => {
-              importedUrls.add(url)
+              importedUrls.add(url.replace(base, '/'))
               if (isEager) staticImportedUrls.add(url)
             })
             if (!(importerModule.file! in server._globImporters)) {
@@ -411,7 +411,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           // record for HMR import chain analysis
           // make sure to normalize away base
-          importedUrls.add(url)
+          importedUrls.add(url.replace(base, '/'))
           if (!isDynamicImport) {
             // for pre-transforming
             staticImportedUrls.add(url)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes hot-reloading issues reported in https://github.com/vitejs/vite/issues/5063.

This code was removed in https://github.com/vitejs/vite/pull/5037/files, presumably by accident, but perhaps on purpose.

### Additional context

I'm not familiar enough with `importAnalysis` to figure out whether this is also needed for `staticImportedUrls`.

I'm also not sure how to test this, so someone else feel free to take over :)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
