### PR TITLE
fix: should load `--config foo.mjs` as an ES module

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -772,6 +772,10 @@ export async function loadConfigFromFile(
     // explicit config path is always resolved from cwd
     resolvedPath = path.resolve(configFile)
     isTS = configFile.endsWith('.ts')
+
+    if (configFile.endsWith('.mjs')) {
+      isMjs = true
+    }
   } else {
     // implicit config file loaded from inline root (if present)
     // otherwise from cwd


### PR DESCRIPTION
### Description

This PR fixes the following bug:
When a user names their config file as `vite.config.mjs`, running `vite` directly can correctly load the file as an ES module, but `vite --config vite.config.mjs` would try to transpile that file to CJS first.

This bug was first mentioned at https://github.com/vitejs/vite/issues/4455#issuecomment-890493729

### Additional context

I didn't find any existing tests for config file loading, so I didn't add one for this issue either.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
