### PR TITLE
fix: use the same `target` for optimized dependencies and source files

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -294,6 +294,7 @@ export async function optimizeDeps(
     entryPoints: Object.keys(flatIdDeps),
     bundle: true,
     format: 'esm',
+    target: config.build.target || undefined,
     external: config.optimizeDeps?.exclude,
     logLevel: 'error',
     splitting: true,


### PR DESCRIPTION
fixes #4897

### Description

It's the same as in https://github.com/vitejs/vite/blob/5d2c50ad229fc8a9e20171ab17053ea525018e71/packages/vite/src/node/plugins/esbuild.ts#L230

As the default target is `modules`, optimizing dependencies no longer introduces the unicode export syntax, therefore the bug can be circumvented.

### Additional context

I would love to add tests but I haven't figured out how to set up a minimal reproduction in vite 😂

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
