### PR TITLE
fix: Allow custom asset URL origin in development

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -575,6 +575,19 @@ createServer()
   })
   ```
 
+### server.origin
+
+- **Type:** `string`
+
+Defines the origin of the generated asset URLs during development.
+
+```js
+export default defineConfig({
+  server: {
+    origin: 'http://127.0.0.1:8080/'
+  }
+})
+
 ## Build Options
 
 ### build.target

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -176,7 +176,8 @@ function fileToDevUrl(id: string, config: ResolvedConfig) {
     // (this is special handled by the serve static middleware
     rtn = path.posix.join(FS_PREFIX + id)
   }
-  return config.base + rtn.replace(/^\//, '')
+  const origin = config.server?.origin ?? ''
+  return origin + config.base + rtn.replace(/^\//, '')
 }
 
 export function getAssetFilename(

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -130,6 +130,10 @@ export interface ServerOptions {
    * Options for files served via '/\@fs/'.
    */
   fs?: FileSystemServeOptions
+  /**
+   * Origin for the generated asset URLs.
+   */
+  origin?: string
 }
 
 export interface ResolvedServerOptions extends ServerOptions {


### PR DESCRIPTION
### Description

This PR fixes the issue where, with a custom back-end, the URLs of the assets during development were stripped of their origin, resulting in 404s because the app URL is different than Vite's dev server URL.

https://github.com/vitejs/vite/pull/4337#issuecomment-923982546
> To sum up the issue: 
> - A page is loaded at `http://custom-url.test`
> - This page loads an asset, `image.png`
> - In development, this asset's path is stripped from its origin by Vite, resulting in `http://custom-url.test/image.png` instead of `http://localhost:3000/image.png`
>
> This implementation solves the issue by allowing us to define an origin (`server.publicPath`), so the > resulting generated asset URL will be the right one. 
>
> The build part was working as expected already, this implementation only changes the development one, so this is what we needed.

### Additional context

This is a fork of @2359634711's fix with the review taken into account. 

This PR:
- Closes https://github.com/vitejs/vite/pull/4337
- Fixes https://github.com/vitejs/vite/issues/3070
- Fixes https://github.com/vitejs/vite/issues/3646
- Fixes https://github.com/vitejs/vite/issues/1539
- Fixes https://github.com/vitejs/vite/issues/4942
- Fixes https://github.com/vitejs/vite/issues/2394
- Fixes https://github.com/vitejs/vite/issues/2714

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
