### PR TITLE
fix: add typescript as valid lang tag

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -230,8 +230,13 @@ function esbuildScanPlugin(
             ) {
               continue
             }
-            if (lang === 'ts' || lang === 'tsx' || lang === 'jsx') {
-              loader = lang
+            if (
+              lang === 'ts' ||
+              lang === 'typescript' ||
+              lang === 'tsx' ||
+              lang === 'jsx'
+            ) {
+              loader = lang === 'typescript' ? 'ts' : lang;
             }
             if (srcMatch) {
               const src = srcMatch[1] || srcMatch[2] || srcMatch[3]


### PR DESCRIPTION
### Description

Treat lang="typescript" the same as lang="ts" as the former is valid for Svelte to signal that the script tag contains TS

### Additional context

If benefitial for the greater ecosystem, I'm okay with this PR getting rejected as "won't do" and instead persuade people into doing `lang="ts"` . Right now everyone who transitions to Vite will need to adhere to it, so we could use that as a way to force people to only write `lang="ts"` from now on. 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
