### PR TITLE
fix: don't overwrite default options unless given new value

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -234,16 +234,6 @@ export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
     cssCodeSplit: !raw?.lib,
     sourcemap: false,
     rollupOptions: {},
-    commonjsOptions: {
-      include: [/node_modules/],
-      extensions: ['.js', '.cjs'],
-      ...raw?.commonjsOptions
-    },
-    dynamicImportVarsOptions: {
-      warnOnError: true,
-      exclude: [/node_modules/],
-      ...raw?.dynamicImportVarsOptions
-    },
     minify: raw?.ssr ? false : 'esbuild',
     terserOptions: {},
     write: true,
@@ -256,7 +246,17 @@ export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
     // brotliSize: true,
     chunkSizeWarningLimit: 500,
     watch: null,
-    ...raw
+    ...raw,
+    commonjsOptions: {
+      include: [/node_modules/],
+      extensions: ['.js', '.cjs'],
+      ...raw?.commonjsOptions
+    },
+    dynamicImportVarsOptions: {
+      warnOnError: true,
+      exclude: [/node_modules/],
+      ...raw?.dynamicImportVarsOptions
+    }
   }
 
   // handle special build targets


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If you set a single option in `commonjsOptions` or `dynamicImportVarsOptions` then the defaults for those options (e.g. `commonjsOptions: { include: [/node_modules/], extensions: ['.js', '.cjs']}` will get overridden on line 259. I'm guessing that's not intended or else lines 240 & 245 could simply be removed

### Additional context

I was investigating an issue that turned out to be an [issue in `@rollup/plugin-commonjs`](https://github.com/rollup/plugins/issues/1004) and was reading the code here when I stumbled across this

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.