### PR TITLE
fix: use global location for import.meta.url rewrite (fix #5087)

### DIFF
--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -46,13 +46,14 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             if (templateLiteral.expressions.length) {
               const pattern = buildGlobPattern(templateLiteral)
               // Note: native import.meta.url is not supported in the baseline
-              // target so we use window.location here -
+              // target so we use the global location here. It can be
+              // window.location or self.location in case it is used in a Web Worker.
               s.overwrite(
                 index,
                 index + exp.length,
                 `new URL(import.meta.globEagerDefault(${JSON.stringify(
                   pattern
-                )})[${rawUrl}], window.location)`
+                )})[${rawUrl}], location)`
               )
               continue
             }
@@ -64,7 +65,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           s.overwrite(
             index,
             index + exp.length,
-            `new URL(${JSON.stringify(builtUrl)}, window.location)`
+            `new URL(${JSON.stringify(builtUrl)}, location)`
           )
         }
         if (s) {

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -48,12 +48,13 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               // Note: native import.meta.url is not supported in the baseline
               // target so we use the global location here. It can be
               // window.location or self.location in case it is used in a Web Worker.
+              // @see https://developer.mozilla.org/en-US/docs/Web/API/Window/self
               s.overwrite(
                 index,
                 index + exp.length,
                 `new URL(import.meta.globEagerDefault(${JSON.stringify(
                   pattern
-                )})[${rawUrl}], location)`
+                )})[${rawUrl}], self.location)`
               )
               continue
             }
@@ -65,7 +66,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           s.overwrite(
             index,
             index + exp.length,
-            `new URL(${JSON.stringify(builtUrl)}, location)`
+            `new URL(${JSON.stringify(builtUrl)}, self.location)`
           )
         }
         if (s) {


### PR DESCRIPTION
Rewriting `import.meta.url`with `window.location` doesn't work in a Web Worker. So I replaced it by just `location` so that is uses the global var whether your are in the main thread or in a worker, which doesn't have access to `window`.

closes #5087 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
