### PR TITLE
feat: add `build.cssTarget` option

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -643,6 +643,17 @@ createServer()
 
   If disabled, all CSS in the entire project will be extracted into a single CSS file.
 
+### build.cssMinifyTarget
+
+- **Type:** `string | string[]`
+- **Default:** the same as [`build.target`](/config/#build-target)
+
+  This options allows users to set a different browser target for CSS minification from the one used for JavaScript transpilation.
+
+  It should only be used when you are targeting a non-mainstream browser.
+  One example is Android WeChat WebView, which supports most modern JavaScript features but not the [`#RGBA` hexadecimal color notation in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb_colors).
+  In this case, you need to set `build.cssMinifyTarget` to `chrome61` to prevent vite from transform `rgba()` colors into `#RGBA` hexadecimal notations.
+
 ### build.sourcemap
 
 - **Type:** `boolean | 'inline' | 'hidden'`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -643,7 +643,7 @@ createServer()
 
   If disabled, all CSS in the entire project will be extracted into a single CSS file.
 
-### build.cssMinifyTarget
+### build.cssTarget
 
 - **Type:** `string | string[]`
 - **Default:** the same as [`build.target`](/config/#build-target)
@@ -652,7 +652,7 @@ createServer()
 
   It should only be used when you are targeting a non-mainstream browser.
   One example is Android WeChat WebView, which supports most modern JavaScript features but not the [`#RGBA` hexadecimal color notation in CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb_colors).
-  In this case, you need to set `build.cssMinifyTarget` to `chrome61` to prevent vite from transform `rgba()` colors into `#RGBA` hexadecimal notations.
+  In this case, you need to set `build.cssTarget` to `chrome61` to prevent vite from transform `rgba()` colors into `#RGBA` hexadecimal notations.
 
 ### build.sourcemap
 

--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -338,3 +338,14 @@ test('inlined', async () => {
   // should not insert css
   expect(await getColor('.inlined')).toBe('black')
 })
+
+test('minify css', async () => {
+  if (!isBuild) {
+    return
+  }
+
+  // should keep the rgba() syntax
+  const cssFile = findAssetFile(/index\.\w+\.css$/)
+  expect(cssFile).toMatch('rgba(')
+  expect(cssFile).not.toMatch('#ffff00b3')
+})

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -1,3 +1,5 @@
+import './minify.css'
+
 import css from './imported.css'
 text('.imported-css', css)
 

--- a/packages/playground/css/minify.css
+++ b/packages/playground/css/minify.css
@@ -1,0 +1,3 @@
+.test-minify {
+  color: rgba(255, 255, 0, 0.7);
+}

--- a/packages/playground/css/vite.config.js
+++ b/packages/playground/css/vite.config.js
@@ -3,6 +3,9 @@ const path = require('path')
  * @type {import('vite').UserConfig}
  */
 module.exports = {
+  build: {
+    cssMinifyTarget: 'chrome61'
+  },
   resolve: {
     alias: {
       '@': __dirname

--- a/packages/playground/css/vite.config.js
+++ b/packages/playground/css/vite.config.js
@@ -4,7 +4,7 @@ const path = require('path')
  */
 module.exports = {
   build: {
-    cssMinifyTarget: 'chrome61'
+    cssTarget: 'chrome61'
   },
   resolve: {
     alias: {

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -86,6 +86,15 @@ function viteLegacyPlugin(options = {}) {
       if (!config.build) {
         config.build = {}
       }
+
+      if (!config.build.cssMinifyTarget) {
+        // Hint for esbuild that we are targeting legacy browsers when minifying CSS.
+        // Full CSS compat table available at https://github.com/evanw/esbuild/blob/78e04680228cf989bdd7d471e02bbc2c8d345dc9/internal/compat/css_table.go
+        // But note that only the `HexRGBA` feature affects the minify outcome.
+        // HSL & rebeccapurple values will be minified away regardless the target.
+        // So targeting `chrome61` suffices to fix the compatiblity issue.
+        config.build.cssMinifyTarget = 'chrome61'
+      }
     }
   }
 
@@ -125,7 +134,7 @@ function viteLegacyPlugin(options = {}) {
           bundle,
           facadeToModernPolyfillMap,
           config.build,
-          options.externalSystemJS,
+          options.externalSystemJS
         )
         return
       }
@@ -156,7 +165,7 @@ function viteLegacyPlugin(options = {}) {
           // force using terser for legacy polyfill minification, since esbuild
           // isn't legacy-safe
           config.build,
-          options.externalSystemJS,
+          options.externalSystemJS
         )
       }
     }

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -87,13 +87,13 @@ function viteLegacyPlugin(options = {}) {
         config.build = {}
       }
 
-      if (!config.build.cssMinifyTarget) {
+      if (!config.build.cssTarget) {
         // Hint for esbuild that we are targeting legacy browsers when minifying CSS.
         // Full CSS compat table available at https://github.com/evanw/esbuild/blob/78e04680228cf989bdd7d471e02bbc2c8d345dc9/internal/compat/css_table.go
         // But note that only the `HexRGBA` feature affects the minify outcome.
         // HSL & rebeccapurple values will be minified away regardless the target.
         // So targeting `chrome61` suffices to fix the compatiblity issue.
-        config.build.cssMinifyTarget = 'chrome61'
+        config.build.cssTarget = 'chrome61'
       }
     }
   }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -103,6 +103,15 @@ export interface BuildOptions {
    */
   cssCodeSplit?: boolean
   /**
+   * An optional separate target for CSS minification.
+   * As esbuild only supports configuring targets to mainstream
+   * browsers, users may need this option when they are targeting
+   * a niche browser that comes with most modern JavaScript features
+   * but has poor CSS support, e.g. Android WeChat WebView, which
+   * doesn't support the #RGBA syntax.
+   */
+  cssMinifyTarget?: TransformOptions['target'] | false
+  /**
    * If `true`, a separate sourcemap file will be created. If 'inline', the
    * sourcemap will be appended to the resulting output file as data URI.
    * 'hidden' works like `true` except that the corresponding sourcemap
@@ -232,6 +241,7 @@ export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
     assetsDir: 'assets',
     assetsInlineLimit: 4096,
     cssCodeSplit: !raw?.lib,
+    cssMinifyTarget: false,
     sourcemap: false,
     rollupOptions: {},
     commonjsOptions: {
@@ -273,6 +283,10 @@ export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
   } else if (resolved.target === 'esnext' && resolved.minify === 'terser') {
     // esnext + terser: limit to es2019 so it can be minified by terser
     resolved.target = 'es2019'
+  }
+
+  if (!resolved.cssMinifyTarget) {
+    resolved.cssMinifyTarget = resolved.target
   }
 
   // normalize false string into actual false

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -110,7 +110,7 @@ export interface BuildOptions {
    * but has poor CSS support, e.g. Android WeChat WebView, which
    * doesn't support the #RGBA syntax.
    */
-  cssMinifyTarget?: TransformOptions['target'] | false
+  cssTarget?: TransformOptions['target'] | false
   /**
    * If `true`, a separate sourcemap file will be created. If 'inline', the
    * sourcemap will be appended to the resulting output file as data URI.
@@ -241,7 +241,7 @@ export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
     assetsDir: 'assets',
     assetsInlineLimit: 4096,
     cssCodeSplit: !raw?.lib,
-    cssMinifyTarget: false,
+    cssTarget: false,
     sourcemap: false,
     rollupOptions: {},
     commonjsOptions: {
@@ -285,8 +285,8 @@ export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
     resolved.target = 'es2019'
   }
 
-  if (!resolved.cssMinifyTarget) {
-    resolved.cssMinifyTarget = resolved.target
+  if (!resolved.cssTarget) {
+    resolved.cssTarget = resolved.target
   }
 
   // normalize false string into actual false

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -906,7 +906,7 @@ async function minifyCSS(css: string, config: ResolvedConfig) {
   const { code, warnings } = await transform(css, {
     loader: 'css',
     minify: true,
-    target: config.build.cssMinifyTarget || undefined
+    target: config.build.cssTarget || undefined
   })
   if (warnings.length) {
     const msgs = await formatMessages(warnings, { kind: 'warning' })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -906,7 +906,7 @@ async function minifyCSS(css: string, config: ResolvedConfig) {
   const { code, warnings } = await transform(css, {
     loader: 'css',
     minify: true,
-    target: config.build.target || undefined
+    target: config.build.cssMinifyTarget || undefined
   })
   if (warnings.length) {
     const msgs = await formatMessages(warnings, { kind: 'warning' })


### PR DESCRIPTION
### Description

fixes #4746
fixes #5070
fixes #4930

### Additional context

This option was discussed in previous meetings.
But I mistakenly thought https://github.com/vitejs/vite/pull/4658 had fixed the issue, so I didn't implement it until now.

The original PR made it possible to work around the issue in legacy browsers and projects without dynamic imports.

But in cases like #4746, if users target `chrome61`, `import()` will be transformed by `esbuild` to `require()`, leading to errors.

So we have to add this new option.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
