### PR TITLE
fix: revert change location of server start log messages #5016

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -1,9 +1,8 @@
 import { cac } from 'cac'
 import chalk from 'chalk'
-import { performance } from 'perf_hooks'
 import { BuildOptions } from './build'
 import { ServerOptions } from './server'
-import { createLogger, LogLevel, printHttpServerUrls } from './logger'
+import { createLogger, LogLevel } from './logger'
 import { resolveConfig } from '.'
 import { preview } from './preview'
 
@@ -91,31 +90,7 @@ cli
         clearScreen: options.clearScreen,
         server: cleanOptions(options)
       })
-
-      const info = server.config.logger.info
-
-      info(
-        chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-          chalk.green(` dev server running at:\n`),
-        {
-          clear: !server.config.logger.hasWarned
-        }
-      )
-
-      if (!server.httpServer) {
-        throw new Error('HTTP server not available')
-      }
-
       await server.listen()
-
-      printHttpServerUrls(server.httpServer, server.config, options)
-
-      // @ts-ignore
-      if (global.__vite_start_time) {
-        // @ts-ignore
-        const startupDuration = performance.now() - global.__vite_start_time
-        info(`\n  ${chalk.cyan(`ready in ${Math.ceil(startupDuration)}ms.`)}\n`)
-      }
     } catch (e) {
       createLogger(options.logLevel).error(
         chalk.red(`error when starting dev server:\n${e.stack}`),
@@ -247,9 +222,7 @@ cli
           'serve',
           'production'
         )
-        const server = await preview(config, cleanOptions(options))
-
-        printHttpServerUrls(server, config, options)
+        await preview(config, cleanOptions(options))
       } catch (e) {
         createLogger(options.logLevel).error(
           chalk.red(`error when starting preview server:\n${e.stack}`),

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -1,13 +1,10 @@
 /* eslint no-console: 0 */
 
 import chalk from 'chalk'
-import { AddressInfo, Server } from 'net'
-import os from 'os'
 import readline from 'readline'
+import os from 'os'
 import { RollupError } from 'rollup'
-import { ResolvedConfig } from '.'
-import { ServerOptions } from './server'
-import { Hostname, resolveHostname } from './utils'
+import { Hostname } from './utils'
 
 export type LogType = 'error' | 'warn' | 'info'
 export type LogLevel = LogType | 'silent'
@@ -140,27 +137,7 @@ export function createLogger(
   return logger
 }
 
-export function printHttpServerUrls(
-  server: Server,
-  config: ResolvedConfig,
-  options: ServerOptions
-): void {
-  const address = server.address()
-  const isAddressInfo = (x: any): x is AddressInfo => x.address
-  if (isAddressInfo(address)) {
-    const hostname = resolveHostname(options.host)
-    const protocol = config.server.https ? 'https' : 'http'
-    printServerUrls(
-      hostname,
-      protocol,
-      address.port,
-      config.base,
-      config.logger.info
-    )
-  }
-}
-
-function printServerUrls(
+export function printServerUrls(
   hostname: Hostname,
   protocol: string,
   port: number,

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,8 +1,8 @@
 import path from 'path'
 import sirv from 'sirv'
+import chalk from 'chalk'
 import connect from 'connect'
 import compression from 'compression'
-import { Server } from 'http'
 import { ResolvedConfig, ServerOptions } from '.'
 import { Connect } from 'types/connect'
 import {
@@ -13,6 +13,7 @@ import {
 import { openBrowser } from './server/openBrowser'
 import corsMiddleware from 'cors'
 import { proxyMiddleware } from './server/middlewares/proxy'
+import { printServerUrls } from './logger'
 import { resolveHostname } from './utils'
 
 /**
@@ -24,7 +25,7 @@ import { resolveHostname } from './utils'
 export async function preview(
   config: ResolvedConfig,
   serverOptions: Pick<ServerOptions, 'port' | 'host'>
-): Promise<Server> {
+): Promise<void> {
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.server,
@@ -69,6 +70,13 @@ export async function preview(
     logger
   })
 
+  logger.info(
+    chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
+      chalk.green(` build preview server running at:\n`)
+  )
+
+  printServerUrls(hostname, protocol, serverPort, base, logger.info)
+
   if (options.open) {
     const path = typeof options.open === 'string' ? options.open : base
     openBrowser(
@@ -79,6 +87,4 @@ export async function preview(
       logger
     )
   }
-
-  return httpServer
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -52,9 +52,11 @@ import {
   ssrRewriteStacktrace
 } from '../ssr/ssrStacktrace'
 import { createMissingImporterRegisterFn } from '../optimizer/registerMissing'
+import { printServerUrls } from '../logger'
 import { resolveHostname } from '../utils'
 import { searchForWorkspaceRoot } from './searchRoot'
 import { CLIENT_DIR } from '../constants'
+import { performance } from 'perf_hooks'
 
 export { searchForWorkspaceRoot } from './searchRoot'
 
@@ -600,6 +602,28 @@ async function startServer(
     host: hostname.host,
     logger: server.config.logger
   })
+
+  info(
+    chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
+      chalk.green(` dev server running at:\n`),
+    {
+      clear: !server.config.logger.hasWarned
+    }
+  )
+
+  printServerUrls(hostname, protocol, serverPort, base, info)
+
+  // @ts-ignore
+  if (global.__vite_start_time) {
+    info(
+      chalk.cyan(
+        `\n  ready in ${Math.round(
+          // @ts-ignore
+          performance.now() - global.__vite_start_time
+        )}ms.\n`
+      )
+    )
+  }
 
   // @ts-ignore
   const profileSession = global.__vite_profile_session


### PR DESCRIPTION
### Description

Revert #5016 

@bluwy reported in Vite Land that #5016 caused logs to be reorder in some cases
```
vite v2.6.0 dev server running at:

Pre-bundling dependencies:
  immer
  svelte/store
  @fortawesome/free-solid-svg-icons
  svelte/transition
  svelte/animate
  (...and 10 more)
(this will be run only when your dependencies or config have changed)
  > Local: http://localhost:3000/
  > Network: use `--host` to expose

  ready in 1477ms.
```

This PR reverts this change, @benmccann was proposing other options to avoid the messages inside `server.listen()`. We can discuss them in other PRs.
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other