### PR TITLE
fix(cli): reorder dev server message

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -92,6 +92,12 @@ cli
         server: cleanOptions(options)
       })
 
+      if (!server.httpServer) {
+        throw new Error('HTTP server not available')
+      }
+
+      await server.listen()
+
       const info = server.config.logger.info
 
       info(
@@ -101,12 +107,6 @@ cli
           clear: !server.config.logger.hasWarned
         }
       )
-
-      if (!server.httpServer) {
-        throw new Error('HTTP server not available')
-      }
-
-      await server.listen()
 
       printHttpServerUrls(server.httpServer, server.config, options)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently, the dev server logs the status like this:

```
  vite v2.6.0 dev server running at:

Pre-bundling dependencies:
  immer
  svelte/store
  @fortawesome/free-solid-svg-icons
  svelte/transition
  svelte/animate
  (...and 10 more)
(this will be run only when your dependencies or config have changed)
  > Local: http://localhost:3000/
  > Network: use `--host` to expose

  ready in 1477ms.
```

This PR moves the prebundling message above the "vite dev server starting at" message.

This also indirectly fixed a strange quirk in the cli playground where it logged the server `ready in 1632938015056.5159ms.`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

- Initially reported on Discord.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
