### PR TITLE
fix: properly handle postfix for getRealPath

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -382,7 +382,7 @@ function tryResolveFile(
   } catch (e) {}
   if (isReadable) {
     if (!fs.statSync(file).isDirectory()) {
-      return normalizePath(ensureVolumeInPath(file)) + postfix
+      return getRealPath(file, preserveSymlinks) + postfix
     } else if (tryIndex) {
       if (!skipPackageJson) {
         const pkgPath = file + '/package.json'
@@ -396,7 +396,7 @@ function tryResolveFile(
             targetWeb,
             preserveSymlinks
           )
-          return resolved ? getRealPath(resolved, preserveSymlinks) : resolved
+          return resolved
         }
       }
       const index = tryFsResolve(file + '/index', options, preserveSymlinks)
@@ -478,8 +478,6 @@ export function tryNodeResolve(
   if (!resolved) {
     return
   }
-
-  resolved = getRealPath(resolved, preserveSymlinks)
 
   // link id to pkg for browser field mapping check
   idToPkgMap.set(resolved, pkg)
@@ -919,8 +917,9 @@ function equalWithoutSuffix(path: string, key: string, suffix: string) {
 }
 
 function getRealPath(resolved: string, preserveSymlinks?: boolean): string {
+  resolved = ensureVolumeInPath(resolved)
   if (!preserveSymlinks && browserExternalId !== resolved) {
-    return normalizePath(fs.realpathSync(resolved))
+    resolved = fs.realpathSync(resolved)
   }
-  return resolved
+  return normalizePath(resolved)
 }


### PR DESCRIPTION
### Description

#4708 introduced a regression in 2.6, `getRealPath` was being called to resolve file+postfix, instead of only the file. This PR moves that call when resolving the file (it also refactor the function to avoid calling normalizePath twice)

Fixes #5053, #5146, #5148
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other