### PR TITLE
fix(plugin-vue): don't use object spread in the config hook

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -118,8 +118,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
       return {
         define: {
           __VUE_OPTIONS_API__: true,
-          __VUE_PROD_DEVTOOLS__: false,
-          ...config.define
+          __VUE_PROD_DEVTOOLS__: false
         },
         ssr: {
           external: ['vue', '@vue/server-renderer']


### PR DESCRIPTION
### Description

The config object will be merged recursively in vite core, so object
spread shouldn't be used:
https://github.com/vitejs/vite/blob/5cf4e69cd3afc7f960e02072171c7c441747e8f0/packages/vite/src/node/config.ts#L308

Otherwise, it would cause an array field to be concatenated with itself.

Fixes #5150

### Additional context

I didn't add a test for that issue, because it's not a use case that we intended to support. The documentation clearly stated that the `define` field is of type `Record<string, string>`.

But it's a good programming practice to remove the unnecessary object spread anyway.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
