### PR TITLE
chore: improve html plugin name

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -500,9 +500,9 @@ export type IndexHtmlTransformHook = (
 export type IndexHtmlTransform =
   | IndexHtmlTransformHook
   | {
-    enforce?: 'pre' | 'post'
-    transform: IndexHtmlTransformHook
-  }
+      enforce?: 'pre' | 'post'
+      transform: IndexHtmlTransformHook
+    }
 
 export function resolveHtmlTransforms(
   plugins: readonly Plugin[]

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -273,8 +273,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             const url =
               attr.name === 'srcset'
                 ? await processSrcSet(value.content, ({ url }) =>
-                  urlToBuiltUrl(url, id, config, this)
-                )
+                    urlToBuiltUrl(url, id, config, this)
+                  )
                 : await urlToBuiltUrl(value.content, id, config, this)
 
             s.overwrite(

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -473,9 +473,9 @@ export type IndexHtmlTransformResult =
   | string
   | HtmlTagDescriptor[]
   | {
-    html: string
-    tags: HtmlTagDescriptor[]
-  }
+      html: string
+      tags: HtmlTagDescriptor[]
+    }
 
 export interface IndexHtmlTransformContext {
   /**

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -37,7 +37,7 @@ const scriptModuleRE =
 
 export function htmlInlineScriptProxyPlugin(): Plugin {
   return {
-    name: 'vite:html',
+    name: 'vite:html-inline-script-proxy',
 
     resolveId(id) {
       if (htmlProxyRE.test(id)) {
@@ -273,8 +273,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             const url =
               attr.name === 'srcset'
                 ? await processSrcSet(value.content, ({ url }) =>
-                    urlToBuiltUrl(url, id, config, this)
-                  )
+                  urlToBuiltUrl(url, id, config, this)
+                )
                 : await urlToBuiltUrl(value.content, id, config, this)
 
             s.overwrite(
@@ -473,9 +473,9 @@ export type IndexHtmlTransformResult =
   | string
   | HtmlTagDescriptor[]
   | {
-      html: string
-      tags: HtmlTagDescriptor[]
-    }
+    html: string
+    tags: HtmlTagDescriptor[]
+  }
 
 export interface IndexHtmlTransformContext {
   /**
@@ -500,9 +500,9 @@ export type IndexHtmlTransformHook = (
 export type IndexHtmlTransform =
   | IndexHtmlTransformHook
   | {
-      enforce?: 'pre' | 'post'
-      transform: IndexHtmlTransformHook
-    }
+    enforce?: 'pre' | 'post'
+    transform: IndexHtmlTransformHook
+  }
 
 export function resolveHtmlTransforms(
   plugins: readonly Plugin[]


### PR DESCRIPTION
### Description

The `htmlInlineScriptProxyPlugin` is named `vite:html`. This plugin has a clear responsibility, that is to load inline scripts of entry html files as separate modules. I think it would be helpful to rename it accordingly so it shows with a more descriptive name in plugin inspect.

This plugin is fundamental to the way Vite works, so IMO there isn't a chance that someone would depend in its name at this point (for example to remove it). It should be safe to merge even as a patch.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other