### PR TITLE
fix: upgrade to @rollup/plugin-commonjs 21.x

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@ampproject/remapping": "^1.0.1",
     "@rollup/plugin-alias": "^3.1.5",
-    "@rollup/plugin-commonjs": "^20.0.0",
+    "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-dynamic-import-vars": "^1.4.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "13.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -625,7 +625,7 @@ importers:
     specifiers:
       '@ampproject/remapping': ^1.0.1
       '@rollup/plugin-alias': ^3.1.5
-      '@rollup/plugin-commonjs': ^20.0.0
+      '@rollup/plugin-commonjs': ^21.0.0
       '@rollup/plugin-dynamic-import-vars': ^1.4.0
       '@rollup/plugin-json': ^4.1.0
       '@rollup/plugin-node-resolve': 13.0.5
@@ -702,7 +702,7 @@ importers:
     devDependencies:
       '@ampproject/remapping': 1.0.1
       '@rollup/plugin-alias': 3.1.5_rollup@2.57.0
-      '@rollup/plugin-commonjs': 20.0.0_rollup@2.57.0
+      '@rollup/plugin-commonjs': 21.0.0_rollup@2.57.0
       '@rollup/plugin-dynamic-import-vars': 1.4.0_rollup@2.57.0
       '@rollup/plugin-json': 4.1.0_rollup@2.57.0
       '@rollup/plugin-node-resolve': 13.0.5_rollup@2.57.0
@@ -1808,8 +1808,8 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@rollup/plugin-commonjs/20.0.0_rollup@2.57.0:
-    resolution: {integrity: sha512-5K0g5W2Ol8hAcTHqcTBHiA7M58tfmYi1o9KxeJuuRNpGaTa5iLjcyemBitCBcKXaHamOBBEH2dGom6v6Unmqjg==}
+  /@rollup/plugin-commonjs/21.0.0_rollup@2.57.0:
+    resolution: {integrity: sha512-XDQimjHl0kNotAV5lLo34XoygaI0teqiKGJ100B3iCU8+15YscJPeqk2KqkqD3NIe1H8ZTUo5lYjUFZyEgASTw==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
       rollup: ^2.38.3


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`@rollup/plugin-commonjs` would hoist requires out of try/catches leading to failures

### Additional context

This should fix issues like https://github.com/sveltejs/kit/issues/2523. SvelteKit is being upgraded as well in https://github.com/sveltejs/kit/pull/2539

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
