### PR TITLE
fix(dev): read property of undefined

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -144,7 +144,7 @@ export function printHttpServerUrls(
   config: ResolvedConfig
 ): void {
   const address = server.address()
-  const isAddressInfo = (x: any): x is AddressInfo => x.address
+  const isAddressInfo = (x: any): x is AddressInfo => x?.address
   if (isAddressInfo(address)) {
     const hostname = resolveHostname(config.server.host)
     const protocol = config.server.https ? 'https' : 'http'


### PR DESCRIPTION
### Description
https://github.com/vitejs/vite/blob/e8a1d19670c2d28fe06efb8fade89b045bebb7ef/packages/vite/src/node/logger.ts#L146-L148

```typescript
const address: string | AddressInfo | null
```
`isAddressInfo` read `.address` property without checking.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
