### PR TITLE
fix(dev): get full worker url path in dev

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -3,7 +3,7 @@ import { Plugin } from '../plugin'
 import { resolvePlugins } from '../plugins'
 import { parse as parseUrl, URLSearchParams } from 'url'
 import { fileToUrl, getAssetHash } from './asset'
-import { cleanUrl, injectQuery } from '../utils'
+import { cleanUrl, injectQuery, resolveHostname } from '../utils'
 import Rollup from 'rollup'
 import { ENV_PUBLIC_PATH } from '../constants'
 import path from 'path'
@@ -101,6 +101,10 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       } else {
         url = await fileToUrl(cleanUrl(id), config, this)
         url = injectQuery(url, WorkerFileId)
+        // Get full worker url path in dev
+        const protocol = config.server.https ? 'https' : 'http'
+        const hostname = resolveHostname(config.server.host)
+        url = `${protocol}://${hostname.name}:${config.server.port}${url}`
       }
 
       const workerConstructor =


### PR DESCRIPTION
### Description
https://github.com/antfu/vitesse-webext/issues/35#issuecomment-927128399

In some special scenarios that the HTML is running at another page, not localhost (such as `chrome-extension:`), the `Worker` constructor is trying to load files from the current origin and then lead to 404.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
