### PR TITLE
fix: better error message for parse failures

### DIFF
--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -39,6 +39,7 @@ export async function ssrTransform(
       locations: true
     }) as any
   } catch (err) {
+    if (!err.loc) throw err
     const line = err.loc.line
     throw new Error(
       `Parse failure: ${err.message}\nContents of line ${line}: ${

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -31,13 +31,13 @@ export async function ssrTransform(
 ): Promise<TransformResult | null> {
   const s = new MagicString(code)
 
-  let ast
+  let ast: any
   try {
     ast = parser.parse(code, {
       sourceType: 'module',
       ecmaVersion: 'latest',
       locations: true
-    }) as any
+    })
   } catch (err) {
     if (!err.loc || !err.loc.line) throw err
     const line = err.loc.line

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -31,11 +31,16 @@ export async function ssrTransform(
 ): Promise<TransformResult | null> {
   const s = new MagicString(code)
 
-  const ast = parser.parse(code, {
-    sourceType: 'module',
-    ecmaVersion: 'latest',
-    locations: true
-  }) as any
+  let ast
+  try {
+    ast = parser.parse(code, {
+      sourceType: 'module',
+      ecmaVersion: 'latest',
+      locations: true
+    }) as any
+  } catch (err) {
+    throw new Error('Parse failure: ' + err.message + '\n' + code)
+  }
 
   let uid = 0
   const deps = new Set<string>()

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -39,7 +39,12 @@ export async function ssrTransform(
       locations: true
     }) as any
   } catch (err) {
-    throw new Error('Parse failure: ' + err.message + '\n' + code)
+    const line = err.loc.line
+    throw new Error(
+      `Parse failure: ${err.message}\nContents of line ${line}: ${
+        code.split('\n')[line - 1]
+      }`
+    )
   }
 
   let uid = 0

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -39,7 +39,7 @@ export async function ssrTransform(
       locations: true
     }) as any
   } catch (err) {
-    if (!err.loc) throw err
+    if (!err.loc || !err.loc.line) throw err
     const line = err.loc.line
     throw new Error(
       `Parse failure: ${err.message}\nContents of line ${line}: ${


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add enough details to allow diagnosing parse failures. Right now, the error message is just `Unexpected token (6:132)`, but there's no clue as to what file or code that occurs in, so is impossible to debug

### Additional context

I've had a long-running project to covert svelte.dev over to SvelteKit. This is one of the current blocking issues. Improving this error message helped us track the down the root cause as another Vite bug: https://github.com/vitejs/vite/issues/3304
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.