### PR TITLE
fix: avoid scan failures in .svelte and .astro files

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -266,18 +266,14 @@ function esbuildScanPlugin(
           }
 
           // This will trigger incorrectly if `export default` is contained
-          // anywhere in a string/template. Svelte files can't have
-          // 'export default` as code so we know if it's encountered it's a
-          // false positive
-          if (
-            !code.includes('export default') ||
-            path.endsWith('.svelte') ||
-            path.endsWith('.astro')
-          ) {
+          // anywhere in a string. Svelte and Astro files can't have
+          // `export default` as code so we know if it's encountered it's a
+          // false positive (e.g. contained in a string)
+          if (!js.includes('export default') && path.endsWith('.vue')) {
             js += '\nexport default {}'
           }
 
-          if (code.includes('import.meta.glob')) {
+          if (js.includes('import.meta.glob')) {
             return {
               // transformGlob already transforms to js
               loader: 'js',

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -269,7 +269,7 @@ function esbuildScanPlugin(
           // anywhere in a string. Svelte and Astro files can't have
           // `export default` as code so we know if it's encountered it's a
           // false positive (e.g. contained in a string)
-          if (!js.includes('export default') || !path.endsWith('.vue')) {
+          if (!path.endsWith('.vue') || !js.includes('export default')) {
             js += '\nexport default {}'
           }
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -265,8 +265,16 @@ function esbuildScanPlugin(
             }
           }
 
-          if (!code.includes(`export default`)) {
-            js += `\nexport default {}`
+          // This will trigger incorrectly if `export default` is contained
+          // anywhere in a string/template. Svelte files can't have
+          // 'export default` as code so we know if it's encountered it's a
+          // false positive
+          if (
+            !code.includes('export default') ||
+            path.endsWith('.svelte') ||
+            path.endsWith('.astro')
+          ) {
+            js += '\nexport default {}'
           }
 
           if (code.includes('import.meta.glob')) {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -269,7 +269,7 @@ function esbuildScanPlugin(
           // anywhere in a string. Svelte and Astro files can't have
           // `export default` as code so we know if it's encountered it's a
           // false positive (e.g. contained in a string)
-          if (!js.includes('export default') && path.endsWith('.vue')) {
+          if (!js.includes('export default') || !path.endsWith('.vue')) {
             js += '\nexport default {}'
           }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The dev server would crash with a hard-to-diagnose error if `export default` was contained anywhere in a `.svelte` file

The code comment explains the fix pretty well

### Additional context

I hit this while working on conversion of svelte.dev to SvelteKit. Thanks to @bluwy for tracking it down!

This is pretty easy to hit in SvelteKit. The following line will do it:
```
const dev = process.env.NODE_ENV === 'development';
```

`process.env.NODE_ENV` gets replace with "development" causing a failure because there's a sourcemap embedded in the template the double quotes aren't escaped causing an invalid syntax.

I imagine this could easily be triggered in other template types as well though perhaps not quite as often and with less severe effects. E.g. if you said:
```
<div>
  <p>
    This is my blog post talking about how to use process.env.NODE_ENV.
    Except you won't see that text. You'll see: This is my blog post talking about how to use "development"
  </p>
<div>
```
That will probably lead to unexpected results in any templating language

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
