### PR TITLE
fix(plugin-react): turn off jsx for .ts

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -97,7 +97,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
         const parserPlugins: typeof userParserPlugins = [
           ...userParserPlugins,
-          'jsx',
           'importMeta',
           // This plugin is applied before esbuild transforms the code,
           // so we need to enable some stage 3 syntax that is supported in
@@ -107,6 +106,10 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           'classPrivateProperties',
           'classPrivateMethods'
         ]
+
+        if (!id.endsWith('.ts')) {
+          parserPlugins.push('jsx')
+        }
 
         const isTypeScript = /\.tsx?$/.test(id)
         if (isTypeScript) {


### PR DESCRIPTION
### Description

```ts
interface A {
  optional?: string;
}

const a = {};
const b = <A>a;

export { b };
```

This ts code will fail when using plugin-react, because `<A>` is treated as a jsx(tsx) tag.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

fix #5102