### PR TITLE
Esbuild downgrade to 0.12.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vitepress": "^0.19.2",
     "yorkie": "^2.0.0",
     "rollup": "^2.57.0",
-    "esbuild": "^0.12.24",
+    "esbuild": "^0.12.29",
     "vite": "workspace:*"
   },
   "gitHooks": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vitepress": "^0.19.2",
     "yorkie": "^2.0.0",
     "rollup": "^2.57.0",
-    "esbuild": "^0.13.2",
+    "esbuild": "^0.12.24",
     "vite": "workspace:*"
   },
   "gitHooks": {


### PR DESCRIPTION
0.12.29 is much stable than the newer version.

newer version: "failed at the esbuild@0.13.3 postinstall script"

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix esbuild error

![image](https://user-images.githubusercontent.com/44498510/136043595-3f3fdd4b-2ecb-4d81-a794-7470416ed7d6.png)

```
343 silly saveTree +-- vite@2.6.3
343 silly saveTree | +-- esbuild@0.13.3
343 silly saveTree | | +-- esbuild-android-arm64@0.13.3
343 silly saveTree | | +-- esbuild-darwin-64@0.13.3
343 silly saveTree | | +-- esbuild-darwin-arm64@0.13.3
343 silly saveTree | | +-- esbuild-freebsd-64@0.13.3
343 silly saveTree | | +-- esbuild-freebsd-arm64@0.13.3
343 silly saveTree | | +-- esbuild-linux-32@0.13.3
343 silly saveTree | | +-- esbuild-linux-64@0.13.3
343 silly saveTree | | +-- esbuild-linux-arm@0.13.3
343 silly saveTree | | +-- esbuild-linux-arm64@0.13.3
343 silly saveTree | | +-- esbuild-linux-mips64le@0.13.3
343 silly saveTree | | +-- esbuild-linux-ppc64le@0.13.3
343 silly saveTree | | +-- esbuild-openbsd-64@0.13.3
343 silly saveTree | | +-- esbuild-sunos-64@0.13.3
343 silly saveTree | | +-- esbuild-windows-32@0.13.3
343 silly saveTree | | +-- esbuild-windows-64@0.13.3
343 silly saveTree | | `-- esbuild-windows-arm64@0.13.3
343 silly saveTree | `-- rollup@2.58.0
343 silly saveTree `-- vue@3.2.19
343 silly saveTree   +-- @vue/compiler-dom@3.2.19
343 silly saveTree   | +-- @vue/compiler-core@3.2.19
343 silly saveTree   | | +-- @babel/parser@7.15.7
343 silly saveTree   | | +-- @vue/shared@3.2.19
343 silly saveTree   | | `-- estree-walker@2.0.2
343 silly saveTree   | `-- @vue/shared@3.2.19
343 silly saveTree   +-- @vue/compiler-sfc@3.2.19
343 silly saveTree   | +-- @vue/compiler-ssr@3.2.19
343 silly saveTree   | +-- @vue/ref-transform@3.2.19
343 silly saveTree   | | `-- magic-string@0.25.7
343 silly saveTree   | |   `-- sourcemap-codec@1.4.8
343 silly saveTree   | `-- magic-string@0.25.7
343 silly saveTree   +-- @vue/runtime-dom@3.2.19
343 silly saveTree   | +-- @vue/runtime-core@3.2.19
343 silly saveTree   | | `-- @vue/reactivity@3.2.19
343 silly saveTree   | `-- csstype@2.6.18
343 silly saveTree   +-- @vue/server-renderer@3.2.19
343 silly saveTree   `-- @vue/shared@3.2.19
344 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-darwin-64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-darwin-64):
345 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-darwin-64@0.13.3: wanted {"os":"darwin","arch":"x64"} (current: {"os":"win32","arch":"x64"})
346 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    darwin
346 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  x64
346 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
346 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
347 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-darwin-arm64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-darwin-arm64):
348 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-darwin-arm64@0.13.3: wanted {"os":"darwin","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
349 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    darwin
349 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  arm64
349 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
349 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
350 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-android-arm64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-android-arm64):
351 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-android-arm64@0.13.3: wanted {"os":"android","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
352 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    android
352 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  arm64
352 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
352 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
353 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-freebsd-64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-freebsd-64):
354 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-freebsd-64@0.13.3: wanted {"os":"freebsd","arch":"x64"} (current: {"os":"win32","arch":"x64"})
355 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    freebsd
355 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  x64
355 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
355 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
356 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-freebsd-arm64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-freebsd-arm64):
357 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-freebsd-arm64@0.13.3: wanted {"os":"freebsd","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
358 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    freebsd
358 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  arm64
358 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
358 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
359 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-linux-64):
360 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-64@0.13.3: wanted {"os":"linux","arch":"x64"} (current: {"os":"win32","arch":"x64"})
361 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    linux
361 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  x64
361 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
361 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
362 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-arm64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-linux-arm64):
363 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-arm64@0.13.3: wanted {"os":"linux","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
364 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    linux
364 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  arm64
364 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
364 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
365 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-arm@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-linux-arm):
366 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-arm@0.13.3: wanted {"os":"linux","arch":"arm"} (current: {"os":"win32","arch":"x64"})
367 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    linux
367 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  arm
367 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
367 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
368 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-mips64le@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-linux-mips64le):
369 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-mips64le@0.13.3: wanted {"os":"linux","arch":"mips64el"} (current: {"os":"win32","arch":"x64"})
370 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    linux
370 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  mips64el
370 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
370 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
371 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-32@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-linux-32):
372 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-32@0.13.3: wanted {"os":"linux","arch":"ia32"} (current: {"os":"win32","arch":"x64"})
373 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    linux
373 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  ia32
373 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
373 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
374 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-linux-ppc64le@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-linux-ppc64le):
375 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-linux-ppc64le@0.13.3: wanted {"os":"linux","arch":"ppc64"} (current: {"os":"win32","arch":"x64"})
376 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    linux
376 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  ppc64
376 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
376 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
377 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-sunos-64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-sunos-64):
378 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-sunos-64@0.13.3: wanted {"os":"sunos","arch":"x64"} (current: {"os":"win32","arch":"x64"})
379 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    sunos
379 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  x64
379 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
379 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
380 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-windows-32@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-windows-32):
381 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-windows-32@0.13.3: wanted {"os":"win32","arch":"ia32"} (current: {"os":"win32","arch":"x64"})
382 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    win32
382 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  ia32
382 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
382 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
383 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-windows-arm64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-windows-arm64):
384 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-windows-arm64@0.13.3: wanted {"os":"win32","arch":"arm64"} (current: {"os":"win32","arch":"x64"})
385 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    win32
385 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  arm64
385 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
385 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
386 warn optional SKIPPING OPTIONAL DEPENDENCY: esbuild-openbsd-64@0.13.3 (node_modules\vite\node_modules\esbuild\node_modules\esbuild-openbsd-64):
387 warn notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for esbuild-openbsd-64@0.13.3: wanted {"os":"openbsd","arch":"x64"} (current: {"os":"win32","arch":"x64"})
388 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid OS:    openbsd
388 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Valid Arch:  x64
388 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual OS:   win32
388 verbose notsup SKIPPING OPTIONAL DEPENDENCY: Actual Arch: x64
391 verbose stack Error: esbuild@0.13.3 postinstall: `node install.js`
391 verbose stack Exit status 1
391 verbose stack     at EventEmitter.<anonymous> (C:\nodejs\node_global\node_modules\npm\node_modules\npm-lifecycle\index.js:332:16)
391 verbose stack     at EventEmitter.emit (events.js:314:20)
391 verbose stack     at ChildProcess.<anonymous> (C:\nodejs\node_global\node_modules\npm\node_modules\npm-lifecycle\lib\spawn.js:55:14)
391 verbose stack     at ChildProcess.emit (events.js:314:20)
391 verbose stack     at maybeClose (internal/child_process.js:1022:16)
391 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
392 verbose pkgid esbuild@0.13.3
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

