### PR TITLE
refactor: normalize scripts and commands naming

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -117,7 +117,7 @@ In a project where Vite is installed, you can use the `vite` binary in your npm 
   "scripts": {
     "dev": "vite", // start dev server
     "build": "vite build", // build for production
-    "serve": "vite preview" // locally preview production build
+    "preview": "vite preview" // locally preview production build
   }
 }
 ```

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -10,7 +10,7 @@ The following guides are based on some shared assumptions:
 {
   "scripts": {
     "build": "vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }
 ```

--- a/packages/create-vite/template-preact-ts/package.json
+++ b/packages/create-vite/template-preact-ts/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "preact": "^10.5.13"

--- a/packages/create-vite/template-preact/package.json
+++ b/packages/create-vite/template-preact/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "preact": "^10.5.13"

--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^17.0.0",

--- a/packages/create-vite/template-react/package.json
+++ b/packages/create-vite/template-react/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^17.0.0",

--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {

--- a/packages/create-vite/template-svelte/package.json
+++ b/packages/create-vite/template-svelte/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.11",

--- a/packages/create-vite/template-vanilla-ts/package.json
+++ b/packages/create-vite/template-vanilla-ts/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "typescript": "^4.3.2",

--- a/packages/create-vite/template-vanilla/package.json
+++ b/packages/create-vite/template-vanilla/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "vite": "^2.6.0"

--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.2.16"

--- a/packages/create-vite/template-vue/package.json
+++ b/packages/create-vite/template-vue/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.2.16"

--- a/packages/playground/alias/package.json
+++ b/packages/playground/alias/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.2.16"

--- a/packages/playground/assets/package.json
+++ b/packages/playground/assets/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/backend-integration/package.json
+++ b/packages/playground/backend-integration/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "tailwindcss": "^2.2.4"

--- a/packages/playground/cli/package.json
+++ b/packages/playground/cli/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/css-codesplit-cjs/package.json
+++ b/packages/playground/css-codesplit-cjs/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/css-codesplit/package.json
+++ b/packages/playground/css-codesplit/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/css/package.json
+++ b/packages/playground/css/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "css-dep": "link:./css-dep",

--- a/packages/playground/css/postcss-caching/blue-app/package.json
+++ b/packages/playground/css/postcss-caching/blue-app/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/css/postcss-caching/green-app/package.json
+++ b/packages/playground/css/postcss-caching/green-app/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/data-uri/package.json
+++ b/packages/playground/data-uri/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/define/package.json
+++ b/packages/playground/define/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/dynamic-import/package.json
+++ b/packages/playground/dynamic-import/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/env/package.json
+++ b/packages/playground/env/package.json
@@ -6,7 +6,7 @@
     "dev": "cross-env VITE_INLINE=inline-serve vite",
     "build": "cross-env VITE_INLINE=inline-build vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "cross-env": "^7.0.3"

--- a/packages/playground/extensions/package.json
+++ b/packages/playground/extensions/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.2.16"

--- a/packages/playground/file-delete-restore/package.json
+++ b/packages/playground/file-delete-restore/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^17.0.1",

--- a/packages/playground/fs-serve/package.json
+++ b/packages/playground/fs-serve/package.json
@@ -6,6 +6,6 @@
     "dev": "vite root",
     "build": "vite build root",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/glob-import/package.json
+++ b/packages/playground/glob-import/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/hmr/package.json
+++ b/packages/playground/hmr/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/html/package.json
+++ b/packages/playground/html/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/json/package.json
+++ b/packages/playground/json/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "vue": "^3.2.16"

--- a/packages/playground/legacy/package.json
+++ b/packages/playground/legacy/package.json
@@ -7,7 +7,7 @@
     "build": "vite build --debug legacy",
     "build:custom-filename": "vite --config ./vite.config-custom-filename.js build  --debug legacy",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "devDependencies": {
     "@vitejs/plugin-legacy": "workspace:*"

--- a/packages/playground/lib/package.json
+++ b/packages/playground/lib/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/multiple-entrypoints/package.json
+++ b/packages/playground/multiple-entrypoints/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/nested-deps/package.json
+++ b/packages/playground/nested-deps/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "test-package-a": "link:./test-package-a",

--- a/packages/playground/optimize-deps/package.json
+++ b/packages/playground/optimize-deps/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview",
+    "preview": "vite preview",
     "postinstall": "node ../../../scripts/patchFileDeps"
   },
   "dependencies": {

--- a/packages/playground/preload/package.json
+++ b/packages/playground/preload/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.2.16",

--- a/packages/playground/preserve-symlinks/package.json
+++ b/packages/playground/preserve-symlinks/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite --force",
     "build": "vite build",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@symlinks/moduleA": "link:./moduleA"

--- a/packages/playground/react-emotion/package.json
+++ b/packages/playground/react-emotion/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@emotion/react": "^11.4.0",

--- a/packages/playground/react/package.json
+++ b/packages/playground/react/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^17.0.1",

--- a/packages/playground/resolve/package.json
+++ b/packages/playground/resolve/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "resolve-exports-path": "link:./exports-path",

--- a/packages/playground/tailwind/package.json
+++ b/packages/playground/tailwind/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "autoprefixer": "^10.3.0",

--- a/packages/playground/tsconfig-json-load-error/package.json
+++ b/packages/playground/tsconfig-json-load-error/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/tsconfig-json/package.json
+++ b/packages/playground/tsconfig-json/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/vue-jsx/package.json
+++ b/packages/playground/vue-jsx/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "vue": "^3.2.16"

--- a/packages/playground/vue/package.json
+++ b/packages/playground/vue/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   },
   "dependencies": {
     "lodash-es": "^4.17.20",

--- a/packages/playground/wasm/package.json
+++ b/packages/playground/wasm/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/playground/worker/package.json
+++ b/packages/playground/worker/package.json
@@ -6,6 +6,6 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
-    "serve": "vite preview"
+    "preview": "vite preview"
   }
 }

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -150,7 +150,7 @@ cli
   .option(
     '--minify [minifier]',
     `[boolean | "terser" | "esbuild"] enable/disable minification, ` +
-    `or specify minifier to use (default: esbuild)`
+      `or specify minifier to use (default: esbuild)`
   )
   .option('--manifest', `[boolean] emit build manifest json`)
   .option('--ssrManifest', `[boolean] emit ssr manifest json`)

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -103,7 +103,7 @@ cli
 
       info(
         chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-        chalk.green(` dev server running at:\n`),
+          chalk.green(` dev server running at:\n`),
         {
           clear: !server.config.logger.hasWarned
         }

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -66,7 +66,8 @@ cli
 // dev
 cli
   .command('[root]') // default command
-  .alias('serve')
+  .alias('serve') // the command is called 'serve' in Vite's API
+  .alias('dev') // alias to align with the script name
   .option('--host [host]', `[string] specify hostname`)
   .option('--port <port>', `[number] specify port`)
   .option('--https', `[boolean] use TLS + HTTP/2`)
@@ -102,7 +103,7 @@ cli
 
       info(
         chalk.cyan(`\n  vite v${require('vite/package.json').version}`) +
-          chalk.green(` dev server running at:\n`),
+        chalk.green(` dev server running at:\n`),
         {
           clear: !server.config.logger.hasWarned
         }
@@ -149,7 +150,7 @@ cli
   .option(
     '--minify [minifier]',
     `[boolean | "terser" | "esbuild"] enable/disable minification, ` +
-      `or specify minifier to use (default: esbuild)`
+    `or specify minifier to use (default: esbuild)`
   )
   .option('--manifest', `[boolean] emit build manifest json`)
   .option('--ssrManifest', `[boolean] emit ssr manifest json`)


### PR DESCRIPTION
### Description

See #5097 for context. That PR explored what would be needed to change `serve` by `dev` everywhere, also in the internal API. As plugins are already using `config.command === 'serve'`, it is hard to justify such a breaking change for the ecosystem.

Looks like SvelteKit, Astro and others are using `preview` as a script name without issues. Maybe this is only a problem when there is a `view` script? (but that would be already in the hands of the user to arrange). So, this PR changes the current setup from:

```
vite / vite serve   / pnpm run dev   | the dev server
       vite build   / pnpm run build | the build command
       vite preview / pnpm run serve | the preview server
```

to:

```
vite / vite dev     / pnpm run dev     | the dev server ('serve' in the API)
       vite build   / pnpm run build   | the build command
       vite preview / pnpm run preview | the preview server
```

1. `pnpm run serve` -> `pnpm run preview`. This is only used internally and in templates, so we don't need to keep the old script around. We could add the script and log a message for a while but it may be overkill and add noise to the starter templates.  

2. `dev` is introduced as an alias for `serve` to run the dev server. Current users are used to seeing `dev` as the script name, and this aligns Vite to other tools in the ecosystem.

3. `serve` isn't deprecated at this point, because the internal API still uses `command === 'serve'`. IMO it is best to keep both aliases for the cli.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other