### PR TITLE
fix: use Function instead of eval to dynamically import config files

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -14,7 +14,8 @@ import {
   isExternalUrl,
   isObject,
   lookupFile,
-  normalizePath
+  normalizePath,
+  dynamicImport
 } from './utils'
 import { resolvePlugins } from './plugins'
 import chalk from 'chalk'
@@ -819,16 +820,15 @@ export async function loadConfigFromFile(
         const bundled = await bundleConfigFile(resolvedPath, true)
         dependencies = bundled.dependencies
         fs.writeFileSync(resolvedPath + '.js', bundled.code)
-        userConfig = (await eval(`import(fileUrl + '.js?t=${Date.now()}')`))
+        userConfig = (await dynamicImport(`${fileUrl}.js?t=${Date.now()}`))
           .default
         fs.unlinkSync(resolvedPath + '.js')
         debug(`TS + native esm config loaded in ${getTime()}`, fileUrl)
       } else {
-        // using eval to avoid this from being compiled away by TS/Rollup
+        // using Function to avoid this from being compiled away by TS/Rollup
         // append a query so that we force reload fresh config in case of
         // server restart
-        userConfig = (await eval(`import(fileUrl + '?t=${Date.now()}')`))
-          .default
+        userConfig = (await dynamicImport(`${fileUrl}?t=${Date.now()}`)).default
         debug(`native esm config loaded in ${getTime()}`, fileUrl)
       }
     }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -568,3 +568,10 @@ export function toUpperCaseDriveLetter(pathName: string): string {
 
 export const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
 export const singlelineCommentsRE = /\/\/.*/g
+
+/**
+ * Dynamically import files. It will make sure it's not being compiled away by TS/Rollup.
+ *
+ * @param file File path to import.
+ */
+export const dynamicImport = new Function('file', 'return import(file)')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Hi Everyone 👋 . I'm a software engineer at [StackBlitz](https://stackblitz.com). When I tested out the Vite example for Svelte through https://vite.new/svelte I noticed that something broke. After some investigation I could track it down to the [`eval()` dynamic import workaround](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts#L830). Currently dynamic imports in `eval()` don't work yet, we're looking at implementing them but can't give any estimate when that would be the case. However, dynamic imports do work in `new Function()` calls and also make the code a bit cleaner and reusable I guess, but that might be just a personal opinion.

After making these changes directly in `node_modules/vite`, it works on StackBlitz as well.

![image](https://user-images.githubusercontent.com/1913805/136336524-60d3a153-962e-4873-aeed-4a883325a141.png)

If this would be merged, this PR https://github.com/vitejs/vite/pull/5197 should make use of the `dynamicImport` method in `utils.ts` as well.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
