### PR TITLE
fix(ssr): improved dependency resolution

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -210,16 +210,16 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           return [url, url]
         }
 
-        // if the resolved id is not a valid browser import specifier,
-        // prefix it to make it valid. We will strip this before feeding it
-        // back into the transform pipeline
-        if (!url.startsWith('.') && !url.startsWith('/')) {
-          url =
-            VALID_ID_PREFIX + resolved.id.replace('\0', NULL_BYTE_PLACEHOLDER)
-        }
-
         // make the URL browser-valid if not SSR
         if (!ssr) {
+          // if the resolved id is not a valid browser import specifier,
+          // prefix it to make it valid. We will strip this before feeding it
+          // back into the transform pipeline
+          if (!url.startsWith('.') && !url.startsWith('/')) {
+            url =
+              VALID_ID_PREFIX + resolved.id.replace('\0', NULL_BYTE_PLACEHOLDER)
+          }
+
           // mark non-js/css imports with `?import`
           url = markExplicitImport(url)
 

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -9,7 +9,7 @@ import {
   resolveFrom,
   unique
 } from '../utils'
-import { ResolvedConfig } from '..'
+import { ResolvedConfig, SSROptions } from '..'
 import { createFilter } from '@rollup/pluginutils'
 
 const debug = createDebugger('vite:ssr-external')
@@ -131,6 +131,26 @@ export function resolveSSRExternal(
     externals = externals.filter((id) => filter(id))
   }
   return externals.filter((id) => id !== 'vite')
+}
+
+/**
+ * Create a function that returns true when the given bare import
+ * should be imported like a Node dependency normally is.
+ */
+export function createSSRExternalsFilter(
+  externals: string[],
+  noExternal?: SSROptions['noExternal']
+) {
+  // Deep imports of an externalized package may be defined
+  // in `ssr.noExternal` so we have to check for that.
+  const noExternalFilter =
+    noExternal && noExternal !== true
+      ? createFilter(undefined, noExternal, { resolve: false })
+      : null
+
+  return (dep: string) =>
+    (!noExternalFilter || noExternalFilter(dep)) &&
+    shouldExternalizeForSSR(dep, externals)
 }
 
 export function shouldExternalizeForSSR(

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -116,7 +116,10 @@ async function instantiateModule(
         pendingDeps.splice(pendingDeps.indexOf(dep), 1)
       }
     }
-    return moduleGraph.urlToModuleMap.get(dep)?.ssrModule
+    // Use `getModuleByUrl` instead of accessing `urlToModuleMap` directly
+    // so that bare imports added to `ssr.noExternal` are normalized.
+    const depModule = await moduleGraph.getModuleByUrl(dep)
+    return depModule?.ssrModule
   }
 
   const ssrDynamicImport = (dep: string) => {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -90,7 +90,7 @@ async function instantiateModule(
   const pendingDeps: string[] = []
 
   const ssrImport = async (dep: string) => {
-    if (dep[0] !== '.' && dep[0] !== '/') {
+    if (dep[0] !== '/') {
       return nodeRequire(
         dep,
         mod.file,
@@ -98,7 +98,6 @@ async function instantiateModule(
         !!server.config.resolve.preserveSymlinks
       )
     }
-    dep = unwrapId(dep)
     if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
       pendingDeps.push(dep)
       if (pendingDeps.length === 1) {


### PR DESCRIPTION
This PR affects SSR only.

- Support `resolveId` hooks that coerce bare imports into local module paths.  
  For example, the `vite-tsconfig-paths` plugin.
  - **How?** After a bare import is resolved by `vite:resolve`, check if the resolved ID is an absolute path that exists in the project root. If it is, avoid marking it as external (for SSR builds) and return the absolute path.

- Respect `ssr.noExternal` inside `ssrImport`
  - Add the `createSSRExternalsFilter` function, which wraps `createFilter` from `@rollup/plugin-utils`
  - Avoid coercing bare imports into absolute paths during import analysis
    - After a bare import is resolved by `vite:resolve`, check if the resolved ID is an absolute path that exists in the project root. If not, preserve the unresolved `id` so the `ssr.noExternal` check in `ssrImport` can work properly.

- Note that `ssrImport` will never receive the following specifiers (after this PR is merged):

  - relative path
  - path with `/@id/` prefix
  - path with `/@fs/` prefix

- Use `moduleGraph.getModuleByUrl` instead of accessing `urlToModuleMap` directly, so that bare imports added to `ssr.noExternal` are normalized first. Otherwise, the module will always be undefined.
  - This issue was reported in Discord [here](https://discord.com/channels/804011606160703521/804440184875122730/894835707829424128), and I've also experienced it myself.

- Remove the need for `unwrapId` inside `ssrImport`
  - **How?** Stop prepending `/@id/` to bare imports inside `vite:import-analysis`
