### PR TITLE
refactor: replace deprecated url.parse

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { parse as parseUrl, pathToFileURL } from 'url'
+import { pathToFileURL } from 'url'
 import { performance } from 'perf_hooks'
 import { createRequire } from 'module'
 import colors from 'picocolors'
@@ -616,7 +616,7 @@ function resolveBaseUrl(
   if (isExternalUrl(base)) {
     if (!isBuild) {
       // get base from full url during dev
-      const parsed = parseUrl(base)
+      const parsed = new URL(base)
       base = parsed.pathname || '/'
     }
   } else {

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import { parse as parseUrl } from 'url'
 import fs, { promises as fsp } from 'fs'
 import * as mrmime from 'mrmime'
 import type { OutputOptions, PluginContext } from 'rollup'
@@ -350,7 +349,7 @@ async function fileToBuiltUrl(
     // https://github.com/rollup/rollup/issues/3415
     const map = assetHashToFilenameMap.get(config)!
     const contentHash = getHash(content)
-    const { search, hash } = parseUrl(id)
+    const { search, hash } = new URL(id)
     const postfix = (search || '') + (hash || '')
     const output = config.build?.rollupOptions?.output
     const assetFileNames =


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Replace deprecated `url.parse` with WHATWG URL API

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
