### PR TITLE
fix(server): skipped for ended response

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -151,6 +151,10 @@ export function indexHtmlMiddleware(
 ): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return async function viteIndexHtmlMiddleware(req, res, next) {
+    if (res.writableEnded) {
+      return next()
+    }
+
     const url = req.url && cleanUrl(req.url)
     // spa-fallback always redirects to /index.html
     if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {

--- a/packages/vite/src/node/server/send.ts
+++ b/packages/vite/src/node/server/send.ts
@@ -20,6 +20,10 @@ export function send(
   cacheControl = 'no-cache',
   map?: SourceMap | null
 ): void {
+  if (res.writableEnded) {
+    return
+  }
+
   if (req.headers['if-none-match'] === etag) {
     res.statusCode = 304
     return res.end()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In middleware mode, or with plugins that interact with the dev server, the request might be handled before Vite sending them out (in our case, the Nuxt integration, https://github.com/nuxt/nuxt.js/issues/11881). This result error:

```
Cannot set headers after they are sent to the client
```

This PR makes the server skip closed response.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes nuxt/framework#123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
