### PR TITLE
feat(ssr): add import.meta.pathname as url in ssr

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { pathToFileURL } from 'url'
 import { ViteDevServer } from '..'
 import { cleanUrl, resolveFrom, unwrapId } from '../utils'
 import { rebindErrorStacktrace, ssrRewriteStacktrace } from './ssrStacktrace'
@@ -80,7 +81,13 @@ async function instantiateModule(
   // referenced before it's been instantiated.
   mod.ssrModule = ssrModule
 
-  const ssrImportMeta = { url }
+  const ssrImportMeta = {
+    // The filesystem URL, matching native Node.js modules
+    url: pathToFileURL(mod.file!).toString(),
+
+    // The dev server pathname
+    pathname: url
+  }
 
   urlStack = urlStack.concat(url)
   const isCircular = (url: string) => urlStack.includes(url)


### PR DESCRIPTION
### Description

Based on discord discussion, opening this PR to spark a discussion on `import.meta.url`. The main thing this does is fix `import.meta.url` to match Node ESM.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

This PR does 2 things:

1. Makes `import.meta.url` be the file URL, matching what Node.js does in native ESM.
2. Creates a separate `import.meta.pathname` which is the server pathname (what is currently import.meta.url in main). Can bikeshed on the name, but having the server pathname is still useful for doing things like creating URLs for dynamic resources.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.


