### PR TITLE
fix(plugin-react): apply `babel.plugins` to project files only

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -108,6 +108,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         []
 
       if (/\.(mjs|[tj]sx?)$/.test(extension)) {
+        const isJSX = extension.endsWith('x')
         const isNodeModules = id.includes('/node_modules/')
         const isProjectFile =
           !isNodeModules && (id[0] === '\0' || id.startsWith(projectRoot + '/'))
@@ -117,8 +118,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         let useFastRefresh = false
         if (!skipFastRefresh && !ssr && !isNodeModules) {
           // Modules with .js or .ts extension must import React.
-          const isReactModule =
-            extension.endsWith('x') || code.includes('react')
+          const isReactModule = isJSX || code.includes('react')
           if (isReactModule && filter(id)) {
             useFastRefresh = true
             plugins.push([
@@ -129,7 +129,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         }
 
         let ast: t.File | null | undefined
-        if (!isProjectFile || extension.endsWith('x')) {
+        if (!isProjectFile || isJSX) {
           if (useAutomaticRuntime) {
             // By reverse-compiling "React.createElement" calls into JSX,
             // React elements provided by dependencies will also use the

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -109,7 +109,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
       if (/\.(mjs|[tj]sx?)$/.test(extension)) {
         const isNodeModules = id.includes('/node_modules/')
-        const isProjectFile = id.startsWith(projectRoot + '/') && !isNodeModules
+        const isProjectFile =
+          !isNodeModules && (id[0] === '\0' || id.startsWith(projectRoot + '/'))
 
         let plugins = isProjectFile ? [...userPlugins] : []
 

--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -11,6 +11,10 @@ export async function restoreJSX(
   filename: string
 ): Promise<RestoredJSX> {
   const [reactAlias, isCommonJS] = parseReactAlias(code)
+  if (!reactAlias) {
+    return [null, false]
+  }
+
   const reactJsxRE = new RegExp(
     '\\b' + reactAlias + '\\.(createElement|Fragment)\\b',
     'g'

--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -4,15 +4,23 @@ type RestoredJSX = [result: t.File | null | undefined, isCommonJS: boolean]
 
 let babelRestoreJSX: Promise<PluginItem> | undefined
 
+const jsxNotFound: RestoredJSX = [null, false]
+
 /** Restore JSX from `React.createElement` calls */
 export async function restoreJSX(
   babel: typeof import('@babel/core'),
   code: string,
   filename: string
 ): Promise<RestoredJSX> {
+  // Avoid parsing the optimized react-dom since it will never
+  // contain compiled JSX and it's a pretty big file (800kb).
+  if (filename.includes('/.vite/react-dom.js')) {
+    return jsxNotFound
+  }
+
   const [reactAlias, isCommonJS] = parseReactAlias(code)
   if (!reactAlias) {
-    return [null, false]
+    return jsxNotFound
   }
 
   const reactJsxRE = new RegExp(
@@ -28,7 +36,7 @@ export async function restoreJSX(
   })
 
   if (!hasCompiledJsx) {
-    return [null, false]
+    return jsxNotFound
   }
 
   // Support modules that use `import {Fragment} from 'react'`


### PR DESCRIPTION
The idea here is to avoid parsing `node_modules` whenever possible, since that can be expensive in larger projects.

Here's the heuristic I'm using to skip parsing:
```ts
 const isNodeModules = id.includes('/node_modules/')
 const isProjectFile = id.startsWith(projectRoot + '/') && !isNodeModules
 const shouldSkip =
   !plugins.length &&
   !opts.babel?.configFile &&
   !(isProjectFile && opts.babel?.babelrc)
```

For global plugins, set `babel.configFile` to true and create a `babel.config.js` file in your project root. 

### Future

We *could* detect a `babel.config.js` file in your project root and enable `babel.configFile` option automatically.