### PR TITLE
feat(ws): expose `on` / `off` for `server.ws`

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -12,6 +12,8 @@ import { Socket } from 'net'
 export const HMR_HEADER = 'vite-hmr'
 
 export interface WebSocketServer {
+  on: WebSocket.Server['on']
+  off: WebSocket.Server['off']
   send(payload: HMRPayload): void
   close(): Promise<void>
 }
@@ -92,6 +94,8 @@ export function createWebSocketServer(
   let bufferedError: ErrorPayload | null = null
 
   return {
+    on: wss.on.bind(wss),
+    off: wss.off.bind(wss),
     send(payload: HMRPayload) {
       if (payload.type === 'error' && !wss.clients.size) {
         bufferedError = payload


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Expose `on` / `off` listeners for `server.ws` for plugins to leverage the events.

### Additional context

The main motivation it that the current interface of `server.ws` is too limited. Let's say if we have a virtual module that needs HMR frequently, I usually mock the `ws` events by sending (since the virtual module will not have the fs event):

```ts
server.moduleGraph.invalidateModule(mod)
server.ws.send({
  type: 'update',
  updates: [{
    acceptedPath: VIRTUAL_ENTRY,
    path: VIRTUAL_ENTRY,
    timestamp: +Date.now(),
    type: 'js-update',
  }],
})
```

The problem is that it will only be received by clients that already established connections. The first client might get the initial content of the virtual module by the `load` hook and processed to load other modules, and then after a while the was connect gets established. This means the ws events during the period won't be received by the client and resulting in the old virtual module get served. This requires users to manually refresh the page to get the latest or having an inaccurate timeout to do the hard refresh.

`load` ---> `hmr event` (lost) ---> `ws connected` ---> page ready (the old content is served)

Having the listeners exposed allowing plugins to pending the events and send them as soon as the client is ready (e.g. `on('connection')` to make the HMR experience seamless.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
