### PR TITLE
fix(deps): bump postcss-load-config to 3.1.0

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -105,7 +105,7 @@
     "open": "^8.2.1",
     "periscopic": "^2.0.3",
     "postcss-import": "^14.0.2",
-    "postcss-load-config": "^3.0.0",
+    "postcss-load-config": "^3.1.0",
     "postcss-modules": "^4.2.2",
     "resolve.exports": "^1.0.2",
     "rollup-plugin-license": "^2.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,7 +679,7 @@ importers:
       periscopic: ^2.0.3
       postcss: ^8.3.8
       postcss-import: ^14.0.2
-      postcss-load-config: ^3.0.0
+      postcss-load-config: ^3.1.0
       postcss-modules: ^4.2.2
       resolve: ^1.20.0
       resolve.exports: ^1.0.2


### PR DESCRIPTION
### Description

Adds .cjs and .ts config support for postcss in vite. I'd like to use a Typescript config for postcss in my vite app.

### Additional context

https://github.com/postcss/postcss-load-config/blob/main/CHANGELOG.md#310-2021-06-14

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
