### PR TITLE
fix: improve HTML script proxying

### DIFF
--- a/packages/playground/ssr-html/__tests__/serve.js
+++ b/packages/playground/ssr-html/__tests__/serve.js
@@ -1,0 +1,36 @@
+// @ts-check
+// this is automtically detected by scripts/jestPerTestSetup.ts and will replace
+// the default e2e test serve behavior
+
+const path = require('path')
+
+const port = (exports.port = 9530)
+
+/**
+ * @param {string} root
+ * @param {boolean} isProd
+ */
+exports.serve = async function serve(root, isProd) {
+  const { createServer } = require(path.resolve(root, 'server.js'))
+  const { app, vite } = await createServer(root, isProd)
+
+  return new Promise((resolve, reject) => {
+    try {
+      const server = app.listen(port, () => {
+        resolve({
+          // for test teardown
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve)
+            })
+            if (vite) {
+              await vite.close()
+            }
+          }
+        })
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}

--- a/packages/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/packages/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -1,0 +1,39 @@
+import { port } from './serve'
+import fetch from 'node-fetch'
+
+const url = `http://localhost:${port}`
+
+describe('injected inline scripts', () => {
+  test('no injected inline scripts are present', async () => {
+    await page.goto(url)
+    const inlineScripts = await page.$$eval('script', (nodes) =>
+      nodes.filter((n) => !n.getAttribute('src') && n.innerHTML)
+    )
+    expect(inlineScripts).toHaveLength(0)
+  })
+
+  test('injected script proxied correctly', async () => {
+    await page.goto(url)
+    const proxiedScripts = await page.$$eval('script', (nodes) =>
+      nodes
+        .filter((n) => {
+          const src = n.getAttribute('src')
+          if (!src) return false
+          return src.includes('?html-proxy&index')
+        })
+        .map((n) => n.getAttribute('src'))
+    )
+
+    // assert at least 1 proxied script exists
+    expect(proxiedScripts).not.toHaveLength(0)
+
+    const scriptContents = await Promise.all(
+      proxiedScripts.map((src) => fetch(url + src).then((res) => res.text()))
+    )
+
+    // all proxied scripts return code
+    for (const code of scriptContents) {
+      expect(code).toBeTruthy()
+    }
+  })
+})

--- a/packages/playground/ssr-html/index.html
+++ b/packages/playground/ssr-html/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SSR HTML</title>
+  </head>
+  <body>
+    <h1>SSR Dynamic HTML</h1>
+  </body>
+</html>

--- a/packages/playground/ssr-html/package.json
+++ b/packages/playground/ssr-html/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-ssr-html",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "node server",
+    "serve": "cross-env NODE_ENV=production node server",
+    "debug": "node --inspect-brk server"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "cross-env": "^7.0.3",
+    "express": "^4.17.1"
+  }
+}

--- a/packages/playground/ssr-html/server.js
+++ b/packages/playground/ssr-html/server.js
@@ -1,0 +1,75 @@
+// @ts-check
+const fs = require('fs')
+const path = require('path')
+const express = require('express')
+
+const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+
+const DYNAMIC_SCRIPTS = `
+  <script type="module">
+    const p = document.createElement('p');
+    p.innerHTML = '✅ Dynamically injected inline script';
+    document.body.appendChild(p);
+  </script>
+  <script type="module" src="/src/app.js"></script>
+`
+
+async function createServer(
+  root = process.cwd(),
+  isProd = process.env.NODE_ENV === 'production'
+) {
+  const resolve = (p) => path.resolve(__dirname, p)
+
+  const app = express()
+
+  /**
+   * @type {import('vite').ViteDevServer}
+   */
+  let vite
+  vite = await require('vite').createServer({
+    root,
+    logLevel: isTest ? 'error' : 'info',
+    server: {
+      middlewareMode: 'ssr',
+      watch: {
+        // During tests we edit the files too fast and sometimes chokidar
+        // misses change events, so enforce polling for consistency
+        usePolling: true,
+        interval: 100
+      }
+    }
+  })
+  // use vite's connect instance as middleware
+  app.use(vite.middlewares)
+
+  app.use('*', async (req, res) => {
+    try {
+      let [url] = req.originalUrl.split('?')
+      if (url.endsWith('/')) url += 'index.html'
+
+      const htmlLoc = resolve(`.${url}`)
+      let html = fs.readFileSync(htmlLoc, 'utf8')
+      html = html.replace('</body>', `${DYNAMIC_SCRIPTS}</body>`)
+      html = await vite.transformIndexHtml(url, html)
+
+      res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+    } catch (e) {
+      vite && vite.ssrFixStacktrace(e)
+      console.log(e.stack)
+      res.status(500).end(e.stack)
+    }
+  })
+
+  return { app, vite }
+}
+
+if (!isTest) {
+  createServer().then(({ app }) =>
+    app.listen(3000, () => {
+      console.log('http://localhost:3000')
+    })
+  )
+}
+
+// for test use
+exports.createServer = createServer

--- a/packages/playground/ssr-html/src/app.js
+++ b/packages/playground/ssr-html/src/app.js
@@ -1,0 +1,3 @@
+const p = document.createElement('p')
+p.innerHTML = '✅ Dynamically injected script from file'
+document.body.appendChild(p)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1,15 +1,14 @@
-import fs from 'fs'
 import path from 'path'
 import { Plugin } from '../plugin'
 import { ViteDevServer } from '../server'
 import { OutputAsset, OutputBundle, OutputChunk } from 'rollup'
 import {
-  slash,
   cleanUrl,
-  isExternalUrl,
-  isDataUrl,
   generateCodeFrame,
-  processSrcSet
+  isDataUrl,
+  isExternalUrl,
+  processSrcSet,
+  slash
 } from '../utils'
 import { ResolvedConfig } from '../config'
 import MagicString from 'magic-string'
@@ -31,11 +30,14 @@ import {
 const htmlProxyRE = /\?html-proxy&index=(\d+)\.js$/
 export const isHTMLProxy = (id: string): boolean => htmlProxyRE.test(id)
 
-const htmlCommentRE = /<!--[\s\S]*?-->/g
-const scriptModuleRE =
-  /(<script\b[^>]*type\s*=\s*(?:"module"|'module')[^>]*>)(.*?)<\/script>/gims
+// HTML Proxy Caches are stored by config -> filePath -> hash (getScriptHash()).
+// Referencing scripts by filePath allows for easier garbage collection & fewer memory leaks
+export const htmlProxyMap = new WeakMap<
+  ResolvedConfig,
+  Map<string, Map<string, string>>
+>()
 
-export function htmlInlineScriptProxyPlugin(): Plugin {
+export function htmlInlineScriptProxyPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:html-inline-script-proxy',
 
@@ -45,25 +47,41 @@ export function htmlInlineScriptProxyPlugin(): Plugin {
       }
     },
 
+    buildStart() {
+      htmlProxyMap.set(config, new Map())
+    },
+
     load(id) {
       const proxyMatch = id.match(htmlProxyRE)
       if (proxyMatch) {
-        const index = Number(proxyMatch[1])
+        const index = proxyMatch[1]
         const file = cleanUrl(id)
-        const html = fs.readFileSync(file, 'utf-8').replace(htmlCommentRE, '')
-        let match: RegExpExecArray | null | undefined
-        scriptModuleRE.lastIndex = 0
-        for (let i = 0; i <= index; i++) {
-          match = scriptModuleRE.exec(html)
-        }
-        if (match) {
-          return match[2]
+        const url = file.replace(config.root, '')
+        const result = htmlProxyMap.get(config)?.get(url)?.get(index)
+        if (result) {
+          return result
         } else {
-          throw new Error(`No matching html proxy module found from ${id}`)
+          throw new Error(`No matching HTML proxy module found from ${id}`)
         }
       }
     }
   }
+}
+
+/** Add script to cache */
+export function addToHTMLProxyCache(
+  config: ResolvedConfig,
+  filePath: string,
+  index: number,
+  code: string
+): void {
+  if (!htmlProxyMap.get(config)) {
+    htmlProxyMap.set(config, new Map())
+  }
+  if (!htmlProxyMap.get(config)!.get(filePath)) {
+    htmlProxyMap.get(config)!.set(filePath, new Map())
+  }
+  htmlProxyMap.get(config)!.get(filePath)!.set(`${index}`, code)
 }
 
 // this extends the config in @vue/compiler-sfc with <link href>
@@ -209,7 +227,17 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 js += `\nimport ${JSON.stringify(url)}`
                 shouldRemove = true
               } else if (node.children.length) {
+                const contents = node.children
+                  .map((child: any) => child.content || '')
+                  .join('')
                 // <script type="module">...</script>
+                const filePath = id.replace(config.root, '')
+                addToHTMLProxyCache(
+                  config,
+                  filePath,
+                  inlineModuleIndex,
+                  contents
+                )
                 js += `\nimport "${id}?html-proxy&index=${inlineModuleIndex}.js"`
                 shouldRemove = true
               }

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -42,7 +42,7 @@ export async function resolvePlugins(
       ssrConfig: config.ssr,
       asSrc: true
     }),
-    htmlInlineScriptProxyPlugin(),
+    htmlInlineScriptProxyPlugin(config),
     cssPlugin(config),
     config.esbuild !== false ? esbuildPlugin(config.esbuild) : null,
     jsonPlugin(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,6 +428,14 @@ importers:
   packages/playground/resolve/inline-package:
     specifiers: {}
 
+  packages/playground/ssr-html:
+    specifiers:
+      cross-env: ^7.0.3
+      express: ^4.17.1
+    devDependencies:
+      cross-env: 7.0.3
+      express: 4.17.1
+
   packages/playground/ssr-react:
     specifiers:
       '@vitejs/plugin-react': workspace:*


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Resolves #5061. A quick summary is that when Vite proxies inline `<script>` tags, it relies on the context of HTML files on disk. This means that if users are using a Vite or Rollup plugin that inserts any inline `<script>` tags, Vite will throw an error trying to find the contents from file.

Without changing the URL schema for `?html-proxy`, this PR saves the contents of inline `<script>` tags in memory at the same time they are transformed to HTML proxy URLs (rather than discarding that info, and hoping it still exists on-disk). Vite will then use load scripts from memory without needing to keep re-reading from disk again when contents may have changed.

_Note: the initial version of this PR did change the URL schema for `?html-proxy`, but we’re attempting to skip that for now._

### Additional context

(see comments)
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
