### PR TITLE
refactor!: plugin container API options

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -405,7 +405,7 @@ export async function resolveConfig(
             ]
           }))
       }
-      return (await container.resolveId(id, importer, undefined, ssr))?.id
+      return (await container.resolveId(id, importer, { ssr }))?.id
     }
   }
 

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -95,7 +95,7 @@ async function doTransform(
 
   // load
   const loadStart = isDebug ? performance.now() : 0
-  const loadResult = await pluginContainer.load(id, ssr)
+  const loadResult = await pluginContainer.load(id, { ssr })
   if (loadResult == null) {
     // if this is an html request and there is no load result, skip ahead to
     // SPA fallback.
@@ -157,7 +157,7 @@ async function doTransform(
 
   // transform
   const transformStart = isDebug ? performance.now() : 0
-  const transformResult = await pluginContainer.transform(code, id, map, ssr)
+  const transformResult = await pluginContainer.transform(code, id, { inMap: map, ssr })
   if (
     transformResult == null ||
     (isObject(transformResult) && transformResult.code == null)


### PR DESCRIPTION
### Description

This refactor is a complement to #5253

Vite exposes in the JS API through the server, access to the `pluginContainer` so users can externally call `resolveId`, `transform`, and `load`. 

We have discussed this change with most players in the ecosystem and looks like no one is using this API. VitePress, SvelteKit, Astro, vite-plugin-ssr, vite-edge, are on board. So I think that even if this is a breaking change, we can include it in the next minor. These functions are not documented. The only reference is that the `pluginContainer` is public here https://vitejs.dev/guide/api-javascript.html#vitedevserver.

The current interface is

```ts
export interface PluginContainer {
  options: InputOptions
  buildStart(options: InputOptions): Promise<void>
  resolveId(
    id: string,
    importer?: string,
    skip?: Set<Plugin>,
    ssr?: boolean
  ): Promise<PartialResolvedId | null>
  transform(
    code: string,
    id: string,
    inMap?: SourceDescription['map'],
    ssr?: boolean
  ): Promise<SourceDescription | null>
  load(id: string, ssr?: boolean): Promise<LoadResult | null>
  close(): Promise<void>
}
```

This PR aligns the API with the plugin hooks, so we are able to introduce or deprecate options without breaking changes in the future. I left the names as they currently were in the API.

```ts
export interface PluginContainer {
  options: InputOptions
  buildStart(options: InputOptions): Promise<void>
  resolveId(
    id: string,
    importer?: string,
    options?: { skip?: Set<Plugin>, ssr?: boolean }
  ): Promise<PartialResolvedId | null>
  transform(
    code: string,
    id: string,
    options?: { inMap?: SourceDescription['map'], ssr?: boolean }
  ): Promise<SourceDescription | null>
  load(
    id: string, 
    options?: { ssr?: boolean }
  ): Promise<LoadResult | null>
  close(): Promise<void>
}
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other