### PR TITLE
fix(esbuild): do not read `tsconfig.json` when tsconfigRaw provided explictly

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -74,7 +74,7 @@ export async function transformWithEsbuild(
   let tsconfigRaw = options?.tsconfigRaw
 
   // if options provide tsconfigraw in string, it takes highest precedence
-  if (typeof tsconfigRaw !== 'string') {
+  if (typeof tsconfigRaw !== 'string' && !tsconfigRaw?.compilerOptions) {
     // these fields would affect the compilation result
     // https://esbuild.github.io/content-types/#tsconfig-json
     const meaningfulFields: Array<keyof TSCompilerOptions> = [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This allows meta frameworks to have better control of the building transformation and also save unnecessary file io

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
