### PR TITLE
fix: regEx for <head> tag, fix #5285

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -622,7 +622,7 @@ function toPublicPath(filename: string, config: ResolvedConfig) {
 }
 
 const headInjectRE = /([ \t]*)<\/head>/
-const headPrependInjectRE = [/([ \t]*)<head.*>/, /<!doctype html>/i]
+const headPrependInjectRE = [/([ \t]*)<head[^>]*>/, /<!doctype html>/i]
 function injectToHead(
   html: string,
   tags: HtmlTagDescriptor[],

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -622,7 +622,7 @@ function toPublicPath(filename: string, config: ResolvedConfig) {
 }
 
 const headInjectRE = /([ \t]*)<\/head>/
-const headPrependInjectRE = [/([ \t]*)<head>/, /<!doctype html>/i]
+const headPrependInjectRE = [/([ \t]*)<head.*>/, /<!doctype html>/i]
 function injectToHead(
   html: string,
   tags: HtmlTagDescriptor[],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The original regEx of html plugin  can't handle the <head> HTML tag with attribute likes `<head lang="en">`.

So ` incrementIndent(p1)` cant work as expected, then it will insert some string before `<script type="module" src="/@vite/client"></script>`.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
