### PR TITLE
fix(build): let top-level `this` refer to `globalThis`

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -422,6 +422,7 @@ async function doBuild(
   const rollup = require('rollup') as typeof Rollup
   const rollupOptions: RollupOptions = {
     input,
+    context: 'window',
     preserveEntrySignatures: ssr
       ? 'allow-extension'
       : libOptions

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -422,7 +422,7 @@ async function doBuild(
   const rollup = require('rollup') as typeof Rollup
   const rollupOptions: RollupOptions = {
     input,
-    context: 'window',
+    context: 'globalThis',
     preserveEntrySignatures: ssr
       ? 'allow-extension'
       : libOptions


### PR DESCRIPTION
### Description

This prevents `THIS_IS_UNDEFINED` warning from Rollup when `@babel/plugin-transform-react-jsx` emits `jsx` calls that pass `this` inside an arrow function component, which in turn leads to `SOURCEMAP_ERROR` warnings, because the `this` reference doesn't exist in the original code.

An example Rollup warning message for `SOURCEMAP_ERROR`:
```
Error when using sourcemap for reporting an error: Can't resolve original location of error.
```

### How code output is changed

This PR is especially important for `@vitejs/plugin-react`.

```ts
  return /* @__PURE__ */ jsxDevRuntime.exports.jsxDEV(Provider, {
    value: props,
    children
  }, void 0, false, {
    fileName: _jsxFileName$z,
    lineNumber: 42,
    columnNumber: 26
  }, this); // <== The problem
```
…becomes…
```ts
  return /* @__PURE__ */ jsxDevRuntime.exports.jsxDEV(Provider, {
    value: props,
    children
  }, void 0, false, {
    fileName: _jsxFileName$z,
    lineNumber: 42,
    columnNumber: 26
  }, window); // <== The solution
```

### Workaround

Ignore the warning, or set `rollupOptions.onwarn` to handle it manually.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other