### PR TITLE
fix(plugin-react): transform .mjs files

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -92,7 +92,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       )
     },
     async transform(code, id, ssr) {
-      if (/\.[tj]sx?$/.test(id)) {
+      if (/\.(mjs|[tj]sx?)$/.test(id)) {
         const plugins = [...userPlugins]
 
         const parserPlugins: typeof userParserPlugins = [


### PR DESCRIPTION

`.mjs` files were not being transformed by `@vitejs/plugin-react`
