### PR TITLE
fix(html): tags prepend doctype regex

### DIFF
--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -165,3 +165,22 @@ if (isBuild) {
     })
   })
 }
+
+
+describe('noHead', () => {
+  // If there isn't a <head>, scripts are injected after <!DOCTYPE html>
+
+  beforeAll(async () => {
+    // viteTestUrl is globally injected in scripts/jestPerTestSetup.ts
+    await page.goto(viteTestUrl + '/noHead.html')
+  })
+
+  test('noHead tags transform', async () => {
+    const el = await page.$('meta[name=description]')
+    expect(await el.getAttribute('content')).toBe('a vite app')
+
+    const kw = await page.$('meta[name=keywords]')
+    expect(await kw.getAttribute('content')).toBe('es modules')
+  })
+
+})

--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -166,7 +166,6 @@ if (isBuild) {
   })
 }
 
-
 describe('noHead', () => {
   // If there isn't a <head>, scripts are injected after <!DOCTYPE html>
 

--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -181,5 +181,4 @@ describe('noHead', () => {
     const kw = await page.$('meta[name=keywords]')
     expect(await kw.getAttribute('content')).toBe('es modules')
   })
-
 })

--- a/packages/playground/html/noHead.html
+++ b/packages/playground/html/noHead.html
@@ -1,0 +1,7 @@
+<link rel="stylesheet" href="/main.css" />
+
+<!-- comment one -->
+<h1>Hello</h1>
+<!-- comment two -->
+
+<script type="module" src="/main.js"></script>

--- a/packages/playground/html/vite.config.js
+++ b/packages/playground/html/vite.config.js
@@ -12,6 +12,7 @@ module.exports = {
         scriptAsync: resolve(__dirname, 'scriptAsync.html'),
         scriptMixed: resolve(__dirname, 'scriptMixed.html'),
         zeroJS: resolve(__dirname, 'zeroJS.html'),
+        noHead: resolve(__dirname, 'noHead.html'),
         inline1: resolve(__dirname, 'inline/shared-1.html'),
         inline2: resolve(__dirname, 'inline/shared-2.html'),
         inline3: resolve(__dirname, 'inline/unique.html')
@@ -24,18 +25,19 @@ module.exports = {
       name: 'pre-transform',
       transformIndexHtml: {
         enforce: 'pre',
-        transform(html) {
+        transform(html, { filename }) {
           if (html.includes('/@vite/client')) {
             throw new Error('pre transform applied at wrong time!')
           }
+          const head = `
+  <head lang="en">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+  </head>`
           return `
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ title }}</title>
-</head>
+<html lang="en">${filename.includes('noHead') ? '' : head}
 <body>
   ${html}
 </body>

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -622,7 +622,8 @@ function toPublicPath(filename: string, config: ResolvedConfig) {
 }
 
 const headInjectRE = /([ \t]*)<\/head>/
-const headPrependInjectRE = [/([ \t]*)<head[^>]*>/, /<!doctype html>/i]
+const headPrependInjectRE = /([ \t]*)<head[^>]*>/
+const doctypePrependInjectRE = /<!doctype html>/i
 function injectToHead(
   html: string,
   tags: HtmlTagDescriptor[],
@@ -630,13 +631,17 @@ function injectToHead(
 ) {
   if (prepend) {
     // inject after head or doctype
-    for (const re of headPrependInjectRE) {
-      if (re.test(html)) {
-        return html.replace(
-          re,
-          (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`
-        )
-      }
+    if (headPrependInjectRE.test(html)) {
+      return html.replace(
+        headPrependInjectRE,
+        (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`
+      )
+    }
+    else if(doctypePrependInjectRE) {
+      return html.replace(
+        doctypePrependInjectRE,
+        `$&\n${serializeTags(tags)}`
+      )
     }
   } else {
     // inject before head close

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -637,7 +637,7 @@ function injectToHead(
         (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`
       )
     }
-    else if(doctypePrependInjectRE) {
+    else if(doctypePrependInjectRE.test(html)) {
       return html.replace(
         doctypePrependInjectRE,
         `$&\n${serializeTags(tags)}`


### PR DESCRIPTION
### Description

Fixes a regression in the doctype regex. There are new tests for an html without a <head> tag.
The build result of this new test is injecting some scripts (the script modules for the app) before <doctype>. This is unrelated to this fix and we should fix it in another PR. I think that if we specify inject to head, a head tag should be created if there isn't one.

The regex issue (no groups) was the reason why we got a `0` in the output here #5285, when the head regex was not matching due to attrs (issue fixed here #5311)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other