### PR TITLE
docs: Add `defineConfig` import in features.md

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -108,6 +108,8 @@ If not using JSX with React or Vue, custom `jsxFactory` and `jsxFragment` can be
 
 ```js
 // vite.config.js
+import { defineConfig } from 'vite'
+
 export default defineConfig({
   esbuild: {
     jsxFactory: 'h',
@@ -122,6 +124,8 @@ You can inject the JSX helpers using `jsxInject` (which is a Vite-only option) t
 
 ```js
 // vite.config.js
+import { defineConfig } from 'vite'
+
 export default defineConfig({
   esbuild: {
     jsxInject: `import React from 'react'`


### PR DESCRIPTION
### Description

Show that `defineConfig` needs to be imported from `vite` in order for the examples shown to work.

```
import { defineConfig } from 'vite'
```

### What is the purpose of this pull request? 

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other
