### PR TITLE
fix(html): ensure head tag when injecting

### DIFF
--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -178,7 +178,7 @@ describe('noHead', () => {
     const el = await page.$('meta[name=description]')
     expect(await el.getAttribute('content')).toBe('a vite app')
 
-    const kw = await page.$('meta[name=keywords]')
+    const kw = await page.$('head meta[name=keywords]')
     expect(await kw.getAttribute('content')).toBe('es modules')
   })
 })

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -637,21 +637,25 @@ function injectToHead(
         (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`
       )
     }
-    else if(doctypePrependInjectRE.test(html)) {
+    else if (doctypePrependInjectRE.test(html)) {
       return html.replace(
         doctypePrependInjectRE,
         `$&\n${serializeTags(tags)}`
       )
     }
   } else {
-    // inject before head close
-    if (headInjectRE.test(html)) {
-      // respect indentation of head tag
-      return html.replace(
-        headInjectRE,
-        (match, p1) => `${serializeTags(tags, incrementIndent(p1))}${match}`
-      )
+    // ensure a head tag is present
+    if (!headInjectRE.test(html)) {
+      const headTag = `<head>\n</head>`
+      html = doctypePrependInjectRE.test(html)
+        ? html.replace(doctypePrependInjectRE, `$&\n${headTag}`)
+        : `${headTag}\n${html}`
     }
+    // inject before head close, respecting indentation of head tag
+    return html.replace(
+      headInjectRE,
+      (match, p1) => `${serializeTags(tags, incrementIndent(p1))}${match}`
+    )
   }
   // if no <head> tag is present, just prepend
   return serializeTags(tags) + html


### PR DESCRIPTION
### Description

After adding tests for #5315, I saw that when there isn't a `<head>` tag, Vite injected the script tags at the beginning of the HTML. `'head-prepend'`, that is the default is currently defined to inject at the start of the `<head>` tag if present or after `<doctype>`. But if the user selects `'head'`, I think we should create a `<head>` tag if it isn't present. This is also what Vite uses internally to add the script modules, preload tags, etc, and currently, if there isn't a `<head>` we are not correctly placing these scripts as expected.

This PR modifies the logic for [injectTo](https://vitejs.dev/guide/api-plugin.html#transformindexhtml) `head` to ensure that there will always be a `<head>` tag when needed. 

### Additional context

I think we could do the same for `'head-prepend'`, and always ensure the presence of a `<head>` tag when injecting. Or maybe I'm missing a drawback explaining why this was not done before.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
