### PR TITLE
fix(plugin-react): account for querystring in transform hook

### DIFF
--- a/packages/playground/react/App.jsx
+++ b/packages/playground/react/App.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import Dummy from './components/Dummy?qs-should-not-break-plugin-react'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -23,6 +24,8 @@ function App() {
           Learn React
         </a>
       </header>
+
+      <Dummy />
     </div>
   )
 }

--- a/packages/playground/react/components/Dummy.jsx
+++ b/packages/playground/react/components/Dummy.jsx
@@ -1,0 +1,3 @@
+export default function Dummy() {
+  return <></>
+}

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -64,6 +64,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   // - import React, {useEffect} from 'react';
   const importReactRE = /(^|\n)import\s+(\*\s+as\s+)?React(,|\s+)/
 
+  // Any extension, including compound ones like '.bs.js'
+  const fileExtensionRE = /\.[^\/\s\?]+$/
+
   const viteBabel: Plugin = {
     name: 'vite:react-babel',
     enforce: 'pre',
@@ -96,10 +99,14 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       )
     },
     async transform(code, id, ssr) {
-      // Remove querystring to check file extension.
-      id = id.split('?')[0]
+      // File extension could be mocked/overriden in querystring.
+      const [filepath, querystring = ''] = id.split('?')
+      const [extension = ''] =
+        querystring.match(fileExtensionRE) ||
+        filepath.match(fileExtensionRE) ||
+        []
 
-      if (/\.(mjs|[tj]sx?)$/.test(id)) {
+      if (/\.(mjs|[tj]sx?)$/.test(extension)) {
         const plugins = [...userPlugins]
 
         const parserPlugins: typeof userParserPlugins = [
@@ -114,11 +121,11 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           'classPrivateMethods'
         ]
 
-        if (!id.endsWith('.ts')) {
+        if (!extension.endsWith('.ts')) {
           parserPlugins.push('jsx')
         }
 
-        const isTypeScript = /\.tsx?$/.test(id)
+        const isTypeScript = /\.tsx?$/.test(extension)
         if (isTypeScript) {
           parserPlugins.push('typescript')
         }
@@ -128,7 +135,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         let useFastRefresh = false
         if (!skipFastRefresh && !ssr && !isNodeModules) {
           // Modules with .js or .ts extension must import React.
-          const isReactModule = id.endsWith('x') || code.includes('react')
+          const isReactModule =
+            extension.endsWith('x') || code.includes('react')
           if (isReactModule && filter(id)) {
             useFastRefresh = true
             plugins.push([
@@ -139,7 +147,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         }
 
         let ast: t.File | null | undefined
-        if (isNodeModules || id.endsWith('x')) {
+        if (isNodeModules || extension.endsWith('x')) {
           if (useAutomaticRuntime) {
             // By reverse-compiling "React.createElement" calls into JSX,
             // React elements provided by dependencies will also use the
@@ -182,7 +190,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           }
         }
 
-        const isReasonReact = id.endsWith('.bs.js')
+        const isReasonReact = extension.endsWith('.bs.js')
 
         const babelOpts: TransformOptions = {
           babelrc: false,

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -96,6 +96,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       )
     },
     async transform(code, id, ssr) {
+      // Remove querystring to check file extension.
+      id = id.split('?')[0]
+
       if (/\.(mjs|[tj]sx?)$/.test(id)) {
         const plugins = [...userPlugins]
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`@vite/plugin-react` currently checks file extension in Rollup's `transform` hook. However, the `id` parameter can contain querystrings when importing a component like this:

```jsx
import MyComponent from './MyComponent.jsx?query-here'
```

This makes the plugin fail when testing `id.endsWith('x')` and similar checks.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Querystrings can be injected by other Vite plugins in order to apply conditional behavior.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
