### PR TITLE
fix: missing tags inject fallback

### DIFF
--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -167,18 +167,32 @@ if (isBuild) {
 }
 
 describe('noHead', () => {
-  // If there isn't a <head>, scripts are injected after <!DOCTYPE html>
-
   beforeAll(async () => {
     // viteTestUrl is globally injected in scripts/jestPerTestSetup.ts
     await page.goto(viteTestUrl + '/noHead.html')
   })
 
-  test('noHead tags transform', async () => {
-    const el = await page.$('meta[name=description]')
+  test('noHead tags injection', async () => {
+    const el = await page.$('html meta[name=description]')
     expect(await el.getAttribute('content')).toBe('a vite app')
 
-    const kw = await page.$('meta[name=keywords]')
+    const kw = await page.$('html meta[name=keywords]')
     expect(await kw.getAttribute('content')).toBe('es modules')
+  })
+})
+
+describe('noBody', () => {
+  beforeAll(async () => {
+    // viteTestUrl is globally injected in scripts/jestPerTestSetup.ts
+    await page.goto(viteTestUrl + '/noBody.html')
+  })
+
+  test('noBody tags injection', async () => {
+    // this selects the first noscript in body, even without a body tag
+    const el = await page.$('body noscript')
+    expect(await el.innerHTML()).toMatch(`<!-- this is prepended to body -->`)
+
+    const kw = await page.$('html:last-child')
+    expect(await kw.innerHTML()).toMatch(`<!-- this is appended to body -->`)
   })
 })

--- a/packages/playground/html/noBody.html
+++ b/packages/playground/html/noBody.html
@@ -1,0 +1,7 @@
+<link rel="stylesheet" href="/main.css" />
+
+<!-- comment one -->
+<h1>Hello</h1>
+<!-- comment two -->
+
+<script type="module" src="/main.js"></script>

--- a/packages/playground/html/vite.config.js
+++ b/packages/playground/html/vite.config.js
@@ -13,6 +13,7 @@ module.exports = {
         scriptMixed: resolve(__dirname, 'scriptMixed.html'),
         zeroJS: resolve(__dirname, 'zeroJS.html'),
         noHead: resolve(__dirname, 'noHead.html'),
+        noBody: resolve(__dirname, 'noBody.html'),
         inline1: resolve(__dirname, 'inline/shared-1.html'),
         inline2: resolve(__dirname, 'inline/shared-2.html'),
         inline3: resolve(__dirname, 'inline/unique.html')
@@ -35,12 +36,11 @@ module.exports = {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}</title>
   </head>`
-          return `
-<!DOCTYPE html>
+          return `<!DOCTYPE html>
 <html lang="en">${filename.includes('noHead') ? '' : head}
-<body>
+${filename.includes('noBody') ? html : `<body>
   ${html}
-</body>
+</body>`}
 </html>
   `
         }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -621,8 +621,9 @@ function toPublicPath(filename: string, config: ResolvedConfig) {
   return isExternalUrl(filename) ? filename : config.base + filename
 }
 
-const headInjectRE = /([ \t]*)<\/head>/
-const headPrependInjectRE = /([ \t]*)<head[^>]*>/
+const headInjectRE = /([ \t]*)<\/head>/i
+const headPrependInjectRE = /([ \t]*)<head[^>]*>/i
+const htmlPrependInjectRE = /([ \t]*)<html[^>]*>/i
 const doctypePrependInjectRE = /<!doctype html>/i
 function injectToHead(
   html: string,
@@ -630,17 +631,11 @@ function injectToHead(
   prepend = false
 ) {
   if (prepend) {
-    // inject after head or doctype
+    // inject as the first element of head
     if (headPrependInjectRE.test(html)) {
       return html.replace(
         headPrependInjectRE,
         (match, p1) => `${match}\n${serializeTags(tags, incrementIndent(p1))}`
-      )
-    }
-    else if(doctypePrependInjectRE.test(html)) {
-      return html.replace(
-        doctypePrependInjectRE,
-        `$&\n${serializeTags(tags)}`
       )
     }
   } else {
@@ -653,12 +648,13 @@ function injectToHead(
       )
     }
   }
-  // if no <head> tag is present, just prepend
-  return serializeTags(tags) + html
+  // if no head tag is present, we prepend the tag for both prepend and append
+  return prependInjectFallback(html, tags)
 }
 
-const bodyInjectRE = /([ \t]*)<\/body>/
-const bodyPrependInjectRE = /([ \t]*)<body[^>]*>/
+const htmlInjectRE = /<\/html>/i
+const bodyInjectRE = /([ \t]*)<\/body>/i
+const bodyPrependInjectRE = /([ \t]*)<body[^>]*>/i
 function injectToBody(
   html: string,
   tags: HtmlTagDescriptor[],
@@ -673,7 +669,7 @@ function injectToBody(
       )
     }
     // if no body, prepend
-    return serializeTags(tags) + html
+    return prependInjectFallback(html, tags)
   } else {
     // inject before body close
     if (bodyInjectRE.test(html)) {
@@ -682,9 +678,26 @@ function injectToBody(
         (match, p1) => `${serializeTags(tags, incrementIndent(p1))}${match}`
       )
     }
-    // if no body, append
+    // if no body tag is present, append to the html tag, or at the end of the file
+    if (htmlInjectRE.test(html)) {
+      return html.replace(htmlInjectRE, `${serializeTags(tags)}\n$&`)
+    }
     return html + `\n` + serializeTags(tags)
   }
+}
+
+function prependInjectFallback(
+  html: string,
+  tags: HtmlTagDescriptor[]
+) {
+  // prepend to the html tag, append after doctype, or the document start
+  if (htmlPrependInjectRE.test(html)) {
+    return html.replace(htmlPrependInjectRE, `$&\n${serializeTags(tags)}`)
+  }
+  if (doctypePrependInjectRE.test(html)) {
+    return html.replace(doctypePrependInjectRE, `$&\n${serializeTags(tags)}`)
+  }
+  return serializeTags(tags) + html
 }
 
 const unaryTags = new Set(['link', 'meta', 'base'])


### PR DESCRIPTION
### Description

When there isn't a `<head>` or `<body>`, make sure to prepend after `<html>` or `<!doctype html>` if present. 

This PR also makes all the regex case insensitive so we also match `<HEAD>` and `<BODY>`.

Before
```html
<meta name="keywords" content="es modules">
<script type="module" crossorigin src="/assets/modulepreload-polyfill.0d94a2e8.js"></script>
<script type="module" crossorigin src="/assets/common.fde954c5.js"></script>
<script type="module" crossorigin src="/assets/main.48436d11.js"></script>
<link rel="stylesheet" href="/assets/common.e7d02c8e.css">
<link rel="stylesheet" href="/assets/main.ebd1b3ad.css">

<!DOCTYPE html>
<meta name="description" content="a vite app">

<html lang="en">
<body>
  <noscript><!-- this is prepended to body --></noscript>
...
```

After
```html

<!DOCTYPE html>
<html lang="en">
<meta name="keywords" content="es modules">

<meta name="description" content="a vite app">

<script type="module" crossorigin src="/assets/modulepreload-polyfill.0d94a2e8.js"></script>
<script type="module" crossorigin src="/assets/common.fde954c5.js"></script>
<script type="module" crossorigin src="/assets/main.48436d11.js"></script>
<link rel="stylesheet" href="/assets/common.e7d02c8e.css">
<link rel="stylesheet" href="/assets/main.ebd1b3ad.css">

<body>
  <noscript><!-- this is prepended to body --></noscript>
...
```

Note: I tried to inject a `<head>` tag if it isn't present in #5327, but I think we should leave this to the user to avoid edge cases. This PR makes sure that the resulting html is well-formed without the tags.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
