### PR TITLE
fix(client): fix typo in overlay config hint

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -106,8 +106,8 @@ code {
   <pre class="stack"></pre>
   <div class="tip">
     Click outside or fix the code to dismiss.<br>
-    You can also disable this overlay with
-    <code>hmr: { overlay: false }</code> in <code>vite.config.js.</code>
+    You can also disable this overlay by setting
+    <code>server.hmr.overlay</code> to <code>false</code> in <code>vite.config.js.</code>
   </div>
 </div>
 `


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I was trying to disable the overlay by setting `hmr.overlay` to `false` in the config as described in the overlay. However, the correct key  is `server.hmr.overlay`. I also phrased it to look more like the [description in the docs](https://vitejs.dev/config/#server-hmr) :-)

### Additional context

No!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
