### PR TITLE
fix(ssr): ssrTransfrom with function declaration in scope, fix #4306

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -175,6 +175,32 @@ test('do not rewrite method definition', async () => {
   expect(result.deps).toEqual(['vue'])
 })
 
+test('do not rewrite when variable is in scope', async () => {
+  const result = await ssrTransform(
+    `import { fn } from 'vue';function A(){ const fn = () => {}; return { fn }; }`,
+    null,
+    null
+  )
+  expect(result.code).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    function A(){ const fn = () => {}; return { fn }; }"
+  `)
+  expect(result.deps).toEqual(['vue'])
+})
+
+test('do not rewrite when function declaration is in scope', async () => {
+  const result = await ssrTransform(
+    `import { fn } from 'vue';function A(){ function fn() {}; return { fn }; }`,
+    null,
+    null
+  )
+  expect(result.code).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    function A(){ function fn() {}; return { fn }; }"
+  `)
+  expect(result.deps).toEqual(['vue'])
+})
+
 test('do not rewrite catch clause', async () => {
   const result = await ssrTransform(
     `import {error} from './dependency';try {} catch(error) {}`,

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -303,7 +303,7 @@ function walk(
         }
       } else if (isFunction(node)) {
         // If it is a function declaration, it could be shadowing an import
-        // Add its name to the scope so it won't gets replaced
+        // Add its name to the scope so it won't get replaced
         if (node.type === 'FunctionDeclaration') {
           const parentFunction = findParentFunction(parentStack)
           if (parentFunction) {

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -302,6 +302,14 @@ function walk(
           onIdentifier(node, parent!, parentStack)
         }
       } else if (isFunction(node)) {
+        // If it is a function declaration, it could be shadowing an import
+        // Add its name to the scope so it won't gets replaced
+        if (node.type === 'FunctionDeclaration') {
+          const parentFunction = findParentFunction(parentStack)
+          if (parentFunction) {
+            setScope(parentFunction, node.id!.name)
+          }
+        }
         // walk function expressions and add its arguments to known identifiers
         // so that we don't prefix them
         node.params.forEach((p) =>


### PR DESCRIPTION
### Description

See #4306 and added test cases for details. Shadowing for variable declarations was already taken into account, but not for function declarations.

Error for the test case before this PR for reference
![image](https://user-images.githubusercontent.com/583075/138344738-ab45f939-a15f-4780-9497-3b55b6ce16d7.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other