### PR TITLE
fix: ensure server.host is passed in preview-mode (fix #5387)

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -239,6 +239,7 @@ cli
             configFile: options.config,
             logLevel: options.logLevel,
             server: {
+              host: options.host,
               open: options.open,
               strictPort: options.strictPort,
               https: options.https


### PR DESCRIPTION
### Description

`options.host` wasn't being passed to `server` even though it was listed as a CLI-option, this passes through the option so host is properly respected

Fixes https://github.com/vitejs/vite/issues/5387

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
