### PR TITLE
fix: apply user-plugins to the build process of a worker (fix #5375)

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -8,6 +8,7 @@ import Rollup from 'rollup'
 import { ENV_PUBLIC_PATH } from '../constants'
 import path from 'path'
 import { onRollupWarning } from '../build'
+import { sortUserPlugins } from '..'
 
 function parseWorkerRequest(id: string): Record<string, string> | null {
   const { search } = parseUrl(id)
@@ -55,9 +56,10 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       if (isBuild) {
         // bundle the file as entry to support imports
         const rollup = require('rollup') as typeof Rollup
+        const [pre, normal, post] = sortUserPlugins([...config.plugins])
         const bundle = await rollup.rollup({
           input: cleanUrl(id),
-          plugins: await resolvePlugins({ ...config }, [], [], []),
+          plugins: await resolvePlugins({ ...config }, pre, normal, post),
           onwarn(warning, warn) {
             onRollupWarning(warning, warn, config)
           }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This applies user-defined-plugins to the build step of the `worker-plugin`

Fixes: https://github.com/vitejs/vite/issues/5375

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
