### PR TITLE
fix(server): use `options` argument in caching of `transformRequest` calls

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -314,7 +314,7 @@ export interface ViteDevServer {
   /**
    * @internal
    */
-  _pendingRequests: Record<string, Promise<TransformResult | null> | null>
+  _pendingRequests: Map<string, Promise<TransformResult | null>>
 }
 
 export async function createServer(
@@ -422,7 +422,7 @@ export async function createServer(
     _isRunningOptimizer: false,
     _registerMissingImport: null,
     _pendingReload: null,
-    _pendingRequests: Object.create(null)
+    _pendingRequests: new Map()
   }
 
   server.transformIndexHtml = createDevHtmlTransformFn(server)

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -48,9 +48,8 @@ export function transformRequest(
   if (!request) {
     request = doTransform(url, server, options)
     server._pendingRequests.set(cacheKey, request)
-    request.finally(() => {
-      server._pendingRequests.delete(cacheKey)
-    })
+    const done = () => server._pendingRequests.delete(cacheKey)
+    request.then(done, done)
   }
   return request
 }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -43,20 +43,16 @@ export function transformRequest(
   server: ViteDevServer,
   options: TransformOptions = {}
 ): Promise<TransformResult | null> {
-  const pending = server._pendingRequests[url]
-  if (pending) {
-    debugTransform(
-      `[reuse pending] for ${prettifyUrl(url, server.config.root)}`
-    )
-    return pending
+  const cacheKey = (options.ssr ? 'ssr:' : options.html ? 'html:' : '') + url
+  let request = server._pendingRequests.get(cacheKey)
+  if (!request) {
+    request = doTransform(url, server, options)
+    server._pendingRequests.set(cacheKey, request)
+    request.finally(() => {
+      server._pendingRequests.delete(cacheKey)
+    })
   }
-  const result = doTransform(url, server, options)
-  server._pendingRequests[url] = result
-  const onDone = () => {
-    server._pendingRequests[url] = null
-  }
-  result.then(onDone, onDone)
-  return result
+  return request
 }
 
 async function doTransform(


### PR DESCRIPTION
The current implementation has a nasty side effect of treating SSR transforms as equivalent to browser transforms, which is obviously wrong.

I also removed a `debugTransform` call, as it's a little noisy when `vite:import-analysis` calls `transformRequest` for every static import in the module graph.