### PR TITLE
fix(worker): Worker bundle to use `es` format

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -65,7 +65,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         let code: string
         try {
           const { output } = await bundle.generate({
-            format: 'iife',
+            format: 'es',
             sourcemap: config.build.sourcemap
           })
           code = output[0].code

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -58,6 +58,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         const bundle = await rollup.rollup({
           input: cleanUrl(id),
           plugins: await resolvePlugins({ ...config }, [], [], []),
+          preserveEntrySignatures: false,
           onwarn(warning, warn) {
             onRollupWarning(warning, warn, config)
           }


### PR DESCRIPTION
<!-- Thank you for contributing! -->
(closes https://github.com/vitejs/vite/issues/5402)

### Description

Rollup does not allow code splitting for `iife` formats, this causes  problem for dynamic imports inside web workers. The format for workers used to be `es` but was changed to `iife` in https://github.com/vitejs/vite/pull/2494

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
