### PR TITLE
fix(ssr): dont transform process.env. in ssr

### DIFF
--- a/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -4,6 +4,15 @@ import fetch from 'node-fetch'
 
 const url = `http://localhost:${port}`
 
+test('/env', async () => {
+  await page.goto(url + '/env')
+  expect(await page.textContent('h1')).toMatch('default message here')
+
+  // raw http request
+  const envHtml = await (await fetch(url + '/env')).text()
+  expect(envHtml).toMatch('API_KEY_qwertyuiop')
+})
+
 test('/about', async () => {
   await page.goto(url + '/about')
   expect(await page.textContent('h1')).toMatch('About')

--- a/packages/playground/ssr-react/server.js
+++ b/packages/playground/ssr-react/server.js
@@ -5,6 +5,8 @@ const express = require('express')
 
 const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
 
+process.env.MY_CUSTOM_SECRET = 'API_KEY_qwertyuiop'
+
 async function createServer(
   root = process.cwd(),
   isProd = process.env.NODE_ENV === 'production'

--- a/packages/playground/ssr-react/src/pages/Env.jsx
+++ b/packages/playground/ssr-react/src/pages/Env.jsx
@@ -1,0 +1,7 @@
+export default function Env() {
+  let msg = 'default message here'
+  try {
+    msg = process.env.MY_CUSTOM_SECRET || msg
+  } catch {}
+  return <h1>{msg}</h1>
+}

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -7,6 +7,16 @@ import { isCSSRequest } from './css'
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
 
+  const processNodeEnv: Record<string, string> = {
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || config.mode),
+    'global.process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || config.mode
+    ),
+    'globalThis.process.env.NODE_ENV': JSON.stringify(
+      process.env.NODE_ENV || config.mode
+    )
+  }
+
   const userDefine: Record<string, string> = {}
   for (const key in config.define) {
     const val = config.define[key]
@@ -30,32 +40,42 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     })
   }
 
-  const replacements: Record<string, string | undefined> = {
-    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || config.mode),
-    'global.process.env.NODE_ENV': JSON.stringify(
-      process.env.NODE_ENV || config.mode
-    ),
-    'globalThis.process.env.NODE_ENV': JSON.stringify(
-      process.env.NODE_ENV || config.mode
-    ),
-    ...userDefine,
-    ...importMetaKeys,
-    'process.env.': `({}).`,
-    'global.process.env.': `({}).`,
-    'globalThis.process.env.': `({}).`
+  function generatePattern(
+    ssr: boolean
+  ): [Record<string, string | undefined>, RegExp] {
+    const processEnv: Record<string, string> = {}
+    if (!ssr || config.ssr?.target === 'webworker') {
+      Object.assign(processEnv, {
+        'process.env.': `({}).`,
+        'global.process.env.': `({}).`,
+        'globalThis.process.env.': `({}).`
+      })
+    }
+
+    const replacements: Record<string, string> = {
+      ...processNodeEnv,
+      ...userDefine,
+      ...importMetaKeys,
+      ...processEnv
+    }
+
+    const pattern = new RegExp(
+      // Do not allow preceding '.', but do allow preceding '...' for spread operations
+      '(?<!(?<!\\.\\.)\\.)\\b(' +
+        Object.keys(replacements)
+          .map((str) => {
+            return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')
+          })
+          .join('|') +
+        ')\\b',
+      'g'
+    )
+
+    return [replacements, pattern]
   }
 
-  const pattern = new RegExp(
-    // Do not allow preceding '.', but do allow preceding '...' for spread operations
-    '(?<!(?<!\\.\\.)\\.)\\b(' +
-      Object.keys(replacements)
-        .map((str) => {
-          return str.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&')
-        })
-        .join('|') +
-      ')\\b',
-    'g'
-  )
+  const defaultPattern = generatePattern(false)
+  const ssrPattern = generatePattern(true)
 
   return {
     name: 'vite:define',
@@ -73,6 +93,8 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       ) {
         return
       }
+
+      const [replacements, pattern] = ssr ? ssrPattern : defaultPattern
 
       if (ssr && !isBuild) {
         // ssr + dev, simple replace


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In SSR and the SSR target is `node`, `process.env.` will be left as is without transformation. Currently, `process.env.FOO` will always be transformed as `({}).FOO`, which is undesirable when running in node.

### Additional context

Supersedes #4192 by @GrygrFlzr (most of the code is borrowed there and we should attribute GrygrFlzr too)
Fixes #3176

Re https://github.com/vitejs/vite/issues/3176#issuecomment-827773555, @benmccann and I had agreed that we should continue replacing `process.env.` in client, but also warn the user that it would be undefined. I can make another PR for this if is desirable.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
