### PR TITLE
refactor!: align preview api

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 import { performance } from 'perf_hooks'
 import { BuildOptions } from './build'
 import { ServerOptions } from './server'
-import { createLogger, LogLevel, printHttpServerUrls } from './logger'
+import { createLogger, LogLevel } from './logger'
 import { resolveConfig } from '.'
 import { preview } from './preview'
 
@@ -217,9 +217,9 @@ cli
   .command('preview [root]')
   .option('--host [host]', `[string] specify hostname`)
   .option('--port <port>', `[number] specify port`)
+  .option('--strictPort', `[boolean] exit if specified port is already in use`)
   .option('--https', `[boolean] use TLS + HTTP/2`)
   .option('--open [path]', `[boolean | string] open browser on startup`)
-  .option('--strictPort', `[boolean] exit if specified port is already in use`)
   .action(
     async (
       root: string,
@@ -232,25 +232,20 @@ cli
       } & GlobalCLIOptions
     ) => {
       try {
-        const config = await resolveConfig(
-          {
-            root,
-            base: options.base,
-            configFile: options.config,
-            logLevel: options.logLevel,
-            server: {
-              host: options.host,
-              open: options.open,
-              strictPort: options.strictPort,
-              https: options.https
-            }
-          },
-          'serve',
-          'production'
-        )
-        const server = await preview(config, cleanOptions(options))
-
-        printHttpServerUrls(server, config)
+        const server = await preview({
+          root,
+          base: options.base,
+          configFile: options.config,
+          logLevel: options.logLevel,
+          server: {
+            host: options.host,
+            port: options.port ?? 5000,
+            strictPort: options.strictPort,
+            https: options.https,
+            open: options.open
+          }
+        })
+        server.printUrls()
       } catch (e) {
         createLogger(options.logLevel).error(
           chalk.red(`error when starting preview server:\n${e.stack}`),

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -26,6 +26,9 @@ export type {
   ResolvedBuildOptions
 } from './build'
 export type {
+  PreviewServer
+} from './preview'
+export type {
   DepOptimizationMetadata,
   DepOptimizationOptions
 } from './optimizer'

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -63,6 +63,10 @@ export interface ServerOptions {
   host?: string | boolean
   port?: number
   /**
+   * If enabled, vite will exit if specified port is already in use
+   */
+  strictPort?: boolean
+  /**
    * Enable TLS + HTTP/2.
    * Note: this downgrades to TLS only when the proxy option is also used.
    */
@@ -71,19 +75,6 @@ export interface ServerOptions {
    * Open browser window on startup
    */
   open?: boolean | string
-  /**
-   * Force dep pre-optimization regardless of whether deps have changed.
-   */
-  force?: boolean
-  /**
-   * Configure HMR-specific options (port, host, path & protocol)
-   */
-  hmr?: HmrOptions | boolean
-  /**
-   * chokidar watch options
-   * https://github.com/paulmillr/chokidar#api
-   */
-  watch?: WatchOptions
   /**
    * Configure custom proxy rules for the dev server. Expects an object
    * of `{ key: options }` pairs.
@@ -114,10 +105,20 @@ export interface ServerOptions {
    * using an object.
    */
   cors?: CorsOptions | boolean
+
   /**
-   * If enabled, vite will exit if specified port is already in use
+   * Force dep pre-optimization regardless of whether deps have changed.
    */
-  strictPort?: boolean
+  force?: boolean
+  /**
+   * Configure HMR-specific options (port, host, path & protocol)
+   */
+  hmr?: HmrOptions | boolean
+  /**
+   * chokidar watch options
+   * https://github.com/paulmillr/chokidar#api
+   */
+  watch?: WatchOptions
   /**
    * Create Vite dev server to be used as a middleware in an existing server
    */


### PR DESCRIPTION
### Description

We exposed the `preview` as experimental in #5014. SvelteKit didn't end up using it, so we are still able to review this API without downstream issues before stabilizing the feature.

We have also been merging some PRs that added options in the second parameter (initially it was only the port), and others that used the external inline config (`open`, `https`, `strictPort`). We now have some in both places (`host`, after #5389, that we merged to fix the logging of URLs as this was using the config instead of the `host` in the second parameter options of preview).

This PR aligns the `preview` API with the `createServer` and `build` functions. In both cases, they take an `InlineConfig` and do the resolution of the config internally. The method also returns a new `PreviewServer` object that exposes the `config`, `httpServer` and `printUrls` following the same pattern we use for `ViteDevServer`. This would also let us extend the preview server in the future if needed.

I'm sending the PR so we can discuss details about the API. Options:

1. Current PR: We are reusing `userConfig.server` and `resolvedConfig.server` following the current design. This is ok because users normally want to share the configuration for both servers (`cors`, `https`, `proxy`, etc). The only config that needs to be overwritten is `port`. This PR proposes that we should let the user change it using the `inlineConfig`. 
2. Same as 1, but we get back to passing the port (and just the port) as the second parameter. So `preview(inlineconfig, port=5000)`. This will be closer to the original function.
3. We create a new `userConfig.preview: { port: 5000, ... }` config option and a `resolvedConfig.preview` that has the resolved info for the preview server. This PR reorders the interface for the `ServerOptions` placing every Http Server Options on the top so it is easier to know what is shared between the dev and preview servers. We could have an `HttpServerOptions` interface that is shared and a new `PreviewServerOptions`. The preview server would default to the options in dev server for `host`, `strictPort`, `https`, `cors`, `proxy` (and maybe `open`) but not for `port`. This would allow the user to define the preview port in `vite.config.js` instead of in the `package.json` script. It could be more clear also to see in the `ResolvedConfig` the resolved HTTP server options for the dev server and the preview server separately.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other