### PR TITLE
fix: exclude dependency of optimized dependency (fix: 5410)

### DIFF
--- a/packages/playground/nested-deps/__tests__/nested-deps.spec.ts
+++ b/packages/playground/nested-deps/__tests__/nested-deps.spec.ts
@@ -7,4 +7,5 @@ test('handle nested package', async () => {
   expect(await page.textContent('.side-c')).toBe(c)
   expect(await page.textContent('.d')).toBe('D@1.0.0')
   expect(await page.textContent('.nested-d')).toBe('D-nested@1.0.0')
+  expect(await page.textContent('.nested-e')).toBe('1')
 })

--- a/packages/playground/nested-deps/index.html
+++ b/packages/playground/nested-deps/index.html
@@ -19,12 +19,16 @@
 <h2>nested dependency nested-D (dep of D)</h2>
 <pre class="nested-d"></pre>
 
+<h2>exclude dependency of pre-bundled dependency</h2>
+<div>nested module instance count: <span class="nested-e"></span></div>
+
 <script type="module">
   import A from 'test-package-a'
   import B, { A as nestedA } from 'test-package-b'
   import C from 'test-package-c'
   import { C as sideC } from 'test-package-c/side'
   import D, { nestedD } from 'test-package-d'
+  import {testExcluded} from 'test-package-e'
 
   text('.a', A)
   text('.b', B)
@@ -35,6 +39,8 @@
 
   text('.d', D)
   text('.nested-d', nestedD)
+
+  text('.nested-e', testExcluded())
 
   function text(sel, text) {
     document.querySelector(sel).textContent = text

--- a/packages/playground/nested-deps/index.html
+++ b/packages/playground/nested-deps/index.html
@@ -28,7 +28,7 @@
   import C from 'test-package-c'
   import { C as sideC } from 'test-package-c/side'
   import D, { nestedD } from 'test-package-d'
-  import {testExcluded} from 'test-package-e'
+  import { testExcluded } from 'test-package-e'
 
   text('.a', A)
   text('.b', B)

--- a/packages/playground/nested-deps/package.json
+++ b/packages/playground/nested-deps/package.json
@@ -12,6 +12,7 @@
     "test-package-a": "link:./test-package-a",
     "test-package-b": "link:./test-package-b",
     "test-package-c": "link:./test-package-c",
-    "test-package-d": "link:./test-package-d"
+    "test-package-d": "link:./test-package-d",
+    "test-package-e": "link:./test-package-e"
   }
 }

--- a/packages/playground/nested-deps/test-package-e/index.js
+++ b/packages/playground/nested-deps/test-package-e/index.js
@@ -1,3 +1,2 @@
-
-export {testIncluded} from 'test-package-e-included'
-export {testExcluded} from 'test-package-e-excluded'
+export { testIncluded } from 'test-package-e-included'
+export { testExcluded } from 'test-package-e-excluded'

--- a/packages/playground/nested-deps/test-package-e/index.js
+++ b/packages/playground/nested-deps/test-package-e/index.js
@@ -1,0 +1,3 @@
+
+export {testIncluded} from 'test-package-e-included'
+export {testExcluded} from 'test-package-e-excluded'

--- a/packages/playground/nested-deps/test-package-e/package.json
+++ b/packages/playground/nested-deps/test-package-e/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "test-package-e",
-    "version": "0.1.0",
-    "main": "index.js",
-    "dependencies": {
-        "test-package-e-excluded": "link:./test-package-e-excluded",
-        "test-package-e-included": "link:./test-package-e-included"
-    }
+  "name": "test-package-e",
+  "version": "0.1.0",
+  "main": "index.js",
+  "dependencies": {
+    "test-package-e-excluded": "link:./test-package-e-excluded",
+    "test-package-e-included": "link:./test-package-e-included"
+  }
 }

--- a/packages/playground/nested-deps/test-package-e/package.json
+++ b/packages/playground/nested-deps/test-package-e/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "test-package-e",
+    "version": "0.1.0",
+    "main": "index.js",
+    "dependencies": {
+        "test-package-e-excluded": "link:./test-package-e-excluded",
+        "test-package-e-included": "link:./test-package-e-included"
+    }
+}

--- a/packages/playground/nested-deps/test-package-e/test-package-e-excluded/index.js
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-excluded/index.js
@@ -1,0 +1,12 @@
+
+const key = '$$excludedDependencyInstanceCount'
+
+if (!(key in window)) {
+    window[key] = 0
+}
+
+++window[key];
+
+export function testExcluded() {
+    return window[key]
+}

--- a/packages/playground/nested-deps/test-package-e/test-package-e-excluded/index.js
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-excluded/index.js
@@ -1,12 +1,11 @@
-
 const key = '$$excludedDependencyInstanceCount'
 
 if (!(key in window)) {
-    window[key] = 0
+  window[key] = 0
 }
 
-++window[key];
+++window[key]
 
 export function testExcluded() {
-    return window[key]
+  return window[key]
 }

--- a/packages/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
@@ -1,0 +1,5 @@
+{
+    "name": "test-package-e-excluded",
+    "version": "0.1.0",
+    "main": "index.js"
+}

--- a/packages/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "test-package-e-excluded",
-    "version": "0.1.0",
-    "main": "index.js"
+  "name": "test-package-e-excluded",
+  "version": "0.1.0",
+  "main": "index.js"
 }

--- a/packages/playground/nested-deps/test-package-e/test-package-e-included/index.js
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-included/index.js
@@ -1,0 +1,6 @@
+
+import {testExcluded} from 'test-package-e-excluded'
+
+export function testIncluded() {
+    return testExcluded()
+}

--- a/packages/playground/nested-deps/test-package-e/test-package-e-included/index.js
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-included/index.js
@@ -1,6 +1,5 @@
-
-import {testExcluded} from 'test-package-e-excluded'
+import { testExcluded } from 'test-package-e-excluded'
 
 export function testIncluded() {
-    return testExcluded()
+  return testExcluded()
 }

--- a/packages/playground/nested-deps/test-package-e/test-package-e-included/package.json
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-included/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "test-package-e-included",
+    "version": "0.1.0",
+    "main": "index.js",
+    "dependencies": {
+        "test-package-e-excluded": "link:../test-package-e-excluded"
+    }
+}

--- a/packages/playground/nested-deps/test-package-e/test-package-e-included/package.json
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-included/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "test-package-e-included",
-    "version": "0.1.0",
-    "main": "index.js",
-    "dependencies": {
-        "test-package-e-excluded": "link:../test-package-e-excluded"
-    }
+  "name": "test-package-e-included",
+  "version": "0.1.0",
+  "main": "index.js",
+  "dependencies": {
+    "test-package-e-excluded": "link:../test-package-e-excluded"
+  }
 }

--- a/packages/playground/nested-deps/vite.config.js
+++ b/packages/playground/nested-deps/vite.config.js
@@ -11,9 +11,6 @@ module.exports = {
       'test-package-d    > test-package-d-nested',
       'test-package-e-included'
     ],
-    exclude: [
-      'test-package-d', 
-      'test-package-e-excluded'
-    ]
+    exclude: ['test-package-d', 'test-package-e-excluded']
   }
 }

--- a/packages/playground/nested-deps/vite.config.js
+++ b/packages/playground/nested-deps/vite.config.js
@@ -8,8 +8,12 @@ module.exports = {
       'test-package-b',
       'test-package-c',
       'test-package-c/side',
-      'test-package-d    > test-package-d-nested'
+      'test-package-d    > test-package-d-nested',
+      'test-package-e-included'
     ],
-    exclude: ['test-package-d']
+    exclude: [
+      'test-package-d', 
+      'test-package-e-excluded'
+    ]
   }
 }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -6,7 +6,8 @@ import {
   isRunningWithYarnPnp,
   flattenId,
   normalizePath,
-  isExternalUrl
+  isExternalUrl,
+  moduleListContains
 } from '../utils'
 import { browserExternalId } from '../plugins/resolve'
 import { ExportsData } from '.'
@@ -67,8 +68,6 @@ export function esbuildDepPlugin(
     return resolver(id, _importer, undefined, ssr)
   }
 
-  const externals = parseExternals(config.optimizeDeps?.exclude)
-
   return {
     name: 'vite:dep-pre-bundle',
     setup(build) {
@@ -101,7 +100,7 @@ export function esbuildDepPlugin(
       build.onResolve(
         { filter: /^[\w@][^:]/ },
         async ({ path: id, importer, kind }) => {
-          if (matchesExternals(id, externals)) {
+          if (moduleListContains(config.optimizeDeps?.exclude, id)) {
             return {
               path: id,
               external: true
@@ -222,52 +221,4 @@ export function esbuildDepPlugin(
       }
     }
   }
-}
-
-// esbuild has 3 kinds of externals: paths, module names and patterns (globs)
-// paths are excluded by the filter in the onResolve above
-// this code reproduces esbuild external handling logic
-// for module names and globs
-interface ParsedExternalGlob {
-  prefix: string
-  suffix: string
-}
-
-interface ParsedExternals {
-  externalModules: Set<string>
-  externalGlobs: ParsedExternalGlob[]
-}
-
-function parseExternals(exclude: string[] = []): ParsedExternals {
-  const externals: ParsedExternals = {
-    externalModules: new Set<string>(),
-    externalGlobs: []
-  }
-
-  for (const ex of exclude) {
-    const p = ex.indexOf('*') // just ignore multiple globs, which is an error in esbuild anyway
-    if (p >= 0) {
-      externals.externalGlobs.push({
-        prefix: ex.substring(0, p),
-        suffix: ex.substring(p + 1)
-      })
-    } else {
-      externals.externalModules.add(ex)
-    }
-  }
-
-  return externals
-}
-
-function matchesExternals(id: string, externals: ParsedExternals): boolean {
-  if (externals.externalModules.has(id)) {
-    return true
-  } else {
-    for (const { prefix, suffix } of externals.externalGlobs) {
-      if (id.startsWith(prefix) && id.endsWith(suffix)) {
-        return true
-      }
-    }
-  }
-  return false
 }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -237,11 +237,17 @@ interface ParsedExternals {
   externalGlobs: ParsedExternalGlob[]
 }
 function parseExternals(exclude: string[] = []): ParsedExternals {
-  const externals: ParsedExternals = { externalModules: new Set<string>(), externalGlobs: [] }
+  const externals: ParsedExternals = {
+    externalModules: new Set<string>(),
+    externalGlobs: []
+  }
   for (const ex of exclude) {
     const p = ex.indexOf('*') // just ignore multiple globs, which is an error in esbuild anyway
     if (p >= 0) {
-      externals.externalGlobs.push({ prefix: ex.substring(0, p), suffix: ex.substring(p + 1) })
+      externals.externalGlobs.push({
+        prefix: ex.substring(0, p),
+        suffix: ex.substring(p + 1)
+      })
     } else {
       externals.externalModules.add(ex)
     }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -232,15 +232,18 @@ interface ParsedExternalGlob {
   prefix: string
   suffix: string
 }
+
 interface ParsedExternals {
   externalModules: Set<string>
   externalGlobs: ParsedExternalGlob[]
 }
+
 function parseExternals(exclude: string[] = []): ParsedExternals {
   const externals: ParsedExternals = {
     externalModules: new Set<string>(),
     externalGlobs: []
   }
+
   for (const ex of exclude) {
     const p = ex.indexOf('*') // just ignore multiple globs, which is an error in esbuild anyway
     if (p >= 0) {
@@ -252,6 +255,7 @@ function parseExternals(exclude: string[] = []): ParsedExternals {
       externals.externalModules.add(ex)
     }
   }
+
   return externals
 }
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -14,6 +14,7 @@ import {
   normalizePath,
   isObject,
   cleanUrl,
+  moduleListContains,
   externalRE,
   dataUrlRE,
   multilineCommentsRE,
@@ -302,7 +303,7 @@ function esbuildScanPlugin(
           filter: /^[\w@][^:]/
         },
         async ({ path: id, importer }) => {
-          if (exclude?.some((e) => e === id || id.startsWith(e + '/'))) {
+          if (moduleListContains(exclude, id)) {
             return externalUnlessEntry({ path: id })
           }
           if (depImports[id]) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -179,13 +179,26 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           url = url.replace(base, '/')
         }
 
-        const resolved = await this.resolve(url, importer)
+        let importerFile = importer
+        if (config.optimizeDeps?.exclude?.includes(url)) {
+          // if the dependency encountered in the optimized file was excluded from the optimization
+          // the dependency needs to be resolved starting from the original source location of the optimized file
+          // because starting from node_modules/.vite will not find the dependency if it was not hoisted
+          // (that is, if it is under node_modules directory in the package source of the optimized file)
+          for (const optimizedModule of Object.values(server._optimizeDepsMetadata?.optimized || {})) {
+            if (optimizedModule.file === importerModule.file) {
+              importerFile = optimizedModule.src
+            }
+          }
+        }
+     
+        const resolved = await this.resolve(url, importerFile)
 
         if (!resolved) {
           this.error(
             `Failed to resolve import "${url}" from "${path.relative(
               process.cwd(),
-              importer
+              importerFile
             )}". Does the file exist?`,
             pos
           )

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -185,13 +185,15 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // the dependency needs to be resolved starting from the original source location of the optimized file
           // because starting from node_modules/.vite will not find the dependency if it was not hoisted
           // (that is, if it is under node_modules directory in the package source of the optimized file)
-          for (const optimizedModule of Object.values(server._optimizeDepsMetadata?.optimized || {})) {
+          for (const optimizedModule of Object.values(
+            server._optimizeDepsMetadata?.optimized || {}
+          )) {
             if (optimizedModule.file === importerModule.file) {
               importerFile = optimizedModule.src
             }
           }
         }
-     
+
         const resolved = await this.resolve(url, importerFile)
 
         if (!resolved) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -19,7 +19,8 @@ import {
   timeFrom,
   normalizePath,
   removeImportQuery,
-  unwrapId
+  unwrapId,
+  moduleListContains
 } from '../utils'
 import {
   debugHmr,
@@ -180,13 +181,16 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
 
         let importerFile = importer
-        if (config.optimizeDeps?.exclude?.includes(url)) {
+        if (
+          moduleListContains(config.optimizeDeps?.exclude, url) &&
+          server._optimizeDepsMetadata
+        ) {
           // if the dependency encountered in the optimized file was excluded from the optimization
           // the dependency needs to be resolved starting from the original source location of the optimized file
           // because starting from node_modules/.vite will not find the dependency if it was not hoisted
           // (that is, if it is under node_modules directory in the package source of the optimized file)
           for (const optimizedModule of Object.values(
-            server._optimizeDepsMetadata?.optimized || {}
+            server._optimizeDepsMetadata.optimized
           )) {
             if (optimizedModule.file === importerModule.file) {
               importerFile = optimizedModule.src

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -46,7 +46,7 @@ export function isBuiltin(id: string): boolean {
 export function moduleListContains(
   moduleList: string[] | undefined,
   id: string
-) {
+): boolean | undefined {
   return moduleList?.some((m) => m === id || id.startsWith(m + '/'))
 }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -43,6 +43,13 @@ export function isBuiltin(id: string): boolean {
   return builtins.includes(id)
 }
 
+export function moduleListContains(
+  moduleList: string[] | undefined,
+  id: string
+) {
+  return moduleList?.some((m) => m === id || id.startsWith(m + '/'))
+}
+
 export const bareImportRE = /^[\w@](?!.*:\/\/)/
 export const deepImportRE = /^([^@][^/]*)\/|^(@[^/]+\/[^/]+)\//
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,11 +226,13 @@ importers:
       test-package-b: link:./test-package-b
       test-package-c: link:./test-package-c
       test-package-d: link:./test-package-d
+      test-package-e: link:./test-package-e
     dependencies:
       test-package-a: link:test-package-a
       test-package-b: link:test-package-b
       test-package-c: link:test-package-c
       test-package-d: link:test-package-d
+      test-package-e: link:test-package-e
 
   packages/playground/nested-deps/test-package-a:
     specifiers: {}
@@ -249,6 +251,23 @@ importers:
 
   packages/playground/nested-deps/test-package-d/test-package-d-nested:
     specifiers: {}
+
+  packages/playground/nested-deps/test-package-e:
+    specifiers:
+      test-package-e-excluded: link:./test-package-e-excluded
+      test-package-e-included: link:./test-package-e-included
+    dependencies:
+      test-package-e-excluded: link:test-package-e-excluded
+      test-package-e-included: link:test-package-e-included
+
+  packages/playground/nested-deps/test-package-e/test-package-e-excluded:
+    specifiers: {}
+
+  packages/playground/nested-deps/test-package-e/test-package-e-included:
+    specifiers:
+      test-package-e-excluded: link:../test-package-e-excluded
+    dependencies:
+      test-package-e-excluded: link:../test-package-e-excluded
 
   packages/playground/optimize-deps:
     specifiers:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds the test and should fix https://github.com/vitejs/vite/issues/5410

### Additional context

The testcase has 3 packages:

- `test-package-e` is the main package which imports both `test-package-e-included` and `test-package-e-excluded`
- `test-package-e-included` is the first level dependency which also imports `test-package-e-excluded`
- `test-package-e-excluded` is the leaf dependency imported by the previous 2 packages

`test-package-e-included` is in `optimizeDeps.include`

`test-package-e-excluded` is in `optimizeDeps.exclude`

`test-package-e-excluded` uses a property on a window object to count how many times the package has been loaded.

Despite being in `optimizeDeps.exclude`, `test-package-e-excluded` is bundled together in the same chunk with the optimized package that uses it. Also, it's loaded by the main package, unoptimized, so the are 2 instances of `test-package-e-excluded` loaded in the application.

To confirm that, `test-package-e-excluded` uses a property on the `window` object, incremented in the package code, to count how many times it was loaded. In the build mode, the `index.html` test page shows that is was loaded twice.

### The fix

Why is `test-package-e-excluded` optimized and bundled, even if it's in the `optimizeDeps.exclude`, and should be in the `external` option passed to the esbuild?

Because `vite` uses resolver plugin with esbuild. The esbuild documentation says 

> For a given import path, all onResolve callbacks from all plugins will be run in the order they were registered until one takes responsibility for path resolution. If no callback returns a path, esbuild will run its default path resolution logic.

What it does not say, but can be seen in the esbuild code, is that [if the plugin resolves the import](https://github.com/evanw/esbuild/blob/master/internal/bundler/bundler.go#L747), the default resolution logic is bypassed entirely, and it's the default resolution logic that's [responsible for skipping external package imports](https://github.com/evanw/esbuild/blob/master/internal/resolver/resolver.go#L656).

It looks like esbuild expects the plugin resolution code to hande `external` option and to return resolution result with `external: true` for external imports. This is implemented in the second commit.

The `external` option in esbuild supports three different formats:
- paths
- module names
- globs
    
Paths are excluded by resolver plugin filter that is given to esbuild by vite. In the review, it was pointed out that vite does not support globs in optimizeDeps.exclude, but should exclude "deep" paths too, so excluding `some-module` should also exclude `some-module/path`.  I added the code to the plugin to do that.

### Additional change in `importAnalysis.ts`

After the fix, optimized code in `node_modules/.vite` has imports referring to the excluded packages.

These imports fail to resolve in the `importAnalysis.ts` if they were not hoisted and were unreachable by regular node resolution lookup that started from `node_modules/.vite` (happens by default with pnpm in the playground test code). The fix tries to find the original source code for the importer of the excluded package, and starts lookup from there.



### The background

In a monorepo, I have an application and a library used by the application.
I want to modify the library, so while it's under development, it is present in the `optimizeDeps.exclude`.

The application also uses a number of components which are developed separately
and are not in the monorepo, but also happen to use the same library. The package with the components is in the `optimizeDeps.include`.

The library is loaded twice in the development mode, which is causing some problems.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
