### PR TITLE
fix(plugin-vue): template src isn't working when script setup

### DIFF
--- a/packages/playground/vue/Main.vue
+++ b/packages/playground/vue/Main.vue
@@ -19,6 +19,7 @@
     <AsyncComponent />
   </Suspense>
   <RefTransform />
+  <SetupImportTemplate />
 </template>
 
 <script setup lang="ts">
@@ -33,6 +34,7 @@ import Slotted from './Slotted.vue'
 import ScanDep from './ScanDep.vue'
 import AsyncComponent from './AsyncComponent.vue'
 import RefTransform from './RefTransform.vue'
+import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
 
 import { ref } from 'vue'
 

--- a/packages/playground/vue/__tests__/vue.spec.ts
+++ b/packages/playground/vue/__tests__/vue.spec.ts
@@ -219,3 +219,11 @@ describe('custom element', () => {
     expect(await getColor('.custom-element')).toBe('green')
   })
 })
+
+describe('setup import template', () => {
+  test('should work', async () => {
+    expect(await page.textContent('.setup-import-template')).toMatch('0')
+    await page.click('.setup-import-template')
+    expect(await page.textContent('.setup-import-template')).toMatch('1')
+  })
+})

--- a/packages/playground/vue/setup-import-template/SetupImportTemplate.vue
+++ b/packages/playground/vue/setup-import-template/SetupImportTemplate.vue
@@ -1,0 +1,5 @@
+<template src="./template.html"></template>
+<script setup>
+let count = $ref(0)
+const inc = () => count++
+</script>

--- a/packages/playground/vue/setup-import-template/template.html
+++ b/packages/playground/vue/setup-import-template/template.html
@@ -1,0 +1,2 @@
+<h2>Setup Import Template</h2>
+<button class="setup-import-template" @click="inc">{{ count }}</button>

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -10,7 +10,7 @@ import {
 } from './utils/descriptorCache'
 import { PluginContext, SourceMap, TransformPluginContext } from 'rollup'
 import { normalizePath } from '@rollup/pluginutils'
-import { resolveScript } from './script'
+import { resolveScript, isUseInlineTemplate } from './script'
 import { transformTemplateInMain } from './template'
 import { isOnlyTemplateChanged, isEqualBlock } from './handleHotUpdate'
 import { RawSourceMap, SourceMapConsumer, SourceMapGenerator } from 'source-map'
@@ -53,14 +53,7 @@ export async function transformMain(
   )
 
   // template
-  // Check if we can use compile template as inlined render function
-  // inside <script setup>. This can only be done for build because
-  // inlined template cannot be individually hot updated.
-  const useInlineTemplate =
-    !devServer &&
-    descriptor.scriptSetup &&
-    !(descriptor.template && descriptor.template.src)
-  const hasTemplateImport = descriptor.template && !useInlineTemplate
+  const hasTemplateImport = descriptor.template && !isUseInlineTemplate(descriptor, !devServer)
 
   let templateCode = ''
   let templateMap: RawSourceMap | undefined

--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -22,6 +22,17 @@ export function setResolvedScript(
   ;(ssr ? ssrCache : clientCache).set(descriptor, script)
 }
 
+// Check if we can use compile template as inlined render function
+// inside <script setup>. This can only be done for build because
+// inlined template cannot be individually hot updated.
+export function isUseInlineTemplate(descriptor: SFCDescriptor, isProd: boolean): boolean {
+  return (
+    isProd &&
+    !!descriptor.scriptSetup &&
+    !(descriptor.template && descriptor.template.src)
+  )
+}
+
 export function resolveScript(
   descriptor: SFCDescriptor,
   options: ResolvedOptions,
@@ -43,7 +54,7 @@ export function resolveScript(
     ...options.script,
     id: descriptor.id,
     isProd: options.isProduction,
-    inlineTemplate: !options.devServer,
+    inlineTemplate: isUseInlineTemplate(descriptor, !options.devServer),
     refTransform: options.refTransform !== false,
     templateOptions: resolveTemplateCompilerOptions(descriptor, options, ssr),
     // @ts-ignore TODO remove ignore when we support this in @vue/compiler-sfc

--- a/packages/plugin-vue/src/script.ts
+++ b/packages/plugin-vue/src/script.ts
@@ -29,7 +29,7 @@ export function isUseInlineTemplate(descriptor: SFCDescriptor, isProd: boolean):
   return (
     isProd &&
     !!descriptor.scriptSetup &&
-    !(descriptor.template && descriptor.template.src)
+    !descriptor.template?.src
   )
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #5324

### Additional context
The `inlineTemplate` option of compile script is not based on the actual situation of `template`
https://github.com/vitejs/vite/blob/d2fc1a1ead1363a15dfcc25fce8587f03289b590/packages/plugin-vue/src/script.ts#L46

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
