### PR TITLE
fix: allowed files logic (fix #5416)

### DIFF
--- a/packages/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/packages/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -24,8 +24,8 @@ describe('main', () => {
     })
 
     test('unsafe fetch', async () => {
-      expect(await page.textContent('.unsafe-fetch')).toMatch('403 Restricted')
-      expect(await page.textContent('.unsafe-fetch-status')).toBe('403')
+      expect(await page.textContent('.unsafe-fetch')).toMatch('')
+      expect(await page.textContent('.unsafe-fetch-status')).toBe('404')
     })
 
     test('safe fs fetch', async () => {
@@ -35,7 +35,7 @@ describe('main', () => {
 
     test('unsafe fs fetch', async () => {
       expect(await page.textContent('.unsafe-fs-fetch')).toBe('')
-      expect(await page.textContent('.unsafe-fs-fetch-status')).toBe('403')
+      expect(await page.textContent('.unsafe-fs-fetch-status')).toBe('404')
     })
 
     test('nested entry', async () => {

--- a/packages/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/packages/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -24,8 +24,8 @@ describe('main', () => {
     })
 
     test('unsafe fetch', async () => {
-      expect(await page.textContent('.unsafe-fetch')).toMatch('')
-      expect(await page.textContent('.unsafe-fetch-status')).toBe('404')
+      expect(await page.textContent('.unsafe-fetch')).toMatch('403 Restricted')
+      expect(await page.textContent('.unsafe-fetch-status')).toBe('403')
     })
 
     test('safe fs fetch', async () => {
@@ -35,7 +35,7 @@ describe('main', () => {
 
     test('unsafe fs fetch', async () => {
       expect(await page.textContent('.unsafe-fs-fetch')).toBe('')
-      expect(await page.textContent('.unsafe-fs-fetch-status')).toBe('404')
+      expect(await page.textContent('.unsafe-fs-fetch-status')).toBe('403')
     })
 
     test('nested entry', async () => {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -24,7 +24,8 @@ import {
   isDataUrl,
   cleanUrl,
   slash,
-  nestedResolveFrom
+  nestedResolveFrom,
+  isFileReadable
 } from '../utils'
 import { ViteDevServer, SSROptions } from '..'
 import { createFilter } from '@rollup/pluginutils'
@@ -372,15 +373,10 @@ function tryResolveFile(
   tryPrefix?: string,
   skipPackageJson?: boolean
 ): string | undefined {
-  let isReadable = false
-  try {
-    // #2051 if we don't have read permission on a directory, existsSync() still
-    // works and will result in massively slow subsequent checks (which are
-    // unnecessary in the first place)
-    fs.accessSync(file, fs.constants.R_OK)
-    isReadable = true
-  } catch (e) {}
-  if (isReadable) {
+  // #2051 if we don't have read permission on a directory, existsSync() still
+  // works and will result in massively slow subsequent checks (which are
+  // unnecessary in the first place)
+  if (isFileReadable(file)) {
     if (!fs.statSync(file).isDirectory()) {
       return getRealPath(file, preserveSymlinks) + postfix
     } else if (tryIndex) {

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -68,35 +68,8 @@ export function errorMiddleware(
     if (allowNext) {
       next()
     } else {
-      if (err instanceof AccessRestrictedError) {
-        res.statusCode = 403
-        res.write(renderErrorHTML(err.message))
-        res.end()
-      }
       res.statusCode = 500
       res.end()
     }
   }
-}
-
-export class AccessRestrictedError extends Error {
-  constructor(msg: string) {
-    super(msg)
-  }
-}
-
-export function renderErrorHTML(msg: string): string {
-  // to have syntax highlighting and autocompletion in IDE
-  const html = String.raw
-  return html`
-    <body>
-      <h1>403 Restricted</h1>
-      <p>${msg.replace(/\n/g, '<br/>')}</p>
-      <style>
-        body {
-          padding: 1em 2em;
-        }
-      </style>
-    </body>
-  `
 }

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -162,9 +162,9 @@ export function isFileServingAllowed(
     server.config.logger.error(
       `The request url "${url}" is outside of Vite serving allow list:
 
-  ${allow.map((i) => `- ${i}`).join('\n')}
+${allow.map((i) => `- ${i}`).join('\n')}
 
-  Refer to docs https://vitejs.dev/config/#server-fs-allow for configurations and more details.`
+Refer to docs https://vitejs.dev/config/#server-fs-allow for configurations and more details.`
     )
   }
 

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import fs from 'fs'
 import { ServerResponse } from 'http'
 import sirv, { Options } from 'sirv'
 import { Connect } from 'types/connect'
@@ -12,7 +11,8 @@ import {
   isImportRequest,
   isInternalRequest,
   isWindows,
-  slash
+  slash,
+  isFileReadable
 } from '../../utils'
 
 const sirvOptions: Options = {
@@ -144,7 +144,7 @@ export function isFileServingAllowed(
     return true
 
   if (!server.config.server.fs.strict) {
-    if (fs.existsSync(file)) {
+    if (isFileReadable(file)) {
       server.config.logger.warnOnce(`Unrestricted file system access to "${url}"`)
       server.config.logger.warnOnce(
         `For security concerns, accessing files outside of serving allow list will ` +
@@ -167,7 +167,7 @@ function ensureServingAccess(
   if (isFileServingAllowed(url, server)) {
     return true
   }
-  if (fs.existsSync(url)) {
+  if (isFileReadable(cleanUrl(url))) {
     const message = `The request url "${url}" is outside of Vite serving allow list:
 
 ${server.config.server.fs.allow.map((i) => `- ${i}`).join('\n')}

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -1,4 +1,6 @@
 import path from 'path'
+import fs from 'fs'
+import { ServerResponse } from 'http'
 import sirv, { Options } from 'sirv'
 import { Connect } from 'types/connect'
 import { normalizePath, ViteDevServer } from '../..'
@@ -12,7 +14,6 @@ import {
   isWindows,
   slash
 } from '../../utils'
-import { AccessRestrictedError } from './error'
 
 const sirvOptions: Options = {
   dev: true,
@@ -51,11 +52,12 @@ export function serveStaticMiddleware(
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteServeStaticMiddleware(req, res, next) {
-    // only serve the file if it's not an html request
+    // only serve the file if it's not an html request  or ends with /
     // so that html requests can fallthrough to our html middleware for
     // special processing
     // also skip internal requests `/@fs/ /@vite-client` etc...
     if (
+      req.url!.endsWith('/') ||
       path.extname(cleanUrl(req.url!)) === '.html' ||
       isInternalRequest(req.url!)
     ) {
@@ -86,8 +88,10 @@ export function serveStaticMiddleware(
     if (resolvedUrl.endsWith('/') && !fileUrl.endsWith('/')) {
       fileUrl = fileUrl + '/'
     }
-    ensureServingAccess(fileUrl, server)
-    
+    if (!ensureServingAccess(fileUrl, server, res, next)) {
+      return
+    }
+
     if (redirected) {
       req.url = redirected
     }
@@ -110,7 +114,10 @@ export function serveRawFsMiddleware(
     // searching based from fs root.
     if (url.startsWith(FS_PREFIX)) {
       // restrict files outside of `fs.allow`
-      ensureServingAccess(slash(path.resolve(fsPathFromId(url))), server)
+      if (!ensureServingAccess(slash(path.resolve(fsPathFromId(url))), server, res, next)) {
+        return
+      }
+
       url = url.slice(FS_PREFIX.length)
       if (isWindows) url = url.replace(/^[A-Z]:/i, '')
 
@@ -133,31 +140,52 @@ export function isFileServingAllowed(
 
   if (server.moduleGraph.safeModulesPath.has(file)) return true
 
-  if (server.config.server.fs.allow.some((i) => file.startsWith(i + '/')))
+  const { allow } = server.config.server.fs
+  if (allow.some((i) => file.startsWith(i + '/')))
     return true
 
   if (!server.config.server.fs.strict) {
-    server.config.logger.warnOnce(`Unrestricted file system access to "${url}"`)
-    server.config.logger.warnOnce(
-      `For security concerns, accessing files outside of serving allow list will ` +
+    if (fs.existsSync(file)) {
+      server.config.logger.warnOnce(`Unrestricted file system access to "${url}"`)
+      server.config.logger.warnOnce(
+        `For security concerns, accessing files outside of serving allow list will ` +
         `be restricted by default in the future version of Vite. ` +
         `Refer to https://vitejs.dev/config/#server-fs-allow for more details.`
-    )
+      )
+    }
     return true
+  }
+
+  // if the file doesn't exist, we shouldn't restrict this path as it can
+  // be an API call. Middlewares would issue a 404 if the file isn't handled
+  if (fs.existsSync(file)) {
+    server.config.logger.error(
+      `The request url "${url}" is outside of Vite serving allow list:
+
+  ${allow.map((i) => `- ${i}`).join('\n')}
+
+  Refer to docs https://vitejs.dev/config/#server-fs-allow for configurations and more details.`
+    )
   }
 
   return false
 }
 
-export function ensureServingAccess(url: string, server: ViteDevServer): void {
-  if (!isFileServingAllowed(url, server)) {
-    const allow = server.config.server.fs.allow
-    throw new AccessRestrictedError(
-      `The request url "${url}" is outside of Vite serving allow list:
-
-${allow.map((i) => `- ${i}`).join('\n')}
-
-Refer to docs https://vitejs.dev/config/#server-fs-allow for configurations and more details.`
-    )
+function ensureServingAccess(
+  url: string,
+  server: ViteDevServer,
+  res: ServerResponse, 
+  next: Connect.NextFunction,
+): boolean {
+  if (isFileServingAllowed(url, server)) {
+    return true
   }
+  if (fs.existsSync(url)) {
+    res.statusCode = 404
+    res.end()
+  }
+  else {
+    next()
+  }
+  return false
 }

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -52,7 +52,7 @@ export function serveStaticMiddleware(
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteServeStaticMiddleware(req, res, next) {
-    // only serve the file if it's not an html request  or ends with /
+    // only serve the file if it's not an html request or ends with `/`
     // so that html requests can fallthrough to our html middleware for
     // special processing
     // also skip internal requests `/@fs/ /@vite-client` etc...

--- a/packages/vite/src/node/server/searchRoot.ts
+++ b/packages/vite/src/node/server/searchRoot.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import { dirname } from 'path'
 import { join } from 'path'
+import { isFileReadable } from '../utils'
 
 // https://github.com/vitejs/vite/issues/2820#issuecomment-812495079
 const ROOT_FILES = [
@@ -21,9 +22,7 @@ const ROOT_FILES = [
 // yarn: https://classic.yarnpkg.com/en/docs/workspaces/#toc-how-to-use-it
 function hasWorkspacePackageJSON(root: string): boolean {
   const path = join(root, 'package.json')
-  try {
-    fs.accessSync(path, fs.constants.R_OK)
-  } catch {
+  if (!isFileReadable(path)) {
     return false
   }
   const content = JSON.parse(fs.readFileSync(path, 'utf-8')) || {}

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -383,7 +383,7 @@ export function writeFile(
  * works and will result in massively slow subsequent checks (which are
  * unnecessary in the first place)
  */
-export function isFileReadable(filename: string,) {
+export function isFileReadable(filename: string): boolean {
   try {
     fs.accessSync(filename, fs.constants.R_OK)
     return true

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -387,8 +387,9 @@ export function isFileReadable(filename: string,) {
   try {
     fs.accessSync(filename, fs.constants.R_OK)
     return true
-  } catch (e) {}
-  return false
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -378,6 +378,20 @@ export function writeFile(
 }
 
 /**
+ * Use instead of fs.existsSync(filename)
+ * #2051 if we don't have read permission on a directory, existsSync() still
+ * works and will result in massively slow subsequent checks (which are
+ * unnecessary in the first place)
+ */
+export function isFileReadable(filename: string,) {
+  try {
+    fs.accessSync(filename, fs.constants.R_OK)
+    return true
+  } catch (e) {}
+  return false
+}
+
+/**
  * Delete every file and subdirectory. **The given directory must exist.**
  * Pass an optional `skip` array to preserve files in the root directory.
  */


### PR DESCRIPTION
### Description

We introduced a new restriction to served files in the `serveStaticMiddleware` in #5361
@benmccann reported an issue with this restriction in #5416 that we later expanded in a discussion in Vite Land. The problem with the new restriction is that it will restrict paths that don't exist in the filesystem. These paths can be an API call that should be later handled by user middlewares.

Instead of a hard error and 403, this PR takes a note from a @antfu here https://github.com/vitejs/vite/pull/5361#discussion_r734061461. To avoid leaking file names information, it replaces errors by a call to `next()` so a restricted file and a file that doesn't exist look the same in the browser (404). An error is still emitted to the console.

File existence is also checked for the warning when strict isn't true. I think some false positives were due to this missing check.

### Additional context

We should merge this PR and do another patch release before moving to the 2.7 beta.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other