### PR TITLE
fix(plugin-react): avoid mangling the sourcemaps of virtual modules

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -199,6 +199,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           ast: !isReasonReact,
           root: projectRoot,
           filename: id,
+          sourceFileName: id,
           parserOpts: {
             ...opts.babel?.parserOpts,
             sourceType: 'module',


### PR DESCRIPTION
Previously, the `sources` array within a virtual module‘s sourcemap would contain the basename (ie: the characters after the last `/`) rather than the entire `id` string, which would trigger a "Sourcemap points to missing source files" warning for each virtual module.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
