### PR TITLE
fix(plugin-vue): exclude direct css request from hmr target

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -11,6 +11,8 @@ import { ResolvedOptions } from '.'
 
 const debug = _debug('vite:hmr')
 
+const directRequestRE = /(\?|&)direct\b/
+
 /**
  * Vite-specific HMR handling
  */
@@ -92,7 +94,8 @@ export async function handleHotUpdate(
       const mod = modules.find(
         (m) =>
           m.url.includes(`type=style&index=${i}`) &&
-          m.url.endsWith(`.${next.lang || 'css'}`)
+          m.url.endsWith(`.${next.lang || 'css'}`) &&
+          !directRequestRE.test(m.url)
       )
       if (mod) {
         affectedModules.add(mod)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes https://github.com/nuxt/nuxt.js/issues/12211

This is really a tricky edge case. So here is the thing, normally this HMR should just work. But the way the plugin is implemented is by caching the style request from the main entry of Vue SFC. Normally the request will be something like `foo.vue?vue&type=style&lang.css`, which will be compiled to a js module with HMR capability like: 

```ts
import { createHotContext as __vite__createHotContext } from "/@vite/client";
import.meta.hot = __vite__createHotContext("/foo.vue?vue&type=style&lang.css");
import { updateStyle, removeStyle } from "/@vite/client"
const id = "..."
const css = "the CSS..."
updateStyle(id, css)
import.meta.hot.accept()
export default css
import.meta.hot.prune(() => removeStyle(id))
```

However, if we do a **direct request** to the CSS - in Nuxt case, we do SSR to embedded the style to prevent FOUC like:

```html
<link rel="stylesheet" href="/foo.vue?vue&type=style&lang.css"></link>
```

Base on the browser request header, the CSS plugin will then resolve the id with to `/foo.vue?direct&vue&type=style&lang.css` with the `?direct` to serve plain CSS instead of js module.

So now the direct request comes before the JS version, it makes the plugin internal state only record the direct one and send hmr event to the wrong module.

![image](https://user-images.githubusercontent.com/11247099/138787400-1dd4f173-7018-471c-a439-dc85cf2e410b.png)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes nuxt/framework#123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
