### PR TITLE
chore(release): git tag right after committing

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -154,6 +154,7 @@ async function main() {
     step('\nCommitting changes...')
     await runIfNotDry('git', ['add', '-A'])
     await runIfNotDry('git', ['commit', '-m', `release: ${tag}`])
+    await runIfNotDry('git', ['tag', tag])
   } else {
     console.log('No changes to commit.')
   }
@@ -162,7 +163,6 @@ async function main() {
   await publishPackage(targetVersion, runIfNotDry)
 
   step('\nPushing to GitHub...')
-  await runIfNotDry('git', ['tag', tag])
   await runIfNotDry('git', ['push', 'origin', `refs/tags/${tag}`])
   await runIfNotDry('git', ['push'])
 


### PR DESCRIPTION
Sometimes the npm publishing might fail due to some network or npm issues. Which causes the following step to be skipped. When doing a manual publish we will need to do a manual git tagging as well, which I think makes more sense to tag right after committing. 