### PR TITLE
fix: do not overwrite pendingReload promise (fix #5448)

### DIFF
--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -94,9 +94,11 @@ export function createMissingImporterRegisterFn(
       currentMissing[id] = resolved
       if (handle) clearTimeout(handle)
       handle = setTimeout(() => rerun(ssr), debounceMs)
-      server._pendingReload = new Promise((r) => {
-        pendingResolve = r
-      })
+      if (!server._pendingReload) {
+        server._pendingReload = new Promise((r) => {
+          pendingResolve = r
+        })
+      }
     }
   }
 }

--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -15,7 +15,7 @@ export function createMissingImporterRegisterFn(
   const { logger } = server.config
   let knownOptimized = server._optimizeDepsMetadata!.optimized
   let currentMissing: Record<string, string> = {}
-  let handle: NodeJS.Timeout
+  let handle: NodeJS.Timeout | undefined
 
   let pendingResolve: (() => void) | null = null
 
@@ -70,8 +70,11 @@ export function createMissingImporterRegisterFn(
       )
     } finally {
       server._isRunningOptimizer = false
-      pendingResolve && pendingResolve()
-      server._pendingReload = pendingResolve = null
+      if (!handle) {
+        // No other rerun() pending so resolve and let pending requests proceed
+        pendingResolve && pendingResolve()
+        server._pendingReload = pendingResolve = null
+      }
     }
 
     // Cached transform results have stale imports (resolved to
@@ -93,7 +96,10 @@ export function createMissingImporterRegisterFn(
     if (!knownOptimized[id]) {
       currentMissing[id] = resolved
       if (handle) clearTimeout(handle)
-      handle = setTimeout(() => rerun(ssr), debounceMs)
+      handle = setTimeout(() => {
+        handle = undefined
+        rerun(ssr)
+      }, debounceMs)
       if (!server._pendingReload) {
         server._pendingReload = new Promise((r) => {
           pendingResolve = r


### PR DESCRIPTION
### Description

In case of this call sequence
1. registerMissingImport
2. a new incoming request
3. registerMissingImport

the request in step 2 will keep waiting indefinitely for a promise that will never resolve as step 3 overwrites the _pendingReload promise without resolving the previous one

Fixes #5448

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
