### PR TITLE
feat(plugin-react): check for `api.reactBabel` on other plugins

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -2,7 +2,7 @@ import type { ParserOptions, TransformOptions, types as t } from '@babel/core'
 import * as babel from '@babel/core'
 import { createFilter } from '@rollup/pluginutils'
 import resolve from 'resolve'
-import type { Plugin, PluginOption, ResolvedConfig } from 'vite'
+import type { Plugin, PluginOption } from 'vite'
 import {
   addRefreshWrapper,
   isRefreshBoundary,

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -2,7 +2,7 @@ import type { ParserOptions, TransformOptions, types as t } from '@babel/core'
 import * as babel from '@babel/core'
 import { createFilter } from '@rollup/pluginutils'
 import resolve from 'resolve'
-import type { Plugin, PluginOption } from 'vite'
+import type { Plugin, PluginOption, ResolvedConfig } from 'vite'
 import {
   addRefreshWrapper,
   isRefreshBoundary,
@@ -43,6 +43,24 @@ export interface Options {
   parserPlugins?: ParserOptions['plugins']
 }
 
+type ReactBabelOptions = {
+  [P in keyof TransformOptions]-?: (P extends 'parserOpts'
+    ? { plugins: Exclude<ParserOptions['plugins'], undefined> }
+    : unknown) &
+    Exclude<TransformOptions[P], null | undefined>
+}
+
+declare module 'vite' {
+  export interface Plugin {
+    api?: {
+      /**
+       * Manipulate the Babel options of `@vitejs/plugin-react`
+       */
+      reactBabel?: (options: ReactBabelOptions, config: ResolvedConfig) => void
+    }
+  }
+}
+
 export default function viteReact(opts: Options = {}): PluginOption[] {
   // Provide default values for Rollup compat.
   let base = '/'
@@ -54,11 +72,18 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
   const useAutomaticRuntime = opts.jsxRuntime !== 'classic'
 
-  const userPlugins = opts.babel?.plugins || []
-  const userParserPlugins =
-    opts.parserPlugins || opts.babel?.parserOpts?.plugins || []
+  const babelOptions = {
+    babelrc: false,
+    configFile: false,
+    ...opts.babel
+  } as ReactBabelOptions
 
-  // Support pattens like:
+  babelOptions.plugins ||= []
+  babelOptions.presets ||= []
+  babelOptions.parserOpts ||= {} as any
+  babelOptions.parserOpts.plugins ||= opts.parserPlugins || []
+
+  // Support patterns like:
   // - import * as React from 'react';
   // - import React from 'react';
   // - import React, {useEffect} from 'react';
@@ -88,15 +113,21 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         )
       }
 
-      config.plugins.forEach(
-        (plugin) =>
-          (plugin.name === 'react-refresh' ||
-            (plugin !== viteReactJsx && plugin.name === 'vite:react-jsx')) &&
-          config.logger.warn(
+      config.plugins.forEach((plugin) => {
+        const hasConflict =
+          plugin.name === 'react-refresh' ||
+          (plugin !== viteReactJsx && plugin.name === 'vite:react-jsx')
+
+        if (hasConflict)
+          return config.logger.warn(
             `[@vitejs/plugin-react] You should stop using "${plugin.name}" ` +
               `since this plugin conflicts with it.`
           )
-      )
+
+        if (plugin.api?.reactBabel) {
+          plugin.api.reactBabel(babelOptions, config)
+        }
+      })
     },
     async transform(code, id, options) {
       const ssr = typeof options === 'boolean' ? options : options?.ssr === true
@@ -113,7 +144,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         const isProjectFile =
           !isNodeModules && (id[0] === '\0' || id.startsWith(projectRoot + '/'))
 
-        const plugins = isProjectFile ? [...userPlugins] : []
+        const plugins = isProjectFile ? [...babelOptions.plugins] : []
 
         let useFastRefresh = false
         if (!skipFastRefresh && !ssr && !isNodeModules) {
@@ -179,15 +210,15 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         // module, including node_modules and linked packages.
         const shouldSkip =
           !plugins.length &&
-          !opts.babel?.configFile &&
-          !(isProjectFile && opts.babel?.babelrc)
+          !babelOptions.configFile &&
+          !(isProjectFile && babelOptions.babelrc)
 
         if (shouldSkip) {
           return // Avoid parsing if no plugins exist.
         }
 
-        const parserPlugins: typeof userParserPlugins = [
-          ...userParserPlugins,
+        const parserPlugins: typeof babelOptions.parserOpts.plugins = [
+          ...babelOptions.parserOpts.plugins,
           'importMeta',
           // This plugin is applied before esbuild transforms the code,
           // so we need to enable some stage 3 syntax that is supported in
@@ -206,35 +237,32 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           parserPlugins.push('typescript')
         }
 
-        const isReasonReact = extension.endsWith('.bs.js')
+        const transformAsync = ast
+          ? babel.transformFromAstAsync.bind(babel, ast, code)
+          : babel.transformAsync.bind(babel, code)
 
-        const babelOpts: TransformOptions = {
-          babelrc: false,
-          configFile: false,
-          ...opts.babel,
+        const isReasonReact = extension.endsWith('.bs.js')
+        const result = await transformAsync({
+          ...babelOptions,
           ast: !isReasonReact,
           root: projectRoot,
           filename: id,
           sourceFileName: filepath,
           parserOpts: {
-            ...opts.babel?.parserOpts,
+            ...babelOptions.parserOpts,
             sourceType: 'module',
             allowAwaitOutsideFunction: true,
             plugins: parserPlugins
           },
           generatorOpts: {
-            ...opts.babel?.generatorOpts,
+            ...babelOptions.generatorOpts,
             decoratorsBeforeExport: true
           },
           plugins,
           sourceMaps: true,
           // Vite handles sourcemap flattening
           inputSourceMap: false as any
-        }
-
-        const result = ast
-          ? await babel.transformFromAstAsync(ast, code, babelOpts)
-          : await babel.transformAsync(code, babelOpts)
+        })
 
         if (result) {
           let code = result.code!

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -13,6 +13,15 @@ import {
 import { babelImportToRequire } from './jsx-runtime/babel-import-to-require'
 import { restoreJSX } from './jsx-runtime/restore-jsx'
 
+declare module 'vite' {
+  export interface Plugin {
+    /**
+     * Babel configuration applied in both dev and prod.
+     */
+    babel?: Pick<TransformOptions, 'plugins' | 'presets'>
+  }
+}
+
 export interface Options {
   include?: string | RegExp | Array<string | RegExp>
   exclude?: string | RegExp | Array<string | RegExp>
@@ -54,7 +63,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
   const useAutomaticRuntime = opts.jsxRuntime !== 'classic'
 
-  const userPlugins = opts.babel?.plugins || []
+  let userPlugins = [...(opts.babel?.plugins || [])]
+  let userPresets = [...(opts.babel?.presets || [])]
+
   const userParserPlugins =
     opts.parserPlugins || opts.babel?.parserOpts?.plugins || []
 
@@ -88,15 +99,33 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         )
       }
 
-      config.plugins.forEach(
-        (plugin) =>
-          (plugin.name === 'react-refresh' ||
-            (plugin !== viteReactJsx && plugin.name === 'vite:react-jsx')) &&
-          config.logger.warn(
+      config.plugins.forEach((plugin) => {
+        const isExtraneous =
+          plugin.name === 'react-refresh' ||
+          (plugin !== viteReactJsx && plugin.name === 'vite:react-jsx')
+
+        if (isExtraneous)
+          return config.logger.warn(
             `[@vitejs/plugin-react] You should stop using "${plugin.name}" ` +
               `since this plugin conflicts with it.`
           )
-      )
+
+        if (plugin.babel) {
+          const { plugins, presets } = plugin.babel
+          if (plugins) {
+            userPlugins =
+              plugin.enforce === 'pre'
+                ? [...plugins, ...userPlugins]
+                : [...userPlugins, ...plugins]
+          }
+          if (presets) {
+            userPresets =
+              plugin.enforce === 'pre'
+                ? [...presets, ...userPresets]
+                : [...userPresets, ...presets]
+          }
+        }
+      })
     },
     async transform(code, id, options) {
       const ssr = typeof options === 'boolean' ? options : options?.ssr === true
@@ -227,6 +256,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             decoratorsBeforeExport: true
           },
           plugins,
+          presets: userPresets,
           sourceMaps: true,
           // Vite handles sourcemap flattening
           inputSourceMap: false as any

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -36,15 +36,15 @@ export interface Options {
   /**
    * Babel configuration applied in both dev and prod.
    */
-  babel?: Pick<TransformOptions, SupportedBabelOptions>
+  babel?: BabelOptions
   /**
    * @deprecated Use `babel.parserOpts.plugins` instead
    */
   parserPlugins?: ParserOptions['plugins']
 }
 
-type SupportedBabelOptions = Exclude<
-  keyof TransformOptions,
+export type BabelOptions = Omit<
+  TransformOptions,
   | 'ast'
   | 'filename'
   | 'root'
@@ -53,11 +53,16 @@ type SupportedBabelOptions = Exclude<
   | 'inputSourceMap'
 >
 
-type ReactBabelOptions = {
-  [P in SupportedBabelOptions]: Exclude<TransformOptions[P], null | undefined> &
-    (P extends 'parserOpts'
-      ? { plugins: Exclude<ParserOptions['plugins'], undefined> }
-      : unknown)
+/**
+ * The object type used by the `options` passed to plugins with
+ * an `api.reactBabel` method.
+ */
+export interface ReactBabelOptions extends BabelOptions {
+  plugins: Extract<BabelOptions['plugins'], any[]>
+  presets: Extract<BabelOptions['presets'], any[]>
+  parserOpts: ParserOptions & {
+    plugins: Extract<ParserOptions['plugins'], any[]>
+  }
 }
 
 declare module 'vite' {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -50,7 +50,7 @@ type SupportedBabelOptions = Exclude<
   | 'root'
   | 'sourceFileName'
   | 'sourceMaps'
-  | 'inlineSourceMap'
+  | 'inputSourceMap'
 >
 
 type ReactBabelOptions = {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -36,7 +36,7 @@ export interface Options {
   /**
    * Babel configuration applied in both dev and prod.
    */
-  babel?: TransformOptions
+  babel?: Pick<TransformOptions, SupportedBabelOptions>
   /**
    * @deprecated Use `babel.parserOpts.plugins` instead
    */

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -43,11 +43,21 @@ export interface Options {
   parserPlugins?: ParserOptions['plugins']
 }
 
+type SupportedBabelOptions = Exclude<
+  keyof TransformOptions,
+  | 'ast'
+  | 'filename'
+  | 'root'
+  | 'sourceFileName'
+  | 'sourceMaps'
+  | 'inlineSourceMap'
+>
+
 type ReactBabelOptions = {
-  [P in keyof TransformOptions]-?: (P extends 'parserOpts'
-    ? { plugins: Exclude<ParserOptions['plugins'], undefined> }
-    : unknown) &
-    Exclude<TransformOptions[P], null | undefined>
+  [P in SupportedBabelOptions]: Exclude<TransformOptions[P], null | undefined> &
+    (P extends 'parserOpts'
+      ? { plugins: Exclude<ParserOptions['plugins'], undefined> }
+      : unknown)
 }
 
 declare module 'vite' {


### PR DESCRIPTION
⚠️ The original description no longer matches this PR's implementation.  
See the discussion below and [this comment](https://github.com/vitejs/vite/pull/5454#issuecomment-1005039192) for more details.

### Description

Allow Vite plugins to define their own Babel presets/plugins.

```ts
// TypeScript modules need this import for the extended Plugin interface.
import "@vitejs/plugin-react"
import * as vite from "vite"

export const myVitePlugin: vite.Plugin = {
  // The `enforce` property is respected. When it equals "pre", the Babel plugins 
  // and presets will be applied *before* user-defined plugins/presets.
  enforce: "pre",
  babel: {
    // Inline plugins and presets are possible.
    plugins: [{ visitor: {...} }],
    // Vite plugins must use `require.resolve` when passing a file path for a preset 
    // or plugin, or else it can't be found by Babel. Another option is to import the
    // preset and pass its module manually.
    presets: [require.resolve('babel-preset-env')],
  }
}
```

### Additional context

This PR is needed for [vite-react-css](https://github.com/alloc/vite-react-css) to work.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
