### PR TITLE
chore(ci): use new node lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         node_version: [12, 14, 16]
         include:
           - os: macos-latest
-            node_version: 14
+            node_version: 16
           - os: windows-latest
-            node_version: 14
+            node_version: 16
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
@@ -34,9 +34,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2
         with:
-          version: 6.15.1
+          version: 6
 
       - name: Set node version to ${{ matrix.node_version }}
         uses: actions/setup-node@v2
@@ -64,21 +64,21 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    name: "Lint: node-14, ubuntu-latest"
+    name: "Lint: node-16, ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.0.1
+        uses: pnpm/action-setup@v2
         with:
-          version: 6.15.1
+          version: 6
 
-      - name: Set node version to 14
+      - name: Set node version to 16
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: "pnpm"
 
       - name: Install deps

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: need reproduction
-        uses: actions-cool/issues-helper@v2.4.3
+        uses: actions-cool/issues-helper@v2
         with:
           actions: "close-issues"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: contribution welcome
         if: github.event.label.name == 'contribution welcome' || github.event.label.name == 'help wanted'
-        uses: actions-cool/issues-helper@v2.4.3
+        uses: actions-cool/issues-helper@v2
         with:
           actions: "create-comment, remove-labels"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -21,7 +21,7 @@ jobs:
 
       - name: remove pending
         if: github.event.label.name == 'enhancement' || github.event.label.name == 'bug' || (contains(github.event.label.name, 'pending triage') == false && startsWith(github.event.label.name, 'bug:') == true)
-        uses: actions-cool/issues-helper@v2.4.3
+        uses: actions-cool/issues-helper@v2
         with:
           actions: "remove-labels"
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'
-        uses: actions-cool/issues-helper@v2.4.3
+        uses: actions-cool/issues-helper@v2
         with:
           actions: "create-comment, remove-labels"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Update the GitHub workflows to use the new node LTS v16 instead of v14
Also we want to use always the newest version of actions and pnpm so we don't pin the exact version of such

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
