### PR TITLE
fix: Vite module graph race condition

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -110,12 +110,13 @@ async function instantiateModule(
       if (pendingDeps.length === 1) {
         pendingImports.set(url, pendingDeps)
       }
-      await ssrLoadModule(dep, server, context, urlStack)
+      const mod = await ssrLoadModule(dep, server, context, urlStack)
       if (pendingDeps.length === 1) {
         pendingImports.delete(url)
       } else {
         pendingDeps.splice(pendingDeps.indexOf(dep), 1)
       }
+      return mod
     }
     return moduleGraph.urlToModuleMap.get(dep)?.ssrModule
   }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -116,6 +116,7 @@ async function instantiateModule(
       } else {
         pendingDeps.splice(pendingDeps.indexOf(dep), 1)
       }
+      // return local module to avoid race condition #5470
       return mod
     }
     return moduleGraph.urlToModuleMap.get(dep)?.ssrModule


### PR DESCRIPTION

### Description

- This fixes a race condition in Vite where, when it encounters a package dep that needs to be built it invalidates the module graph. This means that any in-flight modules being loaded can receive invalid module instances.
- The fix is to prevent reading from global state to find the module instance.

Original author: @matthewp. Any additional context needed?

### Additional context

Vite Discord #ecosystem convo: https://discord.com/channels/804011606160703521/831456449632534538/902934189119266836

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
