### PR TITLE
docs: dev and serve aliases

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -52,21 +52,24 @@ Vite also directly supports TS config files. You can use `vite.config.ts` with t
 
 ### Conditional Config
 
-If the config needs to conditional determine options based on the command (`serve` or `build`) or the [mode](/guide/env-and-mode) being used, it can export a function instead:
+If the config needs to conditional determine options based on the command (`dev`/`serve` or `build`) or the [mode](/guide/env-and-mode) being used, it can export a function instead:
 
 ```js
 export default defineConfig(({ command, mode }) => {
   if (command === 'serve') {
     return {
-      // serve specific config
+      // dev specific config
     }
   } else {
+    // command === 'build'
     return {
       // build specific config
     }
   }
 })
 ```
+
+It is important to note that in Vite's API the `command` value is `serve` during de (in the cli `vite`, `vite dev`, and `vite serve` are aliases), and `build` when building for production (`vite build`).
 
 ### Async Config
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -69,7 +69,7 @@ export default defineConfig(({ command, mode }) => {
 })
 ```
 
-It is important to note that in Vite's API the `command` value is `serve` during de (in the cli `vite`, `vite dev`, and `vite serve` are aliases), and `build` when building for production (`vite build`).
+It is important to note that in Vite's API the `command` value is `serve` during dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases), and `build` when building for production (`vite build`).
 
 ### Async Config
 

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -150,6 +150,8 @@ async function resolveConfig(
 ): Promise<ResolvedConfig>
 ```
 
+The `command` value is `serve` in dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases).
+
 ## `transformWithEsbuild`
 
 **Type Signature:**

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -218,7 +218,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
       // use stored config in other hooks
       transform(code, id) {
         if (config.command === 'serve') {
-          // serve: plugin invoked by dev server
+          // dev: plugin invoked by dev server
         } else {
           // build: plugin invoked by Rollup
         }
@@ -226,6 +226,8 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
     }
   }
   ```
+
+  Note that the `command` value is `serve` in dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases).
 
 ### `configureServer`
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -118,7 +118,7 @@ In a project where Vite is installed, you can use the `vite` binary in your npm 
 ```json
 {
   "scripts": {
-    "dev": "vite", // start dev server
+    "dev": "vite", // start dev server, aliases: `vite dev`, `vite serve`
     "build": "vite build", // build for production
     "preview": "vite preview" // locally preview production build
   }

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -115,7 +115,7 @@ Running `vite` starts the dev server using the current working directory as root
 
 In a project where Vite is installed, you can use the `vite` binary in your npm scripts, or run it directly with `npx vite`. Here is the default npm scripts in a scaffolded Vite project:
 
-```json
+```jsonc
 {
   "scripts": {
     "dev": "vite", // start dev server, aliases: `vite dev`, `vite serve`

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -33,11 +33,11 @@ By default, the build output will be placed at `dist`. You may deploy this `dist
 
 ### Testing The App Locally
 
-Once you've built the app, you may test it locally by running `npm run serve` command.
+Once you've built the app, you may test it locally by running `npm run preview` command.
 
 ```bash
 $ npm run build
-$ npm run serve
+$ npm run preview
 ```
 
 The `vite preview` command will boot up local static web server that serves the files from `dist` at http://localhost:5000. It's an easy way to check if the production build looks OK in your local environment.
@@ -47,7 +47,7 @@ You may configure the port of the server py passing `--port` flag as an argument
 ```json
 {
   "scripts": {
-    "serve": "vite preview --port 8080"
+    "preview": "vite preview --port 8080"
   }
 }
 ```
@@ -55,7 +55,7 @@ You may configure the port of the server py passing `--port` flag as an argument
 Now the `preview` method will launch the server at http://localhost:8080.
 
 ::: tip NOTE
-If you change the script name from `serve` to `preview`, you may run into issues with some package managers due to the way they handle [Pre & Post scripts](https://docs.npmjs.com/cli/v7/using-npm/scripts#pre--post-scripts).
+If you have a `view` command, you may run into issues with the `preview` command in some package managers due to the way they handle [Pre & Post scripts](https://docs.npmjs.com/cli/v7/using-npm/scripts#pre--post-scripts).
 :::
 
 ## GitHub Pages

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -54,10 +54,6 @@ You may configure the port of the server py passing `--port` flag as an argument
 
 Now the `preview` method will launch the server at http://localhost:8080.
 
-::: tip NOTE
-If you have a `view` command, you may run into issues with the `preview` command in some package managers due to the way they handle [Pre & Post scripts](https://docs.npmjs.com/cli/v7/using-npm/scripts#pre--post-scripts).
-:::
-
 ## GitHub Pages
 
 1. Set the correct `base` in `vite.config.js`.


### PR DESCRIPTION
### Description

Improve docs to clarify that in the API the `command` value is `serve` during dev. And correct a few other places where the script remained as `serve` instead of `preview`. See #5207 for reference. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other