### PR TITLE
feat: allow css to be written for systemjs output

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -391,7 +391,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           // this is a shared CSS-only chunk that is empty.
           pureCssChunks.add(chunk.fileName)
         }
-        if (opts.format === 'es' || opts.format === 'cjs') {
+        if (opts.format === 'es' || opts.format === 'cjs' || opts.format === 'system') {
           chunkCSS = await processChunkCSS(chunkCSS, {
             inlined: false,
             minify: true


### PR DESCRIPTION
Not sure why systemjs does not qualify for this, currently css does not get extracted for outputs like systemjs.