### PR TITLE
feat: preview config

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -789,6 +789,77 @@ export default defineConfig({
 
   Set to `{}` to enable rollup watcher. This is mostly used in cases that involve build-only plugins or integrations processes.
 
+## Preview Options
+
+### preview.host
+
+- **Type:** `string | boolean`
+- **Default:** [`server.host`](#server_host)
+
+  Specify which IP addresses the server should listen on.
+  Set this to `0.0.0.0` or `true` to listen on all addresses, including LAN and public addresses.
+
+  This can be set via the CLI using `--host 0.0.0.0` or `--host`.
+
+### preview.port
+
+- **Type:** `number`
+- **Default:** `5000`
+
+  Specify server port. Note if the port is already being used, Vite will automatically try the next available port so this may not be the actual port the server ends up listening on.
+
+**Example:**
+
+  ```js
+  export default defineConfig({
+    server: {
+      port: 3030
+    },
+    preview: {
+      port: 8080
+    }
+  })
+  ```
+
+### preview.strictPort
+
+- **Type:** `boolean`
+- **Default:** [`server.strictPort`](#server_strictport)
+
+  Set to `true` to exit if port is already in use, instead of automatically try the next available port.
+
+### preview.https
+
+- **Type:** `boolean | https.ServerOptions`
+- **Default:** [`server.https`](#server_https)
+
+  Enable TLS + HTTP/2. Note this downgrades to TLS only when the [`server.proxy` option](#server-proxy) is also used.
+
+  The value can also be an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
+
+### preview.open
+
+- **Type:** `boolean | string`
+- **Default:** [`server.open`](#server_open)
+
+  Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can set the env `process.env.BROWSER` (e.g. `firefox`). See [the `open` package](https://github.com/sindresorhus/open#app) for more details.
+
+### preview.proxy
+
+- **Type:** `Record<string, string | ProxyOptions>`
+- **Default:** [`server.proxy`](#server_proxy)
+
+  Configure custom proxy rules for the dev server. Expects an object of `{ key: options }` pairs. If the key starts with `^`, it will be interpreted as a `RegExp`. The `configure` option can be used to access the proxy instance.
+
+  Uses [`http-proxy`](https://github.com/http-party/node-http-proxy). Full options [here](https://github.com/http-party/node-http-proxy#options).
+
+### preview.cors
+
+- **Type:** `boolean | CorsOptions`
+- **Default:** [`server.cors`](#server_proxy)
+
+  Configure CORS for the dev server. This is enabled by default and allows any origin. Pass an [options object](https://github.com/expressjs/cors) to fine tune the behavior or `false` to disable.
+
 ## Dep Optimization Options
 
 - **Related:** [Dependency Pre-Bundling](/guide/dep-pre-bundling)

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -25,6 +25,8 @@ const { createServer } = require('vite')
     }
   })
   await server.listen()
+
+  server.printUrls()
 })()
 ```
 
@@ -135,6 +137,34 @@ const { build } = require('vite')
       }
     }
   })
+})()
+```
+
+## `preview`
+
+**Experimental**
+
+**Type Signature:**
+
+```ts
+async function preview(inlineConfig?: InlineConfig): Promise<PreviewServer>
+```
+
+**Example Usage:**
+
+```js
+const { preview } = require('vite')
+
+;(async () => {
+  const previewServer = await preview({
+    // any valid user config options, plus `mode` and `configFile`
+    preview: {
+      port: 8080,
+      open: true
+    }
+  })
+
+  previewServer.printUrls()
 })()
 ```
 

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -164,3 +164,64 @@ describe('resolveEnvPrefix', () => {
     expect(resolveEnvPrefix(config)).toMatchObject([' ', 'CUSTOM_'])
   })
 })
+
+
+describe('preview config', () => {
+
+  const serverConfig = () => ({
+    port: 3003,
+    strictPort: true,
+    host: true,
+    open: true,
+    https: true,
+    proxy: { '/foo': 'http://localhost:4567' },
+    cors: false
+  })
+
+  test('preview inherits server config with default port', async () => {
+    const config: InlineConfig = {
+      server: serverConfig(),
+    }
+    expect(await resolveConfig(config, 'serve')).toMatchObject({
+      preview: {
+        ...serverConfig(),
+        port: undefined
+      }
+    })
+  })
+
+  test('preview inherits server config with port override', async () => {
+    const config: InlineConfig = {
+      server: serverConfig(),
+      preview: {
+        port: 3006
+      }
+    }
+    expect(await resolveConfig(config, 'serve')).toMatchObject({
+      preview: {
+        ...serverConfig(),
+        port: 3006
+      }
+    })
+  })
+
+  const previewConfig = () => ({
+    port: 3006,
+    strictPort: false,
+    open: false,
+    host: false,
+    https: false,
+    proxy: { '/bar': 'http://localhost:3010' },
+    cors: true
+  })
+
+  test('preview overrides server config', async () => {
+    const config: InlineConfig = {
+      server: serverConfig(),
+      preview: previewConfig()
+    }
+    expect(await resolveConfig(config, 'serve')).toMatchObject({
+      preview: previewConfig()
+    })
+  })
+})

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -165,7 +165,6 @@ describe('resolveEnvPrefix', () => {
   })
 })
 
-
 describe('preview config', () => {
 
   const serverConfig = () => ({

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -238,10 +238,10 @@ cli
           base: options.base,
           configFile: options.config,
           logLevel: options.logLevel,
-          server: {
-            host: options.host,
-            port: options.port ?? 5000,
+          preview: {
+            port: options.port,
             strictPort: options.strictPort,
+            host: options.host,
             https: options.https,
             open: options.open
           }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -7,6 +7,11 @@ import {
   resolveServerOptions,
   ServerOptions
 } from './server'
+import {
+  ResolvedPreviewOptions,
+  resolvePreviewOptions,
+  PreviewOptions
+} from './preview'
 import { CSSOptions } from './plugins/css'
 import {
   arraify,
@@ -141,6 +146,10 @@ export interface UserConfig {
    */
   build?: BuildOptions
   /**
+   * Preview specific options, e.g. host, port, https...
+   */
+  preview?: PreviewOptions
+   /**
    * Dep optimization options
    */
   optimizeDeps?: DepOptimizationOptions
@@ -225,6 +234,7 @@ export type ResolvedConfig = Readonly<
     plugins: readonly Plugin[]
     server: ResolvedServerOptions
     build: ResolvedBuildOptions
+    preview: ResolvedPreviewOptions
     assetsInclude: (file: string) => boolean
     logger: Logger
     createResolver: (options?: Partial<InternalResolveOptions>) => ResolveFn
@@ -418,6 +428,8 @@ export async function resolveConfig(
         )
       : ''
 
+  const server = resolveServerOptions(resolvedRoot, config.server)
+    
   const resolved: ResolvedConfig = {
     ...config,
     configFile: configFile ? normalizePath(configFile) : undefined,
@@ -432,8 +444,9 @@ export async function resolveConfig(
     mode,
     isProduction,
     plugins: userPlugins,
-    server: resolveServerOptions(resolvedRoot, config.server),
+    server,
     build: resolvedBuildOptions,
+    preview: resolvePreviewOptions(config.preview, server),
     env: {
       ...userEnv,
       BASE_URL,

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -8,11 +8,20 @@ import { Connect } from 'types/connect'
 import { Logger } from './logger'
 
 export interface CommonServerOptions {
+  /**
+   * Specify server port. Note if the port is already being used, Vite will 
+   * automatically try the next available port so this may not be the actual 
+   * port the server ends up listening on.
+   */
   port?: number
   /**
    * If enabled, vite will exit if specified port is already in use
    */
   strictPort?: boolean
+  /**
+   * Specify which IP addresses the server should listen on. 
+   * Set to 0.0.0.0 to listen on all addresses, including LAN and public addresses.
+   */
   host?: string | boolean
   /**
    * Enable TLS + HTTP/2.

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -2,13 +2,79 @@ import fs, { promises as fsp } from 'fs'
 import path from 'path'
 import { Server as HttpServer } from 'http'
 import { ServerOptions as HttpsServerOptions } from 'https'
-import { ResolvedConfig, ServerOptions } from '..'
-import { isObject } from '../utils'
+import { isObject } from './utils'
+import { ProxyOptions } from './server/middlewares/proxy'
 import { Connect } from 'types/connect'
-import { Logger } from '../logger'
+import { Logger } from './logger'
+
+export interface CommonServerOptions {
+  port?: number
+  /**
+   * If enabled, vite will exit if specified port is already in use
+   */
+  strictPort?: boolean
+  host?: string | boolean
+  /**
+   * Enable TLS + HTTP/2.
+   * Note: this downgrades to TLS only when the proxy option is also used.
+   */
+  https?: boolean | HttpsServerOptions
+  /**
+   * Open browser window on startup
+   */
+  open?: boolean | string
+  /**
+   * Configure custom proxy rules for the dev server. Expects an object
+   * of `{ key: options }` pairs.
+   * Uses [`http-proxy`](https://github.com/http-party/node-http-proxy).
+   * Full options [here](https://github.com/http-party/node-http-proxy#options).
+   *
+   * Example `vite.config.js`:
+   * ``` js
+   * module.exports = {
+   *   proxy: {
+   *     // string shorthand
+   *     '/foo': 'http://localhost:4567/foo',
+   *     // with options
+   *     '/api': {
+   *       target: 'http://jsonplaceholder.typicode.com',
+   *       changeOrigin: true,
+   *       rewrite: path => path.replace(/^\/api/, '')
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  proxy?: Record<string, string | ProxyOptions>
+  /**
+   * Configure CORS for the dev server.
+   * Uses https://github.com/expressjs/cors.
+   * Set to `true` to allow all methods from any origin, or configure separately
+   * using an object.
+   */
+  cors?: CorsOptions | boolean
+}
+
+/**
+ * https://github.com/expressjs/cors#configuration-options
+ */
+ export interface CorsOptions {
+  origin?:
+    | CorsOrigin
+    | ((origin: string, cb: (err: Error, origins: CorsOrigin) => void) => void)
+  methods?: string | string[]
+  allowedHeaders?: string | string[]
+  exposedHeaders?: string | string[]
+  credentials?: boolean
+  maxAge?: number
+  preflightContinue?: boolean
+  optionsSuccessStatus?: number
+}
+
+export type CorsOrigin = boolean | string | RegExp | (string | RegExp)[]
 
 export async function resolveHttpServer(
-  { proxy }: ServerOptions,
+  { proxy }: CommonServerOptions,
   app: Connect.Server,
   httpsOptions?: HttpsServerOptions
 ): Promise<HttpServer> {
@@ -31,11 +97,12 @@ export async function resolveHttpServer(
 }
 
 export async function resolveHttpsConfig(
-  config: ResolvedConfig
+  https?: boolean | HttpsServerOptions,
+  cacheDir?: string
 ): Promise<HttpsServerOptions | undefined> {
-  if (!config.server.https) return undefined
+  if (!https) return undefined
 
-  const httpsOption = isObject(config.server.https) ? config.server.https : {}
+  const httpsOption = isObject(https) ? https : {}
 
   const { ca, cert, key, pfx } = httpsOption
   Object.assign(httpsOption, {
@@ -45,7 +112,7 @@ export async function resolveHttpsConfig(
     pfx: readFileIfExists(pfx)
   })
   if (!httpsOption.key || !httpsOption.cert) {
-    httpsOption.cert = httpsOption.key = await getCertificate(config)
+    httpsOption.cert = httpsOption.key = await getCertificate(cacheDir)
   }
   return httpsOption
 }
@@ -135,10 +202,10 @@ async function createCertificate() {
   return pems.private + pems.cert
 }
 
-async function getCertificate(config: ResolvedConfig) {
-  if (!config.cacheDir) return await createCertificate()
+async function getCertificate(cacheDir?: string) {
+  if (!cacheDir) return await createCertificate()
 
-  const cachePath = path.join(config.cacheDir, '_cert.pem')
+  const cachePath = path.join(cacheDir, '_cert.pem')
 
   try {
     const [stat, content] = await Promise.all([
@@ -154,7 +221,7 @@ async function getCertificate(config: ResolvedConfig) {
   } catch {
     const content = await createCertificate()
     fsp
-      .mkdir(config.cacheDir, { recursive: true })
+      .mkdir(cacheDir, { recursive: true })
       .then(() => fsp.writeFile(cachePath, content))
       .catch(() => {})
     return content

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -13,6 +13,7 @@ export { normalizePath } from './utils'
 export type {
   CorsOptions,  
   CorsOrigin,
+  CommonServerOptions
 } from './http'
 export type {
   ViteDevServer,

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -11,11 +11,13 @@ export { normalizePath } from './utils'
 
 // additional types
 export type {
+  CorsOptions,  
+  CorsOrigin,
+} from './http'
+export type {
   ViteDevServer,
   ServerOptions,
-  CorsOptions,
   FileSystemServeOptions,
-  CorsOrigin,
   ServerHook,
   ResolvedServerOptions
 } from './server'
@@ -25,7 +27,11 @@ export type {
   LibraryFormats,
   ResolvedBuildOptions
 } from './build'
-export type { PreviewServer } from './preview'
+export type {
+  PreviewOptions,
+  PreviewServer,
+  ResolvedPreviewOptions
+} from './preview'
 export type {
   DepOptimizationMetadata,
   DepOptimizationOptions

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -6,6 +6,7 @@ import os from 'os'
 import readline from 'readline'
 import { RollupError } from 'rollup'
 import { ResolvedConfig } from '.'
+import { CommonServerOptions } from './http'
 import { Hostname, resolveHostname } from './utils'
 
 export type LogType = 'error' | 'warn' | 'info'
@@ -139,15 +140,26 @@ export function createLogger(
   return logger
 }
 
+/**
+ * @deprecated Use `server.printUrls()` instead
+ */
 export function printHttpServerUrls(
   server: Server,
   config: ResolvedConfig
 ): void {
+  printCommonServerUrls(server, config.server, config)
+}
+
+export function printCommonServerUrls(
+  server: Server,
+  options: CommonServerOptions,
+  config: ResolvedConfig,
+): void {
   const address = server.address()
   const isAddressInfo = (x: any): x is AddressInfo => x?.address
   if (isAddressInfo(address)) {
-    const hostname = resolveHostname(config.server.host)
-    const protocol = config.server.https ? 'https' : 'http'
+    const hostname = resolveHostname(options.host)
+    const protocol = options.https ? 'https' : 'http'
     printServerUrls(
       hostname,
       protocol,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -2,19 +2,23 @@ import fs from 'fs'
 import path from 'path'
 import * as net from 'net'
 import * as http from 'http'
-import * as https from 'https'
 import connect from 'connect'
 import corsMiddleware from 'cors'
 import chalk from 'chalk'
 import { AddressInfo } from 'net'
 import chokidar from 'chokidar'
-import { resolveHttpsConfig, resolveHttpServer, httpServerStart } from './http'
+import { 
+  resolveHttpsConfig, 
+  resolveHttpServer, 
+  httpServerStart, 
+  CommonServerOptions 
+} from '../http'
 import { resolveConfig, InlineConfig, ResolvedConfig } from '../config'
 import { createPluginContainer, PluginContainer } from './pluginContainer'
 import { FSWatcher, WatchOptions } from 'types/chokidar'
 import { createWebSocketServer, WebSocketServer } from './ws'
 import { baseMiddleware } from './middlewares/base'
-import { proxyMiddleware, ProxyOptions } from './middlewares/proxy'
+import { proxyMiddleware } from './middlewares/proxy'
 import { spaFallbackMiddleware } from './middlewares/spaFallback'
 import { transformMiddleware } from './middlewares/transform'
 import {
@@ -55,57 +59,11 @@ import { createMissingImporterRegisterFn } from '../optimizer/registerMissing'
 import { resolveHostname } from '../utils'
 import { searchForWorkspaceRoot } from './searchRoot'
 import { CLIENT_DIR } from '../constants'
-import { printHttpServerUrls } from '../logger'
+import { printCommonServerUrls } from '../logger'
 
 export { searchForWorkspaceRoot } from './searchRoot'
 
-export interface ServerOptions {
-  host?: string | boolean
-  port?: number
-  /**
-   * If enabled, vite will exit if specified port is already in use
-   */
-  strictPort?: boolean
-  /**
-   * Enable TLS + HTTP/2.
-   * Note: this downgrades to TLS only when the proxy option is also used.
-   */
-  https?: boolean | https.ServerOptions
-  /**
-   * Open browser window on startup
-   */
-  open?: boolean | string
-  /**
-   * Configure custom proxy rules for the dev server. Expects an object
-   * of `{ key: options }` pairs.
-   * Uses [`http-proxy`](https://github.com/http-party/node-http-proxy).
-   * Full options [here](https://github.com/http-party/node-http-proxy#options).
-   *
-   * Example `vite.config.js`:
-   * ``` js
-   * module.exports = {
-   *   proxy: {
-   *     // string shorthand
-   *     '/foo': 'http://localhost:4567/foo',
-   *     // with options
-   *     '/api': {
-   *       target: 'http://jsonplaceholder.typicode.com',
-   *       changeOrigin: true,
-   *       rewrite: path => path.replace(/^\/api/, '')
-   *     }
-   *   }
-   * }
-   * ```
-   */
-  proxy?: Record<string, string | ProxyOptions>
-  /**
-   * Configure CORS for the dev server.
-   * Uses https://github.com/expressjs/cors.
-   * Set to `true` to allow all methods from any origin, or configure separately
-   * using an object.
-   */
-  cors?: CorsOptions | boolean
-
+export interface ServerOptions extends CommonServerOptions {
   /**
    * Force dep pre-optimization regardless of whether deps have changed.
    */
@@ -173,24 +131,6 @@ export interface FileSystemServeOptions {
    */
   deny?: string[]
 }
-
-/**
- * https://github.com/expressjs/cors#configuration-options
- */
-export interface CorsOptions {
-  origin?:
-    | CorsOrigin
-    | ((origin: string, cb: (err: Error, origins: CorsOrigin) => void) => void)
-  methods?: string | string[]
-  allowedHeaders?: string | string[]
-  exposedHeaders?: string | string[]
-  credentials?: boolean
-  maxAge?: number
-  preflightContinue?: boolean
-  optionsSuccessStatus?: number
-}
-
-export type CorsOrigin = boolean | string | RegExp | (string | RegExp)[]
 
 export type ServerHook = (
   server: ViteDevServer
@@ -333,7 +273,7 @@ export async function createServer(
   const config = await resolveConfig(inlineConfig, 'serve', 'development')
   const root = config.root
   const serverConfig = config.server
-  const httpsOptions = await resolveHttpsConfig(config)
+  const httpsOptions = await resolveHttpsConfig(config.server.https)
   let { middlewareMode } = serverConfig
   if (middlewareMode === true) {
     middlewareMode = 'ssr'
@@ -421,7 +361,7 @@ export async function createServer(
     },
     printUrls() {
       if (httpServer) {
-        printHttpServerUrls(httpServer, config)
+        printCommonServerUrls(httpServer, config.server, config)
       } else {
         throw new Error('cannot print server URLs in middleware mode.')
       }


### PR DESCRIPTION
### Description

Continuation from #5407 

We create a new `userConfig.preview: { port: 5000, ... }` config option and a `resolvedConfig.preview` that has the resolved info for the preview server. There is a new `CommonServerOptions` interface that is shared and a new `PreviewServerOptions`. The preview server defaults to the options in dev server for `host`, `strictPort`, `https`, `cors`, `proxy`, and `open` (I'm not sure about this last one), but not for `port`. This would allow the user to define the preview port in vite.config.js instead of in the package.json script. It is more clear to see in the `ResolvedConfig` the resolved HTTP server options for the dev server and the preview server separately.

This PR deprecates `printHttpServerUrls` because it doesn't work now that `config.server` and `config.preview` are separate in `ResolvedConfig`. It still works fine for printing the URLs from the server, that is what the ecosystem could be using this function for (as the experimental `preview` API was just exposed). Users of `createServer` and `preview` should use `server.printUrls()`. Maybe we should expose. The only place I see it being used is in Vitedge here https://github.com/frandiox/vitedge/blob/d64b6bc46988bf9df6896a32e499453d52476fbf/src/build/preview.js#L76, but this would continue to work.

`src/node/server/http.ts` has been moved to `src/node/http.ts` as it is shared between the dev server and the preview server

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other