### PR TITLE
fix(dev): handle windows relative path handling

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -157,7 +157,10 @@ export function esbuildDepPlugin(
         if (
           !relativePath.startsWith('./') &&
           !relativePath.startsWith('../') &&
-          relativePath !== '.'
+          relativePath !== '.' &&
+          // Windows: when root and entryFile are on different drives, then
+          // getting relative path is not possible.
+          !path.isAbsolute(relativePath)
         ) {
           relativePath = `./${relativePath}`
         }


### PR DESCRIPTION
On Windows, when a folder is on a virtual drive (e.g. `subst X: C:/dev`),
then symlink resolving will end up causing the root of the project
and the imported files to be on separate drives.

This leads into a situations where `path.relative(root, entryFile)` does
not return a relative path.

Updates #4635

### Description

Windows allows to map a folder to a separate drive -- usually, this
makes life working with projects easier. However, this causes resolving the
paths to be on the different drive. This means that all code must deal with
the possibility that `path.relative` doesn't return a relative path, but might
also return an absolute path.

I don't think it fully fixes the issue since rollup has also issues with it.

### Additional context

With a clean clone of the project many of the tests are failing on Windows,
so I'm not sure whether this would break any existing test.

Inclusion of a new test would require changing the github actions to run
things on Windows off of a virtual drive. However, that probably would break
some other tests with regards to symlinking. Also, it seems, there are still
some issues with rollup on a virtual drive.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
