### PR TITLE
fix: multi class error

### DIFF
--- a/packages/playground/vue-jsx/Comp.tsx
+++ b/packages/playground/vue-jsx/Comp.tsx
@@ -1,5 +1,24 @@
 import { defineComponent, ref } from 'vue'
 
+const MultiLineClass = defineComponent(() => {
+  const count = ref(1)
+  const inc = () => count.value++
+
+  return () => (
+    <button
+      class="
+      class-one
+      class-two
+    "
+      onClick={inc}
+    >
+      multi line class {count.value}
+    </button>
+  )
+})
+
+export { MultiLineClass }
+
 const Default = defineComponent(() => {
   const count = ref(3)
   const inc = () => count.value++

--- a/packages/playground/vue-jsx/main.jsx
+++ b/packages/playground/vue-jsx/main.jsx
@@ -1,6 +1,6 @@
 import { createApp } from 'vue'
 import { Named, NamedSpec, default as Default } from './Comps'
-import { default as TsxDefault } from './Comp'
+import { default as TsxDefault, MultiLineClass } from './Comp'
 import OtherExt from './OtherExt.tesx'
 import JsxScript from './Script.vue'
 import JsxSrcImport from './SrcImport.vue'
@@ -12,6 +12,7 @@ function App() {
       <NamedSpec />
       <Default />
       <TsxDefault />
+      <MultiLineClass />
       <OtherExt />
       <JsxScript />
       <JsxSrcImport />

--- a/packages/plugin-vue-jsx/index.js
+++ b/packages/plugin-vue-jsx/index.js
@@ -97,7 +97,10 @@ function vueJsxPlugin(options = {}) {
           plugins.push([
             require('@babel/plugin-transform-typescript'),
             // @ts-ignore
-            { isTSX: true, allowExtensions: true }
+            {
+              isTSX: true,
+              allowExtensions: true
+            }
           ])
         }
 
@@ -109,6 +112,9 @@ function vueJsxPlugin(options = {}) {
           sourceFileName: id,
           configFile: false
         })
+
+        // support multi class in jsx #5525
+        result.code = result.code.replace(/(?<=:\s*(["'][^"']*)?)\s*\n/g, ' ')
 
         if (!ssr && !needHmr) {
           return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vite JSX multiline class support。 See details in [issue #5525](https://github.com/vitejs/vite/issues/5525)
### Additional context

The class in Vue JSX will be compile by babel to in this way:
```js
// jsx
export const Foo = defineComponent({
  name: 'foo',
  setup() {
    return () => <div class="
    jsx
  ">from JSX</div>
  }
})

// compiled jsx
export const Foo = defineComponent({
  name: 'foo',

  setup() {
    return () => _createVNode("div", {
      "class": "
        jsx
    "
    }, [_createTextVNode("from JSX")]);
  }
});
```
---
So in this pr, I use regexp to match the corresponding rule, and then replace the newline character in the corresponding position.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
