### PR TITLE
fix(hmr): revert early break from handleHotUpdate loop

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -92,7 +92,6 @@ export async function handleHMRUpdate(
       const filteredModules = await plugin.handleHotUpdate(hmrContext)
       if (filteredModules) {
         hmrContext.modules = filteredModules
-        break
       }
     }
   }


### PR DESCRIPTION
reverts b3b8c61b37f36713605d61baeb98cfc0deb0b020

<!-- Thank you for contributing! -->

### Description

Breaking the loop that calls handleHotUpdate early once a plugin returns changes results in a "first plugin wins" situation that seems like an odd limitation. 

Especially for plugins like windicss that maintain unrelated virtual modules based on the content of various files.
This means one file change event of single source file can result in multiple hmr updates from different plugins for completely unrelated modules, making it impossible for the user to find a plugin ordering that would work with the limitation mentioned above.

see https://github.com/windicss/vite-plugin-windicss/issues/238#issuecomment-955713612 for details

### Additional context

- If multiple plugins return something from handleHotUpdate, should the changes be merged? 
- What about plugins calling ws.send directly?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
