### PR TITLE
fix(commonjsOptions): expose ignoreTryCatch config

### DIFF
--- a/packages/vite/types/commonjs.d.ts
+++ b/packages/vite/types/commonjs.d.ts
@@ -72,6 +72,26 @@ export interface RollupCommonJSOptions {
    */
   ignore?: ReadonlyArray<string> | ((id: string) => boolean)
   /**
+   * In most cases, where `require` calls are inside a `try-catch` clause,
+   * they should be left unconverted as it requires an optional dependency
+   * that may or may not be installed beside the rolled up package.
+   * Due to the conversion of `require` to a static `import` - the call is hoisted
+   * to the top of the file, outside of the `try-catch` clause.
+   *
+   * - `true`: All `require` calls inside a `try` will be left unconverted.
+   * - `false`: All `require` calls inside a `try` will be converted as if the `try-catch` clause is not there.
+   * - `remove`: Remove all `require` calls from inside any `try` block.
+   * - `string[]`: Pass an array containing the IDs to left unconverted.
+   * - `((id: string) => boolean|'remove')`: Pass a function that control individual IDs.
+   *
+   * @default false
+   */
+  ignoreTryCatch?:
+    | boolean
+    | 'remove'
+    | ReadonlyArray<string>
+    | ((id: string) => boolean | 'remove');
+  /**
    * Controls how to render imports from external dependencies. By default,
    * this plugin assumes that all external dependencies are CommonJS. This
    * means they are rendered as default imports to be compatible with e.g.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#5173 Updated @rollup/plugin-commonjs to 21 (with a new default value for ignoreTryCatch)

This is a safer option, but it is a breaking change for some projects (as mentioned [here](https://github.com/rollup/plugins/pull/1005#issuecomment-954130548)).

This PR merely exposes the `ignoreTryCatch` configuration type under `commonjsOptions`, so broken projects can decide to revert to the previous behavior.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

