### PR TITLE
fix: Windows path error on script proxying

### DIFF
--- a/packages/playground/ssr-pug/__tests__/serve.js
+++ b/packages/playground/ssr-pug/__tests__/serve.js
@@ -1,0 +1,36 @@
+// @ts-check
+// this is automtically detected by scripts/jestPerTestSetup.ts and will replace
+// the default e2e test serve behavior
+
+const path = require('path')
+
+const port = (exports.port = 9530)
+
+/**
+ * @param {string} root
+ * @param {boolean} isProd
+ */
+exports.serve = async function serve(root, isProd) {
+  const { createServer } = require(path.resolve(root, 'server.js'))
+  const { app, vite } = await createServer(root, isProd)
+
+  return new Promise((resolve, reject) => {
+    try {
+      const server = app.listen(port, () => {
+        resolve({
+          // for test teardown
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve)
+            })
+            if (vite) {
+              await vite.close()
+            }
+          }
+        })
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}

--- a/packages/playground/ssr-pug/__tests__/ssr-pug.spec.ts
+++ b/packages/playground/ssr-pug/__tests__/ssr-pug.spec.ts
@@ -1,0 +1,39 @@
+import { port } from './serve'
+import fetch from 'node-fetch'
+
+const url = `http://localhost:${port}`
+
+describe('injected inline scripts', () => {
+  test('no injected inline scripts are present', async () => {
+    await page.goto(url)
+    const inlineScripts = await page.$$eval('script', (nodes) =>
+      nodes.filter((n) => !n.getAttribute('src') && n.innerHTML)
+    )
+    expect(inlineScripts).toHaveLength(0)
+  })
+
+  test('injected script proxied correctly', async () => {
+    await page.goto(url)
+    const proxiedScripts = await page.$$eval('script', (nodes) =>
+      nodes
+        .filter((n) => {
+          const src = n.getAttribute('src')
+          if (!src) return false
+          return src.includes('?html-proxy&index')
+        })
+        .map((n) => n.getAttribute('src'))
+    )
+
+    // assert at least 1 proxied script exists
+    expect(proxiedScripts).not.toHaveLength(0)
+
+    const scriptContents = await Promise.all(
+      proxiedScripts.map((src) => fetch(url + src).then((res) => res.text()))
+    )
+
+    // all proxied scripts return code
+    for (const code of scriptContents) {
+      expect(code).toBeTruthy()
+    }
+  })
+})

--- a/packages/playground/ssr-pug/index.pug
+++ b/packages/playground/ssr-pug/index.pug
@@ -1,0 +1,8 @@
+doctype html
+html
+  head
+    meta(charset='UTF-8')
+    meta(name='viewport' content='width=device-width, initial-scale=1.0')
+    title SSR Pug
+  body
+    h1 SSR Pug

--- a/packages/playground/ssr-pug/package.json
+++ b/packages/playground/ssr-pug/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-ssr-pug",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "node server",
+    "serve": "cross-env NODE_ENV=production node server",
+    "debug": "node --inspect-brk server"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3",
+    "express": "^4.17.1",
+    "pug": "^3.0.0"
+  }
+}

--- a/packages/playground/ssr-pug/server.js
+++ b/packages/playground/ssr-pug/server.js
@@ -1,0 +1,76 @@
+// @ts-check
+const path = require('path')
+const pug = require('pug')
+const express = require('express')
+
+const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+
+const DYNAMIC_SCRIPTS = `
+  <script type="module">
+    const p = document.createElement('p');
+    p.innerHTML = '✅ Dynamically injected inline script';
+    document.body.appendChild(p);
+  </script>
+  <script type="module" src="/src/app.js"></script>
+`
+
+async function createServer(
+  root = process.cwd(),
+  isProd = process.env.NODE_ENV === 'production'
+) {
+  const resolve = (p) => path.resolve(__dirname, p)
+
+  const app = express()
+
+  /**
+   * @type {import('vite').ViteDevServer}
+   */
+  let vite
+  vite = await require('vite').createServer({
+    root,
+    logLevel: isTest ? 'error' : 'info',
+    server: {
+      middlewareMode: 'ssr',
+      watch: {
+        // During tests we edit the files too fast and sometimes chokidar
+        // misses change events, so enforce polling for consistency
+        usePolling: true,
+        interval: 100
+      }
+    }
+  })
+  // use vite's connect instance as middleware
+  app.use(vite.middlewares)
+
+  app.use('*', async (req, res) => {
+    try {
+      let [url] = req.originalUrl.split('?')
+      url = url.replace(/\.html$/, '.pug')
+      if (url.endsWith('/')) url += 'index.pug'
+
+      const htmlLoc = resolve(`.${url}`)
+      let html = pug.renderFile(htmlLoc)
+      html = html.replace('</body>', `${DYNAMIC_SCRIPTS}</body>`)
+      html = await vite.transformIndexHtml(url, html)
+
+      res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+    } catch (e) {
+      vite && vite.ssrFixStacktrace(e)
+      console.log(e.stack)
+      res.status(500).end(e.stack)
+    }
+  })
+
+  return { app, vite }
+}
+
+if (!isTest) {
+  createServer().then(({ app }) =>
+    app.listen(3000, () => {
+      console.log('http://localhost:3000')
+    })
+  )
+}
+
+// for test use
+exports.createServer = createServer

--- a/packages/playground/ssr-pug/src/app.js
+++ b/packages/playground/ssr-pug/src/app.js
@@ -1,0 +1,3 @@
+const p = document.createElement('p')
+p.innerHTML = '✅ Dynamically injected script from file'
+document.body.appendChild(p)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -7,6 +7,7 @@ import {
   generateCodeFrame,
   isDataUrl,
   isExternalUrl,
+  normalizePath,
   processSrcSet,
   slash
 } from '../utils'
@@ -55,7 +56,7 @@ export function htmlInlineScriptProxyPlugin(config: ResolvedConfig): Plugin {
       if (proxyMatch) {
         const index = Number(proxyMatch[1])
         const file = cleanUrl(id)
-        const url = file.replace(config.root, '')
+        const url = file.replace(normalizePath(config.root), '')
         const result = htmlProxyMap.get(config)!.get(url)![index]
         if (result) {
           return result
@@ -230,7 +231,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   .map((child: any) => child.content || '')
                   .join('')
                 // <script type="module">...</script>
-                const filePath = id.replace(config.root, '')
+                const filePath = id.replace(normalizePath(config.root), '')
                 addToHTMLProxyCache(
                   config,
                   filePath,

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -15,7 +15,7 @@ import {
 import { ResolvedConfig, ViteDevServer } from '../..'
 import { send } from '../send'
 import { CLIENT_PUBLIC_PATH, FS_PREFIX } from '../../constants'
-import { cleanUrl, fsPathFromId } from '../../utils'
+import { cleanUrl, fsPathFromId, normalizePath } from '../../utils'
 
 export function createDevHtmlTransformFn(
   server: ViteDevServer
@@ -105,7 +105,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       if (src) {
         processNodeUrl(src, s, config, htmlPath, originalUrl)
       } else if (isModule) {
-        const url = filePath.replace(config.root, '')
+        const url = filePath.replace(normalizePath(config.root), '')
 
         const contents = node.children
           .map((child: any) => child.content || '')
@@ -118,9 +118,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         s.overwrite(
           node.loc.start.offset,
           node.loc.end.offset,
-          `<script type="module" src="${
-            config.base + url.slice(1)
-          }?html-proxy&index=${scriptModuleIndex}.js"></script>`
+          `<script type="module" src="${filePath}?html-proxy&index=${scriptModuleIndex}.js"></script>`
         )
       }
     }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -118,7 +118,9 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         s.overwrite(
           node.loc.start.offset,
           node.loc.end.offset,
-          `<script type="module" src="${filePath}?html-proxy&index=${scriptModuleIndex}.js"></script>`
+          `<script type="module" src="${
+            config.base + url.slice(1)
+          }?html-proxy&index=${scriptModuleIndex}.js"></script>`
         )
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,16 @@ importers:
       cross-env: 7.0.3
       express: 4.17.1
 
+  packages/playground/ssr-pug:
+    specifiers:
+      cross-env: ^7.0.3
+      express: ^4.17.1
+      pug: ^3.0.0
+    devDependencies:
+      cross-env: 7.0.3
+      express: 4.17.1
+      pug: 3.0.2
+
   packages/playground/ssr-react:
     specifiers:
       '@vitejs/plugin-react': workspace:*


### PR DESCRIPTION
### Description

We found some bugs on Windows in Astro, namely around proxied scripts. Some URLs weren’t being correctly normalized on Windows.

### Additional context

Astro uses `.astro` files which convert to HTML. Vite has specific code paths for `.html` files, so a `.pug` test was added to test previously-untested code paths for script proxying for HTML preprocessors.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
