### PR TITLE
fix: sourcemap error with plugin-react

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -52,6 +52,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   let skipFastRefresh = opts.fastRefresh === false
   let skipReactImport = false
 
+  // The dir where pre-bundled deps is stored
+  let cacheDir: string
+
   const useAutomaticRuntime = opts.jsxRuntime !== 'classic'
 
   const userPlugins = opts.babel?.plugins || []
@@ -78,6 +81,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
       })
       isProduction = config.isProduction
       skipFastRefresh ||= isProduction || config.command === 'build'
+      cacheDir = config.cacheDir as string
 
       const jsxInject = config.esbuild && config.esbuild.jsxInject
       if (jsxInject && importReactRE.test(jsxInject)) {
@@ -106,6 +110,11 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         querystring.match(fileExtensionRE) ||
         filepath.match(fileExtensionRE) ||
         []
+
+      // Pre-bundle deps should not be transformed there. #5438
+      if (id.startsWith(cacheDir)) {
+        return
+      }
 
       if (/\.(mjs|[tj]sx?)$/.test(extension)) {
         const plugins = [...userPlugins]

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -520,7 +520,8 @@ export function combineSourcemaps(
   const useArrayInterface =
     sourcemapList.slice(0, -1).find((m) => m.sources.length !== 1) === undefined
   if (useArrayInterface) {
-    map = remapping(sourcemapList, () => null, true)
+    // We cann't exclude sourcesContent there. #5438
+    map = remapping(sourcemapList, () => null, false)
   } else {
     map = remapping(
       sourcemapList[0],
@@ -531,7 +532,7 @@ export function combineSourcemaps(
           return { ...nullSourceMap }
         }
       },
-      true
+      false
     )
   }
   if (!map.file) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7183,7 +7183,7 @@ packages:
     dev: true
 
   /pvutils/1.0.17:
-    resolution: {integrity: sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==}
+    resolution: {integrity: sha1-rePHTf5xeJRP5EgGYmvS4knZlr8=}
     engines: {node: '>=6.0.0'}
     dev: true
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix sourcemap error when using @vitejs/plugin-react，see details in [#5438](https://github.com/vitejs/vite/issues/5438), [#5562](https://github.com/vitejs/vite/issues/5562)

### Additional context
The product of pre-bundle is incorrectly transformed by babel in plugin-react.This led to a series of unpredictable sourcemap problems, because this plugin will generate some sourcemaps which will be push into vite's sourcemapChain and combined after transform hook.

```js
// pluginContainer.ts
async transform(code, id, options) {
  const inMap = options?.inMap
  const ssr = options?.ssr
  const ctx = new TransformContext(id, code, inMap as SourceMap)
  ctx.ssr = !!ssr
  for (const plugin of plugins) {
    if (!plugin.transform) continue
    let result: TransformResult | string | undefined
    try {
      result = await plugin.transform.call(ctx as any, code, id, { ssr })
    } catch (e) {
      ctx.error(e)
    }
    if (isObject(result)) {
      code = result.code || ''
      // push into sourcemapChain
      if (result.map) ctx.sourcemapChain.push(result.map)
    } else {
      code = result
    }
  }
  return {
    code,
    // combine the sourcemaps
    map: ctx._getCombinedSourcemap()
  }
},
```

The reason why the `1.0.6` plugin version does not have this problem is because of the
 request of  pre-bundle deps will carry the querystring suffix of BrowserHash, thus skipping the transform process of react:babel. But in 1.0.7 version the plugin filters out the querystring suffix, so that the pre-bundle  result such as `/xxx/node_modules/.vite/react.js` also enters the transform of babel which is unespect.

Now the solution is as follows:

- For the pre-bundled result, skip babel's transform to avoid huge performance consumption as well as the warning of Babel:
```
[BABEL] Note: The code generator has deoptimised the styling of /Users/sanyuan/react-project/node_modules/.vite/react-dom.js?v=768d5ed4 as it exceeds the max of 500KB.
```
- For warning about SourceMap，i found out sourceContent is excluded in `remapping` process.It can be solved by including sourcesContent after remapping if additional soucemap is added after transform hook.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
