### PR TITLE
fix: replace server.origin in css plugin (fix #5408)

### DIFF
--- a/packages/playground/tailwind/vite.config.ts
+++ b/packages/playground/tailwind/vite.config.ts
@@ -11,5 +11,10 @@ export default defineConfig({
   build: {
     // to make tests faster
     minify: false
+  },
+  server: {
+    // This option caused issues with HMR,
+    // although it should not affect the build
+    origin: "http://localhost:8080/",
   }
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -218,7 +218,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
                   : await moduleGraph.ensureEntryFromUrl(
                       (
                         await fileToUrl(file, config, this)
-                      ).replace(config.base, '/')
+                      ).replace((config.server?.origin ?? '') + config.base, '/')
                     )
               )
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Pull Request #5104 introduced the server.origin configuration option to set a base URL for static assets.
This was implemented by checking for this option in the `fileToDevUrl` function of the assets plugin.
This function is used by the css plugin as well when registering CSS files as build dependencies.
This lead to incorrect added watch dependencies and broke HMR for Tailwind as described in #5408 

This PR fixes this issue by adding the server origin to the already present replace call, that removed the config.base, if the server.origin option is set and should fix #5408.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
