### PR TITLE
feat: expose vite's default manualChunks function

### DIFF
--- a/packages/playground/vue/vite.config.ts
+++ b/packages/playground/vue/vite.config.ts
@@ -2,6 +2,8 @@ import path from 'path'
 import { defineConfig } from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import { vueI18nPlugin } from './CustomBlockPlugin'
+import { createMoveToVendorChunkFn } from 'vite'
+const viteChunks = createMoveToVendorChunkFn()
 
 export default defineConfig({
   resolve: {
@@ -17,7 +19,18 @@ export default defineConfig({
   ],
   build: {
     // to make tests faster
-    minify: false
+    minify: false,
+    rollupOptions: {
+      output: {
+        // partial override of vite's manualChunks
+        manualChunks: (id, api) => {
+          if (id.includes('node_modules') && id.includes('vue')) {
+            return 'vue-chunk'
+          }
+          return viteChunks(id, api)
+        }
+      }
+    }
   },
   css: {
     modules: {

--- a/packages/playground/vue/vite.config.ts
+++ b/packages/playground/vue/vite.config.ts
@@ -2,8 +2,7 @@ import path from 'path'
 import { defineConfig } from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import { vueI18nPlugin } from './CustomBlockPlugin'
-import { createMoveToVendorChunkFn } from 'vite'
-const viteChunks = createMoveToVendorChunkFn()
+import { moveToVendorChunkFn } from 'vite'
 
 export default defineConfig({
   resolve: {
@@ -22,12 +21,12 @@ export default defineConfig({
     minify: false,
     rollupOptions: {
       output: {
-        // partial override of vite's manualChunks
         manualChunks: (id, api) => {
           if (id.includes('node_modules') && id.includes('vue')) {
             return 'vue-chunk'
           }
-          return viteChunks(id, api)
+          // call vite's default manualChunks
+          return moveToVendorChunkFn(id, api)
         }
       }
     }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -477,7 +477,7 @@ async function doBuild(
           !libOptions &&
           output?.format !== 'umd' &&
           output?.format !== 'iife'
-            ? createMoveToVendorChunkFn(config)
+            ? createMoveToVendorChunkFn()
             : undefined,
         ...output
       }
@@ -605,7 +605,7 @@ function getPkgName(root: string) {
   return name?.startsWith('@') ? name.split('/')[1] : name
 }
 
-function createMoveToVendorChunkFn(config: ResolvedConfig): GetManualChunk {
+export function createMoveToVendorChunkFn(): GetManualChunk {
   const cache = new Map<string, boolean>()
   return (id, { getModuleInfo }) => {
     if (

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -1,7 +1,7 @@
 export * from './config'
 export { createServer, searchForWorkspaceRoot } from './server'
 export { preview } from './preview'
-export { build, createMoveToVendorChunkFn } from './build'
+export { build, moveToVendorChunkFn } from './build'
 export { optimizeDeps } from './optimizer'
 export { send } from './server/send'
 export { createLogger, printHttpServerUrls } from './logger'

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -1,7 +1,7 @@
 export * from './config'
 export { createServer, searchForWorkspaceRoot } from './server'
 export { preview } from './preview'
-export { build } from './build'
+export { build, createMoveToVendorChunkFn } from './build'
 export { optimizeDeps } from './optimizer'
 export { send } from './server/send'
 export { createLogger, printHttpServerUrls } from './logger'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #5487 

- The easiest way is to expose `createMoveToVendorChunkFn` so that users can reuse it in custom `manualChunks`.
- Merging is also a way, but after that, the user cannot completely override the vite default `manualChunks`, and the `vendor.hash.js` will always output. Maybe we can add an option to turn it on or off, thinking we need to discuss 🤔

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
