### PR TITLE
fix(sourcemap): tolerate virtual modules in `sources` array

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -9,9 +9,8 @@ const debug = createDebugger('vite:sourcemap', {
 })
 
 // Virtual modules should be prefixed with a null byte to avoid a
-// false positive "missing source" warning. We also check for colons,
-// because the optimizer emits sourcemaps with sources like "dep:react"
-// due to namespacing for special handling in esbuildDepPlugin.
+// false positive "missing source" warning. We also check for certain
+// prefixes used for special handling in esbuildDepPlugin.
 const virtualSourceRE = /^(\0|dep:|browser-external:)/
 
 interface SourceMapLike {

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -8,6 +8,8 @@ const debug = createDebugger('vite:sourcemap', {
   onlyWhenFocused: true
 })
 
+const virtualSourceRE = /:|\0/
+
 interface SourceMapLike {
   sources: string[]
   sourcesContent?: (string | null)[]
@@ -30,7 +32,7 @@ export async function injectSourcesContent(
   const missingSources: string[] = []
   map.sourcesContent = await Promise.all(
     map.sources.map((sourcePath) => {
-      if (sourcePath) {
+      if (sourcePath && !virtualSourceRE.test(sourcePath)) {
         sourcePath = decodeURI(sourcePath)
         if (sourceRoot) {
           sourcePath = path.resolve(sourceRoot, sourcePath)

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -12,7 +12,7 @@ const debug = createDebugger('vite:sourcemap', {
 // false positive "missing source" warning. We also check for colons,
 // because the optimizer emits sourcemaps with sources like "dep:react"
 // due to namespacing for special handling in esbuildDepPlugin.
-const virtualSourceRE = /:|\0/
+const virtualSourceRE = /^(\0|dep:|browser-external:)/
 
 interface SourceMapLike {
   sources: string[]

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -8,6 +8,10 @@ const debug = createDebugger('vite:sourcemap', {
   onlyWhenFocused: true
 })
 
+// Virtual modules should be prefixed with a null byte to avoid a
+// false positive "missing source" warning. We also check for colons,
+// because the optimizer emits sourcemaps with sources like "dep:react"
+// due to namespacing for special handling in esbuildDepPlugin.
 const virtualSourceRE = /:|\0/
 
 interface SourceMapLike {


### PR DESCRIPTION
In the future, we'll want to use Vite's module graph to actually include the content of virtual modules in the `sourcesContent` array. I'm already doing this in my Vite fork, and it works well.

Closes #5438