### PR TITLE
fix(build): resolve `rollupOptions.input` paths

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -596,7 +596,7 @@ async function buildPolyfillChunk(
   bundle[polyfillChunk.name] = polyfillChunk
 }
 
-const polyfillId = 'vite/legacy-polyfills'
+const polyfillId = '\0vite/legacy-polyfills'
 
 /**
  * @param {Set<string>} imports

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,4 +1,4 @@
-import { resolveLibFilename, resolvePaths } from '../build'
+import { resolveLibFilename } from '../build'
 import { resolve } from 'path'
 import { resolveConfig } from '..'
 
@@ -76,9 +76,21 @@ describe('resolvePaths', () => {
         }
       }
     }, 'build', 'production')
-    const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('index.html'))
+    expect(config.build.rollupOptions.input).toBe(resolve('index.html'))
+  })
+  test('resolve build.rollupOptions.input{}', async () => {
+    const config = await resolveConfig({
+      build: {
+        rollupOptions: {
+          input: {
+            index: 'index.html'
+          }
+        }
+      }
+    }, 'build', 'production')
+
+    expect(config.build.rollupOptions.input['index']).toBe(resolve('index.html'))
   })
 
   test('resolve build.rollupOptions.input[]', async () => {
@@ -89,46 +101,37 @@ describe('resolvePaths', () => {
         }
       }
     }, 'build', 'production')
-    const { input } = resolvePaths(config, config.build)
 
-    const resolved = resolve('index.html')
-
-    expect(input).toStrictEqual([resolved])
-    expect(config.build.rollupOptions.input).toStrictEqual([resolved])
+    expect(config.build.rollupOptions.input).toStrictEqual([resolve('index.html')])
   })
 
   test('resolve index.html', async () => {
     const config = await resolveConfig({}, 'build', 'production')
-    const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('index.html'))
+    expect(config.build.rollupOptions.input).toBe(resolve('index.html'))
   })
 
   test('resolve build.outdir', async () => {
     const config = await resolveConfig({ build: { outDir: 'outDir' } }, 'build', 'production')
-    const { outDir } = resolvePaths(config, config.build)
 
-    expect(outDir).toBe(resolve('outDir'))
+    expect(config.build.outDir).toBe(resolve('outDir'))
   })
 
   test('resolve default build.outdir', async () => {
     const config = await resolveConfig({}, 'build', 'production')
-    const { outDir } = resolvePaths(config, config.build)
 
-    expect(outDir).toBe(resolve('dist'))
+    expect(config.build.outDir).toBe(resolve('dist'))
   })
 
   test('resolve build.lib.entry', async () => {
     const config = await resolveConfig({ build: { lib: { entry: 'index.html' } } }, 'build', 'production')
-    const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('index.html'))
+    expect(config.build.rollupOptions.input).toBe(resolve('index.html'))
   })
 
   test('resolve build.ssr', async () => {
     const config = await resolveConfig({ build: { ssr: 'ssr.ts' } }, 'build', 'production')
-    const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('ssr.ts'))
+    expect(config.build.rollupOptions.input).toBe(resolve('ssr.ts'))
   })
 })

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -72,18 +72,17 @@ describe('resolvePaths', () => {
     const config = await resolveConfig({
       build: {
         rollupOptions: {
-          input: 'packages/noname/index.html'
+          input: 'index.html'
         }
       }
     }, 'build', 'production')
     const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('packages/noname/index.html'))
+    expect(input).toBe(resolve('index.html'))
   })
 
   test('resolve build.rollupOptions.input[]', async () => {
     const config = await resolveConfig({
-      root: 'packages/noname',
       build: {
         rollupOptions: {
           input: ['index.html']
@@ -92,39 +91,44 @@ describe('resolvePaths', () => {
     }, 'build', 'production')
     const { input } = resolvePaths(config, config.build)
 
-    const resolved = resolve('packages/noname/index.html')
+    const resolved = resolve('index.html')
 
     expect(input).toStrictEqual([resolved])
     expect(config.build.rollupOptions.input).toStrictEqual([resolved])
   })
 
   test('resolve index.html', async () => {
-    const config = await resolveConfig({
-      root: 'packages/noname',
-    }, 'build', 'production')
+    const config = await resolveConfig({}, 'build', 'production')
     const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('packages/noname/index.html'))
+    expect(input).toBe(resolve('index.html'))
   })
 
   test('resolve build.outdir', async () => {
-    const config = await resolveConfig({ build: { outDir: 'packages/noname' } }, 'build', 'production')
+    const config = await resolveConfig({ build: { outDir: 'outDir' } }, 'build', 'production')
     const { outDir } = resolvePaths(config, config.build)
 
-    expect(outDir).toBe(resolve('packages/noname'))
+    expect(outDir).toBe(resolve('outDir'))
+  })
+
+  test('resolve default build.outdir', async () => {
+    const config = await resolveConfig({}, 'build', 'production')
+    const { outDir } = resolvePaths(config, config.build)
+
+    expect(outDir).toBe(resolve('dist'))
   })
 
   test('resolve build.lib.entry', async () => {
-    const config = await resolveConfig({ build: { lib: { entry: 'packages/noname/index.html' } } }, 'build', 'production')
+    const config = await resolveConfig({ build: { lib: { entry: 'index.html' } } }, 'build', 'production')
     const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('packages/noname/index.html'))
+    expect(input).toBe(resolve('index.html'))
   })
 
   test('resolve build.ssr', async () => {
-    const config = await resolveConfig({ build: { ssr: 'packages/noname/ssr.ts' } }, 'build', 'production')
+    const config = await resolveConfig({ build: { ssr: 'ssr.ts' } }, 'build', 'production')
     const { input } = resolvePaths(config, config.build)
 
-    expect(input).toBe(resolve('packages/noname/ssr.ts'))
+    expect(input).toBe(resolve('ssr.ts'))
   })
 })

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,5 +1,6 @@
-import { resolveLibFilename } from '../build'
+import { resolveLibFilename, resolvePaths } from '../build'
 import { resolve } from 'path'
+import { resolveConfig } from '..'
 
 describe('resolveLibFilename', () => {
   test('custom filename function', () => {
@@ -63,5 +64,67 @@ describe('resolveLibFilename', () => {
         resolve(__dirname, 'packages/noname')
       )
     }).toThrow()
+  })
+})
+
+describe('resolvePaths', () => {
+  test('resolve build.rollupOptions.input', async () => {
+    const config = await resolveConfig({
+      build: {
+        rollupOptions: {
+          input: 'packages/noname/index.html'
+        }
+      }
+    }, 'build', 'production')
+    const { input } = resolvePaths(config, config.build)
+
+    expect(input).toBe(resolve('packages/noname/index.html'))
+  })
+
+  test('resolve build.rollupOptions.input[]', async () => {
+    const config = await resolveConfig({
+      root: 'packages/noname',
+      build: {
+        rollupOptions: {
+          input: ['index.html']
+        }
+      }
+    }, 'build', 'production')
+    const { input } = resolvePaths(config, config.build)
+
+    const resolved = resolve('packages/noname/index.html')
+
+    expect(input).toBe(resolved)
+    expect(config.build.rollupOptions.input[0]).toBe(resolved)
+  })
+
+  test('resolve index.html', async () => {
+    const config = await resolveConfig({
+      root: 'packages/noname',
+    }, 'build', 'production')
+    const { input } = resolvePaths(config, config.build)
+
+    expect(input).toBe(resolve('packages/noname/index.html'))
+  })
+
+  test('resolve build.outdir', async () => {
+    const config = await resolveConfig({ build: { outDir: 'packages/noname' } }, 'build', 'production')
+    const { outDir } = resolvePaths(config, config.build)
+
+    expect(outDir).toBe(resolve('packages/noname'))
+  })
+
+  test('resolve build.lib.entry', async () => {
+    const config = await resolveConfig({ build: { lib: { entry: 'packages/noname/index.html' } } }, 'build', 'production')
+    const { input } = resolvePaths(config, config.build)
+
+    expect(input).toBe(resolve('packages/noname/index.html'))
+  })
+
+  test('resolve build.ssr', async () => {
+    const config = await resolveConfig({ build: { ssr: 'packages/noname/ssr.ts' } }, 'build', 'production')
+    const { input } = resolvePaths(config, config.build)
+
+    expect(input).toBe(resolve('packages/noname/ssr.ts'))
   })
 })

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -94,8 +94,8 @@ describe('resolvePaths', () => {
 
     const resolved = resolve('packages/noname/index.html')
 
-    expect(input).toBe(resolved)
-    expect(config.build.rollupOptions.input[0]).toBe(resolved)
+    expect(input).toStrictEqual([resolved])
+    expect(config.build.rollupOptions.input).toStrictEqual([resolved])
   })
 
   test('resolve index.html', async () => {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -269,7 +269,7 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
     }
   }
 
-  const resolve = (p: string) => path.resolve(root, p)
+  const resolve = (p: string) => p.startsWith('\0') ? p : path.resolve(root, p)
 
   resolved.outDir = resolve(resolved.outDir)
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -279,7 +279,7 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
       : typeof raw.rollupOptions.input === 'object'
       ? Object.assign(
           // @ts-ignore
-          ...Object.keys(raw.rollupOptions.input).map(key => ({[key]: resolve(raw.rollupOptions.input[key]) }))
+          ...Object.keys(raw.rollupOptions.input).map(key => ({ [key]: resolve(raw.rollupOptions.input[key]) }))
         )
       : resolve(raw.rollupOptions.input)
   } else {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -374,6 +374,14 @@ async function doBuild(
   )
 
   const resolve = (p: string) => path.resolve(config.root, p)
+
+  if (Array.isArray(options.rollupOptions?.input)) {
+    options.rollupOptions.input = options.rollupOptions.input.map(input => resolve(input))
+  }
+  else if (typeof options.rollupOptions?.input === 'string') {
+    options.rollupOptions.input = resolve(options.rollupOptions.input)
+  }
+
   const input = libOptions
     ? resolve(libOptions.entry)
     : typeof options.ssr === 'string'

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -277,10 +277,10 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
     resolved.rollupOptions.input = Array.isArray(raw.rollupOptions.input)
       ? raw.rollupOptions.input.map(input => resolve(input))
       : typeof raw.rollupOptions.input === 'object'
-      ? Object.keys(raw.rollupOptions.input).map(key => {
+      ? Object.assign(
           // @ts-ignore
-          raw.rollupOptions.input[key] = resolve(raw.rollupOptions.input[key])
-        }) && raw.rollupOptions.input
+          ...Object.keys(raw.rollupOptions.input).map(key => ({[key]: resolve(raw.rollupOptions.input[key]) }))
+        )
       : resolve(raw.rollupOptions.input)
   } else {
     resolved.rollupOptions.input = resolve(

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -292,6 +292,13 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
     )
   }
 
+  if (!!raw?.ssr && typeof resolved.rollupOptions.input === 'string' && resolved.rollupOptions.input.endsWith('.html')) {
+    throw new Error(
+      `rollupOptions.input should not be an html file when building for SSR. ` +
+        `Please specify a dedicated SSR entry.`
+    )
+  }
+
   // handle special build targets
   if (resolved.target === 'modules') {
     // Support browserslist

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -273,8 +273,10 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
 
   resolved.outDir = resolve(resolved.outDir)
 
+  let input
+
   if (raw?.rollupOptions?.input) {
-    resolved.rollupOptions.input = Array.isArray(raw.rollupOptions.input)
+    input = Array.isArray(raw.rollupOptions.input)
       ? raw.rollupOptions.input.map(input => resolve(input))
       : typeof raw.rollupOptions.input === 'object'
       ? Object.assign(
@@ -283,7 +285,7 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
         )
       : resolve(raw.rollupOptions.input)
   } else {
-    resolved.rollupOptions.input = resolve(
+    input = resolve(
       raw?.lib
         ? raw.lib.entry
         : typeof raw?.ssr === 'string'
@@ -292,12 +294,15 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
     )
   }
 
-  if (!!raw?.ssr && typeof resolved.rollupOptions.input === 'string' && resolved.rollupOptions.input.endsWith('.html')) {
+  if (!!raw?.ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(
       `rollupOptions.input should not be an html file when building for SSR. ` +
         `Please specify a dedicated SSR entry.`
     )
   }
+
+  if (input)
+    resolved.rollupOptions.input = input
 
   // handle special build targets
   if (resolved.target === 'modules') {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -336,21 +336,14 @@ export function resolvePaths(config: ResolvedConfig, options: ResolvedConfig["bu
 
   const resolve = (p: string) => path.resolve(config.root, p)
 
-  rollupOptions.input = Array.isArray(rollupOptions?.input)
-    ? rollupOptions.input.map(input => resolve(input))
-    : typeof rollupOptions?.input === 'string'
-    ? resolve(rollupOptions.input)
-    : undefined
+  if (Array.isArray(rollupOptions?.input))
+    rollupOptions.input = rollupOptions.input.map(input => resolve(input))
 
-  const input = resolve(
-    libOptions
-      ? libOptions.entry
-      : typeof options.ssr === 'string'
-      ? options.ssr
-      : typeof rollupOptions?.input === 'string'
-      ? rollupOptions.input
-      : 'index.html'
-  )
+  const input = libOptions
+    ? libOptions.entry
+    : typeof options.ssr === 'string'
+    ? options.ssr
+    : rollupOptions?.input || 'index.html'
 
   if (ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(
@@ -360,7 +353,7 @@ export function resolvePaths(config: ResolvedConfig, options: ResolvedConfig["bu
   }
 
   return {
-    input: resolve(input),
+    input: typeof input === 'string' ? resolve(input) : input,
     outDir: resolve(options.outDir)
   }
 }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -301,8 +301,7 @@ export function resolveBuildOptions(root: string, raw?: BuildOptions): ResolvedB
     )
   }
 
-  if (input)
-    resolved.rollupOptions.input = input
+  resolved.rollupOptions.input = input
 
   // handle special build targets
   if (resolved.target === 'modules') {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -364,7 +364,7 @@ export async function resolveConfig(
 
   // resolve public base url
   const BASE_URL = resolveBaseUrl(config.base, command === 'build', logger)
-  const resolvedBuildOptions = resolveBuildOptions(config.build)
+  const resolvedBuildOptions = resolveBuildOptions(resolvedRoot, config.build)
 
   // resolve cache directory
   const pkgPath = lookupFile(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Related https://github.com/antfu/unocss/pull/88

Entry points defined in `rollupOptions.input` passed to rollup without resolving. This causing some path issues in Windows.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
