### PR TITLE
fix: plugin-vue dev scripts error in ssr-vue

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -9,7 +9,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "dev": "tsc -p . -w --incremental",
+    "dev": "rimraf dist && run-p dev-types dev-watch",
+    "dev-types": "tsc -p . -w --incremental",
+    "dev-watch": "esbuild src/index.ts --watch --bundle --platform=node --target=node12 --external:@vue/compiler-sfc --external:vue/compiler-sfc --external:vite --outfile=dist/index.js",
     "build": "rimraf dist && run-s build-bundle build-types",
     "build-bundle": "esbuild src/index.ts --bundle --platform=node --target=node12 --external:@vue/compiler-sfc --external:vue/compiler-sfc --external:vite --outfile=dist/index.js",
     "build-types": "tsc -p . --emitDeclarationOnly --outDir temp && api-extractor run && rimraf temp",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -10,7 +10,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "rimraf dist && run-p dev-types dev-watch",
-    "dev-types": "tsc -p . -w --incremental",
+    "dev-types": "tsc -p . -w --incremental --emitDeclarationOnly",
     "dev-watch": "esbuild src/index.ts --watch --bundle --platform=node --target=node12 --external:@vue/compiler-sfc --external:vue/compiler-sfc --external:vite --outfile=dist/index.js",
     "build": "rimraf dist && run-s build-bundle build-types",
     "build-bundle": "esbuild src/index.ts --bundle --platform=node --target=node12 --external:@vue/compiler-sfc --external:vue/compiler-sfc --external:vite --outfile=dist/index.js",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In `packages/plugin-vue` which use `tsc` transform `ts=>js` in development and use `esbuild` compile all dependencies as one file.

Because [https://unpkg.com/browse/slash@4.0.0/index.js](https://unpkg.com/browse/slash@4.0.0/index.js) only export esmodule file which cause `require("slash")` error in some file convert from `tsc` in `ssr-vue` playground.

So, i change plugin-vue dev scripts to use `esbuild --watch` and `tsc` parallelly
![image](https://user-images.githubusercontent.com/17424434/141068856-2821cae1-4c37-47ea-b66d-7e8b4189097e.png)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
