### PR TITLE
docs: add build.ssr in config/index.md

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -750,7 +750,7 @@ export default defineConfig({
 - **Default:** `undefined`
 - **Related:** [Server-Side Rendering](/guide/ssr)
 
-  Assign SSR server entry file path be similar to `vite build --ssr src/entry-server --outDir dist/server`
+  Produce SSR-oriented build. The value can be a string to directly specify the SSR entry, or `true`, which requires specifying the SSR entry via `rollupOptions.input`.
 
 ### build.minify
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -744,6 +744,14 @@ export default defineConfig({
 
   When set to `true`, the build will also generate a SSR manifest for determining style links and asset preload directives in production.
 
+### build.ssr
+
+- **Type:** `string`
+- **Default:** `undefined`
+- **Related:** [Server-Side Rendering](/guide/ssr)
+
+  Assign SSR server entry file path be similar to `vite build --ssr src/entry-server --outDir dist/server`
+
 ### build.minify
 
 - **Type:** `boolean | 'terser' | 'esbuild'`

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -746,7 +746,7 @@ export default defineConfig({
 
 ### build.ssr
 
-- **Type:** `string`
+- **Type:** `boolean | string`
 - **Default:** `undefined`
 - **Related:** [Server-Side Rendering](/guide/ssr)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`build.ssr` option is missing in docs but we can set it in vite.config effectively.

```js
module.exports = {
 ssr: 'xxx'
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
