### PR TITLE
fix: Honor the host param when creating a websocket server

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -41,6 +41,7 @@ export function createWebSocketServer(
   } else {
     const websocketServerOptions: ServerOptions = {}
     const port = (hmr && hmr.port) || 24678
+    const host = (hmr && hmr.host) || undefined
     if (httpsOptions) {
       // if we're serving the middlewares over https, the ws library doesn't support automatically creating an https server, so we need to do it ourselves
       // create an inline https server and mount the websocket server to it
@@ -59,11 +60,14 @@ export function createWebSocketServer(
         res.end(body)
       })
 
-      httpsServer.listen(port)
+      httpsServer.listen(port, host)
       websocketServerOptions.server = httpsServer
     } else {
       // we don't need to serve over https, just let ws handle its own server
       websocketServerOptions.port = port
+      if (host) {
+        websocketServerOptions.host = host
+      }
     }
 
     // vite dev server in middleware mode


### PR DESCRIPTION
### Description

This is similar to the 3c53f8271c776c90143953fd5097d4a57cdf9491 that fixed #2032 but for the websocket server.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ x ] Bug fix


### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
