### PR TITLE
fix(logger): no sameCount if clearScreen is false

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -65,10 +65,9 @@ export function createLogger(
   const loggedErrors = new WeakSet<Error | RollupError>()
   const { prefix = '[vite]', allowClearScreen = true } = options
   const thresh = LogLevels[level]
-  const clear =
+  const canClearScreen =
     allowClearScreen && process.stdout.isTTY && !process.env.CI
-      ? clearScreen
-      : () => {}
+  const clear = canClearScreen ? clearScreen : () => {}
 
   function output(type: LogType, msg: string, options: LogErrorOptions = {}) {
     if (thresh >= LogLevels[type]) {
@@ -89,17 +88,21 @@ export function createLogger(
       if (options.error) {
         loggedErrors.add(options.error)
       }
-      if (type === lastType && msg === lastMsg) {
-        sameCount++
-        clear()
-        console[method](format(), chalk.yellow(`(x${sameCount + 1})`))
-      } else {
-        sameCount = 0
-        lastMsg = msg
-        lastType = type
-        if (options.clear) {
+      if (canClearScreen) {
+        if (type === lastType && msg === lastMsg) {
+          sameCount++
           clear()
+          console[method](format(), chalk.yellow(`(x${sameCount + 1})`))
+        } else {
+          sameCount = 0
+          lastMsg = msg
+          lastType = type
+          if (options.clear) {
+            clear()
+          }
+          console[method](format())
         }
+      } else {
         console[method](format())
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When running the dev server and you're working on a single file, vite will add the amount of times the file was updated at the end of the log like this:
```
8:49:37 PM [vite] hmr update /src/App.vue (x4)
```

This is great since the screen is cleared by default.

It does however become useless when [`clearScreen`](https://vitejs.dev/config/#clearscreen) is set to `false`.
Somthing like this will be logged:
```
8:49:29 PM [vite] hmr update /src/App.vue
8:49:31 PM [vite] hmr update /src/App.vue (x2)
8:49:33 PM [vite] hmr update /src/App.vue (x3)
8:49:37 PM [vite] hmr update /src/App.vue (x4)
...
```

This PR makes it so that the following would be logged instead if `clearScreen` is `false`:
```
8:49:29 PM [vite] hmr update /src/App.vue
8:49:31 PM [vite] hmr update /src/App.vue
8:49:33 PM [vite] hmr update /src/App.vue
8:49:37 PM [vite] hmr update /src/App.vue
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
