### PR TITLE
fix: vitepress/theme in ssrExternals

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -3,6 +3,7 @@ import path from 'path'
 import { tryNodeResolve, InternalResolveOptions } from '../plugins/resolve'
 import {
   createDebugger,
+  isDefined,
   lookupFile,
   normalizePath,
   resolveFrom
@@ -39,7 +40,8 @@ export function resolveSSRExternal(
     seen
   )
 
-  for (const dep of knownImports) {
+  const importedDeps = knownImports.map(getNpmPackageName).filter(isDefined)
+  for (const dep of importedDeps) {
     // Assume external if not yet seen
     // At this point, the project root and any linked packages have had their dependencies checked,
     // so we can safely mark any knownImports not yet seen as external. They are guaranteed to be
@@ -171,4 +173,14 @@ export function shouldExternalizeForSSR(
     }
   })
   return should
+}
+
+function getNpmPackageName(importPath: string): string | null {
+  const parts = importPath.split('/')
+  if (parts[0].startsWith('@')) {
+    if (!parts[1]) return null
+    return `${parts[0]}/${parts[1]}`
+  } else {
+    return parts[0]
+  }
 }


### PR DESCRIPTION
### Description

https://github.com/vitejs/vite/pull/5544 removed the mapping from `knownImports` to `importedDeps` using `getNpmPackageName`. This broke vitepress because `vitepress/theme` ended up in `ssrExternals`, instead of `vitepress` as it was before the PR.

This PR adds this logic back. We still need to review why `vitepress/theme` is in `knownImports` when building without `.vite/_metadata.json` existing, but it isn't there after running dev and the metadata is generated. This was discovered as part of debugging this issue but it is unrelated and it was already present before #5544

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other