### PR TITLE
chore: remove useless cli option

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -14,8 +14,6 @@ interface GlobalCLIOptions {
   '--'?: string[]
   c?: boolean | string
   config?: string
-  r?: string
-  root?: string
   base?: string
   l?: LogLevel
   logLevel?: LogLevel
@@ -38,8 +36,6 @@ function cleanOptions<Options extends GlobalCLIOptions>(
   delete ret['--']
   delete ret.c
   delete ret.config
-  delete ret.r
-  delete ret.root
   delete ret.base
   delete ret.l
   delete ret.logLevel
@@ -55,7 +51,6 @@ function cleanOptions<Options extends GlobalCLIOptions>(
 
 cli
   .option('-c, --config <file>', `[string] use specified config file`)
-  .option('-r, --root <path>', `[string] use specified root directory`)
   .option('--base <path>', `[string] public base path (default: /)`)
   .option('-l, --logLevel <level>', `[string] info | warn | error | silent`)
   .option('--clearScreen', `[boolean] allow/disable clear screen when logging`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
After reviewing it in detail, I confirm that the `-r --root` option is useless, isn't it?

There is no place to use it, and the default command has been passed in the `root` parameter

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
