### PR TITLE
fix: correctly resolve virtual modules during import scan

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -207,7 +207,10 @@ function esbuildScanPlugin(
         { filter: virtualModuleRE },
         async ({ path, importer }) => {
           return {
-            path,
+            path: await resolve(
+              path.substring('virtual-module:'.length),
+              importer
+            ),
             namespace: 'html'
           }
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix bug introduced in https://github.com/vitejs/vite/pull/5464. I'm not quite sure what happened here. `importer` was unused in the version checked in, so it's almost like I accidentally pushed an old version instead of the completed code or something

### Additional context

The `vite-plugin-svelte` test suite is failing against `2.7.0-beta.4`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
