### PR TITLE
fix(ssr): prefer CJS but still allow ESM entries

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -18,6 +18,7 @@ import {
 import { transformRequest } from '../server/transformRequest'
 import { InternalResolveOptions, tryNodeResolve } from '../plugins/resolve'
 import { hookNodeResolve } from '../plugins/ssrRequireHook'
+import { DEFAULT_MAIN_FIELDS } from '../constants'
 
 interface SSRContext {
   global: typeof globalThis
@@ -101,16 +102,19 @@ async function instantiateModule(
     root
   } = server.config
 
+  // The `extensions` and `mainFields` options are used to ensure that
+  // CommonJS modules are preferred. We want to avoid ESM->ESM imports
+  // whenever possible, because `hookNodeResolve` can't intercept them.
   const resolveOptions: InternalResolveOptions = {
-    conditions: ['node'],
+    // By adding "require" to the `conditions` array, resolution of the
+    // pkg.exports field will use "require" condition whenever it comes
+    // before "import" condition.
+    conditions: ['node', 'require'],
     dedupe,
-    // Prefer CommonJS modules.
     extensions: ['.js', '.mjs', '.ts', '.jsx', '.tsx', '.json'],
     isBuild: true,
     isProduction,
-    // Disable "module" condition.
-    isRequire: true,
-    mainFields: ['main'],
+    mainFields: ['main', ...DEFAULT_MAIN_FIELDS],
     root
   }
 

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -18,7 +18,7 @@ import {
 import { transformRequest } from '../server/transformRequest'
 import { InternalResolveOptions, tryNodeResolve } from '../plugins/resolve'
 import { hookNodeResolve } from '../plugins/ssrRequireHook'
-import { DEFAULT_MAIN_FIELDS } from '../constants'
+import { DEFAULT_EXTENSIONS, DEFAULT_MAIN_FIELDS } from '../constants'
 
 interface SSRContext {
   global: typeof globalThis
@@ -102,6 +102,17 @@ async function instantiateModule(
     root
   } = server.config
 
+  const extensions = ['.js', '.mjs', '.ts', '.jsx', '.tsx', '.json']
+  if (typeof jest !== 'undefined') {
+    for (const ext of DEFAULT_EXTENSIONS) {
+      if (!extensions.includes(ext)) {
+        throw new Error(
+          `The module extensions used in SSR should include all DEFAULT_EXTENSIONS`
+        )
+      }
+    }
+  }
+
   // The `extensions` and `mainFields` options are used to ensure that
   // CommonJS modules are preferred. We want to avoid ESM->ESM imports
   // whenever possible, because `hookNodeResolve` can't intercept them.
@@ -111,7 +122,7 @@ async function instantiateModule(
     // before "import" condition.
     conditions: ['node', 'require'],
     dedupe,
-    extensions: ['.js', '.mjs', '.ts', '.jsx', '.tsx', '.json'],
+    extensions,
     isBuild: true,
     isProduction,
     mainFields: ['main', ...DEFAULT_MAIN_FIELDS],

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -131,6 +131,13 @@ async function instantiateModule(
     root
   }
 
+  // Prevent ESM modules from being resolved during test runs, since Jest
+  // cannot `require` them. Note: This prevents testing of ESM-only packages.
+  if (typeof jest !== 'undefined') {
+    resolveOptions.isRequire = true
+    resolveOptions.mainFields = ['main']
+  }
+
   // Since dynamic imports can happen in parallel, we need to
   // account for multiple pending deps and duplicate imports.
   const pendingDeps: string[] = []

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -103,6 +103,10 @@ async function instantiateModule(
   } = server.config
 
   const extensions = ['.js', '.mjs', '.ts', '.jsx', '.tsx', '.json']
+
+  // If an extension is added/removed from DEFAULT_EXTENSIONS, so too
+  // should it be added/removed from our extensions array. To be sure,
+  // we verify this when running tests.
   if (typeof jest !== 'undefined')
     for (const ext of DEFAULT_EXTENSIONS) {
       if (!extensions.includes(ext))

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -103,15 +103,13 @@ async function instantiateModule(
   } = server.config
 
   const extensions = ['.js', '.mjs', '.ts', '.jsx', '.tsx', '.json']
-  if (typeof jest !== 'undefined') {
+  if (typeof jest !== 'undefined')
     for (const ext of DEFAULT_EXTENSIONS) {
-      if (!extensions.includes(ext)) {
+      if (!extensions.includes(ext))
         throw new Error(
           `The module extensions used in SSR should include all DEFAULT_EXTENSIONS`
         )
-      }
     }
-  }
 
   // The `extensions` and `mainFields` options are used to ensure that
   // CommonJS modules are preferred. We want to avoid ESM->ESM imports

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -18,7 +18,7 @@ import {
 import { transformRequest } from '../server/transformRequest'
 import { InternalResolveOptions, tryNodeResolve } from '../plugins/resolve'
 import { hookNodeResolve } from '../plugins/ssrRequireHook'
-import { DEFAULT_EXTENSIONS, DEFAULT_MAIN_FIELDS } from '../constants'
+import { DEFAULT_MAIN_FIELDS } from '../constants'
 
 interface SSRContext {
   global: typeof globalThis
@@ -102,19 +102,6 @@ async function instantiateModule(
     root
   } = server.config
 
-  const extensions = ['.js', '.mjs', '.ts', '.jsx', '.tsx', '.json']
-
-  // If an extension is added/removed from DEFAULT_EXTENSIONS, so too
-  // should it be added/removed from our extensions array. To be sure,
-  // we verify this when running tests.
-  if (typeof jest !== 'undefined')
-    for (const ext of DEFAULT_EXTENSIONS) {
-      if (!extensions.includes(ext))
-        throw new Error(
-          `The module extensions used in SSR should include all DEFAULT_EXTENSIONS`
-        )
-    }
-
   // The `extensions` and `mainFields` options are used to ensure that
   // CommonJS modules are preferred. We want to avoid ESM->ESM imports
   // whenever possible, because `hookNodeResolve` can't intercept them.
@@ -124,7 +111,7 @@ async function instantiateModule(
     // before "import" condition.
     conditions: ['node', 'require'],
     dedupe,
-    extensions,
+    extensions: ['.js', '.cjs', '.mjs', '.jsx', '.json'],
     isBuild: true,
     isProduction,
     mainFields: ['main', ...DEFAULT_MAIN_FIELDS],


### PR DESCRIPTION

### Description

Since ESM support was added in #5197, module resolution should allow `pkg.module` and the `import` condition in `pkg.exports`. This PR fixes that while also still preferring CommonJS, since `hookNodeResolve` can't intercept ESM->ESM imports (therefore, we want to avoid them if possible).

/cc @benmccann @dominikg @patak-js 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
