### PR TITLE
fix: tolerate undefined parent in `hookNodeResolve` callback

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -222,10 +222,15 @@ async function nodeImport(
 
   // When an ESM module imports an ESM dependency, this hook is *not* used.
   const unhookNodeResolve = hookNodeResolve(
-    (nodeResolve) => (id, parent, isMain, options) =>
-      id[0] === '.' || isBuiltin(id)
-        ? nodeResolve(id, parent, isMain, options)
-        : viteResolve(id, parent.id)
+    (nodeResolve) => (id, parent, isMain, options) => {
+      if (id[0] === '.' || isBuiltin(id)) {
+        return nodeResolve(id, parent, isMain, options)
+      }
+      if (!parent) {
+        return id
+      }
+      return viteResolve(id, parent.id)
+    }
   )
 
   let url: string


### PR DESCRIPTION
The parent module is undefined when a ESM module imports a CJS module. At this point, the `id` string is already an absolute path, so just return it.

This fixes a crash reported by SvelteKit and Shopify Hydrogen maintainers.
