### PR TITLE
fix(plugin-react): uncompiled JSX in linked pkgs

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -134,11 +134,12 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
             // By reverse-compiling "React.createElement" calls into JSX,
             // React elements provided by dependencies will also use the
             // automatic runtime!
-            const [restoredAst, isCommonJS] = !isProjectFile
-              ? await restoreJSX(babel, code, id)
-              : [null, false]
+            const [restoredAst, isCommonJS] =
+              !isProjectFile && !isJSX
+                ? await restoreJSX(babel, code, id)
+                : [null, false]
 
-            if (isProjectFile || (ast = restoredAst)) {
+            if (isJSX || (ast = restoredAst)) {
               plugins.push([
                 await loadPlugin(
                   '@babel/plugin-transform-react-jsx' +


### PR DESCRIPTION
Fixes #5642

When a linked package contains a `.jsx` or `.tsx` module, we need to apply the JSX transform using Babel. Previously, `plugin-react` would only look for **compiled** JSX within `.jsx` and `.tsx` modules (if they weren't within the project root) to decide if the Babel JSX transform should be applied.