### PR TITLE
fix(dev): Fix infinite recursion on query imports (#5671)

### DIFF
--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -52,8 +52,8 @@ if (isBuild) {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/assets')
     const files = fs.readdirSync(assetsDir)
-    // should have 2 worker chunk
-    expect(files.length).toBe(3)
+    // should have 3 worker chunk
+    expect(files.length).toBe(4)
     const index = files.find((f) => f.includes('index'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -12,6 +12,11 @@ test('normal', async () => {
   )
 })
 
+test('TS output', async () => {
+  await page.click('.ping-ts-output')
+  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong')
+})
+
 test('inlined', async () => {
   await page.click('.ping-inline')
   await untilUpdated(() => page.textContent('.pong-inline'), 'pong')

--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -7,6 +7,12 @@
 <button class="ping-inline">Ping Inline Worker</button>
 <div>Response from inline worker: <span class="pong-inline"></span></div>
 
+<button class="ping-ts-output">Ping Possible Compiled TS Worker</button>
+<div>
+  Response from worker imported from code that might be compiled TS:
+  <span class="pong-ts-output"></span>
+</div>
+
 <button class="tick-shared">Tick Shared Worker</button>
 <div>
   Tick from shared worker, it syncs between pages:
@@ -17,6 +23,7 @@
   import Worker from './my-worker?worker'
   import InlineWorker from './my-worker?worker&inline'
   import SharedWorker from './my-shared-worker?sharedworker&name=shared'
+  import TSOutputWorker from './possible-ts-output-worker?worker'
   import { mode } from './workerImport'
 
   document.querySelector('.mode-true').textContent = mode
@@ -50,6 +57,15 @@
   })
 
   sharedWorker.port.start()
+
+  const tsOutputWorker = new TSOutputWorker()
+  worker.addEventListener('message', (e) => {
+    text('.pong-ts-output', e.data.msg)
+  })
+
+  document.querySelector('.ping-ts-output').addEventListener('click', () => {
+    inlineWorker.postMessage('ping')
+  })
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/packages/playground/worker/possible-ts-output-worker.mjs
+++ b/packages/playground/worker/possible-ts-output-worker.mjs
@@ -1,0 +1,7 @@
+import { msg, mode } from './workerImport'
+
+self.onmessage = (e) => {
+  if (e.data === 'ping') {
+    self.postMessage({ msg, mode })
+  }
+}

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -172,7 +172,7 @@ export const isTsRequest = (url: string) => knownTsRE.test(cleanUrl(url))
 export const isPossibleTsOutput = (url: string) =>
   knownTsOutputRE.test(cleanUrl(url))
 export const getTsSrcPath = (filename: string) =>
-  filename.replace(/\.([cm])?(js)(x?)$/, '.$1ts$3')
+  filename.replace(/\.([cm])?(js)(x?)(\?|$)/, '.$1ts$3')
 
 const importQueryRE = /(\?|&)import=?(?:&|$)/
 const internalPrefixes = [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since 2.7.0-beta.1 it's been possible for imports with query strings to trigger a crash by infinite recursion (see #5671). Turns out the problem is a missing case in the `getTsSrcPath` regex in `utils.ts` -- it only matches at the end of the import path, but it should treat `?` as a valid final character as well.

`worker.spec.ts` would have caught this, but the workers the module imported were all defined directly in typescript -- and this case is [only applied](https://github.com/vitejs/vite/blob/022db52f6de19e98e6412e7c11bf719b1fd8960c/packages/vite/src/node/plugins/resolve.ts#L460) when the file being imported has an [extension associated with **compiled** typescript](https://github.com/vitejs/vite/blob/1aa7d6c104dafebdcfdcc2df238f16bcd5e2483d/packages/vite/src/node/utils.ts#L170). I added an additional test using an identical worker in an `.mjs` file to cover this case, and confirmed that it failed without my fix.

### Additional context

Unrelated to the PR, but the `debug-serve` command is failing with the following error:

```
/Users/davidjackson/git/vite/node_modules/.bin/jest:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1031:15)
    at Module._compile (node:internal/modules/cjs/loader:1065:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```
It looks like the script at `node_modules/.bin/jest` was recently replaced with a shell script, I'm assuming by an update to Jest. This made debugging a little tricky; I wound up adding `--inspect-brk` to the actual shell script in my `node_modules`. I'm not sure how best to fix it, though, since the shell script hardcodes a call to node with no opportunity to add `--inspect-brk` before the script name:

![image](https://user-images.githubusercontent.com/1735971/141666174-41787393-4021-4d22-8e64-099bd973435b.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
