### PR TITLE
fix(build): don't resolve dynamic imports in dead code (fix #5676)

### DIFF
--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -46,6 +46,9 @@ export async function resolvePlugins(
     config.build.ssr ? ssrRequireHookPlugin(config) : null,
     htmlInlineScriptProxyPlugin(config),
     cssPlugin(config),
+    // Replace constants before running esbuild transform so that dynamic
+    // imports in dead branches won't need to be resolved (#5676).
+    definePlugin(config),
     config.esbuild !== false ? esbuildPlugin(config.esbuild) : null,
     jsonPlugin(
       {
@@ -58,7 +61,6 @@ export async function resolvePlugins(
     webWorkerPlugin(config),
     assetPlugin(config),
     ...normalPlugins,
-    definePlugin(config),
     cssPostPlugin(config),
     ...buildPlugins.pre,
     ...postPlugins,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

By running the define plugin before esbuild, esbuild will rewrite dynamic imports in dead branches to `null`.

Code like:

```typescript
if (import.meta.env.SSR) {
  const { data } = await import('./loadServer');
  console.log(data);
}
```

is transformed to:

```js
if (false) {
  const { data } = await null;
  console.log(data);
}
```

For the browser build, so that `./loadServer` which cannot be bundled for browser won't cause a build failure.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
