### PR TITLE
fix(scan): correctly resolve virtual modules

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -203,18 +203,12 @@ function esbuildScanPlugin(
         external: true
       }))
 
-      build.onResolve(
-        { filter: virtualModuleRE },
-        async ({ path, importer }) => {
-          return {
-            path: await resolve(
-              path.substring('virtual-module:'.length),
-              importer
-            ),
-            namespace: 'html'
-          }
+      build.onResolve({ filter: virtualModuleRE }, ({ path }) => {
+        return {
+          path,
+          namespace: 'html'
         }
-      )
+      })
 
       // html types: extract script contents -----------------------------------
       build.onResolve({ filter: htmlTypesRE }, async ({ path, importer }) => {
@@ -226,7 +220,7 @@ function esbuildScanPlugin(
 
       build.onLoad(
         { filter: virtualModuleRE, namespace: 'html' },
-        async ({ path }) => {
+        ({ path }) => {
           return moduleScripts[path]
         }
       )

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -152,7 +152,8 @@ export const isExternalUrl = (url: string): boolean => externalRE.test(url)
 export const dataUrlRE = /^\s*data:/i
 export const isDataUrl = (url: string): boolean => dataUrlRE.test(url)
 
-export const virtualModuleRE = /virtual-module:.*/
+export const virtualModuleRE = /^virtual-module:.*/
+export const virtualModulePrefix = 'virtual-module:'
 
 const knownJsSrcRE = /\.((j|t)sx?|mjs|vue|marko|svelte|astro)($|\?)/
 export const isJSRequest = (url: string): boolean => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Reverts https://github.com/vitejs/vite/pull/5659 (cc  @benmccann)

Resolve the virtual module to an actual file path for its file imports to be resolved by esbuild. Otherwise the `importer` would be `virtual-module:path/to/file` which fails to resolve.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Interfering with all Svelte and Vue projects as dependencies aren't properly crawled on first run.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
