### PR TITLE
fix(ssr): skip dedupe require in esm

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -172,6 +172,10 @@ export default defineConfig(async ({ command, mode }) => {
 
   If you have duplicated copies of the same dependency in your app (likely due to hoisting or linked packages in monorepos), use this option to force Vite to always resolve listed dependencies to the same copy (from project root).
 
+  :::warning SSR + ESM
+  For SSR builds, deduplication does not work for ESM build outputs configured from `build.rollupOptions.output`. A workaround is to use CJS build outputs until ESM has better plugin support for module loading.
+  :::
+
 ### resolve.conditions
 
 - **Type:** `string[]`
@@ -361,9 +365,8 @@ export default defineConfig(async ({ command, mode }) => {
 
   Env variables starts with `envPrefix` will be exposed to your client source code via import.meta.env.
 
-:::warning SECURITY NOTES
-
-- `envPrefix` should not be set as `''`, which will expose all your env variables and cause unexpected leaking of of sensitive information. Vite will throw error when detecting `''`.
+  :::warning SECURITY NOTES
+  `envPrefix` should not be set as `''`, which will expose all your env variables and cause unexpected leaking of of sensitive information. Vite will throw error when detecting `''`.
   :::
 
 ## Server Options

--- a/packages/vite/src/node/plugins/ssrRequireHook.ts
+++ b/packages/vite/src/node/plugins/ssrRequireHook.ts
@@ -12,9 +12,7 @@ export function ssrRequireHookPlugin(config: ResolvedConfig): Plugin | null {
   if (
     config.command !== 'build' ||
     !config.resolve.dedupe?.length ||
-    arraify(config.build.rollupOptions?.output).find(
-      (output) => output?.format === 'es' || output?.format === 'esm'
-    )
+    isBuildOutputEsm(config)
   ) {
     return null
   }
@@ -73,4 +71,11 @@ export function hookNodeResolve(
   return () => {
     Module._resolveFilename = prevResolver
   }
+}
+
+function isBuildOutputEsm(config: ResolvedConfig) {
+  const outputs = arraify(config.build.rollupOptions?.output)
+  return outputs.some(
+    (output) => output?.format === 'es' || output?.format === 'esm'
+  )
 }

--- a/packages/vite/src/node/plugins/ssrRequireHook.ts
+++ b/packages/vite/src/node/plugins/ssrRequireHook.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string'
 import { ResolvedConfig } from '..'
 import { Plugin } from '../plugin'
+import { arraify } from '../utils'
 
 /**
  * This plugin hooks into Node's module resolution algorithm at runtime,
@@ -8,7 +9,13 @@ import { Plugin } from '../plugin'
  * in development.
  */
 export function ssrRequireHookPlugin(config: ResolvedConfig): Plugin | null {
-  if (config.command !== 'build' || !config.resolve.dedupe?.length) {
+  if (
+    config.command !== 'build' ||
+    !config.resolve.dedupe?.length ||
+    arraify(config.build.rollupOptions?.output).find(
+      (output) => output?.format === 'es' || output?.format === 'esm'
+    )
+  ) {
     return null
   }
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `dedupeRequire` function injected in the build only works in CJS, so we exclude it if we're building for ESM.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Caused by #3951. (cc @aleclarson) I've confirmed this fixes the build tests in `vite-plugin-svelte`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
