### PR TITLE
fix(build): keep IIFE name after minifying (fix #5490)

### DIFF
--- a/packages/playground/lib/__tests__/lib.spec.ts
+++ b/packages/playground/lib/__tests__/lib.spec.ts
@@ -11,6 +11,10 @@ if (isBuild) {
     expect(await page.textContent('.umd')).toBe('It works')
   })
 
+  test('iife', async () => {
+    expect(await page.textContent('.iife')).toBe('It works')
+  })
+
   test('Library mode does not include `preload`', async () => {
     expect(await page.textContent('.dynamic-import-message')).toBe('hello vite')
     const code = fs.readFileSync(

--- a/packages/playground/lib/index.dist.html
+++ b/packages/playground/lib/index.dist.html
@@ -1,6 +1,7 @@
 <!-- the production demo page, copied into dist/ -->
 <div class="es"></div>
 <div class="umd"></div>
+<div class="iife"></div>
 <div class="dynamic-import-message"></div>
 
 <script type="module">
@@ -18,4 +19,10 @@
 <script src="./my-lib-custom-filename.umd.js"></script>
 <script>
   MyLib('.umd')
+  delete window.MyLib // so that it won't affect iife
+</script>
+
+<script src="./my-lib-custom-filename.iife.js"></script>
+<script>
+  MyLib('.iife')
 </script>

--- a/packages/playground/lib/vite.config.js
+++ b/packages/playground/lib/vite.config.js
@@ -9,6 +9,7 @@ module.exports = {
     lib: {
       entry: path.resolve(__dirname, 'src/main.js'),
       name: 'MyLib',
+      formats: ['es', 'umd', 'iife'],
       fileName: (format) => `my-lib-custom-filename.${format}.js`
     }
   },

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -202,7 +202,16 @@ const rollupToEsbuildFormatMap: Record<
 > = {
   es: 'esm',
   cjs: 'cjs',
-  iife: 'iife'
+
+  // passing `var Lib = (() => {})()` to esbuild with format = "iife"
+  // will turn it to `(() => { var Lib = (() => {})() })()`,
+  // so we remove the format config to tell esbuild not doing this
+  //
+  // although esbuild doesn't change format, there is still possibility
+  // that `{ treeShaking: true }` removes a top-level no-side-effect variable
+  // like: `var Lib = 1`, which becomes `` after esbuild transforming,
+  // but thankfully rollup does not do this optimization now
+  iife: undefined
 }
 
 export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Using `minify: true` (which defaults to esbuild) with output format `iife` causes the global variable name missing. This is because of passing `format: "iife"` to `esbuild.transform()` ([see it live](https://hyrious.me/esbuild-repl/?version=0.13.13&shareable=JTdCJTIyY29kZSUyMiUzQSUyMnZhciUyMGElMjAlM0QlMjAoKCklMjAlM0QlM0UlMjAlN0IlN0QpKCklMjIlMkMlMjJjb25maWclMjIlM0ElN0IlMjJmb3JtYXQlMjIlM0ElMjJpaWZlJTIyJTdEJTdE)).

```js
// original code
var a = (() => {})()
// esbuild --format=iife
(() => {
  var a = (() => {
  })();
})();
```

This PR just removed this param.

Fixed #5490.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

We also passed `treeShaking: true` to esbuild minifier to strip some top-level variable/functions that are not in use. However:
- it has no effect on `iife` format because all top-level declarations are wrapped in a closure.
- it has no effect on `esm` format because minifying was turn-ed off manually.
- it has effect on `cjs` format, good news.

Another topic is there's possibility that a simple variable be tree-shaked ([see it live](https://hyrious.me/esbuild-repl/?version=0.13.13&shareable=JTdCJTIyY29kZSUyMiUzQSUyMnZhciUyMGElMjAlM0QlMjAxJTIyJTJDJTIyY29uZmlnJTIyJTNBJTdCJTIydHJlZVNoYWtpbmclMjIlM0F0cnVlJTdEJTdE)).

```js
// original code
var a = 1
// esbuild --tree-shaking
// (nothing left)
```

However, currently the rollup output of `iife` format will never be in this way, so we can just be relieved.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
