### PR TITLE
feat(dev): expose restart function on ViteDevServer

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -107,7 +107,7 @@ interface ViteDevServer {
   /**
    * Restart the server.
    *
-   * @param forceOptimize - force the optimizer to rebundle, same as --force cli flag
+   * @param forceOptimize - force the optimizer to re-bundle, same as --force cli flag
    */
   restart(forceOptimize?: boolean): Promise<void>
   /**

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -105,6 +105,12 @@ interface ViteDevServer {
    */
   listen(port?: number, isRestart?: boolean): Promise<ViteDevServer>
   /**
+   * Restart the server.
+   *
+   * @param forceOptimize - force the optimizer to rebundle, same as --force cli flag
+   */
+  restart(forceOptimize?: boolean): Promise<void>
+  /**
    * Stop the server.
    */
   close(): Promise<void>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Previously, restart function was implemented in hmr.ts and plugins had to simulate a change to the vite config file to trigger a restart. This is both cumbersome and only works when there is a vite config - which isn't always the case.

The new function ViteDevServer#restart  reuses the existing code from hmr, including a flag for force optimizing and prevention of multi-restarts (which could end up with an inconsistent result).

### Additional context

Suggested this here https://github.com/vitejs/vite/pull/3182#issuecomment-886474044 and @antfu liked it. 
Prime candidates for adopting this api would be vite-plugin-svelte ( https://github.com/sveltejs/vite-plugin-svelte/issues/210 ) and https://github.com/antfu/vite-plugin-restart

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
