### PR TITLE
fix: scoped variable with array destructuring & nested arguments

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -188,6 +188,48 @@ test('do not rewrite when variable is in scope', async () => {
   expect(result.deps).toEqual(['vue'])
 })
 
+// #5472
+test('do not rewrite when variable is in scope with object destructuring', async () => {
+  const result = await ssrTransform(
+    `import { fn } from 'vue';function A(){ let {fn, test} = {fn: 'foo', test: 'bar'}; return { fn }; }`,
+    null,
+    null
+  )
+  expect(result.code).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    function A(){ let {fn, test} = {fn: 'foo', test: 'bar'}; return { fn }; }"
+  `)
+  expect(result.deps).toEqual(['vue'])
+})
+
+// #5472
+test('do not rewrite when variable is in scope with array destructuring', async () => {
+  const result = await ssrTransform(
+    `import { fn } from 'vue';function A(){ let [fn, test] = ['foo', 'bar']; return { fn }; }`,
+    null,
+    null
+  )
+  expect(result.code).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    function A(){ let [fn, test] = ['foo', 'bar']; return { fn }; }"
+  `)
+  expect(result.deps).toEqual(['vue'])
+})
+
+// #5727
+test('rewrite variable in string interpolation in function nested arguments', async () => {
+  const result = await ssrTransform(
+    `import { fn } from 'vue';function A({foo = \`test\${fn}\`} = {}){ return {}; }`,
+    null,
+    null
+  )
+  expect(result.code).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    function A({foo = \`test\${__vite_ssr_import_0__.fn}\`} = {}){ return {}; }"
+  `)
+  expect(result.deps).toEqual(['vue'])
+})
+
 test('do not rewrite when function declaration is in scope', async () => {
   const result = await ssrTransform(
     `import { fn } from 'vue';function A(){ function fn() {}; return { fn }; }`,

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -321,10 +321,12 @@ function walk(
                 !isStaticPropertyKey(child, parent) &&
                 // do not record if this is a default value
                 // assignment of a destructuring variable
-                !(
-                  parent &&
-                  parent.type === 'AssignmentPattern' &&
-                  parent.right === child
+                (
+                  !parent || 
+                  (
+                    !(parent.type === 'AssignmentPattern' && parent.right === child) &&
+                    !(parent.type === 'TemplateLiteral' && parent.expressions.includes(child))
+                  )
                 )
               ) {
                 setScope(node, child.name)
@@ -346,7 +348,12 @@ function walk(
                 setScope(parentFunction, (property.value as Identifier).name)
               }
             })
-          } else {
+          } else if (node.id.type === 'ArrayPattern') {
+            node.id.elements.forEach((element) => {
+              setScope(parentFunction, (element as Identifier).name)
+            })
+          }
+          else {
             setScope(parentFunction, (node.id as Identifier).name)
           }
         }

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -315,22 +315,20 @@ function walk(
         node.params.forEach((p) =>
           (eswalk as any)(p.type === 'AssignmentPattern' ? p.left : p, {
             enter(child: Node, parent: Node) {
+              if (child.type !== 'Identifier') return
+              // do not record as scope variable if is a destructuring keyword
+              if (isStaticPropertyKey(child, parent)) return
+              // do not record if this is a default value
+              // assignment of a destructuring variable
               if (
-                child.type === 'Identifier' &&
-                // do not record as scope variable if is a destructuring key
-                !isStaticPropertyKey(child, parent) &&
-                // do not record if this is a default value
-                // assignment of a destructuring variable
-                (
-                  !parent || 
-                  (
-                    !(parent.type === 'AssignmentPattern' && parent.right === child) &&
-                    !(parent.type === 'TemplateLiteral' && parent.expressions.includes(child))
-                  )
-                )
+                (parent?.type === 'AssignmentPattern' &&
+                  parent?.right === child) ||
+                (parent?.type === 'TemplateLiteral' &&
+                  parent?.expressions.includes(child))
               ) {
-                setScope(node, child.name)
+                return
               }
+              setScope(node, child.name)
             }
           })
         )
@@ -352,8 +350,7 @@ function walk(
             node.id.elements.forEach((element) => {
               setScope(parentFunction, (element as Identifier).name)
             })
-          }
-          else {
+          } else {
             setScope(parentFunction, (node.id as Identifier).name)
           }
         }


### PR DESCRIPTION
### Description
This PR solves #5727 and #5472.
Vitejs will check for a locally scoped variable with the same name when destructuring an array.
Vitejs will replace a variable used in a string interpolation as default value for a nested argument in a function declaration.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
