### PR TITLE
fix: ssr-vue prerender need input rootDir parameter

### DIFF
--- a/packages/playground/ssr-vue/prerender.js
+++ b/packages/playground/ssr-vue/prerender.js
@@ -21,7 +21,7 @@ const routesToPrerender = fs
 ;(async () => {
   // pre-render each route...
   for (const url of routesToPrerender) {
-    const [appHtml, preloadLinks] = await render(url, manifest)
+    const [appHtml, preloadLinks] = await render(url, manifest, __dirname)
 
     const html = template
       .replace(`<!--preload-links-->`, preloadLinks)


### PR DESCRIPTION

### Description
vite/packages/playground/ssr-vue
when you run `node prerender.js` get some error

(node:5816) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined


### What is the purpose of this pull request? 

- [x] Bug fix

