### PR TITLE
fix: css codesplit inline problem

### DIFF
--- a/packages/playground/css-codesplit/__tests__/css-codesplit.spec.ts
+++ b/packages/playground/css-codesplit/__tests__/css-codesplit.spec.ts
@@ -3,6 +3,7 @@ import { findAssetFile, getColor, isBuild, readManifest } from '../../testUtils'
 test('should load both stylesheets', async () => {
   expect(await getColor('h1')).toBe('red')
   expect(await getColor('h2')).toBe('blue')
+  expect(await getColor('h3')).toBe('yellow')
 })
 
 if (isBuild) {

--- a/packages/playground/css-codesplit/async.css
+++ b/packages/playground/css-codesplit/async.css
@@ -1,0 +1,3 @@
+h3 {
+  color: yellow;
+}

--- a/packages/playground/css-codesplit/main.js
+++ b/packages/playground/css-codesplit/main.js
@@ -1,6 +1,12 @@
 import './style.css'
 import './main.css'
+import('./async.css?inline').then((css) => {
+  const style = document.createElement('style')
+  style.dataset.import = true
+  style.textContent = css.default
+  document.head.appendChild(style)
+})
 
 document.getElementById(
   'app'
-).innerHTML = `<h1>This should be red</h1><h2>This should be blue</h2>`
+).innerHTML = `<h1>This should be red</h1><h2>This should be blue</h2><h3>This should be yellow</h3>`

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -319,7 +319,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       return {
         code:
           modulesCode ||
-          (usedRE.test(id)
+          (usedRE.test(id) || inlined
             ? `export default ${JSON.stringify(
                 inlined ? await minifyCSS(css, config) : css
               )}`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes https://github.com/vitejs/vite/issues/5348

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
Css code is gone after build when using ?inline and dynamic import. It can reproduce in https://github.com/lovetingyuan/bug-vite-dymamic-import-css.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
