### PR TITLE
fix(plugin-react): remove querystring from sourcemap filename

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -215,7 +215,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           ast: !isReasonReact,
           root: projectRoot,
           filename: id,
-          sourceFileName: id,
+          sourceFileName: filepath,
           parserOpts: {
             ...opts.babel?.parserOpts,
             sourceType: 'module',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The variable used in this [sourcemaps fix in plugin-react](https://github.com/vitejs/vite/commit/8556ffe3c59952d7e64565422bf433699e97756e#diff-d1f942b9a74f586a80bca3733150b7c692a6460e8350bc19cbbad1d53f95b356) might contain a querystring, in which case it does not work. This PR removes the querystring passed to Babel.

### Additional context

In Hydrogen, some React components end in `component.client.jsx?no-proxy` and it shows the warning `sourcemap for xyz points to missing source files` just like in #5438 due to this querystring.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
