### PR TITLE
chore: optimize esm flag

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -775,14 +775,14 @@ export async function loadConfigFromFile(
 
   let resolvedPath: string | undefined
   let isTS = false
-  let isMjs = false
+  let isESM = false
   let dependencies: string[] = []
 
   // check package.json for type: "module" and set `isMjs` to true
   try {
     const pkg = lookupFile(configRoot, ['package.json'])
     if (pkg && JSON.parse(pkg).type === 'module') {
-      isMjs = true
+      isESM = true
     }
   } catch (e) {}
 
@@ -792,7 +792,7 @@ export async function loadConfigFromFile(
     isTS = configFile.endsWith('.ts')
 
     if (configFile.endsWith('.mjs')) {
-      isMjs = true
+      isESM = true
     }
   } else {
     // implicit config file loaded from inline root (if present)
@@ -806,7 +806,7 @@ export async function loadConfigFromFile(
       const mjsconfigFile = path.resolve(configRoot, 'vite.config.mjs')
       if (fs.existsSync(mjsconfigFile)) {
         resolvedPath = mjsconfigFile
-        isMjs = true
+        isESM = true
       }
     }
 
@@ -827,7 +827,7 @@ export async function loadConfigFromFile(
   try {
     let userConfig: UserConfigExport | undefined
 
-    if (isMjs) {
+    if (isESM) {
       const fileUrl = require('url').pathToFileURL(resolvedPath)
       if (isTS) {
         // before we can register loaders without requiring users to run node
@@ -850,7 +850,7 @@ export async function loadConfigFromFile(
       }
     }
 
-    if (!isTS && !isMjs) {
+    if (!isTS && !isESM) {
       // 1. try to directly require the module (assuming commonjs)
       try {
         // clear cache in case of server restart
@@ -906,7 +906,7 @@ export async function loadConfigFromFile(
 
 async function bundleConfigFile(
   fileName: string,
-  mjs = false
+  isESM = false
 ): Promise<{ code: string; dependencies: string[] }> {
   const result = await build({
     absWorkingDir: process.cwd(),
@@ -915,7 +915,7 @@ async function bundleConfigFile(
     write: false,
     platform: 'node',
     bundle: true,
-    format: mjs ? 'esm' : 'cjs',
+    format: isESM ? 'esm' : 'cjs',
     sourcemap: 'inline',
     metafile: true,
     plugins: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Optimize the variable flag. Previously, `isMjs` was used as the flag. In fact, it would be better to use `isESM` because the parsed file may be TS.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
