### PR TITLE
fix: always bundle config file, fix config hmr

### DIFF
--- a/packages/playground/resolve/config-dep.js
+++ b/packages/playground/resolve/config-dep.js
@@ -1,0 +1,3 @@
+module.exports = {
+  a: 1
+}

--- a/packages/playground/resolve/vite.config.js
+++ b/packages/playground/resolve/vite.config.js
@@ -2,12 +2,16 @@ const virtualFile = '@virtual-file'
 const virtualId = '\0' + virtualFile
 
 const customVirtualFile = '@custom-virtual-file'
+const { a } = require('./config-dep');
 
 module.exports = {
   resolve: {
     extensions: ['.mjs', '.js', '.es', '.ts'],
     mainFields: ['custom', 'module'],
     conditions: ['custom']
+  },
+  define: {
+    VITE_CONFIG_DEP_TEST: a
   },
   plugins: [
     {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -850,36 +850,8 @@ export async function loadConfigFromFile(
       }
     }
 
-    if (!isTS && !isESM) {
-      // 1. try to directly require the module (assuming commonjs)
-      try {
-        const bundled = await bundleConfigFile(resolvedPath)
-        dependencies = bundled.dependencies
-        // clear cache in case of server restart
-        delete require.cache[require.resolve(resolvedPath)]
-        userConfig = require(resolvedPath)
-        debug(`cjs config loaded in ${getTime()}`)
-      } catch (e) {
-        const ignored = new RegExp(
-          [
-            `Cannot use import statement`,
-            `Must use import to load ES Module`,
-            // #1635, #2050 some Node 12.x versions don't have esm detection
-            // so it throws normal syntax errors when encountering esm syntax
-            `Unexpected token`,
-            `Unexpected identifier`
-          ].join('|')
-        )
-        if (!ignored.test(e.message)) {
-          throw e
-        }
-      }
-    }
-
     if (!userConfig) {
-      // 2. if we reach here, the file is ts or using es import syntax, or
-      // the user has type: "module" in their package.json (#917)
-      // transpile es import syntax to require syntax using esbuild.
+      // Bundle config file and transpile it to cjs using esbuild.
       const bundled = await bundleConfigFile(resolvedPath)
       dependencies = bundled.dependencies
       userConfig = await loadConfigFromBundledFile(resolvedPath, bundled.code)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fix #5780.In resolveConfig, using `dependencies` variable to record the deps that config file used, but if config file is `js`, the dependencies info will be lost.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
