### PR TITLE
fix: unminified build breaks __vitePreload

### DIFF
--- a/packages/playground/preload/__tests__/preload.spec.ts
+++ b/packages/playground/preload/__tests__/preload.spec.ts
@@ -11,4 +11,15 @@ if (isBuild) {
     const appHtml = await page.content()
     expect(appHtml).toMatch('This is <b>home</b> page.')
   })
+
+  test('dynamic import with comments', async () => {
+    await page.goto(viteTestUrl + '/#/hello')
+    const html = await page.content()
+    expect(html).toMatch(
+      /link rel="modulepreload".*?href="\/assets\/Hello\.\w{8}\.js"/
+    )
+    expect(html).toMatch(
+      /link rel="stylesheet".*?href="\/assets\/Hello\.\w{8}\.css"/
+    )
+  })
 }

--- a/packages/playground/preload/router.js
+++ b/packages/playground/preload/router.js
@@ -4,9 +4,14 @@ import Home from './src/components/Home.vue'
 const routes = [
   { path: '/', name: 'Home', component: Home },
   {
+    path: '/hello',
+    name: 'Hello',
+    component: () => import(/* a comment */ './src/components/Hello.vue')
+  },
+  {
     path: '/about',
     name: 'About',
-    component: () => import(/*breaks*/ './src/components/About.vue')
+    component: () => import('./src/components/About.vue')
   } // Lazy load route component
 ]
 

--- a/packages/playground/preload/router.js
+++ b/packages/playground/preload/router.js
@@ -6,7 +6,7 @@ const routes = [
   {
     path: '/about',
     name: 'About',
-    component: () => import('./src/components/About.vue')
+    component: () => import(/*breaks*/ './src/components/About.vue')
   } // Lazy load route component
 ]
 

--- a/packages/playground/preload/src/components/Hello.vue
+++ b/packages/playground/preload/src/components/Hello.vue
@@ -1,0 +1,18 @@
+<template>
+  <h1>{{ msg }}</h1>
+  <div>
+    This is <b>hello</b> page.
+    <br />
+    Go to <router-link to="/">Home</router-link> page
+  </div>
+</template>
+
+<script setup>
+const msg = 'hello'
+</script>
+
+<style scoped>
+h1 {
+  color: red;
+}
+</style>

--- a/packages/playground/preload/src/components/Home.vue
+++ b/packages/playground/preload/src/components/Home.vue
@@ -3,6 +3,8 @@
     This is <b>home</b> page.
     <br />
     Go to <router-link to="/about">About</router-link> page
+    <br />
+    Go to <router-link to="/hello">Hello</router-link> page
   </div>
 </template>
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
close #5753
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When there are comments in dynamic import, e.g.
```js
import(/*not following dependency*/'./App.vue')
```
We will get `url` =  `/*not following dependency*/ "./App.vue"` ,  which does not meet the conditions:
```js
if (url[0] === `"` && url[url.length - 1] === `"`) {
``` 
In fact `es-module-lexer` will return a `.n` field containing the escaped `url`,  which is `./App.vue` in this example.
So we can use the `.n` field first.

### Additional context
https://github.com/guybedford/es-module-lexer/blob/c5cdb28d848c91e9296bbcf9a17196f230f68a5f/types/lexer.d.ts#L2-L22
```js
 /**
   * Module name
   * 
   * To handle escape sequences in specifier strings, the .n field of imported specifiers will be provided where possible.
   * 
   * For dynamic import expressions, this field will be empty if not a valid JS string.
   * 
   * @example
   * const [imports1, exports1] = parse(String.raw`import './\u0061\u0062.js'`);
   * imports1[0].n;
   * // Returns "./ab.js"
   * 
   * const [imports2, exports2] = parse(`import("./ab.js")`);
   * imports2[0].n;
   * // Returns "./ab.js"
   * 
   * const [imports3, exports3] = parse(`import("./" + "ab.js")`);
   * imports3[0].n;
   * // Returns undefined
   */
  readonly n: string | undefined;
```
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
