### PR TITLE
ci: add release tag action [ci skip]

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'plugin-*' # Push events to matching plugin-*, i.e. plugin-(vue|vue-jsx|react|legacy)@1.0.0
+      - 'create-vite*' # # Push events to matching create-vite*, i.e. create-vite@1.0.0
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get branch and pkgName for tag
+        id: tag
+        run: |
+          # matching v2.0.0 / v2.0.0-beta.8 etc
+          if [[ $GITHUB_REF_NAME =~ ^v.+ ]]; then
+            pkgName="vite"
+          else
+            # `%@*` truncates @ and version number from the right side.
+            # https://stackoverflow.com/questions/9532654/expression-after-last-specific-character
+            pkgName=${GITHUB_REF_NAME%@*}
+          fi
+
+          echo "::set-output name=pkgName::$pkgName"
+
+      - name: Create Release for Tag
+        id: release_tag
+        uses: yyx990803/release-tag@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          body: |
+            Please refer to [CHANGELOG.md](https://github.com/vitejs/vite/blob/${{ github.ref_name }}/packages/${{ steps.tag.outputs.pkgName }}/CHANGELOG.md) for details.

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get branch and pkgName for tag
+      - name: Get pkgName for tag
         id: tag
         run: |
           # matching v2.0.0 / v2.0.0-beta.8 etc

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -3,9 +3,9 @@ name: release
 on:
   push:
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-      - 'plugin-*' # Push events to matching plugin-*, i.e. plugin-(vue|vue-jsx|react|legacy)@1.0.0
-      - 'create-vite*' # # Push events to matching create-vite*, i.e. create-vite@1.0.0
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "plugin-*" # Push events to matching plugin-*, i.e. plugin-(vue|vue-jsx|react|legacy)@1.0.0
+      - "create-vite*" # # Push events to matching create-vite*, i.e. create-vite@1.0.0
 
 # $GITHUB_REF_NAME - https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,6 +7,8 @@ on:
       - 'plugin-*' # Push events to matching plugin-*, i.e. plugin-(vue|vue-jsx|react|legacy)@1.0.0
       - 'create-vite*' # # Push events to matching create-vite*, i.e. create-vite@1.0.0
 
+# $GITHUB_REF_NAME - https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add a release-tag action [same as used in vue-next](https://github.com/vuejs/vue-next/blob/master/.github/workflows/release-tag.yml) tho it handles monorepo releases conditionally.

### Additional context

In the release description, I used the same format as vue-next. Though the difference is we provide the link to the CHANGELOG from the git tag, not from `main` branch since I noticed there is `release/*` branches for minor releases.

To view this PR in action, you can refer to my forked repo and I [tested on this branch](https://github.com/ydcjeff/vite/tree/ci/release-tag-test).

One thing is stable releases of plugins are not considered as latest in GitHub releases.
Maybe because of they use semantic matching for latest release?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
