### PR TITLE
fix: throw full error causing preprocessor to not load

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import glob from 'fast-glob'
 import {
-  // createDebugger,
+  createDebugger,
   isExternalUrl,
   asyncReplace,
   cleanUrl,
@@ -44,7 +44,8 @@ import { Alias } from 'types/alias'
 import type { ModuleNode } from '../server/moduleGraph'
 import { transform, formatMessages } from 'esbuild'
 
-// const debug = createDebugger('vite:css')
+const debug = createDebugger('vite:css')
+const isDebug = !!process.env.DEBUG
 
 export interface CSSOptions {
   /**
@@ -1001,9 +1002,14 @@ function loadPreprocessor(lang: PreprocessLang, root: string): any {
     const resolved = require.resolve(lang, { paths: [root, ...fallbackPaths] })
     return (loadedPreprocessors[lang] = require(resolved))
   } catch (e) {
-    throw new Error(
-      `Preprocessor dependency "${lang}" not found. Did you install it?`
-    )
+    if (isDebug) {
+      debug(`[load] Preprocessor dependency "${lang}" not found. Did you install it?`);
+      throw new Error(e.stack);
+    } else { 
+      throw new Error(
+        `Preprocessor dependency "${lang}" not found. Did you install it?`
+      )
+    }
   }
 }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import glob from 'fast-glob'
 import {
-  createDebugger,
+  // createDebugger,
   isExternalUrl,
   asyncReplace,
   cleanUrl,
@@ -44,8 +44,7 @@ import { Alias } from 'types/alias'
 import type { ModuleNode } from '../server/moduleGraph'
 import { transform, formatMessages } from 'esbuild'
 
-const debug = createDebugger('vite:css')
-const isDebug = !!process.env.DEBUG
+// const debug = createDebugger('vite:css')
 
 export interface CSSOptions {
   /**
@@ -1002,14 +1001,13 @@ function loadPreprocessor(lang: PreprocessLang, root: string): any {
     const resolved = require.resolve(lang, { paths: [root, ...fallbackPaths] })
     return (loadedPreprocessors[lang] = require(resolved))
   } catch (e) {
-    if (isDebug) {
-      debug(`[load] Preprocessor dependency "${lang}" not found. Did you install it?`);
-      throw new Error(e.stack);
-    } else { 
-      throw new Error(
-        `Preprocessor dependency "${lang}" not found. Did you install it?`
-      )
-    }
+    if (e.code === 'MODULE_NOT_FOUND') {
+      throw new Error(`Preprocessor dependency "${lang}" not found. Did you install it?`);
+    } else {
+      const message = new Error(`Preprocessor dependency "${lang}" failed to load:\n${e.message}`);
+      message.stack = e.stack + '\n' + message.stack;
+      throw message;
+    } 
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/vitejs/vite/issues/5815, going through this function I found that the module was being resolved correctly but an error was being thrown during `require`, which the default error message swallowed. If I follow other uses of the debug helpers, this should throw the standard error unless the user's in debug mode, then it should debug the load error and throw the full stack trace.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
