### PR TITLE
feat: support user manualChunks config

### DIFF
--- a/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -1,6 +1,8 @@
 import { editFile, untilUpdated } from '../../testUtils'
 import { port } from './serve'
 import fetch from 'node-fetch'
+import { resolve } from 'path'
+import promises from 'fs/promises'
 
 const url = `http://localhost:${port}`
 
@@ -61,4 +63,13 @@ test(`circular dependecies modules doesn't throw`, async () => {
   expect(await page.textContent('.circ-dep-init')).toMatch(
     'circ-dep-init-a circ-dep-init-b'
   )
+})
+
+test('Home chunk file should be split succeed', async () => {
+  const assetsArr = await promises.readdir(
+    resolve(process.cwd(), './packages/temp/ssr-react/dist/client/assets')
+  )
+  const re = /Home\.chunk/
+  const res = assetsArr.some((asset) => re.test(asset))
+  expect(res).toBe(true)
 })

--- a/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
+++ b/packages/playground/ssr-react/__tests__/ssr-react.spec.ts
@@ -1,8 +1,8 @@
-import { editFile, untilUpdated } from '../../testUtils'
+import { editFile, untilUpdated, isBuild } from '../../testUtils'
 import { port } from './serve'
 import fetch from 'node-fetch'
 import { resolve } from 'path'
-import promises from 'fs/promises'
+import { promises } from 'fs'
 
 const url = `http://localhost:${port}`
 
@@ -66,10 +66,13 @@ test(`circular dependecies modules doesn't throw`, async () => {
 })
 
 test('Home chunk file should be split succeed', async () => {
-  const assetsArr = await promises.readdir(
-    resolve(process.cwd(), './packages/temp/ssr-react/dist/client/assets')
-  )
-  const re = /Home\.chunk/
-  const res = assetsArr.some((asset) => re.test(asset))
-  expect(res).toBe(true)
+  if (isBuild) {
+    const assetsArr = await promises.readdir(
+      resolve(process.cwd(), './packages/temp/ssr-react/dist/client/assets')
+    )
+    const chunkRe = /Home\.chunk/
+    const vendorRe = /vendor/
+    expect(assetsArr.some((asset) => chunkRe.test(asset))).toBe(true)
+    expect(assetsArr.some((asset) => vendorRe.test(asset))).toBe(true)
+  }
 })

--- a/packages/playground/ssr-react/vite.config.js
+++ b/packages/playground/ssr-react/vite.config.js
@@ -6,6 +6,13 @@ const react = require('@vitejs/plugin-react')
 module.exports = {
   plugins: [react()],
   build: {
-    minify: false
+    minify: false,
+    manualChunks: (config) => {
+      return (id) => {
+        if (id.includes('Home.jsx')) {
+          return 'Home.chunk'
+        }
+      }
+    }
   }
 }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -235,7 +235,11 @@ export type ResolvedBuildOptions = Required<
   Omit<
     BuildOptions,
     // make deprecated options optional
-    'base' | 'cleanCssOptions' | 'polyfillDynamicImport' | 'brotliSize' | 'manualChunks'
+    | 'base'
+    | 'cleanCssOptions'
+    | 'polyfillDynamicImport'
+    | 'brotliSize'
+    | 'manualChunks'
   >
 >
 
@@ -509,7 +513,7 @@ async function doBuild(
           !libOptions &&
           output?.format !== 'umd' &&
           output?.format !== 'iife'
-            ? (createMoveToVendorChunkFn(config) && config.build.manualChunks?.(config))
+            ? createManualChunksFn(config)
             : undefined,
         ...output
       }
@@ -637,9 +641,9 @@ function getPkgName(root: string) {
   return name?.startsWith('@') ? name.split('/')[1] : name
 }
 
-function createMoveToVendorChunkFn(config: ResolvedConfig): GetManualChunk {
+function createManualChunksFn(config: ResolvedConfig): GetManualChunk {
   const cache = new Map<string, boolean>()
-  return (id, { getModuleInfo }) => {
+  return (id, { getModuleInfo, getModuleIds }) => {
     if (
       id.includes('node_modules') &&
       !isCSSRequest(id) &&
@@ -647,6 +651,10 @@ function createMoveToVendorChunkFn(config: ResolvedConfig): GetManualChunk {
     ) {
       return 'vendor'
     }
+    return config.build.manualChunks?.(config)(id, {
+      getModuleInfo,
+      getModuleIds
+    })
   }
 }
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -235,7 +235,7 @@ export type ResolvedBuildOptions = Required<
   Omit<
     BuildOptions,
     // make deprecated options optional
-    'base' | 'cleanCssOptions' | 'polyfillDynamicImport' | 'brotliSize'
+    'base' | 'cleanCssOptions' | 'polyfillDynamicImport' | 'brotliSize' | 'manualChunks'
   >
 >
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -215,6 +215,11 @@ export interface BuildOptions {
    * https://rollupjs.org/guide/en/#watchoptions
    */
   watch?: WatcherOptions | null
+  /**
+   * Rollup ManualChunksOption options
+   * https://rollupjs.org/guide/en/#outputmanualchunks
+   */
+  manualChunks?: (config: ResolvedConfig) => GetManualChunk
 }
 
 export interface LibraryOptions {
@@ -504,7 +509,7 @@ async function doBuild(
           !libOptions &&
           output?.format !== 'umd' &&
           output?.format !== 'iife'
-            ? createMoveToVendorChunkFn(config)
+            ? (createMoveToVendorChunkFn(config) && config.build.manualChunks?.(config))
             : undefined,
         ...output
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Now i need a config option that `config.build.manualChunks` will be added after default `createMoveToVendorChunkFn` function called when bundle client files, if not add the option but use `config.build.rollupOptions.manualChunks` will cover default manualChunks function

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I need generate chunk name base on default manualChunks createMoveToVendorChunkFn function.
Or there is another way can implement my requirements？

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
