### PR TITLE
feat: allow ?worker&url to only get the worker url

### DIFF
--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -73,3 +73,11 @@ if (isBuild) {
     expect(content).toMatch(`window.Blob`)
   })
 }
+
+test('?worker&url import', async () => {
+  if (isBuild) {
+    expect(await page.textContent('.worker-url')).toMatch('/assets/my-worker.')
+  } else {
+    expect(await page.textContent('.worker-url')).toMatch('/my-worker.ts?worker_file')
+  }
+})

--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -19,12 +19,18 @@
   <span class="tick-count">0</span>
 </div>
 
+<p>
+  ?worker&url import
+  <code class="worker-url"></code>
+</p>
+
 <script type="module">
   import Worker from './my-worker?worker'
   import InlineWorker from './my-worker?worker&inline'
   import SharedWorker from './my-shared-worker?sharedworker&name=shared'
   import TSOutputWorker from './possible-ts-output-worker?worker'
   import { mode } from './workerImport'
+  import WorkerUrl from './my-worker?worker&url'
 
   document.querySelector('.mode-true').textContent = mode
 
@@ -66,6 +72,8 @@
   document.querySelector('.ping-ts-output').addEventListener('click', () => {
     inlineWorker.postMessage('ping')
   })
+
+  text('.worker-url', WorkerUrl)
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -103,6 +103,10 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         url = injectQuery(url, WorkerFileId)
       }
 
+      if (query.url != null) {
+        return `export default ${JSON.stringify(url)}`
+      }
+
       const workerConstructor =
         query.sharedworker != null ? 'SharedWorker' : 'Worker'
       const workerOptions = { type: 'module' }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR allows you to import a worker with `import worker from './foo?worker&url'`, but instead of returning a worker constructor it returns the url directly.
This is needed for using a Service Worker or a custom wrapper like Workbox.

Using `import worker from './foo?url'` works, but it does not transform (minify) the code or applies vite's `define` macros.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
