### PR TITLE
fix: build pluginContext types error

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -121,6 +121,7 @@ type PluginContext = Omit<
   | 'isExternal'
   | 'moduleIds'
   | 'resolveId'
+  | 'load'
 >
 
 export let parser = acorn.Parser.extend(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

With rollup@2.60.1 types pluginContext load field is required cause build error.
![image](https://user-images.githubusercontent.com/17424434/143541434-e75e10f4-4db5-4182-a6ff-eab6cd29feae.png)


### Additional context

How to reproduce

```bash
$ rm -rf node_modules pnpm-lock.yaml && pnpm i && pnpm build
```
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
