### PR TITLE
fix(scan): handle local scripts with lang=ts

### DIFF
--- a/packages/playground/vue/__tests__/vue.spec.ts
+++ b/packages/playground/vue/__tests__/vue.spec.ts
@@ -22,8 +22,16 @@ test(':slotted', async () => {
   expect(await getColor('.slotted')).toBe('red')
 })
 
-test('scan deps from <script setup lang="ts">', async () => {
-  expect(await page.textContent('.scan')).toBe('ok')
+describe('dep scan', () => {
+  test('scan deps from <script setup lang="ts">', async () => {
+    expect(await page.textContent('.scan')).toBe('ok')
+  })
+
+  test('find deps on initial scan', () => {
+    serverLogs.forEach((log) => {
+      expect(log).not.toMatch('new dependencies found')
+    })
+  })
 })
 
 describe('pre-processors', () => {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -273,12 +273,17 @@ function esbuildScanPlugin(
                 contextMatch &&
                 (contextMatch[1] || contextMatch[2] || contextMatch[3])
               if (
-                (path.endsWith('.vue') && setupRE.test(raw)) ||
+                (path.endsWith('.vue') && setupRE.test(openTag)) ||
                 (path.endsWith('.svelte') && context !== 'module')
               ) {
+                // append imports in TS to prevent esbuild from removing them
+                // since they may be used in the template
+                const localContent =
+                  content +
+                  (loader.startsWith('ts') ? extractImportPaths(content) : '')
                 localScripts[path] = {
                   loader,
-                  contents: content
+                  contents: localContent
                 }
                 js += `import '${virtualModulePrefix}${path}';\n`
               } else {
@@ -286,29 +291,11 @@ function esbuildScanPlugin(
               }
             }
           }
-          // empty singleline & multiline comments to avoid matching comments
-          const code = js
-            .replace(multilineCommentsRE, '/* */')
-            .replace(singlelineCommentsRE, '')
 
-          if (
-            loader.startsWith('ts') &&
-            (path.endsWith('.svelte') ||
-              (path.endsWith('.vue') && setupRE.test(raw)))
-          ) {
-            // when using TS + (Vue + <script setup>) or Svelte, imports may seem
-            // unused to esbuild and dropped in the build output, which prevents
-            // esbuild from crawling further.
-            // the solution is to add `import 'x'` for every source to force
-            // esbuild to keep crawling due to potential side effects.
-            let m
-            while ((m = importsRE.exec(code)) != null) {
-              // This is necessary to avoid infinite loops with zero-width matches
-              if (m.index === importsRE.lastIndex) {
-                importsRE.lastIndex++
-              }
-              js += `\nimport ${m[1]}`
-            }
+          // `<script>` in Svelte has imports that can be used in the template
+          // so we handle them here too
+          if (loader.startsWith('ts') && path.endsWith('.svelte')) {
+            js += extractImportPaths(js)
           }
 
           // This will trigger incorrectly if `export default` is contained
@@ -486,6 +473,31 @@ async function transformGlob(
     s.overwrite(expStart, endIndex, exp)
   }
   return s.toString()
+}
+
+/**
+ * when using TS + (Vue + `<script setup>`) or Svelte, imports may seem
+ * unused to esbuild and dropped in the build output, which prevents
+ * esbuild from crawling further.
+ * the solution is to add `import 'x'` for every source to force
+ * esbuild to keep crawling due to potential side effects.
+ */
+function extractImportPaths(code: string) {
+  // empty singleline & multiline comments to avoid matching comments
+  code = code
+    .replace(multilineCommentsRE, '/* */')
+    .replace(singlelineCommentsRE, '')
+
+  let js = ''
+  let m
+  while ((m = importsRE.exec(code)) != null) {
+    // This is necessary to avoid infinite loops with zero-width matches
+    if (m.index === importsRE.lastIndex) {
+      importsRE.lastIndex++
+    }
+    js += `\nimport ${m[1]}`
+  }
+  return js
 }
 
 export function shouldExternalizeDep(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When `<script setup lang="ts">` in Vue or `<script lang="ts">` in Svelte is written (aka local scripts), esbuild's ts loader skips imports that looks unused. The normal scanner has [a fix](https://github.com/vitejs/vite/blob/1809fccab6267a68336b8374428a88c0514f4ac7/packages/vite/src/node/optimizer/scan.ts#L294-L312) for it, but not for local scripts

Also adds missing tests for #5711. And added global `serverLogs` variable for testing.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
