### PR TITLE
chore: use createApp client-side

### DIFF
--- a/packages/playground/ssr-vue/src/main.js
+++ b/packages/playground/ssr-vue/src/main.js
@@ -1,12 +1,12 @@
 import App from './App.vue'
-import { createSSRApp } from 'vue'
+import { createSSRApp, createApp as _createApp } from 'vue'
 import { createRouter } from './router'
 
 // SSR requires a fresh app instance per request, therefore we export a function
 // that creates a fresh app instance. If using Vuex, we'd also be creating a
 // fresh store here.
 export function createApp() {
-  const app = createSSRApp(App)
+  const app = import.meta.env.SSR ? createSSRApp(App) : _createApp(App);
   const router = createRouter()
   app.use(router)
   return { app, router }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

To prevent the `Attempting to hydrate existing markup but container is empty. Performing full mount instead.` warning in the playground SSR-Vue example, use `createSSRApp` during SSR/prod and `createApp` during SPA-only dev.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
