### PR TITLE
fix(plugin-vue): misleading error thrown after refresh or hmr

### DIFF
--- a/packages/plugin-vue/src/utils/error.ts
+++ b/packages/plugin-vue/src/utils/error.ts
@@ -5,16 +5,22 @@ export function createRollupError(
   id: string,
   error: CompilerError | SyntaxError
 ): RollupError {
-  ;(error as RollupError).id = id
-  ;(error as RollupError).plugin = 'vue'
+  const { message, name, stack } = error
+  const rollupError: RollupError = {
+    id,
+    plugin: 'vue',
+    message,
+    name,
+    stack,
+  }
 
   if ('code' in error && error.loc) {
-    ;(error as any).loc = {
+    rollupError.loc = {
       file: id,
       line: error.loc.start.line,
       column: error.loc.start.column
     }
   }
 
-  return error as RollupError
+  return rollupError
 }

--- a/packages/plugin-vue/src/utils/error.ts
+++ b/packages/plugin-vue/src/utils/error.ts
@@ -11,7 +11,7 @@ export function createRollupError(
     plugin: 'vue',
     message,
     name,
-    stack,
+    stack
   }
 
   if ('code' in error && error.loc) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #5771 
correct error displayed:
```
[vite] Internal server error: Element is missing end tag.
  Plugin: vite:vue
  File: repro/src/components/HelloWorld.vue
```
after refresh or hmr:
```
[vite] Internal server error: Cannot read property 'line' of undefined
  Plugin: vite:vue
  File: repro/src/components/HelloWorld.vue
```

### Additional context
The error comes from the result of the execution of `compiler.parse`:
https://github.com/vitejs/vite/blob/f1b8b5fc9600e4c8607dbd572f5a9d7d8a588e78/packages/plugin-vue/src/utils/descriptorCache.ts#L23-L26
`compiler.parse` will cache the execution results:
https://github.com/vuejs/vue-next/blob/2d4f4554349db6b07027d0c626f56c48d0233f67/packages/compiler-sfc/src/parse.ts#L105-L110
https://github.com/vuejs/vue-next/blob/2d4f4554349db6b07027d0c626f56c48d0233f67/packages/compiler-sfc/src/parse.ts#L274-L278

Changing the loc of the cached error here will throw a new error(`Cannot read property 'line' of undefined`) the next time it is executed:
https://github.com/vitejs/vite/blob/f1b8b5fc9600e4c8607dbd572f5a9d7d8a588e78/packages/plugin-vue/src/utils/error.ts#L12-L16

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
