### PR TITLE
fix(resolve): dont overwrite `isRequire` from `baseOptions`

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -119,9 +119,9 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
         resolveOpts?.custom?.['node-resolve']?.isRequire ?? false
 
       const options: InternalResolveOptions = {
-        ...baseOptions,
-
         isRequire,
+
+        ...baseOptions,
         isFromTsImporter: isTsRequest(importer ?? '')
       }
 


### PR DESCRIPTION
### Description

Fixes #5798

`baseOptions` may already comes with an `isRequire` property.
For example, https://github.com/vitejs/vite/blob/c344865851b1f140f51b2f8d03821419114ac3b9/packages/vite/src/node/optimizer/esbuildDepPlugin.ts#L47-L50 which in turn calls https://github.com/vitejs/vite/blob/c344865851b1f140f51b2f8d03821419114ac3b9/packages/vite/src/node/config.ts#L407-L417

### Additional context

Need to add a test case (that `esbuildDepPlugin` should resolve to the CJS entry of a transitive dependency if it is `require`d) later.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
