### PR TITLE
fix: duplicate variable declaration caused by css modules

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -288,23 +288,26 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         if (isDirectCSSRequest(id)) {
           return css
         } else {
+          const cssStr = JSON.stringify(css)
           // server only
           if (options?.ssr) {
-            return modulesCode || `export default ${JSON.stringify(css)}`
+            return modulesCode || `export default ${cssStr}`
           }
           if (inlined) {
-            return `export default ${JSON.stringify(css)}`
+            return `export default ${cssStr}`
           }
+          const idStr = JSON.stringify(id)
           return [
-            `import { updateStyle, removeStyle } from ${JSON.stringify(
+            `import { updateStyle as __vite__updateStyle, removeStyle as __vite__removeStyle } from ${JSON.stringify(
               path.posix.join(config.base, CLIENT_PUBLIC_PATH)
             )}`,
-            `const id = ${JSON.stringify(id)}`,
-            `const css = ${JSON.stringify(css)}`,
-            `updateStyle(id, css)`,
+            `__vite__updateStyle(${idStr}, ${cssStr})`,
             // css modules exports change on edit so it can't self accept
-            `${modulesCode || `import.meta.hot.accept()\nexport default css`}`,
-            `import.meta.hot.prune(() => removeStyle(id))`
+            `${
+              modulesCode ||
+              `import.meta.hot.accept()\nexport default ${cssStr}`
+            }`,
+            `import.meta.hot.prune(() => __vite__removeStyle(${idStr}))`
           ].join('\n')
         }
       }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -288,26 +288,26 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         if (isDirectCSSRequest(id)) {
           return css
         } else {
-          const cssStr = JSON.stringify(css)
           // server only
           if (options?.ssr) {
-            return modulesCode || `export default ${cssStr}`
+            return modulesCode || `export default ${JSON.stringify(css)}`
           }
           if (inlined) {
-            return `export default ${cssStr}`
+            return `export default ${JSON.stringify(css)}`
           }
-          const idStr = JSON.stringify(id)
           return [
             `import { updateStyle as __vite__updateStyle, removeStyle as __vite__removeStyle } from ${JSON.stringify(
               path.posix.join(config.base, CLIENT_PUBLIC_PATH)
             )}`,
-            `__vite__updateStyle(${idStr}, ${cssStr})`,
+            `const __vite__id = ${JSON.stringify(id)}`,
+            `const __vite__css = ${JSON.stringify(css)}`,
+            `__vite__updateStyle(__vite__id, __vite__css)`,
             // css modules exports change on edit so it can't self accept
             `${
               modulesCode ||
-              `import.meta.hot.accept()\nexport default ${cssStr}`
+              `import.meta.hot.accept()\nexport default __vite__css`
             }`,
-            `import.meta.hot.prune(() => __vite__removeStyle(${idStr}))`
+            `import.meta.hot.prune(() => __vite__removeStyle(__vite__id))`
           ].join('\n')
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #5790

### Additional context
```javascript
import css from "./styles.module.css"
```
``styles.module.css``:
```css
.id {
  color: red;
}
```
generate the following content:
```
import { updateStyle, removeStyle } from "/@vite/client"

const id = "/styles.module.css"
const css = "._id_d3ad011 {color:red}"

updateStyle(id, css)

// modulesCode
export const id = "_id_d3ad011"
export default {
  id: id,
}

import.meta.hot.prune(() => removeStyle(id))
```
variable `id` repeated declaration.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
