### PR TITLE
feat: add customResolver option to resolve.alias

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -158,9 +158,9 @@ export default defineConfig(async ({ command, mode }) => {
 ### resolve.alias
 
 - **Type:**
-  `Record<string, string> | Array<{ find: string | RegExp, replacement: string }>`
+  `Record<string, string> | Array<{ find: string | RegExp, replacement: string | customResolver?: ResolverFunction | ResolverObject }> `
 
-  Will be passed to `@rollup/plugin-alias` as its [entries option](https://github.com/rollup/plugins/tree/master/packages/alias#entries). Can either be an object, or an array of `{ find, replacement }` pairs.
+  Will be passed to `@rollup/plugin-alias` as its [entries option](https://github.com/rollup/plugins/tree/master/packages/alias#entries). Can either be an object, or an array of `{ find, replacement, customResolver }` pairs.
 
   When aliasing to file system paths, always use absolute paths. Relative alias values will be used as-is and will not be resolved into file system paths.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -158,7 +158,7 @@ export default defineConfig(async ({ command, mode }) => {
 ### resolve.alias
 
 - **Type:**
-  `Record<string, string> | Array<{ find: string | RegExp, replacement: string | customResolver?: ResolverFunction | ResolverObject }> `
+  `Record<string, string> | Array<{ find: string | RegExp, replacement: string, customResolver?: ResolverFunction | ResolverObject }> `
 
   Will be passed to `@rollup/plugin-alias` as its [entries option](https://github.com/rollup/plugins/tree/master/packages/alias#entries). Can either be an object, or an array of `{ find, replacement, customResolver }` pairs.
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -158,7 +158,7 @@ export default defineConfig(async ({ command, mode }) => {
 ### resolve.alias
 
 - **Type:**
-  `Record<string, string> | Array<{ find: string | RegExp, replacement: string, customResolver?: ResolverFunction | ResolverObject }> `
+  `Record<string, string> | Array<{ find: string | RegExp, replacement: string, customResolver?: ResolverFunction | ResolverObject }>`
 
   Will be passed to `@rollup/plugin-alias` as its [entries option](https://github.com/rollup/plugins/tree/master/packages/alias#entries). Can either be an object, or an array of `{ find, replacement, customResolver }` pairs.
 

--- a/packages/playground/alias/__tests__/alias.spec.ts
+++ b/packages/playground/alias/__tests__/alias.spec.ts
@@ -43,3 +43,9 @@ test('aliased module', async () => {
     '[success] aliased module'
   )
 })
+
+test('custom resolver', async () => {
+  expect(await page.textContent('.custom-resolver')).toMatch(
+    '[success] alias to custom-resolver path'
+  )
+})

--- a/packages/playground/alias/customResolver.js
+++ b/packages/playground/alias/customResolver.js
@@ -1,0 +1,1 @@
+export const msg = `[success] alias to custom-resolver path`

--- a/packages/playground/alias/index.html
+++ b/packages/playground/alias/index.html
@@ -6,6 +6,7 @@
 <p class="dep"></p>
 <p class="from-script-src"></p>
 <p class="aliased-module"></p>
+<p class="custom-resolver"></p>
 
 <div class="optimized"></div>
 
@@ -15,6 +16,7 @@
   import { msg as regexMsg } from 'regex/test'
   import { msg as depMsg } from 'dep'
   import { msg as moduleMsg } from 'aliased-module/index.js'
+  import { msg as customResolverMsg } from 'custom-resolver'
 
   function text(el, text) {
     document.querySelector(el).textContent = text
@@ -25,6 +27,7 @@
   text('.regex', regexMsg + ' via regex')
   text('.dep', depMsg)
   text('.aliased-module', moduleMsg)
+  text('.custom-resolver', customResolverMsg)
 
   import { createApp } from 'vue'
   import { ref } from 'foo'

--- a/packages/playground/alias/vite.config.js
+++ b/packages/playground/alias/vite.config.js
@@ -17,7 +17,14 @@ module.exports = {
       // aliasing an optimized dep
       { find: 'vue', replacement: 'vue/dist/vue.esm-bundler.js' },
       // aliasing one unoptimized dep to an optimized dep
-      { find: 'foo', replacement: 'vue' }
+      { find: 'foo', replacement: 'vue' },
+      {
+        find: 'custom-resolver',
+        replacement: path.resolve(__dirname, 'test.js'),
+        customResolver(id) {
+          return id.replace('test.js', 'customResolver.js')
+        }
+      }
     ]
   },
   build: {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -730,7 +730,11 @@ function normalizeAlias(o: AliasOptions): Alias[] {
 
 // https://github.com/vitejs/vite/issues/1363
 // work around https://github.com/rollup/plugins/issues/759
-function normalizeSingleAlias({ find, replacement }: Alias): Alias {
+function normalizeSingleAlias({
+  find,
+  replacement,
+  customResolver = null
+}: Alias): Alias {
   if (
     typeof find === 'string' &&
     find.endsWith('/') &&
@@ -739,7 +743,7 @@ function normalizeSingleAlias({ find, replacement }: Alias): Alias {
     find = find.slice(0, find.length - 1)
     replacement = replacement.slice(0, replacement.length - 1)
   }
-  return { find, replacement }
+  return { find, replacement, customResolver }
 }
 
 export function sortUserPlugins(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -733,7 +733,7 @@ function normalizeAlias(o: AliasOptions): Alias[] {
 function normalizeSingleAlias({
   find,
   replacement,
-  customResolver = null
+  customResolver
 }: Alias): Alias {
   if (
     typeof find === 'string' &&
@@ -743,7 +743,15 @@ function normalizeSingleAlias({
     find = find.slice(0, find.length - 1)
     replacement = replacement.slice(0, replacement.length - 1)
   }
-  return { find, replacement, customResolver }
+
+  const alias: Alias = {
+    find,
+    replacement
+  }
+  if (customResolver) {
+    alias.customResolver = customResolver
+  }
+  return alias
 }
 
 export function sortUserPlugins(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #5791 
fix #3331

### Additional context
`resolve.alias` will be passed to @rollup/plugin-alias as its [entries option](https://github.com/rollup/plugins/tree/master/packages/alias#entries) which supports `customResolver` option. 


The `alias.d.ts` contains the `customResolver` option:
https://github.com/vitejs/vite/blob/6891f0fd696f0a594771b18f5a79069c138b315e/packages/vite/types/alias.d.ts#L32-L41

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
