### PR TITLE
fix: resolve error in deepimport

### DIFF
--- a/packages/playground/resolve/__tests__/resolve.spec.ts
+++ b/packages/playground/resolve/__tests__/resolve.spec.ts
@@ -103,3 +103,9 @@ test('resolve package that contains # in path', async () => {
     '[success]'
   )
 })
+
+test('resolve third party module without index', async () => {
+  expect(await page.textContent('.third-party-without-index')).toMatch(
+    'van-button'
+  )
+})

--- a/packages/playground/resolve/index.html
+++ b/packages/playground/resolve/index.html
@@ -71,6 +71,9 @@
 <h2>resolve package that contains # in path</h2>
 <p class="path-contains-sharp-symbol"></p>
 
+<h2>resolve file without index</h2>
+<p class="third-party-without-index"></p>
+
 <script type="module">
   function text(selector, text) {
     document.querySelector(selector).textContent = text
@@ -191,6 +194,9 @@
 
   import es5Ext from 'es5-ext'
   text('.path-contains-sharp-symbol', '[success]')
+
+  import Button from 'vant/lib/button'
+  text('.third-party-without-index', Button.name)
 </script>
 
 <style>

--- a/packages/playground/resolve/package.json
+++ b/packages/playground/resolve/package.json
@@ -17,6 +17,7 @@
     "resolve-custom-main-field": "link:./custom-main-field",
     "resolve-exports-env": "link:./exports-env",
     "resolve-exports-path": "link:./exports-path",
-    "resolve-linked": "workspace:*"
+    "resolve-linked": "workspace:*",
+    "vant": "^3.3.2"
   }
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -838,8 +838,7 @@ function resolveDeepImport(
   }
 
   if (relativeId) {
-    let resolved
-    resolved = tryFsResolve(
+    let resolved = tryFsResolve(
       path.join(dir, relativeId),
       options,
       !exportsField, // try index only if no exports field

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -838,12 +838,21 @@ function resolveDeepImport(
   }
 
   if (relativeId) {
-    const resolved = tryFsResolve(
+    let resolved
+    resolved = tryFsResolve(
       path.join(dir, relativeId),
       options,
       !exportsField, // try index only if no exports field
       targetWeb
     )
+    if (!resolved) {
+      resolved = tryFsResolve(
+        path.join(dir, relativeId),
+        options,
+        true, // try index if not resolved
+        targetWeb
+      )
+    }
     if (resolved) {
       isDebug &&
         debug(`[node/deep-import] ${chalk.cyan(id)} -> ${chalk.dim(resolved)}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,7 @@ importers:
       resolve-exports-env: link:./exports-env
       resolve-exports-path: link:./exports-path
       resolve-linked: workspace:*
+      vant: ^3.3.2
     dependencies:
       '@babel/runtime': 7.16.0
       es5-ext: 0.10.53
@@ -432,6 +433,7 @@ importers:
       resolve-exports-env: link:exports-env
       resolve-exports-path: link:exports-path
       resolve-linked: link:../resolve-linked
+      vant: 3.3.2
 
   packages/playground/resolve-linked:
     specifiers: {}
@@ -1867,6 +1869,10 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
+  /@popperjs/core/2.11.0:
+    resolution: {integrity: sha512-zrsUxjLOKAzdewIDRWy9nsV1GQsKBCWaGwsZQlCgr6/q+vjyZhFgqedLfFBuI9anTPEUT4APq9Mu0SZBTzIcGQ==}
+    dev: false
+
   /@rollup/plugin-alias/3.1.8_rollup@2.59.0:
     resolution: {integrity: sha512-tf7HeSs/06wO2LPqKNY3Ckbvy0JRe7Jyn98bXnt/gfrxbe+AJucoNJlsEVi9sdgbQtXemjbakCpO/76JVgnHpA==}
     engines: {node: '>=8.0.0'}
@@ -2343,6 +2349,20 @@ packages:
       '@typescript-eslint/types': 5.4.0
       eslint-visitor-keys: 3.1.0
     dev: true
+
+  /@vant/icons/1.7.1:
+    resolution: {integrity: sha512-66LPEq89w4kl258nALZcRNd14eUJC8VajvTJwvZKOaZawz6CUeVZ6ybhedTUhQhRjeA8SyWD7dFt4ALf33Sabw==}
+    dev: false
+
+  /@vant/popperjs/1.1.0:
+    resolution: {integrity: sha512-8MD1gz146awV/uPxYjz4pet22f7a9YVKqk7T+gFkWFwT9mEcrIUEg/xPrdOnWKLP9puXyYtm7oVfSDSefZ/p/w==}
+    dependencies:
+      '@popperjs/core': 2.11.0
+    dev: false
+
+  /@vant/use/1.3.4:
+    resolution: {integrity: sha512-XvZkPCjcmEBhD+T3vB68thOG6P9jazld6aBTMenhbAQd4FT/x9AiKIWPJx4MvhYoSIWt7fju6K01XTJldWs1hw==}
+    dev: false
 
   /@vue/babel-helper-vue-transform-on/1.0.2:
     resolution: {integrity: sha512-hz4R8tS5jMn8lDq6iD+yWL6XNB699pGIVLk7WSJnn1dbpjaazsjZQkieJoRX6gW5zpYSCFqQ7jUquPNY65tQYA==}
@@ -8848,6 +8868,16 @@ packages:
 
   /value-equal/1.0.1:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
+    dev: false
+
+  /vant/3.3.2:
+    resolution: {integrity: sha512-2jRO5EOe+1aW7DV40T6A+bHDJ5d2laijtj4noIqy2hOZj+2Z9Vbz3xWZGjUs30D5rUuhYo7CdCHCVi+240a50w==}
+    peerDependencies:
+      vue: ^3.0.0
+    dependencies:
+      '@vant/icons': 1.7.1
+      '@vant/popperjs': 1.1.0
+      '@vant/use': 1.3.4
     dev: false
 
   /vary/1.1.2:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Mentioned https://github.com/vitejs/vite/pull/3039, there are only `tryindex` when no exports field. It will be error in below code.

Maybe there should `tryindex` again when no resolved or `tryindex` always.

![image](https://user-images.githubusercontent.com/17424434/143830137-becf5b21-1656-496b-bb05-1b49fc1595c4.png)

```js
// error
import Button from 'vant/lib/button'
// succeed
import Button from 'vant/lib/button/index.js'
```

### Additional context

There is a reproduction 

```bash
$ git clone git@github.com:zhangyuang/vite-ssr-error-require.git
$ git checkout bug/tryindex
$ yarn && yarn dev 
```
![image](https://user-images.githubusercontent.com/17424434/143832797-610ea82a-d9d3-4348-95eb-711ab5ff9f57.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
