### PR TITLE
fix: invalidate inlined proxy scripts on change

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -115,12 +115,17 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         addToHTMLProxyCache(config, url, scriptModuleIndex, contents)
 
         // inline js module. convert to src="proxy"
+        const modulePath = `${
+          config.base + htmlPath.slice(1)
+        }?html-proxy&index=${scriptModuleIndex}.js`
+
+        // invalidate the module so the newly cached contents will be served
+        server?.moduleGraph.invalidateId(config.root + modulePath)
+
         s.overwrite(
           node.loc.start.offset,
           node.loc.end.offset,
-          `<script type="module" src="${
-            config.base + url.slice(1)
-          }?html-proxy&index=${scriptModuleIndex}.js"></script>`
+          `<script type="module" src="${modulePath}"></script>`
         )
       }
     }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -120,7 +120,10 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         }?html-proxy&index=${scriptModuleIndex}.js`
 
         // invalidate the module so the newly cached contents will be served
-        server?.moduleGraph.invalidateId(config.root + modulePath)
+        const module = server?.moduleGraph.getModuleById(config.root + modulePath)
+        if( module ) {
+          server?.moduleGraph.invalidateModule(module)
+        }
 
         s.overwrite(
           node.loc.start.offset,

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -120,8 +120,10 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         }?html-proxy&index=${scriptModuleIndex}.js`
 
         // invalidate the module so the newly cached contents will be served
-        const module = server?.moduleGraph.getModuleById(config.root + modulePath)
-        if( module ) {
+        const module = server?.moduleGraph.getModuleById(
+          config.root + modulePath
+        )
+        if (module) {
           server?.moduleGraph.invalidateModule(module)
         }
 

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -120,9 +120,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
         }?html-proxy&index=${scriptModuleIndex}.js`
 
         // invalidate the module so the newly cached contents will be served
-        const module = server?.moduleGraph.getModuleById(
-          config.root + modulePath
-        )
+        const module = server?.moduleGraph.getModuleById(modulePath)
         if (module) {
           server?.moduleGraph.invalidateModule(module)
         }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -95,13 +95,6 @@ export class ModuleGraph {
     invalidateSSRModule(mod, seen)
   }
 
-  invalidateId(id: string): void {
-    const mod = this.idToModuleMap.get(id)
-    if (mod) {
-      this.invalidateModule(mod)
-    }
-  }
-
   invalidateAll(): void {
     const seen = new Set<ModuleNode>()
     this.idToModuleMap.forEach((mod) => {

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -95,6 +95,13 @@ export class ModuleGraph {
     invalidateSSRModule(mod, seen)
   }
 
+  invalidateId(id: string): void {
+    const mod = this.idToModuleMap.get(id)
+    if (mod) {
+      this.invalidateModule(mod)
+    }
+  }
+
   invalidateAll(): void {
     const seen = new Set<ModuleNode>()
     this.idToModuleMap.forEach((mod) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The dev HTML plugin converts inline module scripts into external proxy scripts. This change makes it so that when a proxy script is cached it also invalidates the module within the module graph. Without this if the script ever changes then the module will be stale.

### Additional context

None

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
