### PR TITLE
docs: fix gitlab pages deploy syntax

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -159,7 +159,7 @@ You can also run the above script in your CI setup to enable automatic deploymen
        paths:
          - public
      rules:
-       - $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
    ```
 
 ## Netlify


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The GitLab Pages example causes GitLab CI to fail due to invalid syntax:
![Screen Shot 2021-11-30 at 8 33 26 AM](https://user-images.githubusercontent.com/6022168/144066639-373b03ea-4c7b-4d61-9653-0667eedc0b05.png)

Here is the documentation about the syntax: https://docs.gitlab.com/ee/ci/yaml/index.html#rules

This PR fixes the syntax.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This change has been tested to work on GItLab CI.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
