### PR TITLE
docs: fix ssr note and change jsonc to json5 [ci skip]

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -115,12 +115,13 @@ Running `vite` starts the dev server using the current working directory as root
 
 In a project where Vite is installed, you can use the `vite` binary in your npm scripts, or run it directly with `npx vite`. Here is the default npm scripts in a scaffolded Vite project:
 
+<!-- prettier-ignore -->
 ```json5
 {
-  scripts: {
-    dev: 'vite', // start dev server, aliases: `vite dev`, `vite serve`
-    build: 'vite build', // build for production
-    preview: 'vite preview' // locally preview production build
+  "scripts": {
+    "dev": "vite", // start dev server, aliases: `vite dev`, `vite serve`
+    "build": "vite build", // build for production
+    "preview": "vite preview" // locally preview production build
   }
 }
 ```

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -115,12 +115,12 @@ Running `vite` starts the dev server using the current working directory as root
 
 In a project where Vite is installed, you can use the `vite` binary in your npm scripts, or run it directly with `npx vite`. Here is the default npm scripts in a scaffolded Vite project:
 
-```jsonc
+```json5
 {
-  "scripts": {
-    "dev": "vite", // start dev server, aliases: `vite dev`, `vite serve`
-    "build": "vite build", // build for production
-    "preview": "vite preview" // locally preview production build
+  scripts: {
+    dev: 'vite', // start dev server, aliases: `vite dev`, `vite serve`
+    build: 'vite build', // build for production
+    preview: 'vite preview' // locally preview production build
   }
 }
 ```

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -250,7 +250,7 @@ export function mySSRPlugin() {
 
 The options object in `load` and `transform` is optional, rollup is not currently using this object but may extend these hooks with additional metadata in the future.
 
-:::note
+::: tip Note
 Before Vite 2.7, this was informed to plugin hooks with a positional `ssr` param instead of using the `options` object. All major frameworks and plugins are updated but you may find outdated posts using the previous API.
 :::
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix ssr note (#5921 is a wrong PR, sorry about that) and change `jsonc` to `json5` since prismjs didn't have `jsonc` lang.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
