### PR TITLE
fix(ssr): skip dedupe require if noExternal true

### DIFF
--- a/packages/playground/ssr-webworker/vite.config.js
+++ b/packages/playground/ssr-webworker/vite.config.js
@@ -5,6 +5,9 @@ module.exports = {
   build: {
     minify: false
   },
+  resolve: {
+    dedupe: ['react']
+  },
   ssr: {
     target: 'webworker',
     noExternal: true

--- a/packages/vite/src/node/plugins/ssrRequireHook.ts
+++ b/packages/vite/src/node/plugins/ssrRequireHook.ts
@@ -12,6 +12,7 @@ export function ssrRequireHookPlugin(config: ResolvedConfig): Plugin | null {
   if (
     config.command !== 'build' ||
     !config.resolve.dedupe?.length ||
+    config.ssr?.noExternal === true ||
     isBuildOutputEsm(config)
   ) {
     return null


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #5812

If `noExternal` is `true`, there's no need to dedupe any dependencies as everything is already bundled (and deduped by rollup)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
