### PR TITLE
fix: support importing css with ?url

### DIFF
--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -185,9 +185,7 @@ test('?url import', async () => {
 
 test('?url import on css', async () => {
   const txt = await page.textContent('.url-css')
-  expect(txt).toEqual(
-    '/foo/css/icons.css'
-  )
+  expect(txt).toEqual('/foo/css/icons.css')
 })
 
 describe('unicode url', () => {

--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -184,8 +184,13 @@ test('?url import', async () => {
 })
 
 test('?url import on css', async () => {
+  const src = readFile('css/icons.css')
   const txt = await page.textContent('.url-css')
-  expect(txt).toEqual('/foo/css/icons.css')
+  expect(txt).toEqual(
+    isBuild
+      ? `data:text/css;base64,${Buffer.from(src).toString('base64')}`
+      : '/foo/css/icons.css'
+  )
 })
 
 describe('unicode url', () => {

--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -183,6 +183,13 @@ test('?url import', async () => {
   )
 })
 
+test('?url import on css', async () => {
+  const txt = await page.textContent('.url-css')
+  expect(txt).toEqual(
+    '/foo/css/icons.css'
+  )
+})
+
 describe('unicode url', () => {
   test('from js import', async () => {
     const src = readFile('テスト-測試-white space.js')

--- a/packages/playground/assets/index.html
+++ b/packages/playground/assets/index.html
@@ -129,6 +129,9 @@
 <img class="import-meta-url-img" />
 <code class="import-meta-url"></code>
 
+<h2>?url import with css</h2>
+<code class="url-css"></code>
+
 <h2>new URL(`./${dynamic}`, import.meta.url)</h2>
 <p>
   <img class="dynamic-import-meta-url-img-1" />
@@ -167,6 +170,9 @@
 
   import unicodeUrl from './テスト-測試-white space.js?url'
   text('.unicode-url', unicodeUrl)
+
+  import cssUrl from './css/icons.css?url'
+  text('.url-css', cssUrl)
 
   // const url = new URL('non_existent_file.png', import.meta.url)
   const metaUrl = new URL('./nested/asset.png', import.meta.url)

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -20,6 +20,8 @@ const assetUrlQuotedRE = /"__VITE_ASSET__([a-z\d]{8})__(?:\$_(.*?)__)?"/g
 const rawRE = /(\?|&)raw(?:&|$)/
 const urlRE = /(\?|&)url(?:&|$)/
 
+export const isURLRequest = (id: string) => urlRE.test(id);
+
 export const chunkToEmittedAssetsMap = new WeakMap<RenderedChunk, Set<string>>()
 
 const assetCache = new WeakMap<ResolvedConfig, Map<string, string>>()

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -20,7 +20,7 @@ const assetUrlQuotedRE = /"__VITE_ASSET__([a-z\d]{8})__(?:\$_(.*?)__)?"/g
 const rawRE = /(\?|&)raw(?:&|$)/
 const urlRE = /(\?|&)url(?:&|$)/
 
-export const isURLRequest = (id: string) => urlRE.test(id);
+export const isURLRequest = (id: string) => urlRE.test(id)
 
 export const chunkToEmittedAssetsMap = new WeakMap<RenderedChunk, Set<string>>()
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -29,6 +29,7 @@ import { ResolveFn, ViteDevServer } from '../'
 import {
   getAssetFilename,
   assetUrlRE,
+  isURLRequest,
   registerAssetToChunk,
   fileToUrl,
   checkPublicFile
@@ -161,7 +162,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(raw, id) {
-      if (!isCSSRequest(id) || commonjsProxyRE.test(id)) {
+      if (!isCSSRequest(id) || commonjsProxyRE.test(id) || isURLRequest(id)) {
         return
       }
 
@@ -275,7 +276,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(css, id, options) {
-      if (!isCSSRequest(id) || commonjsProxyRE.test(id)) {
+      if (!isCSSRequest(id) || commonjsProxyRE.test(id) || isURLRequest(id)) {
         return
       }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes importing a URL of a CSS file:

```js
import url from './styles.css?url';
// Should be /src/styles.css
```

### Additional context

The `vite:css` plugin should be checking for query params when doing its transforms. This makes it do so.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
