### PR TITLE
feat: export constants from @vite/plugin-legacy

### DIFF
--- a/packages/plugin-legacy/constants.d.ts
+++ b/packages/plugin-legacy/constants.d.ts
@@ -1,0 +1,5 @@
+export const dynamicFallbackInlineCode: string
+export const safari10NoModuleFix: string
+export const legacyPolyfillId: string
+export const legacyEntryId: string
+export const systemJSInlineCode: string

--- a/packages/plugin-legacy/constants.js
+++ b/packages/plugin-legacy/constants.js
@@ -1,0 +1,16 @@
+// https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc
+// DO NOT ALTER THIS CONTENT
+const safari10NoModuleFix = `!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",(function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()}),!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();`
+
+const legacyPolyfillId = 'vite-legacy-polyfill'
+const legacyEntryId = 'vite-legacy-entry'
+const systemJSInlineCode = `System.import(document.getElementById('${legacyEntryId}').getAttribute('data-src'))`
+const dynamicFallbackInlineCode = `!function(){try{new Function("m","return import(m)")}catch(o){console.warn("vite: loading legacy build because dynamic import is unsupported, syntax error above should be ignored");var e=document.getElementById("${legacyPolyfillId}"),n=document.createElement("script");n.src=e.src,n.onload=function(){${systemJSInlineCode}},document.body.appendChild(n)}}();`
+
+module.exports = {
+  dynamicFallbackInlineCode,
+  safari10NoModuleFix,
+  legacyPolyfillId,
+  legacyEntryId,
+  systemJSInlineCode
+}

--- a/packages/plugin-legacy/index.d.ts
+++ b/packages/plugin-legacy/index.d.ts
@@ -33,3 +33,6 @@ declare function createPlugin(options?: Options): Plugin
 export default createPlugin
 
 export const cspHashes: string[]
+
+export const polyfillsAssetNameLegacy: string
+export const polyfillId: string

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -11,14 +11,13 @@ let babel
  */
 const loadBabel = () => babel || (babel = require('@babel/standalone'))
 
-// https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc
-// DO NOT ALTER THIS CONTENT
-const safari10NoModuleFix = `!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",(function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()}),!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();`
-
-const legacyPolyfillId = 'vite-legacy-polyfill'
-const legacyEntryId = 'vite-legacy-entry'
-const systemJSInlineCode = `System.import(document.getElementById('${legacyEntryId}').getAttribute('data-src'))`
-const dynamicFallbackInlineCode = `!function(){try{new Function("m","return import(m)")}catch(o){console.warn("vite: loading legacy build because dynamic import is unsupported, syntax error above should be ignored");var e=document.getElementById("${legacyPolyfillId}"),n=document.createElement("script");n.src=e.src,n.onload=function(){${systemJSInlineCode}},document.body.appendChild(n)}}();`
+const {
+  safari10NoModuleFix,
+  legacyPolyfillId,
+  legacyEntryId,
+  systemJSInlineCode,
+  dynamicFallbackInlineCode
+} = require('./constants.js')
 
 const forceDynamicImportUsage = `export function __vite_legacy_guard(){import('data:text/javascript,')};`
 

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -24,6 +24,8 @@ const forceDynamicImportUsage = `export function __vite_legacy_guard(){import('d
 
 const legacyEnvVarMarker = `__VITE_IS_LEGACY__`
 
+const polyfillsAssetNameLegacy = 'polyfills-legacy'
+
 /**
  * @param {import('.').Options} options
  * @returns {import('vite').Plugin[]}
@@ -166,7 +168,7 @@ function viteLegacyPlugin(options = {}) {
           )
 
         await buildPolyfillChunk(
-          'polyfills-legacy',
+          polyfillsAssetNameLegacy,
           legacyPolyfills,
           bundle,
           facadeToLegacyPolyfillMap,
@@ -700,3 +702,5 @@ viteLegacyPlugin.cspHashes = [
   createHash('sha256').update(systemJSInlineCode).digest('base64'),
   createHash('sha256').update(dynamicFallbackInlineCode).digest('base64')
 ]
+viteLegacyPlugin.polyfillsAssetNameLegacy = polyfillsAssetNameLegacy
+viteLegacyPlugin.polyfillId = polyfillId

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -5,7 +5,9 @@
   "author": "Evan You",
   "files": [
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "constants.js",
+    "constants.d.ts"
   ],
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
### Description

This PR does not changed anything, it just exports some constants.

### Additional context

I'm trying to integrate `@vitejs/plugin-legacy` into [SvelteKit](https://github.com/sveltejs/kit).

SvelteKit has an [independent logic of HTML rendering](https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/server/page/render.js#L22). It seems that SvelteKit could not simply use `@vitejs/plugin-legacy` to directly modify html. With these constants, it is able to do two things:

1. Find with file are polyfills generated by plugin.

2. Generates script tags like this:

```javascript
import * as constants from '@vitejs/plugin-legacy/constants';

const {
	dynamicFallbackInlineCode,
	safari10NoModuleFix,
	legacyPolyfillId,
	legacyEntryId,
	// systemJSInlineCode,
} = constants;

const systemJSInlineCode = `(function(s,i){i(s.getAttribute('data-src')).then(function(m){window._sveltekit_init(m.start,i,s.getAttribute('data-nodes'))})})(document.getElementById('${legacyEntryId}'),function(m){return System.import(m)});`;

/**
 * @param {{
 *   legacy_polyfill_asset?: string;
 *   entry_file: string;
 *   branch: any[];
 *   get_entry: (entry:string)=>string;
 * }} config
 * @return {string[]}
 */
export function render_script_tags({ legacy_polyfill_asset, get_entry, entry_file, branch }) {
	const legacyEntryFilename = get_entry(entry_file);

	const scripts = [];

	// inject dynamic import fallback entry
	if (legacy_polyfill_asset) {
		scripts.push(`<script type="module">${dynamicFallbackInlineCode}</script>`);
	}

	// inject Safari 10 nomodule fix
	if (legacyEntryFilename) {
		scripts.push(`<script nomodule>${safari10NoModuleFix}</script>`);
	}

	// inject legacy polyfills
	if (legacy_polyfill_asset) {
		scripts.push(
			`<script nomodule id="${legacyPolyfillId}" src="${legacy_polyfill_asset}"></script>`
		);
	}

	// inject legacy entry
	if (legacyEntryFilename) {
		scripts.push(
			`<script nomodule id="${legacyEntryId}" data-src="${legacyEntryFilename}" data-nodes="${(
				branch || []
			)
				.map(({ node }) => get_entry(node.entry))
				.join(',')}">${systemJSInlineCode}</script>`
		);
	}

	return scripts;
}

```