### PR TITLE
fix(ssr): allow primitive default exports and forwarded exports

### DIFF
--- a/packages/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/packages/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -17,3 +17,34 @@ test('msg read by fs/promises', async () => {
   await page.goto(url)
   expect(await page.textContent('.file-message')).toMatch('File Content!')
 })
+
+test('msg from primitive export', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.primitive-export-message')).toMatch(
+    'Hello World!'
+  )
+})
+
+test('msg from TS transpiled exports', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.ts-default-export-message')).toMatch(
+    'Hello World!'
+  )
+  expect(await page.textContent('.ts-named-export-message')).toMatch(
+    'Hello World!'
+  )
+})
+
+test('msg from Object.assign exports', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.object-assigned-exports-message')).toMatch(
+    'Hello World!'
+  )
+})
+
+test('msg from forwarded exports', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.forwarded-export-message')).toMatch(
+    'Hello World!'
+  )
+})

--- a/packages/playground/ssr-deps/forwarded-export/index.js
+++ b/packages/playground/ssr-deps/forwarded-export/index.js
@@ -1,0 +1,2 @@
+const original = require('object-assigned-exports')
+module.exports = original

--- a/packages/playground/ssr-deps/forwarded-export/package.json
+++ b/packages/playground/ssr-deps/forwarded-export/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "forwarded-export",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/playground/ssr-deps/object-assigned-exports/index.js
+++ b/packages/playground/ssr-deps/object-assigned-exports/index.js
@@ -1,0 +1,9 @@
+Object.defineProperty(exports, '__esModule', { value: true })
+
+const obj = {
+  hello() {
+    return 'Hello World!'
+  }
+}
+
+Object.assign(exports, obj)

--- a/packages/playground/ssr-deps/object-assigned-exports/package.json
+++ b/packages/playground/ssr-deps/object-assigned-exports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "object-assigned-exports",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/playground/ssr-deps/package.json
+++ b/packages/playground/ssr-deps/package.json
@@ -10,7 +10,11 @@
   },
   "dependencies": {
     "node-addon": "link:./node-addon",
-    "read-file-content": "file:./read-file-content"
+    "primitive-export": "link:./primitive-export",
+    "read-file-content": "file:./read-file-content",
+    "ts-transpiled-exports": "link:./ts-transpiled-exports",
+    "object-assigned-exports": "link:./object-assigned-exports",
+    "forwarded-export": "link:./forwarded-export"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/packages/playground/ssr-deps/primitive-export/index.js
+++ b/packages/playground/ssr-deps/primitive-export/index.js
@@ -1,0 +1,1 @@
+module.exports = 'Hello World!'

--- a/packages/playground/ssr-deps/primitive-export/package.json
+++ b/packages/playground/ssr-deps/primitive-export/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "primitive-export",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/playground/ssr-deps/src/app.js
+++ b/packages/playground/ssr-deps/src/app.js
@@ -1,6 +1,10 @@
 import path from 'path'
 import { hello } from 'node-addon'
 import readFileContent from 'read-file-content'
+import primitiveExport from 'primitive-export'
+import tsDefaultExport, { hello as tsNamedExport } from 'ts-transpiled-exports'
+import objectAssignedExports from 'object-assigned-exports'
+import forwardedExport from 'forwarded-export'
 
 export async function render(url, rootDir) {
   let html = ''
@@ -10,6 +14,20 @@ export async function render(url, rootDir) {
 
   const fileContent = await readFileContent(path.resolve(rootDir, 'message'))
   html += `\n<p class="file-message">msg read via fs/promises: ${fileContent}</p>`
+
+  html += `\n<p class="primitive-export-message">message from primitive export: ${primitiveExport}</p>`
+
+  const tsDefaultExportMessage = tsDefaultExport()
+  html += `\n<p class="ts-default-export-message">message from ts-default-export: ${tsDefaultExportMessage}</p>`
+
+  const tsNamedExportMessage = tsNamedExport()
+  html += `\n<p class="ts-named-export-message">message from ts-named-export: ${tsNamedExportMessage}</p>`
+
+  const objectAssignedExportsMessage = objectAssignedExports.hello()
+  html += `\n<p class="object-assigned-exports-message">message from object-assigned-exports: ${objectAssignedExportsMessage}</p>`
+
+  const forwardedExportMessage = forwardedExport.hello()
+  html += `\n<p class="forwarded-export-message">message from forwarded-export: ${forwardedExportMessage}</p>`
 
   return html + '\n'
 }

--- a/packages/playground/ssr-deps/ts-transpiled-exports/index.js
+++ b/packages/playground/ssr-deps/ts-transpiled-exports/index.js
@@ -1,0 +1,8 @@
+'use strict'
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.hello = void 0
+function hello() {
+  return 'Hello World!'
+}
+exports.hello = hello
+exports.default = hello

--- a/packages/playground/ssr-deps/ts-transpiled-exports/package.json
+++ b/packages/playground/ssr-deps/ts-transpiled-exports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "ts-transpiled-exports",
+  "version": "0.0.0",
+  "private": true
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,14 +458,25 @@ importers:
     specifiers:
       cross-env: ^7.0.3
       express: ^4.17.1
+      forwarded-export: link:./forwarded-export
       node-addon: link:./node-addon
+      object-assigned-exports: link:./object-assigned-exports
+      primitive-export: link:./primitive-export
       read-file-content: file:./read-file-content
+      ts-transpiled-exports: link:./ts-transpiled-exports
     dependencies:
+      forwarded-export: link:forwarded-export
       node-addon: link:node-addon
+      object-assigned-exports: link:object-assigned-exports
+      primitive-export: link:primitive-export
       read-file-content: link:read-file-content
+      ts-transpiled-exports: link:ts-transpiled-exports
     devDependencies:
       cross-env: 7.0.3
       express: 4.17.1
+
+  packages/playground/ssr-deps/forwarded-export:
+    specifiers: {}
 
   packages/playground/ssr-deps/node-addon:
     specifiers:
@@ -473,7 +484,16 @@ importers:
     dependencies:
       node-gyp: 8.4.1
 
+  packages/playground/ssr-deps/object-assigned-exports:
+    specifiers: {}
+
+  packages/playground/ssr-deps/primitive-export:
+    specifiers: {}
+
   packages/playground/ssr-deps/read-file-content:
+    specifiers: {}
+
+  packages/playground/ssr-deps/ts-transpiled-exports:
     specifiers: {}
 
   packages/playground/ssr-html:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes two ESM/CJS interoperability issues in SSR and adds more tests to the ssr-deps playground:

1. Vite was choking on primitive default exports (i.e. `export default "hello"` or `module.exports = "hello"`) because a) the default export unwrapping code blindly uses `in` on the exports object; b) it tries to proxy it (which is not permitted on primitives).
2. Forwarded CJS exports (i.e. `module.exports = require("other-module")` caused unexpected behavior.

### Additional context

I wanted to add a test case for `export default "hello"` but I couldn't figure out how to make jest work with ES modules so I only added a test case for `module.exports = "hello"`.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
