### PR TITLE
bugifx: plugin-vue have some error

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -223,7 +223,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
         )
       } else {
         // sub block request
-        const descriptor = getDescriptor(filename, options)!
+        const descriptor = getDescriptor(filename, options, true, id)!
         if (query.type === 'template') {
           return transformTemplateAsModule(code, descriptor, options, this, ssr)
         } else if (query.type === 'style') {

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -312,7 +312,7 @@ async function genStyleCode(
       const attrsQuery = attrsToQuery(style.attrs, 'css')
       const srcQuery = style.src ? `&src` : ``
       const directQuery = asCustomElement ? `&inline` : ``
-      const query = `?vue&type=style&index=${i}${srcQuery}${directQuery}`
+      const query = `?vue&type=style&index=${i}${srcQuery}${directQuery}&target=${descriptor.filename}`
       const styleRequest = src + query + attrsQuery
       if (style.module) {
         if (asCustomElement) {


### PR DESCRIPTION
测试项目：https://github.com/sufuWang/uniapp_vite/tree/feature/vite
当我在组件和页面引用同一个 less 文件时，会打包失败，因为 plugin-vue 中的 cache 在更新时，会根据 key 值覆盖 value ，导致对 descriptor 的索引失败，详情请克隆测试工程复现此 bug

test project ：https://github.com/sufuWang/uniapp_vite/tree/feature/vite
When I reference the same less file in the component and the page, the package fails, because the cache in plugin-vue overwrites the value according to the key value when it is updated, so the index of `descriptor` fails. For details, please refer to the clone test project to reproduce this bug