### PR TITLE
fix: block.scoped is undefined

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -223,7 +223,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
         )
       } else {
         // sub block request
-        const descriptor = getDescriptor(filename, options)!
+        const descriptor = getDescriptor(filename, options, true, id)!
         if (query.type === 'template') {
           return transformTemplateAsModule(code, descriptor, options, this, ssr)
         } else if (query.type === 'style') {

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -312,7 +312,7 @@ async function genStyleCode(
       const attrsQuery = attrsToQuery(style.attrs, 'css')
       const srcQuery = style.src ? `&src` : ``
       const directQuery = asCustomElement ? `&inline` : ``
-      const query = `?vue&type=style&index=${i}${srcQuery}${directQuery}`
+      const query = `?vue&type=style&index=${i}${srcQuery}${directQuery}&target=${descriptor.filename}`
       const styleRequest = src + query + attrsQuery
       if (style.module) {
         if (asCustomElement) {

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -54,9 +54,12 @@ export function getDescriptor(
   if (cache.has(filename)) {
     const ds = cache.get(filename)
     if (Array.isArray(ds) && id && id.includes('target')) {
-      const target = id.split('?')[1].split('&').find(d => d.includes('target'))?.split('=')[1]
+      let target = /target=(.+)/.exec(id)?.[1]
+      if (target?.includes('&')) {
+        target = /(.+)&/.exec(target)?.[1]
+      }
       if (target) {
-        return ds.filter(({ filename }) => filename === target)[0] 
+        return ds.find(({ filename }) => filename === target)
       }
     }
     return ds as SFCDescriptor
@@ -78,11 +81,11 @@ export function setDescriptor(filename: string, entry: SFCDescriptor): void {
   const ds = cache.get(filename)
   if (ds) {
     if (Array.isArray(ds)) {
-      cache.set(filename, [...ds, entry]);
+      cache.set(filename, [...ds, entry])
     } else {
-      cache.set(filename, [ds, entry]);
+      cache.set(filename, [ds, entry])
     }
-    return;
+    return
   }
   cache.set(filename, entry)
 }


### PR DESCRIPTION
### Description

测试项目：https://github.com/sufuWang/uniapp_vite/tree/feature/vite
当我在组件和页面引用同一个 less 文件时，会打包失败，因为 plugin-vue 中的 cache 在更新时，会根据 key 值覆盖 value ，导致对 descriptor 的索引失败，详情请克隆测试工程复现此 bug

test project ：https://github.com/sufuWang/uniapp_vite/tree/feature/vite
When I reference the same less file in the component and the page, the package fails, because the cache in plugin-vue overwrites the value according to the key value when it is updated, so the index of descriptor fails. For details, please refer to the clone test project to reproduce this bug

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
