### PR TITLE
feat(hmr): modify serve.host print the new urls

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -62,6 +62,10 @@ export async function handleHMRUpdate(
       { clear: true, timestamp: true }
     )
     await server.restart()
+    if (config.server.host !== server.config.server.host) {
+      config.logger.info('')
+      server.printUrls()
+    }
     return
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The default configuration of `vite.config` does not expose the network url. When I modify the configuration to `host: true`, the server automatically updated, but the new url is not printed, so I added this.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
