### PR TITLE
feat: add CLI keyboard shortcuts

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -6,7 +6,6 @@ import { ServerOptions } from './server'
 import { createLogger, LogLevel } from './logger'
 import { resolveConfig } from '.'
 import { preview } from './preview'
-import { bindShortcuts } from './server/shortcuts'
 
 const cli = cac('vite')
 
@@ -106,9 +105,7 @@ cli
       )
 
       server.printUrls()
-      if (options.bindShortcuts !== false) {
-        bindShortcuts(server)
-      }
+      server.bindShortcuts()
 
       // @ts-ignore
       if (global.__vite_start_time) {

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -6,6 +6,7 @@ import { ServerOptions } from './server'
 import { createLogger, LogLevel } from './logger'
 import { resolveConfig } from '.'
 import { preview } from './preview'
+import { bindShortcuts } from './server/shortcuts'
 
 const cli = cac('vite')
 
@@ -105,6 +106,9 @@ cli
       )
 
       server.printUrls()
+      if (options.bindShortcuts !== false) {
+        bindShortcuts(server)
+      }
 
       // @ts-ignore
       if (global.__vite_start_time) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -62,6 +62,7 @@ import { searchForWorkspaceRoot } from './searchRoot'
 import { CLIENT_DIR } from '../constants'
 import { printCommonServerUrls } from '../logger'
 import { performance } from 'perf_hooks'
+import { bindShortcuts } from './shortcuts'
 import { invalidatePackageData } from '../packages'
 import { SourceMap } from 'rollup'
 
@@ -251,6 +252,11 @@ export interface ViteDevServer {
    */
   restart(forceOptimize?: boolean): Promise<void>
   /**
+   * Listen to `process.stdin` for pre-defined keyboard shortcuts, which are
+   * printed to the terminal by this method.
+   */
+  bindShortcuts(): void
+  /**
    * @internal
    */
   _optimizeDepsMetadata: DepOptimizationMetadata | null
@@ -409,6 +415,11 @@ export async function createServer(
         })
       }
       return server._restartPromise
+    },
+    bindShortcuts() {
+      if (serverConfig.bindShortcuts !== false) {
+        bindShortcuts(server)
+      }
     },
 
     _optimizeDepsMetadata: null,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -98,6 +98,13 @@ export interface ServerOptions extends CommonServerOptions {
    * Origin for the generated asset URLs.
    */
   origin?: string
+  /**
+   * Disable key bindings for the server by setting this to `false`. This can be
+   * useful if you need the `process.stdin` stream for another purpose.
+   *
+   * @default true
+   */
+  bindShortcuts?: boolean
 }
 
 export interface ResolvedServerOptions extends ServerOptions {

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -14,7 +14,8 @@ import execa from 'execa'
 import chalk from 'chalk'
 import { execSync } from 'child_process'
 import { Logger } from '../logger'
-
+import type { ViteDevServer } from './index'
+import { resolveHostname } from '../utils'
 // https://github.com/sindresorhus/open#app
 const OSX_CHROME = 'google chrome'
 
@@ -36,6 +37,16 @@ export function openBrowser(
     return startBrowserProcess(browser, url)
   }
   return false
+}
+
+export function resolveBrowserUrl(server: ViteDevServer): string {
+  const options = server.config.server
+  const hostname = resolveHostname(options.host)
+  const port = options.port || 3000
+  const protocol = options.https ? 'https' : 'http'
+  const path =
+    typeof options.open === 'string' ? options.open : server.config.base
+  return `${protocol}://${hostname.name}:${port}${path}`
 }
 
 function executeNodeScript(scriptPath: string, url: string, logger: Logger) {

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import type { ViteDevServer } from '..'
 import { openBrowser, resolveBrowserUrl } from './openBrowser'
 
@@ -57,6 +58,23 @@ export const SHORTCUTS: Shortcut[] = [
     name: 'force restart',
     action(server: ViteDevServer): void {
       server.restart(true)
+    }
+  },
+  {
+    key: 'h',
+    name: 'toggle hmr',
+    action({ config }: ViteDevServer): void {
+      /**
+       * Mutating the server config works because Vite reads from
+       * it on every file change, instead of caching its value.
+       *
+       * Since `undefined` is treated as `true`, we have to
+       * use `!== true` to flip the boolean value.
+       */
+      config.server.hmr = config.server.hmr !== true
+      config.logger.info(
+        chalk.cyanBright(`hmr ${config.server.hmr ? `enabled` : `disabled`}`)
+      )
     }
   }
 ]

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -1,0 +1,62 @@
+import type { ViteDevServer } from '..'
+import { openBrowser, resolveBrowserUrl } from './openBrowser'
+
+export function bindShortcuts(server: ViteDevServer): void {
+  if (!server.httpServer) return
+
+  server.config.logger.info(
+    `  > Shortcuts: ` +
+      SHORTCUTS.map((shortcut) => {
+        return `"${shortcut.key}" ${shortcut.name}`
+      }).join(', ')
+  )
+
+  const onInput = (input: string) => {
+    // ctrl+c or ctrl+d
+    if (input === '\x03' || input === '\x04') {
+      return process.kill(process.pid, 'SIGINT')
+    }
+    const shortcut = SHORTCUTS.find((shortcut) => shortcut.key === input)
+    shortcut?.action(server)
+  }
+
+  process.stdin
+    .on('data', onInput)
+    .setEncoding('utf8')
+    .setRawMode(true)
+    .resume()
+
+  server.httpServer.on('close', () => {
+    process.stdin.off('data', onInput).pause()
+  })
+}
+
+export interface Shortcut {
+  key: string
+  name: string
+  action(server: ViteDevServer): void
+}
+
+export const SHORTCUTS: Shortcut[] = [
+  {
+    key: 'r',
+    name: 'restart',
+    action(server: ViteDevServer): void {
+      server.restart()
+    }
+  },
+  {
+    key: 'o',
+    name: 'open browser',
+    action(server: ViteDevServer): void {
+      openBrowser(resolveBrowserUrl(server), true, server.config.logger)
+    }
+  },
+  {
+    key: 'f',
+    name: 'force restart',
+    action(server: ViteDevServer): void {
+      server.restart(true)
+    }
+  }
+]


### PR DESCRIPTION
### Description

This is a continuation of #3182 with the following changes:
- Rebased onto main branch
- Add `bindShortcuts` method to ViteDevServer
- Added `h` shortcut for toggling HMR updates (useful when debugging)

#### ⚠️ Do not squash!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
