### PR TITLE
chore: use node tsconfig in all src/node builds

### DIFF
--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -133,7 +133,8 @@ const createNodeConfig = (isProduction) => {
         ...(isProduction
           ? {}
           : {
-              tsconfig: 'tsconfig.base.json',
+              tsconfig: 'src/node/tsconfig.json',
+              module: 'esnext',
               declaration: true,
               declarationDir: path.resolve(__dirname, 'dist/')
             })

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -124,6 +124,8 @@ const createNodeConfig = (isProduction) => {
       }),
       nodeResolve({ preferBuiltins: true }),
       typescript({
+        tsconfig: 'src/node/tsconfig.json',
+        module: 'esnext',
         target: 'es2019',
         include: ['src/**/*.ts', 'types/**'],
         exclude: ['src/**/__tests__/**'],
@@ -133,8 +135,6 @@ const createNodeConfig = (isProduction) => {
         ...(isProduction
           ? {}
           : {
-              tsconfig: 'src/node/tsconfig.json',
-              module: 'esnext',
               declaration: true,
               declarationDir: path.resolve(__dirname, 'dist/')
             })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Always use `src/node/tsconfig.json` when compiling `src/node` bundle.

Fixes typescript issue in #5257 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
