### PR TITLE
fix(lexGlobPattern): edge case of glob import

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -296,6 +296,7 @@ Note that:
 - The glob patterns are treated like import specifiers: they must be either relative (start with `./`) or absolute (start with `/`, resolved relative to project root).
 - The glob matching is done via `fast-glob` - check out its documentation for [supported glob patterns](https://github.com/mrmlnc/fast-glob#pattern-syntax).
 - You should also be aware that glob imports do not accept variables, you need to directly pass the string pattern.
+- The glob patterns cannot contain the same quote string (i.e. `'`, `"`, `` ` ``) as outer quotes, e.g. `'/Tom\'s files/**'`, use `"/Tom's files/**"` instead.
 
 ## WebAssembly
 

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -2,7 +2,13 @@
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
-  const modules = import.meta.glob('/dir/**')
+  const modules = import.meta.glob(
+    // for test: annotation contain ")"
+    /*
+     * for test: annotation contain ")"
+     * */
+    '/dir/**'
+  )
 
   for (const path in modules) {
     modules[path]().then((mod) => {

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -3,11 +3,11 @@
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
   const modules = import.meta.glob(
+    '/dir/**'
     // for test: annotation contain ")"
     /*
      * for test: annotation contain ")"
      * */
-    '/dir/**'
   )
 
   for (const path in modules) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

1. when lexing the pattern, it may contain quote strings, e.g. `'/Tom\'s files/**'`, results in `'/Tom\'`
2. simply find index of `)` to get the `endIndex` is fragile, the options code may contain annotation, e.g. 
```ts
import.meta.globEager('/dir/*.json', {
    // (set type)
    assert: { type: 'raw' }
  })
```
get the wrong pos next to `type)<--`

For 1, I tried to get the entire correct pattern string and pass it to `fast-glob`, it still returned an empty array of files (works failed), so just document it.

For 2, fixed it.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
