### PR TITLE
fix: do not overwrite rollupOptions.input in dev

### DIFF
--- a/packages/vite/src/node/__tests__/dev.spec.ts
+++ b/packages/vite/src/node/__tests__/dev.spec.ts
@@ -1,0 +1,18 @@
+import { resolveConfig } from '..'
+
+describe('resolveBuildOptions in dev', () => {
+  test('build.rollupOptions should not have input in lib', async () => {
+    const config = await resolveConfig(
+      {
+        build: {
+          lib: {
+            entry: './index.js'
+          }
+        }
+      },
+      'serve'
+    )
+
+    expect(config.build.rollupOptions).not.toHaveProperty('input')
+  })
+})

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -236,7 +236,8 @@ export type ResolvedBuildOptions = Required<
 
 export function resolveBuildOptions(
   root: string,
-  raw?: BuildOptions
+  raw?: BuildOptions,
+  isBuild?: boolean
 ): ResolvedBuildOptions {
   const resolved: ResolvedBuildOptions = {
     target: 'modules',
@@ -291,14 +292,12 @@ export function resolveBuildOptions(
           ])
         )
       : resolve(raw.rollupOptions.input)
-  } else {
-    input = resolve(
-      raw?.lib
-        ? raw.lib.entry
-        : typeof raw?.ssr === 'string'
-        ? raw.ssr
-        : 'index.html'
-    )
+  } else if (raw?.lib && isBuild) {
+    input = resolve(raw.lib.entry)
+  } else if (typeof raw?.ssr === 'string') {
+    input = resolve(raw.ssr)
+  } else if (isBuild) {
+    input = resolve('index.html')
   }
 
   if (!!raw?.ssr && typeof input === 'string' && input.endsWith('.html')) {
@@ -308,7 +307,9 @@ export function resolveBuildOptions(
     )
   }
 
-  resolved.rollupOptions.input = input
+  if (input) {
+    resolved.rollupOptions.input = input
+  }
 
   // handle special build targets
   if (resolved.target === 'modules') {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -367,7 +367,11 @@ export async function resolveConfig(
 
   // resolve public base url
   const BASE_URL = resolveBaseUrl(config.base, command === 'build', logger)
-  const resolvedBuildOptions = resolveBuildOptions(resolvedRoot, config.build)
+  const resolvedBuildOptions = resolveBuildOptions(
+    resolvedRoot,
+    config.build,
+    command === 'build'
+  )
 
   // resolve cache directory
   const pkgPath = lookupFile(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #6020

`rollupOptions.input` should not be defined in dev mode unless explicitly added by users since Vite crawls `*.html` by default.

### Additional context

Added `dev.spec.ts` to test `dev` command behavior since I can't find the respective file for the tests.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
