### PR TITLE
fix(plugin-react): ignore babel config when running babel-restore-jsx (fixes #5082)

### DIFF
--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -48,6 +48,8 @@ export async function restoreJSX(
   babelRestoreJSX ||= import('./babel-restore-jsx')
 
   const result = await babel.transformAsync(code, {
+    babelrc: false,
+    configFile: false,
     ast: true,
     code: false,
     filename,


### PR DESCRIPTION
### Description
fix #5082

@vitejs/plugin-react restore-jsx babel plugin was loading user babel configs (`.babelrc` & `babel.config.js`). if the user config contained `@babel/preset-react` it could cause an `Maximum call stack size exceeded` error in large react files

### Additional context

while i was unable to create a minimal reproducible example for `Maximum call stack size exceeded` i was able to show the babel config being improperly loaded https://stackblitz.com/edit/vitejs-vite-f6dptj?devtoolsheight=33&file=babel.config.js

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
