### PR TITLE
docs: improve instructions for testing local changes against other packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ To develop and test the core `vite` package:
 
 2. Go to `packages/vite` and run `pnpm run dev`. This starts `rollup` in watch mode.
 
-3. For pnpm, you can use [`pnpm.overrides`](https://pnpm.io/package_json#pnpmoverrides). Please note that `pnpm.overrides` must be specified in the root `package.json` and you must first list the package as a dependency in the root `package.json`:
+## Testing Vite against external packages
+
+You may wish to test your locally-modified copy of Vite against another package that is built with Vite. For pnpm, after building Vite, you can use [`pnpm.overrides`](https://pnpm.io/package_json#pnpmoverrides). Please note that `pnpm.overrides` must be specified in the root `package.json` and you must first list the package as a dependency in the root `package.json`:
 
    ```json
    {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,13 @@ To develop and test the core `vite` package:
 
 2. Go to `packages/vite` and run `pnpm run dev`. This starts `rollup` in watch mode.
 
-3. Run `pnpm link --global` in `packages/vite`. This links `vite` globally so that you can:
-
-   - Run `pnpm link --global vite` in another Vite project to use the locally built Vite;
-   - Use the `vite` binary anywhere.
-
-   If your project has `vite` as a nested dependency, you can customize the dependency resolution instead depending on the package manager used. For pnpm, add this in your project's root `package.json`:
+3. For pnpm, you can use [`pnpm.overrides`](https://pnpm.io/package_json#pnpmoverrides). Please note that `pnpm.overrides` must be specified in the root `package.json` and you must first list the package as a dependency in the root `package.json`:
 
    ```json
    {
+     "dependencies": {
+       "vite": "^2.0.0"
+     },
      "pnpm": {
        "overrides": {
          "vite": "link:../path/to/vite/packages/vite"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,20 +16,20 @@ To develop and test the core `vite` package:
 
 You may wish to test your locally-modified copy of Vite against another package that is built with Vite. For pnpm, after building Vite, you can use [`pnpm.overrides`](https://pnpm.io/package_json#pnpmoverrides). Please note that `pnpm.overrides` must be specified in the root `package.json` and you must first list the package as a dependency in the root `package.json`:
 
-   ```json
-   {
-     "dependencies": {
-       "vite": "^2.0.0"
-     },
-     "pnpm": {
-       "overrides": {
-         "vite": "link:../path/to/vite/packages/vite"
-       }
-     }
-   }
-   ```
+```json
+{
+  "dependencies": {
+    "vite": "^2.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "vite": "link:../path/to/vite/packages/vite"
+    }
+  }
+}
+```
 
-   And re-run `pnpm install` to link the package.
+And re-run `pnpm install` to link the package.
 
 ## Running Tests
 


### PR DESCRIPTION
### Description

`pnpm link` has never worked for me and it might be less clear to list two ways. For `pnpm.overrides`, there was a key step missing, which is that Vite needs to be specified in the root `package.json` and not in a sub-package's `package.json`

### Additional context

I've never been able to test Vite against SvelteKit up until now. Thanks to some help from @bluwy on Discord I finally got it figured out. I thought it'd make sense to update these docs for others

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.