### PR TITLE
feat(hmr): add `server.hmr.retry` option to solve frequent refresh caused by HMR WebSocket connection loss (#6089)

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -479,11 +479,13 @@ export default defineConfig(async ({ command, mode }) => {
 
 ### server.hmr
 
-- **Type:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean, clientPort?: number, server?: Server }`
+- **Type:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean, clientPort?: number, server?: Server, retry?: boolean }`
 
   Disable or configure HMR connection (in cases where the HMR websocket must use a different address from the http server).
 
   Set `server.hmr.overlay` to `false` to disable the server error overlay.
+
+  Set `server.hmr.retry` to `false` to disable the HMR websocket reconnection.
 
   `clientPort` is an advanced option that overrides the port only on the client side, allowing you to serve the websocket on a different port than the client code looks for it on. Useful if you're using an SSL proxy in front of your dev server.
 

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -18,6 +18,7 @@ declare const __HMR_HOSTNAME__: string
 declare const __HMR_PORT__: string
 declare const __HMR_TIMEOUT__: number
 declare const __HMR_ENABLE_OVERLAY__: boolean
+declare const __HMR_RETRY__: boolean
 
 console.log('[vite] connecting...')
 
@@ -219,6 +220,10 @@ async function waitForSuccessfulPing(ms = 1000) {
 // ping server
 socket.addEventListener('close', async ({ wasClean }) => {
   if (wasClean) return
+  if (!__HMR_RETRY__) {
+    console.warn(`[vite] server connection lost. Manual refresh and try again.`)
+    return
+  }
   console.log(`[vite] server connection lost. polling for restart...`)
   await waitForSuccessfulPing()
   location.reload()

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -23,6 +23,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
         const protocol = options.protocol || null
         const timeout = options.timeout || 30000
         const overlay = options.overlay !== false
+        const retry = options.retry === false ? false : true
         let port: number | string | undefined
         if (isObject(config.server.hmr)) {
           port = config.server.hmr.clientPort || config.server.hmr.port
@@ -49,6 +50,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
           .replace(`__HMR_PORT__`, JSON.stringify(port))
           .replace(`__HMR_TIMEOUT__`, JSON.stringify(timeout))
           .replace(`__HMR_ENABLE_OVERLAY__`, JSON.stringify(overlay))
+          .replace(`__HMR_RETRY__`, JSON.stringify(retry))
       } else if (code.includes('process.env.NODE_ENV')) {
         // replace process.env.NODE_ENV
         return code.replace(

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -24,6 +24,7 @@ export interface HmrOptions {
   timeout?: number
   overlay?: boolean
   server?: Server
+  retry?: boolean
 }
 
 export interface HmrContext {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
feat(hmr): add `server.hmr.retry` option to solve frequent refresh caused by HMR WebSocket connection loss (#6089)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
