### PR TITLE
fix(plugin-react): only detect preamble in hmr context

### DIFF
--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -35,14 +35,14 @@ import RefreshRuntime from "${runtimePublicPath}";
 let prevRefreshReg;
 let prevRefreshSig;
 
-if (!window.__vite_plugin_react_preamble_installed__) {
-  throw new Error(
-    "@vitejs/plugin-react can't detect preamble. Something is wrong. " +
-    "See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201"
-  );
-}
-
 if (import.meta.hot) {
+  if (!window.__vite_plugin_react_preamble_installed__) {
+    throw new Error(
+      "@vitejs/plugin-react can't detect preamble. Something is wrong. " +
+      "See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201"
+    );
+  }
+
   prevRefreshReg = window.$RefreshReg$;
   prevRefreshSig = window.$RefreshSig$;
   window.$RefreshReg$ = (type, id) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In Vitest, we do client transform for components to run on node side. I think it make sense for the plugin to only check preamble when hmr is available

https://github.com/antfu-sponsors/vitest/issues/125

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
