### PR TITLE
fix(plugin-react): restore-jsx bug when component name is lowercase

### DIFF
--- a/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.spec.ts
+++ b/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.spec.ts
@@ -108,4 +108,10 @@ describe('babel-restore-jsx', () => {
       )
     ).toMatchInlineSnapshot(`"<h1>{foo ? <p /> : null}</h1>;"`)
   })
+
+  it('should handle lowercase component names', () => {
+    expect(jsx('React.createElement(aaa)')).toMatchInlineSnapshot(
+      `"React.createElement(aaa);"`
+    )
+  })
 })

--- a/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.ts
@@ -76,7 +76,7 @@ export default function ({ types: t }: typeof babel): babel.PluginObj {
       return null
     }
 
-    const name = getJSXIdentifier(node)
+    const name = getJSXIdentifier(node, true)
     if (name != null) {
       return name
     }
@@ -152,9 +152,9 @@ export default function ({ types: t }: typeof babel): babel.PluginObj {
     return children
   }
 
-  function getJSXIdentifier(node: any) {
+  function getJSXIdentifier(node: any, tag = false) {
     //TODO: JSXNamespacedName
-    if (t.isIdentifier(node)) {
+    if (t.isIdentifier(node) && (!tag || node.name.match(/^[A-Z]/))) {
       return t.jsxIdentifier(node.name)
     }
     if (t.isStringLiteral(node)) {


### PR DESCRIPTION
### Description

This PR fixes a bug in JSX restoration of the React plugin: `React.createElement(aaa)` is being transformed into `<aaa />` which actually corresponds to `React.createElement("aaa")`. See the added test case. Of course I wouldn't give my React components lowercase names but minifiers are not always as considerate :)

### Additional context

This fix opts out of the transform if the tag name doesn't start with an uppercase letter. I'm not exactly sure it's the best fix. But the ideal fix (renaming the identifier into something that starts with an uppercase letter) would require much more work and greatly complicate the JSX restoration plugin. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
