### PR TITLE
fix: terminate WebSocket connections before closing WebSocket server

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -114,6 +114,9 @@ export function createWebSocketServer(
 
     close() {
       return new Promise((resolve, reject) => {
+        wss.clients.forEach((client) => {
+          client.terminate()
+        })
         wss.close((err) => {
           if (err) {
             reject(err)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This should ensure that ViteServer.close() doesn't hang until all WebSocket connections have been closed from the client side (i.e. when all browser tabs are closed).

### Additional context

See https://github.com/vitejs/vite/issues/6076 for corresponding bug report.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
