### PR TITLE
fix: pending reload never timeout

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -81,7 +81,7 @@ export function transformMiddleware(
           // If the refresh has not happened after timeout, Vite considers
           // something unexpected has happened. In this case, Vite
           // returns an empty response that will error.
-          new Promise<void>((_, reject) =>
+          new Promise((_, reject) =>
             setTimeout(reject, NEW_DEPENDENCY_BUILD_TIMEOUT)
           )
         ])

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -74,23 +74,29 @@ export function transformMiddleware(
       !req.url?.startsWith(CLIENT_PUBLIC_PATH) &&
       !req.url?.includes('vite/dist/client')
     ) {
-      // missing dep pending reload, hold request until reload happens
-      server._pendingReload.then(() =>
-        // If the refresh has not happened after timeout, Vite considers
-        // something unexpected has happened. In this case, Vite
-        // returns an empty response that will error.
-        setTimeout(() => {
-          // Don't do anything if response has already been sent
-          if (res.writableEnded) return
+      try {
+        // missing dep pending reload, hold request until reload happens
+        await Promise.race([
+          server._pendingReload,
+          // If the refresh has not happened after timeout, Vite considers
+          // something unexpected has happened. In this case, Vite
+          // returns an empty response that will error.
+          new Promise<void>((_, reject) =>
+            setTimeout(reject, NEW_DEPENDENCY_BUILD_TIMEOUT)
+          )
+        ])
+      } catch {
+        // Don't do anything if response has already been sent
+        if (!res.writableEnded) {
           // status code request timeout
           res.statusCode = 408
           res.end(
             `<h1>[vite] Something unexpected happened while optimizing "${req.url}"<h1>` +
               `<p>The current page should have reloaded by now</p>`
           )
-        }, NEW_DEPENDENCY_BUILD_TIMEOUT)
-      )
-      return
+        }
+        return
+      }
     }
 
     let url = decodeURI(removeTimestampQuery(req.url!)).replace(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I guess it was a mistake. The original timeout is inside `.then` which will never work. 

### Additional context

https://github.com/nuxt/nuxt.js/issues/13030

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes nuxt/framework#123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
