### PR TITLE
fix(ssr): `viteResolve` fallback to absolute id

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -217,7 +217,7 @@ async function nodeImport(
     const resolved = tryNodeResolve(id, importer, options, false)
     if (!resolved) {
       if (path.isAbsolute(id)) {
-        return id;
+        return id
       }
       const err: any = new Error(
         `Cannot find module '${id}' imported from '${importer}'`

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -216,6 +216,9 @@ async function nodeImport(
   ) => {
     const resolved = tryNodeResolve(id, importer, options, false)
     if (!resolved) {
+      if (path.isAbsolute(id)) {
+        return id;
+      }
       const err: any = new Error(
         `Cannot find module '${id}' imported from '${importer}'`
       )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds fallback to `viteResolve` logic to just return absolute ids if `tryNodeResolve` doesn't return a match.

Astro's test suite is down to a single failure with this change.

### Additional context

Astro is [attempting](https://github.com/withastro/astro/pull/1866) to upgrade to `vite@2.7.x` but we've been hitting failures in CI. Because Vite is hooking `require` for SSR, _all resolution_ is running through Vite for these tests.

This PR modifies still runs `tryNodeResolve`, but if a Vite-specific match is not found _and_ the path is already absolute, we just fallback to the absolute path.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
