### PR TITLE
test: correct the confusing test case

### DIFF
--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -59,12 +59,12 @@
   sharedWorker.port.start()
 
   const tsOutputWorker = new TSOutputWorker()
-  worker.addEventListener('message', (e) => {
+  tsOutputWorker.addEventListener('message', (e) => {
     text('.pong-ts-output', e.data.msg)
   })
 
   document.querySelector('.ping-ts-output').addEventListener('click', () => {
-    inlineWorker.postMessage('ping')
+    tsOutputWorker.postMessage('ping')
   })
 
   function text(el, text) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The test case introduced in bce4e56 is confused with the test case `worker` and `inline-worker`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
