### PR TITLE
fix: exclude acorn.js from node bundle

### DIFF
--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -170,6 +170,21 @@ const createNodeConfig = (isProduction) => {
           'lilconfig/dist/index.js': {
             pattern: /: require,/g,
             replacement: `: eval('require'),`
+          },
+          // vite imports acorn.mjs while these plugins acorn.js
+          // acorn provides own instance to plugins so force rollup
+          // to not bundle acorn from plugins
+          'acorn-class-fields/index.js': {
+            src: 'require("acorn")',
+            replacement: `eval('require')('acorn')`
+          },
+          'acorn-static-class-features/index.js': {
+            src: 'require("acorn")',
+            replacement: `eval('require')('acorn')`
+          },
+          'acorn-private-class-elements/index.js': {
+            src: 'require("acorn")',
+            replacement: `eval('require')('acorn')`
           }
         }),
       commonjs({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I found vite has bundled both acorn.mjs and acorn.js.
Plugins use it as fallback when parser instance is not passed.

`du -ck dist/node`
before: 12260 kB
after: 11612 kB



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
