### PR TITLE
refactor: rename `mergeConfig` parameters

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -666,13 +666,13 @@ function resolveBaseUrl(
 }
 
 function mergeConfigRecursively(
-  a: Record<string, any>,
-  b: Record<string, any>,
+  defaults: Record<string, any>,
+  overrides: Record<string, any>,
   rootPath: string
 ) {
-  const merged: Record<string, any> = { ...a }
-  for (const key in b) {
-    const value = b[key]
+  const merged: Record<string, any> = { ...defaults }
+  for (const key in overrides) {
+    const value = overrides[key]
     if (value == null) {
       continue
     }
@@ -710,11 +710,11 @@ function mergeConfigRecursively(
 }
 
 export function mergeConfig(
-  a: Record<string, any>,
-  b: Record<string, any>,
+  defaults: Record<string, any>,
+  overrides: Record<string, any>,
   isRoot = true
 ): Record<string, any> {
-  return mergeConfigRecursively(a, b, isRoot ? '' : '.')
+  return mergeConfigRecursively(defaults, overrides, isRoot ? '' : '.')
 }
 
 function mergeAlias(a: AliasOptions = [], b: AliasOptions = []): Alias[] {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is a minor change to make it more obvious which of the passed arguments to `mergeConfig` takes priority over the other one.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
