### PR TITLE
feat(worker): allow passing options to worker constructors

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -336,13 +336,26 @@ import MyWorker from './worker?worker'
 const worker = new MyWorker()
 ```
 
-The worker script can also use `import` statements instead of `importScripts()` - note during dev this relies on browser native support and currently only works in Chrome, but for the production build it is compiled away.
-
 By default, the worker script will be emitted as a separate chunk in the production build. If you wish to inline the worker as base64 strings, add the `inline` query:
 
 ```js
 import MyWorker from './worker?worker&inline'
 ```
+
+The custom worker constructor accepts an optional parameter `options`. It will be passed as the second parameter to the [`Worker`](http://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker) constructor, with the caveat that the default value of field `type` is `"module"`, so if you wish to create a classic worker, `{ type: "classic" }` must be explicity passed:
+
+```js
+import MyClassicWorker from './classic-worker?worker'
+
+const worker = new MyClassicWorker({ type: 'classic' })
+```
+
+### Worker Type Comparisons
+
+|                      | Can use `import` | Browser Support During Development                                                              | Browser Support of Production Build |
+| -------------------- | ---------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `"module"` (default) | Yes              | Safari 15+ and Chrome ([caniuse](https://caniuse.com/mdn-api_worker_worker_ecmascript_modules)) | All                                 |
+| `"classic"`          | No               | All                                                                                             | All                                 |
 
 ## Build Optimizations
 

--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -22,6 +22,11 @@ test('inlined', async () => {
   await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
 })
 
+test('worker options', async () => {
+  await page.click('.ping-classic')
+  await untilUpdated(() => page.textContent('.pong-classic'), 'pong')
+})
+
 const waitSharedWorkerTick = (
   (resolvedSharedWorkerCount: number) => async (page: Page) => {
     await untilUpdated(async () => {

--- a/packages/playground/worker/__tests__/worker.spec.ts
+++ b/packages/playground/worker/__tests__/worker.spec.ts
@@ -57,8 +57,8 @@ if (isBuild) {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/assets')
     const files = fs.readdirSync(assetsDir)
-    // should have 3 worker chunk
-    expect(files.length).toBe(4)
+    // should have 4 worker chunk
+    expect(files.length).toBe(5)
     const index = files.find((f) => f.includes('index'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/packages/playground/worker/classic-worker.ts
+++ b/packages/playground/worker/classic-worker.ts
@@ -1,0 +1,5 @@
+self.onmessage = (e) => {
+  if (e.data === 'ping') {
+    self.postMessage('pong')
+  }
+}

--- a/packages/playground/worker/classic-worker.ts
+++ b/packages/playground/worker/classic-worker.ts
@@ -1,7 +1,7 @@
 self.onmessage = (e) => {
   if (e.data === 'ping') {
     // Ensure that we are not in a module worker (calling importScripts in module workers throws an error).
-    self.importScripts();
+    self.importScripts()
     self.postMessage('pong')
   }
 }

--- a/packages/playground/worker/classic-worker.ts
+++ b/packages/playground/worker/classic-worker.ts
@@ -1,5 +1,7 @@
 self.onmessage = (e) => {
   if (e.data === 'ping') {
+    // Ensure that we are not in a module worker (calling importScripts in module workers throws an error).
+    self.importScripts();
     self.postMessage('pong')
   }
 }

--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -7,6 +7,9 @@
 <button class="ping-inline">Ping Inline Worker</button>
 <div>Response from inline worker: <span class="pong-inline"></span></div>
 
+<button class="ping-classic">Ping Classic Worker</button>
+<div>Response from classic worker: <span class="pong-classic"></span></div>
+
 <button class="ping-ts-output">Ping Possible Compiled TS Worker</button>
 <div>
   Response from worker imported from code that might be compiled TS:
@@ -22,6 +25,7 @@
 <script type="module">
   import Worker from './my-worker?worker'
   import InlineWorker from './my-worker?worker&inline'
+  import ClassicWorker from './classic-worker?worker'
   import SharedWorker from './my-shared-worker?sharedworker&name=shared'
   import TSOutputWorker from './possible-ts-output-worker?worker'
   import { mode } from './workerImport'
@@ -45,6 +49,15 @@
 
   document.querySelector('.ping-inline').addEventListener('click', () => {
     inlineWorker.postMessage('ping')
+  })
+
+  const classicWorker = new ClassicWorker({ type: 'classic' })
+  classicWorker.addEventListener('message', (e) => {
+    text('.pong-classic', e.data)
+  })
+
+  document.querySelector('.ping-classic').addEventListener('click', () => {
+    classicWorker.postMessage('ping')
   })
 
   const sharedWorker = new SharedWorker()

--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -169,7 +169,7 @@ declare module '*.pdf' {
 // web worker
 declare module '*?worker' {
   const workerConstructor: {
-    new (): Worker
+    new (workerOptions?: WorkerOptions): Worker
   }
   export default workerConstructor
 }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -1,4 +1,3 @@
-
 import { ResolvedConfig } from '../config'
 import { Plugin } from '../plugin'
 import { resolvePlugins } from '../plugins'
@@ -44,7 +43,8 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       if (query && query[WorkerFileId] != null) {
         if (query[ClassicWorkerQuery] != null) {
           return {
-            code: `self.importScripts(${JSON.stringify(ENV_PUBLIC_PATH)});\n` + _
+            code:
+              `self.importScripts(${JSON.stringify(ENV_PUBLIC_PATH)});\n` + _
           }
         } else {
           return {
@@ -98,7 +98,8 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
                 objURL && (window.URL || window.webkitURL).revokeObjectURL(objURL);
               }
             }`
-        } else { // isBuild: true, inline: false
+        } else {
+          // isBuild: true, inline: false
           const basename = path.parse(cleanUrl(id)).name
           const contentHash = getAssetHash(content)
           const fileName = path.posix.join(
@@ -118,7 +119,8 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             )
           }`
         }
-      } else { // isBuild: false
+      } else {
+        // isBuild: false
         let url = await fileToUrl(cleanUrl(id), config, this)
         url = injectQuery(url, WorkerFileId)
 
@@ -131,7 +133,6 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           return new ${workerConstructor}(url, workerOptions)
         }`
       }
-
     }
   }
 }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -44,7 +44,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       if (query && query[WorkerFileId] != null) {
         if (query[ClassicWorkerQuery] != null) {
           return {
-            code: `self.importScripts(${JSON.stringify(ENV_PUBLIC_PATH)})\n` + _
+            code: `self.importScripts(${JSON.stringify(ENV_PUBLIC_PATH)});\n` + _
           }
         } else {
           return {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -47,8 +47,6 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       const query = parseWorkerRequest(id)
       if (query && query[WorkerFileId] != null) {
         // For classic workers where `import` is unavailable, we use `importScripts` to inject env.
-        // Note that `importScripts` is not suitable for module workers, because imported modules
-        // would be executed before the env script.
         const importEnvCode =
           query[ClassicWorkerQuery] != null ? classicImportEnv : esImportEnv
         return {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -77,10 +77,13 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           // inline as blob data url
           return `const encodedJs = "${content.toString('base64')}";
             const blob = typeof window !== "undefined" && window.Blob && new Blob([atob(encodedJs)], { type: "text/javascript;charset=utf-8" });
-            export default function WorkerWrapper() {
+            export default function WorkerWrapper(workerOptions) {
               const objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);
               try {
-                return objURL ? new Worker(objURL) : new Worker("data:application/javascript;base64," + encodedJs, {type: "module"});
+                return objURL ? new Worker(objURL) : new Worker(
+                  "data:application/javascript;base64," + encodedJs,
+                  Object.assign({ type: "module" }, workerOptions)
+                );
               } finally {
                 objURL && (window.URL || window.webkitURL).revokeObjectURL(objURL);
               }
@@ -105,12 +108,12 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
 
       const workerConstructor =
         query.sharedworker != null ? 'SharedWorker' : 'Worker'
-      const workerOptions = { type: 'module' }
 
-      return `export default function WorkerWrapper() {
-        return new ${workerConstructor}(${JSON.stringify(
-        url
-      )}, ${JSON.stringify(workerOptions, null, 2)})
+      return `export default function WorkerWrapper(workerOptions) {
+        return new ${workerConstructor}(
+          ${JSON.stringify(url)},
+          Object.assign({ type: "module" }, workerOptions)
+        )
       }`
     }
   }


### PR DESCRIPTION
### Description

This PR adds support for the [`options` parameter](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker) of worker constructors, notably allowing `{ type: "classic" }` (fixes https://github.com/vitejs/vite/issues/2550).

### Additional context

There is https://github.com/vitejs/vite/pull/2578, but it's closed at https://github.com/vitejs/vite/pull/2578#issuecomment-809109102. This PR workarounds that problem by prepending `importScript(...)` instead of `import ...` to classic worker scripts.

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
