### PR TITLE
chore: convert scripts to TS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ To work around this, playground packages that uses the `file:` protocol should a
 ```jsonc
 "scripts": {
   //...
-  "postinstall": "node ../../../scripts/patchFileDeps.cjs"
+  "postinstall": "ts-node ../../../scripts/patchFileDeps.ts"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "gitHooks": {
     "pre-commit": "lint-staged --concurrent false",
-    "commit-msg": "node scripts/verifyCommit.cjs"
+    "commit-msg": "ts-node scripts/verifyCommit.ts"
   },
   "lint-staged": {
     "*": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.14",
+    "@types/prompts": "^2.0.14",
     "@types/semver": "^7.3.9",
     "@typescript-eslint/eslint-plugin": "^5.7.0",
     "@typescript-eslint/parser": "^5.7.0",

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . --lerna-package create-vite",
-    "release": "node updateVersions && node ../../scripts/release.cjs --skipBuild"
+    "release": "ts-node updateVersions && node ../../scripts/release.cjs --skipBuild"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -32,8 +32,5 @@
     "kolorist": "^1.5.0",
     "minimist": "^1.2.5",
     "prompts": "^2.4.2"
-  },
-  "devDependencies": {
-    "@types/prompts": "~2.0.14"
   }
 }

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . --lerna-package create-vite",
-    "release": "ts-node updateVersions && node ../../scripts/release.cjs --skipBuild"
+    "release": "ts-node updateVersions && ts-node ../../scripts/release.ts --skipBuild"
   },
   "engines": {
     "node": ">=12.0.0"
@@ -32,5 +32,8 @@
     "kolorist": "^1.5.0",
     "minimist": "^1.2.5",
     "prompts": "^2.4.2"
+  },
+  "devDependencies": {
+    "@types/prompts": "~2.0.14"
   }
 }

--- a/packages/create-vite/updateVersions.ts
+++ b/packages/create-vite/updateVersions.ts
@@ -1,22 +1,23 @@
-const fs = require('fs')
-const path = require('path')
+import { readdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
 const latestVersion = require('../vite/package.json').version
 const isLatestPreRelease = /beta|alpha|rc/.test(latestVersion)
 
 ;(async () => {
-  const templates = fs
-    .readdirSync(__dirname)
-    .filter((d) => d.startsWith('template-'))
-  for (const t of templates) {
-    const pkgPath = path.join(__dirname, t, `package.json`)
+  const templates = readdirSync(__dirname).filter((dir) =>
+    dir.startsWith('template-')
+  )
+  for (const template of templates) {
+    const pkgPath = join(__dirname, template, `package.json`)
     const pkg = require(pkgPath)
     if (!isLatestPreRelease) {
       pkg.devDependencies.vite = `^` + latestVersion
     }
-    if (t.startsWith('template-vue')) {
+    if (template.startsWith('template-vue')) {
       pkg.devDependencies['@vitejs/plugin-vue'] =
         `^` + require('../plugin-vue/package.json').version
     }
-    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n')
   }
 })()

--- a/packages/playground/alias/package.json
+++ b/packages/playground/alias/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
     "preview": "vite preview",
-    "postinstall": "node ../../../scripts/patchFileDeps.cjs"
+    "postinstall": "ts-node ../../../scripts/patchFileDeps.ts"
   },
   "dependencies": {
     "aliased-module": "file:./dir/module",

--- a/packages/playground/optimize-deps/package.json
+++ b/packages/playground/optimize-deps/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
     "preview": "vite preview",
-    "postinstall": "node ../../../scripts/patchFileDeps.cjs"
+    "postinstall": "ts-node ../../../scripts/patchFileDeps.ts"
   },
   "dependencies": {
     "axios": "^0.24.0",

--- a/packages/playground/optimize-missing-deps/package.json
+++ b/packages/playground/optimize-missing-deps/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "node server",
-    "postinstall": "node ../../../scripts/patchFileDeps.cjs"
+    "postinstall": "ts-node ../../../scripts/patchFileDeps.ts"
   },
   "dependencies": {
     "missing-dep": "file:./missing-dep",

--- a/packages/playground/ssr-deps/package.json
+++ b/packages/playground/ssr-deps/package.json
@@ -6,7 +6,7 @@
     "dev": "node server",
     "serve": "cross-env NODE_ENV=production node server",
     "debug": "node --inspect-brk server",
-    "postinstall": "node ../../../scripts/patchFileDeps.cjs"
+    "postinstall": "ts-node ../../../scripts/patchFileDeps.ts"
   },
   "dependencies": {
     "bcrypt": "^5.0.1",

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -11,7 +11,7 @@
   "types": "index.d.ts",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . --lerna-package plugin-legacy",
-    "release": "node ../../scripts/release.cjs --skipBuild"
+    "release": "ts-node ../../scripts/release.ts --skipBuild"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -18,7 +18,7 @@
     "build-bundle": "esbuild src/index.ts --bundle --platform=node --target=node12 --external:@babel/* --external:@rollup/* --external:resolve --external:react-refresh/* --outfile=dist/index.js",
     "build-types": "tsc -p . --emitDeclarationOnly --outDir temp && api-extractor run && rimraf temp",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . --lerna-package plugin-react",
-    "release": "node ../../scripts/release.cjs"
+    "release": "ts-node ../../scripts/release.ts"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -11,7 +11,7 @@
   "types": "index.d.ts",
   "scripts": {
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . --lerna-package plugin-vue-jsx",
-    "release": "node ../../scripts/release.cjs --skipBuild"
+    "release": "ts-node ../../scripts/release.ts --skipBuild"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -16,7 +16,7 @@
     "build-bundle": "esbuild src/index.ts --bundle --platform=node --target=node12 --external:@vue/compiler-sfc --external:vue/compiler-sfc --external:vite --outfile=dist/index.js",
     "build-types": "tsc -p . --emitDeclarationOnly --outDir temp && api-extractor run && rimraf temp",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . --lerna-package plugin-vue",
-    "release": "node ../../scripts/release.cjs"
+    "release": "ts-node ../../scripts/release.ts"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -1288,26 +1288,27 @@ Repository: https://github.com/mathiasbynens/cssesc.git
 
 ## debug
 License: MIT
-By: TJ Holowaychuk, Nathan Rajlich, Andrew Rhyne, Josh Junon
-Repository: git://github.com/visionmedia/debug.git
+By: Josh Junon, TJ Holowaychuk, Nathan Rajlich, Andrew Rhyne
+Repository: git://github.com/debug-js/debug.git
 
 > (The MIT License)
 > 
-> Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+> Copyright (c) 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
+> Copyright (c) 2018-2021 Josh Junon
 > 
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
-> and associated documentation files (the 'Software'), to deal in the Software without restriction, 
-> including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+> and associated documentation files (the 'Software'), to deal in the Software without restriction,
+> including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
 > and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 > subject to the following conditions:
 > 
-> The above copyright notice and this permission notice shall be included in all copies or substantial 
+> The above copyright notice and this permission notice shall be included in all copies or substantial
 > portions of the Software.
 > 
-> THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
-> LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-> WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+> THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+> LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+> WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 > SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---------------------------------------
@@ -2884,6 +2885,35 @@ Repository: git://github.com/isaacs/minimatch.git
 > WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 > ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 > IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---------------------------------------
+
+## mrmime
+License: MIT
+By: Luke Edwards
+Repository: lukeed/mrmime
+
+> The MIT License (MIT)
+> 
+> Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (https://lukeed.com)
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
 
 ---------------------------------------
 

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint --ext .ts src/**",
     "format": "prettier --write --parser typescript \"src/**/*.ts\"",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path .",
-    "release": "node ../../scripts/release.cjs"
+    "release": "ts-node ../../scripts/release.ts"
   },
   "//": "READ CONTRIBUTING.md to understand what to put under deps vs. devDeps!",
   "dependencies": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -35,7 +35,7 @@
     "build-types": "run-s build-temp-types patch-types roll-types",
     "build-temp-types": "tsc --emitDeclarationOnly --outDir temp/node -p src/node",
     "ci-build": "rimraf dist && run-s build-bundle build-types",
-    "patch-types": "node scripts/patchTypes.cjs",
+    "patch-types": "ts-node scripts/patchTypes.ts",
     "roll-types": "api-extractor run && rimraf temp",
     "lint": "eslint --ext .ts src/**",
     "format": "prettier --write --parser typescript \"src/**/*.ts\"",

--- a/packages/vite/scripts/patchTypes.ts
+++ b/packages/vite/scripts/patchTypes.ts
@@ -55,7 +55,11 @@ function rewriteFile(file: string): void {
       const source = statement.source
       const absoluteTypePath = resolve(typesDir, source.value.slice(6))
       const relativeTypePath = slash(relative(dirname(file), absoluteTypePath))
-      str.overwrite(source.start, source.end, JSON.stringify(relativeTypePath))
+      str.overwrite(
+        source.start!,
+        source.end!,
+        JSON.stringify(relativeTypePath)
+      )
     }
   }
   writeFileSync(file, str.toString())

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,7 @@ importers:
 
   packages/create-vite:
     specifiers:
+      '@types/prompts': ~2.0.14
       kolorist: ^1.5.0
       minimist: ^1.2.5
       prompts: ^2.4.2
@@ -87,6 +88,8 @@ importers:
       kolorist: 1.5.0
       minimist: 1.2.5
       prompts: 2.4.2
+    devDependencies:
+      '@types/prompts': 2.0.14
 
   packages/playground:
     specifiers:
@@ -2289,6 +2292,12 @@ packages:
 
   /@types/prettier/2.4.1:
     resolution: {integrity: sha512-Fo79ojj3vdEZOHg3wR9ksAMRz4P3S5fDB5e/YWZiFnyFQI1WY2Vftu9XoXVVtJfxB7Bpce/QTqWSSntkz2Znrw==}
+    dev: true
+
+  /@types/prompts/2.0.14:
+    resolution: {integrity: sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==}
+    dependencies:
+      '@types/node': 16.11.14
     dev: true
 
   /@types/resolve/1.17.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ importers:
       '@types/fs-extra': ^9.0.13
       '@types/jest': ^27.0.3
       '@types/node': ^16.11.14
+      '@types/prompts': ^2.0.14
       '@types/semver': ^7.3.9
       '@typescript-eslint/eslint-plugin': ^5.7.0
       '@typescript-eslint/parser': ^5.7.0
@@ -47,6 +48,7 @@ importers:
       '@types/fs-extra': 9.0.13
       '@types/jest': 27.0.3
       '@types/node': 16.11.14
+      '@types/prompts': 2.0.14
       '@types/semver': 7.3.9
       '@typescript-eslint/eslint-plugin': 5.7.0_d7a0d6b59468b4d2ea38f782f4f112e3
       '@typescript-eslint/parser': 5.7.0_eslint@8.4.1+typescript@4.4.4
@@ -80,7 +82,6 @@ importers:
 
   packages/create-vite:
     specifiers:
-      '@types/prompts': ~2.0.14
       kolorist: ^1.5.0
       minimist: ^1.2.5
       prompts: ^2.4.2
@@ -88,8 +89,6 @@ importers:
       kolorist: 1.5.0
       minimist: 1.2.5
       prompts: 2.4.2
-    devDependencies:
-      '@types/prompts': 2.0.14
 
   packages/playground:
     specifiers:

--- a/scripts/patchFileDeps.ts
+++ b/scripts/patchFileDeps.ts
@@ -3,19 +3,20 @@
 // This script is called from postinstall hooks in playground packages that
 // uses the file: protocol, and copies the file: deps into node_modules.
 
-const fs = require('fs-extra')
-const path = require('path')
-const root = process.cwd()
-const pkg = require(path.join(root, 'package.json'))
+import { copySync, removeSync } from 'fs-extra'
+import { join, resolve } from 'path'
 
-let hasPatched
-for (const [key, val] of Object.entries(pkg.dependencies)) {
+const root = process.cwd()
+const pkg = require(join(root, 'package.json'))
+
+let hasPatched: boolean = false
+for (const [key, val] of Object.entries<string>(pkg.dependencies)) {
   if (val.startsWith('file:')) {
     hasPatched = true
-    const src = path.resolve(root, val.slice('file:'.length))
-    const dest = path.resolve(root, 'node_modules', key)
-    fs.removeSync(dest)
-    fs.copySync(src, dest, {
+    const src = resolve(root, val.slice('file:'.length))
+    const dest = resolve(root, 'node_modules', key)
+    removeSync(dest)
+    copySync(src, dest, {
       dereference: true
     })
     console.log(`patched ${val}`)
@@ -26,5 +27,5 @@ if (hasPatched) {
   // remove node_modules/.ignored as pnpm will think our patched files are
   // installed by another package manager and move them into this directory.
   // On further installs it will error out if this directory is not empty.
-  fs.removeSync(path.resolve(root, 'node_modules', '.ignored'))
+  removeSync(resolve(root, 'node_modules', '.ignored'))
 }

--- a/scripts/verifyCommit.ts
+++ b/scripts/verifyCommit.ts
@@ -1,8 +1,10 @@
 // Invoked on the commit-msg git hook by yorkie.
 
-const chalk = require('chalk')
-const msgPath = process.env.GIT_PARAMS
-const msg = require('fs').readFileSync(msgPath, 'utf-8').trim()
+import chalk from 'chalk'
+import { readFileSync } from 'fs'
+
+const msgPath = process.env.GIT_PARAMS!
+const msg = readFileSync(msgPath, 'utf-8').trim()
 
 const releaseRE = /^v\d/
 const commitRE =


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Convert scripts to TS

### Additional context

This could help to provide scripts with better type support/checks and so make it easier for other contributors to understand and not break it by accident.

I also thought about to use `esno`, but due to `ts-node` is already in the dev dependencies, I did not introduce another dependency just for the scripts.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
