### PR TITLE
fix(plugin-vue): resolve bug about compiler-sfc when use vue<=3.2.12

### DIFF
--- a/packages/plugin-vue/src/compiler.ts
+++ b/packages/plugin-vue/src/compiler.ts
@@ -10,7 +10,7 @@ import type * as _compiler from 'vue/compiler-sfc'
 export function resolveCompiler(root: string): typeof _compiler {
   // resolve from project root first, then fallback to peer dep (if any)
   const compiler =
-    tryRequire('vue/compiler-sfc', root) || tryRequire('vue/compiler-sfc')
+    tryRequire('vue/compiler-sfc', root) || tryRequire('vue/compiler-sfc') || tryRequire('@vue/compiler-sfc')
 
   if (!compiler) {
     throw new Error(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes a bug in function `resolveCompiler()` of the `@vitejs/plugin-vue` plugin: When I use `vue` 3.2.12, `vite` 2.7.3 and `@vitejs/plugin-vue` 2.0.1, and also **have installed `@vue/compiler-sfc`**, then i run `npx vite`, but plugin-vue still throws an error: "Error: Failed to resolve vue/compiler-sfc".
I think this error can be solved by adding `tryRequire("@vue/compiler-sfc")` or is there a better idea?
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
