### PR TITLE
feat(plugin-react): change how `babel.include/exclude` options behave

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -55,7 +55,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   const userParserPlugins =
     opts.parserPlugins || opts.babel?.parserOpts?.plugins || []
 
-  // Support pattens like:
+  // Support patterns like:
   // - import * as React from 'react';
   // - import React from 'react';
   // - import React, {useEffect} from 'react';

--- a/packages/plugin-react/src/utils.ts
+++ b/packages/plugin-react/src/utils.ts
@@ -12,15 +12,20 @@ export interface FilterOptions {
 const returnTrue = () => true
 const returnFalse = () => false
 
-type FileFilter = (id: string) => boolean
+export type FileFilter = (id: string) => boolean
 
 export function createFileFilter(
-  arg: boolean | FilterOptions,
+  arg: boolean | FilterOptions | undefined,
+  defaultArg: boolean,
   resolve?: string
 ): FileFilter {
-  return arg === false
-    ? returnFalse
-    : arg === true || (!arg.include && !arg.exclude)
+  return arg === true
     ? returnTrue
-    : createFilter(arg.include, arg.exclude, { resolve })
+    : arg === false
+    ? returnFalse
+    : arg && (arg.include || arg.exclude)
+    ? createFilter(arg.include, arg.exclude, { resolve })
+    : defaultArg
+    ? returnTrue
+    : returnFalse
 }

--- a/packages/plugin-react/src/utils.ts
+++ b/packages/plugin-react/src/utils.ts
@@ -1,0 +1,26 @@
+import { createFilter } from '@rollup/pluginutils'
+
+export function loadPlugin(path: string): Promise<any> {
+  return import(path).then((module) => module.default || module)
+}
+
+export interface FilterOptions {
+  include?: string | RegExp | Array<string | RegExp>
+  exclude?: string | RegExp | Array<string | RegExp>
+}
+
+const returnTrue = () => true
+const returnFalse = () => false
+
+type FileFilter = (id: string) => boolean
+
+export function createFileFilter(
+  arg: boolean | FilterOptions,
+  resolve?: string
+): FileFilter {
+  return arg === false
+    ? returnFalse
+    : arg === true || (!arg.include && !arg.exclude)
+    ? returnTrue
+    : createFilter(arg.include, arg.exclude, { resolve })
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

**If someone wants to write tests for this, you're more than welcome!** 😄 

### Description

By default, Babel plugins passed to plugin-react are only applied to modules in the project root (as well as virtual modules), except when they live in a node_modules folder. To override this behavior, you can now define `babel.include` to ensure a module is transformed by those particular plugins (note that babel.config.js can be used to apply plugins/presets to your entire bundle, but you need to pass `configFile: true` to plugin-react first). Similarly, you can define `babel.exclude` to stop a module from being transformed by the Babel plugins passed to plugin-react (as well as .babelrc plugins).

```ts
reactPlugin({
  babel: {
    babelrc: true,
    plugins: [...],
    // Apply plugins above (and plugins in .babelrc) to all node_modules
    include: ['**/node_modules/**'],
    // Skip applying plugins to "src/foo" folder
    exclude: [/src\/foo/],
  }
})
```

There's also a breaking change in this PR: The `include/exclude` options have been moved into the `fastRefresh` option, so as to avoid confusing users into thinking they affect Babel transformation.

### Additional context

Closes vitejs/vite-plugin-react#16

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
