### PR TITLE
fix(dev): increase default session memory limit in HTTPS dev server to prevent disconnections on large projects.

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -97,12 +97,10 @@ export async function resolveHttpServer(
   } else {
     return require('http2').createSecureServer(
       {
-        ...httpsOptions,
-
         // Manually increase the session memory to prevent 502 ENHANCE_YOUR_CALM
         // errors on large numbers of requests
-        maxSessionMemory: (httpsOptions as any).maxSessionMemory ?? 1000,
-
+        maxSessionMemory: 1000,
+        ...httpsOptions,
         allowHTTP1: true
       },
       app

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -126,7 +126,6 @@ export async function resolveHttpsConfig(
   if (!httpsOption.key || !httpsOption.cert) {
     httpsOption.cert = httpsOption.key = await getCertificate(cacheDir)
   }
-
   return httpsOption
 }
 

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -98,6 +98,11 @@ export async function resolveHttpServer(
     return require('http2').createSecureServer(
       {
         ...httpsOptions,
+
+        // Manually increase the session memory to prevent 502 ENHANCE_YOUR_CALM
+        // errors on large numbers of requests
+        maxSessionMemory: (httpsOptions as any).maxSessionMemory ?? 1000,
+
         allowHTTP1: true
       },
       app
@@ -123,6 +128,7 @@ export async function resolveHttpsConfig(
   if (!httpsOption.key || !httpsOption.cert) {
     httpsOption.cert = httpsOption.key = await getCertificate(cacheDir)
   }
+
   return httpsOption
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In projects with a particularly large number of modules, some requests to the dev server will fail when the server is under heavy load. Which requests fail is nondeterministic, but some of them always will. It looks like this:

![image](https://user-images.githubusercontent.com/1735971/146873587-696d4d7c-61fd-4a08-8dc3-9b97902447c1.png)

Here's a repro. Unfortunately, I couldn't do this in StackBlitz -- when I tried to run it there, I couldn't even get the app to start. I'm assuming that's because this involves intentionally thrashing the filesystem and StackBlitz isn't optimized for that kind of fs access, but I don't really know.

### Additional context

When I had this problem with my own app, I did a bunch of research on the `502 ENHANCE_YOUR_CALM` error that I was seeing in my terminal output. I eventually tracked it to [nghttp2](https://github.com/nghttp2/nghttp2/blob/fcc20334da25cd8a447a64fd44d51d997e288899/lib/nghttp2_helper.c#L781), the library Node uses to implement HTTP/2 support. [This now-closed issue](https://github.com/nodejs/node/issues/23116) in Node itself gave me a clue as to what was going on. Apparently the error message is an anti-DDOS mechanism -- in the case of the now-fixed bug, the memory used by requests wasn't getting released.

The [default value](https://nodejs.org/api/http2.html#http2createserveroptions-onrequesthandler) for this limit is 10MB. I guessed that it might just be too small for a large-ish Vite project, so after seeing how the options get passed to `createSecureServer`, I bumped it up in my own project by passing `https: { maxSessionMemory: 1000 }` in my `vite.config.ts`, and this seemed to solve the problem consistently. `100` also seemed to work, but it doesn't for this repro.

Admittedly, the repro is absolutely bonkers. My real project loads ~1800 modules (we're working on code-splitting, but we did some things that inadvertently made that difficult, so it'll take a while 😬 ) but pulls down nowhere near as much data as the repro does. I'm not sure what a reasonable limit is, or what the dangers of bumping the default value might be (will it affect SSR?), so I'm curious what you all think about that. It also seems like something that should probably be configurable, but I had a bit of trouble trying to add it to the allowed types -- the option in question comes from [`SessionOptions`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/node/http2.d.ts#L1035), which doesn't make it into the set of allowed options as considered by Vite for reasons I haven't figured out yet.

Also, if you'd like me to make my repro into a test, let me know! I wasn't sure if this sort of heavyweight thing was appropriate for the test suite, but happy to add it if it is.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
