### PR TITLE
fix(plugin-legacy): Restore guessable polyfill id (fix #6097)

### DIFF
--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -596,7 +596,7 @@ async function buildPolyfillChunk(
   bundle[polyfillChunk.name] = polyfillChunk
 }
 
-const polyfillId = '\0vite/legacy-polyfills'
+const polyfillId = 'vite/legacy-polyfills'
 
 /**
  * @param {Set<string>} imports


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

The name of the polyfill file is determined by a hardcoded string.
Some packages based on this plugin rely on this predefined name.
This name was changed in 3127219bfa4129538fe5448c86b7e9aa1fe4d9ea
to prevent resolving files which don't exist. This commit changes
that behaviour to restore the predefined name.

Closes #6097 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I wanted to write a proper test for this but I wasn't sure where to put this. So if anyone can give me some guidelines I could spend some time on that. 

Next to this, we are a bit doubting if this was a typo or an intended change as discussed in https://github.com/ElMassimo/vite_ruby/issues/156 and https://github.com/nystudio107/craft-vite/issues/20.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
