### PR TITLE
fix: hmr full-reload encodeURI path

### DIFF
--- a/packages/playground/hmr/__tests__/hmr.spec.ts
+++ b/packages/playground/hmr/__tests__/hmr.spec.ts
@@ -133,7 +133,7 @@ if (!isBuild) {
       'unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
       (code) => code.replace('title', 'title2')
     )
-    await page.waitForTimeout(200)
+    await page.waitForEvent('load')
     await untilUpdated(
       async () => (await page.$('#app')).textContent(),
       'title2'

--- a/packages/playground/hmr/__tests__/hmr.spec.ts
+++ b/packages/playground/hmr/__tests__/hmr.spec.ts
@@ -122,4 +122,21 @@ if (!isBuild) {
     editFile('customFile.js', (code) => code.replace('custom', 'edited'))
     await untilUpdated(() => el.textContent(), 'edited')
   })
+
+  test('full-reload encodeURI path', async () => {
+    await page.goto(
+      viteTestUrl + '/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html'
+    )
+    let el = await page.$('#app')
+    expect(await el.textContent()).toBe('title')
+    await editFile(
+      'unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
+      (code) => code.replace('title', 'title2')
+    )
+    await page.waitForTimeout(200)
+    await untilUpdated(
+      async () => (await page.$('#app')).textContent(),
+      'title2'
+    )
+  })
 }

--- a/packages/playground/hmr/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html
+++ b/packages/playground/hmr/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html
@@ -1,0 +1,1 @@
+<div id="app">title</div>

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -100,7 +100,7 @@ async function handleMessage(payload: HMRPayload) {
       if (payload.path && payload.path.endsWith('.html')) {
         // if html file is edited, only reload the page if the browser is
         // currently on that page.
-        const pagePath = location.pathname
+        const pagePath = decodeURI(location.pathname)
         const payloadPath = base + payload.path.slice(1)
         if (
           pagePath === payloadPath ||


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

 fix #6195

If the html file path is encodeURI, such as unicode characters or spaces in the path,  HMR  full-reload does not work

``` 
 // encodeURI path example
/%E5%9C%A8%E4%B8%8D%E5%90%8C%E8%AE%BE%E5%A4%87%E4%B8%8A%E6%98%BE%E7%A4%BA%E4%B8%8D%E4%B8%80%E6%A0%B7%E5%86%85%E5%AE%B9%E7%9A%84%E7%A5%9E%E5%A5%87PNG%E5%9B%BE%E7%89%87/index.html
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
