### PR TITLE
fix: correct ssr flag in resolve calls (fix #6213)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -160,10 +160,11 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       removedPureCssFilesCache.set(config, new Map<string, RenderedChunk>())
     },
 
-    async transform(raw, id) {
+    async transform(raw, id, options) {
       if (!isCSSRequest(id) || commonjsProxyRE.test(id)) {
         return
       }
+      const ssr = options?.ssr === true
 
       const urlReplacer: CssUrlReplacer = async (url, importer) => {
         if (checkPublicFile(url, config)) {
@@ -221,7 +222,8 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
                       ).replace(
                         (config.server?.origin ?? '') + config.base,
                         '/'
-                      )
+                      ),
+                      ssr
                     )
               )
             }
@@ -231,7 +233,8 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
               // The root CSS proxy module is self-accepting and should not
               // have an explicit accept list
               new Set(),
-              isSelfAccepting
+              isSelfAccepting,
+              ssr
             )
             for (const file of deps) {
               this.addWatchFile(file)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -259,7 +259,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // its last updated timestamp to force the browser to fetch the most
           // up-to-date version of this module.
           try {
-            const depModule = await moduleGraph.ensureEntryFromUrl(url)
+            const depModule = await moduleGraph.ensureEntryFromUrl(url, ssr)
             if (depModule.lastHMRTimestamp > 0) {
               url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)
             }
@@ -518,7 +518,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
         const [normalized] = await moduleGraph.resolveUrl(
-          toAbsoluteUrl(markExplicitImport(url))
+          toAbsoluteUrl(markExplicitImport(url)),
+          ssr
         )
         normalizedAcceptedUrls.add(normalized)
         str().overwrite(start, end, JSON.stringify(normalized))
@@ -549,7 +550,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           importerModule,
           importedUrls,
           normalizedAcceptedUrls,
-          isSelfAccepting
+          isSelfAccepting,
+          ssr
         )
         if (hasHMR && prunedImports) {
           handlePrunedModules(prunedImports, server)

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -55,7 +55,7 @@ describe('plugin container', () => {
         plugins: [plugin]
       })
 
-      const entryModule = await moduleGraph.ensureEntryFromUrl(entryUrl)
+      const entryModule = await moduleGraph.ensureEntryFromUrl(entryUrl, false)
       expect(entryModule.meta).toEqual({ x: 1 })
 
       const loadResult: any = await container.load(entryUrl)
@@ -94,7 +94,7 @@ describe('plugin container', () => {
         plugins: [plugin1, plugin2]
       })
 
-      await moduleGraph.ensureEntryFromUrl(entryUrl)
+      await moduleGraph.ensureEntryFromUrl(entryUrl, false)
       await container.load(entryUrl)
 
       expect.assertions(1)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -321,8 +321,8 @@ export async function createServer(
     ...watchOptions
   }) as FSWatcher
 
-  const moduleGraph: ModuleGraph = new ModuleGraph((url) =>
-    container.resolveId(url)
+  const moduleGraph: ModuleGraph = new ModuleGraph((url, ssr) =>
+    container.resolveId(url, undefined, { ssr })
   )
 
   const container = await createPluginContainer(config, moduleGraph, watcher)

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -111,7 +111,7 @@ export function transformMiddleware(
       // since we generate source map references, handle those requests here
       if (isSourceMap) {
         const originalUrl = url.replace(/\.map($|\?)/, '$1')
-        const map = (await moduleGraph.getModuleByUrl(originalUrl))
+        const map = (await moduleGraph.getModuleByUrl(originalUrl, false))
           ?.transformResult?.map
         if (map) {
           return send(req, res, JSON.stringify(map), 'json')
@@ -164,8 +164,8 @@ export function transformMiddleware(
         const ifNoneMatch = req.headers['if-none-match']
         if (
           ifNoneMatch &&
-          (await moduleGraph.getModuleByUrl(url))?.transformResult?.etag ===
-            ifNoneMatch
+          (await moduleGraph.getModuleByUrl(url, false))?.transformResult
+            ?.etag === ifNoneMatch
         ) {
           isDebug && debugCache(`[304] ${prettifyUrl(url, root)}`)
           res.statusCode = 304

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -70,7 +70,7 @@ export class ModuleGraph {
 
   async getModuleByUrl(
     rawUrl: string,
-    ssr: boolean
+    ssr?: boolean
   ): Promise<ModuleNode | undefined> {
     const [url] = await this.resolveUrl(rawUrl, ssr)
     return this.urlToModuleMap.get(url)
@@ -118,7 +118,7 @@ export class ModuleGraph {
     importedModules: Set<string | ModuleNode>,
     acceptedModules: Set<string | ModuleNode>,
     isSelfAccepting: boolean,
-    ssr: boolean
+    ssr?: boolean
   ): Promise<Set<ModuleNode> | undefined> {
     mod.isSelfAccepting = isSelfAccepting
     const prevImports = mod.importedModules
@@ -155,7 +155,7 @@ export class ModuleGraph {
     return noLongerImported
   }
 
-  async ensureEntryFromUrl(rawUrl: string, ssr: boolean): Promise<ModuleNode> {
+  async ensureEntryFromUrl(rawUrl: string, ssr?: boolean): Promise<ModuleNode> {
     const [url, resolvedId, meta] = await this.resolveUrl(rawUrl, ssr)
     let mod = this.urlToModuleMap.get(url)
     if (!mod) {
@@ -204,9 +204,9 @@ export class ModuleGraph {
   // 1. remove the HMR timestamp query (?t=xxxx)
   // 2. resolve its extension so that urls with or without extension all map to
   // the same module
-  async resolveUrl(url: string, ssr: boolean): Promise<ResolvedUrl> {
+  async resolveUrl(url: string, ssr?: boolean): Promise<ResolvedUrl> {
     url = removeImportQuery(removeTimestampQuery(url))
-    const resolved = await this.resolveId(url, ssr)
+    const resolved = await this.resolveId(url, !!ssr)
     const resolvedId = resolved?.id || url
     const ext = extname(cleanUrl(resolvedId))
     const { pathname, search, hash } = parseUrl(url)

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -62,11 +62,17 @@ export class ModuleGraph {
   safeModulesPath = new Set<string>()
 
   constructor(
-    private resolveId: (url: string) => Promise<PartialResolvedId | null>
+    private resolveId: (
+      url: string,
+      ssr: boolean
+    ) => Promise<PartialResolvedId | null>
   ) {}
 
-  async getModuleByUrl(rawUrl: string): Promise<ModuleNode | undefined> {
-    const [url] = await this.resolveUrl(rawUrl)
+  async getModuleByUrl(
+    rawUrl: string,
+    ssr: boolean
+  ): Promise<ModuleNode | undefined> {
+    const [url] = await this.resolveUrl(rawUrl, ssr)
     return this.urlToModuleMap.get(url)
   }
 
@@ -111,7 +117,8 @@ export class ModuleGraph {
     mod: ModuleNode,
     importedModules: Set<string | ModuleNode>,
     acceptedModules: Set<string | ModuleNode>,
-    isSelfAccepting: boolean
+    isSelfAccepting: boolean,
+    ssr: boolean
   ): Promise<Set<ModuleNode> | undefined> {
     mod.isSelfAccepting = isSelfAccepting
     const prevImports = mod.importedModules
@@ -121,7 +128,7 @@ export class ModuleGraph {
     for (const imported of importedModules) {
       const dep =
         typeof imported === 'string'
-          ? await this.ensureEntryFromUrl(imported)
+          ? await this.ensureEntryFromUrl(imported, ssr)
           : imported
       dep.importers.add(mod)
       nextImports.add(dep)
@@ -141,15 +148,15 @@ export class ModuleGraph {
     for (const accepted of acceptedModules) {
       const dep =
         typeof accepted === 'string'
-          ? await this.ensureEntryFromUrl(accepted)
+          ? await this.ensureEntryFromUrl(accepted, ssr)
           : accepted
       deps.add(dep)
     }
     return noLongerImported
   }
 
-  async ensureEntryFromUrl(rawUrl: string): Promise<ModuleNode> {
-    const [url, resolvedId, meta] = await this.resolveUrl(rawUrl)
+  async ensureEntryFromUrl(rawUrl: string, ssr: boolean): Promise<ModuleNode> {
+    const [url, resolvedId, meta] = await this.resolveUrl(rawUrl, ssr)
     let mod = this.urlToModuleMap.get(url)
     if (!mod) {
       mod = new ModuleNode(url)
@@ -197,9 +204,9 @@ export class ModuleGraph {
   // 1. remove the HMR timestamp query (?t=xxxx)
   // 2. resolve its extension so that urls with or without extension all map to
   // the same module
-  async resolveUrl(url: string): Promise<ResolvedUrl> {
+  async resolveUrl(url: string, ssr: boolean): Promise<ResolvedUrl> {
     url = removeImportQuery(removeTimestampQuery(url))
-    const resolved = await this.resolveId(url)
+    const resolved = await this.resolveId(url, ssr)
     const resolvedId = resolved?.id || url
     const ext = extname(cleanUrl(resolvedId))
     const { pathname, search, hash } = parseUrl(url)

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -65,7 +65,7 @@ async function doTransform(
   const prettyUrl = isDebug ? prettifyUrl(url, root) : ''
   const ssr = !!options.ssr
 
-  const module = await server.moduleGraph.getModuleByUrl(url)
+  const module = await server.moduleGraph.getModuleByUrl(url, ssr)
 
   // check if we have a fresh cache
   const cached =
@@ -82,7 +82,8 @@ async function doTransform(
   }
 
   // resolve
-  const id = (await pluginContainer.resolveId(url))?.id || url
+  const id =
+    (await pluginContainer.resolveId(url, undefined, { ssr }))?.id || url
   const file = cleanUrl(id)
 
   let code: string | null = null
@@ -147,7 +148,7 @@ async function doTransform(
   }
 
   // ensure module in graph after successful load
-  const mod = await moduleGraph.ensureEntryFromUrl(url)
+  const mod = await moduleGraph.ensureEntryFromUrl(url, ssr)
   ensureWatchedFile(watcher, mod.file, root)
 
   // transform

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -65,7 +65,7 @@ async function instantiateModule(
   urlStack: string[] = []
 ): Promise<SSRModule> {
   const { moduleGraph } = server
-  const mod = await moduleGraph.ensureEntryFromUrl(url)
+  const mod = await moduleGraph.ensureEntryFromUrl(url, true)
 
   if (mod.ssrModule) {
     return mod.ssrModule


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Correct missing ssr flag in `resolveId` calls (during `ssrLoadModule` calls)

### Additional context

As moduleGraph modified methods can be called by plugin/platform code, maybe we should default the ssr param to false ?
I made it non-optional mostly to ensure no call was missed.

Patched build was published as `vite-with-ssr-flag-fixed@2.7.4-0` so you can experience the fix in the linked issue [stackblitz repo](https://stackblitz.com/edit/vitejs-vite-hjuxca?file=vite.config.js&terminal=dev) by doing `npm i -D vite@npm:vite-with-ssr-flag-fixed@2.7.4-0`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
