### PR TITLE
fix: remove virtual module prefix while generating manifest

### DIFF
--- a/packages/playground/legacy/__tests__/legacy.spec.ts
+++ b/packages/playground/legacy/__tests__/legacy.spec.ts
@@ -1,4 +1,4 @@
-import { isBuild, untilUpdated } from '../../testUtils'
+import { isBuild, readManifest, untilUpdated } from '../../testUtils'
 
 test('should work', async () => {
   expect(await page.textContent('#app')).toMatch('Hello')
@@ -44,3 +44,12 @@ test('generates assets', async () => {
     true
   )
 })
+
+
+if (isBuild) {
+  test('should generate correct manifest', async () => {
+    const manifest = readManifest()
+    expect(manifest['../../../vite/legacy-polyfills']).toBeDefined()
+    expect(manifest['../../../vite/legacy-polyfills'].src).toBe('../../../vite/legacy-polyfills')
+  })
+}

--- a/packages/playground/legacy/__tests__/legacy.spec.ts
+++ b/packages/playground/legacy/__tests__/legacy.spec.ts
@@ -45,11 +45,12 @@ test('generates assets', async () => {
   )
 })
 
-
 if (isBuild) {
   test('should generate correct manifest', async () => {
     const manifest = readManifest()
     expect(manifest['../../../vite/legacy-polyfills']).toBeDefined()
-    expect(manifest['../../../vite/legacy-polyfills'].src).toBe('../../../vite/legacy-polyfills')
+    expect(manifest['../../../vite/legacy-polyfills'].src).toBe(
+      '../../../vite/legacy-polyfills'
+    )
   })
 }

--- a/packages/playground/legacy/vite.config.js
+++ b/packages/playground/legacy/vite.config.js
@@ -10,6 +10,7 @@ module.exports = {
   ],
 
   build: {
+    manifest: true,
     rollupOptions: {
       output: {
         chunkFileNames(chunkInfo) {

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -41,7 +41,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
             const ext = path.extname(name)
             name = name.slice(0, -ext.length) + `-legacy` + ext
           }
-          return name
+          return name.replace(/\0/g, '')
         } else {
           return `_` + path.basename(chunk.fileName)
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Closes #6097
Closes #6208

Thanks to @khalwat for letting me know about the issue.
Related: https://github.com/vitejs/vite/pull/5601#issuecomment-998723120

Related: https://github.com/ElMassimo/vite_ruby/issues/156
Related: https://github.com/nystudio107/craft-vite/issues/20

/cc @StefSchenkelaars @ElMassimo I didn't tested this with latest version of vite-ruby but you might need to revert your changes.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
