### PR TITLE
fix: strip query when resolving entry

### DIFF
--- a/packages/playground/vue/ExternalStyleCss.vue
+++ b/packages/playground/vue/ExternalStyleCss.vue
@@ -1,0 +1,1 @@
+<style src="css-with-exports-field/dist/style.css"></style>

--- a/packages/playground/vue/Main.vue
+++ b/packages/playground/vue/Main.vue
@@ -20,6 +20,7 @@
   </Suspense>
   <ReactivityTransform :foo="time" />
   <SetupImportTemplate />
+  <ExternalStyleCss />
 </template>
 
 <script setup lang="ts">
@@ -35,6 +36,7 @@ import ScanDep from './ScanDep.vue'
 import AsyncComponent from './AsyncComponent.vue'
 import ReactivityTransform from './ReactivityTransform.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
+import ExternalStyleCss from './ExternalStyleCss.vue'
 
 import { ref } from 'vue'
 

--- a/packages/playground/vue/package.json
+++ b/packages/playground/vue/package.json
@@ -18,6 +18,7 @@
     "less": "^4.1.2",
     "pug": "^3.0.2",
     "sass": "^1.43.4",
-    "stylus": "^0.55.0"
+    "stylus": "^0.55.0",
+    "css-with-exports-field": "^1.0.0"
   }
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -802,6 +802,11 @@ function resolveDeepImport(
   targetWeb: boolean,
   options: InternalResolveOptions
 ): string | undefined {
+  // id might contain ?query
+  // e.g. when using `<style src="some-pkg/dist/style.css"></style>` in .vue file
+  // the id will be ./dist/style.css?vue&type=style&index=0&src=xxx&lang.css
+  // id = id.replace(/\?.*$/, '')
+
   const cache = getResolvedCache(id, targetWeb)
   if (cache) {
     return cache

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -104,7 +104,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
       }
 
       // fast path for commonjs proxy modules
-      if (/\?commonjs/.test(id) || id === 'commonjsHelpers.js') {
+      if (/commonjs/.test(id) || id === 'commonjsHelpers.js') {
         return
       }
 
@@ -805,7 +805,7 @@ function resolveDeepImport(
   // id might contain ?query
   // e.g. when using `<style src="some-pkg/dist/style.css"></style>` in .vue file
   // the id will be ./dist/style.css?vue&type=style&index=0&src=xxx&lang.css
-  id = id.replace(/\?.*$/, '')
+  id = id.split('?')[0]
 
   const cache = getResolvedCache(id, targetWeb)
   if (cache) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -104,7 +104,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
       }
 
       // fast path for commonjs proxy modules
-      if (/commonjs/.test(id) || id === 'commonjsHelpers.js') {
+      if (id.includes('commonjs') {
         return
       }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -104,7 +104,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
       }
 
       // fast path for commonjs proxy modules
-      if (id.includes('commonjs') {
+      if (/commonjs/.test(id) || id === 'commonjsHelpers.js') {
         return
       }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -104,7 +104,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
       }
 
       // fast path for commonjs proxy modules
-      if (/commonjs/.test(id) || id === 'commonjsHelpers.js') {
+      if (/\?commonjs/.test(id) || id === 'commonjsHelpers.js') {
         return
       }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -805,7 +805,7 @@ function resolveDeepImport(
   // id might contain ?query
   // e.g. when using `<style src="some-pkg/dist/style.css"></style>` in .vue file
   // the id will be ./dist/style.css?vue&type=style&index=0&src=xxx&lang.css
-  // id = id.replace(/\?.*$/, '')
+  id = id.replace(/\?.*$/, '')
 
   const cache = getResolvedCache(id, targetWeb)
   if (cache) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,6 +608,7 @@ importers:
   packages/playground/vue:
     specifiers:
       '@vitejs/plugin-vue': workspace:*
+      css-with-exports-field: ^1.0.0
       js-yaml: ^4.1.0
       less: ^4.1.2
       lodash-es: ^4.17.21
@@ -620,6 +621,7 @@ importers:
       vue: 3.2.25
     devDependencies:
       '@vitejs/plugin-vue': link:../../plugin-vue
+      css-with-exports-field: 1.0.0
       js-yaml: 4.1.0
       less: 4.1.2
       pug: 3.0.2
@@ -3719,6 +3721,16 @@ packages:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
 
+  /create-vite/2.7.2:
+    resolution: {integrity: sha512-4Eint1oL6GcZWGkgLbSmbzY1UNTkqQyjD9T4aM1YQsltKQ5ZNWDy+rvgYRPV9dR0XD6eLPs8TUUoge1xQCd4BA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      kolorist: 1.5.0
+      minimist: 1.2.5
+      prompts: 2.4.2
+    dev: false
+
   /cross-env/7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -3773,6 +3785,10 @@ packages:
   /css-unit-converter/1.1.2:
     resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
     dev: false
+
+  /css-with-exports-field/1.0.0:
+    resolution: {integrity: sha512-YCPKv36/w3+SrxwZ8E1FJXhDGTeGTKQmNA00VSePNTaO4VqSUdgB5XkhLL9qbF07m7Y+3nlTQJL5YLgRoewKFQ==}
+    dev: true
 
   /css/3.0.0:
     resolution: {integrity: sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==}


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

id might contain `?query`

e.g. when using `<style src="some-pkg/dist/style.css"></style>` in .vue file, the id will be ./dist/style.css?vue&type=style&index=0&src=xxx&lang.css

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
