### PR TITLE
feat(plugin-react): allow options.babel to be a function

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -172,19 +172,19 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         const isProjectFile =
           !isNodeModules && (id[0] === '\0' || id.startsWith(projectRoot + '/'))
 
-        let babelOptions = staticBabelOptions
+        let reactBabelOptions = staticBabelOptions
         if (typeof opts.babel === 'function') {
           const rawOptions = opts.babel(id, { ssr })
-          babelOptions = createBabelOptions(id, rawOptions, ssr)
-          runPluginOverrides(babelOptions)
-        } else if (!babelOptions) {
-          babelOptions = createBabelOptions(id, opts.babel, ssr)
-          if (!runPluginOverrides(babelOptions)) {
-            staticBabelOptions = babelOptions
+          reactBabelOptions = createBabelOptions(id, rawOptions, ssr)
+          runPluginOverrides(reactBabelOptions)
+        } else if (!reactBabelOptions) {
+          reactBabelOptions = createBabelOptions(id, opts.babel, ssr)
+          if (!runPluginOverrides(reactBabelOptions)) {
+            staticBabelOptions = reactBabelOptions
           }
         }
 
-        const plugins = isProjectFile ? [...babelOptions.plugins] : []
+        const plugins = isProjectFile ? [...reactBabelOptions.plugins] : []
 
         let useFastRefresh = false
         if (!skipFastRefresh && !ssr && !isNodeModules) {
@@ -251,15 +251,15 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         // module, including node_modules and linked packages.
         const shouldSkip =
           !plugins.length &&
-          !babelOptions.configFile &&
-          !(isProjectFile && babelOptions.babelrc)
+          !reactBabelOptions.configFile &&
+          !(isProjectFile && reactBabelOptions.babelrc)
 
         if (shouldSkip) {
           return // Avoid parsing if no plugins exist.
         }
 
-        const parserPlugins: typeof babelOptions.parserOpts.plugins = [
-          ...babelOptions.parserOpts.plugins,
+        const parserPlugins: typeof reactBabelOptions.parserOpts.plugins = [
+          ...reactBabelOptions.parserOpts.plugins,
           'importMeta',
           // This plugin is applied before esbuild transforms the code,
           // so we need to enable some stage 3 syntax that is supported in
@@ -283,6 +283,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
           : babel.transformAsync.bind(babel, code)
 
         const isReasonReact = extension.endsWith('.bs.js')
+        const { ssr: _ssr, file: _file, ...babelOptions } = reactBabelOptions
         const result = await transformAsync({
           ...babelOptions,
           ast: !isReasonReact,


### PR DESCRIPTION
### Description

This PR adds an `ssrPlugins` options to plugin-react that overrides the `babel.plugins` option for SSR because sometimes different transforms are needed in the browser than on the server.

**UPDATE:** We settled on allowing `options.babel` to be a function to solve the same problem more generally instead.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
