### PR TITLE
fix(ssr): nested destucture

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -433,3 +433,68 @@ const a = () => {
     "
   `)
 })
+
+test('nested object destructure alias', async () => {
+  expect(
+    (
+      await ssrTransform(
+        `
+import { remove, add, get, set, rest, objRest } from 'vue'
+
+function a() {
+  const {
+    o: { remove },
+    a: { b: { c: [ add ] }},
+    d: [{ get }, set, ...rest],
+    ...objRest
+  } = foo
+
+  remove()
+  add()
+  get()
+  set()
+  rest()
+  objRest()
+}
+
+remove()
+add()
+get()
+set()
+rest()
+objRest()
+`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "
+    const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+
+
+    function a() {
+      const {
+        o: { remove },
+        a: { b: { c: [ add ] }},
+        d: [{ get }, set, ...rest],
+        ...objRest
+      } = foo
+
+      remove()
+      add()
+      get()
+      set()
+      rest()
+      objRest()
+    }
+
+    __vite_ssr_import_0__.remove()
+    __vite_ssr_import_0__.add()
+    __vite_ssr_import_0__.get()
+    __vite_ssr_import_0__.set()
+    __vite_ssr_import_0__.rest()
+    __vite_ssr_import_0__.objRest()
+    "
+  `)
+})

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -7,8 +7,7 @@ import type {
   Node as _Node,
   Property,
   Function as FunctionNode,
-  Pattern,
-  RestElement
+  Pattern
 } from 'estree'
 import { extract_names as extractNames } from 'periscopic'
 import { walk as eswalk } from 'estree-walker'

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -6,7 +6,9 @@ import type {
   Identifier,
   Node as _Node,
   Property,
-  Function as FunctionNode
+  Function as FunctionNode,
+  Pattern,
+  RestElement
 } from 'estree'
 import { extract_names as extractNames } from 'periscopic'
 import { walk as eswalk } from 'estree-walker'
@@ -339,26 +341,31 @@ function walk(
       } else if (node.type === 'VariableDeclarator') {
         const parentFunction = findParentFunction(parentStack)
         if (parentFunction) {
-          if (node.id.type === 'ObjectPattern') {
-            node.id.properties.forEach((property) => {
-              if (property.type === 'RestElement') {
-                setScope(parentFunction, (property.argument as Identifier).name)
-              } else if (property.value.type === 'AssignmentPattern') {
-                setScope(
-                  parentFunction,
-                  (property.value.left as Identifier).name
-                )
-              } else {
-                setScope(parentFunction, (property.value as Identifier).name)
-              }
-            })
-          } else if (node.id.type === 'ArrayPattern') {
-            node.id.elements.filter(Boolean).forEach((element) => {
-              setScope(parentFunction, (element as Identifier).name)
-            })
-          } else {
-            setScope(parentFunction, (node.id as Identifier).name)
+          const handlePattern = (p: Pattern) => {
+            if (p.type === 'Identifier') {
+              setScope(parentFunction, p.name)
+            } else if (p.type === 'RestElement') {
+              handlePattern(p.argument)
+            } else if (p.type === 'ObjectPattern') {
+              p.properties.forEach((property) => {
+                if (property.type === 'RestElement') {
+                  setScope(
+                    parentFunction,
+                    (property.argument as Identifier).name
+                  )
+                } else handlePattern(property.value)
+              })
+            } else if (p.type === 'ArrayPattern') {
+              p.elements.forEach((element) => {
+                if (element) handlePattern(element)
+              })
+            } else if (p.type === 'AssignmentPattern') {
+              handlePattern(p.left)
+            } else {
+              setScope(parentFunction, (p as any).name)
+            }
           }
+          handlePattern(node.id)
         }
       }
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Hello again :)

This causing Vite transforming the wrong code of Vue runtime, making `<Suspense>` failed to work in Vitest.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
