### PR TITLE
fix: update the vue version in the error message

### DIFF
--- a/packages/plugin-vue/src/compiler.ts
+++ b/packages/plugin-vue/src/compiler.ts
@@ -15,7 +15,7 @@ export function resolveCompiler(root: string): typeof _compiler {
   if (!compiler) {
     throw new Error(
       `Failed to resolve vue/compiler-sfc.\n` +
-        `@vitejs/plugin-vue requires vue (>=3.2.13) or @vue/compiler-sfc ` +
+        `@vitejs/plugin-vue requires vue (>=3.2.25) ` +
         `to be present in the dependency tree.`
     )
   }


### PR DESCRIPTION
### Description

to match the peer dependency version in the `package.json`.

`@vue/compiler-sfc` is no longer used, therefore removed from the message.

Closes #6234

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
