### PR TITLE
feat: allow assets to be external instead of inline in lib mode.

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -222,6 +222,7 @@ export interface BuildOptions {
 export interface LibraryOptions {
   entry: string
   name?: string
+  noForceInlineAssets?: boolean
   formats?: LibraryFormats[]
   fileName?: string | ((format: ModuleFormat) => string)
 }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -333,7 +333,7 @@ async function fileToBuiltUrl(
 
   let url: string
   if (
-    config.build.lib ||
+    (config.build.lib && config.build.lib.noForceInlineAssets) ||
     (!file.endsWith('.svg') &&
       content.length < Number(config.build.assetsInlineLimit))
   ) {

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -142,14 +142,10 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
           encoding: 'utf8'
         })
         assets.forEach((asset) => {
-          if (asset.endsWith('.css')) {
-            data = `import './${asset}';\n${data}`
-          } else {
-            data = data.replace(
-              new RegExp(`var (.+?) = "${config.base || '/'}${asset}";`),
-              `import $1 from "./${asset}";`
-            )
-          }
+          data = data.replace(
+            new RegExp(`var (.+?) = "${config.base || '/'}${asset}";`),
+            `import $1 from "./${asset}";`
+          )
         })
         fs.writeFileSync(filePath, data)
       }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,4 +1,4 @@
-import path, { resolve } from 'path';
+import path, { resolve } from 'path'
 import { parse as parseUrl } from 'url'
 import fs, { promises as fsp } from 'fs'
 import mime from 'mime/lite'
@@ -113,39 +113,44 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     },
 
     writeBundle(options, bundle) {
-      if (!config || !config.build || !config.build.lib || options.format !== 'es') {
+      if (
+        !config ||
+        !config.build ||
+        !config.build.lib ||
+        options.format !== 'es'
+      ) {
         // only for lib mode and es build
-        return;
+        return
       }
-      const assets = [];
-      let entry = null;
+      const assets = []
+      let entry = null
       for (const key in bundle) {
         if (bundle[key].type === 'asset') {
-          assets.push(key);
+          assets.push(key)
           // @ts-ignore
         } else if (bundle[key].isEntry) {
-          entry = bundle[key];
+          entry = bundle[key]
         }
       }
       if (!entry) {
-        return;
+        return
       }
-      const outDir = config.build.outDir || 'dist';
-      const filePath = resolve(config.root, outDir, entry.fileName);
+      const outDir = config.build.outDir || 'dist'
+      const filePath = resolve(config.root, outDir, entry.fileName)
       let data = fs.readFileSync(filePath, {
-        encoding: 'utf8',
-      });
+        encoding: 'utf8'
+      })
       assets.forEach((asset) => {
         if (asset.endsWith('.css')) {
-          data = `import './${asset}';\n${data}`;
+          data = `import './${asset}';\n${data}`
         } else {
           data = data.replace(
             new RegExp(`var (.+?) = "${config.base || '/'}${asset}";`),
             `import $1 from "./${asset}";`
-          );
+          )
         }
-      });
-      fs.writeFileSync(filePath, data);
+      })
+      fs.writeFileSync(filePath, data)
     },
 
     generateBundle(_, bundle) {

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -120,12 +120,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       const assets = [];
       let entry = null;
       for (const key in bundle) {
-        if (
-          bundle[key].type === 'asset' &&
-          /.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$/.test(
-            key
-          )
-        ) {
+        if (bundle[key].type === 'asset') {
           assets.push(key);
           // @ts-ignore
         } else if (bundle[key].isEntry) {
@@ -141,10 +136,14 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
         encoding: 'utf8',
       });
       assets.forEach((asset) => {
-        data = data.replace(
-          new RegExp(`var (.+?) = "${config.base || '/'}${asset}";`),
-          `import $1 from "./${asset}";`
-        );
+        if (asset.endsWith('.css')) {
+          data = `import './${asset}';\n${data}`;
+        } else {
+          data = data.replace(
+            new RegExp(`var (.+?) = "${config.base || '/'}${asset}";`),
+            `import $1 from "./${asset}";`
+          );
+        }
       });
       fs.writeFileSync(filePath, data);
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

this PR solved #4454

As a newbie to vite, I have no idea whether this solution  or the option design is is good enough, but it works in my case. I can tweak this if any feedback. If this looks too stupid, sry to bother, pls close it at will.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This feature generate code like this in library mode:

```js
import { defineComponent, openBlock, createElementBlock, unref, ref, computed, watch, nextTick, onBeforeUnmount, onMounted, normalizeClass, Fragment, renderList, renderSlot, normalizeStyle, createVNode, withCtx, createCommentVNode, pushScopeId, popScopeId, createElementVNode, createTextVNode } from "vue";
import _imports_0$1 from "./assets/some-image.68d77419.png"; // <-
import _imports_1$1 from "./assets/other-image.58733637.png"; // <-

// ...
```

css (if any):

```css
/* added a dot in front of asset path */
.list-loading[data-v-5e2e31c0]{background:url(./assets/list-loading-dark.e0e27964.gif)}
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
