### PR TITLE
feat: add lerna workspace support to `searchForWorkspaceRoot`

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -580,6 +580,7 @@ createServer()
 
   - contains `workspaces` field in `package.json`
   - contains one of the following file
+    - `lerna.json`
     - `pnpm-workspace.yaml`
 
   Accepts a path to specify the custom workspace root. Could be a absolute path or a path relative to [project root](/guide/#index-html-and-project-root). For example:

--- a/packages/vite/src/node/server/__tests__/fixtures/lerna/nested/package.json
+++ b/packages/vite/src/node/server/__tests__/fixtures/lerna/nested/package.json
@@ -1,0 +1,3 @@
+{
+  "private": true
+}

--- a/packages/vite/src/node/server/__tests__/search-root.spec.ts
+++ b/packages/vite/src/node/server/__tests__/search-root.spec.ts
@@ -2,6 +2,13 @@ import { searchForWorkspaceRoot } from '../searchRoot'
 import { resolve } from 'path'
 
 describe('searchForWorkspaceRoot', () => {
+  test('lerna', () => {
+    const resolved = searchForWorkspaceRoot(
+      resolve(__dirname, 'fixtures/lerna/nested')
+    )
+    expect(resolved).toBe(resolve(__dirname, 'fixtures/lerna'))
+  })
+
   test('pnpm', () => {
     const resolved = searchForWorkspaceRoot(
       resolve(__dirname, 'fixtures/pnpm/nested')

--- a/packages/vite/src/node/server/searchRoot.ts
+++ b/packages/vite/src/node/server/searchRoot.ts
@@ -8,14 +8,17 @@ const ROOT_FILES = [
   // '.git',
 
   // https://pnpm.js.org/workspaces/
-  'pnpm-workspace.yaml'
+  'pnpm-workspace.yaml',
 
   // https://rushjs.io/pages/advanced/config_files/
   // 'rush.json',
 
   // https://nx.dev/latest/react/getting-started/nx-setup
   // 'workspace.json',
-  // 'nx.json'
+  // 'nx.json',
+
+  // https://github.com/lerna/lerna#lernajson
+  'lerna.json'
 ]
 
 // npm: https://docs.npmjs.com/cli/v7/using-npm/workspaces#installing-workspaces


### PR DESCRIPTION
### Description

Add support for lerna workspace in the `searchForWorkspaceRoot` function (needed due to `server.fs.strict` turned on by default).
This allow vite to serve content from a sibling packages which is symlinked with lerna.

A lerna workspace can be defined using a `lerna.json` file at the root of the project or via `workspaces: []` in the `package.json` (already supported).

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
