### PR TITLE
fix: don't force terser on non-legacy (fix #6266)

### DIFF
--- a/packages/playground/legacy/__tests__/legacy.spec.ts
+++ b/packages/playground/legacy/__tests__/legacy.spec.ts
@@ -1,4 +1,9 @@
-import { isBuild, readManifest, untilUpdated } from '../../testUtils'
+import {
+  findAssetFile,
+  isBuild,
+  readManifest,
+  untilUpdated
+} from '../../testUtils'
 
 test('should work', async () => {
   expect(await page.textContent('#app')).toMatch('Hello')
@@ -52,5 +57,20 @@ if (isBuild) {
     expect(manifest['../../../vite/legacy-polyfills'].src).toBe(
       '../../../vite/legacy-polyfills'
     )
+  })
+
+  test('should minify legacy chunks with terser', async () => {
+    // This is a ghetto heuristic, but terser output seems to reliably start
+    // with one of the following, and non-terser output (including unminified or
+    // ebuild-minified) does not!
+    const terserPatt = /^(?:!function|System.register)/
+
+    expect(findAssetFile(/chunk-async-legacy/)).toMatch(terserPatt)
+    expect(findAssetFile(/chunk-async\./)).not.toMatch(terserPatt)
+    expect(findAssetFile(/immutable-chunk-legacy/)).toMatch(terserPatt)
+    expect(findAssetFile(/immutable-chunk\./)).not.toMatch(terserPatt)
+    expect(findAssetFile(/index-legacy/)).toMatch(terserPatt)
+    expect(findAssetFile(/index\./)).not.toMatch(terserPatt)
+    expect(findAssetFile(/polyfills-legacy/)).toMatch(terserPatt)
   })
 }

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -105,23 +105,6 @@ function viteLegacyPlugin(options = {}) {
     name: 'vite:legacy-generate-polyfill-chunk',
     apply: 'build',
 
-    config() {
-      return {
-        build: {
-          minify: 'terser'
-        }
-      }
-    },
-
-    configResolved(config) {
-      if (!config.build.ssr && genLegacy && config.build.minify === 'esbuild') {
-        throw new Error(
-          `Can't use esbuild as the minifier when targeting legacy browsers ` +
-            `because esbuild minification is not legacy safe.`
-        )
-      }
-    },
-
     async generateBundle(opts, bundle) {
       if (config.build.ssr) {
         return
@@ -296,6 +279,11 @@ function viteLegacyPlugin(options = {}) {
       // @ts-ignore avoid esbuild transform on legacy chunks since it produces
       // legacy-unsafe code - e.g. rewriting object properties into shorthands
       opts.__vite_skip_esbuild__ = true
+
+      // @ts-ignore force terser for legacy chunks. This only takes effect if
+      // minification isn't disabled, because that leaves out the terser plugin
+      // entirely.
+      opts.__vite_force_terser__ = true
 
       const needPolyfills =
         options.polyfills !== false && !Array.isArray(options.polyfills)

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -33,6 +33,6 @@
     "systemjs": "^6.11.0"
   },
   "peerDependencies": {
-    "vite": "^2.0.0"
+    "vite": "^2.7.8"
   }
 }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -365,7 +365,7 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
     post: [
       buildImportAnalysisPlugin(config),
       buildEsbuildPlugin(config),
-      ...(options.minify === 'terser' ? [terserPlugin(config)] : []),
+      ...(options.minify ? [terserPlugin(config)] : []),
       ...(options.manifest ? [manifestPlugin(config)] : []),
       ...(options.ssrManifest ? [ssrManifestPlugin(config)] : []),
       buildReporterPlugin(config),

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -21,6 +21,17 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:terser',
 
     async renderChunk(code, _chunk, outputOptions) {
+      // This plugin is included for any non-false value of config.build.minify,
+      // so that normal chunks can use the preferred minifier, and legacy chunks
+      // can use terser.
+      if (
+        config.build.minify !== 'terser' &&
+        // @ts-ignore injected by @vitejs/plugin-legacy
+        !outputOptions.__vite_force_terser__
+      ) {
+        return null
+      }
+
       // Do not minify ES lib output since that would remove pure annotations
       // and break tree-shaking
       if (config.build.lib && outputOptions.format === 'es') {

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -4,18 +4,21 @@ import type { Terser } from 'types/terser'
 import type { ResolvedConfig } from '..'
 
 export function terserPlugin(config: ResolvedConfig): Plugin {
-  const worker = new Worker(
-    (basedir: string, code: string, options: Terser.MinifyOptions) => {
-      // when vite is linked, the worker thread won't share the same resolve
-      // root with vite itself, so we have to pass in the basedir and resolve
-      // terser first.
-      // eslint-disable-next-line node/no-restricted-require
-      const terserPath = require.resolve('terser', {
-        paths: [basedir]
-      })
-      return require(terserPath).minify(code, options) as Terser.MinifyOutput
-    }
-  )
+  const makeWorker = () =>
+    new Worker(
+      (basedir: string, code: string, options: Terser.MinifyOptions) => {
+        // when vite is linked, the worker thread won't share the same resolve
+        // root with vite itself, so we have to pass in the basedir and resolve
+        // terser first.
+        // eslint-disable-next-line node/no-restricted-require
+        const terserPath = require.resolve('terser', {
+          paths: [basedir]
+        })
+        return require(terserPath).minify(code, options) as Terser.MinifyOutput
+      }
+    )
+
+  let worker: ReturnType<typeof makeWorker>
 
   return {
     name: 'vite:terser',
@@ -33,10 +36,13 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
       }
 
       // Do not minify ES lib output since that would remove pure annotations
-      // and break tree-shaking
+      // and break tree-shaking.
       if (config.build.lib && outputOptions.format === 'es') {
         return null
       }
+
+      // Lazy load worker.
+      worker ||= makeWorker()
 
       const res = await worker.run(__dirname, code, {
         safari10: true,
@@ -52,7 +58,7 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
     },
 
     closeBundle() {
-      worker.stop()
+      worker?.stop()
     }
   }
 }


### PR DESCRIPTION
### Description

This fixes two misbehaviors of the legacy plugin:

1. Respect {minify: false} for legacy assets.
2. Don't inflict es2019/terser on non-legacy chunks.

For the first problem, we could have fixed by checking for false in
viteLegacyPlugin.config(). Unfortunately that would have left the second
problem unsolved. Without adding significant complexity to the config,
there's no easy way to use different minifiers in the build depending on
the individual chunk.

So instead we include terserPlugin() whenever minify is enabled, even
true or 'esbuild', then check the actual configuration in the plugin.
This allows the legacy plugin to inject its special override, leaving
all the non-legacy stuff intact and uncomplicated.

Fixes #6266

See also, previous attempts: #5157 #5168

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
