### PR TITLE
feat: runtime error overlay

### DIFF
--- a/packages/playground/runtime-error/__tests__/runtime.spec.ts
+++ b/packages/playground/runtime-error/__tests__/runtime.spec.ts
@@ -1,0 +1,165 @@
+import { isBuild } from '../../testUtils'
+
+interface testErrorOverlayOptions {
+  message: string | RegExp
+  file: string | RegExp | null
+  frame: (string | RegExp)[] | null
+  stack: (string | RegExp)[]
+}
+
+const testErrorOverlay = async (
+  btnSelector: string,
+  { message, file, frame, stack }: testErrorOverlayOptions
+) => {
+  await (await page.$(btnSelector)).click()
+
+  const overlay = await page.waitForSelector('vite-error-overlay')
+  expect(overlay).toBeTruthy()
+
+  const overlayMessage = await (await overlay.$('.message-body'))?.innerHTML()
+  expect(overlayMessage).toMatch(message)
+
+  const overlayFile =
+    (await (await overlay.$('.file > .file-link'))?.innerText()) || null
+
+  if (file == null) {
+    expect(overlayFile).toBeNull()
+  } else {
+    expect(overlayFile).toMatch(file)
+  }
+
+  const overlayFrame = (await (await overlay.$('.frame')).innerText()) || null
+
+  if (frame == null) {
+    expect(overlayFrame).toBeNull()
+  } else {
+    frame.forEach((f) => {
+      expect(overlayFrame).toMatch(f)
+    })
+  }
+
+  const overlayStack = await (await overlay.$('.stack')).innerText()
+  stack.forEach((s) => {
+    expect(overlayStack).toMatch(s)
+  })
+}
+
+if (!isBuild) {
+  beforeEach(async () => {
+    // reset the page before each run
+    // viteTestUrl is globally injected in scripts/jestPerTestSetup.ts
+    await page.goto(viteTestUrl)
+  })
+
+  describe('unhandled exceptions', () => {
+    test('should catch unhandled errors', async () => {
+      await testErrorOverlay('#throwBtn', {
+        message: 'Why did you click the button',
+        file: '/runtime-error/src/entry-client.ts:4:8',
+        frame: [
+          'querySelector<HTMLButtonElement>',
+          "new Error('Why did you click the button')"
+        ],
+        stack: [
+          'Error: Why did you click the button',
+          '/runtime-error/src/entry-client.ts:4:8'
+        ]
+      })
+    })
+
+    test('should catch runtime errors', async () => {
+      await testErrorOverlay('#invalidAccessor', {
+        message: 'Cannot set properties of undefined',
+        file: '/runtime-error/src/entry-client.ts:9:16',
+        frame: [
+          'querySelector<HTMLButtonElement>',
+          '//@ts-expect-error',
+          'window.doesnt.exists = 5'
+        ],
+        stack: [
+          'TypeError: Cannot set properties of undefined',
+          'HTMLButtonElement.document.querySelector.onclick',
+          '/runtime-error/src/entry-client.ts:9:16'
+        ]
+      })
+    })
+
+    test('should handle string errors', async () => {
+      await testErrorOverlay('#throwStr', {
+        message: 'String Error',
+        file: '/runtime-error/src/entry-client.ts:17:2',
+        frame: ['querySelector<HTMLButtonElement>', "throw 'String Error'"],
+        stack: [
+          "a non-error was thrown please check your browser's devtools for more information"
+        ]
+      })
+    })
+
+    test('should handle number errors', async () => {
+      await testErrorOverlay('#throwNum', {
+        message: '42',
+        file: '/runtime-error/src/entry-client.ts:21:2',
+        frame: ['querySelector<HTMLButtonElement>', 'throw 42'],
+        stack: [
+          "a non-error was thrown please check your browser's devtools for more information"
+        ]
+      })
+    })
+    test('should show stack trace from multiple files', async () => {
+      await testErrorOverlay('#throwExternal', {
+        message: 'Throw from externalThrow',
+        file: '/src/external.js:2:9',
+        frame: [
+          'export const externalThrow',
+          "throw new Error('Throw from externalThrow')"
+        ],
+        stack: [
+          'Error: Throw from externalThrow',
+          '/src/external.js',
+          '2:9',
+          'HTMLButtonElement.document.querySelector.onclick',
+          '/runtime-error/src/entry-client.ts:25:2'
+        ]
+      })
+    })
+  })
+
+  describe('unhandled rejections', () => {
+    test('should catch unhandled promises', async () => {
+      await testErrorOverlay('#reject', {
+        message: 'async failure',
+        file: '/runtime-error/src/entry-client.ts:13:17',
+        frame: ['const asyncFunc = async () => {', 'async failure'],
+        stack: [
+          'asyncFunc',
+          'runtime-error/src/entry-client.ts:13:17',
+          'HTMLButtonElement.document.querySelector.onclick',
+          'runtime-error/src/entry-client.ts:29:8'
+        ]
+      })
+    })
+
+    test('should handle uncaught string reason', async () => {
+      await testErrorOverlay('#rejectExternal', {
+        message: 'Reject from externalAsync',
+        file: null,
+        frame: null,
+        stack: [
+          "a non-error was thrown please check your browser's devtools for more information"
+        ]
+      })
+    })
+
+    test('should handle rejected module', async () => {
+      await testErrorOverlay('#rejectExternalModule', {
+        message: 'Thrown From Module',
+        file: '/runtime-error/src/module-thrown.ts:1:6',
+        frame: ["throw new Error('Thrown From Module')"],
+        stack: [
+          'Error: Thrown From Module',
+          '/runtime-error/src/module-thrown.ts:1:6'
+        ]
+      })
+    })
+  })
+}

--- a/packages/playground/runtime-error/__tests__/runtime.spec.ts
+++ b/packages/playground/runtime-error/__tests__/runtime.spec.ts
@@ -44,7 +44,13 @@ const testErrorOverlay = async (
   })
 }
 
-if (!isBuild) {
+if (isBuild) {
+  test('Should not show overlay in build', async () => {
+    await (await page.$('#throwBtn')).click()
+    const overlay = await page.$('vite-error-overlay')
+    expect(overlay).toBeFalsy()
+  })
+} else {
   beforeEach(async () => {
     // reset the page before each run
     // viteTestUrl is globally injected in scripts/jestPerTestSetup.ts

--- a/packages/playground/runtime-error/index.html
+++ b/packages/playground/runtime-error/index.html
@@ -12,6 +12,9 @@
     <button id="promise">Promise</button>
     <button id="throwStr">Throw String</button>
     <button id="throwNum">Throw Number</button>
+    <button id="throwExternal">Throw External</button>
+    <button id="rejectExternal">Reject External Import</button>
+    <button id="rejectExternalModule">Reject External Module</button>
     <script type="module" src="/src/entry-client.ts"></script>
     <!-- <script type="module">
       setTimeout(() => {

--- a/packages/playground/runtime-error/index.html
+++ b/packages/playground/runtime-error/index.html
@@ -9,6 +9,12 @@
     <h1>Runtime Error</h1>
     <button id="throwBtn">Throw Error</button>
     <button id="invalidAccessor">Invalid Accessor</button>
+    <button id="promise">Promise</button>
     <script type="module" src="/src/entry-client.ts"></script>
+    <!-- <script type="module">
+      setTimeout(() => {
+        throw new Error('Index Script')
+      }, 5000)
+    </script> -->
   </body>
 </html>

--- a/packages/playground/runtime-error/index.html
+++ b/packages/playground/runtime-error/index.html
@@ -9,10 +9,12 @@
     <h1>Runtime Error</h1>
     <button id="throwBtn">Throw Error</button>
     <button id="invalidAccessor">Invalid Accessor</button>
-    <button id="promise">Promise</button>
+
     <button id="throwStr">Throw String</button>
     <button id="throwNum">Throw Number</button>
     <button id="throwExternal">Throw External</button>
+
+    <button id="reject">reject</button>
     <button id="rejectExternal">Reject External Import</button>
     <button id="rejectExternalModule">Reject External Module</button>
     <script type="module" src="/src/entry-client.ts"></script>

--- a/packages/playground/runtime-error/index.html
+++ b/packages/playground/runtime-error/index.html
@@ -18,10 +18,5 @@
     <button id="rejectExternal">Reject External Import</button>
     <button id="rejectExternalModule">Reject External Module</button>
     <script type="module" src="/src/entry-client.ts"></script>
-    <!-- <script type="module">
-      setTimeout(() => {
-        throw new Error('Index Script')
-      }, 5000)
-    </script> -->
   </body>
 </html>

--- a/packages/playground/runtime-error/index.html
+++ b/packages/playground/runtime-error/index.html
@@ -8,6 +8,7 @@
   <body>
     <h1>Runtime Error</h1>
     <button id="throwBtn">Throw Error</button>
+    <button id="invalidAccessor">Invalid Accessor</button>
     <script type="module" src="/src/entry-client.ts"></script>
   </body>
 </html>

--- a/packages/playground/runtime-error/index.html
+++ b/packages/playground/runtime-error/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Run Time ErrorL</title>
+  </head>
+  <body>
+    <h1>Runtime Error</h1>
+    <button id="throwBtn">Throw Error</button>
+    <script type="module" src="/src/entry-client.ts"></script>
+  </body>
+</html>

--- a/packages/playground/runtime-error/index.html
+++ b/packages/playground/runtime-error/index.html
@@ -10,6 +10,8 @@
     <button id="throwBtn">Throw Error</button>
     <button id="invalidAccessor">Invalid Accessor</button>
     <button id="promise">Promise</button>
+    <button id="throwStr">Throw String</button>
+    <button id="throwNum">Throw Number</button>
     <script type="module" src="/src/entry-client.ts"></script>
     <!-- <script type="module">
       setTimeout(() => {

--- a/packages/playground/runtime-error/package.json
+++ b/packages/playground/runtime-error/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-runtime-error",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "preview": "vite preview"
+  }
+}

--- a/packages/playground/runtime-error/src/entry-client.ts
+++ b/packages/playground/runtime-error/src/entry-client.ts
@@ -5,3 +5,11 @@ document.querySelector<HTMLButtonElement>('#throwBtn').onclick = () => {
 document.querySelector<HTMLButtonElement>('#invalidAccessor').onclick = () => {
   window.doesnt.exists = 5
 }
+
+const asyncFunc = async () => {
+  throw new Error('async failure')
+}
+
+document.querySelector<HTMLButtonElement>('#promise').onclick = async () => {
+  await asyncFunc()
+}

--- a/packages/playground/runtime-error/src/entry-client.ts
+++ b/packages/playground/runtime-error/src/entry-client.ts
@@ -1,0 +1,3 @@
+document.querySelector<HTMLButtonElement>('#throwBtn').onclick = () => {
+  throw new Error('Why did you click the button')
+}

--- a/packages/playground/runtime-error/src/entry-client.ts
+++ b/packages/playground/runtime-error/src/entry-client.ts
@@ -16,7 +16,7 @@ document.querySelector<HTMLButtonElement>('#promise').onclick = async () => {
 }
 
 document.querySelector<HTMLButtonElement>('#throwStr').onclick = () => {
-  throw "String Error"
+  throw 'String Error'
 }
 
 document.querySelector<HTMLButtonElement>('#throwNum').onclick = () => {

--- a/packages/playground/runtime-error/src/entry-client.ts
+++ b/packages/playground/runtime-error/src/entry-client.ts
@@ -1,3 +1,7 @@
 document.querySelector<HTMLButtonElement>('#throwBtn').onclick = () => {
   throw new Error('Why did you click the button')
 }
+
+document.querySelector<HTMLButtonElement>('#invalidAccessor').onclick = () => {
+  window.doesnt.exists = 5
+}

--- a/packages/playground/runtime-error/src/entry-client.ts
+++ b/packages/playground/runtime-error/src/entry-client.ts
@@ -3,6 +3,7 @@ document.querySelector<HTMLButtonElement>('#throwBtn').onclick = () => {
 }
 
 document.querySelector<HTMLButtonElement>('#invalidAccessor').onclick = () => {
+  //@ts-expect-error
   window.doesnt.exists = 5
 }
 
@@ -12,4 +13,12 @@ const asyncFunc = async () => {
 
 document.querySelector<HTMLButtonElement>('#promise').onclick = async () => {
   await asyncFunc()
+}
+
+document.querySelector<HTMLButtonElement>('#throwStr').onclick = () => {
+  throw "String Error"
+}
+
+document.querySelector<HTMLButtonElement>('#throwNum').onclick = () => {
+  throw 42
 }

--- a/packages/playground/runtime-error/src/entry-client.ts
+++ b/packages/playground/runtime-error/src/entry-client.ts
@@ -10,11 +10,7 @@ document.querySelector<HTMLButtonElement>('#invalidAccessor').onclick = () => {
 }
 
 const asyncFunc = async () => {
-  throw new Error('async failure')
-}
-
-document.querySelector<HTMLButtonElement>('#promise').onclick = async () => {
-  await asyncFunc()
+  Promise.reject(new Error('async failure'))
 }
 
 document.querySelector<HTMLButtonElement>('#throwStr').onclick = () => {
@@ -29,12 +25,16 @@ document.querySelector<HTMLButtonElement>('#throwExternal').onclick = () => {
   externalThrow()
 }
 
-document.querySelector<HTMLButtonElement>('#rejectExternal').onclick =
-  async () => {
-    ;(await import('./external')).externalAsync()
-  }
+document.querySelector<HTMLButtonElement>('#reject').onclick = async () => {
+  await asyncFunc()
+}
 
 document.querySelector<HTMLButtonElement>('#rejectExternalModule').onclick =
   async () => {
     await import('./module-thrown')
+  }
+
+document.querySelector<HTMLButtonElement>('#rejectExternal').onclick =
+  async () => {
+    ;(await import('./external')).externalAsync()
   }

--- a/packages/playground/runtime-error/src/entry-client.ts
+++ b/packages/playground/runtime-error/src/entry-client.ts
@@ -1,3 +1,5 @@
+import { externalThrow } from './external'
+
 document.querySelector<HTMLButtonElement>('#throwBtn').onclick = () => {
   throw new Error('Why did you click the button')
 }
@@ -22,3 +24,17 @@ document.querySelector<HTMLButtonElement>('#throwStr').onclick = () => {
 document.querySelector<HTMLButtonElement>('#throwNum').onclick = () => {
   throw 42
 }
+
+document.querySelector<HTMLButtonElement>('#throwExternal').onclick = () => {
+  externalThrow()
+}
+
+document.querySelector<HTMLButtonElement>('#rejectExternal').onclick =
+  async () => {
+    ;(await import('./external')).externalAsync()
+  }
+
+document.querySelector<HTMLButtonElement>('#rejectExternalModule').onclick =
+  async () => {
+    await import('./module-thrown')
+  }

--- a/packages/playground/runtime-error/src/external.js
+++ b/packages/playground/runtime-error/src/external.js
@@ -3,5 +3,5 @@ export const externalThrow = () => {
 }
 
 export const externalAsync = async () => {
-  throw new Error('Rejection from externalAsync')
+  return Promise.reject('Reject from externalAsync')
 }

--- a/packages/playground/runtime-error/src/external.js
+++ b/packages/playground/runtime-error/src/external.js
@@ -1,0 +1,7 @@
+export const externalThrow = () => {
+  throw new Error('Throw from externalThrow')
+}
+
+export const externalAsync = async () => {
+  throw new Error('Rejection from externalAsync')
+}

--- a/packages/playground/runtime-error/src/module-thrown.ts
+++ b/packages/playground/runtime-error/src/module-thrown.ts
@@ -1,0 +1,1 @@
+throw new Error('Thrown From Module')

--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -40,6 +40,7 @@ const clientConfig = {
   input: path.resolve(__dirname, 'src/client/client.ts'),
   external: ['./env', '@vite/env'],
   plugins: [
+    nodeResolve(),
     typescript({
       target: 'es2018',
       include: ['src/client/**/*.ts'],
@@ -47,7 +48,8 @@ const clientConfig = {
       paths: {
         'types/*': ['../../types/*']
       }
-    })
+    }),
+    commonjs({ extensions: ['.js', '.ts'], sourceMap: true })
   ],
   output: {
     file: path.resolve(__dirname, 'dist/client', 'client.mjs'),

--- a/packages/vite/src/client/__tests__/error.spec.ts
+++ b/packages/vite/src/client/__tests__/error.spec.ts
@@ -1,67 +1,66 @@
-import type { StackLineInfo, StackLineResult } from '../error';
-import { getStackLineInformation } from '../error';
-
+import type { StackLineInfo, StackLineResult } from '../error'
+import { getStackLineInformation } from '../error'
 
 describe('getStackLineInformation', () => {
-    describe('chrome', () => {
-        test('should parse stack line', () => {
-            const input = '    at a (http://domain.com/script.js:1:11764)'
-            const result = getStackLineInformation(input)
+  describe('chrome', () => {
+    test('should parse stack line', () => {
+      const input = '    at a (http://domain.com/script.js:1:11764)'
+      const result = getStackLineInformation(input)
 
-            expect(result).toStrictEqual({
-                input,
-                varName: 'a',
-                url: 'http://domain.com/script.js',
-                line: 1,
-                column: 11764,
-                vendor: 'chrome'
-            })
-        })
-
-        test('should parse stack line with eval', () => {
-            const input = '    at Object.eval (eval at <anonymous> (http://domain.com/script.js:1:11764), <anonymous>:35:3729)'
-            const result = getStackLineInformation(input)
-
-            expect(result).toStrictEqual({
-                input,
-                varName: 'Object.eval',
-                url: 'http://domain.com/script.js',
-                line: 1,
-                column: 11764,
-                vendor: 'chrome'
-            })
-        })
+      expect(result).toStrictEqual({
+        input,
+        varName: 'a',
+        url: 'http://domain.com/script.js',
+        line: 1,
+        column: 11764,
+        vendor: 'chrome'
+      })
     })
 
-    describe('firefox', () => {
-        test('should parse stack line', () => {
-            const input = 'a@(http://domain.com/script.js:1:11764)'
-            const result = getStackLineInformation(input)
+    test('should parse stack line with eval', () => {
+      const input =
+        '    at Object.eval (eval at <anonymous> (http://domain.com/script.js:1:11764), <anonymous>:35:3729)'
+      const result = getStackLineInformation(input)
 
-            expect(result).toStrictEqual({
-                input,
-                varName: 'a',
-                url: 'http://domain.com/script.js',
-                line: 1,
-                column: 11764,
-                vendor: 'firefox'
-            })
-        })
-
-        test('should parse stack line with eval', () => {
-            const input = 'Object.eval@http://domain.com/script.js line 1 > eval line 1 > eval:35:3729'
-            const result = getStackLineInformation(input)
-
-            expect(result).toStrictEqual({
-                input,
-                varName: 'Object.eval',
-                url: 'http://domain.com/script.js',
-                line: 1,
-                column: 0,
-                vendor: 'firefox'
-            })
-        })
+      expect(result).toStrictEqual({
+        input,
+        varName: 'Object.eval',
+        url: 'http://domain.com/script.js',
+        line: 1,
+        column: 11764,
+        vendor: 'chrome'
+      })
     })
+  })
+
+  describe('firefox', () => {
+    test('should parse stack line', () => {
+      const input = 'a@(http://domain.com/script.js:1:11764)'
+      const result = getStackLineInformation(input)
+
+      expect(result).toStrictEqual({
+        input,
+        varName: 'a',
+        url: 'http://domain.com/script.js',
+        line: 1,
+        column: 11764,
+        vendor: 'firefox'
+      })
+    })
+
+    test('should parse stack line with eval', () => {
+      const input =
+        'Object.eval@http://domain.com/script.js line 1 > eval line 1 > eval:35:3729'
+      const result = getStackLineInformation(input)
+
+      expect(result).toStrictEqual({
+        input,
+        varName: 'Object.eval',
+        url: 'http://domain.com/script.js',
+        line: 1,
+        column: 0,
+        vendor: 'firefox'
+      })
+    })
+  })
 })
-
-// describe()

--- a/packages/vite/src/client/__tests__/error.spec.ts
+++ b/packages/vite/src/client/__tests__/error.spec.ts
@@ -1,0 +1,67 @@
+import type { StackLineInfo, StackLineResult } from '../error';
+import { getStackLineInformation } from '../error';
+
+
+describe('getStackLineInformation', () => {
+    describe('chrome', () => {
+        test('should parse stack line', () => {
+            const input = '    at a (http://domain.com/script.js:1:11764)'
+            const result = getStackLineInformation(input)
+
+            expect(result).toStrictEqual({
+                input,
+                varName: 'a',
+                url: 'http://domain.com/script.js',
+                line: 1,
+                column: 11764,
+                vendor: 'chrome'
+            })
+        })
+
+        test('should parse stack line with eval', () => {
+            const input = '    at Object.eval (eval at <anonymous> (http://domain.com/script.js:1:11764), <anonymous>:35:3729)'
+            const result = getStackLineInformation(input)
+
+            expect(result).toStrictEqual({
+                input,
+                varName: 'Object.eval',
+                url: 'http://domain.com/script.js',
+                line: 1,
+                column: 11764,
+                vendor: 'chrome'
+            })
+        })
+    })
+
+    describe('firefox', () => {
+        test('should parse stack line', () => {
+            const input = 'a@(http://domain.com/script.js:1:11764)'
+            const result = getStackLineInformation(input)
+
+            expect(result).toStrictEqual({
+                input,
+                varName: 'a',
+                url: 'http://domain.com/script.js',
+                line: 1,
+                column: 11764,
+                vendor: 'firefox'
+            })
+        })
+
+        test('should parse stack line with eval', () => {
+            const input = 'Object.eval@http://domain.com/script.js line 1 > eval line 1 > eval:35:3729'
+            const result = getStackLineInformation(input)
+
+            expect(result).toStrictEqual({
+                input,
+                varName: 'Object.eval',
+                url: 'http://domain.com/script.js',
+                line: 1,
+                column: 0,
+                vendor: 'firefox'
+            })
+        })
+    })
+})
+
+// describe()

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -8,11 +8,9 @@ import type {
 } from 'types/hmrPayload'
 import type { CustomEventName } from 'types/customEvent'
 import { ErrorOverlay, overlayId } from './overlay'
-import { getStackLineInformation, isStackLineInfo, transformError } from './error'
+import { getStackLineInformation, isStackLineInfo, transformError, generateErrorPayload } from './error'
 // eslint-disable-next-line node/no-missing-import
 import '@vite/env'
-import type { RawSourceMap } from 'source-map'
-import { SourceMapConsumer } from 'source-map'
 
 // injected by the hmr plugin when served
 declare const __BASE__: string
@@ -489,176 +487,6 @@ export function injectQuery(url: string, queryToInject: string): string {
   }`
 }
 
-const extractSourceMapData = (fileContent: string) => {
-  const re = /[#@]\ssourceMappingURL=\s*(\S+)/gm
-  let match: RegExpExecArray | null = null
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const next = re.exec(fileContent)
-    if (next == null) {
-      break
-    }
-    match = next
-  }
-
-  if (!(match && match[0])) {
-    return null
-  }
-
-  return match[1]
-}
-
-const getSourceMapForFile = async (
-  fileName: string
-): Promise<{
-  sourceMapConsumer?: SourceMapConsumer
-  baseSource: string
-}> => {
-  const source = await (await fetch(fileName)).text()
-  const sourceMapData = extractSourceMapData(source)
-
-  if (!sourceMapData) {
-    return { baseSource: source }
-  }
-
-  // TODO: extract this string to a const
-  if (sourceMapData.indexOf('data:application/json;base64,') === 0) {
-    let sm = sourceMapData.substring('data:application/json;base64,'.length)
-    sm = window.atob(sm)
-    const sourceMapConsumer = new SourceMapConsumer(
-      JSON.parse(sm) as RawSourceMap
-    )
-
-    return {
-      baseSource: source,
-      sourceMapConsumer
-    }
-  }
-
-  // TODO: add support for url source maps
-  return {
-    baseSource: source
-  }
-}
-
-const generateFrame = (
-  line: number,
-  column: number,
-  source: string,
-  count = 2
-): string => {
-  const lines = source.split('\n')
-  const result: string[] = []
-
-  for (
-    let index = Math.max(0, line - 1 - count);
-    index <= Math.min(lines.length - 1, line - 1 + count);
-    ++index
-  ) {
-    const lineNumber = index + 1
-    result.push(`${lineNumber.toString().padEnd(3)}|  ${lines[index]}`)
-    if (index === line - 1) {
-      result.push(
-        ' '.padStart(Math.max(index.toString().length, 3)) +
-          '|  ' +
-          '^'.padStart(column + 1)
-      )
-    }
-  }
-
-  return result.join('\n')
-}
-
-
-
-const transformStackTrace = async (stack: string): Promise<string> => {
-  return (
-    await Promise.all(
-      stack.split('\n').map(async (l) => {
-        const result =
-          getStackLineInformation(l)
-
-        if (!isStackLineInfo(result)) return result.input
-
-        const { input, varName, url, line, column, vendor } = result;
-        const { sourceMapConsumer } = await getSourceMapForFile(url)
-
-        if (!(sourceMapConsumer instanceof SourceMapConsumer)) {
-          return input
-        }
-
-        const pos = sourceMapConsumer.originalPositionFor({
-          line: line,
-          column: column
-        })
-
-        if (!pos.source) {
-          return input
-        }
-
-        if (vendor === 'chrome') {
-          const source = `${pos.source}:${pos.line || 0}:${pos.column || 0}`
-          if (!varName || varName === 'eval') {
-            return `    at ${source}`
-          } else {
-            return `    at ${varName} (${source})`
-          }
-        } else {
-          // TODO: strip eval and function
-          return `${varName}@${pos.source}:${pos.line || 0}:${pos.column || 0}`
-        }
-      })
-    )
-  ).join('\n')
-}
-
-//TODO: better support for files without source maps
-const generateErrorPayload = async (
-  message: string,
-  filename: string,
-  lineno: number,
-  colno: number,
-  stack: string
-): Promise<ErrorPayload['err']> => {
-  const { sourceMapConsumer, baseSource } = await getSourceMapForFile(filename)
-
-  let source = baseSource
-  let loc = {
-    line: lineno,
-    column: colno,
-    file: filename
-  }
-  if (sourceMapConsumer instanceof SourceMapConsumer) {
-    const {
-      line,
-      column,
-      source: sourceFileName
-    } = sourceMapConsumer.originalPositionFor({
-      line: lineno,
-      column: colno
-    })
-
-    source = sourceMapConsumer.sourceContentFor(sourceFileName)
-    loc = {
-      file:
-        sourceFileName && !filename.includes('@vite')
-          ? sourceFileName
-          : loc.file,
-      line,
-      column
-    }
-  }
-
-  const frame = generateFrame(loc.line, loc.column, source)
-
-  return {
-    message,
-    stack: await transformStackTrace(stack),
-    loc,
-    frame
-  }
-}
-
 const exceptionHandler = async (e: ErrorEvent): Promise<void> => {
   try {
     const error = transformError(e.error)
@@ -672,10 +500,8 @@ const exceptionHandler = async (e: ErrorEvent): Promise<void> => {
     )
 
     createErrorOverlay(payload)
-  } catch (err: Error) {
-    // TODO handle errors that we throw
-    console.log(err)
-    // frame = err.message;
+  } catch (err: unknown) {
+    console.error('Failed to generate error overlay', err)
   }
 }
 
@@ -707,10 +533,8 @@ const rejectionHandler = async (e: PromiseRejectionEvent): Promise<void> => {
     )
 
     createErrorOverlay(payload)
-  } catch (err: Error) {
-    // TODO handle errors that we throw
-    console.log(err)
-    // frame = err.message;
+  } catch (err: unknown) {
+    console.error('Failed to generate error overlay', err)
   }
 }
 

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -8,7 +8,12 @@ import type {
 } from 'types/hmrPayload'
 import type { CustomEventName } from 'types/customEvent'
 import { ErrorOverlay, overlayId } from './overlay'
-import { getStackLineInformation, isStackLineInfo, transformError, generateErrorPayload } from './error'
+import {
+  getStackLineInformation,
+  isStackLineInfo,
+  transformError,
+  generateErrorPayload
+} from './error'
 // eslint-disable-next-line node/no-missing-import
 import '@vite/env'
 
@@ -538,10 +543,9 @@ const rejectionHandler = async (e: PromiseRejectionEvent): Promise<void> => {
   }
 }
 
-if(enableOverlay) {
+if (enableOverlay) {
   window.addEventListener('error', exceptionHandler)
   window.addEventListener('unhandledrejection', rejectionHandler)
 }
-
 
 export { ErrorOverlay }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -538,8 +538,10 @@ const rejectionHandler = async (e: PromiseRejectionEvent): Promise<void> => {
   }
 }
 
-// TODO: respect __HMR_ENABLE_OVERLAY__
-window.addEventListener('error', exceptionHandler)
-window.addEventListener('unhandledrejection', rejectionHandler)
+if(enableOverlay) {
+  window.addEventListener('error', exceptionHandler)
+  window.addEventListener('unhandledrejection', rejectionHandler)
+}
+
 
 export { ErrorOverlay }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -694,6 +694,25 @@ const exceptionHandler =
     callback(payload)
   }
 
+const rejectionHandler =
+  (callback: ErrorOverlayCallback) =>
+  async (e: PromiseRejectionEvent): Promise<void> => {
+    
+    // TODO: get frame from stack trace
+    const payload: ErrorPayload['err'] = {
+      message: e.reason.message,
+      stack: await transformStackTrace(e.reason.stack)
+      // loc: {
+      //   column: position.column,
+      //   line: position.line,
+      //   file: fileName
+      // },
+      // frame
+    }
+
+    callback(payload)
+  }
+
 const showErrorOverlay = (err: ErrorPayload['err']) => {
   console.log(err)
   const overlay = new ErrorOverlay(err)
@@ -702,7 +721,10 @@ const showErrorOverlay = (err: ErrorPayload['err']) => {
 
 // TODO: respect __HMR_ENABLE_OVERLAY__
 window.addEventListener('error', exceptionHandler(showErrorOverlay))
-// window.addEventListener('unhandledrejection', rejectionHandler(showErrorOverlay))
+window.addEventListener(
+  'unhandledrejection',
+  rejectionHandler(showErrorOverlay)
+)
 
 // setTimeout(() => {
 //   throw new Error('External Module Error')

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -703,7 +703,6 @@ const rejectionHandler =
     // Chromes will include the erroe message as the first line of the stack trace so we have to check for a match or check the next line
     if (!stackInfo.url) {
       stackInfo = getStackInformation(stackLines[1])
-      console.log(stackInfo);
       if (!stackInfo.url) {
         console.error('failed to get source info for rejection')
         return

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -555,7 +555,7 @@ const generateFrame = (
     ++index
   ) {
     const lineNumber = index + 1
-    result.push(`${lineNumber}  |  ${lines[index]}`)
+    result.push(`${lineNumber.toString().padEnd(3)}|  ${lines[index]}`)
     if (index === line - 1) {
       result.push(
         Array(index.toString().length).fill(' ').join('') +

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -697,7 +697,6 @@ const exceptionHandler =
 const rejectionHandler =
   (callback: ErrorOverlayCallback) =>
   async (e: PromiseRejectionEvent): Promise<void> => {
-    
     // TODO: get frame from stack trace
     const payload: ErrorPayload['err'] = {
       message: e.reason.message,

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -727,14 +727,19 @@ const exceptionHandler =
 const rejectionHandler =
   (callback: ErrorOverlayCallback) =>
   async (e: PromiseRejectionEvent): Promise<void> => {
+    const error = transformError(e.reason)
     // Since promisejectection doesn't return the file we have to get it from the stack trace
-    const stackLines = e.reason.stack.split('\n')
+    const stackLines = error.stack!.split('\n')
     let stackInfo = getStackInformation(stackLines[0])
-    // Chromes will include the erroe message as the first line of the stack trace so we have to check for a match or check the next line
+    // Chromes will include the error message as the first line of the stack trace so we have to check for a match or check the next line
     if (!stackInfo.url) {
       stackInfo = getStackInformation(stackLines[1])
       if (!stackInfo.url) {
-        console.error('failed to get source info for rejection')
+        const payload: ErrorPayload['err'] = {
+          message: error.message,
+          stack: error.stack!
+        }
+        callback(payload)
         return
       }
     }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -509,14 +509,6 @@ const extractSourceMapData = (fileContetnt: string) => {
   return match[1]
 }
 
-const findRealPath = (
-  fileName: string,
-  sources: string[]
-): string | undefined => {
-  const filePath = new URL(fileName).pathname
-  return sources.find((path) => path.includes(filePath))
-}
-
 const getSourceMapForFile = async (
   fileName: string
 ): Promise<{
@@ -540,7 +532,7 @@ const getSourceMapForFile = async (
 
     return {
       baseSource: source,
-      sourceMapConsumer,
+      sourceMapConsumer
     }
   }
 
@@ -577,20 +569,6 @@ const generateFrame = (
   return result.join('\n')
 }
 
-// const regexValidFrame_Chrome = /^\s*(at|in)\s.+(:\d+)/;
-// const regexValidFrame_FireFox = /(^|@)\S+:\d+|.+line\s+\d+\s+>\s+(eval|Function).+/;
-
-// const transformStack = (stack: string) => {
-//   return stack.split('\n')
-//   .filter(
-//     e => regexValidFrame_Chrome.test(e) || regexValidFrame_FireFox.test(e)
-//   )
-//   .map((e) => {
-//     return e
-//   })
-//   .join('\n')
-// }
-
 const exceptionHandler =
   (callback: ErrorOverlayCallback) =>
   async (e: ErrorEvent): Promise<void> => {
@@ -600,14 +578,17 @@ const exceptionHandler =
     let position = { column: e.colno, line: e.lineno }
     let stack = e.error.stack
     try {
-      const {
-        sourceMapConsumer,
-        baseSource,
-      } = await getSourceMapForFile(e.filename)
+      const { sourceMapConsumer, baseSource } = await getSourceMapForFile(
+        e.filename
+      )
 
-      let source = baseSource;
+      let source = baseSource
       if (sourceMapConsumer instanceof SourceMapConsumer) {
-        const { line, column, source: sourceFileName } = sourceMapConsumer.originalPositionFor({
+        const {
+          line,
+          column,
+          source: sourceFileName
+        } = sourceMapConsumer.originalPositionFor({
           line: e.lineno,
           column: e.colno
         })
@@ -620,8 +601,6 @@ const exceptionHandler =
       }
 
       frame = generateFrame(position.line, position.column, source)
-
-      // stack = transformStack(stack)
     } catch (err: Error) {
       // TODO handle errors that we throw
       console.log(err)
@@ -652,6 +631,8 @@ const showErrorOverlay = (err: ErrorPayload['err']) => {
 window.addEventListener('error', exceptionHandler(showErrorOverlay))
 // window.addEventListener('unhandledrejection', rejectionHandler(showErrorOverlay))
 
-setTimeout(() => {throw new Error('External Module Error')}, 2000)
+// setTimeout(() => {
+//   throw new Error('External Module Error')
+// }, 2000)
 
 export { ErrorOverlay }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -570,10 +570,10 @@ const generateFrame = (
 }
 
 const RE_CHROME_STACKTRACE =
-  /^ {4}at (?:(.+?)\s+\()?(?:(.+?)\?+)(?:(?:.+?):(\d+)(?::(\d+))?)\)?/
+  /^ {4}at (?:(.+?)\s+)?\(?(.+?)(?::(\d+))?(?::(\d+))?\)?$/
 
 const RE_FIREFOX_STACKTRACE =
-  /(?:(?:(^|.+?)@)(?:(.+?)\?+))(?:(?:.+?):(\d+)(?::(\d+))?)\)?/
+  /^(?:(?:(^|.+?)@))\(?(.+?)(?::(\d+))?(?::(\d+))?\)?$/
 
 const transformStackTrace = async (stack: string) => {
   const getStackInformation = (line: string) => {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -490,12 +490,12 @@ export function injectQuery(url: string, queryToInject: string): string {
 
 type ErrorOverlayCallback = (err: ErrorPayload['err']) => void
 
-const extractSourceMapData = (fileContetnt: string) => {
+const extractSourceMapData = (fileContent: string) => {
   const re = /[#@]\ssourceMappingURL=\s*(\S+)/gm
   let match: RegExpExecArray | null = null
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const next = re.exec(fileContetnt)
+    const next = re.exec(fileContent)
     if (next == null) {
       break
     }
@@ -705,7 +705,6 @@ const exceptionHandler =
   (callback: ErrorOverlayCallback) =>
   async (e: ErrorEvent): Promise<void> => {
     try {
-      console.log(e)
       const error = transformError(e.error)
 
       const payload = await generateErrorPayload(
@@ -728,13 +727,14 @@ const rejectionHandler =
   (callback: ErrorOverlayCallback) =>
   async (e: PromiseRejectionEvent): Promise<void> => {
     const error = transformError(e.reason)
-    // Since promisejectection doesn't return the file we have to get it from the stack trace
+    // Since promise rejection doesn't return the file we have to get it from the stack trace
     const stackLines = error.stack!.split('\n')
     let stackInfo = getStackInformation(stackLines[0])
     // Chromes will include the error message as the first line of the stack trace so we have to check for a match or check the next line
     if (!stackInfo.url) {
       stackInfo = getStackInformation(stackLines[1])
       if (!stackInfo.url) {
+        // no stack trace create a basic overlay
         const payload: ErrorPayload['err'] = {
           message: error.message,
           stack: error.stack!
@@ -762,7 +762,6 @@ const rejectionHandler =
   }
 
 const showErrorOverlay = (err: ErrorPayload['err']) => {
-  console.log(err)
   const overlay = new ErrorOverlay(err)
   document.body.appendChild(overlay)
 }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -536,7 +536,9 @@ const getSourceMapForFile = async (
   }
 
   // TODO: add support for url source maps
-  throw new Error('Only base64 source maps are supported')
+  return {
+    baseSource: source
+  }
 }
 
 const generateFrame = (
@@ -687,11 +689,10 @@ const rejectionHandler = async (e: PromiseRejectionEvent): Promise<void> => {
     stackInfo = getStackLineInformation(stackLines[1])
     if (!isStackLineInfo(stackInfo)) {
       // no stack trace create a basic overlay
-      const payload: ErrorPayload['err'] = {
+      createErrorOverlay({
         message: error.message,
         stack: error.stack!
-      }
-      createErrorOverlay(payload)
+      })
       return
     }
   }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -557,7 +557,8 @@ const generateFrame = (
     const lineNumber = index + 1
     result.push(`${lineNumber.toString().padEnd(3)}|  ${lines[index]}`)
     if (index === line - 1) {
-      result.push(" ".padStart(Math.max(index.toString().length, 3)) +
+      result.push(
+        ' '.padStart(Math.max(index.toString().length, 3)) +
           '|  ' +
           '^'.padStart(column + 1)
       )
@@ -643,14 +644,21 @@ const transformStackTrace = async (stack: string) => {
   ).join('\n')
 }
 
-const generateErrorPayload = async (message: string, filename: string, lineno: number, colno: number, stack: string): Promise<ErrorPayload['err']> => {
-  const { sourceMapConsumer, baseSource } = await getSourceMapForFile(
-    filename
-  )
+//TODO: better support for files without source maps
+const generateErrorPayload = async (
+  message: string,
+  filename: string,
+  lineno: number,
+  colno: number,
+  stack: string
+): Promise<ErrorPayload['err']> => {
+  const { sourceMapConsumer, baseSource } = await getSourceMapForFile(filename)
 
   let source = baseSource
   let loc = {
-    line: lineno, column: colno, file: filename
+    line: lineno,
+    column: colno,
+    file: filename
   }
   if (sourceMapConsumer instanceof SourceMapConsumer) {
     const {
@@ -663,11 +671,17 @@ const generateErrorPayload = async (message: string, filename: string, lineno: n
     })
 
     source = sourceMapConsumer.sourceContentFor(sourceFileName)
-    loc = {file: sourceFileName && !filename.includes('@vite') ? sourceFileName : loc.file, line,column }
+    loc = {
+      file:
+        sourceFileName && !filename.includes('@vite')
+          ? sourceFileName
+          : loc.file,
+      line,
+      column
+    }
   }
 
   const frame = generateFrame(loc.line, loc.column, source)
-
 
   return {
     message,
@@ -678,8 +692,8 @@ const generateErrorPayload = async (message: string, filename: string, lineno: n
 }
 
 const transformError = (error: any): Error => {
-  if(error instanceof Error) {
-    return error;
+  if (error instanceof Error) {
+    return error
   }
 
   const e = Error(error ?? 'unknown')
@@ -694,9 +708,15 @@ const exceptionHandler =
       console.log(e)
       const error = transformError(e.error)
 
-      const payload = await generateErrorPayload(error.message, e.filename, e.lineno, e.colno, error.stack!)
+      const payload = await generateErrorPayload(
+        error.message,
+        e.filename,
+        e.lineno,
+        e.colno,
+        error.stack!
+      )
 
-      callback(payload);
+      callback(payload)
     } catch (err: Error) {
       // TODO handle errors that we throw
       console.log(err)
@@ -720,15 +740,20 @@ const rejectionHandler =
     }
 
     try {
-      const payload = await generateErrorPayload(e.reason.message, stackInfo.url, Number(stackInfo.lineNo), Number(stackInfo.columnNo), e.reason.stack)
+      const payload = await generateErrorPayload(
+        e.reason.message,
+        stackInfo.url,
+        Number(stackInfo.lineNo),
+        Number(stackInfo.columnNo),
+        e.reason.stack
+      )
 
-      callback(payload);
+      callback(payload)
     } catch (err: Error) {
       // TODO handle errors that we throw
       console.log(err)
       // frame = err.message;
     }
-
   }
 
 const showErrorOverlay = (err: ErrorPayload['err']) => {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -515,7 +515,7 @@ const rejectionHandler = async (e: PromiseRejectionEvent): Promise<void> => {
   // Since promise rejection doesn't return the file we have to get it from the stack trace
   const stackLines = error.stack!.split('\n')
   let stackInfo = getStackLineInformation(stackLines[0])
-  // Chromes will include the error message as the first line of the stack trace so we have to check for a match or check the next line
+  // Chrome will include the error message as the first line of the stack trace so we have to check for a match or check the next line
   if (!isStackLineInfo(stackInfo)) {
     stackInfo = getStackLineInformation(stackLines[1])
     if (!isStackLineInfo(stackInfo)) {

--- a/packages/vite/src/client/error.ts
+++ b/packages/vite/src/client/error.ts
@@ -1,4 +1,4 @@
-import type { RawSourceMap} from 'source-map';
+import type { RawSourceMap } from 'source-map'
 import { SourceMapConsumer } from 'source-map'
 import type { ErrorPayload } from 'types/hmrPayload'
 
@@ -18,20 +18,19 @@ const RE_CHROME_STACKTRACE =
 const RE_FIREFOX_STACKTRACE =
   /^(?:(?:(^|.+?)@))\(?(.+?)(?::(\d+))?(?::(\d+))?\)?$/
 
-
 export interface StackLineInfo {
-    input: string
-    varName: string
-    url: string
-    line: number
-    column: number
-    vendor: 'chrome' | 'firefox'
+  input: string
+  varName: string
+  url: string
+  line: number
+  column: number
+  vendor: 'chrome' | 'firefox'
 }
 
 export type StackLineResult = Partial<StackLineInfo> & { input: string }
 
 export const isStackLineInfo = (res: StackLineResult): res is StackLineInfo => {
-    return res.url !== undefined;
+  return res.url !== undefined
 }
 
 export const getStackLineInformation = (line: string): StackLineResult => {
@@ -39,10 +38,10 @@ export const getStackLineInformation = (line: string): StackLineResult => {
   if (match) {
     let [input, varName, body, line, column] = match
     // strip eval
-    if(body.indexOf('eval at') !== -1) {
+    if (body.indexOf('eval at') !== -1) {
       body = body.replace(/(eval at.*\()|(\),.*)/g, '')
-      const lcMatch = /(.*):(\d+)?:(\d+)?$/.exec(body);
-      if(lcMatch) {
+      const lcMatch = /(.*):(\d+)?:(\d+)?$/.exec(body)
+      if (lcMatch) {
         body = lcMatch[1]
         line = lcMatch[2]
         column = lcMatch[3]
@@ -69,11 +68,13 @@ export const getStackLineInformation = (line: string): StackLineResult => {
     let [input, varName, body, line, column] = match
     // strip eval & function
 
-
-    if((/> eval|Function/).test(body)) {
-      body = body.replace(/ line (\d+)(?: > eval line \d+|(?: > eval|Function))*/,':$1')
-      const lcMatch = /(.*):(\d+)/.exec(body);
-      if(lcMatch) {
+    if (/> eval|Function/.test(body)) {
+      body = body.replace(
+        / line (\d+)(?: > eval line \d+|(?: > eval|Function))*/,
+        ':$1'
+      )
+      const lcMatch = /(.*):(\d+)/.exec(body)
+      if (lcMatch) {
         body = lcMatch[1]
         line = lcMatch[2]
         column = ''
@@ -180,18 +181,15 @@ const generateFrame = (
   return result.join('\n')
 }
 
-
-
 const transformStackTrace = async (stack: string): Promise<string> => {
   return (
     await Promise.all(
       stack.split('\n').map(async (l) => {
-        const result =
-          getStackLineInformation(l)
+        const result = getStackLineInformation(l)
 
         if (!isStackLineInfo(result)) return result.input
 
-        const { input, varName, url, line, column, vendor } = result;
+        const { input, varName, url, line, column, vendor } = result
         const { sourceMapConsumer } = await getSourceMapForFile(url)
 
         if (!(sourceMapConsumer instanceof SourceMapConsumer)) {

--- a/packages/vite/src/client/error.ts
+++ b/packages/vite/src/client/error.ts
@@ -1,0 +1,99 @@
+import type { ErrorPayload } from 'types/hmrPayload'
+
+export const transformError = (error: any): Error => {
+  if (error instanceof Error) {
+    return error
+  }
+
+  const e = Error(error ?? 'unknown')
+  e.stack = `a non-error was thrown please check your browser's devtools for more information`
+  return e
+}
+
+// TODO Clean up these regex
+const RE_CHROME_STACKTRACE =
+  /^ {4}at (?:(.+?)\s+)?\(?(.+?)(?::(\d+))?(?::(\d+))?\)?$/
+const RE_FIREFOX_STACKTRACE =
+  /^(?:(?:(^|.+?)@))\(?(.+?)(?::(\d+))?(?::(\d+))?\)?$/
+
+
+export interface StackLineInfo {
+    input: string
+    varName: string
+    url: string
+    line: number
+    column: number
+    vendor: 'chrome' | 'firefox'
+}
+
+export type StackLineResult = Partial<StackLineInfo> & { input: string }
+
+export const isStackLineInfo = (res: StackLineResult): res is StackLineInfo => {
+    return res.url !== undefined;
+}
+
+export const getStackLineInformation = (line: string): StackLineResult => {
+  let match = RE_CHROME_STACKTRACE.exec(line)
+  if (match) {
+    let [input, varName, body, line, column] = match
+    // strip eval
+    if(body.indexOf('eval at') !== -1) {
+      body = body.replace(/(eval at.*\()|(\),.*)/g, '')
+      const lcMatch = /(.*):(\d+)?:(\d+)?$/.exec(body);
+      if(lcMatch) {
+        body = lcMatch[1]
+        line = lcMatch[2]
+        column = lcMatch[3]
+      } else {
+        // can't extract line column
+        return {
+          input
+        }
+      }
+    }
+
+    return {
+      input,
+      varName,
+      url: body,
+      line: Number(line),
+      column: Number(column),
+      vendor: 'chrome' as const
+    }
+  }
+
+  match = RE_FIREFOX_STACKTRACE.exec(line)
+  if (match) {
+    let [input, varName, body, line, column] = match
+    // strip eval & function
+
+
+    if((/> eval|Function/).test(body)) {
+      body = body.replace(/ line (\d+)(?: > eval line \d+|(?: > eval|Function))*/,':$1')
+      const lcMatch = /(.*):(\d+)/.exec(body);
+      if(lcMatch) {
+        body = lcMatch[1]
+        line = lcMatch[2]
+        column = ''
+      } else {
+        return {
+          // can't extract column
+          input
+        }
+      }
+    }
+
+    return {
+      input: input,
+      varName: varName,
+      url: body,
+      line: Number(line),
+      column: Number(column),
+      vendor: 'firefox' as const
+    }
+  }
+
+  return {
+    input: line
+  }
+}

--- a/packages/vite/src/client/error.ts
+++ b/packages/vite/src/client/error.ts
@@ -12,7 +12,6 @@ export const transformError = (error: any): Error => {
   return e
 }
 
-// TODO Clean up these regex
 const RE_CHROME_STACKTRACE =
   /^ {4}at (?:(.+?)\s+)?\(?(.+?)(?::(\d+))?(?::(\d+))?\)?$/
 const RE_FIREFOX_STACKTRACE =
@@ -46,7 +45,7 @@ export const getStackLineInformation = (line: string): StackLineResult => {
         line = lcMatch[2]
         column = lcMatch[3]
       } else {
-        // can't extract line column
+        // can't extract column
         return {
           input
         }
@@ -79,8 +78,8 @@ export const getStackLineInformation = (line: string): StackLineResult => {
         line = lcMatch[2]
         column = ''
       } else {
+        // can't extract column
         return {
-          // can't extract column
           input
         }
       }
@@ -133,7 +132,6 @@ const getSourceMapForFile = async (
     return { baseSource: source }
   }
 
-  // TODO: extract this string to a const
   if (sourceMapData.indexOf('data:application/json;base64,') === 0) {
     let sm = sourceMapData.substring('data:application/json;base64,'.length)
     sm = window.atob(sm)
@@ -213,7 +211,6 @@ const transformStackTrace = async (stack: string): Promise<string> => {
             return `    at ${varName} (${source})`
           }
         } else {
-          // TODO: strip eval and function
           return `${varName}@${pos.source}:${pos.line || 0}:${pos.column || 0}`
         }
       })

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -158,9 +158,9 @@ export class ErrorOverlay extends HTMLElement {
     if (!linkFiles) {
       el.textContent = text
     } else {
-      if(!fileRE.test(text)){
+      if (!fileRE.test(text)) {
         el.textContent = text
-        return;
+        return
       } else {
         fileRE.lastIndex = 0
       }

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -158,6 +158,12 @@ export class ErrorOverlay extends HTMLElement {
     if (!linkFiles) {
       el.textContent = text
     } else {
+      if(!fileRE.test(text)){
+        el.textContent = text
+        return;
+      } else {
+        fileRE.lastIndex = 0
+      }
       let curIndex = 0
       let match: RegExpExecArray | null
       while ((match = fileRE.exec(text))) {

--- a/packages/vite/src/client/tsconfig.json
+++ b/packages/vite/src/client/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["./", "../../types"],
+  "exclude": ["**/__tests__"],
   "compilerOptions": {
     "outDir": "../../dist/client",
     "module": "esnext",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,12 +716,6 @@ importers:
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.16.5
       hash-sum: 2.0.0
 
-  packages/temp:
-    specifiers:
-      css-color-names: ^1.0.1
-    devDependencies:
-      css-color-names: 1.0.1
-
   packages/vite:
     specifiers:
       '@ampproject/remapping': ^1.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
   packages/playground/resolve/inline-package:
     specifiers: {}
 
+  packages/playground/runtime-error:
+    specifiers: {}
+
   packages/playground/ssr-deps:
     specifiers:
       bcrypt: ^5.0.1
@@ -712,6 +715,12 @@ importers:
       '@rollup/pluginutils': 4.1.2
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.16.5
       hash-sum: 2.0.0
+
+  packages/temp:
+    specifiers:
+      css-color-names: ^1.0.1
+    devDependencies:
+      css-color-names: 1.0.1
 
   packages/vite:
     specifiers:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #2076

To add support for runtime error overlays using vites built in overlay.

it is currently possible to use `create-react-app`'s react-error-overlay in vite but this experience is subpar to how server errors are currently handled

### Additional context

This works as a base impetration but i would love to get some feedback on potential addition features and unknowns.
- [Collapsing React's error stack](https://github.com/facebook/create-react-app/blob/9673858a3715287c40aef9e800c431c7d45c05a2/packages/react-error-overlay/src/effects/proxyConsole.js#L26-L69) 
  - potentially the same for vue. i've never worked with vue before so I'm unfamiliar to how errors are handled
  - Should we provide a api for plugins to extend this so we don't have to handle errors for every possible framework ie `import.meta.error`
- How should multiple errors be handled
  - Should we show multiple overlays at the same time an require multiple clicks from the user
  - Should be collect multiple errors and provide a button to toggle between them
- Should the user be able to [follow the stack trace down with sources](https://raw.githubusercontent.com/gregberge/error-overlay-webpack-plugin/master/docs/example.png)
- Should users be able to view the error in source and compiled

https://user-images.githubusercontent.com/32745766/147496218-491de50c-46ea-413f-a8a0-1ed5d833395d.mp4

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
