### PR TITLE
fix: prevent dev server crashing on malformed URI (fix #6300)

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -99,7 +99,7 @@ export function transformMiddleware(
       }
     }
 
-    let url:string
+    let url: string
     try {
       url = decodeURI(removeTimestampQuery(req.url!)).replace(
         NULL_BYTE_PLACEHOLDER,

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -98,7 +98,6 @@ export function transformMiddleware(
         return
       }
     }
-
     let url: string
     try {
       url = decodeURI(removeTimestampQuery(req.url!)).replace(
@@ -106,8 +105,7 @@ export function transformMiddleware(
         '\0'
       )
     } catch (e) {
-      res.end(`Bad request: ${e.message}`)
-      return
+      return next(e)
     }
 
     const withoutQuery = cleanUrl(url)

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -99,10 +99,16 @@ export function transformMiddleware(
       }
     }
 
-    let url = decodeURI(removeTimestampQuery(req.url!)).replace(
-      NULL_BYTE_PLACEHOLDER,
-      '\0'
-    )
+    let url:string
+    try {
+      url = decodeURI(removeTimestampQuery(req.url!)).replace(
+        NULL_BYTE_PLACEHOLDER,
+        '\0'
+      )
+    } catch (e) {
+      res.end(`Bad request: ${e.message}`)
+      return
+    }
 
     const withoutQuery = cleanUrl(url)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---
when there is URIError, the dev server will crash because it didn't catch the error
reprodution : open url like  http://localhost:3000/a%a