### PR TITLE
feat: option to disable pre-transform

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -564,7 +564,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         )
 
       // pre-transform known direct imports
-      if (staticImportedUrls.size) {
+      if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach((url) => {
           transformRequest(unwrapId(removeImportQuery(url)), server, { ssr })
         })

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -98,6 +98,7 @@ export interface ServerOptions extends CommonServerOptions {
   /**
    * Pre-transform known direct imports
    *
+   * @expiremental this options is expiremental and might be changed in the future
    * @default true
    */
   preTransformRequests?: boolean

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -97,7 +97,7 @@ export interface ServerOptions extends CommonServerOptions {
   origin?: string
   /**
    * Pre-transform known direct imports
-   * 
+   *
    * @default true
    */
   preTransformRequests?: boolean
@@ -700,7 +700,7 @@ export function resolveServerOptions(
 ): ResolvedServerOptions {
   const server: ResolvedServerOptions = {
     preTransformRequests: true,
-    ...raw as ResolvedServerOptions,
+    ...(raw as ResolvedServerOptions)
   }
   let allowDirs = server.fs?.allow
   const deny = server.fs?.deny || ['.env', '.env.*', '*.{crt,pem}']

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -95,6 +95,12 @@ export interface ServerOptions extends CommonServerOptions {
    * Origin for the generated asset URLs.
    */
   origin?: string
+  /**
+   * Pre-transform known direct imports
+   * 
+   * @default true
+   */
+  preTransformRequests?: boolean
 }
 
 export interface ResolvedServerOptions extends ServerOptions {
@@ -692,7 +698,10 @@ export function resolveServerOptions(
   root: string,
   raw?: ServerOptions
 ): ResolvedServerOptions {
-  const server = raw || {}
+  const server: ResolvedServerOptions = {
+    preTransformRequests: true,
+    ...raw as ResolvedServerOptions,
+  }
   let allowDirs = server.fs?.allow
   const deny = server.fs?.deny || ['.env', '.env.*', '*.{crt,pem}']
 
@@ -713,7 +722,7 @@ export function resolveServerOptions(
     allow: allowDirs,
     deny
   }
-  return server as ResolvedServerOptions
+  return server
 }
 
 async function restartServer(server: ViteDevServer) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pre-transformation is a brilliant optimization to improve the waterfall requests for browsers. But when it's been used for other senario (Vitest, Nuxt, etc.) with lower request overhead, this sometimes could become a negative optimization.

Resolves https://github.com/vitest-dev/vitest/issues/229#issuecomment-1002685027

### Additional context

Another option is to provide the option in `transformRequest`, but that requires a bit complex options passing for plugins and might introduce too much complexity.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
