### PR TITLE
fix: use `hires: true` for SSR require hook source map

### DIFF
--- a/packages/vite/src/node/plugins/ssrRequireHook.ts
+++ b/packages/vite/src/node/plugins/ssrRequireHook.ts
@@ -31,7 +31,8 @@ export function ssrRequireHookPlugin(config: ResolvedConfig): Plugin | null {
         return {
           code: s.toString(),
           map: s.generateMap({
-            source: id
+            source: id,
+            hires: true
           })
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I believe this is the one spot in the Vite codebase where `hires: true` was missed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
