### PR TITLE
docs(lib-mode): add a caveat to the build.minify docs for 'es' format

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -786,6 +786,8 @@ export default defineConfig({
 - **Default:** `'esbuild'`
 
   Set to `false` to disable minification, or specify the minifier to use. The default is [Esbuild](https://github.com/evanw/esbuild) which is 20 ~ 40x faster than terser and only 1 ~ 2% worse compression. [Benchmarks](https://github.com/privatenumber/minification-benchmarks)
+  
+  Note the `build.minify` option is not available when using the `'es'` format in lib mode.
 
 ### build.terserOptions
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -786,7 +786,7 @@ export default defineConfig({
 - **Default:** `'esbuild'`
 
   Set to `false` to disable minification, or specify the minifier to use. The default is [Esbuild](https://github.com/evanw/esbuild) which is 20 ~ 40x faster than terser and only 1 ~ 2% worse compression. [Benchmarks](https://github.com/privatenumber/minification-benchmarks)
-  
+
   Note the `build.minify` option is not available when using the `'es'` format in lib mode.
 
 ### build.terserOptions


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Update docs to reflect that the `build.minify` option does not work in "lib mode" for the `'es'` format.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

see this commit for reference: https://github.com/vitejs/vite/commit/06d86e4a2e90ca916a43d450bca1e6c28bc4bfe2

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
