### PR TITLE
fix: chunk split for dynamic import dep

### DIFF
--- a/packages/playground/dynamic-import/dep-a/index.js
+++ b/packages/playground/dynamic-import/dep-a/index.js
@@ -1,0 +1,1 @@
+export default () => 'A@2.0.0'

--- a/packages/playground/dynamic-import/dep-a/package.json
+++ b/packages/playground/dynamic-import/dep-a/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep-a",
+  "version": "2.0.0",
+  "main": "index.js"
+}

--- a/packages/playground/dynamic-import/package.json
+++ b/packages/playground/dynamic-import/package.json
@@ -7,5 +7,8 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "dep-a": "file:./dep-a"
   }
 }

--- a/packages/playground/dynamic-import/views/bar.js
+++ b/packages/playground/dynamic-import/views/bar.js
@@ -1,1 +1,4 @@
+import getName from 'dep-a'
+console.log('bar' + getName())
+
 export const msg = 'Bar view'

--- a/packages/playground/dynamic-import/vite.config.js
+++ b/packages/playground/dynamic-import/vite.config.js
@@ -2,6 +2,9 @@ const fs = require('fs')
 const path = require('path')
 
 module.exports = {
+  resolve: {
+    preserveSymlinks: true
+  },
   plugins: [
     {
       name: 'copy',

--- a/packages/playground/dynamic-import/vite.config.js
+++ b/packages/playground/dynamic-import/vite.config.js
@@ -5,6 +5,9 @@ module.exports = {
   resolve: {
     preserveSymlinks: true
   },
+  optimizeDeps: {
+    exclude: ['dep-a']
+  },
   plugins: [
     {
       name: 'copy',

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -700,7 +700,7 @@ function resolveDynamicImportEntry(
   id: string,
   getModuleInfo: GetModuleInfo,
   importStack: string[] = []
-): string | void {
+): string | undefined {
   const mod = getModuleInfo(id)
   if (!mod || importStack.includes(id)) {
     return
@@ -710,8 +710,8 @@ function resolveDynamicImportEntry(
     mod.dynamicImporters.length > 0 &&
     mod.dynamicImporters.some((importer) => !importer.includes('node_modules'))
   ) {
+    const dirs = id.split(path.sep)
     if (id.includes('node_modules')) {
-      const dirs = id.split(path.sep)
       const nodeModulesIndex = dirs.lastIndexOf('node_modules')
       let packageName = dirs[nodeModulesIndex + 1]
       if (packageName.startsWith('@')) {
@@ -719,10 +719,12 @@ function resolveDynamicImportEntry(
       }
       return packageName
     }
-    return path.basename(id, path.extname(id))
+    let [parentDir, basename] = dirs.slice(-2)
+    basename = basename.replace(path.extname(basename), '')
+    return `${parentDir}-${basename}`
   }
 
-  let entry
+  let entry: string | undefined
   for (const importer of mod.importers) {
     entry = resolveDynamicImportEntry(
       importer,
@@ -733,6 +735,7 @@ function resolveDynamicImportEntry(
       return entry
     }
   }
+  return
 }
 
 export function resolveLibFilename(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,12 @@ importers:
     specifiers: {}
 
   packages/playground/dynamic-import:
+    specifiers:
+      dep-a: file:./dep-a
+    dependencies:
+      dep-a: link:dep-a
+
+  packages/playground/dynamic-import/dep-a:
     specifiers: {}
 
   packages/playground/env:
@@ -712,6 +718,12 @@ importers:
       '@rollup/pluginutils': 4.1.2
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.16.5
       hash-sum: 2.0.0
+
+  packages/temp:
+    specifiers:
+      css-color-names: ^1.0.1
+    devDependencies:
+      css-color-names: 1.0.1
 
   packages/vite:
     specifiers:
@@ -4616,7 +4628,7 @@ packages:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=}
 
   /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -6212,7 +6224,7 @@ packages:
       sourcemap-codec: 1.4.8
 
   /make-dir/2.1.0:
-    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
+    resolution: {integrity: sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=}
     engines: {node: '>=6'}
     requiresBuild: true
     dependencies:
@@ -7319,7 +7331,7 @@ packages:
     dev: true
 
   /pvutils/1.0.17:
-    resolution: {integrity: sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==}
+    resolution: {integrity: sha1-rePHTf5xeJRP5EgGYmvS4knZlr8=}
     engines: {node: '>=6.0.0'}
     dev: true
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For a dynamic import module，the application code and the third-party dep code will be seperated.In the meanwhile, each async-vendor will be divided in terms of dynamic import entry, instead of all being packaged into a single file, so huge async vendor can be avoided.

See details in #6289. 


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
