### PR TITLE
docs(react): document opting out of automatic JSX runtime

### DIFF
--- a/packages/plugin-react/README.md
+++ b/packages/plugin-react/README.md
@@ -33,6 +33,16 @@ react({
 })
 ```
 
+## Opting out of the automatic JSX runtime
+
+By default, the plugin uses the [automatic JSX runtime](https://github.com/alloc/vite-react-jsx#faq). However, if you encounter any issues, you may opt out using the `jsxRuntime` option.
+
+```js
+react({
+  jsxRuntime: 'classic'
+})
+```
+
 ## Babel configuration
 
 The `babel` option lets you add plugins, presets, and [other configuration](https://babeljs.io/docs/en/options) to the Babel transformation performed on each JSX/TSX file.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR documents opting out of the automatic JSX runtime for the React plugin.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This documents a workaround for people having issues with "React is not defined" for certain dependencies in the production build of their application.

https://github.com/vitejs/vite/issues/5608

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
