### PR TITLE
refactor: rewrite vendor chunk to handle redirect exports

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/vendorAnalysis.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/vendorAnalysis.spec.ts
@@ -79,6 +79,13 @@ describe('plugin mock', () => {
         export const foo = 1
       `,
       '/node_modules/dep/dep3.js': `
+        import 'dep4'
+        export * from 'dep5'
+      `,
+      '/node_modules/dep/dep4.js': `
+        export default 4
+      `,
+      '/node_modules/dep/dep5.js': `
         export default 2
         export const foo = 3
       `
@@ -90,7 +97,9 @@ describe('plugin mock', () => {
       dep: '/node_modules/dep/index.js',
       dep1: '/node_modules/dep/dep1.js',
       dep2: '/node_modules/dep/dep2.js',
-      dep3: '/node_modules/dep/dep3.js'
+      dep3: '/node_modules/dep/dep3.js',
+      dep4: '/node_modules/dep/dep4.js',
+      dep5: '/node_modules/dep/dep5.js'
     }
 
     const getModuleInfo = (id: string): ModuleInfo | null => {
@@ -134,7 +143,11 @@ describe('plugin mock', () => {
     expect(manualChunks('/node_modules/dep/dep1.js')).toBeUndefined()
     // dep2 shouldn't since it's not imported by index.js
     expect(manualChunks('/node_modules/dep/dep2.js')).toBeUndefined()
-    // dep3 should be a vendor chunk
-    expect(manualChunks('/node_modules/dep/dep3.js')).toBe('vendor')
+    // dep3 shouldn't, rollup will handle this
+    expect(manualChunks('/node_modules/dep/dep3.js')).toBeUndefined()
+    // dep4 should since it's imported by dep3
+    expect(manualChunks('/node_modules/dep/dep4.js')).toBe('vendor')
+    // dep5 should since it's imported by dep3
+    expect(manualChunks('/node_modules/dep/dep5.js')).toBe('vendor')
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/vendorAnalysis.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/vendorAnalysis.spec.ts
@@ -1,0 +1,140 @@
+import type { ModuleInfo, ResolvedId } from 'rollup'
+import {
+  buildVendorAnalysisPlugin,
+  exportFromRE,
+  importRE,
+  splitAsRE
+} from '../../plugins/vendorAnalysis'
+
+describe('regexp tests', () => {
+  const [, exps] = 'export { default, foo as bar } from "foo.js"'.match(
+    exportFromRE
+  )
+  const [, expsMulti] = `export {
+    default,
+    foo as bar
+  } from "foo.js"`.match(exportFromRE)
+
+  test('export from', () => {
+    expect(exps.trim()).toBe('default, foo as bar')
+    expect(expsMulti.trim()).toBe('default,\n    foo as bar')
+  })
+
+  test('split as', () => {
+    const [exp1, exp2] = expsMulti.split(',')
+
+    const [, impName1, alias1] = exp1.trim().match(splitAsRE) || []
+    expect(impName1).toBe('default')
+    expect(alias1).toBeFalsy()
+
+    const [, impName2, alias2] = exp2.trim().match(splitAsRE) || []
+    expect(impName2).toBe('foo')
+    expect(alias2).toBe('bar')
+  })
+
+  test('import', () => {
+    const [, impDef, imps] =
+      'import def, { foo, bar as alias } from "foo.js"'.match(importRE) || []
+    expect(impDef).toBe('def')
+    expect(imps).toBe(' foo, bar as alias ')
+  })
+})
+
+describe('plugin mock', () => {
+  test('disable when manualChunks is set', () => {
+    const plugin = buildVendorAnalysisPlugin()
+
+    expect(
+      plugin.outputOptions.call(
+        {},
+        { manualChunks: undefined, __vite_vendor_chunk__: true }
+      )
+    ).toBeUndefined()
+  })
+
+  test('disable when __vite_vendor_chunk__ is false', () => {
+    const plugin = buildVendorAnalysisPlugin()
+
+    expect(
+      plugin.outputOptions.call({}, { __vite_vendor_chunk__: false })
+    ).toBeUndefined()
+  })
+
+  test('in vendor or not', async () => {
+    const plugin = buildVendorAnalysisPlugin()
+
+    const modules = {
+      '/index.js': `
+        import { bar } from 'dep'
+      `,
+      '/node_modules/dep/index.js': `
+        export { foo as bar } from 'dep1'
+        export { foo } from 'dep2'
+      `,
+      '/node_modules/dep/dep1.js': `
+        export * from 'dep3'
+      `,
+      '/node_modules/dep/dep2.js': `
+        export default 0
+        export const foo = 1
+      `,
+      '/node_modules/dep/dep3.js': `
+        export default 2
+        export const foo = 3
+      `
+    }
+
+    const moduleIds = Object.keys(modules)
+
+    const resolveMap = {
+      dep: '/node_modules/dep/index.js',
+      dep1: '/node_modules/dep/dep1.js',
+      dep2: '/node_modules/dep/dep2.js',
+      dep3: '/node_modules/dep/dep3.js'
+    }
+
+    const getModuleInfo = (id: string): ModuleInfo | null => {
+      if (!(id in modules)) return null
+      const code = modules[id]
+      return {
+        id,
+        code,
+        isEntry: id === '/index.js'
+      } as ModuleInfo
+    }
+
+    const resolve = async (
+      imp: string,
+      importer: string
+    ): Promise<ResolvedId | null> => {
+      if (!(imp in resolveMap)) return null
+      return {
+        id: resolveMap[imp]
+      } as ResolvedId
+    }
+
+    const getModuleIds = () => moduleIds
+
+    await plugin.buildEnd.call({
+      getModuleInfo,
+      resolve,
+      getModuleIds
+    })
+
+    const manualChunks = plugin.outputOptions.call(
+      {},
+      { __vite_vendor_chunk__: true }
+    ).manualChunks as (id: string) => string | undefined
+
+    // it's a source module, not a vendor module
+    expect(manualChunks('/index.js')).toBeUndefined()
+    // dep shouldn't be a vendor chunk since it's just redirects
+    expect(manualChunks('/node_modules/dep/index.js')).toBeUndefined()
+    // dep1 shouldn't since it just redirects dep3
+    expect(manualChunks('/node_modules/dep/dep1.js')).toBeUndefined()
+    // dep2 shouldn't since it's not imported by index.js
+    expect(manualChunks('/node_modules/dep/dep2.js')).toBeUndefined()
+    // dep3 should be a vendor chunk
+    expect(manualChunks('/node_modules/dep/dep3.js')).toBe('vendor')
+  })
+})

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -12,8 +12,6 @@ import type {
   OutputOptions,
   RollupOutput,
   ExternalOption,
-  GetManualChunk,
-  GetModuleInfo,
   WatcherOptions,
   RollupWatcher,
   RollupError,
@@ -37,12 +35,12 @@ import { dataURIPlugin } from './plugins/dataUri'
 import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
 import { resolveSSRExternal, shouldExternalizeForSSR } from './ssr/ssrExternal'
 import { ssrManifestPlugin } from './ssr/ssrManifestPlugin'
-import { isCSSRequest } from './plugins/css'
 import type { DepOptimizationMetadata } from './optimizer'
 import { scanImports } from './optimizer/scan'
 import { assetImportMetaUrlPlugin } from './plugins/assetImportMetaUrl'
 import { loadFallbackPlugin } from './plugins/loadFallback'
 import { watchPackageDataPlugin } from './packages'
+import { buildVendorAnalysisPlugin } from './plugins/vendorAnalysis'
 
 export interface BuildOptions {
   /**
@@ -364,6 +362,7 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
     ],
     post: [
       buildImportAnalysisPlugin(config),
+      buildVendorAnalysisPlugin(config),
       buildEsbuildPlugin(config),
       ...(options.minify ? [terserPlugin(config)] : []),
       ...(options.manifest ? [manifestPlugin(config)] : []),
@@ -490,36 +489,46 @@ async function doBuild(
         )
       }
 
-      return {
-        dir: outDir,
-        format: ssr ? 'cjs' : 'es',
-        exports: ssr ? 'named' : 'auto',
-        sourcemap: options.sourcemap,
-        name: libOptions ? libOptions.name : undefined,
-        entryFileNames: ssr
-          ? `[name].js`
-          : libOptions
-          ? resolveLibFilename(libOptions, output.format || 'es', config.root)
-          : path.posix.join(options.assetsDir, `[name].[hash].js`),
-        chunkFileNames: libOptions
-          ? `[name].js`
-          : path.posix.join(options.assetsDir, `[name].[hash].js`),
-        assetFileNames: libOptions
-          ? `[name].[ext]`
-          : path.posix.join(options.assetsDir, `[name].[hash].[ext]`),
-        // #764 add `Symbol.toStringTag` when build es module into cjs chunk
-        // #1048 add `Symbol.toStringTag` for module default export
-        namespaceToStringTag: true,
-        inlineDynamicImports: ssr && typeof input === 'string',
-        manualChunks:
-          !ssr &&
-          !libOptions &&
-          output?.format !== 'umd' &&
-          output?.format !== 'iife'
-            ? createMoveToVendorChunkFn(config)
-            : undefined,
-        ...output
-      }
+      return new Proxy(
+        {
+          dir: outDir,
+          format: ssr ? 'cjs' : 'es',
+          exports: ssr ? 'named' : 'auto',
+          sourcemap: options.sourcemap,
+          name: libOptions ? libOptions.name : undefined,
+          entryFileNames: ssr
+            ? `[name].js`
+            : libOptions
+            ? resolveLibFilename(libOptions, output.format || 'es', config.root)
+            : path.posix.join(options.assetsDir, `[name].[hash].js`),
+          chunkFileNames: libOptions
+            ? `[name].js`
+            : path.posix.join(options.assetsDir, `[name].[hash].js`),
+          assetFileNames: libOptions
+            ? `[name].[ext]`
+            : path.posix.join(options.assetsDir, `[name].[hash].[ext]`),
+          // #764 add `Symbol.toStringTag` when build es module into cjs chunk
+          // #1048 add `Symbol.toStringTag` for module default export
+          namespaceToStringTag: true,
+          inlineDynamicImports: ssr && typeof input === 'string',
+          ...output
+        },
+        {
+          get(target, prop) {
+            // @ts-ignore
+            if (prop in target) return target[prop]
+            if (prop === '__vite_vendor_chunk__')
+              // tell vendorAnalysisPlugin if vendor chunk is needed
+              // using a proxy to prevent rollup from throwing a warning
+              return (
+                !ssr &&
+                !libOptions &&
+                output?.format !== 'umd' &&
+                output?.format !== 'iife'
+              )
+          }
+        }
+      )
     }
 
     // resolve lib mode outputs
@@ -642,55 +651,6 @@ function getPkgName(root: string) {
   const { name } = JSON.parse(lookupFile(root, ['package.json']) || `{}`)
 
   return name?.startsWith('@') ? name.split('/')[1] : name
-}
-
-function createMoveToVendorChunkFn(config: ResolvedConfig): GetManualChunk {
-  const cache = new Map<string, boolean>()
-  return (id, { getModuleInfo }) => {
-    if (
-      id.includes('node_modules') &&
-      !isCSSRequest(id) &&
-      staticImportedByEntry(id, getModuleInfo, cache)
-    ) {
-      return 'vendor'
-    }
-  }
-}
-
-function staticImportedByEntry(
-  id: string,
-  getModuleInfo: GetModuleInfo,
-  cache: Map<string, boolean>,
-  importStack: string[] = []
-): boolean {
-  if (cache.has(id)) {
-    return cache.get(id) as boolean
-  }
-  if (importStack.includes(id)) {
-    // circular deps!
-    cache.set(id, false)
-    return false
-  }
-  const mod = getModuleInfo(id)
-  if (!mod) {
-    cache.set(id, false)
-    return false
-  }
-
-  if (mod.isEntry) {
-    cache.set(id, true)
-    return true
-  }
-  const someImporterIs = mod.importers.some((importer) =>
-    staticImportedByEntry(
-      importer,
-      getModuleInfo,
-      cache,
-      importStack.concat(id)
-    )
-  )
-  cache.set(id, someImporterIs)
-  return someImporterIs
 }
 
 export function resolveLibFilename(

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -362,7 +362,7 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
     ],
     post: [
       buildImportAnalysisPlugin(config),
-      buildVendorAnalysisPlugin(config),
+      buildVendorAnalysisPlugin(),
       buildEsbuildPlugin(config),
       ...(options.minify ? [terserPlugin(config)] : []),
       ...(options.manifest ? [manifestPlugin(config)] : []),

--- a/packages/vite/src/node/plugins/vendorAnalysis.ts
+++ b/packages/vite/src/node/plugins/vendorAnalysis.ts
@@ -56,10 +56,7 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
                   if (!impName) continue
                   const varName = alias || impName
 
-                  redirects.set(
-                    info.id + '/+/' + varName,
-                    id + '/+/' + impName
-                  )
+                  redirects.set(info.id + '/+/' + varName, id + '/+/' + impName)
                 }
               }
             }
@@ -76,9 +73,7 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
         const addImport = async (imp: string) => {
           // if it's a redirect, use the resolved id
           const getTrueImp = (imp: string): string =>
-            redirects.has(imp)
-              ? getTrueImp(redirects.get(imp)!)
-              : imp
+            redirects.has(imp) ? getTrueImp(redirects.get(imp)!) : imp
           const trueImp = getTrueImp(imp)
           const impId = trueImp.split('/+/')[0]
           imps.add(trueImp)

--- a/packages/vite/src/node/plugins/vendorAnalysis.ts
+++ b/packages/vite/src/node/plugins/vendorAnalysis.ts
@@ -148,9 +148,9 @@ export function buildVendorAnalysisPlugin(): Plugin {
       const traceImport = async (ids: Set<string>, imps: Set<string>) => {
         const nextids = new Set<string>()
         // push the import to vendor
-        const addImport = async (imp: string) => {
+        const addImport = (imp: string) => {
           // if it's a redirect, use the resolved id
-          const getTrueImp = async (imp: string): Promise<string> => {
+          const getTrueImp = (imp: string): string => {
             const file = imp.split('/+/', 2)[0]
             nextids.add(file)
             if (redirects.has(imp)) {
@@ -159,7 +159,7 @@ export function buildVendorAnalysisPlugin(): Plugin {
             }
             return imp
           }
-          const trueImp = await getTrueImp(imp)
+          const trueImp = getTrueImp(imp)
           const impId = trueImp.split('/+/', 2)[0]
           imps.add(trueImp)
           nextids.add(impId)
@@ -187,7 +187,7 @@ export function buildVendorAnalysisPlugin(): Plugin {
               ) {
                 // import "foo.js"
                 // import * as foo from "foo.js"
-                await addImport(id + '/+/*')
+                addImport(id + '/+/*')
                 nextids.add(id)
               } else if (!statment.startsWith('export')) {
                 // import def, { foo, bar } from "foo.js"
@@ -200,14 +200,14 @@ export function buildVendorAnalysisPlugin(): Plugin {
 
                 // default import
                 if (impDef) {
-                  await addImport(id + '/+/default')
+                  addImport(id + '/+/default')
                 }
                 // named imports
                 if (imps) {
                   for (const name of imps.split(',')) {
                     const [, impName] = name.trim().match(splitAsRE) || []
                     if (!impName) continue
-                    await addImport(id + '/+/' + impName)
+                    addImport(id + '/+/' + impName)
                   }
                 }
               }

--- a/packages/vite/src/node/plugins/vendorAnalysis.ts
+++ b/packages/vite/src/node/plugins/vendorAnalysis.ts
@@ -1,5 +1,6 @@
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
+import type { ModuleInfo } from 'rollup'
 import type { ImportSpecifier } from 'es-module-lexer'
 import { init, parse as parseImports } from 'es-module-lexer'
 import { isCSSRequest } from './css'
@@ -20,10 +21,66 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
     async buildEnd() {
       await init
 
-      /* find all redirects */
       const entrieIds = new Set<string>()
-      const redirects = new Map<string, string>()
       const importsCache = new Map<string, readonly ImportSpecifier[]>()
+      const exportsCache = new Map<string, readonly string[]>()
+      const parseImps = async (
+        info: ModuleInfo,
+        trace: string[]
+      ): Promise<[readonly ImportSpecifier[], readonly string[]]> => {
+        // circular dependency
+        if (trace.includes(info.id))
+          return [
+            importsCache.get(info.id) || [],
+            exportsCache.get(info.id) || []
+          ]
+        trace.push(info.id)
+
+        const [imports, exps] = parseImports(info.code!)
+        const exports = [...exps]
+
+        // process export *
+        for (const imp of imports) {
+          // don't process dynamic imports
+          if (imp.d !== -1 || !imp.n) continue
+          // resolve the absolute id
+          const id = (await this.resolve(imp.n, info.id))?.id
+          if (!id) continue
+          const rinfo = this.getModuleInfo(id)
+          if (!rinfo || !rinfo.code) continue
+          const statment: string = info.code!.substring(imp.ss, imp.se)
+          if (
+            statment.startsWith('export *') &&
+            !statment.startsWith('export * as')
+          ) {
+            // merge all exports from module
+            ;(await findExports(rinfo, trace)).forEach((exp) => {
+              exports.push(exp)
+            })
+          }
+        }
+
+        importsCache.set(info.id, imports)
+        exportsCache.set(info.id, exports)
+        return [imports, exports]
+      }
+      const findImports = async (info: ModuleInfo, trace: string[] = []) => {
+        if (!info.code) return []
+        if (importsCache.has(info.id)) {
+          return importsCache.get(info.id)!
+        }
+        return (await parseImps(info, trace))[0]
+      }
+      const findExports = async (info: ModuleInfo, trace: string[] = []) => {
+        if (!info.code) return []
+        if (exportsCache.has(info.id)) {
+          return exportsCache.get(info.id)!
+        }
+        return (await parseImps(info, trace))[1]
+      }
+
+      /* find all redirects */
+      const redirects = new Map<string, string>()
       let modulesAnalyzed = 0
       const collectRedirectsStart = performance.now()
       await Promise.all(
@@ -33,8 +90,7 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
           if (info && info.code) {
             if (info.isEntry) entrieIds.add(module)
             // get all imports from module
-            const [imports] = parseImports(info.code)
-            importsCache.set(module, imports)
+            const imports = await findImports(info)
             for (const imp of imports) {
               // don't process dynamic imports
               if (imp.d !== -1 || !imp.n) continue
@@ -42,22 +98,39 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
               const id = (await this.resolve(imp.n, module))?.id
               if (!id) continue
               const statment: string = info.code.substring(imp.ss, imp.se)
-              // match export from statement
-              const [, impDef, imps] =
-                statment.match(/export\s+(?:([^,]+)\s*,\s*)?{([^}]+)/) || []
-              // default import
-              if (impDef) {
-                redirects.set(info.id + '/+/' + impDef, id + '/+/default')
-              }
-              // named imports
-              if (imps) {
-                for (const name of imps.split(',')) {
-                  const [, impName, alias] =
-                    name.trim().match(/([\S]+)(?:\s+as\s+([\S]+))?/) || []
-                  if (!impName) continue
-                  const varName = alias || impName
+              if (statment.startsWith('export * as')) {
+                // export * as foo from "foo.js"
+                const name = statment.substring(12).split(' ', 2)[0]
+                redirects.set(info.id + '/+/' + name, id + '/+/*')
+              } else if (statment.startsWith('export *')) {
+                // export * from "foo.js"
+                const impInfo = this.getModuleInfo(id)
+                if (!impInfo) continue
+                const exports = await findExports(impInfo)
+                for (const exp of exports) {
+                  redirects.set(info.id + '/+/' + exp, id + '/+/' + exp)
+                }
+              } else {
+                // match export from statement
+                const [, impDef, imps] =
+                  statment.match(/export\s+(?:([^,]+)\s*,\s*)?{([^}]+)/) || []
+                // default import
+                if (impDef) {
+                  redirects.set(info.id + '/+/' + impDef, id + '/+/default')
+                }
+                // named imports
+                if (imps) {
+                  for (const name of imps.split(',')) {
+                    const [, impName, alias] =
+                      name.trim().match(/([\S]+)(?:\s+as\s+([\S]+))?/) || []
+                    if (!impName) continue
+                    const varName = alias || impName
 
-                  redirects.set(info.id + '/+/' + varName, id + '/+/' + impName)
+                    redirects.set(
+                      info.id + '/+/' + varName,
+                      id + '/+/' + impName
+                    )
+                  }
                 }
               }
             }
@@ -71,12 +144,12 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
       const traceImport = async (ids: Set<string>, imps: Set<string>) => {
         const nextids = new Set<string>()
         // push the import to vendor
-        const addImport = async (imp: string) => {
+        const addImport = (imp: string) => {
           // if it's a redirect, use the resolved id
           const getTrueImp = (imp: string): string =>
             redirects.has(imp) ? getTrueImp(redirects.get(imp)!) : imp
           const trueImp = getTrueImp(imp)
-          const impId = trueImp.split('/+/')[0]
+          const impId = trueImp.split('/+/', 2)[0]
           imps.add(trueImp)
           nextids.add(impId)
         }
@@ -87,7 +160,7 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
             const info = this.getModuleInfo(module)
             if (!info || !info.code) return
             // get all imports from module
-            const imports = importsCache.get(module) || []
+            const imports = await findImports(info)
             for (const imp of imports) {
               // ignore dynamic imports
               if (imp.d !== -1 || !imp.n) continue
@@ -139,7 +212,7 @@ export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
 
       /* collect all files imported by entry */
       for (const imp of vendorImps) {
-        const file = imp.split('/+/')[0]
+        const file = imp.split('/+/', 2)[0]
         if (file.includes('node_modules')) vendorImports.add(file)
       }
 

--- a/packages/vite/src/node/plugins/vendorAnalysis.ts
+++ b/packages/vite/src/node/plugins/vendorAnalysis.ts
@@ -10,7 +10,8 @@ const isDebug = !!process.env.DEBUG
 const debug = createDebugger('vite:vendor-analysis')
 
 /**
- * Build only.
+ * Build only. Analyze which modules are used by entries and
+ * generate manualChunks config to split those files to vendor.
  */
 export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
   const vendorImports = new Set<string>()

--- a/packages/vite/src/node/plugins/vendorAnalysis.ts
+++ b/packages/vite/src/node/plugins/vendorAnalysis.ts
@@ -213,7 +213,7 @@ export function buildVendorAnalysisPlugin(): Plugin {
       await traceImport(entryIds, vendorImps)
       isDebug && debug(`${timeFrom(startTrace)} trace imports`)
 
-      /* collect all files imported by entry */
+      // collect all files imported by entry
       for (const imp of vendorImps) {
         const file = imp.split('/+/', 2)[0]
         if (file.includes('node_modules')) vendorImports.add(file)

--- a/packages/vite/src/node/plugins/vendorAnalysis.ts
+++ b/packages/vite/src/node/plugins/vendorAnalysis.ts
@@ -1,0 +1,175 @@
+import type { ResolvedConfig } from '../config'
+import type { Plugin } from '../plugin'
+import type { ImportSpecifier } from 'es-module-lexer'
+import { init, parse as parseImports } from 'es-module-lexer'
+import { isCSSRequest } from './css'
+import { createDebugger, timeFrom } from '../utils'
+import { performance } from 'perf_hooks'
+
+const isDebug = !!process.env.DEBUG
+const debug = createDebugger('vite:vendor-analysis')
+
+/**
+ * Build only.
+ */
+export function buildVendorAnalysisPlugin(config: ResolvedConfig): Plugin {
+  const vendorImports = new Set<string>()
+  return {
+    name: 'vite:vendor-analysis',
+    async buildEnd() {
+      await init
+
+      /* find all redirects */
+      const entrieIds = new Set<string>()
+      const redirects = new Map<string, string>()
+      const importsCache = new Map<string, readonly ImportSpecifier[]>()
+      let modulesAnalyzed = 0
+      const collectRedirectsStart = performance.now()
+      await Promise.all(
+        Array.from(this.getModuleIds()).map(async (module) => {
+          modulesAnalyzed++
+          const info = this.getModuleInfo(module)
+          if (info && info.code) {
+            if (info.isEntry) entrieIds.add(module)
+            // get all imports from module
+            const [imports] = parseImports(info.code)
+            importsCache.set(module, imports)
+            for (const imp of imports) {
+              // don't process dynamic imports
+              if (imp.d !== -1 || !imp.n) continue
+              // resolve the absolute id
+              const id = (await this.resolve(imp.n, module))?.id
+              if (!id) continue
+              const statment: string = info.code.substring(imp.ss, imp.se)
+              // match export from statement
+              const [, impDef, imps] =
+                statment.match(/export\s+(?:([^,]+)\s*,\s*)?{([^}]+)/) || []
+              // default import
+              if (impDef) {
+                redirects.set(info.id + '/+/' + impDef, id + '/+/default')
+              }
+              // named imports
+              if (imps) {
+                for (const name of imps.split(',')) {
+                  const [, impName, alias] =
+                    name.trim().match(/([\S]+)(?:\s+as\s+([\S]+))?/) || []
+                  if (!impName) continue
+                  const varName = alias || impName
+
+                  redirects.set(
+                    info.id + '/+/' + varName,
+                    id + '/+/' + impName
+                  )
+                }
+              }
+            }
+          }
+        })
+      )
+      isDebug && debug(`${timeFrom(collectRedirectsStart)} collect redirects`)
+
+      /* trace all files imported by entry */
+      const traced = new Set<string>()
+      const traceImport = async (ids: Set<string>, imps: Set<string>) => {
+        const nextids = new Set<string>()
+        // push the import to vendor
+        const addImport = async (imp: string) => {
+          // if it's a redirect, use the resolved id
+          const getTrueImp = (imp: string): string =>
+            redirects.has(imp)
+              ? getTrueImp(redirects.get(imp)!)
+              : imp
+          const trueImp = getTrueImp(imp)
+          const impId = trueImp.split('/+/')[0]
+          imps.add(trueImp)
+          nextids.add(impId)
+        }
+        await Promise.all(
+          Array.from(ids).map(async (module) => {
+            if (traced.has(module)) return
+            traced.add(module)
+            const info = this.getModuleInfo(module)
+            if (!info || !info.code) return
+            // get all imports from module
+            const imports = importsCache.get(module) || []
+            for (const imp of imports) {
+              // ignore dynamic imports
+              if (imp.d !== -1 || !imp.n) continue
+              // resolve the absolute id
+              const id = (await this.resolve(imp.n, module))?.id
+              if (!id) continue
+              const statment: string = info.code.substring(imp.ss, imp.se)
+              if (
+                statment.startsWith('import "') ||
+                statment.startsWith("import '") ||
+                statment.startsWith('import *')
+              ) {
+                // import "foo.js"
+                // import * as foo from "foo.js"
+                nextids.add(id)
+              } else {
+                // import def, { foo, bar } from "foo.js"
+
+                // impDef: def
+                // imps:  foo, bar
+                const [, impDef, imps] =
+                  statment.match(
+                    /(?:import|export)\s+(?:([^,\s{]+)\s*)?(?:\s*,\s*)?(?:\{([^\}]+))?/
+                  ) || []
+
+                // default import
+                if (impDef) {
+                  addImport(id + '/+/default')
+                }
+                // named imports
+                if (imps) {
+                  for (const name of imps.split(',')) {
+                    const [, impName] =
+                      name.trim().match(/([\S]+)(?:\s+as\s+([\S]+))?/) || []
+                    if (!impName) continue
+                    addImport(id + '/+/' + impName)
+                  }
+                }
+              }
+            }
+          })
+        )
+        if (nextids.size) await traceImport(nextids, imps)
+      }
+      const vendorImps = new Set<string>()
+      const startTrace = performance.now()
+      await traceImport(entrieIds, vendorImps)
+      isDebug && debug(`${timeFrom(startTrace)} trace imports`)
+
+      /* collect all files imported by entry */
+      for (const imp of vendorImps) {
+        const file = imp.split('/+/')[0]
+        if (file.includes('node_modules')) vendorImports.add(file)
+      }
+
+      isDebug &&
+        debug(
+          `${modulesAnalyzed} modules analyzed, ${entrieIds.size} entries, ${vendorImports.size} vendor files`
+        )
+    },
+    outputOptions(options) {
+      if (
+        // allow setting `manualChunks` to `undefined` to disable vendor chunk
+        'manualChunks' in options ||
+        // @ts-ignore injected by buildOutputOptions
+        !options.__vite_vendor_chunk__
+      ) {
+        isDebug && debug('vendor chunk disabled')
+        return
+      }
+      return {
+        ...options,
+        manualChunks(id) {
+          if (vendorImports.has(id) && !isCSSRequest(id)) {
+            return 'vendor'
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix #3731

I decided to not open a discussion, but this implementation should be more tested. I have no idea if it actually solved that kind of issue, but tested it solved that particular issue.

Before:
![200KB vendor](https://user-images.githubusercontent.com/31543482/147846871-b8f8bd40-8901-465b-b46b-5fe450f861d7.png)

After:
![131KB vendor](https://user-images.githubusercontent.com/31543482/147867704-edcb462c-deb6-4f1f-a798-75444c19da2b.png)

And yes, performance is not great on large size projects, but I only have a medium size project, and here is the result:
![1609 modules, 798.96ms collect redirects + 51.31ms trace imports](https://user-images.githubusercontent.com/31543482/147867687-b82293b4-7754-4061-af6b-d4fa5237e7b2.png)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

The real problem is the current implementation of vendor doesn't handle redirect exports, dependencies like `framer-motion` provided a combined export kinds of like this:

```js
// index.js
export { foo } from "./foo.js"
export { bar } from "./bar.js"
```

and the import looks like:

```js
// main.js
import { foo } from "./index.js"
```

In the current implementation of vendor, the file `index.js` is considered to be a vendor file, so every import to `index.js` is put inside vendor chunk.

But rollup handles this situation just fine, when vendor chunk is disabled, rollup splits dynamic import to `bar` seperately.

This implementation scans all redirect exports. Instead of marking `index.js` as a vendor file, this pr detects `foo` import from `main.js` and only marks `foo.js` as a vendor file, fixes the issue.

#6318 probably should be based on this implementation.

Side note: this implementation still allows setting `manualChunks` to `undefined` to disable vendor chunk.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
