### PR TITLE
vite server: escape colon in path

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -499,6 +499,15 @@ export async function createServer(
     middlewares.use(corsMiddleware(typeof cors === 'boolean' ? {} : cors))
   }
 
+  // escape colon in path
+  middlewares.use(function escapeColonMiddleware(req, res, next) {
+    if (req.url) {
+      // example url: /node_modules/.vite/node:stream.js?v=xxxxxxxx
+      req.url = req.url.replace(/:/g, '_')
+    }
+    next()
+  })
+
   // proxy
   const { proxy } = serverConfig
   if (proxy) {


### PR DESCRIPTION
part of issue https://github.com/vitejs/vite/issues/5398#issuecomment-1004111239

module `node:stream` is cached as `node_modules/.vite/node_stream.js`

but importing `node:stream` returns http 404 not found

solution: rewrite the url path: escape colon to underscore

```diff
-/node_modules/.vite/node:stream.js?v=xxxxxxxx
+/node_modules/.vite/node_stream.js?v=xxxxxxxx
```

### todo

replace only `/node_modules/.vite/xxxx` paths
but not `/@id/__vite-xxxx` etc

todo: test production mode
only tested in development mode (npx vite)

todo: maybe parse `req.url` to only replace the path
avoid false replacements like

```diff
-http://localhost:1234/node_modules/.vite/node:stream.js?v=xxxxxxxx
+http_//localhost_1234/node_modules/.vite/node_stream.js?v=xxxxxxxx
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
