### PR TITLE
fix(build): fix watch crash with inline module

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -51,6 +51,10 @@ export const htmlProxyMap = new WeakMap<
 export const htmlProxyResult = new Map<string, string>()
 
 export function htmlInlineProxyPlugin(config: ResolvedConfig): Plugin {
+  // Should do this when `constructor` rather than when `buildStart`,
+  // `buildStart` will be triggered multiple times then the cached result will be emptied.
+  // https://github.com/vitejs/vite/issues/6372
+  htmlProxyMap.set(config, new Map())
   return {
     name: 'vite:html-inline-proxy',
 
@@ -58,10 +62,6 @@ export function htmlInlineProxyPlugin(config: ResolvedConfig): Plugin {
       if (htmlProxyRE.test(id)) {
         return id
       }
-    },
-
-    buildStart() {
-      htmlProxyMap.set(config, new Map())
     },
 
     load(id) {
@@ -211,13 +211,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     isExternalUrl(url) ||
     isDataUrl(url) ||
     checkPublicFile(url, config)
+  // Same reason with `htmlInlineProxyPlugin`
+  isAsyncScriptMap.set(config, new Map())
 
   return {
     name: 'vite:build-html',
-
-    buildStart() {
-      isAsyncScriptMap.set(config, new Map())
-    },
 
     async transform(html, id) {
       if (id.endsWith('.html')) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When use `build -w`, `htmlInlineProxyPlugin` initial `htmlProxyMap` when `buildStart`, but in the following builds without html change, `htmlPlugin transform` wouldn't be triggered, then the htmlProxyMap is emptied.

`htmlPlugin isAsyncScriptMap` have the same problem.

fix #6372

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
All plugin do initial when `buildStart` have the same risk.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
