### PR TITLE
build: fix `declarationDir` for development builds

### DIFF
--- a/packages/vite/rollup.config.js
+++ b/packages/vite/rollup.config.js
@@ -135,7 +135,7 @@ const createNodeConfig = (isProduction) => {
           ? {}
           : {
               declaration: true,
-              declarationDir: path.resolve(__dirname, 'dist/')
+              declarationDir: path.resolve(__dirname, 'dist/node')
             })
       }),
       // Some deps have try...catch require of optional deps, but rollup will


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When running `pnpm dev` inside `packages/vite`, the type declarations are emitted to `dist` instead of `dist/node` where they belong. This leads to TypeScript errors.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
