### PR TITLE
chore: pin esbuild to 0.14.3 in plugin-vue and plugin-react only

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/parser": "^5.8.1",
     "conventional-changelog-cli": "^2.2.2",
     "cross-env": "^7.0.3",
-    "esbuild": "0.14.3",
+    "esbuild": "^0.14.10",
     "eslint": "^8.5.0",
     "eslint-define-config": "^1.2.1",
     "eslint-plugin-node": "^11.1.0",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -39,7 +39,7 @@
     "@babel/plugin-transform-react-jsx-self": "^7.16.5",
     "@babel/plugin-transform-react-jsx-source": "^7.16.5",
     "@rollup/pluginutils": "^4.1.2",
-    "esbuild": "npm:esbuild@0.14.3",
+    "esbuild": "0.14.3",
     "react-refresh": "^0.11.0",
     "resolve": "^1.20.0"
   }

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -39,6 +39,7 @@
     "@babel/plugin-transform-react-jsx-self": "^7.16.5",
     "@babel/plugin-transform-react-jsx-source": "^7.16.5",
     "@rollup/pluginutils": "^4.1.2",
+    "esbuild": "npm:esbuild@0.14.3",
     "react-refresh": "^0.11.0",
     "resolve": "^1.20.0"
   }

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -38,6 +38,7 @@
     "@rollup/pluginutils": "^4.1.2",
     "@types/hash-sum": "^1.0.0",
     "debug": "^4.3.3",
+    "esbuild": "npm:esbuild@0.14.3",
     "hash-sum": "^2.0.0",
     "rollup": "^2.59.0",
     "slash": "^4.0.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -38,7 +38,7 @@
     "@rollup/pluginutils": "^4.1.2",
     "@types/hash-sum": "^1.0.0",
     "debug": "^4.3.3",
-    "esbuild": "npm:esbuild@0.14.3",
+    "esbuild": "0.14.3",
     "hash-sum": "^2.0.0",
     "rollup": "^2.59.0",
     "slash": "^4.0.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -44,7 +44,7 @@
   },
   "//": "READ CONTRIBUTING.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
-    "esbuild": "0.14.3",
+    "esbuild": "^0.14.10",
     "json5": "^2.2.0",
     "postcss": "^8.4.5",
     "resolve": "^1.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
       '@typescript-eslint/parser': ^5.8.1
       conventional-changelog-cli: ^2.2.2
       cross-env: ^7.0.3
-      esbuild: 0.14.3
+      esbuild: ^0.14.10
       eslint: ^8.5.0
       eslint-define-config: ^1.2.1
       eslint-plugin-node: ^11.1.0
@@ -54,7 +54,7 @@ importers:
       '@typescript-eslint/parser': 5.8.1_eslint@8.5.0+typescript@4.5.4
       conventional-changelog-cli: 2.2.2
       cross-env: 7.0.3
-      esbuild: 0.14.3
+      esbuild: 0.14.10
       eslint: 8.5.0
       eslint-define-config: 1.2.1
       eslint-plugin-node: 11.1.0_eslint@8.5.0
@@ -74,7 +74,7 @@ importers:
       semver: 7.3.5
       simple-git-hooks: 2.7.0
       sirv: 2.0.0
-      ts-jest: 27.1.2_1b5a1be2010a86e622f02a11eaeb730f
+      ts-jest: 27.1.2_3c1c922175eb899d7693858b07afed6f
       ts-node: 10.4.0_00264fd83560919cd06c986889baae0a
       typescript: 4.5.4
       vite: link:packages/vite
@@ -427,6 +427,9 @@ importers:
       resolve-exports-path: link:exports-path
       resolve-linked: link:../resolve-linked
 
+  packages/playground/resolve-config:
+    specifiers: {}
+
   packages/playground/resolve-linked:
     specifiers: {}
 
@@ -670,6 +673,7 @@ importers:
       '@babel/plugin-transform-react-jsx-self': ^7.16.5
       '@babel/plugin-transform-react-jsx-source': ^7.16.5
       '@rollup/pluginutils': ^4.1.2
+      esbuild: npm:esbuild@0.14.3
       react-refresh: ^0.11.0
       resolve: ^1.20.0
     dependencies:
@@ -679,6 +683,7 @@ importers:
       '@babel/plugin-transform-react-jsx-self': 7.16.5_@babel+core@7.16.5
       '@babel/plugin-transform-react-jsx-source': 7.16.5_@babel+core@7.16.5
       '@rollup/pluginutils': 4.1.2
+      esbuild: 0.14.3
       react-refresh: 0.11.0
       resolve: 1.20.0
 
@@ -687,6 +692,7 @@ importers:
       '@rollup/pluginutils': ^4.1.2
       '@types/hash-sum': ^1.0.0
       debug: ^4.3.3
+      esbuild: npm:esbuild@0.14.3
       hash-sum: ^2.0.0
       rollup: ^2.59.0
       slash: ^4.0.0
@@ -696,6 +702,7 @@ importers:
       '@rollup/pluginutils': 4.1.2
       '@types/hash-sum': 1.0.0
       debug: 4.3.3
+      esbuild: 0.14.3
       hash-sum: 2.0.0
       rollup: 2.62.0
       slash: 4.0.0
@@ -717,6 +724,12 @@ importers:
       '@rollup/pluginutils': 4.1.2
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.16.5
       hash-sum: 2.0.0
+
+  packages/temp:
+    specifiers:
+      css-color-names: ^1.0.1
+    devDependencies:
+      css-color-names: 1.0.1
 
   packages/vite:
     specifiers:
@@ -757,7 +770,7 @@ importers:
       dotenv: ^10.0.0
       dotenv-expand: ^5.1.0
       es-module-lexer: ^0.9.3
-      esbuild: 0.14.3
+      esbuild: ^0.14.10
       estree-walker: ^2.0.2
       etag: ^1.8.1
       fast-glob: ^3.2.7
@@ -791,7 +804,7 @@ importers:
       types: link:./types
       ws: ^8.4.0
     dependencies:
-      esbuild: 0.14.3
+      esbuild: 0.14.10
       json5: 2.2.0
       postcss: 8.4.5
       resolve: 1.20.0
@@ -3982,6 +3995,13 @@ packages:
       ext: 1.6.0
     dev: false
 
+  /esbuild-android-arm64/0.14.10:
+    resolution: {integrity: sha512-vzkTafHKoiMX4uIN1kBnE/HXYLpNT95EgGanVk6DHGeYgDolU0NBxjO7yZpq4ZGFPOx8384eAdDrBYhO11TAlQ==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /esbuild-android-arm64/0.14.3:
     resolution: {integrity: sha512-v/vdnGJiSGWOAXzg422T9qb4S+P3tOaYtc5n3FDR27Bh3/xQDS7PdYz/yY7HhOlVp0eGwWNbPHEi8FcEhXjsuw==}
     cpu: [arm64]
@@ -3989,9 +4009,23 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-darwin-64/0.14.10:
+    resolution: {integrity: sha512-DJwzFVB95ZV7C3PQbf052WqaUuuMFXJeZJ0LKdnP1w+QOU0rlbKfX0tzuhoS//rOXUj1TFIwRuRsd0FX6skR7A==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /esbuild-darwin-64/0.14.3:
     resolution: {integrity: sha512-swY5OtEg6cfWdgc/XEjkBP7wXSyXXeZHEsWMdh1bDiN1D6GmRphk9SgKFKTj+P3ZHhOGIcC1+UdIwHk5bUcOig==}
     cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.10:
+    resolution: {integrity: sha512-RNaaoZDg3nsqs5z56vYCjk/VJ76npf752W0rOaCl5lO5TsgV9zecfdYgt7dtUrIx8b7APhVaNYud+tGsDOVC9g==}
+    cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
@@ -4003,9 +4037,23 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-freebsd-64/0.14.10:
+    resolution: {integrity: sha512-10B3AzW894u6bGZZhWiJOHw1uEHb4AFbUuBdyml1Ht0vIqd+KqWW+iY/yMwQAzILr2WJZqEhbOXRkJtY8aRqOw==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
   /esbuild-freebsd-64/0.14.3:
     resolution: {integrity: sha512-WDY5ENsmyceeE+95U3eI+FM8yARY5akWkf21M/x/+v2P5OVsYqCYELglSeAI5Y7bhteCVV3g4i2fRqtkmprdSA==}
     cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.10:
+    resolution: {integrity: sha512-mSQrKB7UaWvuryBTCo9leOfY2uEUSimAvcKIaUWbk5Hth9Sg+Try+qNA/NibPgs/vHkX0KFo/Rce6RPea+P15g==}
+    cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     optional: true
@@ -4017,9 +4065,23 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-32/0.14.10:
+    resolution: {integrity: sha512-lktF09JgJLZ63ANYHIPdYe339PDuVn19Q/FcGKkXWf+jSPkn5xkYzAabboNGZNUgNqSJ/vY7VrOn6UrBbJjgYA==}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /esbuild-linux-32/0.14.3:
     resolution: {integrity: sha512-8yhsnjLG/GwCA1RAIndjmCHWViRB2Ol0XeOh2fCXS9qF8tlVrJB7qAiHZpm2vXx+yjOA/bFLTxzU+5pMKqkn5A==}
     cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-linux-64/0.14.10:
+    resolution: {integrity: sha512-K+gCQz2oLIIBI8ZM77e9sYD5/DwEpeYCrOQ2SYXx+R4OU2CT9QjJDi4/OpE7ko4AcYMlMW7qrOCuLSgAlEj4Wg==}
+    cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -4031,9 +4093,23 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-arm/0.14.10:
+    resolution: {integrity: sha512-BYa60dZ/KPmNKYxtHa3LSEdfKWHcm/RzP0MjB4AeBPhjS0D6/okhaBesZIY9kVIGDyeenKsJNOmnVt4+dhNnvQ==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /esbuild-linux-arm/0.14.3:
     resolution: {integrity: sha512-YcMvJHAQnWrWKb+eLxN9e/iWUC/3w01UF/RXuMknqOW3prX8UQ63QknWz9/RI8BY/sdrdgPEbSmsTU2jy2cayQ==}
     cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.10:
+    resolution: {integrity: sha512-+qocQuQvcp5wo/V+OLXxqHPc+gxHttJEvbU/xrCGE03vIMqraL4wMua8JQx0SWEnJCWP+Nhf//v8OSwz1Xr5kA==}
+    cpu: [arm64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -4045,9 +4121,23 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-mips64le/0.14.10:
+    resolution: {integrity: sha512-nmUd2xoBXpGo4NJCEWoaBj+n4EtDoLEvEYc8Z3aSJrY0Oa6s04czD1flmhd0I/d6QEU8b7GQ9U0g/rtBfhtxBg==}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /esbuild-linux-mips64le/0.14.3:
     resolution: {integrity: sha512-DdmfM5rcuoqjQL3px5MbquAjZWnySB5LdTrg52SSapp0gXMnGcsM6GY2WVta02CMKn5qi7WPVG4WbqTWE++tJw==}
     cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.10:
+    resolution: {integrity: sha512-vsOWZjm0rZix7HSmqwPph9arRVCyPtUpcURdayQDuIhMG2/UxJxpbdRaa//w4zYqcJzAWwuyH2PAlyy0ZNuxqQ==}
+    cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     optional: true
@@ -4059,10 +4149,31 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-linux-s390x/0.14.10:
+    resolution: {integrity: sha512-knArKKZm0ypIYWOWyOT7+accVwbVV1LZnl2FWWy05u9Tyv5oqJ2F5+X2Vqe/gqd61enJXQWqoufXopvG3zULOg==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-netbsd-64/0.14.10:
+    resolution: {integrity: sha512-6Gg8neVcLeyq0yt9bZpReb8ntZ8LBEjthxrcYWVrBElcltnDjIy1hrzsujt0+sC2rL+TlSsE9dzgyuvlDdPp2w==}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    optional: true
+
   /esbuild-netbsd-64/0.14.3:
     resolution: {integrity: sha512-Z/UB9OUdwo1KDJCSGnVueDuKowRZRkduLvRMegHtDBHC3lS5LfZ3RdM1i+4MMN9iafyk8Q9FNcqIXI178ZujvA==}
     cpu: [x64]
     os: [netbsd]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.10:
+    resolution: {integrity: sha512-9rkHZzp10zI90CfKbFrwmQjqZaeDmyQ6s9/hvCwRkbOCHuto6RvMYH9ghQpcr5cUxD5OQIA+sHXi0zokRNXjcg==}
+    cpu: [x64]
+    os: [openbsd]
     requiresBuild: true
     optional: true
 
@@ -4073,6 +4184,13 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-sunos-64/0.14.10:
+    resolution: {integrity: sha512-mEU+pqkhkhbwpJj5DiN3vL0GUFR/yrL3qj8ER1amIVyRibKbj02VM1QaIuk1sy5DRVIKiFXXgCaHvH3RNWCHIw==}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    optional: true
+
   /esbuild-sunos-64/0.14.3:
     resolution: {integrity: sha512-pldqx/Adxl4V4ymiyKxOOyJmHn6nUIo3wqk2xBx07iDgmL2XTcDDQd7N4U4QGu9LnYN4ZF+8IdOYa3oRRpbjtg==}
     cpu: [x64]
@@ -4080,9 +4198,23 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-windows-32/0.14.10:
+    resolution: {integrity: sha512-Z5DieUL1N6s78dOSdL95KWf8Y89RtPGxIoMF+LEy8ChDsX+pZpz6uAVCn+YaWpqQXO+2TnrcbgBIoprq2Mco1g==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /esbuild-windows-32/0.14.3:
     resolution: {integrity: sha512-AqzvA/KbkC2m3kTXGpljLin3EttRbtoPTfBn6w6n2m9MWkTEbhQbE1ONoOBxhO5tExmyJdL/6B87TJJD5jEFBQ==}
     cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /esbuild-windows-64/0.14.10:
+    resolution: {integrity: sha512-LE5Mm62y0Bilu7RDryBhHIX8rK3at5VwJ6IGM3BsASidCfOBTzqcs7Yy0/Vkq39VKeTmy9/66BAfVoZRNznoDw==}
+    cpu: [x64]
     os: [win32]
     requiresBuild: true
     optional: true
@@ -4094,12 +4226,43 @@ packages:
     requiresBuild: true
     optional: true
 
+  /esbuild-windows-arm64/0.14.10:
+    resolution: {integrity: sha512-OJOyxDtabvcUYTc+O4dR0JMzLBz6G9+gXIHA7Oc5d5Fv1xiYa0nUeo8+W5s2e6ZkPRdIwOseYoL70rZz80S5BA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /esbuild-windows-arm64/0.14.3:
     resolution: {integrity: sha512-qB2izYu4VpigGnOrAN2Yv7ICYLZWY/AojZtwFfteViDnHgW4jXPYkHQIXTISJbRz25H2cYiv+MfRQYK31RNjlw==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     optional: true
+
+  /esbuild/0.14.10:
+    resolution: {integrity: sha512-ibZb+NwFqBwHHJlpnFMtg4aNmVK+LUtYMFC9CuKs6lDCBEvCHpqCFZFEirpqt1jOugwKGx8gALNGvX56lQyfew==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-arm64: 0.14.10
+      esbuild-darwin-64: 0.14.10
+      esbuild-darwin-arm64: 0.14.10
+      esbuild-freebsd-64: 0.14.10
+      esbuild-freebsd-arm64: 0.14.10
+      esbuild-linux-32: 0.14.10
+      esbuild-linux-64: 0.14.10
+      esbuild-linux-arm: 0.14.10
+      esbuild-linux-arm64: 0.14.10
+      esbuild-linux-mips64le: 0.14.10
+      esbuild-linux-ppc64le: 0.14.10
+      esbuild-linux-s390x: 0.14.10
+      esbuild-netbsd-64: 0.14.10
+      esbuild-openbsd-64: 0.14.10
+      esbuild-sunos-64: 0.14.10
+      esbuild-windows-32: 0.14.10
+      esbuild-windows-64: 0.14.10
+      esbuild-windows-arm64: 0.14.10
 
   /esbuild/0.14.3:
     resolution: {integrity: sha512-zyEC5hkguW2oieXRXp8VJzQdcO/1FxCS5GjzqOHItRlojXnx/cTavsrkxdWvBH9li2lUq0bN+LeeVEmyCwiR/Q==}
@@ -8390,7 +8553,7 @@ packages:
       utf8-byte-length: 1.0.4
     dev: true
 
-  /ts-jest/27.1.2_1b5a1be2010a86e622f02a11eaeb730f:
+  /ts-jest/27.1.2_3c1c922175eb899d7693858b07afed6f:
     resolution: {integrity: sha512-eSOiJOWq6Hhs6Khzk5wKC5sgWIXgXqOCiIl1+3lfnearu58Hj4QpE5tUhQcA3xtZrELbcvAGCsd6HB8OsaVaTA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -8413,7 +8576,7 @@ packages:
     dependencies:
       '@types/jest': 27.0.3
       bs-logger: 0.2.6
-      esbuild: 0.14.3
+      esbuild: 0.14.10
       fast-json-stable-stringify: 2.1.0
       jest: 27.4.5_ts-node@10.4.0
       jest-util: 27.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,7 +673,7 @@ importers:
       '@babel/plugin-transform-react-jsx-self': ^7.16.5
       '@babel/plugin-transform-react-jsx-source': ^7.16.5
       '@rollup/pluginutils': ^4.1.2
-      esbuild: npm:esbuild@0.14.3
+      esbuild: 0.14.3
       react-refresh: ^0.11.0
       resolve: ^1.20.0
     dependencies:
@@ -692,7 +692,7 @@ importers:
       '@rollup/pluginutils': ^4.1.2
       '@types/hash-sum': ^1.0.0
       debug: ^4.3.3
-      esbuild: npm:esbuild@0.14.3
+      esbuild: 0.14.3
       hash-sum: ^2.0.0
       rollup: ^2.59.0
       slash: ^4.0.0


### PR DESCRIPTION
and update to ^0.14.10 for vite itself

<!-- Thank you for contributing! -->

### Description

alternative fix to the issue that esbuild 0.14.4+ builds differently for cjs with default and named exports

### Additional context

this causes 2 esbuild versions to exist, but is a lot less changes than #6329  

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
