### PR TITLE
fix: reduce number of `fs.realpath` calls

### DIFF
--- a/packages/vite/src/node/__tests__/SymlinkResolver.spec.ts
+++ b/packages/vite/src/node/__tests__/SymlinkResolver.spec.ts
@@ -1,0 +1,158 @@
+import { join, relative, resolve } from 'path'
+import type { SymlinkResolver } from '../symlinks'
+import { createSymlinkResolver } from '../symlinks'
+
+let resolver: SymlinkResolver
+
+const realpathMock = jest.fn()
+const readlinkMock = jest.fn()
+
+const root = '/dev/root'
+const realpathSync = (p: string) => {
+  return resolver.realpathSync(resolve(root, p))
+}
+
+describe('SymlinkResolver', () => {
+  beforeEach(() => {
+    mockRealPath({})
+    mockReadLink({})
+    resolver = createSymlinkResolver(root, {
+      realpathSync: { native: realpathMock },
+      readlinkSync: readlinkMock
+    })
+  })
+
+  describe('inside project root', () => {
+    test('no symlinks present', () => {
+      const result = realpathSync('foo/bar')
+      expect(result).toMatchInlineSnapshot(`"/dev/root/foo/bar"`)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`2`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`0`)
+
+      // …is cached?
+      expect(realpathSync('foo/bar')).toBe(result)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`2`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`1`)
+    })
+
+    test('given path is a symlink', () => {
+      mockReadLink({ 'foo/bar': './baz' })
+
+      const result = realpathSync('foo/bar')
+      expect(result).toMatchInlineSnapshot(`"/dev/root/foo/baz"`)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`3`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`0`)
+
+      // …is cached?
+      expect(realpathSync('foo/bar')).toBe(result)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`3`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`1`)
+    })
+
+    test('given path is a symlink pointing out of root', () => {
+      mockReadLink({ foo: '/dev/foo' })
+
+      const result = realpathSync('foo')
+      expect(result).toMatchInlineSnapshot(`"/dev/foo"`)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`4`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`0`)
+
+      // …is cached?
+      expect(realpathSync('foo')).toBe(result)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`4`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`1`)
+    })
+
+    test('given path is a symlink within a symlink', () => {
+      mockRealPath({ foo: 'red' })
+      mockReadLink({ 'red/bar': './baz' })
+
+      const result = realpathSync('foo/bar')
+      expect(result).toMatchInlineSnapshot(`"/dev/root/red/baz"`)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`3`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`0`)
+
+      // …is cached?
+      expect(realpathSync('foo/bar')).toBe(result)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`3`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`1`)
+    })
+
+    test('given path has symlink grand parent', () => {
+      mockRealPath({ 'foo/bar': 'red/bar' })
+
+      const result = realpathSync('foo/bar/main.js')
+      expect(result).toMatchInlineSnapshot(`"/dev/root/red/bar/main.js"`)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`2`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`0`)
+
+      // …is cached?
+      expect(realpathSync('foo/bar/main.js')).toBe(result)
+      expect(realpathSync('foo/bar')).toMatchInlineSnapshot(
+        `"/dev/root/red/bar"`
+      )
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`2`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`2`)
+    })
+
+    test('given path has two symlink parents', () => {
+      mockRealPath({ 'foo/bar': 'red/blue' })
+
+      const result = realpathSync('foo/bar/main.js')
+      expect(result).toMatchInlineSnapshot(`"/dev/root/red/blue/main.js"`)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`2`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`0`)
+
+      // …is cached?
+      expect(realpathSync('foo/bar/main.js')).toBe(result)
+      expect(realpathSync('foo/bar')).toMatchInlineSnapshot(
+        `"/dev/root/red/blue"`
+      )
+      expect(realpathSync('foo')).toMatchInlineSnapshot(`"/dev/root/red"`)
+      expect(resolver.fsCalls).toMatchInlineSnapshot(`2`)
+      expect(resolver.cacheHits).toMatchInlineSnapshot(`3`)
+    })
+  })
+
+  test('symlink outside project root', () => {
+    // Mock a symlink that points to another symlink.
+    mockReadLink({ '../foo': './bar', '../bar': './baz' })
+
+    const result = realpathSync('../foo')
+    expect(result).toMatchInlineSnapshot(`"/dev/baz"`)
+    expect(resolver.fsCalls).toMatchInlineSnapshot(`4`)
+    expect(resolver.cacheHits).toMatchInlineSnapshot(`0`)
+
+    // …is cached?
+    expect(realpathSync('../foo')).toBe(result)
+    expect(realpathSync('../bar')).toMatchInlineSnapshot(`"/dev/baz"`)
+    expect(realpathSync('../baz')).toMatchInlineSnapshot(`"/dev/baz"`)
+    expect(resolver.fsCalls).toMatchInlineSnapshot(`4`)
+    expect(resolver.cacheHits).toMatchInlineSnapshot(`3`)
+  })
+})
+
+function mockRealPath(pathMap: Record<string, string>) {
+  realpathMock.mockReset()
+  realpathMock.mockImplementation((arg) => {
+    return resolve(root, pathMap[relative(root, arg)] || arg)
+  })
+}
+
+// Thrown by fs.readlinkSync if given a path that's not a symlink.
+const throwInvalid = throwError(-22)
+
+function mockReadLink(linkMap: Record<string, string>) {
+  readlinkMock.mockReset()
+  readlinkMock.mockImplementation((arg) => {
+    return linkMap[relative(root, arg)] || throwInvalid()
+  })
+}
+
+function throwError(errno: number) {
+  return () => {
+    const e: any = new Error()
+    e.errno = errno
+    throw e
+  }
+}

--- a/packages/vite/src/node/__tests__/SymlinkResolver.spec.ts
+++ b/packages/vite/src/node/__tests__/SymlinkResolver.spec.ts
@@ -1,11 +1,12 @@
 import { relative, resolve } from 'node:path'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { SymlinkResolver } from '../symlinks'
 import { createSymlinkResolver } from '../symlinks'
 
 let resolver: SymlinkResolver
 
-const realpathMock = jest.fn()
-const readlinkMock = jest.fn()
+const realpathMock = vi.fn()
+const readlinkMock = vi.fn()
 
 const root = '/dev/root'
 const realpathSync = (p: string) => {

--- a/packages/vite/src/node/__tests__/SymlinkResolver.spec.ts
+++ b/packages/vite/src/node/__tests__/SymlinkResolver.spec.ts
@@ -1,4 +1,4 @@
-import { join, relative, resolve } from 'path'
+import { relative, resolve } from 'node:path'
 import type { SymlinkResolver } from '../symlinks'
 import { createSymlinkResolver } from '../symlinks'
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -64,6 +64,8 @@ import type { PackageCache } from './packages'
 import { loadEnv, resolveEnvPrefix } from './env'
 import type { ResolvedSSROptions, SSROptions } from './ssr'
 import { resolveSSROptions } from './ssr'
+import { createSymlinkResolver } from './symlinks'
+import type { SymlinkResolver } from './symlinks'
 
 const debug = createDebugger('vite:config')
 
@@ -348,6 +350,8 @@ export type ResolvedConfig = Readonly<
     createResolver: (options?: Partial<InternalResolveOptions>) => ResolveFn
     optimizeDeps: DepOptimizationOptions
     /** @internal */
+    symlinkResolver: SymlinkResolver
+    /** @internal */
     packageCache: PackageCache
     worker: ResolveWorkerOptions
     appType: AppType
@@ -558,6 +562,7 @@ export async function resolveConfig(
               aliasPlugin({ entries: resolved.resolve.alias }),
               resolvePlugin({
                 ...resolved.resolve,
+                symlinkResolver: resolved.symlinkResolver,
                 root: resolvedRoot,
                 isProduction,
                 isBuild: command === 'build',
@@ -655,6 +660,7 @@ export async function resolveConfig(
     },
     logger,
     packageCache: new Map(),
+    symlinkResolver: createSymlinkResolver(resolvedRoot),
     createResolver,
     optimizeDeps: {
       disabled: 'build',

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -51,7 +51,8 @@ export type {
   SSRTarget
 } from './ssr'
 export type { Plugin, HookHandler } from './plugin'
-export type { PackageCache, PackageData } from './packages'
+export type { PackageCache, PackageData, LoadPackageOptions } from './packages'
+export type { SymlinkResolver } from './symlinks'
 export type {
   Logger,
   LogOptions,

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -109,7 +109,6 @@ export type LoadPackageOptions = {
   preserveSymlinks?: boolean
   symlinkResolver?: SymlinkResolver
   packageCache?: PackageCache
-  cjsInclude?: (string | RegExp)[]
 }
 
 /**
@@ -141,28 +140,11 @@ export function loadPackageData(
       ? { preserveSymlinks: arg2, packageCache: arg3 }
       : arg2 || {}
 
-  if (options.preserveSymlinks !== true) {
-    const originalPkgPath = pkgPath
-
-    // Support uncached realpath calls for backwards compatibility.
-    pkgPath = getRealPath(
-      pkgPath,
-      options.symlinkResolver,
-      options.preserveSymlinks
-    )
-
-    // In case a linked package is a local clone of a CommonJS dependency,
-    // we need to ensure @rollup/plugin-commonjs analyzes the package even
-    // after it's been resolved to its actual file location.
-    if (options.cjsInclude && pkgPath !== originalPkgPath) {
-      const filter = createFilter(options.cjsInclude, undefined, {
-        resolve: false
-      })
-      if (!filter(pkgPath) && filter(originalPkgPath)) {
-        options.cjsInclude.push(path.dirname(pkgPath) + '/**')
-      }
-    }
-  }
+  pkgPath = getRealPath(
+    pkgPath,
+    options.symlinkResolver,
+    options.preserveSymlinks
+  )
 
   let cached: PackageData | undefined
   if ((cached = options.packageCache?.get(pkgPath))) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -364,7 +364,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const getContentWithSourcemap = async (content: string) => {
           if (config.css?.devSourcemap) {
             const sourcemap = this.getCombinedSourcemap()
-            await injectSourcesContent(sourcemap, cleanUrl(id), config.logger)
+            await injectSourcesContent(
+              sourcemap,
+              cleanUrl(id),
+              config.logger,
+              config.symlinkResolver
+            )
             return getCodeWithSourcemap('css', content, sourcemap)
           }
           return content

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -63,6 +63,7 @@ export async function resolvePlugins(
       isProduction: config.isProduction,
       isBuild,
       packageCache: config.packageCache,
+      symlinkResolver: config.symlinkResolver,
       ssrConfig: config.ssr,
       asSrc: true,
       getDepsOptimizer: (ssr: boolean) => getDepsOptimizer(config, ssr),

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'node:fs'
 import type { SourceMap } from 'rollup'
 import type { Logger } from '../logger'
 import { createDebugger } from '../utils'
+import type { SymlinkResolver } from '../symlinks'
 
 const isDebug = !!process.env.DEBUG
 const debug = createDebugger('vite:sourcemap', {
@@ -23,12 +24,13 @@ interface SourceMapLike {
 export async function injectSourcesContent(
   map: SourceMapLike,
   file: string,
-  logger: Logger
+  logger: Logger,
+  symlinkResolver: SymlinkResolver
 ): Promise<void> {
   let sourceRoot: string | undefined
   try {
     // The source root is undefined for virtual modules and permission errors.
-    sourceRoot = await fs.realpath(
+    sourceRoot = symlinkResolver.realpathSync(
       path.resolve(path.dirname(file), map.sourceRoot || '')
     )
   } catch {}

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -259,7 +259,7 @@ async function loadAndTransform(
   if (map && mod.file) {
     map = (typeof map === 'string' ? JSON.parse(map) : map) as SourceMap
     if (map.mappings && !map.sourcesContent) {
-      await injectSourcesContent(map, mod.file, logger)
+      await injectSourcesContent(map, mod.file, logger, config.symlinkResolver)
     }
   }
 

--- a/packages/vite/src/node/symlinks.ts
+++ b/packages/vite/src/node/symlinks.ts
@@ -1,4 +1,5 @@
-import path from 'path'
+import path from 'node:path'
+import nodeFs from 'node:fs'
 import { createDebugger } from './utils'
 
 const isDebug = !!process.env.DEBUG
@@ -24,7 +25,7 @@ export interface FileSystem {
  */
 export function createSymlinkResolver(
   root: string,
-  fs: FileSystem = require('fs')
+  fs: FileSystem = nodeFs
 ): SymlinkResolver {
   const cache: Record<string, string> = Object.create(null)
 

--- a/packages/vite/src/node/symlinks.ts
+++ b/packages/vite/src/node/symlinks.ts
@@ -1,0 +1,170 @@
+import path from 'path'
+import { createDebugger } from './utils'
+
+const isDebug = !!process.env.DEBUG
+const isVerbose = isDebug && false
+const debug = createDebugger('vite:symlinks')
+
+export interface SymlinkResolver {
+  fsCalls: number
+  cacheHits: number
+  cacheSize: number
+  realpathSync(path: string, seen?: Set<string>): string
+  invalidate(path: string): void
+}
+
+export interface FileSystem {
+  realpathSync: { native(path: string): string }
+  readlinkSync(path: string): string
+}
+
+/**
+ * Create a symlink resolver that uses a cache to reduce the
+ * number of I/O calls. See #6030 for more information.
+ */
+export function createSymlinkResolver(
+  root: string,
+  fs: FileSystem = require('fs')
+): SymlinkResolver {
+  const cache: Record<string, string> = Object.create(null)
+
+  // Recursively check the cache.
+  const resolveWithCache = (unresolvedPath: string) => {
+    let resolvedPath: string | undefined
+    while (
+      (resolvedPath = cache[unresolvedPath]) &&
+      resolvedPath !== unresolvedPath
+    ) {
+      unresolvedPath = resolvedPath
+    }
+    return resolvedPath
+  }
+
+  const rootParent = path.dirname(root)
+  const cacheRecursively = (resolvedPath: string) => {
+    while (resolvedPath !== rootParent) {
+      cache[resolvedPath] = resolvedPath
+      resolvedPath = path.dirname(resolvedPath)
+    }
+  }
+
+  return {
+    // Increment "fsCalls" whenever fs.realpath or fs.readlink are called.
+    fsCalls: 0,
+    // Increment "cacheHits" when a call to our `realpathSync` method
+    // is short-circuited by the cache.
+    cacheHits: 0,
+    get cacheSize() {
+      return Object.keys(cache).length
+    },
+    // This method assumes `unresolvedPath` is normalized.
+    realpathSync(unresolvedPath, seen) {
+      if (isVerbose && !seen) {
+        debug(`Called realpathSync on "${unresolvedPath}"`)
+      }
+
+      let resolvedPath = resolveWithCache(unresolvedPath)
+      if (resolvedPath) {
+        this.cacheHits++
+        if (isVerbose) {
+          debug(`Resolution of "${unresolvedPath}" was cached`)
+        }
+        return resolvedPath
+      }
+
+      let parentPath = path.dirname(unresolvedPath)
+
+      // Check all parent directories within the project root.
+      // If our unresolved path is outside the project root, we only
+      // check the immediate parent directory (for optimal performance).
+      const isInRoot = unresolvedPath.startsWith(root + '/')
+      if (isInRoot)
+        while (parentPath !== root && !cache[parentPath]) {
+          parentPath = path.dirname(parentPath)
+        }
+
+      // Use the nearest parent with a cached resolution.
+      const cachedParent = (resolvedPath = cache[parentPath])
+      if (!cachedParent) {
+        if (isInRoot) {
+          // Always use the immediate parent when calling fs.realpath
+          parentPath = path.dirname(unresolvedPath)
+        }
+
+        this.fsCalls++
+        resolvedPath = fs.realpathSync.native(parentPath)
+        cache[parentPath] = resolvedPath
+        if (isDebug && parentPath !== resolvedPath) {
+          debug(`Resolved "${parentPath}" to "${resolvedPath}"`)
+        }
+        // Since fs.realpath resolves all directories in a given path,
+        // we can safely cache every directory in the resolved path.
+        if (resolvedPath.startsWith(root + '/')) {
+          cacheRecursively(resolvedPath)
+        }
+      }
+
+      // Append the unresolved subpath.
+      resolvedPath += unresolvedPath.slice(parentPath.length)
+
+      if (resolvedPath !== unresolvedPath) {
+        cache[unresolvedPath] = resolvedPath
+        if (isDebug) {
+          debug(`Resolved "${unresolvedPath}" to "${resolvedPath}"`)
+        }
+
+        // Check the cache again now that our parent directories are resolved.
+        unresolvedPath = resolvedPath
+        resolvedPath = resolveWithCache(unresolvedPath) || unresolvedPath
+        if (resolvedPath !== unresolvedPath) {
+          if (isVerbose) {
+            debug(`Found "${unresolvedPath}" in cache`)
+          }
+          if (cachedParent) {
+            this.cacheHits++
+          }
+          return resolvedPath
+        }
+      }
+
+      // When the `unresolvedPath` is itself a symlink, we must follow it
+      // *after* resolving parent directories, in case its target path is
+      // pointing to a location outside a symlinked parent directory.
+      try {
+        this.fsCalls++
+        const targetPath = fs.readlinkSync(resolvedPath)
+        if (targetPath) {
+          resolvedPath = path.resolve(path.dirname(resolvedPath), targetPath)
+
+          // Avoid deadlocks from circular symlinks.
+          if (seen?.has(resolvedPath)) {
+            return resolvedPath
+          }
+          seen ??= new Set()
+          seen.add(resolvedPath)
+
+          // The resolved path may be a file within a symlinked directory
+          // and/or a symlink itself.
+          resolvedPath = this.realpathSync(resolvedPath, seen)
+        }
+      } catch (e: any) {
+        if (e.errno !== -22) {
+          // Non-existent path or forbidden access
+          return unresolvedPath
+        }
+      }
+
+      cache[unresolvedPath] = resolvedPath
+      if (isDebug && resolvedPath !== unresolvedPath) {
+        debug(`Resolved "${unresolvedPath}" to "${resolvedPath}"`)
+      } else if (isVerbose && !seen) {
+        debug(`Nothing to resolve for "${unresolvedPath}"`)
+      }
+
+      return resolvedPath
+    },
+    invalidate(unresolvedPath) {
+      delete cache[unresolvedPath]
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#6030 reported a performance regression related to `fs.realpath` calls, so I've implemented a cache for symlink resolution. We need some people to test this on bigger projects where the regression is most noticeable. :eyes:

### Additional context

Use this plugin to inspect the effectiveness of this approach:

```ts
export function debugSymlinkResolver(): vite.Plugin {
  return {
    name: 'debugSymlinkResolver',
    configResolved(config) {
      const { symlinkResolver } = config
      this.generateBundle = () => {
        console.log('cacheSize: %O', symlinkResolver.cacheSize)
        console.log('cacheHits: %O', symlinkResolver.cacheHits)
        console.log('fsCalls:   %O', symlinkResolver.fsCalls)
      }
    },
  }
}
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
