### PR TITLE
fix(types): add missing options parameter to importMeta

### DIFF
--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -4,6 +4,8 @@
 
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
+import type { AssertOptions } from '../src/node/importGlob'
+
 interface ImportMeta {
   url: string
 
@@ -50,14 +52,20 @@ interface ImportMeta {
 
   readonly env: ImportMetaEnv
 
-  glob(pattern: string): Record<
+  glob(
+    pattern: string,
+    options?: AssertOptions
+  ): Record<
     string,
     () => Promise<{
       [key: string]: any
     }>
   >
 
-  globEager(pattern: string): Record<
+  globEager(
+    pattern: string,
+    options?: AssertOptions
+  ): Record<
     string,
     {
       [key: string]: any


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The new feature to import as raw was merged but IDE will display an error because the typings only accept the pattern and don't allow the options.  #5545

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
