### PR TITLE
fix(ssr): fix resolution for nested ssr externals on windows (#6080)

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -238,7 +238,13 @@ async function nodeImport(
         return nodeResolve(id, parent, isMain, options)
       }
       if (parent) {
-        return viteResolve(id, parent.id)
+        let resolved = viteResolve(id, parent.id)
+        if (resolved) {
+          // hookNodeResolve must use platform-specific path.normalize
+          // to be compatible with dynamicImport (#6080)
+          resolved = path.normalize(resolved)
+        }
+        return resolved
       }
       // Importing a CJS module from an ESM module. In this case, the import
       // specifier is already an absolute path, so this is a no-op.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes double-loading of `solid-js` reported in #6080 which happens in ssr mode on windows like this:

- first, the `solid-start` ssr code loads `solid-js/web` library, which has cjs export and is loaded by `dynamicImport` [using absolute file URL](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/ssrModuleLoader.ts#L264), which node converts to windows-normalized absolute path, with backslashes, to register it in the require.cache (vite package.json does not have `"type": "module"` so dynamic import is compatible with cjs require and uses the same require.cache)

- `solid-js/web` requires `solid-js` which is intercepted by `hookNodeResolve`, which returns [posix-normalized result of](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/ssrModuleLoader.ts#L241) `viteResolve`, which is used by node as is to register `solid-js` in require.cache (path with forward slashes)

- then `solid-start` ssr code loads `solid-js` directly, which, like `solid-js/web` has cjs export, is loaded by `dynamicImport` using backslash-normalized path, so it's loaded twice

The fix is to use platform-specific `path.normalize` in `hookNodeResolve`, to match what the internal node resolver in `dynamicImport` is doing.

### Additional context

I could not find the tests for `ssrModuleLoader`, moreover the code in the issue depends on `usingDynamicImport` being true, but `utils.ts` has

```ts
export const usingDynamicImport = typeof jest === 'undefined'
```

which I believe makes it impossible to test with jest.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
