### PR TITLE
fix: hmr on web worker

### DIFF
--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -103,4 +103,22 @@
     )
   })
   w2.port.start()
+
+  if (import.meta.hot) {
+    import.meta.hot.accept(
+      [
+        './my-worker?worker',
+        './my-worker?inline',
+        './possible-ts-output-worker?worker',
+        './workerImport'
+      ],
+      ([a, b, c, d]) => {
+        // the callback receives the updated modules in an Array
+        console.log(a)
+        console.log(b)
+        console.log(c)
+        console.log(d)
+      }
+    )
+  }
 </script>

--- a/packages/playground/worker/my-worker.ts
+++ b/packages/playground/worker/my-worker.ts
@@ -1,8 +1,18 @@
-import { msg, mode } from './workerImport'
+import { msg as originalMsg, mode } from './workerImport'
 import { bundleWithPlugin } from './test-plugin'
+
+let msg = originalMsg
 
 self.onmessage = (e) => {
   if (e.data === 'ping') {
     self.postMessage({ msg, mode, bundleWithPlugin })
   }
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+  import.meta.hot.accept('./workerImport', (newImportModule) => {
+    if (newImportModule && newImportModule.msg) msg = newImportModule.msg
+    else console.log(`Unexpected HMR received: ${newImportModule}`)
+  })
 }

--- a/packages/playground/worker/my-worker.ts
+++ b/packages/playground/worker/my-worker.ts
@@ -10,7 +10,6 @@ self.onmessage = (e) => {
 }
 
 if (import.meta.hot) {
-  import.meta.hot.accept()
   import.meta.hot.accept('./workerImport', (newImportModule) => {
     if (newImportModule && newImportModule.msg) msg = newImportModule.msg
     else console.log(`Unexpected HMR received: ${newImportModule}`)

--- a/packages/playground/worker/possible-ts-output-worker.mjs
+++ b/packages/playground/worker/possible-ts-output-worker.mjs
@@ -1,7 +1,16 @@
-import { msg, mode } from './workerImport'
+import { msg as originalMsg, mode } from './workerImport'
+
+let msg = originalMsg
 
 self.onmessage = (e) => {
   if (e.data === 'ping') {
     self.postMessage({ msg, mode })
   }
+}
+
+if (import.meta.hot) {
+  import.meta.hot.accept('./workerImport', (newImportModule) => {
+    if (newImportModule && newImportModule.msg) msg = newImportModule.msg
+    else console.log(`Unexpected HMR received: ${newImportModule}`)
+  })
 }

--- a/packages/playground/worker/tsconfig.json
+++ b/packages/playground/worker/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM", "WebWorker"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+
+    "useDefineForClassFields": true,
+    "importsNotUsedAsValues": "preserve"
+  },
+  "include": ["."]
+}

--- a/packages/playground/worker/workerImport.js
+++ b/packages/playground/worker/workerImport.js
@@ -1,2 +1,2 @@
-export const msg = 'pong'
+export const msg = 'pong2'
 export const mode = process.env.NODE_ENV

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -125,6 +125,7 @@ code {
   const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
   const codeframeRE = /^(?:>?\s+\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
+  // @ts-ignore
   class DOMErrorOverlay extends HTMLElement implements ErrorOverlay {
     root: ShadowRoot
 
@@ -191,10 +192,6 @@ code {
     close(): void {
       this.parentNode?.removeChild(this)
     }
-  }
-
-  ErrorOverlayFactory = (err: CtrType) => {
-    return new DOMErrorOverlay(err) as ErrorOverlay
   }
 
   ErrorOverlay = DOMErrorOverlay


### PR DESCRIPTION
### Description

Fix client and overlay modules for HMR on web workers.

This PR will be on draft since I need to add some test and what to do on `clearErrorOverlay`, line 200 of `client.ts`. 

I just push it if anyone can review the changes on `packages/vite/src/client`.

I've included on worker playground 2 examples to update `msg` from `workerImport` module, also modified the `index.html` page to log HMR updates for `my-worker` (normal and inlined), `possible-ts-output-worker` and `workerImport` to avoid full reload.

Here you can check the HMR working with playground web workers: https://streamable.com/0gtb8d

closes  #25
closes #5396

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
