### PR TITLE
fix(ssr): avoid using `tryNodeResolve` on absolute paths

### DIFF
--- a/packages/playground/ssr-deps/package.json
+++ b/packages/playground/ssr-deps/package.json
@@ -17,6 +17,7 @@
     "only-object-assigned-exports": "file:./only-object-assigned-exports",
     "primitive-export": "file:./primitive-export",
     "read-file-content": "file:./read-file-content",
+    "require-absolute": "file:./require-absolute",
     "ts-transpiled-exports": "file:./ts-transpiled-exports"
   },
   "devDependencies": {

--- a/packages/playground/ssr-deps/require-absolute/foo.js
+++ b/packages/playground/ssr-deps/require-absolute/foo.js
@@ -1,0 +1,1 @@
+module.exports.hello = 'Hello World!'

--- a/packages/playground/ssr-deps/require-absolute/index.js
+++ b/packages/playground/ssr-deps/require-absolute/index.js
@@ -1,0 +1,3 @@
+const path = require('path')
+
+module.exports.hello = () => require(path.resolve(__dirname, './foo.js')).hello

--- a/packages/playground/ssr-deps/require-absolute/package.json
+++ b/packages/playground/ssr-deps/require-absolute/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "require-absolute",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/playground/ssr-deps/src/app.js
+++ b/packages/playground/ssr-deps/src/app.js
@@ -8,6 +8,7 @@ import bcrypt from 'bcrypt'
 import definePropertiesExports from 'define-properties-exports'
 import definePropertyExports from 'define-property-exports'
 import onlyObjectAssignedExports from 'only-object-assigned-exports'
+import requireAbsolute from 'require-absolute'
 
 export async function render(url, rootDir) {
   let html = ''
@@ -40,6 +41,9 @@ export async function render(url, rootDir) {
 
   const onlyObjectAssignedExportsMessage = onlyObjectAssignedExports.hello()
   html += `\n<p class="only-object-assigned-exports-msg">message from only-object-assigned-exports: ${onlyObjectAssignedExportsMessage}</p>`
+
+  const requireAbsoluteMessage = requireAbsolute.hello()
+  html += `\n<p class="require-absolute-msg">message from require-absolute: ${requireAbsoluteMessage}</p>`
 
   return html + '\n'
 }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { pathToFileURL } from 'url'
 import type { ViteDevServer } from '../server'
 import {
+  bareImportRE,
   dynamicImport,
   isBuiltin,
   unwrapId,
@@ -232,14 +233,9 @@ async function nodeImport(
   // When an ESM module imports an ESM dependency, this hook is *not* used.
   const unhookNodeResolve = hookNodeResolve(
     (nodeResolve) => (id, parent, isMain, options) => {
-      // Fix #5709, use require to resolve files with the '.node' file extension.
-      // See detail, https://nodejs.org/api/addons.html#addons_loading_addons_using_require
-      if (
-        id[0] === '.' ||
-        path.isAbsolute(id) ||
-        isBuiltin(id) ||
-        id.endsWith('.node')
-      ) {
+      // Use the Vite resolver only for bare imports while skipping
+      // any built-in modules and binary modules.
+      if (!bareImportRE.test(id) || isBuiltin(id) || id.endsWith('.node')) {
         return nodeResolve(id, parent, isMain, options)
       }
       if (parent) {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -234,7 +234,12 @@ async function nodeImport(
     (nodeResolve) => (id, parent, isMain, options) => {
       // Fix #5709, use require to resolve files with the '.node' file extension.
       // See detail, https://nodejs.org/api/addons.html#addons_loading_addons_using_require
-      if (id[0] === '.' || isBuiltin(id) || id.endsWith('.node')) {
+      if (
+        id[0] === '.' ||
+        path.isAbsolute(id) ||
+        isBuiltin(id) ||
+        id.endsWith('.node')
+      ) {
         return nodeResolve(id, parent, isMain, options)
       }
       if (parent) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,7 @@ importers:
       only-object-assigned-exports: file:./only-object-assigned-exports
       primitive-export: file:./primitive-export
       read-file-content: file:./read-file-content
+      require-absolute: file:./require-absolute
       ts-transpiled-exports: file:./ts-transpiled-exports
     dependencies:
       bcrypt: 5.0.1
@@ -473,6 +474,7 @@ importers:
       only-object-assigned-exports: link:only-object-assigned-exports
       primitive-export: link:primitive-export
       read-file-content: link:read-file-content
+      require-absolute: link:require-absolute
       ts-transpiled-exports: link:ts-transpiled-exports
     devDependencies:
       cross-env: 7.0.3
@@ -497,6 +499,9 @@ importers:
     specifiers: {}
 
   packages/playground/ssr-deps/read-file-content:
+    specifiers: {}
+
+  packages/playground/ssr-deps/require-absolute:
     specifiers: {}
 
   packages/playground/ssr-deps/ts-transpiled-exports:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes https://github.com/sveltejs/kit/issues/3118

If `require()` an absolute path, use default node resolution algorithm instead of Vite's.

### Additional context

Question: Does SSR transform rewrite paths for `require(...)` to absolute? If so, this might not be the best solution then.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
