### PR TITLE
fix: make `globEntries()` implementation more robust

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -131,6 +131,10 @@ export async function scanImports(config: ResolvedConfig): Promise<{
 }
 
 function globEntries(pattern: string | string[], config: ResolvedConfig) {
+  if (Array.isArray(pattern)) {
+    // If a pattern is `undefined` then `glob` chokes.
+    pattern = pattern.filter(Boolean)
+  }
   return glob(pattern, {
     cwd: config.root,
     ignore: [


### PR DESCRIPTION
This fixes a bug occurring in `vite-plugin-ssr`'s test suite.

I skipped the PR template, but let me know if I should stick to the PR template even for small changes like this.