### PR TITLE
fix: improve alias merging

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -28,18 +28,50 @@ describe('mergeConfig', () => {
       resolve: {
         alias: [
           {
-            find: 'foo',
-            replacement: 'foo-value'
-          },
-          {
             find: 'bar',
             replacement: 'bar-value'
           },
           {
             find: 'baz',
             replacement: 'baz-value'
+          },
+          {
+            find: 'foo',
+            replacement: 'foo-value'
           }
         ]
+      }
+    }
+
+    expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+  })
+
+  test('keep object alias schema', () => {
+    const baseConfig = {
+      resolve: {
+        alias: {
+          bar: 'bar-value',
+          baz: 'baz-value'
+        }
+      }
+    }
+
+    const newConfig = {
+      resolve: {
+        alias: {
+          bar: 'bar-value-2',
+          foo: 'foo-value'
+        }
+      }
+    }
+
+    const mergedConfig = {
+      resolve: {
+        alias: {
+          bar: 'bar-value-2',
+          baz: 'baz-value',
+          foo: 'foo-value'
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Changes in https://github.com/vitejs/vite/pull/6344 expose the problem of alias merging strategy.

E.g.

```ts
mergeConfig(
  {
    resolve: { alias: { foo: 'old' }}
  },
  {
    resolve: { alias: { foo: 'new' }}
  }
)
```

With will be normalized to 

```ts
[
  { find: 'foo', replacement: 'old' },
  { find: 'foo', replacement: 'new' }
]
```

Since @rollup/plugin-alias resolve the alias from top-down, it makes `foo` always resolved to `foo`, and makes the later config fail to override the previous.

Leading the error in Nuxt: https://github.com/nuxt/framework/pull/2716

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
