### PR TITLE
fix: merge debug params instead of overwrite (#6504)

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -28,7 +28,7 @@ if (debugIndex > 0) {
       .map((v) => `vite:${v}`)
       .join(',')
   }
-  process.env.DEBUG = value
+  process.env.DEBUG = `${process.env.DEBUG || ''},${value}`
 
   if (filterIndex > 0) {
     const filter = process.argv[filterIndex + 1]

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -28,7 +28,7 @@ if (debugIndex > 0) {
       .map((v) => `vite:${v}`)
       .join(',')
   }
-  process.env.DEBUG = `${process.env.DEBUG || ''},${value}`
+  process.env.DEBUG = `${process.env.DEBUG ? process.env.DEBUG + ',' : ''}${value}`
 
   if (filterIndex > 0) {
     const filter = process.argv[filterIndex + 1]

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -28,7 +28,9 @@ if (debugIndex > 0) {
       .map((v) => `vite:${v}`)
       .join(',')
   }
-  process.env.DEBUG = `${process.env.DEBUG ? process.env.DEBUG + ',' : ''}${value}`
+  process.env.DEBUG = `${
+    process.env.DEBUG ? process.env.DEBUG + ',' : ''
+  }${value}`
 
   if (filterIndex > 0) {
     const filter = process.argv[filterIndex + 1]


### PR DESCRIPTION
### Description
fix: #6504
Running `DEBUG=some-vite-plugin vite dev --debug` enabled only debug on `vite:*` without `some-vite-plugin`, because vite overrided DEBUG env.
`--debug` should only widen the scope of DEBUG var instead of overriding it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
