### PR TITLE
fix: Check port usage correctly (fix #6519)

### DIFF
--- a/packages/playground/preview/__tests__/preview.spec.ts
+++ b/packages/playground/preview/__tests__/preview.spec.ts
@@ -1,5 +1,5 @@
-import { httpServerStart } from '../http'
-import { resolveConfig } from '..'
+import { httpServerStart } from 'vite/src/node/http'
+import { resolveConfig } from 'vite/src/node'
 
 describe('start preview server', () => {
   test('[strictPort=false, host=127.0.0.1] should use another port when already start a server on localhost.', async () => {

--- a/packages/playground/preview/__tests__/preview.spec.ts
+++ b/packages/playground/preview/__tests__/preview.spec.ts
@@ -1,13 +1,14 @@
 import { httpServerStart } from 'vite/src/node/http'
 import { resolveConfig } from 'vite/src/node'
+import { createServer } from 'http'
 
 describe('start preview server', () => {
   test('[strictPort=false, host=127.0.0.1] should use another port when already start a server on localhost.', async () => {
     const originalPort = 5000
-    const server = require('http').createServer()
+    const server = createServer()
     server.listen(originalPort, 'localhost')
 
-    const testServer = require('http').createServer()
+    const testServer = createServer()
     const config = await resolveConfig({}, 'serve', 'production')
     const port = await httpServerStart(testServer, {
       port: originalPort,
@@ -24,12 +25,12 @@ describe('start preview server', () => {
 
   test('[strictPort=true, host=127.0.0.1] should use another port when already start a server on localhost.', async () => {
     const originalPort = 5000
-    const server = require('http').createServer()
+    const server = createServer()
     server.listen(originalPort, 'localhost')
 
     const config = await resolveConfig({}, 'serve', 'production')
-    const testServer = require('http').createServer()
-    expect(
+    const testServer = createServer()
+    await expect(
       httpServerStart(testServer, {
         port: originalPort,
         strictPort: true,

--- a/packages/playground/preview/index.html
+++ b/packages/playground/preview/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Preview</title>
+  </head>
+  <body>
+    <h1>Preview</h1>
+    <div><!--app-html--></div>
+  </body>
+</html>

--- a/packages/playground/preview/package.json
+++ b/packages/playground/preview/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "preview",
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite --force",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/packages/vite/src/node/__tests__/http.spec.ts
+++ b/packages/vite/src/node/__tests__/http.spec.ts
@@ -1,0 +1,44 @@
+import { httpServerStart } from '../http'
+import { resolveConfig } from '..'
+
+describe('start preview server', () => {
+  test('[strictPort=false, host=127.0.0.1] should use another port when already start a server on localhost.', async () => {
+    const originalPort = 5000
+    const server = require('http').createServer()
+    server.listen(originalPort, 'localhost')
+
+    const testServer = require('http').createServer()
+    const config = await resolveConfig({}, 'serve', 'production')
+    const port = await httpServerStart(testServer, {
+      port: originalPort,
+      strictPort: false,
+      host: '127.0.0.1',
+      logger: config.logger
+    })
+
+    expect(port).not.toEqual(originalPort)
+
+    server.close()
+    testServer.close()
+  })
+
+  test('[strictPort=true, host=127.0.0.1] should use another port when already start a server on localhost.', async () => {
+    const originalPort = 5000
+    const server = require('http').createServer()
+    server.listen(originalPort, 'localhost')
+
+    const config = await resolveConfig({}, 'serve', 'production')
+    const testServer = require('http').createServer()
+    expect(
+      httpServerStart(testServer, {
+        port: originalPort,
+        strictPort: true,
+        host: '127.0.0.1',
+        logger: config.logger
+      })
+    ).rejects.toEqual(new Error(`Port ${originalPort} is already in use`))
+
+    server.close()
+    testServer.close()
+  })
+})

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -183,6 +183,39 @@ async function getCertificate(cacheDir?: string) {
   }
 }
 
+function checkPortOccupied(
+  port: number,
+  host?: string
+): Promise<{ port: number; occupied: boolean }> {
+  return new Promise((resolve, reject) => {
+    const tempServer = require('http').createServer()
+
+    const onError = (e: Error & { code?: string }) => {
+      if (e.code === 'EADDRINUSE') {
+        checkPortOccupied(++port, host)
+          .then((r) => {
+            resolve({
+              port: r.port,
+              occupied: true
+            })
+          })
+          .catch(reject)
+      } else {
+        reject(e)
+      }
+      tempServer.removeListener('error', onError)
+      tempServer.close()
+    }
+
+    tempServer.on('error', onError)
+
+    tempServer.listen(port, host, () => {
+      tempServer.removeListener('error', onError)
+      tempServer.close(() => resolve({ port, occupied: false }))
+    })
+  })
+}
+
 export async function httpServerStart(
   httpServer: HttpServer,
   serverOptions: {
@@ -192,28 +225,39 @@ export async function httpServerStart(
     logger: Logger
   }
 ): Promise<number> {
-  return new Promise((resolve, reject) => {
-    let { port, strictPort, host, logger } = serverOptions
+  const { strictPort, host, logger } = serverOptions
+  // Check the port usage of serverOptions.host
+  let checkInfo = await checkPortOccupied(serverOptions.port, host)
 
-    const onError = (e: Error & { code?: string }) => {
-      if (e.code === 'EADDRINUSE') {
-        if (strictPort) {
-          httpServer.removeListener('error', onError)
-          reject(new Error(`Port ${port} is already in use`))
-        } else {
-          logger.info(`Port ${port} is in use, trying another one...`)
-          httpServer.listen(++port, host)
-        }
-      } else {
-        httpServer.removeListener('error', onError)
-        reject(e)
-      }
+  if (host === '127.0.0.1') {
+    // Check the port usage of localhost
+    checkInfo = await checkPortOccupied(serverOptions.port, 'localhost')
+  }
+
+  return new Promise((resolve, reject) => {
+    const { port, occupied } = checkInfo
+
+    if (occupied && strictPort) {
+      reject(new Error(`Port ${serverOptions.port} is already in use`))
+      return
+    }
+
+    const onError = (e: Error) => {
+      httpServer.removeListener('error', onError)
+      reject(e)
     }
 
     httpServer.on('error', onError)
 
     httpServer.listen(port, host, () => {
       httpServer.removeListener('error', onError)
+
+      if (occupied) {
+        logger.info(
+          `Port ${serverOptions.port} is in use, trying another one...`
+        )
+      }
+
       resolve(port)
     })
   })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixed: #6519 

I hope there is an accurate notification when a port is occupied, as this can take a lot of time for most novices to debug. He may not be able to tell if it's a problem with his business code or a problem with the project configuration.

### Additional context

Should I continue to check localhost after checking for 127.0.0.1? Because we probably don't know if the user's 127.0.0.1 domain name is localhost either, although most of them are.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Other
- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
