### PR TITLE
fix: avoid referencing importGlob from importMeta.d.ts

### DIFF
--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -4,6 +4,15 @@
 
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
+// Duplicate import('../src/node/importGlob').AssertOptions
+// Avoid breaking the production client type because this file is referenced
+// in vite/client.d.ts and in production src/node/importGlob.ts doesn't exist
+interface AssertOptions {
+  assert?: {
+    type: string
+  }
+}
+
 interface ImportMeta {
   url: string
 
@@ -52,7 +61,7 @@ interface ImportMeta {
 
   glob(
     pattern: string,
-    options?: import('../src/node/importGlob').AssertOptions
+    options?: AssertOptions
   ): Record<
     string,
     () => Promise<{
@@ -62,7 +71,7 @@ interface ImportMeta {
 
   globEager(
     pattern: string,
-    options?: import('../src/node/importGlob').AssertOptions
+    options?: AssertOptions
   ): Record<
     string,
     {


### PR DESCRIPTION
### Description

See https://github.com/vitejs/vite/pull/6456#discussion_r785408803

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
