### PR TITLE
fix: prevent race condition between `transformRequest` and `optimizeDeps` (fix #6508)

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -113,6 +113,13 @@ async function doTransform(
         }
       }
     }
+
+    // If the optimizer has been run, further transformations are useless
+    // as the optimizer will invalidate all the modules anyway.
+    if (server._isRunningOptimizer) {
+      return null
+    }
+
     if (code) {
       try {
         map = (


### PR DESCRIPTION
### Description

Fixes #6508

The idea behind this PR is to prevent further transformations of a module in the case the deps optimizer has been run after reading the module's source code but before reading the source maps. It is useless to continue transformations as running the optimizer will invalidate all the modules in the end. This should prevent the race condition described in the linked issue and fix irrelevant `Failed to load source map for .vite/chunk-AJFLDE.js` warnings that are caused by that race condition.

### Additional context

The `transformRequest` function can be invoked:

1. By making a direct HTTP request to a module. In this case, the change will cause the server to return `404` for the module if the optimizer has been run in the mentioned circumstances. The module will be transformed normally after a full reload that the optimizer will cause eventually.
2. By the `importAnalysis` plugin during the pre-transformation of the module's imports. In this case, the module will be just skipped until a full reload that the optimizer will cause eventually.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
