### PR TITLE
fix(dev): Prevent stripping query params from CSS in HMR

### DIFF
--- a/packages/playground/hmr/__tests__/hmr.spec.ts
+++ b/packages/playground/hmr/__tests__/hmr.spec.ts
@@ -142,9 +142,17 @@ if (!isBuild) {
 
   test('CSS update preserves query params', async () => {
     await page.goto(viteTestUrl)
-    const el = await page.$('.css')
+
     editFile('global.css', (code) => code.replace('white', 'tomato'))
 
-    await untilUpdated(() => el.textContent(), '/global.css?param=required')
+    const elprev = await page.$('.css-prev')
+    const elpost = await page.$('.css-post')
+    await untilUpdated(() => elprev.textContent(), 'param=required')
+    await untilUpdated(() => elpost.textContent(), 'param=required')
+    const textprev = await elprev.textContent()
+    const textpost = await elpost.textContent()
+    expect(textprev).not.toBe(textpost)
+    expect(textprev).not.toMatch('direct')
+    expect(textpost).not.toMatch('direct')
   })
 }

--- a/packages/playground/hmr/__tests__/hmr.spec.ts
+++ b/packages/playground/hmr/__tests__/hmr.spec.ts
@@ -139,4 +139,12 @@ if (!isBuild) {
       'title2'
     )
   })
+
+  test('CSS update preserves query params', async () => {
+    await page.goto(viteTestUrl)
+    const el = await page.$('.css')
+    editFile('global.css', (code) => code.replace('white', 'tomato'))
+
+    await untilUpdated(() => el.textContent(), '/global.css?param=required')
+  })
 }

--- a/packages/playground/hmr/global.css
+++ b/packages/playground/hmr/global.css
@@ -1,0 +1,3 @@
+body {
+  background: white;
+}

--- a/packages/playground/hmr/hmr.js
+++ b/packages/playground/hmr/hmr.js
@@ -35,6 +35,19 @@ if (import.meta.hot) {
 
   import.meta.hot.on('vite:beforeUpdate', (event) => {
     console.log(`>>> vite:beforeUpdate -- ${event.type}`)
+
+    const cssUpdate = event.updates.find(
+      (update) =>
+        update.type === 'css-update' && update.path.match('global.css')
+    )
+    if (cssUpdate) {
+      const el = document.querySelector('#global-css')
+      text('.css-prev', el.href)
+      // We don't have a vite:afterUpdate event, but updates are currently sync
+      setTimeout(() => {
+        text('.css-post', el.href)
+      }, 0)
+    }
   })
 
   import.meta.hot.on('vite:error', (event) => {
@@ -43,13 +56,6 @@ if (import.meta.hot) {
 
   import.meta.hot.on('foo', ({ msg }) => {
     text('.custom', msg)
-  })
-
-  import.meta.hot.on('vite:afterUpdate:css', (el) => {
-    let url = new URL(el.href, location)
-    url.searchParams.delete('t')
-    url.searchParams.delete('direct')
-    text('.css', url.pathname + url.search)
   })
 }
 

--- a/packages/playground/hmr/hmr.js
+++ b/packages/playground/hmr/hmr.js
@@ -44,6 +44,13 @@ if (import.meta.hot) {
   import.meta.hot.on('foo', ({ msg }) => {
     text('.custom', msg)
   })
+
+  import.meta.hot.on('vite:afterUpdate:css', (el) => {
+    let url = new URL(el.href, location)
+    url.searchParams.delete('t')
+    url.searchParams.delete('direct')
+    text('.css', url.pathname + url.search)
+  })
 }
 
 function text(el, text) {

--- a/packages/playground/hmr/index.html
+++ b/packages/playground/hmr/index.html
@@ -1,6 +1,8 @@
+<link rel="stylesheet" href="./global.css?param=required" />
 <script type="module" src="./hmr.js"></script>
 
 <div class="app"></div>
 <div class="dep"></div>
 <div class="nested"></div>
 <div class="custom"></div>
+<div class="css"></div>

--- a/packages/playground/hmr/index.html
+++ b/packages/playground/hmr/index.html
@@ -1,8 +1,9 @@
-<link rel="stylesheet" href="./global.css?param=required" />
+<link id="global-css" rel="stylesheet" href="./global.css?param=required" />
 <script type="module" src="./hmr.js"></script>
 
 <div class="app"></div>
 <div class="dep"></div>
 <div class="nested"></div>
 <div class="custom"></div>
-<div class="css"></div>
+<div class="css-prev"></div>
+<div class="css-post"></div>

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -88,12 +88,12 @@ async function handleMessage(payload: HMRPayload) {
             document.querySelectorAll<HTMLLinkElement>('link')
           ).find((e) => cleanUrl(e.href).includes(searchUrl))
           if (el) {
-            const newPath = `${base}${path.slice(1)}${
-              path.includes('?') ? '&' : '?'
+            const newPath = `${base}${searchUrl.slice(1)}${
+              searchUrl.includes('?') ? '&' : '?'
             }t=${timestamp}`
             el.href = new URL(newPath, el.href).href
           }
-          console.log(`[vite] css hot updated: ${path}`)
+          console.log(`[vite] css hot updated: ${searchUrl}`)
           notifyListeners<'vite:afterUpdate:css'>('vite:afterUpdate:css', el)
         }
       })

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -94,7 +94,6 @@ async function handleMessage(payload: HMRPayload) {
             el.href = new URL(newPath, el.href).href
           }
           console.log(`[vite] css hot updated: ${searchUrl}`)
-          notifyListeners<'vite:afterUpdate:css'>('vite:afterUpdate:css', el)
         }
       })
       break


### PR DESCRIPTION
### Description

During HMR, this change prevents query params from being stripped when
reloading the CSS.

### Additional context

None

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
