### PR TITLE
docs: `serve` runs in development mode.

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -83,7 +83,7 @@ interface ImportMeta {
 
 ## Modes
 
-By default, the dev server (`dev` command) runs in `development` mode and the `build` and `serve` commands run in `production` mode.
+By default, the dev server (`dev` command) runs in `development` mode and the `build` command run in `production` mode.
 
 This means when running `vite build`, it will load the env variables from `.env.production` if there is one:
 


### PR DESCRIPTION
Documentation correction.

### Description

> - Normalize scripts and commands naming ([#5207](https://github.com/vitejs/vite/pull/5207))
  Adds a new `vite dev` command alias for `vite serve`, preparing for the new release of create-vite where package scripts are renamed to `dev`, `build`, and `preview`.

Above from CHANGE LOG of 2.7.0 says that `serve` and `dev` both run in the same mode.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other