### PR TITLE
docs(config): added an example about proxying websockets

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -482,6 +482,11 @@ export default defineConfig(async ({ command, mode }) => {
           configure: (proxy, options) => {
             // proxy will be an instance of 'http-proxy'
           }
+        },
+        // Proxying websockets or socket.io
+        '/socket.io': {
+          target: 'ws://localhost:3000',
+          ws: true
         }
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I had trouble with the proxy option and socket.io: it only worked with long polling.

### Additional context

I feel like working with websockets is not a rare use-case, and adding an example on how to make it work is relevant.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
