### PR TITLE
fix: Re-enable minifying es lib

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -801,8 +801,6 @@ export default defineConfig({
 
   Set to `false` to disable minification, or specify the minifier to use. The default is [Esbuild](https://github.com/evanw/esbuild) which is 20 ~ 40x faster than terser and only 1 ~ 2% worse compression. [Benchmarks](https://github.com/privatenumber/minification-benchmarks)
 
-  Note the `build.minify` option is not available when using the `'es'` format in lib mode.
-
 ### build.terserOptions
 
 - **Type:** `TerserOptions`

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -251,7 +251,7 @@ export function resolveBuildOptions(
     cssTarget: false,
     sourcemap: false,
     rollupOptions: {},
-    minify: raw?.ssr ? false : 'esbuild',
+    minify: raw?.ssr || raw?.lib ? false : 'esbuild',
     terserOptions: {},
     write: true,
     emptyOutDir: null,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -227,13 +227,7 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
       }
 
       const target = config.build.target
-      const minify =
-        config.build.minify === 'esbuild' &&
-        // Do not minify ES lib output since that would remove pure annotations
-        // and break tree-shaking
-        // https://github.com/vuejs/core/issues/2860#issuecomment-926882793
-        !(config.build.lib && opts.format === 'es')
-
+      const minify = config.build.minify === 'esbuild'
       if ((!target || target === 'esnext') && !minify) {
         return null
       }

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -35,12 +35,6 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
         return null
       }
 
-      // Do not minify ES lib output since that would remove pure annotations
-      // and break tree-shaking.
-      if (config.build.lib && outputOptions.format === 'es') {
-        return null
-      }
-
       // Lazy load worker.
       worker ||= makeWorker()
 


### PR DESCRIPTION
### Description

@yyx990803 said "We should probably default to not minifying in lib mode in Vite" [here](https://github.com/vuejs/core/issues/2860#issuecomment-926928968).

Instead of this requested behaviour, this commit https://github.com/vitejs/vite/commit/06d86e4a2e90ca916a43d450bca1e6c28bc4bfe2 prevents es libs to be minified even if the `minify` option is set to `true`, `esbuild` or `terser`.

This PR change the default value of the `minify` option to `false` if a `lib` option is present, re-enabling minifying es lib if `minify` is requested.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
