### PR TITLE
fix: debug `dotenv` when specifically scoped

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1090,7 +1090,7 @@ export function loadEnv(
     const path = lookupFile(envDir, [file], true)
     if (path) {
       const parsed = dotenv.parse(fs.readFileSync(path), {
-        debug: process.env.DEBUG?.includes('dotenv') || undefined
+        debug: process.env.DEBUG?.includes('vite:dotenv') || undefined
       })
 
       // let environment variables use each other

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1090,7 +1090,7 @@ export function loadEnv(
     const path = lookupFile(envDir, [file], true)
     if (path) {
       const parsed = dotenv.parse(fs.readFileSync(path), {
-        debug: !!process.env.DEBUG || undefined
+        debug: process.env.DEBUG?.includes('dotenv') || undefined
       })
 
       // let environment variables use each other


### PR DESCRIPTION
### Description

This minor PR changes how the `debug` option of `dotenv` is determined. Currently, it is true if `DEBUG` is not empty. This PR changes this behavior to only make it to true if `DEBUG` contains `dotenv`.

The reason for this is that when debugging with `.env` files with empty values, which is quite common, `dotenv` emits a lot of warnings. 

![](https://i.imgur.com/FqAIhxR.png)

I don't think it's wanted behavior to have `dotenv` on debug mode when `DEBUG` is not empty, as this variable is commonly used with specific scopes.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
