### PR TITLE
fix: revert #5342, only run build-html plugin on bundler inputs

### DIFF
--- a/packages/playground/html/__tests__/html.spec.ts
+++ b/packages/playground/html/__tests__/html.spec.ts
@@ -197,25 +197,6 @@ describe('noBody', () => {
   })
 })
 
-describe('importAsString', () => {
-  // The build-html plugin should not alter HTML that is not an input.
-  test('not transformed', async () => {
-    const messages = []
-    function addConsoleMessage(message) {
-      messages.push(message.args()[0])
-    }
-
-    page.on('console', addConsoleMessage)
-    await page.goto(viteTestUrl + '/index.html')
-    await page.waitForLoadState()
-    page.off('console', addConsoleMessage)
-
-    const result = messages.map((m) => m.toString()).join('\n')
-    expect(result).toMatch('Some imported HTML')
-    expect(result).not.toMatch('This is injected')
-  })
-})
-
 describe('unicode path', () => {
   test('direct access', async () => {
     await page.goto(

--- a/packages/playground/html/importAsString.html
+++ b/packages/playground/html/importAsString.html
@@ -1,5 +1,0 @@
-<html>
-  <body>
-    Some imported HTML
-  </body>
-</html>

--- a/packages/playground/html/main.js
+++ b/packages/playground/html/main.js
@@ -1,6 +1,4 @@
 import { msg } from './shared'
-import asString from './importAsString.html'
 import './common.css'
 
 console.log(msg + ' from main')
-console.log('loaded string ' + asString)

--- a/packages/playground/html/vite.config.js
+++ b/packages/playground/html/vite.config.js
@@ -157,18 +157,6 @@ ${
           }
         ]
       }
-    },
-    {
-      // Emulate rollup-plugin-string
-      name: 'import-as-string-module',
-      transform(code, id) {
-        if (id.endsWith('importAsString.html')) {
-          return {
-            code: `export default ${JSON.stringify(code)}`,
-            map: { mappings: '' }
-          }
-        }
-      }
     }
   ]
 }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -221,32 +221,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   // Same reason with `htmlInlineProxyPlugin`
   isAsyncScriptMap.set(config, new Map())
 
-  const inputFiles = new Set<string>()
-
   return {
     name: 'vite:build-html',
 
-    buildStart({ input }) {
-      isAsyncScriptMap.set(config, new Map())
-
-      let allInputs: string[]
-      if (typeof input === 'string') {
-        allInputs = [input]
-      } else if (Array.isArray(input)) {
-        allInputs = input
-      } else {
-        allInputs = Object.values(input)
-      }
-
-      for (const filename of allInputs) {
-        if (filename.endsWith('.html')) {
-          inputFiles.add(normalizePath(filename))
-        }
-      }
-    },
-
     async transform(html, id) {
-      if (inputFiles.has(id)) {
+      if (id.endsWith('.html')) {
         const publicPath = `/${slash(path.relative(config.root, id))}`
         // pre-transform
         html = await applyHtmlTransforms(html, preHooks, {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This reverts commit 7541a8d570d9bbf0ab0cd4264cae985dddaf3189.


### Additional context

The change from #5342 causes [storybook-builder-vite](https://github.com/eirslett/storybook-builder-vite) to error during production build, since it constructs a virtual html entry file based on various options.  I asked on discord if there was a way to update our code to handle the new change, and was asked to submit a PR to revert it, as it was deemed too risky for a minor version release.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
