### PR TITLE
feat(plugin-react): ensure `overrides` array exists before `api.reactBabel` hooks are called

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -60,6 +60,7 @@ export type BabelOptions = Omit<
 export interface ReactBabelOptions extends BabelOptions {
   plugins: Extract<BabelOptions['plugins'], any[]>
   presets: Extract<BabelOptions['presets'], any[]>
+  overrides: Extract<BabelOptions['overrides'], any[]>
   parserOpts: ParserOptions & {
     plugins: Extract<ParserOptions['plugins'], any[]>
   }
@@ -95,6 +96,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
   babelOptions.plugins ||= []
   babelOptions.presets ||= []
+  babelOptions.overrides ||= []
   babelOptions.parserOpts ||= {} as any
   babelOptions.parserOpts.plugins ||= opts.parserPlugins || []
 


### PR DESCRIPTION
### Description

This allows plugins using `api.reactBabel` to define Babel overrides without checking if the array exists first.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
