### PR TITLE
fix(ssr): skip vite resolve for windows absolute path

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -234,8 +234,13 @@ async function nodeImport(
   const unhookNodeResolve = hookNodeResolve(
     (nodeResolve) => (id, parent, isMain, options) => {
       // Use the Vite resolver only for bare imports while skipping
-      // any built-in modules and binary modules.
-      if (!bareImportRE.test(id) || isBuiltin(id) || id.endsWith('.node')) {
+      // any absolute paths, built-in modules and binary modules.
+      if (
+        !bareImportRE.test(id) ||
+        path.isAbsolute(id) ||
+        isBuiltin(id) ||
+        id.endsWith('.node')
+      ) {
         return nodeResolve(id, parent, isMain, options)
       }
       if (parent) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When `hookNodeResolve` encounters path like `C:/foo/bar` or `D:\\foo\\bar`, skip `viteResolve` too.

### Additional context

Follow-up from #6488. Reported by @natemoo-re from discord. No tests since we haven't really had tests for this feature, but I think it's fine with #6591 coming.

I initially planned to modify `bareImportRE` instead, but handling it there generically may cause breaking changes in other places, so I resorted to the changes here now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
