### PR TITLE
chore: ensure local package private

### DIFF
--- a/packages/create-vite/template-lit-ts/package.json
+++ b/packages/create-vite/template-lit-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-lit-ts-starter",
+  "private": true,
   "version": "0.0.0",
   "main": "dist/my-element.es.js",
   "exports": {

--- a/packages/create-vite/template-lit/package.json
+++ b/packages/create-vite/template-lit/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-lit-starter",
+  "private": true,
   "version": "0.0.0",
   "main": "dist/my-element.es.js",
   "exports": {

--- a/packages/create-vite/template-preact-ts/package.json
+++ b/packages/create-vite/template-preact-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-preact-ts-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/create-vite/template-preact/package.json
+++ b/packages/create-vite/template-preact/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-preact-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-react-typescript-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/create-vite/template-react/package.json
+++ b/packages/create-vite/template-react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-react-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-svelte-ts-starter",
+  "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/packages/create-vite/template-svelte/package.json
+++ b/packages/create-vite/template-svelte/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-svelte-starter",
+  "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/packages/create-vite/template-vanilla-ts/package.json
+++ b/packages/create-vite/template-vanilla-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-typescript-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/create-vite/template-vanilla/package.json
+++ b/packages/create-vite/template-vanilla/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-vue-typescript-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/create-vite/template-vue/package.json
+++ b/packages/create-vite/template-vue/package.json
@@ -1,5 +1,6 @@
 {
   "name": "vite-vue-starter",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/packages/playground/css/css-dep/package.json
+++ b/packages/playground/css/css-dep/package.json
@@ -1,5 +1,6 @@
 {
   "name": "css-dep",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "style": "index.css",

--- a/packages/playground/css/pkg-dep/package.json
+++ b/packages/playground/css/pkg-dep/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js"
 }

--- a/packages/playground/nested-deps/test-package-a/package.json
+++ b/packages/playground/nested-deps/test-package-a/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-a",
+  "private": true,
   "version": "2.0.0",
   "main": "index.js"
 }

--- a/packages/playground/nested-deps/test-package-b/package.json
+++ b/packages/playground/nested-deps/test-package-b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-b",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js"
 }

--- a/packages/playground/nested-deps/test-package-c/package.json
+++ b/packages/playground/nested-deps/test-package-c/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-c",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "module": "index-es.js"

--- a/packages/playground/nested-deps/test-package-d/package.json
+++ b/packages/playground/nested-deps/test-package-d/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-d",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {

--- a/packages/playground/nested-deps/test-package-d/test-package-d-nested/package.json
+++ b/packages/playground/nested-deps/test-package-d/test-package-d-nested/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-d-nested",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js"
 }

--- a/packages/playground/nested-deps/test-package-e/package.json
+++ b/packages/playground/nested-deps/test-package-e/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-e",
+  "private": true,
   "version": "0.1.0",
   "main": "index.js",
   "dependencies": {

--- a/packages/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-e-excluded",
+  "private": true,
   "version": "0.1.0",
   "main": "index.js"
 }

--- a/packages/playground/nested-deps/test-package-e/test-package-e-included/package.json
+++ b/packages/playground/nested-deps/test-package-e/test-package-e-included/package.json
@@ -1,5 +1,6 @@
 {
   "name": "test-package-e-included",
+  "private": true,
   "version": "0.1.0",
   "main": "index.js",
   "dependencies": {

--- a/packages/playground/optimize-deps/dep-cjs-compiled-from-cjs/package.json
+++ b/packages/playground/optimize-deps/dep-cjs-compiled-from-cjs/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep-cjs-compiled-from-cjs",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js"
 }

--- a/packages/playground/optimize-deps/dep-cjs-compiled-from-esm/package.json
+++ b/packages/playground/optimize-deps/dep-cjs-compiled-from-esm/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep-cjs-compiled-from-esm",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js"
 }

--- a/packages/playground/optimize-deps/dep-esbuild-plugin-transform/package.json
+++ b/packages/playground/optimize-deps/dep-esbuild-plugin-transform/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep-esbuild-plugin-transform",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js"
 }

--- a/packages/playground/optimize-deps/dep-linked-include/package.json
+++ b/packages/playground/optimize-deps/dep-linked-include/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep-linked-include",
+  "private": true,
   "version": "0.0.0",
   "main": "index.mjs",
   "dependencies": {

--- a/packages/playground/optimize-deps/dep-linked/package.json
+++ b/packages/playground/optimize-deps/dep-linked/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep-linked",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js",
   "dependencies": {

--- a/packages/playground/optimize-deps/nested-exclude/nested-include/package.json
+++ b/packages/playground/optimize-deps/nested-exclude/nested-include/package.json
@@ -1,5 +1,6 @@
 {
   "name": "nested-include",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js"
 }

--- a/packages/playground/optimize-deps/nested-exclude/package.json
+++ b/packages/playground/optimize-deps/nested-exclude/package.json
@@ -1,5 +1,6 @@
 {
   "name": "nested-exclude",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {

--- a/packages/playground/optimize-missing-deps/missing-dep/package.json
+++ b/packages/playground/optimize-missing-deps/missing-dep/package.json
@@ -1,5 +1,6 @@
 {
   "name": "missing-dep",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js",
   "dependencies": {

--- a/packages/playground/optimize-missing-deps/multi-entry-dep/package.json
+++ b/packages/playground/optimize-missing-deps/multi-entry-dep/package.json
@@ -1,5 +1,6 @@
 {
   "name": "multi-entry-dep",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js",
   "browser": {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-playground",
-  "version": "1.0.0",
   "private": true,
+  "version": "1.0.0",
   "devDependencies": {
     "css-color-names": "^1.0.1"
   }

--- a/packages/playground/preserve-symlinks/moduleA/package.json
+++ b/packages/playground/preserve-symlinks/moduleA/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@symlinks/moduleA",
+  "private": true,
   "version": "0.0.0",
   "main": "linked.js"
 }

--- a/packages/playground/preserve-symlinks/package.json
+++ b/packages/playground/preserve-symlinks/package.json
@@ -1,5 +1,6 @@
 {
   "name": "preserve-symlinks",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite --force",

--- a/packages/playground/resolve-config/package.json
+++ b/packages/playground/resolve-config/package.json
@@ -1,5 +1,6 @@
 {
   "name": "resolve-config",
+  "private": true,
   "version": "0.0.0",
   "scripts": {
     "dev": "vite --force",

--- a/packages/playground/resolve-linked/package.json
+++ b/packages/playground/resolve-linked/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resolve-linked",
-  "version": "0.0.0",
   "private": true,
+  "version": "0.0.0",
   "main": "src/index.js"
 }

--- a/packages/playground/resolve/browser-field/package.json
+++ b/packages/playground/resolve/browser-field/package.json
@@ -1,5 +1,6 @@
 {
   "name": "resolve-browser-field",
+  "private": true,
   "version": "1.0.0",
   "//": "real world example: https://github.com/axios/axios/blob/3f2ef030e001547eb06060499f8a2e3f002b5a14/package.json#L71-L73",
   "main": "out/cjs.node.js",

--- a/packages/playground/resolve/custom-condition/package.json
+++ b/packages/playground/resolve/custom-condition/package.json
@@ -1,5 +1,6 @@
 {
   "name": "resolve-custom-condition",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "exports": {

--- a/packages/playground/resolve/custom-main-field/package.json
+++ b/packages/playground/resolve/custom-main-field/package.json
@@ -1,5 +1,6 @@
 {
   "name": "resolve-custom-main-field",
+  "private": true,
   "version": "1.0.0",
   "main": "index.js",
   "custom": "index.custom.js"

--- a/packages/playground/resolve/exports-env/package.json
+++ b/packages/playground/resolve/exports-env/package.json
@@ -1,5 +1,6 @@
 {
   "name": "resolve-exports-env",
+  "private": true,
   "version": "1.0.0",
   "exports": {
     "import": {

--- a/packages/playground/resolve/exports-path/package.json
+++ b/packages/playground/resolve/exports-path/package.json
@@ -1,5 +1,6 @@
 {
   "name": "resolve-exports-path",
+  "private": true,
   "version": "1.0.0",
   "exports": {
     ".": {

--- a/packages/playground/resolve/inline-package/package.json
+++ b/packages/playground/resolve/inline-package/package.json
@@ -1,6 +1,7 @@
 {
   "name": "inline-package",
   "private": true,
+  "version": "0.0.0",
   "sideEffects": false,
   "main": "./inline"
 }

--- a/packages/playground/ssr-deps/define-properties-exports/package.json
+++ b/packages/playground/ssr-deps/define-properties-exports/package.json
@@ -1,5 +1,5 @@
 {
   "name": "define-properties-exports",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/define-property-exports/package.json
+++ b/packages/playground/ssr-deps/define-property-exports/package.json
@@ -1,5 +1,5 @@
 {
   "name": "define-property-exports",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/forwarded-export/package.json
+++ b/packages/playground/ssr-deps/forwarded-export/package.json
@@ -1,5 +1,5 @@
 {
   "name": "forwarded-export",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/object-assigned-exports/package.json
+++ b/packages/playground/ssr-deps/object-assigned-exports/package.json
@@ -1,5 +1,5 @@
 {
   "name": "object-assigned-exports",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/only-object-assigned-exports/package.json
+++ b/packages/playground/ssr-deps/only-object-assigned-exports/package.json
@@ -1,5 +1,5 @@
 {
   "name": "only-object-assigned-exports",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/primitive-export/package.json
+++ b/packages/playground/ssr-deps/primitive-export/package.json
@@ -1,5 +1,5 @@
 {
   "name": "primitive-export",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/read-file-content/package.json
+++ b/packages/playground/ssr-deps/read-file-content/package.json
@@ -1,5 +1,5 @@
 {
   "name": "read-file-content",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/require-absolute/package.json
+++ b/packages/playground/ssr-deps/require-absolute/package.json
@@ -1,5 +1,5 @@
 {
   "name": "require-absolute",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-deps/ts-transpiled-exports/package.json
+++ b/packages/playground/ssr-deps/ts-transpiled-exports/package.json
@@ -1,5 +1,5 @@
 {
   "name": "ts-transpiled-exports",
-  "version": "0.0.0",
-  "private": true
+  "private": true,
+  "version": "0.0.0"
 }

--- a/packages/playground/ssr-vue/dep-import-type/package.json
+++ b/packages/playground/ssr-vue/dep-import-type/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep-import-type",
+  "private": true,
   "version": "0.0.0",
   "main": "index.js"
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Ensure local packages have `"private": true` to prevent accidental publish. Also set for `create-vite` templates.

### Additional context

There are two `package.json` in `packages/vite/src/node/__tests__/packages` that I didn't update since it could affect the tests, but the `package.json` themselves are already invalid so it prevents publishing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
