### PR TITLE
fix: revert #6233, strip query when resolving entry (fix #6797)

### DIFF
--- a/packages/playground/vue/ExternalStyleCss.vue
+++ b/packages/playground/vue/ExternalStyleCss.vue
@@ -1,1 +1,0 @@
-<style src="css-with-exports-field/dist/style.css"></style>

--- a/packages/playground/vue/Main.vue
+++ b/packages/playground/vue/Main.vue
@@ -20,7 +20,6 @@
   </Suspense>
   <ReactivityTransform :foo="time" />
   <SetupImportTemplate />
-  <ExternalStyleCss />
 </template>
 
 <script setup lang="ts">
@@ -36,7 +35,6 @@ import ScanDep from './ScanDep.vue'
 import AsyncComponent from './AsyncComponent.vue'
 import ReactivityTransform from './ReactivityTransform.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
-import ExternalStyleCss from './ExternalStyleCss.vue'
 
 import { ref } from 'vue'
 

--- a/packages/playground/vue/package.json
+++ b/packages/playground/vue/package.json
@@ -18,7 +18,6 @@
     "less": "^4.1.2",
     "pug": "^3.0.2",
     "sass": "^1.43.4",
-    "stylus": "^0.55.0",
-    "css-with-exports-field": "^1.0.0"
+    "stylus": "^0.55.0"
   }
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -802,11 +802,6 @@ function resolveDeepImport(
   targetWeb: boolean,
   options: InternalResolveOptions
 ): string | undefined {
-  // id might contain ?query
-  // e.g. when using `<style src="some-pkg/dist/style.css"></style>` in .vue file
-  // the id will be ./dist/style.css?vue&type=style&index=0&src=xxx&lang.css
-  id = id.split('?')[0]
-
   const cache = getResolvedCache(id, targetWeb)
   if (cache) {
     return cache

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,7 +616,6 @@ importers:
   packages/playground/vue:
     specifiers:
       '@vitejs/plugin-vue': workspace:*
-      css-with-exports-field: ^1.0.0
       js-yaml: ^4.1.0
       less: ^4.1.2
       lodash-es: ^4.17.21
@@ -629,7 +628,6 @@ importers:
       vue: 3.2.26
     devDependencies:
       '@vitejs/plugin-vue': link:../../plugin-vue
-      css-with-exports-field: 1.0.0
       js-yaml: 4.1.0
       less: 4.1.2
       pug: 3.0.2
@@ -3810,10 +3808,6 @@ packages:
   /css-unit-converter/1.1.2:
     resolution: {integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==}
     dev: false
-
-  /css-with-exports-field/1.0.0:
-    resolution: {integrity: sha512-YCPKv36/w3+SrxwZ8E1FJXhDGTeGTKQmNA00VSePNTaO4VqSUdgB5XkhLL9qbF07m7Y+3nlTQJL5YLgRoewKFQ==}
-    dev: true
 
   /css/3.0.0:
     resolution: {integrity: sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==}


### PR DESCRIPTION
This reverts commit 000ba2e00b14e6c595febfa6dcae862e2d341823.

### Description

See https://github.com/vitejs/vite/issues/6797#issuecomment-1031455343

@egoist we should add your fix back, doing a quick revert now so we can test and keep the release of 2.8 in the next days

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other