### PR TITLE
fix: fix rollup plugin compatibility when getModuleInfo() is used

### DIFF
--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -9,6 +9,7 @@ import {
 } from './plugins/importAnalysisBuild'
 import { cleanUrl } from './utils'
 import type { RollupError } from 'rollup'
+import type { ResolvedUrl } from './server/moduleGraph'
 
 export interface AssertOptions {
   assert?: {
@@ -22,7 +23,7 @@ export async function transformImportGlob(
   importer: string,
   importIndex: number,
   root: string,
-  normalizeUrl?: (url: string, pos: number) => Promise<[string, string]>,
+  normalizeUrl?: (url: string, pos: number) => Promise<ResolvedUrl>,
   preload = true
 ): Promise<{
   importsString: string

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -260,7 +260,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // its last updated timestamp to force the browser to fetch the most
           // up-to-date version of this module.
           try {
-            const depModule = await moduleGraph.ensureEntryFromUrl(url, ssr)
+            const depModule = moduleGraph.ensureEntryFromResolved([
+              url,
+              resolved.id,
+              resolved.meta
+            ])
             if (depModule.lastHMRTimestamp > 0) {
               url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)
             }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -155,8 +155,7 @@ export class ModuleGraph {
     return noLongerImported
   }
 
-  async ensureEntryFromUrl(rawUrl: string, ssr?: boolean): Promise<ModuleNode> {
-    const [url, resolvedId, meta] = await this.resolveUrl(rawUrl, ssr)
+  ensureEntryFromResolved([url, resolvedId, meta]: ResolvedUrl): ModuleNode {
     let mod = this.urlToModuleMap.get(url)
     if (!mod) {
       mod = new ModuleNode(url)
@@ -173,6 +172,11 @@ export class ModuleGraph {
       fileMappedModules.add(mod)
     }
     return mod
+  }
+
+  async ensureEntryFromUrl(rawUrl: string, ssr?: boolean): Promise<ModuleNode> {
+    const resolvedUrl = await this.resolveUrl(rawUrl, ssr)
+    return this.ensureEntryFromResolved(resolvedUrl)
   }
 
   // some deps, like a css file referenced via @import, don't have its own

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -128,7 +128,7 @@ export class ModuleGraph {
     for (const imported of importedModules) {
       const dep =
         typeof imported === 'string'
-          ? await this.ensureEntryFromUrl(imported, ssr)
+          ? this.urlToModuleMap.get(imported)!
           : imported
       dep.importers.add(mod)
       nextImports.add(dep)
@@ -170,9 +170,6 @@ export class ModuleGraph {
         this.fileToModulesMap.set(file, fileMappedModules)
       }
       fileMappedModules.add(mod)
-    } else if (mod.id !== resolvedId) {
-      this.idToModuleMap.set(resolvedId, mod)
-      if (meta) mod.meta = { ...mod.meta, ...meta }
     }
     return mod
   }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -170,6 +170,9 @@ export class ModuleGraph {
         this.fileToModulesMap.set(file, fileMappedModules)
       }
       fileMappedModules.add(mod)
+    } else if (mod.id !== resolvedId) {
+      this.idToModuleMap.set(resolvedId, mod)
+      if (meta) mod.meta = { ...mod.meta, ...meta }
     }
     return mod
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Hello.  This PR addresses and fixes #6766. @aleclarson requested I present it. In the issue, I show how a Rollup plugin such as this:
```js
//vite-config.js
import path from 'path';
export default {
    plugins: [
        {
            enforce: 'pre',
            async resolveId(id) {
                let [file, query] = id.split('?');
                const probe = query && query.match(/xoption=([^&]+)/)
                const x = probe && Number(probe[1])
                if (x) return {id: path.resolve(file), meta: {x}}
            },
            async transform(blob, id) {
                const x = this.getModuleInfo(id)?.meta?.x
                if (x) return `window.THE_X = ${x}\n` + blob;
            }
        }
    ]
}
```
... exhibits different behaviour when exercised via `vite build`  and `vite dev`. The two small files `main.js` and `foo.js` can help understand the context.

```js
//main.js
import fn from './foo.js?xoption=21'
document.querySelector('#app').innerHTML = `<h1>Hello Vite: ${fn()}</h1>`
```

```js
//foo.js
export default function () {return 21 + window.THE_X;}
```

### Additional context

This change improves the parity of behaviour between `vite build` and `vite dev` when Rollup plugins retuning non-null `meta` properties from `resolveId()` hooks are used.
    
If one takes the Rollup behavior as reference in this case (I think it's well inside of [this criteria](https://vitejs.dev/guide/api-plugin.html#rollup-plugin-compatibility)) then this is fixing a small bug in Vite.

That bug was in a very large part already fixed by PR #5465 which @aleclarson authored. Upgrading to a recent Vite version containing the PR is my prime motivation for this PR. 
 
Here's an explanation of the faulty behaviour:
    
The `normalizeUrl()` helper calls user plugins's `resolveId()` twice.
    
- Once with the URL string containing a query suffix.  Here it _ignores_ the meta reply.
    
- Again, with the URL no longer containing said suffix.  Here it doesn't ignore the meta reply.  It is stored in the moduleGraph node.
    
As can be seen, if the user's plugin meta reply depends on the query suffix being passed in the imported URL, that meta reply won't be registered correctly in the module graph and is not retrievable via getModuleInfo() later on.
    
This change makes it so that the first call doesn't ignore the meta reply. This makes Vite's dev server match Rollup's plugin-calling behaviour and fixes #6766.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
