### PR TITLE
feat: add ssr.format to force esm output for ssr

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -367,6 +367,7 @@ async function doBuild(
   const config = await resolveConfig(inlineConfig, 'build', 'production')
   const options = config.build
   const ssr = !!options.ssr
+  const esm = config.ssr?.format === 'es' || !ssr
   const libOptions = options.lib
 
   config.logger.info(
@@ -464,8 +465,8 @@ async function doBuild(
 
       return {
         dir: outDir,
-        format: ssr ? 'cjs' : 'es',
-        exports: ssr ? 'named' : 'auto',
+        format: esm ? 'es' : 'cjs',
+        exports: esm ? 'auto' : 'named',
         sourcemap: options.sourcemap,
         name: libOptions ? libOptions.name : undefined,
         entryFileNames: ssr

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -221,6 +221,12 @@ export interface SSROptions {
    * Default: 'node'
    */
   target?: SSRTarget
+
+  /**
+   * Define the module format for the ssr build.
+   * Default: 'cjs'
+   */
+  format?: 'es' | 'cjs'
 }
 
 export interface ResolveWorkerOptions {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add new config: `ssr.format` to force an specific module format of the SSR build

### Additional context

Deno, Cloudflare and other platforms might run SSR code, but it needs to be described in ESM format. 

This PR solves the same issue as https://github.com/vitejs/vite/pull/2157, but takes a more explicit approach, not using package.json.

Closes #2152

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
