### PR TITLE
fix(client): wait on the socket host, not the ping host

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -201,12 +201,10 @@ async function waitForSuccessfulPing(ms = 1000) {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
-      const pingResponse = await fetch(`${base}__vite_ping`)
-
-      // success - 2xx status code
-      if (pingResponse.ok) break
-      // failure - non-2xx status code
-      else throw new Error()
+      // A fetch on a websocket URL will return a successful promise with status 400,
+      // but will reject a networking error.
+      await fetch(`${location.protocol}//${socketHost}`)
+      break
     } catch (e) {
       // wait ms before attempting to ping again
       await new Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
fix(client): if the websocket fails to connect, wait on the socket host, not the ping host

The problem with checking the ping host is that the ping host can
pass, even if the socket host fails, leading to infinite reloads.

Infinite reloads are a bad way to deal with this failure.
This makes the failure less bad.

For examples, see:
https://github.com/vitejs/vite/issues/6814
https://github.com/vitejs/vite/issues/3093

<!-- Thank you for contributing! -->

### Description

There are many bug reports where Vite infinitely reloads if there's an HMR misconfiguration. This doesn't fix the misconfiguration, but fixes the infinite loop.

### Additional context

I tested this PR manually. I looked around for a way to exercise this in a unit test or integration test, but couldn't figure out a good way to do it. I'm open to ideas.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
