### PR TITLE
fix: CSS dynamic import in node_modules dependencies

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -112,7 +112,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     async transform(source, importer) {
       if (
         importer.includes('node_modules') &&
-        !source.includes('import.meta.glob')
+        !source.includes('import.meta.glob') &&
+        !source.match(/import\(.+\)/m))
       ) {
         return
       }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -110,7 +110,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer) {
-      const asyncImportRe = new RegExp('import\\(.+\\)', 'm');
+      const asyncImportRe = new RegExp('import\\(.+\\)', 'm')
       if (
         importer.includes('node_modules') &&
         source.includes('import.meta.glob') &&

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -113,8 +113,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       const asyncImportRe = new RegExp('import\\(.+\\)', 'm')
       if (
         importer.includes('node_modules') &&
-        source.includes('import.meta.glob') &&
-        source.match(asyncImportRe)
+        !source.includes('import.meta.glob') &&
+        !source.match(asyncImportRe)
       ) {
         return
       }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -110,10 +110,11 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer) {
+      const asyncImportRe = new RegExp('import\\(.+\\)', 'm');
       if (
         importer.includes('node_modules') &&
-        !source.includes('import.meta.glob') &&
-        !source.match(/import\(.+\)/m))
+        source.includes('import.meta.glob') &&
+        source.match(asyncImportRe)
       ) {
         return
       }


### PR DESCRIPTION
### Description
Bug describe and reproduce: #6823 

This PR allow dynamic import (predominantly CSS) in node_modules dependencies while running buildImportAnalysisPlugin.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
