### PR TITLE
fix(plugin-react): React is not defined when component name is lowercase

### DIFF
--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.spec.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.spec.ts
@@ -1,0 +1,55 @@
+import { restoreJSX } from './restore-jsx'
+import * as babel from '@babel/core'
+
+async function jsx(sourceCode: string) {
+  const [ast] = await restoreJSX(babel, sourceCode, 'test.js')
+  if (ast === null) {
+    return ast
+  }
+  const { code } = await babel.transformFromAstAsync(ast, null, {
+    configFile: false
+  })
+  return code
+}
+// jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+// React__default.createElement(Foo)`)
+// Tests adapted from: https://github.com/flying-sheep/babel-plugin-transform-react-createelement-to-jsx/blob/63137b6/test/index.js
+describe('restore-jsx', () => {
+  it('should trans to ', async () => {
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+      React__default.createElement(foo)`)
+    ).toBeNull()
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+      React__default.createElement("h1")`)
+    ).toMatch(`<h1 />;`)
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+      React__default.createElement(Foo)`)
+    ).toMatch(`<Foo />;`)
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+      React__default.createElement(Foo.Bar)`)
+    ).toMatch(`<Foo.Bar />;`)
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+    React__default.createElement(Foo.Bar.Baz)`)
+    ).toMatch(`<Foo.Bar.Baz />;`)
+  })
+
+  it('should handle props', async () => {
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+      React__default.createElement(foo, {hi: there})`)
+    ).toBeNull()
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+    React__default.createElement("h1", {hi: there})`)
+    ).toMatch(`<h1 hi={there} />;`)
+    expect(
+      await jsx(`import React__default, { PureComponent, Component, forwardRef, memo, createElement } from 'react';
+      React__default.createElement(Foo, {hi: there})`)
+    ).toMatch(`<Foo hi={there} />;`)
+  })
+})

--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -24,16 +24,24 @@ export async function restoreJSX(
     return jsxNotFound
   }
 
-  const reactJsxRE = new RegExp(
-    '\\b' + reactAlias + '\\.(createElement|Fragment)\\b',
+  const reactJsxFragmentRE = new RegExp(
+    '\\b' + reactAlias + '\\.(Fragment)\\b',
+    'g'
+  )
+  const reactJsxCreatElementRE = new RegExp(
+    '\\b' + reactAlias + '\\.(createElement)\\b(\\([A-Z]\\w)',
     'g'
   )
 
   let hasCompiledJsx = false
-  code = code.replace(reactJsxRE, (_, prop) => {
+  code = code.replace(reactJsxFragmentRE, (_, prop) => {
     hasCompiledJsx = true
     // Replace with "React" so JSX can be reverse compiled.
     return 'React.' + prop
+  })
+  code = code.replace(reactJsxCreatElementRE, (_, prop, prop2) => {
+    hasCompiledJsx = true
+    return 'React.' + prop + prop2
   })
 
   if (!hasCompiledJsx) {

--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -20,6 +20,7 @@ export async function restoreJSX(
   }
 
   const [reactAlias, isCommonJS] = parseReactAlias(code)
+
   if (!reactAlias) {
     return jsxNotFound
   }
@@ -29,7 +30,7 @@ export async function restoreJSX(
     'g'
   )
   const reactJsxCreatElementRE = new RegExp(
-    '\\b' + reactAlias + '\\.(createElement)\\b(\\([A-Z]\\w)',
+    '\\b' + reactAlias + '\\.(createElement)\\b(\\([A-Z"]\\w)',
     'g'
   )
 

--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -25,35 +25,36 @@ export async function restoreJSX(
     return jsxNotFound
   }
 
-  const reactJsxFragmentRE = new RegExp(
-    '\\b' + reactAlias + '\\.(Fragment)\\b',
-    'g'
-  )
-  const reactJsxCreatElementRE = new RegExp(
-    '\\b' + reactAlias + '\\.(createElement)\\b(\\([A-Z"]\\w)',
-    'g'
-  )
-
   let hasCompiledJsx = false
-  code = code.replace(reactJsxFragmentRE, (_, prop) => {
-    hasCompiledJsx = true
-    // Replace with "React" so JSX can be reverse compiled.
-    return 'React.' + prop
-  })
-  code = code.replace(reactJsxCreatElementRE, (_, prop, prop2) => {
-    hasCompiledJsx = true
-    return 'React.' + prop + prop2
-  })
+
+  const fragmentPattern = `\\b${reactAlias}\\.Fragment\\b`
+  const createElementPattern = `\\b${reactAlias}\\.createElement\\(\\s*([A-Z"'][\\w$.]*["']?)`
+
+  // Replace the alias with "React" so JSX can be reverse compiled.
+  code = code
+    .replace(new RegExp(fragmentPattern, 'g'), () => {
+      hasCompiledJsx = true
+      return 'React.Fragment'
+    })
+    .replace(new RegExp(createElementPattern, 'g'), (original, component) => {
+      if (/^[a-z][\w$]*$/.test(component)) {
+        // Take care not to replace the alias for `createElement` calls whose
+        // component is a lowercased variable, since the `restoreJSX` Babel
+        // plugin leaves them untouched.
+        return original
+      }
+      hasCompiledJsx = true
+      return (
+        'React.createElement(' +
+        // Assume `Fragment` is equivalent to `React.Fragment` so modules
+        // that use `import {Fragment} from 'react'` are reverse compiled.
+        (component === 'Fragment' ? 'React.Fragment' : component)
+      )
+    })
 
   if (!hasCompiledJsx) {
     return jsxNotFound
   }
-
-  // Support modules that use `import {Fragment} from 'react'`
-  code = code.replace(
-    /createElement\(Fragment,/g,
-    'createElement(React.Fragment,'
-  )
 
   babelRestoreJSX ||= import('./babel-restore-jsx')
 


### PR DESCRIPTION
### Description
Bug describe and reproduce: https://github.com/vitejs/vite/issues/6537

This PR is fix React is not defined on production。
When the react variables (such as React__default) of the code in our third-party dependencies are converted to React, and the component name is lowercase, it is not converted to jsx, which will cause React to be undefined after restoring the code.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
