### PR TITLE
fix: reoptimize deps on esbuild options change

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -392,7 +392,12 @@ function getDepHash(root: string, config: ResolvedConfig): string {
       plugins: config.plugins.map((p) => p.name),
       optimizeDeps: {
         include: config.optimizeDeps?.include,
-        exclude: config.optimizeDeps?.exclude
+        exclude: config.optimizeDeps?.exclude,
+        esbuildOptions: {
+          plugins: config.optimizeDeps?.esbuildOptions?.plugins?.map(
+            (p) => p.name
+          )
+        }
       }
     },
     (_, value) => {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -394,6 +394,7 @@ function getDepHash(root: string, config: ResolvedConfig): string {
         include: config.optimizeDeps?.include,
         exclude: config.optimizeDeps?.exclude,
         esbuildOptions: {
+          ...config.optimizeDeps?.esbuildOptions,
           plugins: config.optimizeDeps?.esbuildOptions?.plugins?.map(
             (p) => p.name
           )


### PR DESCRIPTION
### Description

fix: #6853

`optimizeDeps.esbuildOptions.plugins` was missing from the main metadata `hash` of optimized deps. There could be other `esbuildOptions` that should be added.

Adding the `esbuildOptions.plugins` field to the hash generation will invalidate the caches for every user, even if there aren't plugins. I think that this is a good idea because there could be some caches that are stale and the user doesn't even know right now.
 
### Additional context

We don't have currently a test for re-running the optimizer, I don't think is needed for this PR but it would be good to test this path.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other