### PR TITLE
fix(scan): escape for virtual modules

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -284,7 +284,7 @@ function esbuildScanPlugin(
                   loader,
                   contents: localContent
                 }
-                js += `import '${virtualModulePrefix}${path}';\n`
+                js += `import ${JSON.stringify(virtualModulePrefix + path)}\n`
               } else {
                 js += content + '\n'
               }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #6717

### Additional context

There's already an existing pattern that uses `JSON.stringify`, so this should be the same.

https://github.com/vitejs/vite/blob/f63a72e77214ea31884680a3c5facf4fcee5d226/packages/vite/src/node/optimizer/scan.ts#L265

I can't quite reproduce the issue though, so I've not added tests, though from the code, it can theoretically happen.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
