### PR TITLE
perf: improve isFileReadable performance

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -421,12 +421,15 @@ export function writeFile(
  * unnecessary in the first place)
  */
 export function isFileReadable(filename: string): boolean {
+  let stat = null
   try {
-    fs.accessSync(filename, fs.constants.R_OK)
-    return true
-  } catch {
-    return false
+    stat = fs.statSync(filename, { throwIfNoEntry: false })
+  } catch (e) {
+    if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false
+
+    throw e
   }
+  return !!stat
 }
 
 /**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -421,15 +421,12 @@ export function writeFile(
  * unnecessary in the first place)
  */
 export function isFileReadable(filename: string): boolean {
-  let stat = null
   try {
-    stat = fs.statSync(filename, { throwIfNoEntry: false })
-  } catch (e) {
-    if (e && (e.code === 'ENOENT' || e.code === 'ENOTDIR')) return false
-
-    throw e
+    const stat = fs.statSync(filename, { throwIfNoEntry: false })
+    return !!stat
+  } catch {
+    return false
   }
-  return !!stat
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
`accessSync` used in `isFileReadable` is slow because it throws and Node spends significant time generating stack trace.
This PR uses `statSync` with `throwIfNoEntry: false` parameter to make it not throw.

Build performance improvement on my machine was around 10%.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
After profiling Vite 2.7 I found that `resolve` package is slow. After updating Vite, performance issue with `resolve` package was fixed, but I saw the same stack trace in Vite code. Tracked down `resolve` solution to this issue https://github.com/browserify/resolve/issues/255. Backported this solution to Vite.

I could not find mentioned in the comment issue to test for that case. #2051 looks completely unrelated.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
