### PR TITLE
fix(plugin-legacy): require Vite 2.8.0 (#6272)

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -33,6 +33,6 @@
     "systemjs": "^6.12.1"
   },
   "peerDependencies": {
-    "vite": "^2.7.8"
+    "vite": "^2.8.0"
   }
 }


### PR DESCRIPTION
### Description

Now that the changes in #6272 have been released in Vite proper, the legacy plugin's peer dep needs to reflect that.

### Additional context

See conversation starting at https://github.com/vitejs/vite/pull/6272#issuecomment-1003042103