### PR TITLE
fix(create-vite): allow slash at the end of project path

### DIFF
--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -129,10 +129,12 @@ const renameFiles = {
 }
 
 async function init() {
-  let targetDir = argv._[0].replace(/\/+$/g, '')
+  let targetDir = argv._[0]
   let template = argv.template || argv.t
 
-  const defaultProjectName = !targetDir ? 'vite-project' : targetDir
+  const defaultProjectName = !targetDir
+    ? 'vite-project'
+    : targetDir.trim().replace(/\/+$/g, '')
 
   let result = {}
 

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -222,7 +222,7 @@ async function init() {
   // user choice associated with prompts
   const { framework, overwrite, packageName, variant } = result
 
-  const root = path.join(cwd, targetDir)
+  const root = path.resolve(cwd, targetDir)
 
   if (overwrite) {
     emptyDir(root)

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -145,7 +145,7 @@ async function init() {
           message: reset('Project name:'),
           initial: defaultProjectName,
           onState: (state) =>
-            (targetDir = state.value.trim() || defaultProjectName)
+            (targetDir = state.value.trim().replace(/\/+$/g, '') || defaultProjectName)
         },
         {
           type: () =>

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -129,7 +129,7 @@ const renameFiles = {
 }
 
 async function init() {
-  let targetDir = argv._[0]
+  let targetDir = argv._[0].replace(/\/+$/g, '')
   let template = argv.template || argv.t
 
   const defaultProjectName = !targetDir ? 'vite-project' : targetDir
@@ -145,7 +145,8 @@ async function init() {
           message: reset('Project name:'),
           initial: defaultProjectName,
           onState: (state) =>
-            (targetDir = state.value.trim().replace(/\/+$/g, '') || defaultProjectName)
+            (targetDir =
+              state.value.trim().replace(/\/+$/g, '') || defaultProjectName)
         },
         {
           type: () =>
@@ -222,7 +223,7 @@ async function init() {
   // user choice associated with prompts
   const { framework, overwrite, packageName, variant } = result
 
-  const root = path.resolve(cwd, targetDir)
+  const root = path.join(cwd, targetDir)
 
   if (overwrite) {
     emptyDir(root)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This pull request fix the root path when creating a new project. It looks like the current way doesn't get the relative ``./`` path.

### Additional context

fix: #6896

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
