### PR TITLE
feat(ssr): always define __dirname and __filename

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -177,6 +177,8 @@ async function instantiateModule(
       ssrImportKey,
       ssrDynamicImportKey,
       ssrExportAllKey,
+      '__filename',
+      '__dirname',
       result.code + `\n//# sourceURL=${mod.url}`
     )
     await initModule(
@@ -185,7 +187,9 @@ async function instantiateModule(
       ssrImportMeta,
       ssrImport,
       ssrDynamicImport,
-      ssrExportAll
+      ssrExportAll,
+      mod.file,
+      mod.file && path.dirname(mod.file)
     )
   } catch (e) {
     if (e.stack) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #6899 by injecting `__dirname` and `__filename` as arguments to the `initModule` function.

### Additional context

I couldn't figure out where to add a test case for this. None of the SSR playgrounds seemed appropriate. I'll be happy to add a test case if reviewers can point me in the right direction. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
