### PR TITLE
fix: handle css transform split '?'

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -138,11 +138,13 @@ export function transformMiddleware(
           )
         }
       }
-
+      let fixIndex = url.indexOf('?')
+      let fixUrl = url
+      if (fixIndex > 0) fixUrl = url.substring(0, fixIndex)
       if (
         isJSRequest(url) ||
         isImportRequest(url) ||
-        isCSSRequest(url) ||
+        isCSSRequest(fixUrl) ||
         isHTMLProxy(url)
       ) {
         // strip ?import


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close #6894

The transform middleware just check the extension to figure out which file is css file.
There have a problem.
`/?key=index.css` will be treated as css file, but it's not a css file actually.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix the specific case, when the url `/?key=index.css` has been visited.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Or there are some other way to fix this?
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
