### PR TITLE
chore: fix ts checking on used-before-assigned

### DIFF
--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -220,14 +220,15 @@ function startStaticServer(): Promise<string> {
 export async function notifyRebuildComplete(
   watcher: RollupWatcher
 ): Promise<RollupWatcher> {
-  let callback: (event: RollupWatcherEvent) => void
-  await new Promise<void>((resolve, reject) => {
-    callback = (event) => {
-      if (event.code === 'END') {
-        resolve()
-      }
+  let resolveFn: undefined | (() => void)
+  const callback = (event: RollupWatcherEvent): void => {
+    if (event.code === 'END') {
+      resolveFn?.()
     }
-    watcher.on('event', callback)
+  }
+  watcher.on('event', callback)
+  await new Promise<void>((resolve) => {
+    resolveFn = resolve
   })
   return watcher.removeListener('event', callback)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Typescript(not lint) reports callback is used before assigned.

![image](https://user-images.githubusercontent.com/1303154/154186807-887401b2-4108-4626-ac63-16b4e3ec9b27.png)

Resolve it by Keeping the same logic same.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
