### PR TITLE
fix: normalize postcss dependency messages

### DIFF
--- a/packages/playground/tailwind/__test__/tailwind.spec.ts
+++ b/packages/playground/tailwind/__test__/tailwind.spec.ts
@@ -5,7 +5,7 @@ test('should render', async () => {
 })
 
 if (!isBuild) {
-  test('regenerate CSS and HMR', async () => {
+  test('regenerate CSS and HMR (glob pattern)', async () => {
     browserLogs.length = 0
     const el = await page.$('#pagetitle')
     const el2 = await page.$('#helloroot')
@@ -33,6 +33,26 @@ if (!isBuild) {
     expect(browserLogs).toMatchObject([
       '[vite] css hot updated: /index.css',
       '[vite] hot updated: /src/components/HelloWorld.vue'
+    ])
+
+    browserLogs.length = 0
+  })
+
+  test('regenerate CSS and HMR (relative path)', async () => {
+    browserLogs.length = 0
+    const el = await page.$('h1')
+
+    expect(await getColor(el)).toBe('black')
+
+    editFile('src/App.vue', (code) =>
+      code.replace('text-black', 'text-[rgb(11,22,33)]')
+    )
+
+    await untilUpdated(() => getColor(el), 'rgb(11, 22, 33)')
+
+    expect(browserLogs).toMatchObject([
+      '[vite] css hot updated: /index.css',
+      '[vite] hot updated: /src/App.vue'
     ])
 
     browserLogs.length = 0

--- a/packages/playground/tailwind/src/App.vue
+++ b/packages/playground/tailwind/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h1>Tailwind app</h1>
+    <h1 class="text-black">Tailwind app</h1>
     {{ foo }}
   </div>
   <router-view />

--- a/packages/playground/tailwind/tailwind.config.js
+++ b/packages/playground/tailwind/tailwind.config.js
@@ -1,6 +1,8 @@
 module.exports = {
   mode: 'jit',
   purge: [
+    // Before editing this section, make sure no paths are matching with `/src/App.vue`
+    // Look https://github.com/vitejs/vite/pull/6959 for more details
     __dirname + '/src/{components,views}/**/*.vue',
     __dirname + '/src/App.vue'
   ],

--- a/packages/playground/tailwind/tailwind.config.js
+++ b/packages/playground/tailwind/tailwind.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   mode: 'jit',
-  purge: [__dirname + '/src/**/*.vue'],
+  purge: [
+    __dirname + '/src/{components,views}/**/*.vue',
+    __dirname + '/src/App.vue'
+  ],
   darkMode: false, // or 'media' or 'class'
   theme: {
     extend: {}

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -759,7 +759,7 @@ async function compileCSS(
   // record CSS dependencies from @imports
   for (const message of postcssResult.messages) {
     if (message.type === 'dependency') {
-      deps.add(message.file as string)
+      deps.add(normalizePath(message.file as string))
     } else if (message.type === 'dir-dependency') {
       // https://github.com/postcss/postcss/blob/main/docs/guidelines/plugin.md#3-dependencies
       const { dir, glob: globPattern = '**' } = message


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It seems Vite normalizes `dir-dependency` messages but not `dependency` messages.

On my **Windows** machine, files defined in `tailwind.config.js` <ins>without glob patterns</ins> was not triggering HMR updates for CSS files.

Tailwind sends `dependency` message for non-glob patterns and `dir-dependency` message for glob patterns:
https://github.com/tailwindlabs/tailwindcss/blob/23b1b301a11178697db6f0b12785f99945fe0ef4/src/util/parseDependency.js#L35-L40

Take this config as reference:
```js
  content: [
    './index.html',
    './src/App.vue',
    './src/components/**/*.vue',
  ],
  ```
Changes in files matching with `./src/components/**/*.vue` pattern will trigger CSS HMR for those files, but changes in `./src/App.vue` will not.

Reproduction:
https://github.com/sibbng/vite-tailwind-repro

Steps:
- Get a Windows machine
- Change bg color in `App.vue`, change will not trigger HMR for style.css
- Change bg color in `HelloWorld.vue`, change will trigger HMR for style.css and both div's background should be updated


### Additional context

This issue could potentially `fix` https://github.com/vitejs/vite/issues/5808. But this bug report comes from a macOS user and there is no reproduction.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
