### PR TITLE
fix: adjust vue template sourcemap

### DIFF
--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -159,7 +159,7 @@ export async function transformMain(
     const generator = SourceMapGenerator.fromSourceMap(
       new SourceMapConsumer(map)
     )
-    const offset = (scriptCode.match(/\r?\n/g)?.length ?? 1) + 1
+    const offset = (scriptCode.match(/\r?\n/g)?.length ?? 0) + 1
     const templateMapConsumer = new SourceMapConsumer(templateMap)
     templateMapConsumer.eachMapping((m) => {
       generator.addMapping({

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -159,7 +159,7 @@ export async function transformMain(
     const generator = SourceMapGenerator.fromSourceMap(
       new SourceMapConsumer(map)
     )
-    const offset = scriptCode.match(/\r?\n/g)?.length || 1
+    const offset = (scriptCode.match(/\r?\n/g)?.length ?? 1) + 1
     const templateMapConsumer = new SourceMapConsumer(templateMap)
     templateMapConsumer.eachMapping((m) => {
       generator.addMapping({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vue template sourcemaps were off by one line. This fixes Vue template coverage in Vitest.

Fixes https://github.com/vitest-dev/vitest/issues/751

Sourcemap before:

![before](https://user-images.githubusercontent.com/2339406/154643140-343549bb-f80b-430d-a457-9e93a1e277de.png)

Sourcemap after:

![after](https://user-images.githubusercontent.com/2339406/154643198-69da9525-9365-497e-a314-f23bdf8bc935.png)

Vitest coverage before:

![image](https://user-images.githubusercontent.com/2339406/154022833-663dedcc-1ef0-4a23-954e-b14e030ec0e2.png)

Vitest coverage after:

![vitest-fixed](https://user-images.githubusercontent.com/2339406/154643480-7170f867-b589-463a-bd03-289d2d596422.png)

### Additional context

Code is being concatenated using newlines here:
https://github.com/vitejs/vite/blob/b146007b7e0f78f08c9dc5959de4a4055ceec1b2/packages/plugin-vue/src/main.ts#L192 
So need to adjust sourcemaps by one line too.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
