### PR TITLE
fix(worker): don't inject import statements in classic worker

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -60,7 +60,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       const query = parseRequest(id)
       if (query && query[WorkerFileId] != null) {
         return {
-          code: `import '${ENV_PUBLIC_PATH}'\n` + _
+          code: `importScripts('${ENV_PUBLIC_PATH}');\n` + _
         }
       }
       if (

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -25,7 +25,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       const query = parseRequest(id)
       if (query && query[WORKER_FILE_ID] != null) {
         return {
-          code: `import '${ENV_PUBLIC_PATH}'\n` + code
+          code: `importScripts('${ENV_PUBLIC_PATH}');\n` + code
         }
       }
       if (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Use `importScripts` which is available in Classic Worker instead of ES import statements to import `@vite/env` module, which avoids breaking even though a Web Worker script doesn't have any import statements.

Fixes #4586 
Fixes #5853 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
