### PR TITLE
chore: fix publish, build vite before plugin-react and plugin-vue

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -18,7 +18,7 @@
     "build-bundle": "esbuild src/index.ts --bundle --platform=node --target=node12 --external:@babel/* --external:@rollup/* --external:resolve --external:react-refresh/* --outfile=dist/index.js && npm run patch-dist",
     "patch-dist": "ts-node ../../scripts/patchEsbuildDist.ts dist/index.js viteReact",
     "build-types": "tsc -p . --emitDeclarationOnly --outDir temp && api-extractor run && rimraf temp",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "(cd ../vite && npm run build) && npm run build"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -16,7 +16,7 @@
     "build-bundle": "esbuild src/index.ts --bundle --platform=node --target=node12 --external:@vue/compiler-sfc --external:vue/compiler-sfc --external:vite --outfile=dist/index.js & npm run patch-dist",
     "patch-dist": "ts-node ../../scripts/patchEsbuildDist.ts dist/index.js vuePlugin",
     "build-types": "tsc -p . --emitDeclarationOnly --outDir temp && api-extractor run && rimraf temp",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "(cd ../vite && npm run build) && npm run build"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
### Description

See failed publish of plugin-vue, vite needs to be built before the plugin

https://github.com/vitejs/vite/runs/5248415916?check_suite_focus=true

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other