### PR TITLE
fix: prevent loading env outside of root

### DIFF
--- a/packages/playground/.env
+++ b/packages/playground/.env
@@ -1,0 +1,1 @@
+VITE_PARENT_ENV=dont_load_me

--- a/packages/playground/.env
+++ b/packages/playground/.env
@@ -1,1 +1,0 @@
-VITE_PARENT_ENV=dont_load_me

--- a/packages/playground/env-nested/.env
+++ b/packages/playground/env-nested/.env
@@ -1,0 +1,1 @@
+VITE_PARENT_ENV=dont_load_me

--- a/packages/playground/env-nested/__tests__/env-nested.spec.ts
+++ b/packages/playground/env-nested/__tests__/env-nested.spec.ts
@@ -1,0 +1,15 @@
+import { isBuild } from 'testUtils'
+
+const mode = isBuild ? `production` : `development`
+
+test('mode', async () => {
+  expect(await page.textContent('.mode')).toBe(mode)
+})
+
+test('mode file override', async () => {
+  expect(await page.textContent('.mode-file')).toBe(`.env.${mode}`)
+})
+
+test('should not load parent .env file', async () => {
+  expect(await page.textContent('.parent-env')).not.toBe('dont_load_me')
+})

--- a/packages/playground/env-nested/envs/.env.development
+++ b/packages/playground/env-nested/envs/.env.development
@@ -1,0 +1,1 @@
+VITE_EFFECTIVE_MODE_FILE_NAME=.env.development

--- a/packages/playground/env-nested/envs/.env.production
+++ b/packages/playground/env-nested/envs/.env.production
@@ -1,0 +1,1 @@
+VITE_EFFECTIVE_MODE_FILE_NAME=.env.production

--- a/packages/playground/env-nested/index.html
+++ b/packages/playground/env-nested/index.html
@@ -1,0 +1,16 @@
+<h1>Nested Environment Variables</h1>
+<p>import.meta.env.MODE: <code class="mode"></code></p>
+<p>
+  import.meta.env.VITE_EFFECTIVE_MODE_FILE_NAME: <code class="mode-file"></code>
+</p>
+<p>Empty import.meta.env.VITE_PARENT_ENV: <code class="parent-env"></code></p>
+
+<script type="module">
+  text('.mode', import.meta.env.MODE)
+  text('.mode-file', import.meta.env.VITE_EFFECTIVE_MODE_FILE_NAME)
+  text('.parent-env', import.meta.env.VITE_PARENT_ENV)
+
+  function text(el, text) {
+    document.querySelector(el).textContent = text
+  }
+</script>

--- a/packages/playground/env-nested/package.json
+++ b/packages/playground/env-nested/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-env-nested",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../vite/bin/vite",
+    "preview": "vite preview"
+  }
+}

--- a/packages/playground/env-nested/vite.config.js
+++ b/packages/playground/env-nested/vite.config.js
@@ -1,0 +1,5 @@
+const { defineConfig } = require('vite')
+
+module.exports = defineConfig({
+  envDir: './envs'
+})

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -385,7 +385,7 @@ export async function resolveConfig(
     : resolvedRoot
   const userEnv =
     inlineConfig.envFile !== false &&
-    loadEnv(mode, envDir, resolveEnvPrefix(config), false)
+    loadEnv(mode, envDir, resolveEnvPrefix(config))
 
   // Note it is possible for user to have a custom mode, e.g. `staging` where
   // production-like behavior is expected. This is indicated by NODE_ENV=production
@@ -1050,8 +1050,7 @@ async function loadConfigFromBundledFile(
 export function loadEnv(
   mode: string,
   envDir: string,
-  prefixes: string | string[] = 'VITE_',
-  searchAboveEnvDir = true
+  prefixes: string | string[] = 'VITE_'
 ): Record<string, string> {
   if (mode === 'local') {
     throw new Error(
@@ -1080,10 +1079,7 @@ export function loadEnv(
   }
 
   for (const file of envFiles) {
-    const path = lookupFile(envDir, [file], {
-      pathOnly: true,
-      rootDir: searchAboveEnvDir ? undefined : envDir
-    })
+    const path = lookupFile(envDir, [file], { pathOnly: true, rootDir: envDir })
     if (path) {
       const parsed = dotenv.parse(fs.readFileSync(path), {
         debug: process.env.DEBUG?.includes('vite:dotenv') || undefined

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -292,20 +292,28 @@ export function isDefined<T>(value: T | undefined | null): value is T {
   return value != null
 }
 
+interface LookupFileOptions {
+  pathOnly?: boolean
+  rootDir?: string
+}
+
 export function lookupFile(
   dir: string,
   formats: string[],
-  pathOnly = false
+  options?: LookupFileOptions
 ): string | undefined {
   for (const format of formats) {
     const fullPath = path.join(dir, format)
     if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
-      return pathOnly ? fullPath : fs.readFileSync(fullPath, 'utf-8')
+      return options?.pathOnly ? fullPath : fs.readFileSync(fullPath, 'utf-8')
     }
   }
   const parentDir = path.dirname(dir)
-  if (parentDir !== dir) {
-    return lookupFile(parentDir, formats, pathOnly)
+  if (
+    parentDir !== dir &&
+    (!options?.rootDir || parentDir.startsWith(options?.rootDir))
+  ) {
+    return lookupFile(parentDir, formats, options)
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #6933 
Fixes #5712

Loading env files will only load from the `envDir` only, anything above the directory is not checked.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
