### PR TITLE
fix: inlined module css

### DIFF
--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -346,6 +346,13 @@ test('inlined-code', async () => {
   expect(code).not.toContain('__VITE_ASSET__')
 })
 
+test('inlined-module', async () => {
+  const code = await page.textContent('.inlined-module')
+  // should resolve assets
+  expect(code).toContain('color: orangered;')
+  expect(code).not.toContain('__VITE_ASSET__')
+})
+
 test('minify css', async () => {
   if (!isBuild) {
     return

--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -104,6 +104,7 @@
 
   <p class="inlined">Inlined import - this should NOT be red.</p>
   <pre class="inlined-code"></pre>
+  <pre class="inlined-module"></pre>
 </div>
 
 <script type="module" src="./main.js"></script>

--- a/packages/playground/css/inline.module.css
+++ b/packages/playground/css/inline.module.css
@@ -1,0 +1,7 @@
+.heading {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: left;
+  color: orangered;
+}

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -68,3 +68,7 @@ if (import.meta.env.DEV) {
 // inlined
 import inlined from './inlined.css?inline'
 text('.inlined-code', inlined)
+
+// inlined module css
+import inlinedModule from './inline.module.css?inline'
+text('.inlined-module', inlinedModule)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -300,7 +300,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             return modulesCode || `export default ${JSON.stringify(css)}`
           }
           if (inlined) {
-            return `export default ${JSON.stringify(css)}`
+            return [
+              modulesCode?.replace(/\bexport default {[\s\S]*}?;/, '') || '',
+              `export default ${JSON.stringify(css)}`
+            ].join('\n')
           }
           return [
             `import { updateStyle as __vite__updateStyle, removeStyle as __vite__removeStyle } from ${JSON.stringify(
@@ -337,15 +340,19 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       if (!inlined) {
         styles.set(id, css)
       }
-
       return {
-        code:
-          modulesCode ||
-          (usedRE.test(id)
-            ? `export default ${JSON.stringify(
-                inlined ? await minifyCSS(css, config) : css
-              )}`
-            : `export default ''`),
+        code: modulesCode
+          ? inlined
+            ? [
+                modulesCode?.replace(/\bexport default {[\s\S]*}?;/, '') || '',
+                `export default ${JSON.stringify(css)}`
+              ].join('\n')
+            : modulesCode
+          : usedRE.test(id)
+          ? `export default ${JSON.stringify(
+              inlined ? await minifyCSS(css, config) : css
+            )}`
+          : `export default ''`,
         map: { mappings: '' },
         // avoid the css module from being tree-shaken so that we can retrieve
         // it in renderChunk()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #6984

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

The typescript declare `?inlined` default export is string. So I replace the `dataToEsm` default export to css code and keep the json module of module css.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
