### PR TITLE
fix: restart optimize

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -755,7 +755,8 @@ async function restartServer(server: ViteDevServer) {
 
   for (const key in newServer) {
     if (key === '_restartPromise') {
-      // @ts-ignore prevent new server `restart` function from calling
+      // prevent new server `restart` function from calling
+      // @ts-ignore
       newServer[key] = server[key]
     } else if (key !== 'app') {
       // @ts-ignore

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -298,7 +298,8 @@ export interface ViteDevServer {
 }
 
 export async function createServer(
-  inlineConfig: InlineConfig = {}
+  inlineConfig: InlineConfig = {},
+  oldServer?: ViteDevServer
 ): Promise<ViteDevServer> {
   const config = await resolveConfig(inlineConfig, 'serve', 'development')
   const root = config.root
@@ -400,7 +401,7 @@ export async function createServer(
         throw new Error('cannot print server URLs in middleware mode.')
       }
     },
-    async restart(forceOptimize: boolean) {
+    async restart(forceOptimize?: boolean) {
       if (!server._restartPromise) {
         server._forceOptimizeOnRestart = !!forceOptimize
         server._restartPromise = restartServer(server).finally(() => {
@@ -414,8 +415,8 @@ export async function createServer(
     _optimizeDepsMetadata: null,
     _ssrExternals: null,
     _globImporters: Object.create(null),
-    _restartPromise: null,
-    _forceOptimizeOnRestart: false,
+    _restartPromise: oldServer?._restartPromise ?? null,
+    _forceOptimizeOnRestart: oldServer?._forceOptimizeOnRestart ?? false,
     _isRunningOptimizer: false,
     _registerMissingImport: null,
     _pendingReload: null,
@@ -736,7 +737,7 @@ async function restartServer(server: ViteDevServer) {
 
   let newServer = null
   try {
-    newServer = await createServer(server.config.inlineConfig)
+    newServer = await createServer(server.config.inlineConfig, server)
   } catch (err: any) {
     server.config.logger.error(err.message, {
       timestamp: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When calling `server.restart(true)`, properly restart the vite dev server.

### Additional context

I was developing a vite plugin using this function when I found it doesn't work correctly. Turns out when we instantiate a new server during server restart, the new server doesn't contain the old metadata to tell whether we should force optimize.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
