### PR TITLE
fix(resolve): try .tsx extension for .js import from typescript module

### DIFF
--- a/packages/playground/resolve/index.html
+++ b/packages/playground/resolve/index.html
@@ -38,6 +38,17 @@
 </h2>
 <p class="ts-extension">fail</p>
 
+<h2>
+  A ts module can import another tsx module using its corresponding jsx file
+  name
+</h2>
+<p class="jsx-extension">fail</p>
+
+<h2>
+  A ts module can import another tsx module using its corresponding js file name
+</h2>
+<p class="tsx-extension">fail</p>
+
 <h2>Resolve file name containing dot</h2>
 <p class="dot">fail</p>
 
@@ -129,6 +140,12 @@
 
   import { msg as tsExtensionMsg } from './ts-extension'
   text('.ts-extension', tsExtensionMsg)
+
+  import { msgJsx as tsJsxExtensionMsg } from './ts-extension'
+  text('.jsx-extension', tsJsxExtensionMsg)
+
+  import { msgTsx as tsTsxExtensionMsg } from './ts-extension'
+  text('.tsx-extension', tsTsxExtensionMsg)
 
   // filename with dot
   import { bar } from './util/bar.util'

--- a/packages/playground/resolve/ts-extension/hellojsx.tsx
+++ b/packages/playground/resolve/ts-extension/hellojsx.tsx
@@ -1,0 +1,1 @@
+export const msgJsx = '[success] use .jsx extension to import a tsx module'

--- a/packages/playground/resolve/ts-extension/hellotsx.tsx
+++ b/packages/playground/resolve/ts-extension/hellotsx.tsx
@@ -1,0 +1,1 @@
+export const msgTsx = '[success] use .js extension to import a tsx module'

--- a/packages/playground/resolve/ts-extension/index.ts
+++ b/packages/playground/resolve/ts-extension/index.ts
@@ -1,3 +1,5 @@
 import { msg } from './hello.js'
+import { msgJsx } from './hellojsx.jsx'
+import { msgTsx } from './hellotsx.js'
 
-export { msg }
+export { msg, msgJsx, msgTsx }

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -74,11 +74,3 @@ test('ts import of file with .js and query param', () => {
     'test-file.js.tsx?lee=123'
   ])
 })
-
-test('ts import of non js file', () => {
-  expect(getPotentialTsSrcPaths('test-file.wasm')).toEqual(['test-file.wasm'])
-})
-
-test('ts import without any extension', () => {
-  expect(getPotentialTsSrcPaths('test-file')).toEqual(['test-file'])
-})

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,4 +1,4 @@
-import { injectQuery, isWindows } from '../utils'
+import { getPotentialTsSrcPaths, injectQuery, isWindows } from '../utils'
 
 if (isWindows) {
   // this test will work incorrectly on unix systems
@@ -37,4 +37,26 @@ test('path with unicode, space, and %', () => {
   expect(injectQuery('/usr/vite/東京 %20 hello', 'direct')).toEqual(
     '/usr/vite/東京 %20 hello?direct'
   )
+})
+
+test('ts import of file with .js extension', () => {
+  expect(getPotentialTsSrcPaths('test-file.js')).toEqual([
+    'test-file.ts',
+    'test-file.tsx'
+  ])
+})
+
+test('ts import of file with .jsx extension', () => {
+  expect(getPotentialTsSrcPaths('test-file.jsx')).toEqual(['test-file.tsx'])
+})
+
+test('ts import of file .mjs,.cjs extension', () => {
+  expect(getPotentialTsSrcPaths('test-file.cjs')).toEqual(['test-file.cts'])
+  expect(getPotentialTsSrcPaths('test-file.mjs')).toEqual(['test-file.mts'])
+})
+
+test('ts import should not match .js that is not extension', () => {
+  expect(getPotentialTsSrcPaths('test-file.js.mjs')).toEqual([
+    'test-file.js.mts'
+  ])
 })

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -51,12 +51,34 @@ test('ts import of file with .jsx extension', () => {
 })
 
 test('ts import of file .mjs,.cjs extension', () => {
-  expect(getPotentialTsSrcPaths('test-file.cjs')).toEqual(['test-file.cts'])
-  expect(getPotentialTsSrcPaths('test-file.mjs')).toEqual(['test-file.mts'])
+  expect(getPotentialTsSrcPaths('test-file.cjs')).toEqual([
+    'test-file.cts',
+    'test-file.ctsx'
+  ])
+  expect(getPotentialTsSrcPaths('test-file.mjs')).toEqual([
+    'test-file.mts',
+    'test-file.mtsx'
+  ])
 })
 
-test('ts import should not match .js that is not extension', () => {
-  expect(getPotentialTsSrcPaths('test-file.js.mjs')).toEqual([
-    'test-file.js.mts'
+test('ts import of file with .js before extension', () => {
+  expect(getPotentialTsSrcPaths('test-file.js.js')).toEqual([
+    'test-file.js.ts',
+    'test-file.js.tsx'
   ])
+})
+
+test('ts import of file with .js and query param', () => {
+  expect(getPotentialTsSrcPaths('test-file.js.js?lee=123')).toEqual([
+    'test-file.js.ts?lee=123',
+    'test-file.js.tsx?lee=123'
+  ])
+})
+
+test('ts import of non js file', () => {
+  expect(getPotentialTsSrcPaths('test-file.wasm')).toEqual(['test-file.wasm'])
+})
+
+test('ts import without any extension', () => {
+  expect(getPotentialTsSrcPaths('test-file')).toEqual(['test-file'])
 })

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -27,7 +27,7 @@ import {
   isFileReadable,
   isTsRequest,
   isPossibleTsOutput,
-  getTsSrcPath
+  getPotentialTsSrcPaths
 } from '../utils'
 import type { ViteDevServer, SSROptions } from '..'
 import type { PartialResolvedId } from 'rollup'
@@ -436,16 +436,20 @@ function tryResolveFile(
 
   const tryTsExtension = options.isFromTsImporter && isPossibleTsOutput(file)
   if (tryTsExtension) {
-    const tsSrcPath = getTsSrcPath(file)
-    return tryResolveFile(
-      tsSrcPath,
-      postfix,
-      options,
-      tryIndex,
-      targetWeb,
-      tryPrefix,
-      skipPackageJson
-    )
+    const tsSrcPaths = getPotentialTsSrcPaths(file)
+    for (const srcPath of tsSrcPaths) {
+      const res = tryResolveFile(
+        srcPath,
+        postfix,
+        options,
+        tryIndex,
+        targetWeb,
+        tryPrefix,
+        skipPackageJson
+      )
+      if (res) return res
+    }
+    return
   }
 
   if (tryPrefix) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -189,8 +189,16 @@ const knownTsOutputRE = /\.(js|mjs|cjs|jsx)$/
 export const isTsRequest = (url: string) => knownTsRE.test(cleanUrl(url))
 export const isPossibleTsOutput = (url: string) =>
   knownTsOutputRE.test(cleanUrl(url))
-export const getTsSrcPath = (filename: string) =>
-  filename.replace(/\.([cm])?(js)(x?)(\?|$)/, '.$1ts$3')
+export const getPotentialTsSrcPaths = (filename: string) => {
+  // Special handling for filenames that end in `.js`, since they may actually
+  // refer to a `.ts` or `.tsx` file in TypeScript.
+  if (filename.endsWith('.js')) {
+    const extensionLessFile = filename.slice(0, -3)
+    return [`${extensionLessFile}.ts`, `${extensionLessFile}.tsx`]
+  }
+
+  return [filename.replace(/\.([cm])?(js)(x?)(\?|$)/, '.$1ts$3')]
+}
 
 const importQueryRE = /(\?|&)import=?(?:&|$)/
 const internalPrefixes = [

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -190,11 +190,16 @@ export const isTsRequest = (url: string) => knownTsRE.test(cleanUrl(url))
 export const isPossibleTsOutput = (url: string) =>
   knownTsOutputRE.test(cleanUrl(url))
 export const getPotentialTsSrcPaths = (filename: string) => {
-  // Special handling for filenames that end in `.js`, since they may actually
-  // refer to a `.ts` or `.tsx` file in TypeScript.
-  if (filename.endsWith('.js')) {
-    const extensionLessFile = filename.slice(0, -3)
-    return [`${extensionLessFile}.ts`, `${extensionLessFile}.tsx`]
+  // TODO: @Lee fully test this out.
+  const fileParts = filename.split(/(\.jsx?\?|\.jsx?$)/)
+  if (fileParts.length === 3) {
+    const [tsPart, tsxPart] = fileParts[2].length
+      ? ['.ts?', '.tsx?']
+      : ['.ts', '.tsx']
+    return [
+      `${fileParts[0]}${tsPart}${fileParts[2]}`,
+      `${fileParts[0]}${tsxPart}${fileParts[2]}`
+    ]
   }
 
   return [filename.replace(/\.([cm])?(js)(x?)(\?|$)/, '.$1ts$3')]

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -189,21 +189,13 @@ const knownTsOutputRE = /\.(js|mjs|cjs|jsx)$/
 export const isTsRequest = (url: string) => knownTsRE.test(cleanUrl(url))
 export const isPossibleTsOutput = (url: string) =>
   knownTsOutputRE.test(cleanUrl(url))
-export const getPotentialTsSrcPaths = (filename: string) => {
-  const fileParts = filename.split(/(\.[cm]?js\?|\.[cm]?js$)/)
-
-  // If there are three parts, the file uses a .js, .mjs or .cjs extension.
-  // We replace the 'js' part with 'ts' and 'tsx'.
-  if (fileParts.length === 3) {
-    const [namePart, extension, queryPart] = fileParts
-
-    return [
-      `${namePart}${extension.replace('js', 'ts')}${queryPart}`,
-      `${namePart}${extension.replace('js', 'tsx')}${queryPart}`
-    ]
+export function getPotentialTsSrcPaths(filePath: string) {
+  const [name, type, query = ''] = filePath.split(/(\.(?:[cm]?js|jsx))(\?.*)?$/)
+  const paths = [name + type.replace('js', 'ts') + query]
+  if (!type.endsWith('x')) {
+    paths.push(name + type.replace('js', 'tsx') + query)
   }
-
-  return [filename.replace(/\.([cm])?(js)(x?)(\?|$)/, '.$1ts$3')]
+  return paths
 }
 
 const importQueryRE = /(\?|&)import=?(?:&|$)/

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -190,7 +190,7 @@ export const isTsRequest = (url: string) => knownTsRE.test(cleanUrl(url))
 export const isPossibleTsOutput = (url: string) =>
   knownTsOutputRE.test(cleanUrl(url))
 export const getPotentialTsSrcPaths = (filename: string) => {
-  const fileParts = filename.split(/(\.[cm]?js?\?|\.[cm]?js?$)/)
+  const fileParts = filename.split(/(\.[cm]?js\?|\.[cm]?js$)/)
 
   // If there are three parts, the file uses a .js, .mjs or .cjs extension.
   // We replace the 'js' part with 'ts' and 'tsx'.

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -190,15 +190,16 @@ export const isTsRequest = (url: string) => knownTsRE.test(cleanUrl(url))
 export const isPossibleTsOutput = (url: string) =>
   knownTsOutputRE.test(cleanUrl(url))
 export const getPotentialTsSrcPaths = (filename: string) => {
-  // TODO: @Lee fully test this out.
-  const fileParts = filename.split(/(\.jsx?\?|\.jsx?$)/)
+  const fileParts = filename.split(/(\.[cm]?js?\?|\.[cm]?js?$)/)
+
+  // If there are three parts, the file uses a .js, .mjs or .cjs extension.
+  // We replace the 'js' part with 'ts' and 'tsx'.
   if (fileParts.length === 3) {
-    const [tsPart, tsxPart] = fileParts[2].length
-      ? ['.ts?', '.tsx?']
-      : ['.ts', '.tsx']
+    const [namePart, extension, queryPart] = fileParts
+
     return [
-      `${fileParts[0]}${tsPart}${fileParts[2]}`,
-      `${fileParts[0]}${tsxPart}${fileParts[2]}`
+      `${namePart}${extension.replace('js', 'ts')}${queryPart}`,
+      `${namePart}${extension.replace('js', 'tsx')}${queryPart}`
     ]
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Packages that use native ESM and TypeScript may import `.ts` files, which contain `import` that end with a `.js` extension. Vite currently tries to resolve these `.js` extensions to `.ts`, `.ts.mjs`, etc. However, it doesn't try `.tsx`.
This PR fixes this, and ensures Vite also checks for a `.tsx` extension when the file is imported via `TypeScript`.

### Additional Context

closes #6866 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
