### PR TITLE
fix: prebundle dep with colon

### DIFF
--- a/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -87,3 +87,7 @@ test('import from hidden dir', async () => {
 test('import optimize-excluded package that imports optimized-included package', async () => {
   expect(await page.textContent('.nested-include')).toBe('nested-include')
 })
+
+test('import aliased package with colon', async () => {
+  expect(await page.textContent('.url')).toBe('vitejs.dev')
+})

--- a/packages/playground/optimize-deps/index.html
+++ b/packages/playground/optimize-deps/index.html
@@ -53,6 +53,9 @@
 <h2>Nested include</h2>
 <div>Module path: <span class="nested-include"></span></div>
 
+<h2>Alias with colon</h2>
+<div>URL: <span class="url"></span></div>
+
 <script type="module">
   // test dep detection in globbed files
   const globbed = import.meta.globEager('./glob/*.js')
@@ -84,6 +87,9 @@
 
   import { nestedInclude } from 'nested-exclude'
   text('.nested-include', nestedInclude)
+
+  import { parse } from 'node:url'
+  text('.url', parse('https://vitejs.dev').hostname)
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/packages/playground/optimize-deps/package.json
+++ b/packages/playground/optimize-deps/package.json
@@ -23,6 +23,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "resolve-linked": "workspace:0.0.0",
+    "url": "^0.11.0",
     "vue": "^3.2.25",
     "vuex": "^4.0.0"
   },

--- a/packages/playground/optimize-deps/vite.config.js
+++ b/packages/playground/optimize-deps/vite.config.js
@@ -5,7 +5,10 @@ const vue = require('@vitejs/plugin-vue')
  */
 module.exports = {
   resolve: {
-    dedupe: ['react']
+    dedupe: ['react'],
+    alias: {
+      'node:url': 'url'
+    }
   },
 
   optimizeDeps: {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -33,7 +33,7 @@ export function unwrapId(id: string): string {
 }
 
 export const flattenId = (id: string): string =>
-  id.replace(/(\s*>\s*)/g, '__').replace(/[\/\.]/g, '_')
+  id.replace(/(\s*>\s*)/g, '__').replace(/[\/\.:]/g, '_')
 
 export const normalizeId = (id: string): string =>
   id.replace(/(\s*>\s*)/g, ' > ')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,7 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       resolve-linked: workspace:0.0.0
+      url: ^0.11.0
       vue: ^3.2.25
       vuex: ^4.0.0
     dependencies:
@@ -300,6 +301,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       resolve-linked: link:../resolve-linked
+      url: 0.11.0
       vue: 3.2.26
       vuex: 4.0.2_vue@3.2.26
     devDependencies:
@@ -7663,6 +7665,10 @@ packages:
       once: 1.4.0
     dev: true
 
+  /punycode/1.3.2:
+    resolution: {integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=}
+    dev: false
+
   /punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
@@ -7698,6 +7704,12 @@ packages:
     resolution: {integrity: sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==}
     engines: {node: '>=0.6'}
     dev: true
+
+  /querystring/0.2.0:
+    resolution: {integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=}
+    engines: {node: '>=0.4.x'}
+    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: false
 
   /queue-microtask/1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9061,6 +9073,13 @@ packages:
     dependencies:
       punycode: 2.1.1
     dev: true
+
+  /url/0.11.0:
+    resolution: {integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=}
+    dependencies:
+      punycode: 1.3.2
+      querystring: 0.2.0
+    dev: false
 
   /utf8-byte-length/1.0.4:
     resolution: {integrity: sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #6729 
Closes #6364 (supersedes)

When importing a package like `node:url` (aliased to a browser-safe package), handle the colon when flattening the id.

### Additional context

With aliases, technically the import path could be anything that needs to be escaped, but colon only for now sounds fine to be strict.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
