### PR TITLE
feat(lib): allow multiple entries

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -111,10 +111,10 @@ Options to pass on to [@rollup/plugin-dynamic-import-vars](https://github.com/ro
 
 ## build.lib
 
-- **Type:** `{ entry: string, name?: string, formats?: ('es' | 'cjs' | 'umd' | 'iife')[], fileName?: string | ((format: ModuleFormat) => string) }`
+- **Type:** `{ entry: string | string[] | { [entryAlias: string]: string }, name?: string, formats?: ('es' | 'cjs' | 'umd' | 'iife')[], fileName?: string | ((format: ModuleFormat, entryName: string) => string) }`
 - **Related:** [Library Mode](/guide/build#library-mode)
 
-Build as a library. `entry` is required since the library cannot use HTML as entry. `name` is the exposed global variable and is required when `formats` includes `'umd'` or `'iife'`. Default `formats` are `['es', 'umd']`. `fileName` is the name of the package file output, default `fileName` is the name option of package.json, it can also be defined as function taking the `format` as an argument.
+Build as a library. `entry` is required since the library cannot use HTML as entry. `name` is the exposed global variable and is required when `formats` includes `'umd'` or `'iife'`. Default `formats` are `['es', 'umd']`. `fileName` is the name of the package file output, default `fileName` is the name option of package.json, it can also be defined as function taking the `format` and `entryAlias` as arguments.
 
 ## build.manifest
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -128,6 +128,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   build: {
     lib: {
+      // Could also be a dictionary or array of multiple entry points
       entry: resolve(__dirname, 'lib/main.js'),
       name: 'MyLib',
       // the proper extensions will be added
@@ -180,6 +181,28 @@ Recommended `package.json` for your lib:
     ".": {
       "import": "./dist/my-lib.js",
       "require": "./dist/my-lib.umd.cjs"
+    }
+  }
+}
+```
+
+Or, if exposing multiple entry points:
+
+```json
+{
+  "name": "my-lib",
+  "type": "module",
+  "files": ["dist"],
+  "main": "./dist/my-lib.cjs",
+  "module": "./dist/my-lib.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/my-lib.mjs",
+      "require": "./dist/my-lib.cjs"
+    },
+    "./secondary": {
+      "import": "./dist/secondary.mjs",
+      "require": "./dist/secondary.cjs"
     }
   }
 }

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -20,6 +20,7 @@ describe('resolveLibFilename', () => {
         entry: 'mylib.js'
       },
       'es',
+      'myLib',
       resolve(__dirname, 'packages/name')
     )
 
@@ -33,6 +34,7 @@ describe('resolveLibFilename', () => {
         entry: 'mylib.js'
       },
       'es',
+      'myLib',
       resolve(__dirname, 'packages/name')
     )
 
@@ -45,6 +47,7 @@ describe('resolveLibFilename', () => {
         entry: 'mylib.js'
       },
       'es',
+      'myLib',
       resolve(__dirname, 'packages/name')
     )
 
@@ -58,6 +61,7 @@ describe('resolveLibFilename', () => {
         entry: 'mylib.js'
       },
       'es',
+      'myLib',
       resolve(__dirname, 'packages/noname')
     )
 
@@ -71,6 +75,7 @@ describe('resolveLibFilename', () => {
           entry: 'mylib.js'
         },
         'es',
+        'myLib',
         resolve(__dirname, 'packages/noname')
       )
     }).toThrow()
@@ -88,6 +93,7 @@ describe('resolveLibFilename', () => {
       const filename = resolveLibFilename(
         baseLibOptions,
         format,
+        'myLib',
         resolve(__dirname, 'packages/noname')
       )
 
@@ -107,10 +113,134 @@ describe('resolveLibFilename', () => {
       const filename = resolveLibFilename(
         baseLibOptions,
         format,
+        'myLib',
         resolve(__dirname, 'packages/module')
       )
 
       expect(expectedFilename).toBe(filename)
     }
+  })
+
+  test('multiple entries with aliases', () => {
+    const libOptions: LibraryOptions = {
+      entry: {
+        entryA: 'entryA.js',
+        entryB: 'entryB.js'
+      }
+    }
+
+    const [fileName1, fileName2] = ['entryA', 'entryB'].map((entryAlias) =>
+      resolveLibFilename(
+        libOptions,
+        'es',
+        entryAlias,
+        resolve(__dirname, 'packages/name')
+      )
+    )
+
+    expect(fileName1).toBe('entryA.mjs')
+    expect(fileName2).toBe('entryB.mjs')
+  })
+
+  test('multiple entries with aliases: custom filename function', () => {
+    const libOptions: LibraryOptions = {
+      entry: {
+        entryA: 'entryA.js',
+        entryB: 'entryB.js'
+      },
+      fileName: (format, entryAlias) =>
+        `custom-filename-function.${entryAlias}.${format}.js`
+    }
+
+    const [fileName1, fileName2] = ['entryA', 'entryB'].map((entryAlias) =>
+      resolveLibFilename(
+        libOptions,
+        'es',
+        entryAlias,
+        resolve(__dirname, 'packages/name')
+      )
+    )
+
+    expect(fileName1).toBe('custom-filename-function.entryA.es.js')
+    expect(fileName2).toBe('custom-filename-function.entryB.es.js')
+  })
+
+  test('multiple entries with aliases: custom filename string', () => {
+    const libOptions: LibraryOptions = {
+      entry: {
+        entryA: 'entryA.js',
+        entryB: 'entryB.js'
+      },
+      fileName: 'custom-filename'
+    }
+
+    const [fileName1, fileName2] = ['entryA', 'entryB'].map((entryAlias) =>
+      resolveLibFilename(
+        libOptions,
+        'es',
+        entryAlias,
+        resolve(__dirname, 'packages/name')
+      )
+    )
+
+    expect(fileName1).toBe('custom-filename.mjs')
+    expect(fileName2).toBe('custom-filename.mjs')
+  })
+
+  test('multiple entries as array', () => {
+    const libOptions: LibraryOptions = {
+      entry: ['entryA.js', 'entryB.js']
+    }
+
+    const [fileName1, fileName2] = ['entryA', 'entryB'].map((entryAlias) =>
+      resolveLibFilename(
+        libOptions,
+        'es',
+        entryAlias,
+        resolve(__dirname, 'packages/name')
+      )
+    )
+
+    expect(fileName1).toBe('entryA.mjs')
+    expect(fileName2).toBe('entryB.mjs')
+  })
+
+  test('multiple entries as array: custom filename function', () => {
+    const libOptions: LibraryOptions = {
+      entry: ['entryA.js', 'entryB.js'],
+      fileName: (format, entryAlias) =>
+        `custom-filename-function.${entryAlias}.${format}.js`
+    }
+
+    const [fileName1, fileName2] = ['entryA', 'entryB'].map((entryAlias) =>
+      resolveLibFilename(
+        libOptions,
+        'es',
+        entryAlias,
+        resolve(__dirname, 'packages/name')
+      )
+    )
+
+    expect(fileName1).toBe('custom-filename-function.entryA.es.js')
+    expect(fileName2).toBe('custom-filename-function.entryB.es.js')
+  })
+
+  test('multiple entries as array: custom filename string', () => {
+    const libOptions: LibraryOptions = {
+      entry: ['entryA.js', 'entryB.js'],
+      fileName: 'custom-filename'
+    }
+
+    const [fileName1, fileName2] = ['entryA', 'entryB'].map((entryAlias) =>
+      resolveLibFilename(
+        libOptions,
+        'es',
+        entryAlias,
+        resolve(__dirname, 'packages/name')
+      )
+    )
+
+    expect(fileName1).toBe('custom-filename.mjs')
+    expect(fileName2).toBe('custom-filename.mjs')
   })
 })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import colors from 'picocolors'
 import type {
   ExternalOption,
+  InputOption,
   InternalModuleFormat,
   ModuleFormat,
   OutputOptions,
@@ -208,7 +209,7 @@ export interface LibraryOptions {
   /**
    * Path of library entry
    */
-  entry: string
+  entry: InputOption
   /**
    * The name of the exposed global variable. Required when the `formats` option includes
    * `umd` or `iife`
@@ -224,7 +225,7 @@ export interface LibraryOptions {
    * of the project package.json. It can also be defined as a function taking the
    * format as an argument.
    */
-  fileName?: string | ((format: ModuleFormat) => string)
+  fileName?: string | ((format: ModuleFormat, entryName: string) => string)
 }
 
 export type LibraryFormats = 'es' | 'cjs' | 'umd' | 'iife'
@@ -373,7 +374,17 @@ async function doBuild(
 
   const resolve = (p: string) => path.resolve(config.root, p)
   const input = libOptions
-    ? options.rollupOptions?.input || resolve(libOptions.entry)
+    ? options.rollupOptions?.input ||
+      (typeof libOptions.entry === 'string'
+        ? resolve(libOptions.entry)
+        : Array.isArray(libOptions.entry)
+        ? libOptions.entry.map(resolve)
+        : Object.fromEntries(
+            Object.entries(libOptions.entry).map(([alias, file]) => [
+              alias,
+              resolve(file)
+            ])
+          ))
     : typeof options.ssr === 'string'
     ? resolve(options.ssr)
     : options.rollupOptions?.input || resolve('index.html')
@@ -470,7 +481,8 @@ async function doBuild(
         entryFileNames: ssr
           ? `[name].${jsExt}`
           : libOptions
-          ? resolveLibFilename(libOptions, format, config.root, jsExt)
+          ? ({ name }) =>
+              resolveLibFilename(libOptions, format, name, config.root, jsExt)
           : path.posix.join(options.assetsDir, `[name].[hash].${jsExt}`),
         chunkFileNames: libOptions
           ? `[name].[hash].${jsExt}`
@@ -620,15 +632,20 @@ function resolveOutputJsExtension(
 export function resolveLibFilename(
   libOptions: LibraryOptions,
   format: ModuleFormat,
+  entryName: string,
   root: string,
   extension?: JsExt
 ): string {
   if (typeof libOptions.fileName === 'function') {
-    return libOptions.fileName(format)
+    return libOptions.fileName(format, entryName)
   }
 
   const packageJson = getPkgJson(root)
-  const name = libOptions.fileName || getPkgName(packageJson.name)
+  const name =
+    libOptions.fileName ||
+    (typeof libOptions.entry === 'string'
+      ? getPkgName(packageJson.name)
+      : entryName)
 
   if (!name)
     throw new Error(
@@ -651,14 +668,22 @@ function resolveBuildOutputs(
 ): OutputOptions | OutputOptions[] | undefined {
   if (libOptions) {
     const formats = libOptions.formats || ['es', 'umd']
-    if (
-      (formats.includes('umd') || formats.includes('iife')) &&
-      !libOptions.name
-    ) {
-      throw new Error(
-        `Option "build.lib.name" is required when output formats ` +
-          `include "umd" or "iife".`
-      )
+    if (formats.includes('umd') || formats.includes('iife')) {
+      if (
+        typeof libOptions.entry !== 'string' &&
+        Object.values(libOptions.entry).length > 1
+      ) {
+        throw new Error(
+          `Multiple entry points are not supported when output formats include "umd" or "iife".`
+        )
+      }
+
+      if (!libOptions.name) {
+        throw new Error(
+          `Option "build.lib.name" is required when output formats ` +
+            `include "umd" or "iife".`
+        )
+      }
     }
     if (!outputs) {
       return formats.map((format) => ({ format }))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Hi, I think it's a common occurrence that libraries provide multiple entrypoints, so it would be nice if Vite's library mode supported this scenario. Since rollup does the heavy lifting, the main challenge is to provide a nice and simple interface.

The idea would be for `entry` to have rollup's InputOption interface and to tweak `fileName` and the resulting file names and chunk names accordingly. All without chaning the behavior for existing cases of course.

Example:
```ts
lib: {
  entry: {
      primary: 'src/index.ts',
      secondary: 'src/secondary.ts'
  },
  formats: ['es', 'cjs']
}
// => primary.es.js, primary.cjs.js, secondary.es.js, secondary.cjs.js
```

or

```ts
lib: {
  entry: ['src/index.ts', 'src/secondary.ts'],
  formats: ['es', 'cjs']
}
// => index.es.js, index.cjs.js, secondary.es.js, secondary.cjs.js
```

### Additional context
There is an issue regarding the topic, though the proposed interface differs: https://github.com/vitejs/vite/issues/4530
Some discussion has been going on here: https://github.com/vitejs/vite/discussions/1736
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
