### PR TITLE
feat(plugin-react): adding jsxPure option

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -35,7 +35,7 @@ export interface Options {
   /**
    * Set this to `true` to annotate the JSX factory with `\/* @__PURE__ *\/`.
    * This option is ignored when `jsxRuntime` is not `"automatic"`.
-   * @default false
+   * @default true
    */
   jsxPure?: boolean
 
@@ -202,7 +202,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
                 {
                   runtime: 'automatic',
                   importSource: opts.jsxImportSource,
-                  pure: opts.jsxPure === true
+                  pure: opts.jsxPure !== false
                 }
               ])
 

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -32,6 +32,12 @@ export interface Options {
    * @default "react"
    */
   jsxImportSource?: string
+  /**
+   * Set this to `true` to annotate the JSX factory with `\/* @__PURE__ *\/`.
+   * This option is ignored when `jsxRuntime` is not `"automatic"`.
+   * @default false
+   */
+  jsxPure?: boolean
 
   /**
    * Babel configuration applied in both dev and prod.
@@ -195,7 +201,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
                 ),
                 {
                   runtime: 'automatic',
-                  importSource: opts.jsxImportSource
+                  importSource: opts.jsxImportSource,
+                  pure: opts.jsxPure === true
                 }
               ])
 


### PR DESCRIPTION
### Description

Passing the `pure` option to `@babel/plugin-transform-react-jsx` in order to force pure annotation for custom JSX factory (like `@emotion/react`).

By default, [Babel disable pure annotations](https://github.com/babel/babel/blob/7686fc0817a727d22836c7b5b267e2afed522757/packages/babel-plugin-transform-react-jsx/src/create-plugin.ts#L227) if the jsx `importSource` is not `react` but we have the opportunity to force pure annotations by adding the `pure` option to the babel plugin like explained here:
https://github.com/babel/babel/pull/11126#issuecomment-585435534
This is useful in library mode and it improve treeshaking. 

For example:
```typescript
export default defineConfig({
    plugins: [
        react({
            jsxImportSource: "@emotion/react"
        }),
    ],
});
```

produce the following output:

```javascript
import { jsx, jsxs, Fragment } from "@emotion/react/jsx-runtime";

const Component1 = ({
  prop1,
  prop2
}) => {
  return jsxs(Fragment, {
    children: [jsx(Component2, {
      children: prop1
    }), jsx(Component3, {
      prop2
    })]
  });
};
```

But with:
```typescript
export default defineConfig({
    plugins: [
        react({
            jsxImportSource: "@emotion/react",
            jsxPure: true,
        }),
    ],
});
```

it produce the following output:
```javascript
import { jsx, jsxs, Fragment } from "@emotion/react/jsx-runtime";

const Component1 = ({
  prop1,
  prop2
}) => {
  return /* @__PURE__ */ jsxs(Fragment, {
    children: [/* @__PURE__ */ jsx(Component2, {
      children: prop1
    }), /* @__PURE__ */ jsx(Component3, {
        prop2
    })]
  });
};
```

### Additional context

[Pure annotation explanation](https://babeljs.io/blog/2018/08/27/7.0.0#pure-annotation-support)

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
