### PR TITLE
fix: `?html-proxy` with trailing `=` added by some servers

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -41,7 +41,7 @@ interface ScriptAssetsUrl {
   url: string
 }
 
-const htmlProxyRE = /\?html-proxy[&inline\-css]*&index=(\d+)\.(js|css)$/
+const htmlProxyRE = /\?html-proxy=?[&inline\-css]*&index=(\d+)\.(js|css)$/
 const inlineCSSRE = /__VITE_INLINE_CSS__([^_]+_\d+)__/g
 const inlineImportRE = /\bimport\s*\(("[^"]*"|'[^']*')\)/g
 export const isHTMLProxy = (id: string): boolean => htmlProxyRE.test(id)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Similar to #3805, `vercel dev` replaces the urls that Vite uses. For example:

- When using `vite dev`: `/home/juanm04/dev/tests/test-vercel/src/pages/index.astro?html-proxy&index=0.js`
- When using `vercel dev`: `/home/juanm04/dev/tests/test-vercel/src/pages/index.astro?html-proxy=&index=0.js`

To prevent Vercel for breaking the dev enviroment, I changed the regex to accept both `?html-proxy` and `html-proxy=`

### Additional context

Fixes withastro/astro#2639

Error generated when using Astro (that uses Vite internally) and `vercel dev`:

```
[vite] Internal server error: Failed to parse source for import analysis because the content contains invalid JS syntax. If you are using JSX, make sure to name the file with the .jsx or .tsx extension.
  Plugin: vite:import-analysis
  File: /home/juanm04/dev/tests/test-vercel/src/pages/index.astro?html-proxy=&index=0.js
  6  |                  <meta charset="utf-8" />
  7  |                  <meta name="viewport" content="width=device-width" />
  8  |                  <title>Astro</title>
     |                        ^
  9  |          </head>
  10 |          <body>
      at formatError (/home/juanm04/dev/tests/test-vercel/node_modules/vite/dist/node/chunks/dep-971d9e33.js:38082:46)
      at TransformContext.error (/home/juanm04/dev/tests/test-vercel/node_modules/vite/dist/node/chunks/dep-971d9e33.js:38078:19)
      at TransformContext.transform (/home/juanm04/dev/tests/test-vercel/node_modules/vite/dist/node/chunks/dep-971d9e33.js:69759:22)
      at async Object.transform (/home/juanm04/dev/tests/test-vercel/node_modules/vite/dist/node/chunks/dep-971d9e33.js:38318:30)
      at async doTransform (/home/juanm04/dev/tests/test-vercel/node_modules/vite/dist/node/chunks/dep-971d9e33.js:53014:29)
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
