### PR TITLE
fix(build): ensure linked packages are analyzed for commonjs

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -82,7 +82,6 @@ export interface InternalResolveOptions extends ResolveOptions {
 export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
   const {
     root,
-    isBuild,
     isProduction,
     asSrc,
     ssrConfig,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -58,6 +58,7 @@ export interface InternalResolveOptions extends ResolveOptions {
   isProduction: boolean
   ssrConfig?: SSROptions
   packageCache?: PackageCache
+  cjsInclude?: (string | RegExp)[]
   /**
    * src code mode also attempts the following:
    * - resolving /xxx as URLs
@@ -81,6 +82,7 @@ export interface InternalResolveOptions extends ResolveOptions {
 export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
   const {
     root,
+    isBuild,
     isProduction,
     asSrc,
     ssrConfig,
@@ -119,6 +121,9 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
 
         ...baseOptions,
         isFromTsImporter: isTsRequest(importer ?? '')
+      }
+      if (!options.isBuild) {
+        options.cjsInclude = undefined
       }
 
       let res: string | PartialResolvedId | undefined
@@ -520,7 +525,13 @@ export function tryNodeResolve(
 
   let pkg: PackageData | undefined
   const pkgId = possiblePkgIds.reverse().find((pkgId) => {
-    pkg = resolvePackageData(pkgId, basedir, preserveSymlinks, packageCache)!
+    pkg = resolvePackageData(
+      pkgId,
+      basedir,
+      preserveSymlinks,
+      packageCache,
+      options.cjsInclude
+    )!
     return pkg
   })!
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -610,7 +610,7 @@ export function resolveHostname(
   return { host, name }
 }
 
-export function arraify<T>(target: T | T[]): T[] {
+export function arraify<T>(target: T | readonly T[]): T[] {
   return Array.isArray(target) ? target : [target]
 }
 


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

Ensure linked packages are analyzed for commonjs if the symlink pointing to them is matched by any of the `commonjsOptions.include` patterns.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Fixes #5668
Fixes #2697

Thanks to @fwouts for sponsoring this PR :)

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
