### PR TITLE
Draft: Deep import HTML and non-ESM files with exports and `?url` query

### DIFF
--- a/packages/playground/resolve/__tests__/resolve.spec.ts
+++ b/packages/playground/resolve/__tests__/resolve.spec.ts
@@ -20,6 +20,20 @@ test('deep import with query with exports field', async () => {
   expect(await page.textContent('.exports-deep-query')).not.toMatch('fail')
 })
 
+test('deep import SVG with query with exports field', async () => {
+  expect(await page.textContent('.exports-deep-svg-query')).not.toMatch('fail')
+})
+
+test('deep import HTML with query with exports field', async () => {
+  expect(await page.textContent('.exports-deep-html-query')).not.toMatch('fail')
+})
+
+test('deep import non-ESM with query with exports field', async () => {
+  expect(await page.textContent('.exports-deep-non-esm-query')).not.toMatch(
+    'fail'
+  )
+})
+
 test('deep import with exports field + exposed dir', async () => {
   expect(await page.textContent('.exports-deep-exposed-dir')).toMatch(
     '[success]'

--- a/packages/playground/resolve/exports-path/deep-non-esm.js
+++ b/packages/playground/resolve/exports-path/deep-non-esm.js
@@ -1,0 +1,1 @@
+console.log('foo')

--- a/packages/playground/resolve/exports-path/deep.html
+++ b/packages/playground/resolve/exports-path/deep.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <div>foo</div>
+  </body>
+</html>

--- a/packages/playground/resolve/exports-path/deep.svg
+++ b/packages/playground/resolve/exports-path/deep.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>

--- a/packages/playground/resolve/exports-path/package.json
+++ b/packages/playground/resolve/exports-path/package.json
@@ -9,6 +9,9 @@
     },
     "./deep.js": "./deep.js",
     "./deep.json": "./deep.json",
+    "./deep.svg": "./deep.svg",
+    "./deep.html": "./deep.html",
+    "./deep-non-esm.js": "./deep-non-esm.js",
     "./dir/": "./dir/",
     "./dir-mapped/*": {
       "import": "./dir/*",

--- a/packages/playground/resolve/index.html
+++ b/packages/playground/resolve/index.html
@@ -15,6 +15,15 @@
 <h2>Deep import with query with exports field</h2>
 <p class="exports-deep-query">fail</p>
 
+<h2>Deep import SVG file with query with exports field</h2>
+<p class="exports-deep-svg-query">fail</p>
+
+<h2>Deep import HTML file with query with exports field</h2>
+<p class="exports-deep-html-query">fail</p>
+
+<h2>Deep import non-ESM file with query with exports field</h2>
+<p class="exports-deep-non-esm-query">fail</p>
+
 <h2>Deep import with exports field + exposed directory</h2>
 <p class="exports-deep-exposed-dir">fail</p>
 
@@ -106,6 +115,18 @@
   // deep import w/ exports w/ query
   import deepPath from 'resolve-exports-path/deep.json?url'
   text('.exports-deep-query', deepPath)
+
+  // deep import SVG w/ exports w/ query
+  import deepSvgPath from 'resolve-exports-path/deep.svg?url'
+  text('.exports-deep-svg-query', deepSvgPath)
+
+  // deep import HTML w/ exports w/ query
+  import deepHtmlPath from 'resolve-exports-path/deep.html?url'
+  text('.exports-deep-html-query', deepHtmlPath)
+
+  // deep import non-ESM w/ exports w/ query
+  import deepNonEsmPath from 'resolve-exports-path/deep-non-esm.js?url'
+  text('.exports-deep-non-esm-query', deepNonEsmPath)
 
   // deep import w/ exposed dir
   import { msg as exposedDirMsg } from 'resolve-exports-path/dir/dir'


### PR DESCRIPTION
Deep import HTML and non-ESM files with exports and `?url` query

Related to https://github.com/vitejs/vite/issues/6725 -> https://github.com/vitejs/vite/pull/7073 which fixed up some cases like `import deepPath from 'resolve-exports-path/deep.js?url'`

Relevant to this discussion: https://github.com/vitejs/vite/discussions/6459

Fix https://github.com/vector-im/hydrogen-web/issues/686 -> https://github.com/vector-im/hydrogen-web/pull/693

TODO: This is just tracking some tests atm. Still working out a fix.



### Dev notes

```
pnpm run test-serve -- resolve

pnpm run test-serve -- resolve --silent=false --verbose --runInBand

pnpm run debug-serve -- --runInBand resolve
```

When using `pnpm run debug-serve`, in order to get the Chromium window with the playwright results to not just close before you can see the results and inspect the devtools console there, add a `debugger` statement to the `afterAll` hook in [`scripts/jestPerTestSetup.ts#L162`](https://github.com/vitejs/vite/blob/5818ac927861783ea2b05450761fed30f40e7399/scripts/jestPerTestSetup.ts#L162)

It would be really nice if those console errors were piped up to the normal Jest logging to see.

The ["Debugging" section of the contributing guide](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#debugging) doesn't work for me as I don't see the "Javascript Debug Terminal" button in VSCode. Is there supposed to be a `launch.json` somewhere to define what goes on there? Perhaps I need to be on a `.js` or `.ts` file first but I was on `index.html` for the tests I wanted to debug.

---

Trying to run the test suite on Windows 10, I encountered a problem with symlinks. As suggested by https://github.com/lovell/sharp/issues/1671#issuecomment-714239903, running in a console tab as admin works 🤷 

```
$ pnpm run test

> vite-monorepo@ test C:\Users\MLM\Documents\GitHub\vite
> run-s test-serve test-build


> vite-monorepo@ test-serve C:\Users\MLM\Documents\GitHub\vite
> jest

Error: Jest: Got error running globalSetup - C:\Users\MLM\Documents\GitHub\vite\scripts\jestGlobalSetup.cjs, reason: EPERM: operation not permitted, symlink 'C:\Users\MLM\Documents\GitHub\vite\packages\plugin-vue-jsx' -> 'C:\Users\MLM\Documents\GitHub\vite\packages\temp\worker\node_modules\@vitejs\plugin-vue-jsx'
 ELIFECYCLE  Command failed with exit code 1.
ERROR: "test-serve" exited with 1.
 ELIFECYCLE  Test failed. See above for more details.
```

---

Trying to use `pnpm run debug-serve`, shows me the following error in the devtools console but this can be solved by updating the path for `jest` in the `package.json`, see https://github.com/facebook/jest/issues/3750#issuecomment-308118403

Fix: [`"debug-serve": "cross-env VITE_DEBUG_SERVE=1 node --inspect-brk ./node_modules/.bin/jest",`](https://github.com/vitejs/vite/blob/5818ac927861783ea2b05450761fed30f40e7399/package.json#L21) -> `"debug-serve": "cross-env VITE_DEBUG_SERVE=1 node --inspect-brk ./node_modules/jest/bin/jest.js",`

Error:
```
...
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^
SyntaxError: missing ) after argument list
...
```




<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
