### PR TITLE
fix: throw Error when can't preload CSS

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -76,7 +76,7 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
         return new Promise((res, rej) => {
           link.addEventListener('load', res)
           link.addEventListener('error', () =>
-            rej(new Error(`Unable to load CSS for ${dep}`))
+            rej(new Error(`Unable to preload CSS for ${dep}`))
           )
         })
       }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -75,7 +75,9 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
       if (isCss) {
         return new Promise((res, rej) => {
           link.addEventListener('load', res)
-          link.addEventListener('error', () => rej(new Error(`Unable to load CSS for ${dep}`)))
+          link.addEventListener('error', () =>
+            rej(new Error(`Unable to load CSS for ${dep}`))
+          )
         })
       }
     })

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -75,7 +75,7 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
       if (isCss) {
         return new Promise((res, rej) => {
           link.addEventListener('load', res)
-          link.addEventListener('error', rej)
+          link.addEventListener('error', () => rej(new Error(`Unable to load CSS for ${dep}`)))
         })
       }
     })


### PR DESCRIPTION
Closes https://github.com/vitejs/vite/issues/7107