### PR TITLE
fix: `ssrExternal` should not skip nested dependencies

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrExternal.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrExternal.spec.ts
@@ -1,0 +1,5 @@
+import { stripNesting } from '../ssrExternal'
+
+test('stripNesting', async () => {
+  expect(stripNesting(['c', 'p1>c1', 'p2 > c2'])).toEqual(['c', 'c1', 'c2'])
+})

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -15,6 +15,16 @@ import { createFilter } from '@rollup/pluginutils'
 const debug = createDebugger('vite:ssr-external')
 
 /**
+ * Converts "parent > child" syntax to just "child"
+ */
+export function stripNesting(packages: string[]) {
+  return packages.map((s) => {
+    const arr = s.split('>')
+    return arr[arr.length - 1].trim()
+  })
+}
+
+/**
  * Heuristics for determining whether a dependency should be externalized for
  * server-side rendering.
  */
@@ -22,6 +32,10 @@ export function resolveSSRExternal(
   config: ResolvedConfig,
   knownImports: string[]
 ): string[] {
+  // strip nesting since knownImports may be passed in from optimizeDeps which
+  // supports a "parent > child" syntax
+  knownImports = stripNesting(knownImports)
+
   const ssrConfig = config.ssr
   if (ssrConfig?.noExternal === true) {
     return []


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`ssrExternal` is skipping nested dependencies causing breakages during SSR

### Additional context

Before digging into this, I suspected it was an issue in `vite-plugin-svelte` and filed an issue there: https://github.com/sveltejs/vite-plugin-svelte/issues/281. It turned out to be an issue in Vite instead

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
