### PR TITLE
fix(plugin-vue): user defined transformAssetUrls ignored in production build

### DIFF
--- a/packages/plugin-vue/src/template.ts
+++ b/packages/plugin-vue/src/template.ts
@@ -123,7 +123,7 @@ export function resolveTemplateCompilerOptions(
           slash(path.relative(options.root, path.dirname(filename)))
       }
     }
-  } else {
+  } else if (transformAssetUrls !== false) {
     // build: force all asset urls into import requests so that they go through
     // the assets plugin for asset registration
     assetUrlOptions = {


### PR DESCRIPTION
### Description

Whenever `options.devServer` is `false` it overrides `assetUrlOptions`, this makes it impossible to fully disable `transformAssetUrls`.

### Additional context

In my setup I have been trying to make rollup not import any `<img src="">`, this I fixed by overwriting the supported tags
https://vue-loader.vuejs.org/options.html#transformasseturls
```js
plugins: [
    vue({
        template: {
            transformAssetUrls: {
                // Do not transform any asset urls
                tags: {},
            },
        }
    }),
}
```

However this doesn't disable automatic srcset importing, for that I have to be able to fully set `transformAssetUrls` to `false` but I'm unable to because of the override on `vite build`. (see: https://github.com/vuejs/core/blob/main/packages/compiler-sfc/src/templateTransformSrcset.ts)

See https://github.com/vuejs/core/blob/main/packages/compiler-sfc/src/compileTemplate.ts#L67, it should be able to support booleans:
```js
/**
 * Configure what tags/attributes to transform into asset url imports,
 * or disable the transform altogether with `false`.
 */
transformAssetUrls?: AssetURLOptions | AssetURLTagConfig | boolean
```
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
