### PR TITLE
feat(wasm): option for initWasm() to return the instance (#3847 #5615)

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -154,7 +154,20 @@ declare module '*.otf' {
 
 // other
 declare module '*.wasm' {
-  const initWasm: (options: WebAssembly.Imports) => Promise<WebAssembly.Exports>
+  function initWasm(
+    options: WebAssembly.Imports,
+    getInstance: true
+  ): Promise<WebAssembly.Instance>
+  function initWasm(
+    options: WebAssembly.Imports,
+    getInstance: false
+  ): Promise<WebAssembly.Exports>
+  function initWasm(options: WebAssembly.Imports): Promise<WebAssembly.Exports>
+
+  function initWasm(
+    options: WebAssembly.Imports,
+    getInstance?: boolean
+  ): Promise<WebAssembly.Instance | WebAssembly.Exports>
   export default initWasm
 }
 declare module '*.webmanifest' {

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -4,7 +4,7 @@ import { fileToUrl } from './asset'
 
 const wasmHelperId = '/__vite-wasm-helper'
 
-const wasmHelper = async (opts = {}, url: string) => {
+const wasmHelper = async (opts = {}, url: string, getInstance = false) => {
   let result
   if (url.startsWith('data:')) {
     // @ts-ignore
@@ -37,7 +37,7 @@ const wasmHelper = async (opts = {}, url: string) => {
       result = await WebAssembly.instantiate(buffer, opts)
     }
   }
-  return result.instance.exports
+  return getInstance ? result.instance : result.instance.exports
 }
 
 const wasmHelperCode = wasmHelper.toString()
@@ -65,7 +65,9 @@ export const wasmPlugin = (config: ResolvedConfig): Plugin => {
 
       return `
 import initWasm from "${wasmHelperId}"
-export default opts => initWasm(opts, ${JSON.stringify(url)})
+export default (opts, getInstance) => initWasm(opts, ${JSON.stringify(
+        url
+      )}, getInstance)
 `
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

In Vite's builtin `wasm` plugin, the exported function `initWasm` returns the `exports` property of the WASM instance, which is not always what we want. Some needs the module instance itself (e.g. #3847 #5615).

I added an option `getInstance` as `initWasm`'s 2-nd parameter. When pass `true` it will return the instance instead of `exports`. This is a non-breaking change since omitting the parameter we still get the old behavior.

This PR will close #3847 and close #5615.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
