### PR TITLE
docs: clarify what triggers rebuild for watch flag

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -72,6 +72,8 @@ module.exports = defineConfig({
 })
 ```
 
+With the `--watch` flag enabled, changes to the `vite.config.js`, as well as any files to be bundled, will trigger a rebuild.
+
 ## Multi-Page App
 
 Suppose you have the following source code structure:


### PR DESCRIPTION
Rollup docs also don't make it clear that edits to the config file itself are watched and trigger a rebuild, which I had to test out in order to verify that edits to the config file does indeed trigger a rebuild.