### PR TITLE
fix(css): handle different preprocessor options

### DIFF
--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -118,6 +118,7 @@ test('less', async () => {
 test('stylus', async () => {
   const imported = await page.$('.stylus')
   const additionalData = await page.$('.stylus-additional-data')
+  const extensionAdditionalData = await page.$('.stylus-ext-additional-data')
   const relativeImport = await page.$('.stylus-import')
   const relativeImportAlias = await page.$('.stylus-import-alias')
   const optionsRelativeImport = await page.$('.stylus-options-relative-import')
@@ -125,6 +126,7 @@ test('stylus', async () => {
 
   expect(await getColor(imported)).toBe('blue')
   expect(await getColor(additionalData)).toBe('orange')
+  expect(await getColor(extensionAdditionalData)).toBe('orange')
   expect(await getColor(relativeImport)).toBe('darkslateblue')
   expect(await getColor(relativeImportAlias)).toBe('darkslateblue')
   expect(await getBg(relativeImportAlias)).toMatch(

--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -49,6 +49,9 @@
   <p class="stylus-additional-data">
     Stylus additionalData: This should be orange
   </p>
+  <p class="stylus-ext-additional-data">
+    .stylus extension additionalData: This should be orange
+  </p>
   <p class="stylus-import">@import from Stylus: This should be darkslateblue</p>
   <p class="stylus-import-alias">
     @import from Stylus: This should be darkslateblue and have bg image which

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -10,6 +10,7 @@ import less from './less.less'
 text('.imported-less', less)
 
 import stylus from './stylus.styl'
+import './stylus.stylus'
 text('.imported-stylus', stylus)
 
 import mod from './mod.module.css'

--- a/packages/playground/css/stylus.stylus
+++ b/packages/playground/css/stylus.stylus
@@ -1,0 +1,3 @@
+.stylus-ext-additional-data
+  /* injected via vite.config.js */
+  color $injectedColor

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -622,7 +622,7 @@ async function compileCSS(
   // 2. pre-processors: sass etc.
   if (isPreProcessor(lang)) {
     const preProcessor = preProcessors[lang]
-    let opts = (preprocessorOptions && preprocessorOptions[lang]) || {}
+    let opts: any
     // support @import from node dependencies by default
     switch (lang) {
       case PreprocessLang.scss:
@@ -630,17 +630,27 @@ async function compileCSS(
         opts = {
           includePaths: ['node_modules'],
           alias: config.resolve.alias,
-          ...opts
+          ...(preprocessorOptions?.scss || preprocessorOptions?.sass || {})
         }
         break
       case PreprocessLang.less:
+        opts = {
+          paths: ['node_modules'],
+          alias: config.resolve.alias,
+          ...(preprocessorOptions?.less || {})
+        }
+        break
       case PreprocessLang.styl:
       case PreprocessLang.stylus:
         opts = {
           paths: ['node_modules'],
           alias: config.resolve.alias,
-          ...opts
+          ...(preprocessorOptions?.stylus || preprocessorOptions?.styl || {})
         }
+        break
+      default:
+        opts = preprocessorOptions?.[lang] || {}
+        break
     }
     // important: set this for relative import resolving
     opts.filename = cleanUrl(id)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #2851

When resolving `css.preprocessorOptions`, consider alternate option names (not based on file extension). Example:

- `.scss` can be configured by `css.preprocessorOptions.scss` and `css.preprocessorOptions.sass`
- `.styl` can be configured by `styl` and `stylus`

### Additional context

Are there use cases where `css.preprocessorOptions.scss` and `css.preprocessorOptions.sass` are different? Because that would be breaking, but I'm not sure why one would do that.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
