### PR TITLE
fix(css): vite can't handle images in css correctly

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -671,6 +671,12 @@ async function compileCSS(
   const postcssPlugins =
     postcssConfig && postcssConfig.plugins ? postcssConfig.plugins.slice() : []
 
+  postcssPlugins.unshift(
+    UrlRewritePostcssPlugin({
+      replacer: urlReplacer
+    }) as Postcss.Plugin
+  )
+
   if (needInlineImport) {
     const isHTMLProxy = htmlProxyRE.test(id)
     postcssPlugins.unshift(
@@ -692,11 +698,6 @@ async function compileCSS(
       })
     )
   }
-  postcssPlugins.push(
-    UrlRewritePostcssPlugin({
-      replacer: urlReplacer
-    }) as Postcss.Plugin
-  )
 
   if (isModule) {
     postcssPlugins.unshift(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The scene where the problem occurs during the following demo:
[click me](https://github.com/wkstudy/vite-demo)

1. Run `npm run build`, vite prompts that the package is successful but the images in the css are not processed
2. After deleting the postcss plugin of the demo, run `npm run build` again, the packaging is normal
### Additional context
The reason for the problem is
1. Currently `vite-url-plugin` is executed after the user-defined component
````
// https://github.com/wkstudy/vite/blob/4194cce60f7d9a5664ef9aea279f1f69631cdc84/packages/vite/src/node/plugins/css.ts#L695

postcssPlugins.push(
    UrlRewritePostcssPlugin({
      replacer: urlReplacer
    }) as Postcss.Plugin
  )
````
2. `vite-url-plugin` relies on the `input.file` property to change the resource path
````
// https://github.com/wkstudy/vite/blob/4194cce60f7d9a5664ef9aea279f1f69631cdc84/packages/vite/src/node/plugins/css.ts#L865
 const importer = declaration.source?.input.file
````
3. `input.file` must have opts to generate, otherwise it will disappear
````
// https://github.com/postcss/postcss/blob/d533f80b3cb4ef394cc7b523f675828ef7ec8466/lib/parse.js#L8
...
function parse(css, opts) {
  const input = new Input(css, opts)
}

...
// https://github.com/postcss/postcss/blob/d533f80b3cb4ef394cc7b523f675828ef7ec8466/lib/input.js#L36
...
if (opts.from) {
  if (!pathAvailable || /^\w+:\/\//.test(opts.from) || isAbsolute(opts.from)) {
    this.file = opts.from
  } else {
    this.file = resolve(opts.from)
  }
}
...
````
4. The `postcss-px2rem-exclude`plugin is called in my demo, and the postcss.parse method is called here, but the opts object is not passed, causing the subsequent css astobj to lose the input.file attribute
````
// https://github.com/saionjisekai/px2rem-postcss/blob/1edc6763ad2fe8288ac6a8bda482319f006d8bb6/lib/index.js#L15
    result.root = postcss.parse(newCssText)
````
5. The final input.file value is undefined, the vite package is successful but the url in the css is not processed
6. My understanding is that there is no problem with vite and postcss plugins, but it is best to call the plugin inside vite first, and then call the user-defined plugin
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
