### PR TITLE
fix: handle files with multiple comments

### DIFF
--- a/packages/vite/src/node/__tests__/scan.spec.ts
+++ b/packages/vite/src/node/__tests__/scan.spec.ts
@@ -30,7 +30,8 @@ describe('optimizer-scan:script-test', () => {
     scriptRE.lastIndex = 0
     const ret = scriptRE.exec(
       `<template>
-        <!--  <script >var test = null</script> -->
+        <!--  <script >var test1 = null</script> -->
+        <!--  <script >var test2 = null</script> -->
       </template>`.replace(commentRE, '')
     )
     expect(ret).toEqual(null)

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -143,7 +143,7 @@ function globEntries(pattern: string | string[], config: ResolvedConfig) {
 const scriptModuleRE =
   /(<script\b[^>]*type\s*=\s*(?:"module"|'module')[^>]*>)(.*?)<\/script>/gims
 export const scriptRE = /(<script\b(?:\s[^>]*>|>))(.*?)<\/script>/gims
-export const commentRE = /<!--(.|[\r\n])*?-->/
+export const commentRE = /<!--(.|[\r\n])*?-->/g
 const srcRE = /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im
 const typeRE = /\btype\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im
 const langRE = /\blang\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -143,7 +143,7 @@ function globEntries(pattern: string | string[], config: ResolvedConfig) {
 const scriptModuleRE =
   /(<script\b[^>]*type\s*=\s*(?:"module"|'module')[^>]*>)(.*?)<\/script>/gims
 export const scriptRE = /(<script\b(?:\s[^>]*>|>))(.*?)<\/script>/gims
-export const commentRE = /<!--(.|[\r\n])*?-->/g
+export const commentRE = /<!--.*?-->/gs
 const srcRE = /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im
 const typeRE = /\btype\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im
 const langRE = /\blang\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/im


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Import scan for dependency optimizer is bombing out if a file has multiple comments

Adding the `g` flag appeared sufficient for fixing it. I had also considered whether I should make it `gims` instead for consistency with the lines above it

### Additional context

Originally reported as https://github.com/sveltejs/kit/issues/3985

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
