### PR TITLE
feat: support custom modifiers for glob imports

### DIFF
--- a/packages/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/packages/playground/glob-import/__tests__/glob-import.spec.ts
@@ -66,6 +66,18 @@ const rawResult = {
   }
 }
 
+const customModifierResult = {
+  '/dir/alias.js': {
+    exportNames: ['default']
+  },
+  '/dir/foo.js': {
+    exportNames: ['msg']
+  },
+  '/dir/index.js': {
+    exportNames: ['modules', 'globWithAlias']
+  }
+}
+
 test('should work', async () => {
   expect(await page.textContent('.result')).toBe(
     JSON.stringify(allResult, null, 2)
@@ -78,6 +90,12 @@ test('should work', async () => {
 test('import glob raw', async () => {
   expect(await page.textContent('.globraw')).toBe(
     JSON.stringify(rawResult, null, 2)
+  )
+})
+
+test('custom modifer', async () => {
+  expect(await page.textContent('.custom-modifier')).toBe(
+    JSON.stringify(customModifierResult, null, 2)
   )
 })
 

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -1,6 +1,7 @@
 <pre class="result"></pre>
 <pre class="result-node_modules"></pre>
 <pre class="globraw"></pre>
+<pre class="custom-modifier"></pre>
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
@@ -48,6 +49,17 @@
   })
   document.querySelector('.globraw').textContent = JSON.stringify(
     globraw,
+    null,
+    2
+  )
+</script>
+
+<script type="module">
+  const modulesMeta = import.meta.globEager('/dir/*.js', {
+    as: 'meta'
+  })
+  document.querySelector('.custom-modifier').textContent = JSON.stringify(
+    modulesMeta,
     null,
     2
   )

--- a/packages/playground/glob-import/package.json
+++ b/packages/playground/glob-import/package.json
@@ -7,5 +7,8 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../vite/bin/vite",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "es-module-lexer": "^0.9.3"
   }
 }

--- a/packages/playground/glob-import/vite.config.ts
+++ b/packages/playground/glob-import/vite.config.ts
@@ -1,10 +1,39 @@
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig, Plugin } from 'vite'
+import { init, parse } from 'es-module-lexer'
 
 export default defineConfig({
   resolve: {
     alias: {
       '@dir': path.resolve(__dirname, './dir/')
     }
-  }
+  },
+  plugins: [customModifierPlugin()]
 })
+
+function customModifierPlugin() {
+  const metaRE = /(\?|&)meta(?:&|$)/
+  return {
+    name: 'custom-modifier',
+    async transform(src, id) {
+      if (!metaRE.test(id)) {
+        return
+      }
+
+      const exportNames = await getExportNames(src)
+
+      const code = `export const exportNames = ${JSON.stringify(exportNames)};`
+
+      return {
+        code,
+        map: { mappings: '' }
+      }
+    }
+  } as Plugin
+}
+
+async function getExportNames(src: string): Promise<readonly string[]> {
+  await init
+  const exportNames = parse(src)[1]
+  return exportNames
+}

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -150,7 +150,10 @@ export async function transformImportGlob(
         await fsp.readFile(path.join(base, file), 'utf-8')
       )},`
     } else {
-      const importeeUrl = isCSSRequest(importee) ? `${importee}?used` : importee
+      let importeeUrl = isCSSRequest(importee) ? `${importee}?used` : importee
+      if (options?.as) {
+        importeeUrl = `${importee}?${options.as}`
+      }
       if (isEager) {
         const identifier = `__glob_${importIndex}_${i}`
         // css imports injecting a ?used query to export the css string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,7 +201,10 @@ importers:
     specifiers: {}
 
   packages/playground/glob-import:
-    specifiers: {}
+    specifiers:
+      es-module-lexer: ^0.9.3
+    dependencies:
+      es-module-lexer: 0.9.3
 
   packages/playground/hmr:
     specifiers: {}
@@ -4328,7 +4331,6 @@ packages:
 
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
-    dev: true
 
   /es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}


### PR DESCRIPTION
### Description

Add support for custom modifiers for glob imports.

```js
import.meta.globEager('/pages/**/*.page.client.js', {
  assert: { type: 'some-custom-modifier' }
})
```

### Additional context

Two frameworks that are being built on top of `vite-plugin-ssr` need this.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ x Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
