### PR TITLE
fix: build optimize deps metada location

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -36,6 +36,7 @@ import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
 import { resolveSSRExternal, shouldExternalizeForSSR } from './ssr/ssrExternal'
 import { ssrManifestPlugin } from './ssr/ssrManifestPlugin'
 import type { DepOptimizationMetadata } from './optimizer'
+import { getDepsCacheDir } from './optimizer'
 import { scanImports } from './optimizer/scan'
 import { assetImportMetaUrlPlugin } from './plugins/assetImportMetaUrl'
 import { loadFallbackPlugin } from './plugins/loadFallback'
@@ -401,7 +402,7 @@ async function doBuild(
   if (ssr) {
     // see if we have cached deps data available
     let knownImports: string[] | undefined
-    const dataPath = path.join(config.cacheDir, '_metadata.json')
+    const dataPath = path.join(getDepsCacheDir(config), '_metadata.json')
     try {
       const data = JSON.parse(
         fs.readFileSync(dataPath, 'utf-8')


### PR DESCRIPTION
### Description

Fixes missing pre bundle metadata location when building after https://github.com/vitejs/vite/pull/6758

Fix [marko/vite](https://github.com/marko-js/vite) CI issue with 2.9 beta
See: https://github.com/vitejs/vite-ecosystem-ci/runs/5443497900?check_suite_focus=true

### Additional context

It isn't directly related to the fix but the same error can be reproduced in the current test suite against vite 2.8.x (or any prev version) if you comment the dev step and we only test the build step.
If you don't run vite dev, the pre-bundling step isn't run, so the `_metadata.json` with the known imports isn't available and the build process then runs a fresh scan phase. For some reason, this scan phase seems to be given a different set of deps because I ended up with the same error then we are seeing in vite-ecosystem-ci. We need to investigate that afterward.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other