### PR TITLE
fix: deprecate `{ assert: { type: raw }}` in favor of `{ as: raw }` (fix #7017)

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -298,10 +298,10 @@ const modules = {
 }
 ```
 
-`import.meta.glob` and `import.meta.globEager` also support importing files as strings, similar to [Importing Asset as String](https://vitejs.dev/guide/assets.html#importing-asset-as-string). Here, we use the [Import Assertions](https://github.com/tc39/proposal-import-assertions#synopsis) syntax to import.
+`import.meta.glob` and `import.meta.globEager` also support importing files as strings (similar to [Importing Asset as String](https://vitejs.dev/guide/assets.html#importing-asset-as-string)) with the [Import Reflection](https://github.com/tc39/proposal-import-reflection) syntax:
 
 ```js
-const modules = import.meta.glob('./dir/*.js', { assert: { type: 'raw' } })
+const modules = import.meta.glob('./dir/*.js', { as: 'raw' })
 ```
 
 The above will be transformed into the following:

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -40,7 +40,7 @@
 
 <script type="module">
   const rawModules = import.meta.globEager('/dir/*.json', {
-    assert: { type: 'raw' }
+    as: 'raw'
   })
   const globraw = {}
   Object.keys(rawModules).forEach((key) => {

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -141,7 +141,7 @@ export async function transformImportGlob(
         logger.warn(
           colors.yellow(
             colors.bold(
-              "(!) Use `import.meta.globEager('/dir/*.js', { as: 'raw' })` instead of `import.meta.globEager('/dir/*.js', { assert: { type: 'raw' } })` (it will be deprecated in Vite 3.0)."
+              "(!) import.meta.glob('...', { assert: { type: 'raw' }}) is deprecated. Use import.meta.glob('...', { as: 'raw' }) instead."
             )
           )
         )

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -133,18 +133,19 @@ export async function transformImportGlob(
       ;[importee] = await normalizeUrl(file, pos)
     }
     imports.push(importee)
-    if (
-      options?.as === 'raw' ||
-      // TODO remove assert syntax for the Vite 3.0 release.
-      options?.assert?.type === 'raw'
-    ) {
-      logger.warn(
-        colors.yellow(
-          colors.bold(
-            "(!) Use `import.meta.globEager('/dir/*.js', { as: 'raw' })` instead of `import.meta.globEager('/dir/*.js', { assert: { type: 'raw' } })` (it will be deprecated in Vite 3.0)."
+    // TODO remove assert syntax for the Vite 3.0 release.
+    const isRawAssert = options?.assert?.type === 'raw'
+    const isRawType = options?.as === 'raw'
+    if (isRawType || isRawAssert) {
+      if (isRawAssert) {
+        logger.warn(
+          colors.yellow(
+            colors.bold(
+              "(!) Use `import.meta.globEager('/dir/*.js', { as: 'raw' })` instead of `import.meta.globEager('/dir/*.js', { assert: { type: 'raw' } })` (it will be deprecated in Vite 3.0)."
+            )
           )
         )
-      )
+      }
       entries += ` ${JSON.stringify(file)}: ${JSON.stringify(
         await fsp.readFile(path.join(base, file), 'utf-8')
       )},`

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -28,6 +28,9 @@ interface GlobParams {
 
 interface GlobOptions {
   as?: string
+  /**
+   * @deprecated
+   */
   assert?: {
     type: string
   }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import glob from 'fast-glob'
-import type { ResolvedConfig } from '..'
+import type { ResolvedConfig, Logger } from '..'
 import type { Loader, Plugin, OnLoadResult } from 'esbuild'
 import { build, transform } from 'esbuild'
 import {
@@ -296,7 +296,8 @@ function esbuildScanPlugin(
                     path,
                     config.root,
                     loader,
-                    resolve
+                    resolve,
+                    config.logger
                   )
                 }
               } else {
@@ -454,7 +455,8 @@ function esbuildScanPlugin(
             id,
             config.root,
             ext as Loader,
-            resolve
+            resolve,
+            config.logger
           ).then((contents) => ({
             loader: ext as Loader,
             contents
@@ -474,7 +476,8 @@ async function transformGlob(
   importer: string,
   root: string,
   loader: Loader,
-  resolve: (url: string, importer?: string) => Promise<string | undefined>
+  resolve: (url: string, importer?: string) => Promise<string | undefined>,
+  logger: Logger
 ) {
   // transform the content first since es-module-lexer can't handle non-js
   if (loader !== 'js') {
@@ -495,6 +498,7 @@ async function transformGlob(
       normalizePath(importer),
       index,
       root,
+      logger,
       undefined,
       resolve
     )

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -355,6 +355,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               importer,
               index,
               root,
+              config.logger,
               normalizeUrl,
               resolve
             )

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -158,6 +158,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               importer,
               index,
               config.root,
+              config.logger,
               undefined,
               resolve,
               insertPreload

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -8,6 +8,10 @@
 // avoid breaking the production client type. Because this file is referenced
 // in vite/client.d.ts and in production src/node/importGlob.ts doesn't exist.
 interface GlobOptions {
+  as?: string
+  /**
+   * @deprecated
+   */
   assert?: {
     type: string
   }

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -4,10 +4,10 @@
 
 /* eslint-disable @typescript-eslint/consistent-type-imports */
 
-// Duplicate import('../src/node/importGlob').AssertOptions
-// Avoid breaking the production client type because this file is referenced
-// in vite/client.d.ts and in production src/node/importGlob.ts doesn't exist
-interface AssertOptions {
+// Duplicate of import('../src/node/importGlob').GlobOptions in order to
+// avoid breaking the production client type. Because this file is referenced
+// in vite/client.d.ts and in production src/node/importGlob.ts doesn't exist.
+interface GlobOptions {
   assert?: {
     type: string
   }
@@ -61,12 +61,12 @@ interface ImportMeta {
 
   glob<Module = { [key: string]: any }>(
     pattern: string,
-    options?: AssertOptions
+    options?: GlobOptions
   ): Record<string, () => Promise<Module>>
 
   globEager<Module = { [key: string]: any }>(
     pattern: string,
-    options?: AssertOptions
+    options?: GlobOptions
   ): Record<string, Module>
 }
 


### PR DESCRIPTION

### Description

Implements the following [comment](https://github.com/vitejs/vite/issues/7017#issuecomment-1051014818) in https://github.com/vitejs/vite/issues/7017.

> We talked about this PR and we think we should add `{ as: 'raw' }` for glob import marked as experimental in Vite 2.9 and deprecate the `{ assert: { type: 'raw' }}` syntax. We can then remove the `assert` syntax in Vite 3.0 at the beginning of May.


### Additional context


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
