### PR TITLE
fix: optimizeDeps.include missing in known imports fallback

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -36,7 +36,7 @@ import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
 import { resolveSSRExternal, shouldExternalizeForSSR } from './ssr/ssrExternal'
 import { ssrManifestPlugin } from './ssr/ssrManifestPlugin'
 import type { DepOptimizationMetadata } from './optimizer'
-import { getDepsCacheDir } from './optimizer'
+import { getDepsCacheDir, addManuallyIncludedOptimizeDeps } from './optimizer'
 import { scanImports } from './optimizer/scan'
 import { assetImportMetaUrlPlugin } from './plugins/assetImportMetaUrl'
 import { loadFallbackPlugin } from './plugins/loadFallback'
@@ -411,7 +411,9 @@ async function doBuild(
     } catch (e) {}
     if (!knownImports) {
       // no dev deps optimization data, do a fresh scan
-      knownImports = Object.keys((await scanImports(config)).deps)
+      const deps = (await scanImports(config)).deps
+      addManuallyIncludedOptimizeDeps(deps, config)
+      knownImports = Object.keys(deps)
     }
     external = resolveExternal(
       resolveSSRExternal(config, knownImports),

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -36,8 +36,7 @@ import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
 import { resolveSSRExternal, shouldExternalizeForSSR } from './ssr/ssrExternal'
 import { ssrManifestPlugin } from './ssr/ssrManifestPlugin'
 import type { DepOptimizationMetadata } from './optimizer'
-import { getDepsCacheDir, addManuallyIncludedOptimizeDeps } from './optimizer'
-import { scanImports } from './optimizer/scan'
+import { getDepsCacheDir, findKnownImports } from './optimizer'
 import { assetImportMetaUrlPlugin } from './plugins/assetImportMetaUrl'
 import { loadFallbackPlugin } from './plugins/loadFallback'
 import { watchPackageDataPlugin } from './packages'
@@ -411,9 +410,7 @@ async function doBuild(
     } catch (e) {}
     if (!knownImports) {
       // no dev deps optimization data, do a fresh scan
-      const deps = (await scanImports(config)).deps
-      await addManuallyIncludedOptimizeDeps(deps, config)
-      knownImports = Object.keys(deps)
+      knownImports = await findKnownImports(config)
     }
     external = resolveExternal(
       resolveSSRExternal(config, knownImports),

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -412,7 +412,7 @@ async function doBuild(
     if (!knownImports) {
       // no dev deps optimization data, do a fresh scan
       const deps = (await scanImports(config)).deps
-      addManuallyIncludedOptimizeDeps(deps, config)
+      await addManuallyIncludedOptimizeDeps(deps, config)
       knownImports = Object.keys(deps)
     }
     external = resolveExternal(

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -273,7 +273,12 @@ export async function createOptimizeDepsRun(
       )
     }
 
-    await addManuallyIncludedOptimizeDeps(deps, config)
+    try {
+      await addManuallyIncludedOptimizeDeps(deps, config)
+    } catch (e) {
+      processing.resolve()
+      throw e
+    }
 
     // update browser hash
     metadata.browserHash = getOptimizedBrowserHash(metadata.hash, deps)

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -527,7 +527,15 @@ export async function createOptimizeDepsRun(
   }
 }
 
-export async function addManuallyIncludedOptimizeDeps(
+export async function findKnownImports(
+  config: ResolvedConfig
+): Promise<string[]> {
+  const deps = (await scanImports(config)).deps
+  await addManuallyIncludedOptimizeDeps(deps, config)
+  return Object.keys(deps)
+}
+
+async function addManuallyIncludedOptimizeDeps(
   deps: Record<string, string>,
   config: ResolvedConfig
 ): Promise<void> {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -273,7 +273,7 @@ export async function createOptimizeDepsRun(
       )
     }
 
-    addManuallyIncludedOptimizeDeps(deps, config)
+    await addManuallyIncludedOptimizeDeps(deps, config)
 
     // update browser hash
     metadata.browserHash = getOptimizedBrowserHash(metadata.hash, deps)


### PR DESCRIPTION
### Description

While debugging the issue fixed in https://github.com/vitejs/vite/pull/7214, I found that the same error can be reproduced in the current Marko test suite against vite 2.8.x (or any prev version) if you comment the dev step and we only test the build step.
If you don't run vite dev, the pre-bundling step isn't run, so the _metadata.json with the known imports isn't available and the build process then runs a fresh scan phase. For some reason, this scan phase seems to be given a different set of deps because I ended up with the same error then we are seeing in vite-ecosystem-ci. We need to investigate that afterward.

The issue was that `optimizeDeps.include` was being ignored in the build known imports fallback. Tested this PR against the marko CI removing the dev step and it is working correctly.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other