### PR TITLE
fix: `import.meta.url` should not throw

### DIFF
--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -19,7 +19,11 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:asset-import-meta-url',
     async transform(code, id, options) {
-      if (code.includes('new URL') && code.includes(`import.meta.url`)) {
+      if (
+        !options?.ssr &&
+        code.includes('new URL') &&
+        code.includes(`import.meta.url`)
+      ) {
         const importMetaUrlRE =
           /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*,?\s*\)/g
         const noCommentsCode = code
@@ -29,13 +33,6 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         let match: RegExpExecArray | null
         while ((match = importMetaUrlRE.exec(noCommentsCode))) {
           const { 0: exp, 1: rawUrl, index } = match
-
-          if (options?.ssr) {
-            this.error(
-              `\`new URL(url, import.meta.url)\` is not supported in SSR.`,
-              index
-            )
-          }
 
           if (!s) s = new MagicString(code)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

SvelteKit, like many other Vite-based frameworks, executes user code on both the server and client. The typical way that SvelteKit users run code only on the client would be to put that code in an `if (!import.meta.env.SSR)` check or Svelte's `onMount` function so that it is only executed on the client.

Vite currently throws an exception if `import.meta.url` is encountered on the server. This is happening even if the code is never run and even if the code isn't in the final bundle because the bundler knows it's never run and removes it via dead code elimination / tree shaking.

There is other code like `window` and `navigator` that similarly cannot be run on the server. In those instances, we don't throw an exception if those are contained in the SSR build. I don't think it's really necessary to treat `import.meta.url` more strictly than `window` or `navigator`. If we did want to add some check it'd be better to find a way to do it in the end like in `closeBundle` after dead code elimination / tree shaking happens, but I'm not quite sure the API would allow an easy way to do that and I don't really see that it's needed.

### Additional context

This seems to come up a lot when people try to use SvelteKit + wasm. E.g. https://github.com/sveltejs/kit/issues/1896

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
