### PR TITLE
fix: root import

### DIFF
--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -7,13 +7,19 @@ import type { Connect } from 'types/connect'
 export function baseMiddleware({
   config
 }: ViteDevServer): Connect.NextHandleFunction {
-  const base = config.base
+  const { base, root } = config
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteBaseMiddleware(req, res, next) {
     const url = req.url!
     const parsed = parseUrl(url)
     const path = parsed.pathname || '/'
+
+    if (path.startsWith(root)) {
+      // If set the base URL to root on Linux, need to replace root to emtry string (#7220)
+      req.url = url.replace(root, '')
+      return next()
+    }
 
     if (path.startsWith(base)) {
       // rewrite url to remove base.. this ensures that other middleware does


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: vitejs/vite-plugin-vue#25

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

If set the base URL to root on Linux and use vue plugin, vue plugin will import css by absolute path. And vite will replace base to `/`, and absolute path startWith `base path` will got a error.
this PR analy `req.url(absolute path)` include `root` will replace it to emtry strings and then it will be a `<root>/[relative path]`

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
