### PR TITLE
docs(vue): add transformAssetUrls example

### DIFF
--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -64,7 +64,14 @@ export default {
           // ...
         },
         transformAssetUrls: {
-          'custom-img': ['src']
+          // default tags
+          tags: {
+            video: ['src', 'poster'],
+            source: ['src'],
+            img: ['src'],
+            image: ['xlink:href', 'href'],
+            use: ['xlink:href', 'href']
+          }
         }
       }
     })

--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -51,7 +51,7 @@ export interface Options {
 }
 ```
 
-## Example for passing options to `@vue/compiler-dom`:
+## Example for passing options to `@vue/compiler-sfc`:
 
 ```ts
 import vue from '@vitejs/plugin-vue'
@@ -62,6 +62,9 @@ export default {
       template: {
         compilerOptions: {
           // ...
+        },
+        transformAssetUrls: {
+          'custom-img': ['src']
         }
       }
     })

--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -51,7 +51,7 @@ export interface Options {
 }
 ```
 
-## Example for passing options to `@vue/compiler-sfc`:
+## Example for passing options to `vue/compiler-sfc`:
 
 ```ts
 import vue from '@vitejs/plugin-vue'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/vitejs/vite/issues/3459

### Additional context

I can't seem to find official documentation for the compiler-sfc options to link to.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
