### PR TITLE
docs(vite-legacy): Note about using `regenerator-runtime` in Content Security Policy environment

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -173,6 +173,8 @@ These values (without the `sha256-` prefix) can also be retrieved via
 const { cspHashes } = require('@vitejs/plugin-legacy')
 ```
 
+The `regenerator-runtime` polyfill attempts to use `globalThis` object to register itself. If `globalThis` is not available (it is [fairly new](https://caniuse.com/?search=globalThis) and not widely supported, including IE 11), it attempts to perform dynamic `Function(...)` call which violates the CSP. To avoid dynamic `eval` in the absence of `globalThis` consider adding `core-js/proposals/global-this` to `additionalLegacyPolyfills` to define it.
+
 ## References
 
 - [Vue CLI modern mode](https://cli.vuejs.org/guide/browser-compatibility.html#modern-mode)

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -173,7 +173,7 @@ These values (without the `sha256-` prefix) can also be retrieved via
 const { cspHashes } = require('@vitejs/plugin-legacy')
 ```
 
-The `regenerator-runtime` polyfill attempts to use `globalThis` object to register itself. If `globalThis` is not available (it is [fairly new](https://caniuse.com/?search=globalThis) and not widely supported, including IE 11), it attempts to perform dynamic `Function(...)` call which violates the CSP. To avoid dynamic `eval` in the absence of `globalThis` consider adding `core-js/proposals/global-this` to `additionalLegacyPolyfills` to define it.
+When using the `regenerator-runtime` polyfill, it will attempt to use the `globalThis` object to register itself. If `globalThis` is not available (it is [fairly new](https://caniuse.com/?search=globalThis) and not widely supported, including IE 11), it attempts to perform dynamic `Function(...)` call which violates the CSP. To avoid dynamic `eval` in the absence of `globalThis` consider adding `core-js/proposals/global-this` to `additionalLegacyPolyfills` to define it.
 
 ## References
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Can't use `regenerator-runtime` with CSP on old browsers (e.g. Chrome 38, IE 11). Caused by lack of `globalThis` and resorting to dynamic eval. Add documentation how to workaround it.

### Additional context

I encounter this problem while migrating to Vite. I'd like to update the documentation for giving other users heads up. Here is the relevant [`regenrator-runtime` fragment](https://github.com/facebook/regenerator/blob/main/packages/runtime/runtime.js#L736-L754), and different [attempt to fix it](https://stephencharlesweiss.com/unsafe-eval-regenerator-runtime)


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
