### PR TITLE
fix: needs es interop check for newly discovered deps

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -300,10 +300,7 @@ export async function createOptimizeDepsRun(
     // server is running
     deps = depsFromOptimizedDepInfo(newDeps)
 
-    // Clone optimized info objects, fileHash, browserHash may be changed for them
-    for (const o of Object.keys(newDeps)) {
-      metadata.optimized[o] = { ...newDeps[o] }
-    }
+    metadata.optimized = newDeps
 
     // update global browser hash, but keep newDeps individual hashs until we know
     // if files are stable so we can avoid a full page reload
@@ -737,4 +734,40 @@ function getDepHash(root: string, config: ResolvedConfig): string {
     }
   )
   return createHash('sha256').update(content).digest('hex').substring(0, 8)
+}
+
+export function optimizeDepInfoFromFile(
+  metadata: DepOptimizationMetadata,
+  file: string
+): OptimizedDepInfo | undefined {
+  return (
+    findFileInfo(metadata.optimized, file) ||
+    findFileInfo(metadata.discovered, file)
+  )
+}
+
+function findFileInfo(
+  dependenciesInfo: Record<string, OptimizedDepInfo>,
+  file: string
+): OptimizedDepInfo | undefined {
+  for (const o of Object.keys(dependenciesInfo)) {
+    const info = dependenciesInfo[o]
+    if (info.file === file) {
+      return info
+    }
+  }
+}
+
+export async function optimizedDepNeedsInterop(
+  metadata: DepOptimizationMetadata,
+  file: string
+): Promise<boolean | undefined> {
+  const depInfo = optimizeDepInfoFromFile(metadata, file)
+
+  if (!depInfo) return undefined
+
+  // Wait until the dependency has been pre-bundled
+  await depInfo.processing
+
+  return depInfo?.needsInterop
 }

--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -79,7 +79,14 @@ export function createMissingImporterRegisterFn(
 
     // All deps, previous known and newly discovered are rebundled,
     // respect insertion order to keep the metadata file stable
-    const newDeps = { ...metadata.optimized, ...metadata.discovered }
+
+    // Clone optimized info objects, fileHash, browserHash may be changed for them
+    const clonedOptimizedDeps: Record<string, OptimizedDepInfo> = {}
+    for (const o of Object.keys(metadata.optimized)) {
+      clonedOptimizedDeps[o] = { ...metadata.optimized[o] }
+    }
+
+    const newDeps = { ...clonedOptimizedDeps, ...metadata.discovered }
     const thisDepOptimizationProcessing = depOptimizationProcessing
 
     // Other rerun will await until this run is finished
@@ -119,9 +126,8 @@ export function createMissingImporterRegisterFn(
       // While optimizeDeps is running, new missing deps may be discovered,
       // in which case they will keep being added to metadata.discovered
       for (const o of Object.keys(metadata.discovered)) {
-        if (!newData.optimized[o] && !newData.discovered[o]) {
+        if (!newData.optimized[o]) {
           newData.discovered[o] = metadata.discovered[o]
-          delete metadata.discovered[o]
         }
       }
       newData.processing = thisDepOptimizationProcessing.promise

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -3,8 +3,7 @@ import type { Plugin } from '../plugin'
 import colors from 'picocolors'
 import { DEP_VERSION_RE } from '../constants'
 import { cleanUrl, createDebugger } from '../utils'
-import { isOptimizedDepFile } from '../optimizer'
-import type { DepOptimizationMetadata, OptimizedDepInfo } from '../optimizer'
+import { isOptimizedDepFile, optimizeDepInfoFromFile } from '../optimizer'
 import type { ViteDevServer } from '..'
 
 export const ERR_OPTIMIZE_DEPS_PROCESSING_ERROR =
@@ -33,6 +32,8 @@ export function optimizedDepsPlugin(): Plugin {
           const browserHash = versionMatch
             ? versionMatch[1].split('=')[1]
             : undefined
+
+          // Search in both the currently optimized and newly discovered deps
           const info = optimizeDepInfoFromFile(metadata, file)
           if (info) {
             if (browserHash && info.browserHash !== browserHash) {
@@ -92,26 +93,4 @@ function throwOutdatedRequest(id: string) {
   // This error will be caught by the transform middleware that will
   // send a 504 status code request timeout
   throw err
-}
-
-function optimizeDepInfoFromFile(
-  metadata: DepOptimizationMetadata,
-  file: string
-): OptimizedDepInfo | undefined {
-  return (
-    findFileInfo(metadata.optimized, file) ||
-    findFileInfo(metadata.discovered, file)
-  )
-}
-
-function findFileInfo(
-  dependenciesInfo: Record<string, OptimizedDepInfo>,
-  file: string
-): OptimizedDepInfo | undefined {
-  for (const o of Object.keys(dependenciesInfo)) {
-    const info = dependenciesInfo[o]
-    if (info.file === file) {
-      return info
-    }
-  }
 }


### PR DESCRIPTION
### Description

This PR fixes the needs es interop check for newly discovered dependencies. It is an edge case, and this is why we didn't discover it so far. What needs to happen is that:
- There is a missing dependency that needs es interop 
- and when re-processing the deps there is no need for a full-page reload. 

And CI is going to fail for react-emotion because when we call `moduleGraph.invalidateAll()` before doing the full-reload after re-processing, there are requests that are on the fly and end up updating their module info... so when the browser requests them after the full reload... these modules are stale. @vursen this is what we were seeing in Vaadin with the 504 errors in the browser that didn't disappear even when reloading the page manually.

We need that a full-reload call will also stop every currently processing request to avoid modifying the module graph.

I think this could have been also present before, but now it is more visible because we aren't blocking the requests as before while processing. So a solution here may fix hard-to-replicate issues that we got in the past. 

I'll work on a PR to fix the race condition next, I'm sending this PR to serve as a bug reproduction once CI fails.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other