### PR TITLE
feat: allow `react/jsx-dev-runtime` imports

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -39,7 +39,6 @@
     "@babel/plugin-transform-react-jsx-self": "^7.16.7",
     "@babel/plugin-transform-react-jsx-source": "^7.16.7",
     "@rollup/pluginutils": "^4.2.1",
-    "react-refresh": "^0.12.0",
-    "resolve": "^1.22.0"
+    "react-refresh": "^0.12.0"
   }
 }

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -361,9 +361,12 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         reactPackageRoot,
         'cjs/react-jsx-runtime.production.min.js'
       )
-      // These must be optimized since they are CommonJS.
       optimizeDeps.include = [
-        ...(optimizeDeps.include || []),
+        ...(optimizeDeps.include || []).filter(
+          // Disable old workaround so unnecessary work is avoided.
+          (id) => id !== prodRuntimeId && id !== devRuntimeId
+        ),
+        // These must be optimized since they are CommonJS.
         prodEntry,
         devEntry
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -771,7 +771,6 @@ importers:
       '@babel/plugin-transform-react-jsx-source': ^7.16.7
       '@rollup/pluginutils': ^4.2.1
       react-refresh: ^0.12.0
-      resolve: ^1.22.0
     dependencies:
       '@babel/core': 7.17.9
       '@babel/plugin-transform-react-jsx': 7.17.3_@babel+core@7.17.9
@@ -780,7 +779,6 @@ importers:
       '@babel/plugin-transform-react-jsx-source': 7.16.7_@babel+core@7.17.9
       '@rollup/pluginutils': 4.2.1
       react-refresh: 0.12.0
-      resolve: 1.22.0
 
   packages/plugin-vue:
     specifiers:


### PR DESCRIPTION
### Description

This PR contains the following changes:

- Imports of `react/jsx-runtime` and `react/jsx-dev-runtime` are now resolved with the same module ID and globally deduplicated
- Skip over the actual `react/jsx-runtime.js` module (which uses `process.env.NODE_ENV` checking) in favor of manual resolution using the `isProduction` local variable
- Ensure both `react/cjs/react-jsx-dev-runtime.development.js` and `react/cjs/react-jsx-runtime.production.min.js` are processed by Vite's optimizer

### Additional context

Fixes #6215

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
