### PR TITLE
Warnings to avoid hard-to-debug base config errors

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -134,6 +134,10 @@ export default defineConfig(({ command, mode }) => {
   - Full URL, e.g. `https://foo.com/`
   - Empty string or `./` (for embedded deployment)
 
+  Beware that using a relative `base` path for a single-page web-based app may break when calls to window.history.pushState change the path in the address bar, as your code will attempt to load assets relative to that modified path in production, but often not in serve (AKA dev) mode used for development testing. This can cause workers to silently fail to load in production when the relative path fails to find the worker that appeared to be at the correct location at compile time and when running via serve/dev.
+  
+  Beware that using an absolute `base` path will likely break electron and other apps that run on the local filesystem and are not served via the web, as these apps may be installed in different locations and should thus rely on file-system based relative paths. For example, when building such filesystem-based app, a `base` of `""` (or equivalently `"./"`) will cause `vite` to use paths that will be relative to the current directory when the code is executed.
+
   See [Public Base Path](/guide/build#public-base-path) for more details.
 
 ### mode


### PR DESCRIPTION
I lost three days of debugging because I had copied my vite.config electron setting for `base` to my web configuration because I didn't realize what would happen when my web-based code called window.history.pushState (as most single-page apps will).  This is in part because the implications of different `base` settings are not obvious from the documentation, but also because the failures are very hard to debug.

I'm hoping these warnings will save others as I'm guessing it's a common error.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
