### PR TITLE
feat: optimize the resolve logic of devServer's port and the server running at... log(#7271)

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -92,3 +92,6 @@ export const DEFAULT_ASSETS_RE = new RegExp(
 )
 
 export const DEP_VERSION_RE = /[\?&](v=[\w\.-]+)\b/
+
+export const DEFAULT_IPV4_ADDR = '0.0.0.0'
+export const DEFAULT_IPV6_ADDR = '::'

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -635,8 +635,10 @@ export function resolveHostname(
   optionsHost: string | boolean | undefined
 ): Hostname {
   let host: string | undefined
-  if (optionsHost === undefined || optionsHost === false) {
-    // Use a secure default
+  if (!optionsHost) {
+    // Use a secure default when optionsHost can transfer to false
+    // to avoid node listen on default_addr. ie: optionsHost is '' or 0 or other false values
+    // see https://github.com/nodejs/node/blob/v17.7.1/lib/net.js#L906
     host = '127.0.0.1'
   } else if (optionsHost === true) {
     // If passed --host in the CLI without arguments


### PR DESCRIPTION
…unning at... log(#7271)

<!-- Thank you for contributing! -->

### Description
This PR is solving #7271 and #5241.

It will guarantee that the url displayed to the user is accessible.

In addition, when server.host is '' or 0 or other false value,it handles correctly .
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

I'm not sure if this is a vite feature or a bug,and the code may not be particularly elegant.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
