### PR TITLE
fix: use browserHash for imports from node_modules

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -606,7 +606,7 @@ export function tryNodeResolve(
       // otherwise we may introduce duplicated modules for externalized files
       // from pre-bundled deps.
 
-      const versionHash = server._optimizeDepsMetadata?.hash
+      const versionHash = server._optimizeDepsMetadata?.browserHash
       if (versionHash && isJsType) {
         resolved = injectQuery(resolved, `v=${versionHash}`)
       }


### PR DESCRIPTION
### Description

Fix VitePress. 

Revert a change introduced by #6758. See https://github.com/vitejs/vite/pull/6758/files#diff-9b81bb364c02eab9494a7d27a5effc400cacbffd3b8f349c192f890c37bfc83fR609

I wrote in the PR description:
> Note: `hash` is used instead of `browserHash` for files excluded from optimization. This is unrelated to the PR, but as we need to re-test quite a bit to be able to merge this one, I think we could also check it in. hash only depends on the lock file, but should be enough here AFAICS

`browserHash` is actually needed here, as `hash` will be stable after a reload and these files will be stale.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other