### PR TITLE
fix: use hmr port if specified

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -536,7 +536,7 @@ export default defineConfig(({ command, mode }) => {
 
   `clientPort` is an advanced option that overrides the port only on the client side, allowing you to serve the websocket on a different port than the client code looks for it on. Useful if you're using an SSL proxy in front of your dev server.
 
-  When using `server.middlewareMode` or `server.https`, assigning `server.hmr.server` to your HTTP(S) server will process HMR connection requests through your server. This can be helpful when using self-signed certificates or when you want to expose Vite over a network on a single port.
+  If specifying `server.hmr.server`, Vite will process HMR connection requests through the provided server. If not in middleware mode, Vite will attempt to process HMR connection requests through the existing server. This can be helpful when using self-signed certificates or when you want to expose Vite over a network on a single port.
 
 ### server.watch
 

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -28,7 +28,9 @@ export function createWebSocketServer(
   let httpsServer: Server | undefined = undefined
 
   const hmr = isObject(config.server.hmr) && config.server.hmr
-  const wsServer = (hmr && hmr.server) || (!(hmr && hmr.port) && server)
+  const wsServer =
+    (hmr && hmr.server) ||
+    ((!(hmr && hmr.port) || hmr.port !== config.server.port) && server)
 
   if (wsServer) {
     wss = new WebSocket({ noServer: true })

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -28,7 +28,7 @@ export function createWebSocketServer(
   let httpsServer: Server | undefined = undefined
 
   const hmr = isObject(config.server.hmr) && config.server.hmr
-  const wsServer = (hmr && hmr.server) || server
+  const wsServer = (hmr && hmr.server) || (!(hmr && hmr.port) && server)
 
   if (wsServer) {
     wss = new WebSocket({ noServer: true })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/vitejs/vite/issues/6068

### Additional context

I don't understand what the hmr code is trying to do and it doesn't match the behavior described in [the docs](https://vitejs.dev/config/#server-hmr), which say:

>When using server.middlewareMode or server.https, assigning server.hmr.server to your HTTP(S) server will process HMR connection requests through your server.

But the "assigning server.hmr.server to your HTTP(S) server" part is being completely ignored and it's using the user's server all the time. What's described in the docs is kind of a funny concept because normally you create the config and then pass it to Vite to create the server, but how would you provide the server to `server.hmr.server` when it hasn't been created yet? So I'm not really clear how this is intended to behave and there's probably more that could be fixed here. 

In this PR, I'm just trying to fix one specific thing that's clearly broken which is that the `hmr.port` setting is currently ignored. I'll let y'all decide if you want to do more cleanup beyond that, but it's probably beyond the scope of what I would do because I think the tests rely on the current behavior and it's not super clear what else should be changed

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
