### PR TITLE
fix: pending requests after module invalidation

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -297,7 +297,14 @@ export interface ViteDevServer {
   /**
    * @internal
    */
-  _pendingRequests: Map<string, Promise<TransformResult | null>>
+  _pendingRequests: Map<
+    string,
+    {
+      request: Promise<TransformResult | null>
+      timestamp: number
+      abort: () => void
+    }
+  >
 }
 
 export async function createServer(


### PR DESCRIPTION
### Description

Continuation on the work started by #7254

When we invalidate a module, we don't cache results for in-fly requests after #7254.

We also cache pending requests so we can collapse requests for the same resource while processing. This is important due to the way Vite crawls the whole module graph eagerly even before the browser does the requests.

After invalidation, we need to also consider the case
```
// Request 1 for module A     (pending.timestamp)
// Invalidate module A        (module.lastInvalidationTimestamp)
// Request 2 for module A     (timestamp)
// Finish processing 1, then 2 ends up with a stale result
```

This PR fixes this case. This is another case that is difficult to test and reproduce, so users may have run against it without being able to send the report.

@antfu I didn't use AbortController as we need Node 15 IIUC. It could be interesting to save the promise in the Module instead of in `_pendingRequests` that would lead to a similar scheme like you proposed but looks like we may not always have a Module since we only create it in the module graph after a successful load (so in the middle of the processing). Maybe we could create a Module upfront and keep it in a `moduleGraph._pending` and only add it after load. Maybe we could do this refactoring in another PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other