### PR TITLE
test: fix server port conflict

### DIFF
--- a/packages/playground/css/__tests__/postcss-plugins-different-dir.spec.ts
+++ b/packages/playground/css/__tests__/postcss-plugins-different-dir.spec.ts
@@ -4,7 +4,7 @@ import path from 'path'
 
 // Regression test for https://github.com/vitejs/vite/issues/4000
 test('postcss plugins in different dir', async () => {
-  const port = 5005
+  const port = 5006
   const server = await createServer({
     root: path.join(__dirname, '..', '..', 'tailwind'),
     logLevel: 'silent',


### PR DESCRIPTION
### Description
These two tests use the same port and it failed with `Port 5005 is already in use` in my environment.

https://github.com/vitejs/vite/blob/bf57c5398937cfc307171c7dcc658727575b004b/packages/playground/css/__tests__/postcss-plugins-different-dir.spec.ts#L7
https://github.com/vitejs/vite/blob/bf57c5398937cfc307171c7dcc658727575b004b/packages/playground/css/postcss-caching/css.spec.ts#L6

This PR simply changes the port to fix this.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
