### PR TITLE
fix: dep with dynamic import wrong error log

### DIFF
--- a/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -66,6 +66,12 @@ test('import from dep with .notjs files', async () => {
   expect(await page.textContent('.not-js')).toMatch(`[success]`)
 })
 
+test('dep with dynamic import', async () => {
+  expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
+    `[success]`
+  )
+})
+
 test('dep with css import', async () => {
   expect(await getColor('h1')).toBe('red')
 })

--- a/packages/playground/optimize-deps/dep-with-dynamic-import/dynamic.js
+++ b/packages/playground/optimize-deps/dep-with-dynamic-import/dynamic.js
@@ -1,0 +1,1 @@
+export const foo = '[success] dependency with dynamic import'

--- a/packages/playground/optimize-deps/dep-with-dynamic-import/index.js
+++ b/packages/playground/optimize-deps/dep-with-dynamic-import/index.js
@@ -1,0 +1,4 @@
+export const lazyFoo = async function () {
+  const { foo } = await import('./dynamic.js')
+  return foo
+}

--- a/packages/playground/optimize-deps/dep-with-dynamic-import/package.json
+++ b/packages/playground/optimize-deps/dep-with-dynamic-import/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep-with-dynamic-import",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/packages/playground/optimize-deps/index.html
+++ b/packages/playground/optimize-deps/index.html
@@ -41,6 +41,9 @@
 <h2>Import from dependency with .notjs files</h2>
 <div class="not-js"></div>
 
+<h2>Import from dependency with dynamic import</h2>
+<div class="dep-with-dynamic-import"></div>
+
 <h2>Dep w/ special file format supported via plugins</h2>
 <div class="plugin"></div>
 
@@ -87,6 +90,11 @@
 
   import { notjsValue } from 'dep-not-js'
   text('.not-js', notjsValue)
+
+  import { lazyFoo } from 'dep-with-dynamic-import'
+  lazyFoo().then((foo) => {
+    text('.dep-with-dynamic-import', foo)
+  })
 
   import { createApp } from 'vue'
   import { createStore } from 'vuex'

--- a/packages/playground/optimize-deps/package.json
+++ b/packages/playground/optimize-deps/package.json
@@ -18,6 +18,7 @@
     "dep-linked": "link:./dep-linked",
     "dep-linked-include": "link:./dep-linked-include",
     "dep-not-js": "file:./dep-not-js",
+    "dep-with-dynamic-import": "file:./dep-with-dynamic-import",
     "lodash-es": "^4.17.21",
     "nested-exclude": "file:./nested-exclude",
     "phoenix": "^1.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,6 +299,7 @@ importers:
       dep-linked: link:./dep-linked
       dep-linked-include: link:./dep-linked-include
       dep-not-js: file:./dep-not-js
+      dep-with-dynamic-import: file:./dep-with-dynamic-import
       lodash-es: ^4.17.21
       nested-exclude: file:./nested-exclude
       phoenix: ^1.6.2
@@ -317,6 +318,7 @@ importers:
       dep-linked: link:dep-linked
       dep-linked-include: link:dep-linked-include
       dep-not-js: link:dep-not-js
+      dep-with-dynamic-import: link:dep-with-dynamic-import
       lodash-es: 4.17.21
       nested-exclude: link:nested-exclude
       phoenix: 1.6.5


### PR DESCRIPTION
### Description

Added a test case to showcase the issue. The comment in the code explains why this isn't an error. These dynamic imports are of the form `OriginalFileName-{hash}.js`.

I think later we could save in the metadata the names of all non-entry outputs, chunks, and dynamic imports, so we can do these checks against the real file names.

Reproduction with 2.9-beta.1 here: https://stackblitz.com/edit/vitejs-vite-kvca58

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other