### PR TITLE
chore(ci): setup auto docs publish workflow for release vX.X.X tag

### DIFF
--- a/.github/workflows/deploy-docs-on-netlify.yml
+++ b/.github/workflows/deploy-docs-on-netlify.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           publish-dir: "docs/.vitepress/dist"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          production-deploy: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          production-deploy: ${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta') }}
           deploy-message: "Deploy docs to Netlify by ref: ${{ github.ref }} from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: true

--- a/.github/workflows/deploy-docs-on-netlify.yml
+++ b/.github/workflows/deploy-docs-on-netlify.yml
@@ -37,7 +37,7 @@ jobs:
           publish-dir: "docs/.vitepress/dist"
           github-token: ${{ secrets.VITE_GITHUB_TOKEN }}
           production-deploy: ${{ startsWith(github.ref.start, 'refs/tags/v') }}
-          deploy-message: "Deploy docs to Netlify by event: ${{ github.event_name }} from GitHub Actions"
+          deploy-message: "Deploy docs to Netlify by ref: ${{ github.ref }} from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: true
           overwrites-pull-request-comment: true

--- a/.github/workflows/deploy-docs-on-netlify.yml
+++ b/.github/workflows/deploy-docs-on-netlify.yml
@@ -2,8 +2,10 @@ name: Publish docs on release
 
 on:
   push:
-    tags:
-      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+    paths:
+      - "docs/**"
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -33,13 +35,13 @@ jobs:
         uses: nwtgck/actions-netlify@v1.2
         with:
           publish-dir: "docs/.vitepress/dist"
-          production-branch: main
           github-token: ${{ secrets.VITE_GITHUB_TOKEN }}
-          deploy-message: "Deploy docs on release from GitHub Actions"
+          production-deploy: ${{ github.event_name == 'release' }}
+          deploy-message: "Deploy docs to Netlify by event: ${{ github.event_name }} from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: true
           overwrites-pull-request-comment: true
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 1
+        timeout-minutes: 5

--- a/.github/workflows/deploy-docs-on-netlify.yml
+++ b/.github/workflows/deploy-docs-on-netlify.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           publish-dir: "docs/.vitepress/dist"
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          production-deploy: ${{ startsWith(github.ref.start, 'refs/tags/v') }}
+          production-deploy: ${{ startsWith(github.ref, 'refs/tags/v') }}
           deploy-message: "Deploy docs to Netlify by ref: ${{ github.ref }} from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: true

--- a/.github/workflows/deploy-docs-on-netlify.yml
+++ b/.github/workflows/deploy-docs-on-netlify.yml
@@ -35,7 +35,7 @@ jobs:
         uses: nwtgck/actions-netlify@v1.2
         with:
           publish-dir: "docs/.vitepress/dist"
-          github-token: ${{ secrets.VITE_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           production-deploy: ${{ startsWith(github.ref.start, 'refs/tags/v') }}
           deploy-message: "Deploy docs to Netlify by ref: ${{ github.ref }} from GitHub Actions"
           enable-pull-request-comment: true

--- a/.github/workflows/deploy-docs-on-netlify.yml
+++ b/.github/workflows/deploy-docs-on-netlify.yml
@@ -4,8 +4,8 @@ on:
   push:
     paths:
       - "docs/**"
-  release:
-    types: [published]
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   deploy:
@@ -36,7 +36,7 @@ jobs:
         with:
           publish-dir: "docs/.vitepress/dist"
           github-token: ${{ secrets.VITE_GITHUB_TOKEN }}
-          production-deploy: ${{ github.event_name == 'release' }}
+          production-deploy: ${{ startsWith(github.ref.start, 'refs/tags/v') }}
           deploy-message: "Deploy docs to Netlify by event: ${{ github.event_name }} from GitHub Actions"
           enable-pull-request-comment: true
           enable-commit-comment: true

--- a/.github/workflows/deploy-docs-on-release.yml
+++ b/.github/workflows/deploy-docs-on-release.yml
@@ -1,0 +1,45 @@
+name: Publish docs on release
+
+on:
+  push:
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 6
+
+      - name: Set node version to 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "pnpm"
+
+      - name: Install deps
+        run: pnpm install
+
+      - name: Build docs
+        run: pnpm run ci-docs
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: "docs/.vitepress/dist"
+          production-branch: main
+          github-token: ${{ secrets.VITE_GITHUB_TOKEN }}
+          deploy-message: "Deploy docs on release from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: true
+          overwrites-pull-request-comment: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,0 @@
-[build.environment]
-  NODE_VERSION = "16"
-  NPM_FLAGS = "--version" # prevent Netlify npm install
-[build]
-  publish = "docs/.vitepress/dist"
-  command = "npx pnpm i --store=node_modules/.pnpm-store && npm run ci-docs"


### PR DESCRIPTION
# Automatic workflow for release docs publish

I wrote these guides in order to give our reviewers more context and information here.

## Why for this PR ?

After publishing a new release of Vite, we must open Netlify UI to trigger docs build & publish manually now.

It's because the contents of `docs` folder are actively updating, and we'll always see the latest content on docs site if we use Netlify's git-based deployment, but actually there's something ahead of current release.

So I'm wondering if there's some ways for setting up an automatically deploy workflow which only targets on `vX.X.X` tag, it's a significant sign.

## Is these changes enough ?

Actually, NO. we should add more configs around.

## First: turn off Netlify builds

Since now this repo would not trigger a new deploy by commit pushing, we can skip this step if it's already done.

1. Go to Netlify UI, site administration page.
2. Open **`Site Setting`** panel
3. Open **`Build & Deploy`** tab on the left side
4. Scroll down to **`Build Settings`**, and click **`Edit Settings`**
5. Select **`Builds --> Stop Builds`**

## Second: setting up secrets

This step may requires @yyx990803, @patak-dev or someone has right to access this repo's setting panel, to create a list of following fields:

1. `VITE_GITHUB_TOKEN`: this is a Github Access Token, may need to be generated by manually creating @yyx990803 

    https://github.com/settings/tokens

2. `NETLIFY_AUTH_TOKEN`: this is a personal access token which is supposed to be generate on Netlify.

    https://app.netlify.com/user/applications#personal-access-tokens

3. `NETLIFY_SITE_ID`: this one could be found at [General | Site settings](https://app.netlify.com/sites/vitejs/settings/general)

    But I could use an open API of Netlify to query for result:

```bash
curl https://api.netlify.com/api/v1/sites/vitejs.dev

// id: 8c66140b-3a31-475e-b0c6-ff6689563820
```

![image](https://user-images.githubusercontent.com/46062972/158433303-a81e9517-7169-4c90-8c41-ccea92d45246.png)

## That's all for configuration.