### PR TITLE
feat: Support use alias in dynamic import statements

### DIFF
--- a/packages/playground/dynamic-import/index.html
+++ b/packages/playground/dynamic-import/index.html
@@ -8,6 +8,8 @@
 <button class="issue-2658-1">Issue 2658 - 1</button>
 <button class="issue-2658-2">Issue 2658 - 2</button>
 <button class="css">css</button>
+<button class="alias-foo">Alias Foo</button>
+<button class="alias-bar">Alias Bar</button>
 
 <div class="view"></div>
 

--- a/packages/playground/dynamic-import/nested/index.js
+++ b/packages/playground/dynamic-import/nested/index.js
@@ -6,8 +6,18 @@ async function setView(view) {
   text('.view', msg)
 }
 
+async function setViewWithAlias(view) {
+  const { msg } = await import(`@views/${view}.js`)
+  text('.view', msg + ' with alias')
+}
+
 ;['foo', 'bar'].forEach((id) => {
   document.querySelector(`.${id}`).addEventListener('click', () => setView(id))
+})
+;['foo', 'bar'].forEach((id) => {
+  document
+    .querySelector(`.alias-${id}`)
+    .addEventListener('click', () => setViewWithAlias(id))
 })
 
 // literal dynamic

--- a/packages/playground/dynamic-import/vite.config.js
+++ b/packages/playground/dynamic-import/vite.config.js
@@ -20,5 +20,10 @@ module.exports = {
         )
       }
     }
-  ]
+  ],
+  resolve: {
+    alias: {
+      '@views': path.resolve(__dirname, 'views')
+    }
+  }
 }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -653,10 +653,6 @@ function isSupportedDynamicImport(url: string) {
   if (!url.startsWith('./') && !url.startsWith('../')) {
     return false
   }
-  // must have extension
-  if (!path.extname(url)) {
-    return false
-  }
   // must be more specific if importing from same dir
   if (url.startsWith('./${') && url.indexOf('/') === url.lastIndexOf('/')) {
     return false

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -649,8 +649,12 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
  */
 function isSupportedDynamicImport(url: string) {
   url = url.trim().slice(1, -1)
-  // must be relative
-  if (!url.startsWith('./') && !url.startsWith('../')) {
+  // must be relative or root path
+  if (
+    !url.startsWith('./') &&
+    !url.startsWith('../') &&
+    !url.startsWith('/')
+  ) {
     return false
   }
   // must be more specific if importing from same dir


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

1. [chore: remove extension restrict](https://github.com/caoxiemeihao/vite/commit/911077615afe9e15499aff85d4da32b04af3be9b)

The extension not be necessary during `vite serve` phase, because the variables in `import()` can be correctly resolved at runtime

2. [chroe: must be relative or root path](https://github.com/caoxiemeihao/vite/commit/dbe90377a130c0b1cff63d1fac3c7f4b659245d4)

When i use alias in `import()`, it may get an absolute path like `/User/name/project-path`, which can work normally in the `vite serve` phase.


3. [feat: dynamic import support alias](https://github.com/caoxiemeihao/vite/commit/af4aab59b886207abd86ade7c42e17735b4aa5f3)

When I use `import()`, I hope I can also support alias, which is a very common case

e.g.

```js
// source
import(`@/views/${component}`)

// transpile
import(`/User/name/project-path/views/${component}`)
```

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
