### PR TITLE
fix: early discovery of missing deps, fix #7333

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -307,6 +307,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         return [url, resolved.id]
       }
 
+      // Import rewrites, we do them after all the URLs have been resolved
+      // to help with the discovery of new dependencies. If we need to wait
+      // for each dependency there could be one reload per import
+      const importRewrites: (() => Promise<void>)[] = []
+
       for (let index = 0; index < imports.length; index++) {
         const {
           s: start,
@@ -433,61 +438,67 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // record as safe modules
           server?.moduleGraph.safeModulesPath.add(fsPathFromUrl(url))
 
-          // rewrite
           if (url !== specifier) {
-            let rewriteDone = false
-            if (
-              isOptimizedDepFile(resolvedId, config) &&
-              !resolvedId.match(optimizedDepChunkRE)
-            ) {
-              // for optimized cjs deps, support named imports by rewriting named imports to const assignments.
-              // internal optimized chunks don't need es interop and are excluded
+            importRewrites.push(async () => {
+              let rewriteDone = false
+              if (
+                isOptimizedDepFile(resolvedId, config) &&
+                !resolvedId.match(optimizedDepChunkRE)
+              ) {
+                // for optimized cjs deps, support named imports by rewriting named imports to const assignments.
+                // internal optimized chunks don't need es interop and are excluded
 
-              // The browserHash in resolvedId could be stale in which case there will be a full
-              // page reload. We could return a 404 in that case but it is safe to return the request
-              const file = cleanUrl(resolvedId) // Remove ?v={hash}
+                // The browserHash in resolvedId could be stale in which case there will be a full
+                // page reload. We could return a 404 in that case but it is safe to return the request
+                const file = cleanUrl(resolvedId) // Remove ?v={hash}
 
-              const needsInterop = await optimizedDepNeedsInterop(
-                server._optimizeDepsMetadata!,
-                file
-              )
+                const needsInterop = await optimizedDepNeedsInterop(
+                  server._optimizeDepsMetadata!,
+                  file
+                )
 
-              if (needsInterop === undefined) {
-                // Non-entry dynamic imports from dependencies will reach here as there isn't
-                // optimize info for them, but they don't need es interop. If the request isn't
-                // a dynamic import, then it is an internal Vite error
-                if (!file.match(optimizedDepDynamicRE)) {
-                  config.logger.error(
-                    colors.red(
-                      `Vite Error, ${url} optimized info should be defined`
+                if (needsInterop === undefined) {
+                  // Non-entry dynamic imports from dependencies will reach here as there isn't
+                  // optimize info for them, but they don't need es interop. If the request isn't
+                  // a dynamic import, then it is an internal Vite error
+                  if (!file.match(optimizedDepDynamicRE)) {
+                    config.logger.error(
+                      colors.red(
+                        `Vite Error, ${url} optimized info should be defined`
+                      )
                     )
-                  )
-                }
-              } else if (needsInterop) {
-                debug(`${url} needs interop`)
-                if (isDynamicImport) {
-                  // rewrite `import('package')` to expose the default directly
-                  str().overwrite(
-                    dynamicIndex,
-                    end + 1,
-                    `import('${url}').then(m => m.default && m.default.__esModule ? m.default : ({ ...m.default, default: m.default }))`
-                  )
-                } else {
-                  const exp = source.slice(expStart, expEnd)
-                  const rewritten = transformCjsImport(exp, url, rawUrl, index)
-                  if (rewritten) {
-                    str().overwrite(expStart, expEnd, rewritten)
-                  } else {
-                    // #1439 export * from '...'
-                    str().overwrite(start, end, url)
                   }
+                } else if (needsInterop) {
+                  debug(`${url} needs interop`)
+                  if (isDynamicImport) {
+                    // rewrite `import('package')` to expose the default directly
+                    str().overwrite(
+                      dynamicIndex,
+                      end + 1,
+                      `import('${url}').then(m => m.default && m.default.__esModule ? m.default : ({ ...m.default, default: m.default }))`
+                    )
+                  } else {
+                    const exp = source.slice(expStart, expEnd)
+                    const rewritten = transformCjsImport(
+                      exp,
+                      url,
+                      rawUrl,
+                      index
+                    )
+                    if (rewritten) {
+                      str().overwrite(expStart, expEnd, rewritten)
+                    } else {
+                      // #1439 export * from '...'
+                      str().overwrite(start, end, url)
+                    }
+                  }
+                  rewriteDone = true
                 }
-                rewriteDone = true
               }
-            }
-            if (!rewriteDone) {
-              str().overwrite(start, end, isDynamicImport ? `'${url}'` : url)
-            }
+              if (!rewriteDone) {
+                str().overwrite(start, end, isDynamicImport ? `'${url}'` : url)
+              }
+            })
           }
 
           // record for HMR import chain analysis
@@ -640,6 +651,14 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             config.logger.error(e.message)
           })
         })
+      }
+
+      // Await for import rewrites that requires dependencies to be pre-bundled to
+      // know if es interop is needed after starting further transformRequest calls
+      // This will let Vite process deeper into the user code and find more missing
+      // dependencies before the next page reload
+      for (const rewrite of importRewrites) {
+        await rewrite()
       }
 
       if (s) {


### PR DESCRIPTION
### Description

Related https://github.com/vitejs/vite/pull/7345

This PR moves the rewrite of URL imports to happen after the eager transformation of imported modules. These rewrites need to know if es interop is needed, so awaiting for them is blocked by pre-bundling processing. After this PR, missing dependencies can be discovered in batch avoiding full reloads. This also allows Vite to process more requests while dependencies are being pre-bundled on cold start.

#7333 worked fine with beta-0 because invalidation wasn't being handled properly, with beta-2 and a file like:
```js
import format from 'date-fns/format/index.js';
import getYear from 'date-fns/getYear/index.js';
import getMonth from 'date-fns/getMonth/index.js';
import getQuarter from 'date-fns/getQuarter/index.js';
import getDay from 'date-fns/getDay/index.js';
import isAfter from 'date-fns/isAfter/index.js';
import isBefore from 'date-fns/isBefore/index.js';
import isEqual from 'date-fns/isEqual/index.js';
```
When each import was analyzed, the new dep will be discovered but import analysis will be blocked until we know if it needs es-interop... and because a full reload was needed, each new import in this file will end up generating a full reload.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other