### PR TITLE
fix(build): update broken link in chunk size warning

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -213,7 +213,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
           colors.yellow(
             `\n(!) Some chunks are larger than ${chunkLimit} KiB after minification. Consider:\n` +
               `- Using dynamic import() to code-split the application\n` +
-              `- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/guide/en/#outputmanualchunks\n` +
+              `- Use build.rollupOptions.output.manualChunks to improve chunking: https://www.rollupjs.org/guide/en/#outputmanualchunks\n` +
               `- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.`
           )
         )


### PR DESCRIPTION
### Description

Updates the link to the Rollup docs about manual chunking. The site does not automatically redirect to `www.rollupjs.org` and without it does not resolve.

Previous link, leading nowhere: [link](https://rollupjs.org/guide/en/#outputmanualchunks)
Updated link, leading to the correct part of the docs: [link](https://www.rollupjs.org/guide/en/#outputmanualchunks)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
