### PR TITLE
chore: remove configuration object after applied

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -53,6 +53,7 @@ export function proxyMiddleware(
 
     if (opts.configure) {
       opts.configure(proxy, opts)
+      delete opts.configure
     }
     // clone before saving because http-proxy mutates the options
     proxies[context] = [proxy, { ...opts }]


### PR DESCRIPTION
### Description

The `configuration` object is added to the config object, but no longer useful to the running proxy. Drop it.
Found while investigating why events are not firing (#6129).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
