### PR TITLE
fix: handle relative path glob raw import, fix #7307

### DIFF
--- a/packages/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/packages/playground/glob-import/__tests__/glob-import.spec.ts
@@ -66,6 +66,11 @@ const rawResult = {
   }
 }
 
+// issue #7307
+const relativeRawResult = {
+  '../dynamic-import/nested/shared.js': 'export const n = 1\n'
+}
+
 test('should work', async () => {
   expect(await page.textContent('.result')).toBe(
     JSON.stringify(allResult, null, 2)
@@ -78,6 +83,13 @@ test('should work', async () => {
 test('import glob raw', async () => {
   expect(await page.textContent('.globraw')).toBe(
     JSON.stringify(rawResult, null, 2)
+  )
+})
+
+// issue #7307
+test('import relative glob raw', async () => {
+  expect(await page.textContent('.relative-glob-raw')).toBe(
+    JSON.stringify(relativeRawResult, null, 2)
   )
 })
 

--- a/packages/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/packages/playground/glob-import/__tests__/glob-import.spec.ts
@@ -66,9 +66,10 @@ const rawResult = {
   }
 }
 
-// issue #7307
 const relativeRawResult = {
-  '../dynamic-import/nested/shared.js': 'export const n = 1\n'
+  '../glob-import/dir/baz.json': {
+    msg: 'baz'
+  }
 }
 
 test('should work', async () => {
@@ -86,7 +87,6 @@ test('import glob raw', async () => {
   )
 })
 
-// issue #7307
 test('import relative glob raw', async () => {
   expect(await page.textContent('.relative-glob-raw')).toBe(
     JSON.stringify(relativeRawResult, null, 2)

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -1,6 +1,7 @@
 <pre class="result"></pre>
 <pre class="result-node_modules"></pre>
 <pre class="globraw"></pre>
+<pre class="relative-glob-raw"><!--issue #7307--></pre>
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
@@ -48,6 +49,25 @@
   })
   document.querySelector('.globraw').textContent = JSON.stringify(
     globraw,
+    null,
+    2
+  )
+</script>
+
+<script type="module">
+  // issue #7307
+  const relativeRawModules = import.meta.globEager(
+    '../dynamic-import/nested/shar*.js',
+    {
+      as: 'raw'
+    }
+  )
+  const relativeGlobRaw = {}
+  Object.keys(relativeRawModules).forEach((key) => {
+    relativeGlobRaw[key] = relativeRawModules[key]
+  })
+  document.querySelector('.relative-glob-raw').textContent = JSON.stringify(
+    relativeGlobRaw,
     null,
     2
   )

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -1,7 +1,7 @@
 <pre class="result"></pre>
 <pre class="result-node_modules"></pre>
 <pre class="globraw"></pre>
-<pre class="relative-glob-raw"><!--issue #7307--></pre>
+<pre class="relative-glob-raw"></pre>
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
@@ -55,16 +55,15 @@
 </script>
 
 <script type="module">
-  // issue #7307
   const relativeRawModules = import.meta.globEager(
-    '../dynamic-import/nested/shar*.js',
+    '../glob-import/dir/*.json',
     {
       as: 'raw'
     }
   )
   const relativeGlobRaw = {}
   Object.keys(relativeRawModules).forEach((key) => {
-    relativeGlobRaw[key] = relativeRawModules[key]
+    relativeGlobRaw[key] = JSON.parse(relativeRawModules[key])
   })
   document.querySelector('.relative-glob-raw').textContent = JSON.stringify(
     relativeGlobRaw,

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -146,7 +146,6 @@ export async function transformImportGlob(
           )
         )
       }
-      // issue #7307
       entries += ` ${JSON.stringify(file)}: ${JSON.stringify(
         await fsp.readFile(path.join(base, files[i]), 'utf-8')
       )},`

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -146,8 +146,9 @@ export async function transformImportGlob(
           )
         )
       }
+      // issue #7307
       entries += ` ${JSON.stringify(file)}: ${JSON.stringify(
-        await fsp.readFile(path.join(base, file), 'utf-8')
+        await fsp.readFile(path.join(base, files[i]), 'utf-8')
       )},`
     } else {
       const importeeUrl = isCSSRequest(importee) ? `${importee}?used` : importee


### PR DESCRIPTION
### Description

`import.meta.glob("../index.html", { as: "raw" })` fails to resolve the correct path during a `readFile` operation.

This fix will add a test for the failing use case of glob-importing with both a relative parent folder path and a raw import,
and fix this by using the unmanipulated file path as reference when reading the file. `file` is manipulated to add the `../`-parts from the glob pattern, while `files[i]` is the bare path relative to `base`.

Closes #7307

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
