### PR TITLE
fix: do not warn (about not being able to bundle non module scripts) when src is an external url

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -297,9 +297,11 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               someScriptsAreAsync ||= isAsync
               someScriptsAreDefer ||= !isAsync
             } else if (url && !isPublicFile) {
-              config.logger.warn(
-                `<script src="${url}"> in "${publicPath}" can't be bundled without type="module" attribute`
-              )
+              if (!isExcludedUrl(url)) {
+                config.logger.warn(
+                  `<script src="${url}"> in "${publicPath}" can't be bundled without type="module" attribute`
+                )
+              }
             } else if (node.children.length) {
               const scriptNode = node.children.pop()! as TextNode
               const code = scriptNode.content


### PR DESCRIPTION
### Description

Do not warn (about not being able to bundle non module scripts injected into /index.html) when src is an external url.

### Additional context

Example of script tag in /index.html causing following warning:
```
<script src="https://www.googletagmanager.com/gtag/js?id=..."> in "/index.html" can't be bundled without type="module" attribute
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
