### PR TITLE
fix: avoid mangling code from incorrect magic-string usage

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -503,7 +503,7 @@ async function transformGlob(
       resolve
     )
     s.prepend(importsString)
-    s.overwrite(expStart, endIndex, exp)
+    s.overwrite(expStart, endIndex, exp, { contentOnly: true })
   }
   return s.toString()
 }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -100,7 +100,9 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
         const file = getAssetFilename(hash, config) || this.getFileName(hash)
         chunk.viteMetadata.importedAssets.add(cleanUrl(file))
         const outputFilepath = config.base + file + postfix
-        s.overwrite(match.index, match.index + full.length, outputFilepath)
+        s.overwrite(match.index, match.index + full.length, outputFilepath, {
+          contentOnly: true
+        })
       }
 
       if (s) {

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -51,7 +51,8 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
                 index + exp.length,
                 `new URL(import.meta.globEagerDefault(${JSON.stringify(
                   pattern
-                )})[${rawUrl}], self.location)`
+                )})[${rawUrl}], self.location)`,
+                { contentOnly: true }
               )
               continue
             }
@@ -70,7 +71,8 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           s.overwrite(
             index,
             index + exp.length,
-            `new URL(${JSON.stringify(builtUrl)}, self.location)`
+            `new URL(${JSON.stringify(builtUrl)}, self.location)`,
+            { contentOnly: true }
           )
         }
         if (s) {

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -130,7 +130,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
         const start = match.index
         const end = start + match[0].length
         const replacement = '' + replacements[match[1]]
-        s.overwrite(start, end, replacement)
+        s.overwrite(start, end, replacement, { contentOnly: true })
       }
 
       if (!hasReplaced) {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -266,7 +266,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               s.overwrite(
                 src!.value!.loc.start.offset,
                 src!.value!.loc.end.offset,
-                `"${config.base + url.slice(1)}"`
+                `"${config.base + url.slice(1)}"`,
+                { contentOnly: true }
               )
             }
 
@@ -340,7 +341,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   s.overwrite(
                     p.value.loc.start.offset,
                     p.value.loc.end.offset,
-                    `"${config.base + url.slice(1)}"`
+                    `"${config.base + url.slice(1)}"`,
+                    { contentOnly: true }
                   )
                 }
               }
@@ -370,7 +372,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             s.overwrite(
               styleNode.loc.start.offset,
               styleNode.loc.end.offset,
-              `"__VITE_INLINE_CSS__${cleanUrl(id)}_${inlineModuleIndex}__"`
+              `"__VITE_INLINE_CSS__${cleanUrl(id)}_${inlineModuleIndex}__"`,
+              { contentOnly: true }
             )
           }
 
@@ -430,7 +433,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               s.overwrite(
                 value.loc.start.offset,
                 value.loc.end.offset,
-                `"${url}"`
+                `"${url}"`,
+                { contentOnly: true }
               )
             } catch (e) {
               if (e.code !== 'ENOENT') {
@@ -442,9 +446,16 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         // emit <script>import("./aaa")</script> asset
         for (const { start, end, url } of scriptUrls) {
           if (!isExcludedUrl(url)) {
-            s.overwrite(start, end, await urlToBuiltUrl(url, id, config, this))
+            s.overwrite(
+              start,
+              end,
+              await urlToBuiltUrl(url, id, config, this),
+              { contentOnly: true }
+            )
           } else if (checkPublicFile(url, config)) {
-            s.overwrite(start, end, config.base + url.slice(1))
+            s.overwrite(start, end, config.base + url.slice(1), {
+              contentOnly: true
+            })
           }
         }
 
@@ -599,7 +610,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           s.overwrite(
             match.index,
             match.index + full.length,
-            cssTransformedCode
+            cssTransformedCode,
+            { contentOnly: true }
           )
         }
         if (s) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -365,7 +365,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               resolve
             )
             str().prepend(importsString)
-            str().overwrite(expStart, endIndex, exp)
+            str().overwrite(expStart, endIndex, exp, { contentOnly: true })
             imports.forEach((url) => {
               url = url.replace(base, '/')
               importedUrls.add(url)
@@ -472,7 +472,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                     str().overwrite(
                       expStart,
                       expEnd,
-                      `import('${url}').then(m => m.default && m.default.__esModule ? m.default : ({ ...m.default, default: m.default }))`
+                      `import('${url}').then(m => m.default && m.default.__esModule ? m.default : ({ ...m.default, default: m.default }))`,
+                      { contentOnly: true }
                     )
                   } else {
                     const exp = source.slice(expStart, expEnd)
@@ -483,17 +484,24 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                       index
                     )
                     if (rewritten) {
-                      str().overwrite(expStart, expEnd, rewritten)
+                      str().overwrite(expStart, expEnd, rewritten, {
+                        contentOnly: true
+                      })
                     } else {
                       // #1439 export * from '...'
-                      str().overwrite(start, end, url)
+                      str().overwrite(start, end, url, { contentOnly: true })
                     }
                   }
                   rewriteDone = true
                 }
               }
               if (!rewriteDone) {
-                str().overwrite(start, end, isDynamicImport ? `'${url}'` : url)
+                str().overwrite(
+                  start,
+                  end,
+                  isDynamicImport ? `'${url}'` : url,
+                  { contentOnly: true }
+                )
               }
             })
           }
@@ -533,7 +541,12 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             isExplicitImportRequired(url.slice(1, -1))
           ) {
             needQueryInjectHelper = true
-            str().overwrite(start, end, `__vite__injectQuery(${url}, 'import')`)
+            str().overwrite(
+              start,
+              end,
+              `__vite__injectQuery(${url}, 'import')`,
+              { contentOnly: true }
+            )
           }
         }
       }
@@ -589,7 +602,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           ssr
         )
         normalizedAcceptedUrls.add(normalized)
-        str().overwrite(start, end, JSON.stringify(normalized))
+        str().overwrite(start, end, JSON.stringify(normalized), {
+          contentOnly: true
+        })
       }
 
       // update the module graph for HMR analysis.

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -165,7 +165,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               insertPreload
             )
           str().prepend(importsString)
-          str().overwrite(expStart, endIndex, exp)
+          str().overwrite(expStart, endIndex, exp, { contentOnly: true })
           if (!isEager) {
             needPreloadHelper = true
           }
@@ -176,7 +176,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           needPreloadHelper = true
           const original = source.slice(expStart, expEnd)
           const replacement = `${preloadMethod}(() => ${original},${isModernFlag}?"${preloadMarker}":void 0)`
-          str().overwrite(expStart, expEnd, replacement)
+          str().overwrite(expStart, expEnd, replacement, { contentOnly: true })
         }
 
         // Differentiate CSS imports that use the default export from those that
@@ -191,7 +191,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           !(bareImportRE.test(specifier) && !specifier.includes('/'))
         ) {
           const url = specifier.replace(/\?|$/, (m) => `?used${m ? '&' : ''}`)
-          str().overwrite(start, end, dynamicIndex > -1 ? `'${url}'` : url)
+          str().overwrite(start, end, dynamicIndex > -1 ? `'${url}'` : url, {
+            contentOnly: true
+          })
         }
       }
 
@@ -223,7 +225,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
             s.overwrite(
               match.index,
               match.index + isModernFlag.length,
-              isModern
+              isModern,
+              { contentOnly: true }
             )
           }
           return {
@@ -303,7 +306,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                         hasRemovedPureCssChunk = true
                       }
 
-                      s.overwrite(expStart, expEnd, 'Promise.resolve({})')
+                      s.overwrite(expStart, expEnd, 'Promise.resolve({})', {
+                        contentOnly: true
+                      })
                     }
                   }
                 }
@@ -330,7 +335,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                     // main chunk is removed
                     (hasRemovedPureCssChunk && deps.size > 0)
                     ? `[${[...deps].map((d) => JSON.stringify(d)).join(',')}]`
-                    : `[]`
+                    : `[]`,
+                  { contentOnly: true }
                 )
               }
             }

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -155,7 +155,9 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             url = injectQuery(url, WORKER_FILE_ID)
             url = injectQuery(url, `type=${workerType}`)
           }
-          s.overwrite(urlIndex, urlIndex + exp.length, JSON.stringify(url))
+          s.overwrite(urlIndex, urlIndex + exp.length, JSON.stringify(url), {
+            contentOnly: true
+          })
         }
         if (s) {
           return {

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -64,7 +64,8 @@ const processNodeUrl = (
     s.overwrite(
       node.value!.loc.start.offset,
       node.value!.loc.end.offset,
-      `"${config.base + url.slice(1)}"`
+      `"${config.base + url.slice(1)}"`,
+      { contentOnly: true }
     )
   } else if (
     url.startsWith('.') &&
@@ -82,7 +83,8 @@ const processNodeUrl = (
       `"${path.posix.join(
         path.posix.relative(originalUrl, '/'),
         url.slice(1)
-      )}"`
+      )}"`,
+      { contentOnly: true }
     )
   }
 }
@@ -123,7 +125,8 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     s.overwrite(
       node.loc.start.offset,
       node.loc.end.offset,
-      `<script type="module" src="${modulePath}"></script>`
+      `<script type="module" src="${modulePath}"></script>`,
+      { contentOnly: true }
     )
   }
 

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -158,7 +158,8 @@ export async function ssrTransform(
         s.overwrite(
           node.start,
           node.start + 14 /* 'export default'.length */,
-          `${ssrModuleExportsKey}.default =`
+          `${ssrModuleExportsKey}.default =`,
+          { contentOnly: true }
         )
       }
     }
@@ -207,14 +208,16 @@ export async function ssrTransform(
           s.prependRight(topNode.start, `const ${id.name} = ${binding};\n`)
         }
       } else {
-        s.overwrite(id.start, id.end, binding)
+        s.overwrite(id.start, id.end, binding, { contentOnly: true })
       }
     },
     onImportMeta(node) {
-      s.overwrite(node.start, node.end, ssrImportMetaKey)
+      s.overwrite(node.start, node.end, ssrImportMetaKey, { contentOnly: true })
     },
     onDynamicImport(node) {
-      s.overwrite(node.start, node.start + 6, ssrDynamicImportKey)
+      s.overwrite(node.start, node.start + 6, ssrDynamicImportKey, {
+        contentOnly: true
+      })
       if (node.type === 'ImportExpression' && node.source.type === 'Literal') {
         dynamicDeps.add(node.source.value as string)
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes https://github.com/vitejs/vite/issues/7365

The current default in `magic-string` seems like a bit of a footgun. Until / unless the default is changed (https://github.com/Rich-Harris/magic-string/pull/211), we should manually specify `contentOnly: true`

### Additional context

This is causing difficult to diagnose errors in SvelteKit with SvelteKit itself giving errors like "Method not allowed" due to incorrectly compiled `.js` files

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
