### PR TITLE
fix: fix preview.proxy does not work when server.proxy is empty

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -32,7 +32,7 @@ export function proxyMiddleware(
   httpServer: http.Server | null,
   config: ResolvedConfig
 ): Connect.NextHandleFunction {
-  const options = config.server.proxy!
+  const options = config.mode === 'production' ? config.preview.proxy : config.server.proxy!
 
   // lazy require only when proxy is used
   const proxies: Record<string, [HttpProxy.Server, ProxyOptions]> = {}


### PR DESCRIPTION
[7414](https://github.com/vitejs/vite/issues/7414)