### PR TITLE
feat: hide optimized deps found during scan phase logs

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -253,6 +253,8 @@ export function loadCachedDepOptimizationMetadata(
       // need to resolve the processing promise so requests can move on
       return cachedMetadata
     }
+  } else {
+    config.logger.info('Forced re-optimization of dependencies')
   }
 
   // Start with a fresh cache

--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -51,9 +51,7 @@ export function createOptimizedDeps(server: ViteDevServer): OptimizedDeps {
     if (newDepsToLog.length) {
       config.logger.info(
         colors.green(
-          `✨ new dependencies optimized: ${depsLogString(
-            newDepsToLog
-          )}`
+          `✨ new dependencies optimized: ${depsLogString(newDepsToLog)}`
         ),
         {
           timestamp: true

--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -51,7 +51,7 @@ export function createOptimizedDeps(server: ViteDevServer): OptimizedDeps {
     if (newDepsToLog.length) {
       config.logger.info(
         colors.green(
-          `✨ newly discovered dependencies optimized: ${depsLogString(
+          `✨ newfound dependencies optimized: ${depsLogString(
             newDepsToLog
           )}`
         ),

--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -51,7 +51,7 @@ export function createOptimizedDeps(server: ViteDevServer): OptimizedDeps {
     if (newDepsToLog.length) {
       config.logger.info(
         colors.green(
-          `✨ newfound dependencies optimized: ${depsLogString(
+          `✨ new dependencies optimized: ${depsLogString(
             newDepsToLog
           )}`
         ),


### PR DESCRIPTION
### Description

As part of https://github.com/vitejs/vite/pull/7379, we modified the logs to make them more concise now that the user will generally not notice the extra time to scan and pre-bundle during cold start.

It now looks like this:

![image](https://user-images.githubusercontent.com/583075/159735235-5ed0219c-487c-4151-abf9-f8d1fda53ede.png)

The logs can still be a bit noisy for projects like StoryBook, Cypress, Ladle, etc where there are a lot of newly discovered deps as the use explores the app:

![image](https://user-images.githubusercontent.com/583075/159735192-63f09469-021a-450d-905e-edda98f2ee8d.png)

IMO the only important log here is the last one. Since there is a page reload, we need to communicate to the user why we are doing so. But the rest of the logs feel more like implementation details to me. It isn't that useful for the user to know when a dependency has been pre-bundled if there is not a big noticeable delay in server start or during a rerun. 

This PR hides these logs, and only shows them when debugging or when using `--force`. I think that having them when using force is a good idea since the user is focused on re-bundling the dependencies so it is good feedback in that case.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other