### PR TITLE
test: increment jest timeout

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@ const config: Config.InitialOptions = {
   testMatch: process.env.VITE_TEST_BUILD
     ? ['**/playground/**/*.spec.[jt]s?(x)']
     : ['**/*.spec.[jt]s?(x)'],
-  testTimeout: process.env.CI ? 30000 : 10000,
+  testTimeout: process.env.CI ? 50000 : 20000,
   globalSetup: './scripts/jestGlobalSetup.cjs',
   globalTeardown: './scripts/jestGlobalTeardown.cjs',
   testEnvironment: './scripts/jestEnv.cjs',


### PR DESCRIPTION
### Description

Increment a jest CI timeout from 30sec to 50sec, and local from 10sec to 20sec.

I'm seeing some windows tests take ~20sec or ~30sec. I think we should check if the timeout is the issue here. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other