### PR TITLE
fix: inline style css sourcemap

### DIFF
--- a/packages/playground/css-sourcemap/__tests__/serve.spec.ts
+++ b/packages/playground/css-sourcemap/__tests__/serve.spec.ts
@@ -34,7 +34,59 @@ if (!isBuild) {
     const css = await getStyleTagContentIncluding('.inline ')
     const map = extractSourcemap(css)
     expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
-      TODO
+      Object {
+        "mappings": "AAGO;AACP,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACX,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACf,CAAC,CAAC,CAAC;",
+        "sources": Array [
+          "/root/index.html",
+        ],
+        "sourcesContent": Array [
+          "<link rel=\\"stylesheet\\" href=\\"./linked.css\\" />
+      <link rel=\\"stylesheet\\" href=\\"./linked-with-import.css\\" />
+
+      <style>
+        .inline {
+          color: red;
+        }
+      </style>
+
+      <div class=\\"wrapper\\">
+        <h1>CSS Sourcemap</h1>
+
+        <p class=\\"inline\\">&lt;inline&gt;</p>
+
+        <p class=\\"linked\\">&lt;linked&gt;: no import</p>
+        <p class=\\"linked-with-import\\">&lt;linked&gt;: with import</p>
+
+        <p class=\\"imported\\">&lt;imported&gt;: no import</p>
+        <p class=\\"imported-with-import\\">&lt;imported&gt;: with import</p>
+
+        <p class=\\"imported-sass\\">&lt;imported sass&gt;</p>
+        <p class=\\"imported-sass-module\\">&lt;imported sass&gt; with module</p>
+
+        <p class=\\"imported-less\\">&lt;imported less&gt; with string additionalData</p>
+
+        <p class=\\"imported-stylus\\">&lt;imported stylus&gt;</p>
+      </div>
+
+      <script type=\\"module\\">
+        import './imported.css'
+        import './imported-with-import.css'
+
+        import './imported.sass'
+        import sassModule from './imported.module.sass'
+
+        document
+          .querySelector('.imported-sass-module')
+          .classList.add(sassModule['imported-sass-module'])
+
+        import './imported.less'
+
+        import './imported.styl'
+      </script>
+      ",
+        ],
+        "version": 3,
+      }
     `)
   })
 

--- a/packages/playground/css-sourcemap/__tests__/serve.spec.ts
+++ b/packages/playground/css-sourcemap/__tests__/serve.spec.ts
@@ -207,6 +207,12 @@ if (!isBuild) {
       }
     `)
   })
+
+  test('should not output missing source file warning', () => {
+    serverLogs.forEach((log) => {
+      expect(log).not.toMatch(/Sourcemap for .+ points to missing source files/)
+    })
+  })
 } else {
   test('this file only includes test for serve', () => {
     expect(true).toBe(true)

--- a/packages/playground/css-sourcemap/__tests__/serve.spec.ts
+++ b/packages/playground/css-sourcemap/__tests__/serve.spec.ts
@@ -30,6 +30,14 @@ if (!isBuild) {
     return m
   }
 
+  test('inline css', async () => {
+    const css = await getStyleTagContentIncluding('.inline ')
+    const map = extractSourcemap(css)
+    expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
+      TODO
+    `)
+  })
+
   test('linked css', async () => {
     const res = await page.request.get(
       new URL('./linked.css', page.url()).href,

--- a/packages/playground/css-sourcemap/index.html
+++ b/packages/playground/css-sourcemap/index.html
@@ -1,8 +1,16 @@
 <link rel="stylesheet" href="./linked.css" />
 <link rel="stylesheet" href="./linked-with-import.css" />
 
+<style>
+  .inline {
+    color: red;
+  }
+</style>
+
 <div class="wrapper">
   <h1>CSS Sourcemap</h1>
+
+  <p class="inline">&lt;inline&gt;</p>
 
   <p class="linked">&lt;linked&gt;: no import</p>
   <p class="linked-with-import">&lt;linked&gt;: with import</p>

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -148,7 +148,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
       if (src) {
         processNodeUrl(src, s, config, htmlPath, originalUrl, moduleGraph)
-      } else if (isModule) {
+      } else if (isModule && node.children.length) {
         addInlineModule(node, 'js')
       }
     }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -109,7 +109,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       .join('')
 
     // add HTML Proxy to Map
-    addToHTMLProxyCache(config, url, inlineModuleIndex, contents)
+    addToHTMLProxyCache(config, url, inlineModuleIndex, { code: contents })
 
     // inline js module. convert to src="proxy"
     const modulePath = `${

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -38,7 +38,9 @@ function getHtmlFilename(url: string, server: ViteDevServer) {
   if (url.startsWith(FS_PREFIX)) {
     return decodeURIComponent(fsPathFromId(url))
   } else {
-    return decodeURIComponent(path.join(server.config.root, url.slice(1)))
+    return decodeURIComponent(
+      normalizePath(path.join(server.config.root, url.slice(1)))
+    )
   }
 }
 

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import MagicString from 'magic-string'
-import type { AttributeNode, ElementNode } from '@vue/compiler-dom'
+import type { AttributeNode, ElementNode, TextNode } from '@vue/compiler-dom'
 import { NodeTypes } from '@vue/compiler-dom'
 import type { Connect } from 'types/connect'
 import type { IndexHtmlTransformHook } from '../../plugins/html'
@@ -92,7 +92,7 @@ const processNodeUrl = (
 }
 const devHtmlHook: IndexHtmlTransformHook = async (
   html,
-  { path: htmlPath, server, originalUrl }
+  { path: htmlPath, filename, server, originalUrl }
 ) => {
   const { config, moduleGraph } = server!
   const base = config.base || '/'
@@ -106,12 +106,17 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
     const url = filePath.replace(normalizePath(config.root), '')
 
-    const contents = node.children
-      .map((child: any) => child.content || '')
-      .join('')
+    const contentNode = node.children[0] as TextNode
+
+    const code = contentNode.content
+    const map = new MagicString(html)
+      .snip(contentNode.loc.start.offset, contentNode.loc.end.offset)
+      .generateMap({ hires: true })
+    map.sources = [filename]
+    map.file = filename
 
     // add HTML Proxy to Map
-    addToHTMLProxyCache(config, url, inlineModuleIndex, { code: contents })
+    addToHTMLProxyCache(config, url, inlineModuleIndex, { code, map })
 
     // inline js module. convert to src="proxy"
     const modulePath = `${

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -442,7 +442,7 @@ export async function createPluginContainer(
           ? new MagicString(this.originalCode).generateMap({
               includeContent: true,
               hires: true,
-              source: this.filename
+              source: cleanUrl(this.filename)
             })
           : null
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#7432

fixes `Sourcemap for "something.html" points to missing source files`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
