### PR TITLE
perf: make fast-glob always ignore `node_modules` while allowing patterns to include `node_modules`

### DIFF
--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -262,8 +262,8 @@ function error(pos: number) {
 // work with patterns that include `node_modules/`. So that Vite can support patterns
 // like `import.meta.glob('node_modules/some-framework/**/*.page.js')`.
 function glob(pattern: string, base: string): string[] {
-  const rebase = pattern.match(/.*\/?node_modules\//)?.[0] ?? ''
-  if (rebase !== '') {
+  const rebase = pattern.match(/.*\/?node_modules\//)?.[0]
+  if (rebase) {
     pattern = pattern.slice(rebase.length)
     base = path.posix.join(base, rebase)
   }
@@ -273,7 +273,7 @@ function glob(pattern: string, base: string): string[] {
     ignore: ['**/node_modules/**']
   })
 
-  if (rebase !== '') {
+  if (rebase) {
     files = files.map((file) => path.posix.join(rebase, file))
   }
 


### PR DESCRIPTION

### Description

This is a performance improvement on top of @frandiox's PR https://github.com/vitejs/vite/pull/6056.

### Additional context

Hydrogen and vps frameworks (will) use `import.meta.glob` for crawling inside `node_modules/`, e.g. `import.meta.glob('node_modules/some-framework/**/*.page.js')`. This PR increases the performance by, potentially, several orders of magnitude.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
