### PR TITLE
feat(dev): expose APIs for client-server communication

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -126,7 +126,7 @@ Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plu
 
 ## `hot.send(event, payload)`
 
-Send custom event back to server.
+Send custom events back to Vite's dev server.
 
 If called before connected, the data will be buffered and sent once the connection is established.
 

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -123,3 +123,9 @@ The following HMR events are dispatched by Vite automatically:
 - `'vite:error'` when an error occurs (e.g. syntax error)
 
 Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plugin#handlehotupdate) for more details.
+
+## `hot.send(payload)`
+
+Send custom data back to server.
+
+If called before connected, the data will be buffered and sent once the connection is established.

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -124,8 +124,10 @@ The following HMR events are dispatched by Vite automatically:
 
 Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plugin#handlehotupdate) for more details.
 
-## `hot.send(payload)`
+## `hot.send(event, payload)`
 
-Send custom data back to server.
+Send custom event back to server.
 
 If called before connected, the data will be buffered and sent once the connection is established.
+
+See [Client-server Communication](/guide/api-plugin.html#client-server-communication) for more details.

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -124,7 +124,7 @@ The following HMR events are dispatched by Vite automatically:
 
 Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plugin#handlehotupdate) for more details.
 
-## `hot.send({ event, data })`
+## `hot.send(event, data)`
 
 Send custom events back to Vite's dev server.
 

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -124,7 +124,7 @@ The following HMR events are dispatched by Vite automatically:
 
 Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plugin#handlehotupdate) for more details.
 
-## `hot.send(event, payload)`
+## `hot.send({ event, data })`
 
 Send custom events back to Vite's dev server.
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -495,7 +495,7 @@ normalizePath('foo/bar') // 'foo/bar'
 
 ## Client-server Communication
 
-As in Vite 2.9, we provides some utilities for plugins to handle the communcation with clients easier.
+As in Vite 2.9, we provide some utilities for plugins to handle the communication with clients easier.
 
 ### Server to Client
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -495,7 +495,7 @@ normalizePath('foo/bar') // 'foo/bar'
 
 ## Client-server Communication
 
-As in Vite 2.9, we provide some utilities for plugins to handle the communication with clients easier.
+Since Vite 2.9, we provide some utilities for plugins to help handle the communication with clients.
 
 ### Server to Client
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -544,7 +544,7 @@ if (import.meta.hot) {
 }
 ```
 
-On the plugin side, we can use `server.ws.onMessage` listening to the events:
+On the plugin side, we can use `server.ws.onEvent` listening to the events:
 
 ```js
 // vite.config.js
@@ -553,7 +553,7 @@ export default defineConfig({
     {
       // ...
       configureServer(server) {
-        server.ws.onMessage('from-client', (data, client) => {
+        server.ws.onEvent('from-client', (data, client) => {
           console.log('Message from client:', data.msg) // Hey!
           // reply only to the client (if needed)
           client.send({

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -537,7 +537,10 @@ To send events from the client to the server, we can use [`hot.send`](/guide/api
 ```ts
 // client side
 if (import.meta.hot) {
-  import.meta.hot.send('from-client', { msg: 'Hey!' })
+  import.meta.hot.send({
+    event: 'from-client',
+    data: { msg: 'Hey!' }
+  })
 }
 ```
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -508,23 +508,23 @@ export default defineConfig({
     {
       // ...
       configureServer(server) {
-        server.ws.send({
-          type: 'custom',
-          event: 'greetings',
-          data: { msg: 'hello' }
-        })
+        server.ws.send('my:greetings', { msg: 'hello' })
       }
     }
   ]
 })
 ```
 
-And on the client side, we can use [`hot.on`](/guide/api-hmr.html#hot-on-event-cb) to listen to the events:
+::: tip NOTE
+We recommend **alway prefixing** your event names to avoid collisions with other plugins.
+:::
+
+On the client side, use [`hot.on`](/guide/api-hmr.html#hot-on-event-cb) to listen to the events:
 
 ```ts
 // client side
 if (import.meta.hot) {
-  import.meta.hot.on('greetings', (data) => {
+  import.meta.hot.on('my:greetings', (data) => {
     console.log(data.msg) // hello
   })
 }
@@ -537,14 +537,11 @@ To send events from the client to the server, we can use [`hot.send`](/guide/api
 ```ts
 // client side
 if (import.meta.hot) {
-  import.meta.hot.send({
-    event: 'from-client',
-    data: { msg: 'Hey!' }
-  })
+  import.meta.hot.send('my:from-client', { msg: 'Hey!' })
 }
 ```
 
-On the plugin side, we can use `server.ws.onEvent` listening to the events:
+Then use `server.ws.on` and listen to the events on the server side:
 
 ```js
 // vite.config.js
@@ -553,14 +550,10 @@ export default defineConfig({
     {
       // ...
       configureServer(server) {
-        server.ws.onEvent('from-client', (data, client) => {
+        server.ws.on('my:from-client', (data, client) => {
           console.log('Message from client:', data.msg) // Hey!
           // reply only to the client (if needed)
-          client.send({
-            type: 'custom',
-            event: 'ack',
-            data: { msg: 'Hi! I got your message!' }
-          })
+          client.send('my:ack', { msg: 'Hi! I got your message!' })
         })
       }
     }

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -480,7 +480,7 @@ export default defineConfig({
 
 Check out [Vite Rollup Plugins](https://vite-rollup-plugins.patak.dev) for a list of compatible official Rollup plugins with usage instructions.
 
-## Path normalization
+## Path Normalization
 
 Vite normalizes paths while resolving ids to use POSIX separators ( / ) while preserving the volume in Windows. On the other hand, Rollup keeps resolved paths untouched by default, so resolved ids have win32 separators ( \\ ) in Windows. However, Rollup plugins use a [`normalizePath` utility function](https://github.com/rollup/plugins/tree/master/packages/pluginutils#normalizepath) from `@rollup/pluginutils` internally, which converts separators to POSIX before performing comparisons. This means that when these plugins are used in Vite, the `include` and `exclude` config pattern and other similar paths against resolved ids comparisons work correctly.
 
@@ -491,4 +491,76 @@ import { normalizePath } from 'vite'
 
 normalizePath('foo\\bar') // 'foo/bar'
 normalizePath('foo/bar') // 'foo/bar'
+```
+
+## Client-server Communication
+
+As in Vite 2.9, we provides some utilities for plugins to handle the communcation with clients easier.
+
+### Server to Client
+
+On the plugin side, we could use `server.ws.send` to boardcast events to all the clients:
+
+```js
+// vite.config.js
+export default defineConfig({
+  plugins: [
+    {
+      // ...
+      configureServer(server) {
+        server.ws.send({
+          type: 'custom',
+          event: 'greetings',
+          data: { msg: 'hello' }
+        })
+      }
+    }
+  ]
+})
+```
+
+And on the client side, we can use [`hot.on`](/guide/api-hmr.html#hot-on-event-cb) to listen to the events:
+
+```ts
+// client side
+if (import.meta.hot) {
+  import.meta.hot.on('greetings', (data) => {
+    console.log(data.msg) // hello
+  })
+}
+```
+
+### Client to Server
+
+To send events from the client to the server, we can use [`hot.send`](/guide/api-hmr.html#hot-send-event-payload):
+
+```ts
+// client side
+if (import.meta.hot) {
+  import.meta.hot.send('from-client', { msg: 'Hey!' })
+}
+```
+
+On the plugin side, we can use `server.ws.onMessage` listening to the events:
+
+```js
+// vite.config.js
+export default defineConfig({
+  plugins: [
+    {
+      // ...
+      configureServer(server) {
+        server.ws.onMessage('from-client', (data, client) => {
+          console.log('Message from client:', data.msg) // Hey!
+          // reply only to the client (if needed)
+          client.send({
+            type: 'custom',
+            event: 'ack',
+            data: { msg: 'Hi! I got your message!' }
+          })
+        })
+      }
+    }
+  ]
+})
 ```

--- a/packages/playground/hmr/__tests__/hmr.spec.ts
+++ b/packages/playground/hmr/__tests__/hmr.spec.ts
@@ -123,11 +123,16 @@ if (!isBuild) {
     await untilUpdated(() => el.textContent(), 'edited')
   })
 
+  test('plugin client-server communication', async () => {
+    const el = await page.$('.custom-communication')
+    await untilUpdated(() => el.textContent(), '3')
+  })
+
   test('full-reload encodeURI path', async () => {
     await page.goto(
       viteTestUrl + '/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html'
     )
-    let el = await page.$('#app')
+    const el = await page.$('#app')
     expect(await el.textContent()).toBe('title')
     await editFile(
       'unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',

--- a/packages/playground/hmr/hmr.js
+++ b/packages/playground/hmr/hmr.js
@@ -57,6 +57,12 @@ if (import.meta.hot) {
   import.meta.hot.on('foo', ({ msg }) => {
     text('.custom', msg)
   })
+
+  // send custom event to server to calculate 1 + 2
+  import.meta.hot.send('remote-add', { a: 1, b: 2 })
+  import.meta.hot.on('remote-add-result', ({ result }) => {
+    text('.custom-communication', result)
+  })
 }
 
 function text(el, text) {

--- a/packages/playground/hmr/hmr.js
+++ b/packages/playground/hmr/hmr.js
@@ -59,7 +59,7 @@ if (import.meta.hot) {
   })
 
   // send custom event to server to calculate 1 + 2
-  import.meta.hot.send({ event: 'remote-add', data: { a: 1, b: 2 } })
+  import.meta.hot.send('remote-add', { a: 1, b: 2 })
   import.meta.hot.on('remote-add-result', ({ result }) => {
     text('.custom-communication', result)
   })

--- a/packages/playground/hmr/hmr.js
+++ b/packages/playground/hmr/hmr.js
@@ -59,7 +59,7 @@ if (import.meta.hot) {
   })
 
   // send custom event to server to calculate 1 + 2
-  import.meta.hot.send('remote-add', { a: 1, b: 2 })
+  import.meta.hot.send({ event: 'remote-add', data: { a: 1, b: 2 } })
   import.meta.hot.on('remote-add-result', ({ result }) => {
     text('.custom-communication', result)
   })

--- a/packages/playground/hmr/index.html
+++ b/packages/playground/hmr/index.html
@@ -5,5 +5,6 @@
 <div class="dep"></div>
 <div class="nested"></div>
 <div class="custom"></div>
+<div class="custom-communication"></div>
 <div class="css-prev"></div>
 <div class="css-post"></div>

--- a/packages/playground/hmr/vite.config.js
+++ b/packages/playground/hmr/vite.config.js
@@ -9,7 +9,7 @@ module.exports = {
         if (file.endsWith('customFile.js')) {
           const content = await read()
           const msg = content.match(/export const msg = '(\w+)'/)[1]
-          server.ws.send('foo', { data: msg })
+          server.ws.send('foo', { msg })
         }
       },
       configureServer(server) {

--- a/packages/playground/hmr/vite.config.js
+++ b/packages/playground/hmr/vite.config.js
@@ -9,22 +9,12 @@ module.exports = {
         if (file.endsWith('customFile.js')) {
           const content = await read()
           const msg = content.match(/export const msg = '(\w+)'/)[1]
-          server.ws.send({
-            type: 'custom',
-            event: 'foo',
-            data: {
-              msg
-            }
-          })
+          server.ws.send('foo', { data: msg })
         }
       },
       configureServer(server) {
-        server.ws.onEvent('remote-add', ({ a, b }, client) => {
-          client.send({
-            type: 'custom',
-            event: 'remote-add-result',
-            data: { result: a + b }
-          })
+        server.ws.on('remote-add', ({ a, b }, client) => {
+          client.send('remote-add-result', { result: a + b })
         })
       }
     }

--- a/packages/playground/hmr/vite.config.js
+++ b/packages/playground/hmr/vite.config.js
@@ -19,7 +19,7 @@ module.exports = {
         }
       },
       configureServer(server) {
-        server.ws.onMessage('remote-add', ({ a, b }, client) => {
+        server.ws.onEvent('remote-add', ({ a, b }, client) => {
           client.send({
             type: 'custom',
             event: 'remote-add-result',

--- a/packages/playground/hmr/vite.config.js
+++ b/packages/playground/hmr/vite.config.js
@@ -17,6 +17,15 @@ module.exports = {
             }
           })
         }
+      },
+      configureServer(server) {
+        server.ws.onMessage('remote-add', ({ a, b }, client) => {
+          client.send({
+            type: 'custom',
+            event: 'remote-add-result',
+            data: { result: a + b }
+          })
+        })
       }
     }
   ]

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -63,7 +63,7 @@ async function handleMessage(payload: HMRPayload) {
       sendMessageBuffer()
       // proxy(nginx, docker) hmr ws maybe caused timeout,
       // so send ping package let ws keep alive.
-      setInterval(() => socket.send('ping'), __HMR_TIMEOUT__)
+      setInterval(() => socket.send('{"type":"ping"}'), __HMR_TIMEOUT__)
       break
     case 'update':
       notifyListeners('vite:beforeUpdate', payload)
@@ -489,8 +489,8 @@ export const createHotContext = (ownerPath: string) => {
       addToMap(newListeners)
     },
 
-    send: (payload: string) => {
-      messageBuffer.push(payload)
+    send: (event: string, data?: unknown) => {
+      messageBuffer.push(JSON.stringify({ type: 'custom', event, data }))
       sendMessageBuffer()
     }
   }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -6,7 +6,7 @@ import type {
   Update,
   UpdatePayload
 } from 'types/hmrPayload'
-import type { CustomEventName, CustomEventPayload } from 'types/customEvent'
+import type { CustomEventName } from 'types/customEvent'
 import { ErrorOverlay, overlayId } from './overlay'
 // eslint-disable-next-line node/no-missing-import
 import '@vite/env'
@@ -489,8 +489,8 @@ export const createHotContext = (ownerPath: string) => {
       addToMap(newListeners)
     },
 
-    send: (payload: CustomEventPayload) => {
-      messageBuffer.push(JSON.stringify({ type: 'custom', ...payload }))
+    send: (event: string, data?: any) => {
+      messageBuffer.push(JSON.stringify({ type: 'custom', event, data }))
       sendMessageBuffer()
     }
   }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -6,7 +6,7 @@ import type {
   Update,
   UpdatePayload
 } from 'types/hmrPayload'
-import type { CustomEventName } from 'types/customEvent'
+import type { CustomEventName, CustomEventPayload } from 'types/customEvent'
 import { ErrorOverlay, overlayId } from './overlay'
 // eslint-disable-next-line node/no-missing-import
 import '@vite/env'
@@ -489,8 +489,8 @@ export const createHotContext = (ownerPath: string) => {
       addToMap(newListeners)
     },
 
-    send: (event: string, data?: unknown) => {
-      messageBuffer.push(JSON.stringify({ type: 'custom', event, data }))
+    send: (payload: CustomEventPayload) => {
+      messageBuffer.push(JSON.stringify({ type: 'custom', ...payload }))
       sendMessageBuffer()
     }
   }

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -73,7 +73,11 @@ export type { TransformOptions as EsbuildTransformOptions } from 'esbuild'
 export type { ESBuildOptions, ESBuildTransformResult } from './plugins/esbuild'
 export type { Manifest, ManifestChunk } from './plugins/manifest'
 export type { ResolveOptions, InternalResolveOptions } from './plugins/resolve'
-export type { WebSocketServer } from './server/ws'
+export type {
+  WebSocketServer,
+  WebSocketClient,
+  WebSocketCustomListener
+} from './server/ws'
 export type { PluginContainer } from './server/pluginContainer'
 export type { ModuleGraph, ModuleNode, ResolvedUrl } from './server/moduleGraph'
 export type { SendOptions } from './server/send'

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -32,7 +32,7 @@ export interface WebSocketServer {
   /**
    * Handle custom event emitted by `import.meta.hot.send`
    */
-  onMessage<T>(event: string, listener: WebSocketCustomListener<T>): () => void
+  onEvent<T>(event: string, listener: WebSocketCustomListener<T>): () => void
   /**
    * Listen to raw events from the WebSocket server.
    * @advanced
@@ -217,7 +217,7 @@ export function createWebSocketServer(
       })
     },
 
-    onMessage<T>(event: string, listener: WebSocketCustomListener<T>) {
+    onEvent<T>(event: string, listener: WebSocketCustomListener<T>) {
       if (!customListeners.has(event)) customListeners.set(event, new Set())
       customListeners.get(event)!.add(listener)
 

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -3,9 +3,3 @@ export type CustomEventName<T extends string> = (T extends `vite:${T}`
   ? never
   : T) &
   (`vite:${T}` extends T ? never : T)
-
-export interface CustomEventPayload {
-  type?: 'custom'
-  event: string
-  data?: any
-}

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -3,3 +3,9 @@ export type CustomEventName<T extends string> = (T extends `vite:${T}`
   ? never
   : T) &
   (`vite:${T}` extends T ? never : T)
+
+export interface CustomEventPayload {
+  type?: 'custom'
+  event: string
+  data?: any
+}

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -59,6 +59,8 @@ interface ImportMeta {
         cb: (data: any) => void
       ): void
     }
+
+    send(payload: string): void
   }
 
   readonly env: ImportMetaEnv

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -60,7 +60,7 @@ interface ImportMeta {
       ): void
     }
 
-    send(event: string, data?: unknown): void
+    send(payload: import('./customEvent').CustomEventPayload): void
   }
 
   readonly env: ImportMetaEnv

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -60,7 +60,7 @@ interface ImportMeta {
       ): void
     }
 
-    send(payload: string): void
+    send(event: string, data?: unknown): void
   }
 
   readonly env: ImportMetaEnv

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -60,7 +60,7 @@ interface ImportMeta {
       ): void
     }
 
-    send(payload: import('./customEvent').CustomEventPayload): void
+    send(event: string, data?: any): void
   }
 
   readonly env: ImportMetaEnv


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vite as a server really opens up a lot of DX improvements we could make. However, currently, it only allows clients to receive updates from the server but not another way around. To let the client communicate with the server, plugins often need to register a custom middleware to handle the messages as HTTP requests. Which requires quite some effort and could break with various `base`, `port` configs with a different environment.  

For examples:

- `vite-plugin-inspect` needs to send invalidation events from the client:
  - https://github.com/antfu/vite-plugin-inspect/blob/5dd8f0188a74c107fa5694c0dddae5c86152d82e/src/node/index.ts#L156-L233
  - https://github.com/antfu/vite-plugin-inspect/blob/c19bec8d133d2dc88a055d1f9a046a984f09135b/src/client/pages/index/module.vue#L34
- Slidev need to sync client state with server
  - https://github.com/antfu/vite-plugin-vue-server-ref
- UnoCSS need to ask for an update when all modules get loaded (injected the code as this PR)
  - https://github.com/antfu/unocss/blob/c0ac754979b584c1d3e5d5e2a5c72ec0d7728631/packages/vite/src/modes/global/dev.ts#L143-L161

Adding this `import.meta.hot.send()` API allows plugins and libraries to communicate with the server much easier.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
