### PR TITLE
fix(resolve): skip `module` field when the importer is a `require` call

### DIFF
--- a/packages/playground/resolve/__tests__/resolve.spec.ts
+++ b/packages/playground/resolve/__tests__/resolve.spec.ts
@@ -58,6 +58,12 @@ test('dont add extension to directory name (./dir-with-ext.js/index.js)', async 
   expect(await page.textContent('.dir-with-ext')).toMatch('[success]')
 })
 
+test('do not resolve to the `module` field if the importer is a `require` call', async () => {
+  expect(await page.textContent('.require-pkg-with-module-field')).toMatch(
+    '[success]'
+  )
+})
+
 test('a ts module can import another ts module using its corresponding js file name', async () => {
   expect(await page.textContent('.ts-extension')).toMatch('[success]')
 })

--- a/packages/playground/resolve/index.html
+++ b/packages/playground/resolve/index.html
@@ -58,6 +58,9 @@
 <h2>Browser Field</h2>
 <p class="browser">fail</p>
 
+<h2>Don't resolve to the `module` field if the importer is a `require` call</h2>
+<p class="require-pkg-with-module-field">fail</p>
+
 <h2>CSS Entry</h2>
 <p class="css"></p>
 
@@ -180,6 +183,9 @@
   ) {
     text('.browser', main)
   }
+
+  import { msg as requireButWithModuleFieldMsg } from 'require-pkg-with-module-field'
+  text('.require-pkg-with-module-field', requireButWithModuleFieldMsg)
 
   import { msg as customExtMsg } from './custom-ext'
   text('.custom-ext', customExtMsg)

--- a/packages/playground/resolve/package.json
+++ b/packages/playground/resolve/package.json
@@ -12,6 +12,7 @@
     "@babel/runtime": "^7.16.0",
     "es5-ext": "0.10.53",
     "normalize.css": "^8.0.1",
+    "require-pkg-with-module-field": "link:./require-pkg-with-module-field",
     "resolve-browser-field": "link:./browser-field",
     "resolve-custom-condition": "link:./custom-condition",
     "resolve-custom-main-field": "link:./custom-main-field",

--- a/packages/playground/resolve/require-pkg-with-module-field/dep.cjs
+++ b/packages/playground/resolve/require-pkg-with-module-field/dep.cjs
@@ -1,0 +1,5 @@
+const BigNumber = require('bignumber.js')
+
+const x = new BigNumber('1111222233334444555566')
+
+module.exports = x.toString()

--- a/packages/playground/resolve/require-pkg-with-module-field/index.cjs
+++ b/packages/playground/resolve/require-pkg-with-module-field/index.cjs
@@ -1,0 +1,8 @@
+const dep = require('./dep.cjs')
+
+const msg =
+  dep === '1.111222233334444555566e+21'
+    ? '[success] require-pkg-with-module-field'
+    : '[failed] require-pkg-with-module-field'
+
+exports.msg = msg

--- a/packages/playground/resolve/require-pkg-with-module-field/package.json
+++ b/packages/playground/resolve/require-pkg-with-module-field/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "require-pkg-with-module-field",
+  "private": true,
+  "version": "1.0.0",
+  "main": "./index.cjs",
+  "dependencies": {
+    "bignumber.js": "9.0.2"
+  }
+}

--- a/packages/playground/resolve/vite.config.js
+++ b/packages/playground/resolve/vite.config.js
@@ -40,5 +40,8 @@ module.exports = {
         }
       }
     }
-  ]
+  ],
+  optimizeDeps: {
+    include: ['require-pkg-with-module-field']
+  }
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -738,7 +738,11 @@ export function resolvePackageEntry(
           : isObject(data.browser) && data.browser['.']
       if (browserEntry) {
         // check if the package also has a "module" field.
-        if (typeof data.module === 'string' && data.module !== browserEntry) {
+        if (
+          !options.isRequire &&
+          typeof data.module === 'string' &&
+          data.module !== browserEntry
+        ) {
           // if both are present, we may have a problem: some package points both
           // to ESM, with "module" targeting Node.js, while some packages points
           // "module" to browser ESM and "browser" to UMD.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,7 @@ importers:
       '@babel/runtime': ^7.16.0
       es5-ext: 0.10.53
       normalize.css: ^8.0.1
+      require-pkg-with-module-field: link:./require-pkg-with-module-field
       resolve-browser-field: link:./browser-field
       resolve-custom-condition: link:./custom-condition
       resolve-custom-main-field: link:./custom-main-field
@@ -466,6 +467,7 @@ importers:
       '@babel/runtime': 7.16.5
       es5-ext: 0.10.53
       normalize.css: 8.0.1
+      require-pkg-with-module-field: link:require-pkg-with-module-field
       resolve-browser-field: link:browser-field
       resolve-custom-condition: link:custom-condition
       resolve-custom-main-field: link:custom-main-field
@@ -496,6 +498,12 @@ importers:
 
   packages/playground/resolve/inline-package:
     specifiers: {}
+
+  packages/playground/resolve/require-pkg-with-module-field:
+    specifiers:
+      bignumber.js: 9.0.2
+    dependencies:
+      bignumber.js: 9.0.2
 
   packages/playground/ssr-deps:
     specifiers:
@@ -3363,6 +3371,10 @@ packages:
       node-addon-api: 3.2.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /bignumber.js/9.0.2:
+    resolution: {integrity: sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==}
     dev: false
 
   /binary-extensions/2.2.0:


### PR DESCRIPTION
### Description

Fixes #7053

### Additional context

I used a `require-pkg-with-module-field` package in the test, instead of
`json-bigint`, because I need to pin the `bignumber.js` version to 9.0.2
in case it changed its `package.json` in future releases.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
