### PR TITLE
fix: virtual html sourcemap warning

### DIFF
--- a/packages/playground/css-sourcemap/__tests__/serve.spec.ts
+++ b/packages/playground/css-sourcemap/__tests__/serve.spec.ts
@@ -83,6 +83,8 @@ if (!isBuild) {
 
         import './imported.styl'
       </script>
+
+      <iframe src=\\"virtual.html\\"></iframe>
       ",
         ],
         "version": 3,

--- a/packages/playground/css-sourcemap/index.html
+++ b/packages/playground/css-sourcemap/index.html
@@ -41,3 +41,5 @@
 
   import './imported.styl'
 </script>
+
+<iframe src="virtual.html"></iframe>

--- a/packages/playground/css-sourcemap/vite.config.js
+++ b/packages/playground/css-sourcemap/vite.config.js
@@ -36,5 +36,25 @@ module.exports = {
   },
   build: {
     sourcemap: true
-  }
+  },
+  plugins: [
+    {
+      name: 'virtual-html',
+      configureServer(server) {
+        server.middlewares.use(async (req, res, next) => {
+          if (req.url === '/virtual.html') {
+            const t = await server.transformIndexHtml(
+              '/virtual.html',
+              '<style> .foo { color: red; } </style> <p class="foo">virtual html</p>'
+            )
+            res.setHeader('Content-Type', 'text/html')
+            res.statusCode = 200
+            res.end(t)
+            return
+          }
+          next()
+        })
+      }
+    }
+  ]
 }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -705,6 +705,8 @@ export function resolveHtmlTransforms(
   return [preHooks, postHooks]
 }
 
+export const maybeVirtualHtmlSet = new Set<string>()
+
 export async function applyHtmlTransforms(
   html: string,
   hooks: IndexHtmlTransformHook[],
@@ -714,6 +716,8 @@ export async function applyHtmlTransforms(
   const headPrependTags: HtmlTagDescriptor[] = []
   const bodyTags: HtmlTagDescriptor[] = []
   const bodyPrependTags: HtmlTagDescriptor[] = []
+
+  maybeVirtualHtmlSet.add(ctx.filename)
 
   for (const hook of hooks) {
     const res = await hook(html, ctx)

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -1,8 +1,9 @@
 import path from 'path'
 import { promises as fs } from 'fs'
 import type { Logger } from '../logger'
-import { createDebugger } from '../utils'
+import { createDebugger, normalizePath } from '../utils'
 import type { SourceMap } from 'rollup'
+import { maybeVirtualHtmlSet } from '../plugins/html'
 
 const isDebug = !!process.env.DEBUG
 const debug = createDebugger('vite:sourcemap', {
@@ -42,6 +43,7 @@ export async function injectSourcesContent(
           sourcePath = path.resolve(sourceRoot, sourcePath)
         }
         return fs.readFile(sourcePath, 'utf-8').catch(() => {
+          if (maybeVirtualHtmlSet.has(normalizePath(sourcePath))) return null
           missingSources.push(sourcePath)
           return null
         })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#7432

fixes `Sourcemap for "something.html" points to missing source files.` with virtual html files.

### Additional context

I am not sure what is the best way to fix this.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
