### PR TITLE
fix: sourcemap missing source files warning with cached vue

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -615,13 +615,16 @@ export function combineSourcemaps(
 
   // hack for parse broken with normalized absolute paths on windows (C:/path/to/something).
   // escape them to linux like paths
-  sourcemapList.forEach((sourcemap) => {
-    sourcemap.sources = sourcemap.sources.map((source) =>
+  // also avoid mutation here to prevent breaking plugin's using cache to generate sourcemaps like vue (see #7442)
+  sourcemapList = sourcemapList.map((sourcemap) => {
+    const newSourcemaps = { ...sourcemap }
+    newSourcemaps.sources = sourcemap.sources.map((source) =>
       source ? escapeToLinuxLikePath(source) : null
     )
     if (sourcemap.sourceRoot) {
-      sourcemap.sourceRoot = escapeToLinuxLikePath(sourcemap.sourceRoot)
+      newSourcemaps.sourceRoot = escapeToLinuxLikePath(sourcemap.sourceRoot)
     }
+    return newSourcemaps
   })
   const escapedFilename = escapeToLinuxLikePath(filename)
 


### PR DESCRIPTION
### Description

#7432

fixes `Sourcemap for "something.vue" points to missing source files` which will happen with vue (and potentially with others)

### Additional context

`vue/compiler-sfc` caches the parse result.
https://github.com/vuejs/core/blob/1070f127a78bfe7da6fe550cc272ef11a1f434a0/packages/compiler-sfc/src/parse.ts#L107-L110
Here  the parse result is pass directly without cloning.
https://github.com/vitejs/vite/blob/47668b541989c4abd48a4b232654b4e33c795714/packages/plugin-vue/src/index.ts#L177-L194
And then `combineSourcemaps` will be called somewhere and it will mutate the parse result.
So when calling parse second time, the parse result is mutated by `combineSourcemaps` and will not match the result on first time.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
