### PR TITLE
fix: optimizeDeps.entries default ignore paths

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -965,9 +965,9 @@ export default defineConfig({
 
 - **Type:** `string | string[]`
 
-  By default, Vite will crawl your `index.html` to detect dependencies that need to be pre-bundled. If `build.rollupOptions.input` is specified, Vite will crawl those entry points instead.
+  By default, Vite will crawl all your `.html` files to detect dependencies that need to be pre-bundled (ignoring `node_modules`, `build.outDir`, `__tests__` and `coverage`). If `build.rollupOptions.input` is specified, Vite will crawl those entry points instead.
 
-  If neither of these fit your needs, you can specify custom entries using this option - the value should be a [fast-glob pattern](https://github.com/mrmlnc/fast-glob#basic-syntax) or array of patterns that are relative from Vite project root. This will overwrite default entries inference.
+  If neither of these fit your needs, you can specify custom entries using this option - the value should be a [fast-glob pattern](https://github.com/mrmlnc/fast-glob#basic-syntax) or array of patterns that are relative from Vite project root. This will overwrite default entries inference. Only `node_modules` and `build.outDir` folders will be ignored by default when `optimizeDeps.entries` is explicitily defined. If other folders needs to be ignored, you can use an ignore pattern as part of the entries list, marked with an initial `!`.
 
 ### optimizeDeps.exclude
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -142,7 +142,10 @@ function globEntries(pattern: string | string[], config: ResolvedConfig) {
     ignore: [
       '**/node_modules/**',
       `**/${config.build.outDir}/**`,
-      `**/__tests__/**`
+      // if there aren't explicit entries, also ignore other common folders
+      ...(config.optimizeDeps.entries
+        ? []
+        : [`**/__tests__/**`, `**/coverage/**`])
     ],
     absolute: true
   })


### PR DESCRIPTION
### Description

Fix #5131
Fix #2599

- Remove `__tests__` from the ignore list if `optimizeDeps.entries` is specified
- Add `coverage` to the ignore list if `optimizeDeps.entries` is not explicit
- Document that you can use ! to ignore certain folders or patterns: [mrmlnc/fast-glob#how-to-exclude-directory-from-reading](https://github.com/mrmlnc/fast-glob#how-to-exclude-directory-from-reading)

Ping @tajo, @IanVS, @Akryum @edikdeisling, @JessicaSachs
 
Should we add other common folders? #2599 mentions `cypress-coverage` for example.

### Additional context

An interesting issue here is that adding a lot of entries to be scanned may have a big impact on cold start, even now that the scanning is non-blocking, we still need to finish it before being able to respond to dependencies requests.
@tajo tried it out in Ladle and got:
- cold start takes 30s when all stories are in entries and all deps prebundled
- 5s without entries

@JessicaSachs so for Cypress, you may need to choose between increasing cold start or being able to show something to the user and perform some reloads when finding missing deps.

One option for the future, we could add a new `optimizeDeps.lazyEntries`. The entries marked as lazy will be scanned but not pre-bundled and they will be added once the first missing dependency is found. So at least we only suffer from one full-reload on cold start, keeping the first load fast enough. For cypress, this may not be a good idea since every test may need to run, but for Storybook, Ladle, Historie this may be a good compromise.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other