### PR TITLE
test: instructions when encountering symlink error on Windows

### DIFF
--- a/scripts/jestGlobalSetup.cjs
+++ b/scripts/jestGlobalSetup.cjs
@@ -21,11 +21,21 @@ module.exports = async () => {
 
   const tempDir = path.resolve(__dirname, '../packages/temp')
   await fs.remove(tempDir)
-  await fs.copy(path.resolve(__dirname, '../packages/playground'), tempDir, {
-    dereference: false,
-    filter(file) {
-      file = file.replace(/\\/g, '/')
-      return !file.includes('__tests__') && !file.match(/dist(\/|$)/)
-    }
-  })
+  await fs
+    .copy(path.resolve(__dirname, '../packages/playground'), tempDir, {
+      dereference: false,
+      filter(file) {
+        file = file.replace(/\\/g, '/')
+        return !file.includes('__tests__') && !file.match(/dist(\/|$)/)
+      }
+    })
+    .catch(async (error) => {
+      if (error.code === 'EPERM' && error.syscall === 'symlink') {
+        throw new Error(
+          'Could not create symlinks. On Windows, consider activating Developer Mode to allow non-admin users to create symlinks by following the instructions at https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development.'
+        )
+      } else {
+        throw error
+      }
+    })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Catches the error when setting up tests on Windows as a non-admin without admin privileges (#7390) and outputs instructions on how to fix it.

The error now looks like this:

    $ pnpm run test
    
    > vite-monorepo@ test C:\Users\Johannes\Code\vite
    > run-s test-serve test-build
    
    
    > vite-monorepo@ test-serve C:\Users\Johannes\Code\vite
    > jest
    
    Error: Jest: Got error running globalSetup - C:\Users\Johannes\Code\vite\scripts\jestGlobalSetup.cjs, reason: Could not create symlinks. On Windows, consider activating Developer Mode to allow non-admin users to create symlinks by following the instructions at https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development.
        at C:\Users\Johannes\Code\vite\scripts\jestGlobalSetup.cjs:32:13      
        at async module.exports (C:\Users\Johannes\Code\vite\scripts\jestGlobalSetup.cjs:24:3)
        at async C:\Users\Johannes\Code\vite\node_modules\.pnpm\@jest+core@27.5.1_ts-node@10.4.0\node_modules\@jest\core\build\runGlobalHook.js:125:13  
        at async waitForPromiseWithCleanup (C:\Users\Johannes\Code\vite\node_modules\.pnpm\@jest+transform@27.5.1\node_modules\@jest\transform\build\ScriptTransformer.js:209:5)
        at async runGlobalHook (C:\Users\Johannes\Code\vite\node_modules\.pnpm\@jest+core@27.5.1_ts-node@10.4.0\node_modules\@jest\core\build\runGlobalHook.js:116:9)
        at async runJest (C:\Users\Johannes\Code\vite\node_modules\.pnpm\@jest+core@27.5.1_ts-node@10.4.0\node_modules\@jest\core\build\runJest.js:369:5)
        at async _run10000 (C:\Users\Johannes\Code\vite\node_modules\.pnpm\@jest+core@27.5.1_ts-node@10.4.0\node_modules\@jest\core\build\cli\index.js:320:7)
        at async runCLI (C:\Users\Johannes\Code\vite\node_modules\.pnpm\@jest+core@27.5.1_ts-node@10.4.0\node_modules\@jest\core\build\cli\index.js:173:3)
        at async Object.run (C:\Users\Johannes\Code\vite\node_modules\.pnpm\jest-cli@27.5.1_ts-node@10.4.0\node_modules\jest-cli\build\cli\index.js:155:37)
    ELIFECYCLE  Command failed with exit code 1.
    ERROR: "test-serve" exited with 1.
    ELIFECYCLE  Test failed. See above for more details.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
1. Is the error description appropriate?
2. Is there a way to pass on the underlying error? Or is it preferable to just show the high-level error as is now?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
