### PR TITLE
feat: add `ignore` option to `import.meta.glob`

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -319,6 +319,7 @@ Note that:
 - This is a Vite-only feature and is not a web or ES standard.
 - The glob patterns are treated like import specifiers: they must be either relative (start with `./`) or absolute (start with `/`, resolved relative to project root) or an alias path (see [`resolve.alias` option](/config/#resolve-alias)).
 - The glob matching is done via `fast-glob` - check out its documentation for [supported glob patterns](https://github.com/mrmlnc/fast-glob#pattern-syntax).
+- By default Vite sets the `fast-glob` option `ignore` to `['**/node_modules/**']`, which you can override, e.g. `import.meta.glob('node_modules/library/**/*.js', { ignore: ['node_modules/library/**/node_modules/**'] })`.
 - You should also be aware that glob imports do not accept variables, you need to directly pass the string pattern.
 - The glob patterns cannot contain the same quote string (i.e. `'`, `"`, `` ` ``) as outer quotes, e.g. `'/Tom\'s files/**'`, use `"/Tom's files/**"` instead.
 

--- a/packages/playground/glob-import/index.html
+++ b/packages/playground/glob-import/index.html
@@ -34,7 +34,7 @@
   )
   useImports(modules, '.result')
 
-  const nodeModules = import.meta.glob('/dir/node_modules/**')
+  const nodeModules = import.meta.glob('/dir/node_modules/**', { ignore: [] })
   useImports(nodeModules, '.result-node_modules')
 </script>
 

--- a/packages/vite/src/node/importGlob.ts
+++ b/packages/vite/src/node/importGlob.ts
@@ -34,6 +34,7 @@ interface GlobOptions {
   assert?: {
     type: string
   }
+  ignore?: string[]
 }
 
 function formatGlobRelativePattern(base: string, pattern: string): GlobParams {
@@ -114,8 +115,7 @@ export async function transformImportGlob(
 
   const files = glob.sync(pattern, {
     cwd: base,
-    // Ignore node_modules by default unless explicitly indicated in the pattern
-    ignore: /(^|\/)node_modules\//.test(pattern) ? [] : ['**/node_modules/**']
+    ignore: options?.ignore ?? ['**/node_modules/**']
   })
   const imports: string[] = []
   let importsString = ``


### PR DESCRIPTION
### Description

Allows the user to define the `ignore` option of `fast-glob`:

```js
import.meta.glob('node_modules/framework/**/*.page.js', { 
  ignore: 'node_modules/framework/**/node_modules/**' 
})
```

I removed @frandiox's changes:

```diff
-    // Ignore node_modules by default unless explicitly indicated in the pattern
-    ignore: /(^|\/)node_modules\//.test(pattern) ? [] : ['**/node_modules/**']
+    ignore: options?.ignore ?? ['**/node_modules/**']
```

Because this PR makes it obsolete. AFAICT only Hydrogen is using that functionality, thus I'm not worried about the breaking change. (I don't see why a Vite end-user would want to use a gob import to search inside `node_modules/`.)

I will additionally ping Fran on Discord about this.

### Additional context

Follow up of https://github.com/vitejs/vite/pull/7436 and more specifically https://github.com/vitejs/vite/pull/7436#issuecomment-1079460822.

Playground confirming that this PR works as intended: https://github.com/brillout/fast-glob-playground.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
