### PR TITLE
fix: removed empty line after ssr import

### DIFF
--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -60,7 +60,7 @@ export async function ssrTransform(
     const importId = `__vite_ssr_import_${uid++}__`
     s.appendLeft(
       node.start,
-      `const ${importId} = await ${ssrImportKey}(${JSON.stringify(source)});\n`
+      `const ${importId} = await ${ssrImportKey}(${JSON.stringify(source)});`
     )
     return importId
   }


### PR DESCRIPTION
### Description

#### Original code

```js
import { createRequire as _createRequire } from "module";
const __require = _createRequire(import.meta.url);
const openapi = __require("@nestjs/swagger");
import { PrismaService } from '@bonfire/prisma';
import { Controller, Get } from '@nestjs/common';
```

#### Before this fix

```js
const __vite_ssr_import_0__ = await __vite_ssr_import__("module");

const __require = __vite_ssr_import_0__.createRequire(__vite_ssr_import_meta__.url);
const openapi = __require("@nestjs/swagger");
const __vite_ssr_import_1__ = await __vite_ssr_import__("/@fs/home/Gautier/projects/bonfire/packages/prisma/build/index.js");

const __vite_ssr_import_2__ = await __vite_ssr_import__("@nestjs/common");

```

#### After this fix

```js
const __vite_ssr_import_0__ = await __vite_ssr_import__("module");
const __require = __vite_ssr_import_0__.createRequire(__vite_ssr_import_meta__.url);
const openapi = __require("@nestjs/swagger");
const __vite_ssr_import_1__ = await __vite_ssr_import__("/@fs/home/Gautier/projects/bonfire/packages/prisma/build/index.js");
const __vite_ssr_import_2__ = await __vite_ssr_import__("@nestjs/common");
```

### Additional context

This is a temporary workaround for #7487

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
