### PR TITLE
fix: add workaround to fix build-temp-types on Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,13 @@
     "overrides": {
       "vite": "workspace:*",
       "@vitejs/plugin-vue": "workspace:*"
+    },
+    "packageExtensions": {
+      "postcss-load-config": {
+        "peerDependencies": {
+          "postcss": "*"
+        }
+      }
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ overrides:
   vite: workspace:*
   '@vitejs/plugin-vue': workspace:*
 
+packageExtensionsChecksum: 696422bac84dd936748019990f84746e
+
 importers:
 
   .:
@@ -935,7 +937,7 @@ importers:
       periscopic: 2.0.3
       picocolors: 1.0.0
       postcss-import: 14.1.0_postcss@8.4.12
-      postcss-load-config: 3.1.3_ts-node@10.4.0
+      postcss-load-config: 3.1.3_postcss@8.4.12+ts-node@10.4.0
       postcss-modules: 4.3.1_postcss@8.4.12
       resolve.exports: 1.1.0
       rollup-plugin-license: 2.6.1_rollup@2.62.0
@@ -7528,6 +7530,7 @@ packages:
     resolution: {integrity: sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==}
     engines: {node: '>= 10'}
     peerDependencies:
+      postcss: '*'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       ts-node:
@@ -7539,16 +7542,18 @@ packages:
       yaml: 1.10.2
     dev: false
 
-  /postcss-load-config/3.1.3_ts-node@10.4.0:
+  /postcss-load-config/3.1.3_postcss@8.4.12+ts-node@10.4.0:
     resolution: {integrity: sha512-5EYgaM9auHGtO//ljHH+v/aC/TQ5LHXtL7bQajNAUBKUVKiYE8rYpFms7+V26D9FncaGe2zwCoPQsFKb5zF/Hw==}
     engines: {node: '>= 10'}
     peerDependencies:
+      postcss: '*'
       ts-node: '>=9.0.0'
     peerDependenciesMeta:
       ts-node:
         optional: true
     dependencies:
       lilconfig: 2.0.4
+      postcss: 8.4.12
       ts-node: 10.4.0_44ef5af6cbbc24239b4e70b5c7b0d7a6
       yaml: 1.10.2
     dev: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes an issue that occurs in the Netlify build, as reported by @patak-dev in https://github.com/vitejs/vite/pull/6856#issuecomment-1064510820

This is caused by postcss-load-config missing postcss as a peer dependency, causing a crash when running `tsc` since it cannot find the corresponding type definitions because of pnpm's strictness. Thank you @bluwy for the idea!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
