### PR TITLE
fix: custom event payload type

### DIFF
--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -13,4 +13,4 @@ export interface CustomEventMap {
 }
 
 export type InferCustomEventPayload<T extends string> =
-  T extends keyof CustomEventMap ? CustomEventMap[T] : unknown
+  T extends keyof CustomEventMap ? CustomEventMap[T] : any


### PR DESCRIPTION
### Description

Fix VitePress.

Looks like https://github.com/vitejs/vite/pull/7476/files#diff-5bc77abd0513da66cf1ce3d8c50e8108daf0c149a5f5f973eeea3c9d4a47bffbR16 broke VitePress. 

See vite-ecosystem-ci run https://github.com/vitejs/vite-ecosystem-ci/runs/5714794922?check_suite_focus=true#step:6:384.

Better message when running locally:
```
> vitepress@0.22.3 build-client /Users/patak/vitepress
> tsc -p src/client && node scripts/copyClient

src/client/app/index.ts:134:29 - error TS2571: Object is of type 'unknown'.

134         router.route.data = payload.pageData
                                ~~~~~~~
Found 1 error.
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other