### PR TITLE
fix: worker match only run in js

### DIFF
--- a/packages/playground/vue/Main.vue
+++ b/packages/playground/vue/Main.vue
@@ -20,6 +20,7 @@
   </Suspense>
   <ReactivityTransform :foo="time" />
   <SetupImportTemplate />
+  <WorkerTest />
 </template>
 
 <script setup lang="ts">
@@ -35,7 +36,7 @@ import ScanDep from './ScanDep.vue'
 import AsyncComponent from './AsyncComponent.vue'
 import ReactivityTransform from './ReactivityTransform.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
-
+import WorkerTest from './worker.vue'
 import { ref } from 'vue'
 
 const time = ref('loading...')

--- a/packages/playground/vue/__tests__/vue.spec.ts
+++ b/packages/playground/vue/__tests__/vue.spec.ts
@@ -242,3 +242,9 @@ describe('setup import template', () => {
     expect(await page.textContent('.setup-import-template')).toMatch('1')
   })
 })
+
+describe('vue worker', () => {
+  test('should work', async () => {
+    expect(await page.textContent('.vue-worker')).toMatch('worker load!')
+  })
+})

--- a/packages/playground/vue/worker.vue
+++ b/packages/playground/vue/worker.vue
@@ -1,6 +1,5 @@
 <template>
   <h2>worker template error match</h2>
-  <p>it will render in a string express.</p>
   <code>
     const worker = new Worker(new URL('./worker.js', import.meta.url))
   </code>

--- a/packages/playground/vue/worker.vue
+++ b/packages/playground/vue/worker.vue
@@ -4,4 +4,15 @@
   <code>
     const worker = new Worker(new URL('./worker.js', import.meta.url))
   </code>
+  <div class="vue-worker">{{ message }}</div>
 </template>
+
+<script setup>
+import { ref } from 'vue'
+
+const message = ref('')
+const worker = new Worker(new URL('./workerTest.js', import.meta.url))
+worker.addEventListener('message', (ev) => {
+  message.value = ev.data
+})
+</script>

--- a/packages/playground/vue/worker.vue
+++ b/packages/playground/vue/worker.vue
@@ -1,7 +1,7 @@
 <template>
   <h2>worker template error match</h2>
+  <p>it will render in a string express.</p>
   <code>
-    it will render in a string express. const worker = new Worker(new
-    URL('./worker.js', import.meta.url))
+    const worker = new Worker(new URL('./worker.js', import.meta.url))
   </code>
 </template>

--- a/packages/playground/vue/worker.vue
+++ b/packages/playground/vue/worker.vue
@@ -1,0 +1,7 @@
+<template>
+  <h2>worker template error match</h2>
+  <code>
+    it will render in a string express. const worker = new Worker(new
+    URL('./worker.js', import.meta.url))
+  </code>
+</template>

--- a/packages/playground/vue/workerTest.js
+++ b/packages/playground/vue/workerTest.js
@@ -1,0 +1,1 @@
+self.postMessage('worker load!')

--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -1,3 +1,8 @@
+<code>
+  worker template error match: it will render in a html tag. const worker = new
+  Worker(new URL('./worker.js', import.meta.url))
+</code>
+
 <h2 class="format-iife">format iife:</h2>
 <div>Expected values: <span class="mode-true"></span></div>
 <button class="ping">Ping</button>

--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -1,4 +1,4 @@
-<p>worker template error match: it will render in a html tag.</p>
+<p>worker template error match:</p>
 <code>
   const worker = new Worker(new URL('./worker.js', import.meta.url))
 </code>

--- a/packages/playground/worker/index.html
+++ b/packages/playground/worker/index.html
@@ -1,6 +1,6 @@
+<p>worker template error match: it will render in a html tag.</p>
 <code>
-  worker template error match: it will render in a html tag. const worker = new
-  Worker(new URL('./worker.js', import.meta.url))
+  const worker = new Worker(new URL('./worker.js', import.meta.url))
 </code>
 
 <h2 class="format-iife">format iife:</h2>

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -19,7 +19,6 @@ import type {
 } from 'rollup'
 import type Rollup from 'rollup'
 import { buildReporterPlugin } from './plugins/reporter'
-import { buildHtmlPlugin } from './plugins/html'
 import { buildEsbuildPlugin } from './plugins/esbuild'
 import { terserPlugin } from './plugins/terser'
 import type { Terser } from 'types/terser'
@@ -310,7 +309,6 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
   return {
     pre: [
       watchPackageDataPlugin(config),
-      buildHtmlPlugin(config),
       commonjsPlugin(options.commonjsOptions),
       dataURIPlugin(),
       dynamicImportVars(options.dynamicImportVarsOptions),

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -19,6 +19,7 @@ import type {
 } from 'rollup'
 import type Rollup from 'rollup'
 import { buildReporterPlugin } from './plugins/reporter'
+import { buildHtmlPlugin } from './plugins/html'
 import { buildEsbuildPlugin } from './plugins/esbuild'
 import { terserPlugin } from './plugins/terser'
 import type { Terser } from 'types/terser'
@@ -309,6 +310,7 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
   return {
     pre: [
       watchPackageDataPlugin(config),
+      buildHtmlPlugin(config),
       commonjsPlugin(options.commonjsOptions),
       dataURIPlugin(),
       dynamicImportVars(options.dynamicImportVarsOptions),

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -33,7 +33,7 @@ import colors from 'picocolors'
 
 const debug = createDebugger('vite:deps')
 
-const htmlTypesRE = /\.(html|vue|svelte|astro)$/
+export const htmlTypesRE = /\.(html|vue|svelte|astro)$/
 
 // A simple regex to detect import sources. This is only used on
 // <script lang="ts"> blocks in vue (setup only) or svelte files, since

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -33,7 +33,7 @@ import colors from 'picocolors'
 
 const debug = createDebugger('vite:deps')
 
-export const htmlTypesRE = /\.(html|vue|svelte|astro)$/
+const htmlTypesRE = /\.(html|vue|svelte|astro)$/
 
 // A simple regex to detect import sources. This is only used on
 // <script lang="ts"> blocks in vue (setup only) or svelte files, since

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -29,10 +29,19 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         const noCommentsCode = code
           .replace(multilineCommentsRE, (m) => ' '.repeat(m.length))
           .replace(singlelineCommentsRE, (m) => ' '.repeat(m.length))
+          .replace(
+            /"[^"]*"|'[^']*'|`[^`]*`/g,
+            (m) => `'${'\0'.repeat(m.length - 2)}'`
+          )
+
         let s: MagicString | null = null
         let match: RegExpExecArray | null
         while ((match = importMetaUrlRE.exec(noCommentsCode))) {
-          const { 0: exp, 1: rawUrl, index } = match
+          const { 0: exp, 1: emptyUrl, index } = match
+
+          const urlStart = exp.indexOf(emptyUrl) + index
+          const urlEnd = urlStart + emptyUrl.length
+          const rawUrl = code.slice(urlStart, urlEnd)
 
           if (!s) s = new MagicString(code)
 

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -29,9 +29,15 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         const noCommentsCode = code
           .replace(multilineCommentsRE, (m) => ' '.repeat(m.length))
           .replace(singlelineCommentsRE, (m) => ' '.repeat(m.length))
+
+        const noStringCode = noCommentsCode.replace(
+          /"[^"]*"|'[^']*'|`[^`]*`/g,
+          (m) => `'${' '.repeat(m.length - 2)}'`
+        )
+
         let s: MagicString | null = null
         let match: RegExpExecArray | null
-        while ((match = importMetaUrlRE.exec(noCommentsCode))) {
+        while ((match = importMetaUrlRE.exec(noStringCode))) {
           const { 0: exp, 1: rawUrl, index } = match
 
           if (!s) s = new MagicString(code)

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -7,9 +7,6 @@ import { multilineCommentsRE, singlelineCommentsRE } from '../utils'
 import { JS_TYPES_RE } from '../constants'
 import { htmlTypesRE, scriptRE } from '../optimizer/scan'
 
-const importMetaUrlRE =
-  /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*,?\s*\)/g
-
 /**
  * Convert `new URL('./foo.png', import.meta.url)` to its resolved built URL
  *
@@ -49,6 +46,8 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         content: string,
         start: number
       ) => {
+        const importMetaUrlRE =
+          /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*,?\s*\)/g
         const noCommentsCode = content
           .replace(multilineCommentsRE, (m) => ' '.repeat(m.length))
           .replace(singlelineCommentsRE, (m) => ' '.repeat(m.length))

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -4,7 +4,7 @@ import path from 'path'
 import { fileToUrl } from './asset'
 import type { ResolvedConfig } from '../config'
 import { multilineCommentsRE, singlelineCommentsRE } from '../utils'
-import { JS_TYPES_RE, OPTIMIZABLE_ENTRY_RE } from '../constants'
+import { JS_TYPES_RE } from '../constants'
 
 /**
  * Convert `new URL('./foo.png', import.meta.url)` to its resolved built URL
@@ -21,7 +21,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:asset-import-meta-url',
     async transform(code, id, options) {
       // only run in js file
-      if (!(OPTIMIZABLE_ENTRY_RE.test(id) || JS_TYPES_RE.test(id))) {
+      if (!JS_TYPES_RE.test(id)) {
         return
       }
 

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -3,7 +3,12 @@ import MagicString from 'magic-string'
 import path from 'path'
 import { fileToUrl } from './asset'
 import type { ResolvedConfig } from '../config'
-import { multilineCommentsRE, singlelineCommentsRE } from '../utils'
+import {
+  multilineCommentsRE,
+  singlelineCommentsRE,
+  stringsRE,
+  blankReplacer
+} from '../utils'
 
 /**
  * Convert `new URL('./foo.png', import.meta.url)` to its resolved built URL
@@ -27,12 +32,9 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         const importMetaUrlRE =
           /\bnew\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*,?\s*\)/g
         const noCommentsCode = code
-          .replace(multilineCommentsRE, (m) => ' '.repeat(m.length))
-          .replace(singlelineCommentsRE, (m) => ' '.repeat(m.length))
-          .replace(
-            /"[^"]*"|'[^']*'|`[^`]*`/g,
-            (m) => `'${'\0'.repeat(m.length - 2)}'`
-          )
+          .replace(multilineCommentsRE, blankReplacer)
+          .replace(singlelineCommentsRE, blankReplacer)
+          .replace(stringsRE, (m) => `'${'\0'.repeat(m.length - 2)}'`)
 
         let s: MagicString | null = null
         let match: RegExpExecArray | null

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -9,7 +9,7 @@ import { importAnalysisPlugin } from './importAnalysis'
 import { cssPlugin, cssPostPlugin } from './css'
 import { assetPlugin } from './asset'
 import { clientInjectionsPlugin } from './clientInjections'
-import { htmlInlineProxyPlugin } from './html'
+import { buildHtmlPlugin, htmlInlineProxyPlugin } from './html'
 import { wasmPlugin } from './wasm'
 import { modulePreloadPolyfillPlugin } from './modulePreloadPolyfill'
 import { webWorkerPlugin } from './worker'
@@ -61,12 +61,13 @@ export async function resolvePlugins(
     ),
     wasmPlugin(config),
     webWorkerPlugin(config),
-    workerImportMetaUrlPlugin(config),
     assetPlugin(config),
     ...normalPlugins,
     definePlugin(config),
     cssPostPlugin(config),
     config.build.ssr ? ssrRequireHookPlugin(config) : null,
+    isBuild && buildHtmlPlugin(config),
+    workerImportMetaUrlPlugin(config),
     ...buildPlugins.pre,
     ...postPlugins,
     ...buildPlugins.post,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -9,7 +9,7 @@ import { importAnalysisPlugin } from './importAnalysis'
 import { cssPlugin, cssPostPlugin } from './css'
 import { assetPlugin } from './asset'
 import { clientInjectionsPlugin } from './clientInjections'
-import { buildHtmlPlugin, htmlInlineProxyPlugin } from './html'
+import { htmlInlineProxyPlugin } from './html'
 import { wasmPlugin } from './wasm'
 import { modulePreloadPolyfillPlugin } from './modulePreloadPolyfill'
 import { webWorkerPlugin } from './worker'
@@ -60,14 +60,13 @@ export async function resolvePlugins(
       isBuild
     ),
     wasmPlugin(config),
+    webWorkerPlugin(config),
+    workerImportMetaUrlPlugin(config),
     assetPlugin(config),
     ...normalPlugins,
     definePlugin(config),
     cssPostPlugin(config),
     config.build.ssr ? ssrRequireHookPlugin(config) : null,
-    isBuild && buildHtmlPlugin(config),
-    webWorkerPlugin(config),
-    workerImportMetaUrlPlugin(config),
     ...buildPlugins.pre,
     ...postPlugins,
     ...buildPlugins.post,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -9,7 +9,7 @@ import { importAnalysisPlugin } from './importAnalysis'
 import { cssPlugin, cssPostPlugin } from './css'
 import { assetPlugin } from './asset'
 import { clientInjectionsPlugin } from './clientInjections'
-import { htmlInlineProxyPlugin } from './html'
+import { buildHtmlPlugin, htmlInlineProxyPlugin } from './html'
 import { wasmPlugin } from './wasm'
 import { modulePreloadPolyfillPlugin } from './modulePreloadPolyfill'
 import { webWorkerPlugin } from './worker'
@@ -60,13 +60,14 @@ export async function resolvePlugins(
       isBuild
     ),
     wasmPlugin(config),
-    webWorkerPlugin(config),
-    workerImportMetaUrlPlugin(config),
     assetPlugin(config),
     ...normalPlugins,
     definePlugin(config),
     cssPostPlugin(config),
     config.build.ssr ? ssrRequireHookPlugin(config) : null,
+    isBuild && buildHtmlPlugin(config),
+    webWorkerPlugin(config),
+    workerImportMetaUrlPlugin(config),
     ...buildPlugins.pre,
     ...postPlugins,
     ...buildPlugins.post,

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -13,12 +13,7 @@ import {
 import path from 'path'
 import { bundleWorkerEntry } from './worker'
 import { parseRequest } from '../utils'
-import {
-  ENV_ENTRY,
-  ENV_PUBLIC_PATH,
-  JS_TYPES_RE,
-  OPTIMIZABLE_ENTRY_RE
-} from '../constants'
+import { ENV_ENTRY, ENV_PUBLIC_PATH, JS_TYPES_RE } from '../constants'
 import MagicString from 'magic-string'
 import type { ViteDevServer } from '..'
 import type { RollupError } from 'rollup'
@@ -93,8 +88,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(code, id, options) {
-      // only run in js file
-      if (!(OPTIMIZABLE_ENTRY_RE.test(id) || JS_TYPES_RE.test(id))) {
+      if (!JS_TYPES_RE.test(id)) {
         return
       }
 
@@ -123,6 +117,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           code: injectEnv + code
         }
       }
+
       if (
         (code.includes('new Worker') || code.includes('new ShareWorker')) &&
         code.includes('new URL') &&

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -7,16 +7,16 @@ import {
   cleanUrl,
   injectQuery,
   multilineCommentsRE,
-  singlelineCommentsRE
+  singlelineCommentsRE,
+  stringsRE
 } from '../utils'
 import path from 'path'
 import { bundleWorkerEntry } from './worker'
 import { parseRequest } from '../utils'
-import { ENV_ENTRY, ENV_PUBLIC_PATH, JS_TYPES_RE } from '../constants'
+import { ENV_ENTRY, ENV_PUBLIC_PATH } from '../constants'
 import MagicString from 'magic-string'
 import type { ViteDevServer } from '..'
 import type { RollupError } from 'rollup'
-import { htmlTypesRE, scriptRE } from '../optimizer/scan'
 
 type WorkerType = 'classic' | 'module' | 'ignore'
 
@@ -113,39 +113,30 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           code: injectEnv + code
         }
       }
-
-      let inHTML = false
-      if (htmlTypesRE.test(id)) {
-        inHTML = true
-      } else if (JS_TYPES_RE.test(id)) {
-        inHTML = false
-      } else {
-        return
-      }
-
       if (
-        !(code.includes('new Worker') || code.includes('new ShareWorker')) ||
-        !code.includes('new URL') ||
-        !code.includes(`import.meta.url`)
+        (code.includes('new Worker') || code.includes('new ShareWorker')) &&
+        code.includes('new URL') &&
+        code.includes(`import.meta.url`)
       ) {
-        return
-      }
-
-      let s: MagicString | undefined
-      const transformWorkerImportMetaUrl = async (
-        snippet: string,
-        start: number
-      ): Promise<void> => {
         const importMetaUrlRE =
           /\bnew\s+(Worker|SharedWorker)\s*\(\s*(new\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*\))/g
-        const noCommentsCode = snippet
+        const noCommentsCode = code
           .replace(multilineCommentsRE, blankReplacer)
           .replace(singlelineCommentsRE, blankReplacer)
+
+        const noStringCode = noCommentsCode.replace(
+          stringsRE,
+          (m) => `'${' '.repeat(m.length - 2)}'`
+        )
         let match: RegExpExecArray | null
-        while ((match = importMetaUrlRE.exec(noCommentsCode))) {
-          const { 0: allExp, 2: exp, 3: rawUrl, index: matchIndex } = match
-          const index = start + matchIndex
+        let s: MagicString | null = null
+        while ((match = importMetaUrlRE.exec(noStringCode))) {
+          const { 0: allExp, 2: exp, 3: emptyUrl, index } = match
           const urlIndex = allExp.indexOf(exp) + index
+
+          const urlStart = allExp.indexOf(emptyUrl) + index
+          const urlEnd = urlStart + emptyUrl.length
+          const rawUrl = code.slice(urlStart, urlEnd)
 
           if (options?.ssr) {
             this.error(
@@ -164,9 +155,9 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
           s ||= new MagicString(code)
           const workerType = getWorkerType(
-            snippet,
+            code,
             noCommentsCode,
-            matchIndex + allExp.length
+            index + allExp.length
           )
           const file = path.resolve(path.dirname(id), rawUrl.slice(1, -1))
           let url: string
@@ -192,26 +183,14 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             contentOnly: true
           })
         }
-      }
-
-      if (inHTML) {
-        let scriptMatch: RegExpExecArray | null = null
-        while ((scriptMatch = scriptRE.exec(code))) {
-          const { 0: exp, 2: script, index: scriptMatchIndex } = scriptMatch
-          const index = exp.indexOf(script) + scriptMatchIndex
-          await transformWorkerImportMetaUrl(script, index)
+        if (s) {
+          return {
+            code: s.toString(),
+            map: config.build.sourcemap ? s.generateMap({ hires: true }) : null
+          }
         }
-      } else {
-        await transformWorkerImportMetaUrl(code, 0)
+        return null
       }
-
-      if (s) {
-        return {
-          code: s.toString(),
-          map: config.build.sourcemap ? s.generateMap({ hires: true }) : null
-        }
-      }
-      return null
     }
   }
 }

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -114,7 +114,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         }
       }
 
-      // transfrom code
       let inHTML = false
       if (htmlTypesRE.test(id)) {
         inHTML = true

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -7,7 +7,8 @@ import {
   cleanUrl,
   injectQuery,
   multilineCommentsRE,
-  singlelineCommentsRE
+  singlelineCommentsRE,
+  stringsRE
 } from '../utils'
 import path from 'path'
 import { bundleWorkerEntry } from './worker'
@@ -122,9 +123,15 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         const noCommentsCode = code
           .replace(multilineCommentsRE, blankReplacer)
           .replace(singlelineCommentsRE, blankReplacer)
+
+        const noStringCode = noCommentsCode.replace(
+          stringsRE,
+          (m) => `'${' '.repeat(m.length - 2)}'`
+        )
+
         let match: RegExpExecArray | null
         let s: MagicString | null = null
-        while ((match = importMetaUrlRE.exec(noCommentsCode))) {
+        while ((match = importMetaUrlRE.exec(noStringCode))) {
           const { 0: allExp, 2: exp, 3: rawUrl, index } = match
           const urlIndex = allExp.indexOf(exp) + index
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -732,3 +732,4 @@ export function parseRequest(id: string): Record<string, string> | null {
 }
 
 export const blankReplacer = (match: string) => ' '.repeat(match.length)
+export const stringsRE = /"[^"]*"|'[^']*'|`[^`]*`/g

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -708,6 +708,7 @@ export function toUpperCaseDriveLetter(pathName: string): string {
 
 export const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
 export const singlelineCommentsRE = /\/\/.*/g
+export const stringsRE = /"[^"]*"|'[^']*'|`[^`]*`/g
 
 export const usingDynamicImport = typeof jest === 'undefined'
 /**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -708,7 +708,6 @@ export function toUpperCaseDriveLetter(pathName: string): string {
 
 export const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//gm
 export const singlelineCommentsRE = /\/\/.*/g
-export const stringsRE = /"[^"]*"|'[^']*'|`[^`]*`/g
 
 export const usingDynamicImport = typeof jest === 'undefined'
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #7499

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

~~`buildHtmlPlugin` will remove tag in Html, only return script tag content for later plugin transform. So make `worker plugin` position close to `assetImportMetaUrlPlugin` is ok?~~

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
