### PR TITLE
fix(plugin-legacy): polyfill latest features

### DIFF
--- a/packages/playground/legacy/__tests__/legacy.spec.ts
+++ b/packages/playground/legacy/__tests__/legacy.spec.ts
@@ -83,4 +83,8 @@ if (isBuild) {
   test('should emit css file', async () => {
     expect(listAssets().some((filename) => filename.endsWith('.css')))
   })
+
+  test('includes structuredClone polyfill which is supported after core-js v3', () => {
+    expect(findAssetFile(/polyfills-legacy/)).toMatch('"structuredClone"')
+  })
 }

--- a/packages/playground/legacy/index.html
+++ b/packages/playground/legacy/index.html
@@ -1,6 +1,7 @@
 <h1 id="app"></h1>
 <div id="env"></div>
 <div id="iterators"></div>
+<div id="features-after-corejs-3"></div>
 <div id="babel-helpers"></div>
 <div id="assets"></div>
 <script type="module" src="./main.js"></script>

--- a/packages/playground/legacy/main.js
+++ b/packages/playground/legacy/main.js
@@ -21,6 +21,12 @@ text('#env', `is legacy: ${isLegacy}`)
 // Iterators
 text('#iterators', [...new Set(['hello'])].join(''))
 
+// structuredClone is supported core.js v3.20.0+
+text(
+  '#features-after-corejs-3',
+  JSON.stringify(structuredClone({ foo: 'foo' }))
+)
+
 // babel-helpers
 // Using `String.raw` to inject `@babel/plugin-transform-template-literals`
 // helpers.

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -330,7 +330,10 @@ function viteLegacyPlugin(options = {}) {
               loose: false,
               useBuiltIns: needPolyfills ? 'usage' : false,
               corejs: needPolyfills
-                ? { version: 3, proposals: false }
+                ? {
+                    version: require('core-js/package.json').version,
+                    proposals: false
+                  }
                 : undefined,
               shippedProposals: true,
               ignoreBrowserslistConfig: options.ignoreBrowserslistConfig


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
plugin-legacy was not polyfilling features which are supported by core-js `3<`.
For example, `structuredClone` is [supported by core-js@v3.20.0](https://github.com/zloirock/core-js/releases/tag/v3.20.0) but the polyfill was not included currently.

### Additional context
While looking at #7449, I found https://github.com/babel/babel/issues/13701#issuecomment-904741727 and found this bug.
But for #7449 I think it is working correctly and this PR is not related.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
