### PR TITLE
feat(client): support "full-reload" event with any page path

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -103,7 +103,7 @@ async function handleMessage(payload: HMRPayload) {
     }
     case 'full-reload':
       notifyListeners('vite:beforeFullReload', payload)
-      if (payload.path && payload.path.endsWith('.html')) {
+      if (payload.path && payload.path !== '*') {
         // if html file is edited, only reload the page if the browser is
         // currently on that page.
         const pagePath = decodeURI(location.pathname)
@@ -114,7 +114,6 @@ async function handleMessage(payload: HMRPayload) {
         ) {
           location.reload()
         }
-        return
       } else {
         location.reload()
       }


### PR DESCRIPTION
In other words, stop requiring a `.html` extension for a selective page reload, because that prevents certain pages from being selectively reloaded.

For example, if I send a `"full-reload"` event with a `path` of `"/foo.html"`, it will **not** reload clients whose location is `"/foo"`. Similarly, sending a full-reload event with a path of `"/foo/index.html"` will **not** reload `"/foo"` clients either. In this case, only clients at `"/foo/"` will be reloaded.

Therefore, we should allow sending a `full-reload` event with a path of `"/foo"` to specifically target clients at `"/foo"`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
