### PR TITLE
chore(plugin-vue): revert #7527, lower vite peer dep

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/vitejs/vite/tree/main/packages/plugin-vue#readme",
   "peerDependencies": {
-    "vite": "^2.9.0",
+    "vite": "^2.5.10",
     "vue": "^3.2.25"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts vitejs/vite#7472

- `css.devSourcemap` option is introduce in vite@2.9.0
- plugin-vue uses the new function (`formatPostcssSourceMap`) only when `css.devSourcemap` is enabled

plugin-vue@2.3.0 actually works with vite@2.8.6.
https://stackblitz.com/edit/vitejs-vite-nffywg?file=package.json&terminal=dev
