### PR TITLE
fix: remove unneeded skipping optimization log

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -371,7 +371,6 @@ export async function runOptimizeDeps(
       commit() {
         // Write metadata file, delete `deps` folder and rename the `processing` folder to `deps`
         commitProcessingDepsCacheSync()
-        config.logger.info(`No dependencies to bundle. Skipping.\n\n\n`)
       },
       cancel
     }


### PR DESCRIPTION
### Description

Screenshot sent by @antfu:
![image](https://user-images.githubusercontent.com/583075/160902242-187e9f27-ad54-4ed3-8947-da26ffcd432c.png)

We discussed and this log isn't needed anymore. It should have been removed as part of https://github.com/vitejs/vite/pull/7419 

We can directly remove it because this isn't useful for debugging, as we have the info of the found dependencies. This was intended for user feedback since we always will show a message before the server start.
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other