### PR TITLE
fix: fix HMR propagation when imports not analyzed

### DIFF
--- a/packages/playground/hmr/__tests__/hmr.spec.ts
+++ b/packages/playground/hmr/__tests__/hmr.spec.ts
@@ -178,7 +178,12 @@ if (!isBuild) {
     await btn.click()
     expect(await btn.textContent()).toBe('Counter 1')
 
-    // Modifying a dynamic import that has not been loaded has no effect (doesn't trigger a page reload)
+    // #7561
+    // `dep.ts` defines `import.module.hot.accept` and has not been loaded.
+    // Therefore, modifying it has no effect (doesn't trigger a page reload).
+    // (Note that, a dynamic import that is never loaded and that does not
+    // define `accept.module.hot.accept` may wrongfully trigger a full page
+    // reload, see discussion at #7561.)
     editFile('dynamic-import/dep.ts', (code) => code)
     try {
       await page.waitForNavigation({ timeout: 1000 })

--- a/packages/playground/hmr/dynamic-import/dep.ts
+++ b/packages/playground/hmr/dynamic-import/dep.ts
@@ -1,1 +1,2 @@
 // This file is never loaded
+import.meta.hot.accept(() => {})

--- a/packages/playground/hmr/dynamic-import/dep.ts
+++ b/packages/playground/hmr/dynamic-import/dep.ts
@@ -1,0 +1,1 @@
+// This file is never loaded

--- a/packages/playground/hmr/dynamic-import/index.html
+++ b/packages/playground/hmr/dynamic-import/index.html
@@ -1,0 +1,2 @@
+<button>Counter 0</button>
+<script type="module" src="./index.ts"></script>

--- a/packages/playground/hmr/dynamic-import/index.ts
+++ b/packages/playground/hmr/dynamic-import/index.ts
@@ -1,0 +1,12 @@
+const btn = document.querySelector('button')
+let count = 0
+const update = () => {
+  btn.textContent = `Counter ${count}`
+}
+btn.onclick = () => {
+  count++
+  update()
+}
+function neverCalled() {
+  import('./dep')
+}

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -122,6 +122,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer, options) {
+      // In a real app `server` is always defined, but it can be `null` when
+      // running the test https://github.com/vitejs/vite/blob/a74bd7ba9947be193bccf636b8918bd1f59e89ae/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
       if (server === null) {
         return null
       }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -112,7 +112,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
     tryIndex: false,
     extensions: []
   })
-  let server: ViteDevServer | null = null
+  let server: ViteDevServer
 
   return {
     name: 'vite:import-analysis',
@@ -122,9 +122,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer, options) {
-      // In a real app `server` is always defined, but it can be `null` when
+      // In a real app `server` is always defined, but it is undefined when
       // running src/node/server/__tests__/pluginContainer.spec.ts
-      if (server === null) {
+      if (!server) {
         return null
       }
 
@@ -205,7 +205,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
         let importerFile = importer
         if (moduleListContains(config.optimizeDeps?.exclude, url)) {
-          const optimizedDeps = server!._optimizedDeps
+          const optimizedDeps = server._optimizedDeps
           if (optimizedDeps) {
             await optimizedDeps.scanProcessing
 
@@ -666,7 +666,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             NULL_BYTE_PLACEHOLDER,
             '\0'
           )
-          transformRequest(url, server!, { ssr }).catch((e) => {
+          transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors
               return

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -123,7 +123,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
     async transform(source, importer, options) {
       // In a real app `server` is always defined, but it can be `null` when
-      // running the test https://github.com/vitejs/vite/blob/a74bd7ba9947be193bccf636b8918bd1f59e89ae/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+      // running src/node/server/__tests__/pluginContainer.spec.ts
       if (server === null) {
         return null
       }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -225,6 +225,12 @@ function propagateUpdate(
   }>,
   currentChain: ModuleNode[] = [node]
 ): boolean /* hasDeadEnd */ {
+  // if the imports of `node` have not been analyzed, then `node` has not
+  // been loaded in the browser and we should stop propagation.
+  if (node.id && node.isSelfAccepting === null) {
+    return false
+  }
+
   if (node.isSelfAccepting) {
     boundaries.add({
       boundary: node,

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -225,9 +225,10 @@ function propagateUpdate(
   }>,
   currentChain: ModuleNode[] = [node]
 ): boolean /* hasDeadEnd */ {
+  // #7561
   // if the imports of `node` have not been analyzed, then `node` has not
   // been loaded in the browser and we should stop propagation.
-  if (node.id && node.isSelfAccepting === null) {
+  if (node.id && node.isSelfAccepting === undefined) {
     return false
   }
 

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -27,7 +27,7 @@ export class ModuleNode {
   importers = new Set<ModuleNode>()
   importedModules = new Set<ModuleNode>()
   acceptedHmrDeps = new Set<ModuleNode>()
-  isSelfAccepting: boolean | null = null
+  isSelfAccepting?: boolean
   transformResult: TransformResult | null = null
   ssrTransformResult: TransformResult | null = null
   ssrModule: Record<string, any> | null = null

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -27,7 +27,7 @@ export class ModuleNode {
   importers = new Set<ModuleNode>()
   importedModules = new Set<ModuleNode>()
   acceptedHmrDeps = new Set<ModuleNode>()
-  isSelfAccepting = false
+  isSelfAccepting: boolean | null = null
   transformResult: TransformResult | null = null
   ssrTransformResult: TransformResult | null = null
   ssrModule: Record<string, any> | null = null


### PR DESCRIPTION
### Description

In some situations, the HMR signal hits a module that has not been analyzed.

For example, a dynamic import that is never called `const neverCalled = () => import('./dep.js')`. Here the `dep.js` file is never loaded and thus never analyzed by the `importAnalysis.ts` plugin.

If the HMR signal hits such non-analyzed module, then this means that the module has not been loaded.

Because it has not be loaeded there is nothing to refresh; we can and should stop the HMR propagation. Otherwise the HMR signal triggers a wrongful full page reload.

### Additional context

This is a vps 0.4 release blocker. (This situation used to be an edge case with vps 0.3 but, with the new vps architecture, this is a common and problematic case.)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

