### PR TITLE
test(optimizer): add cjs browser field bare import test

### DIFF
--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -57,6 +57,10 @@ test('cjs browser field (axios)', async () => {
   expect(await page.textContent('.cjs-browser-field')).toBe('pong')
 })
 
+test('cjs browser field bare', async () => {
+  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
+})
+
 test('dep from linked dep (lodash-es)', async () => {
   expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
 })

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: 'foo'
+}

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const internal = require('./internal')
+
+module.exports = internal

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const events = require('events')
+
+module.exports = 'foo' in events ? 'pong' : ''

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dep-cjs-browser-field-bare",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "browser": {
+    "events": "./events-shim.js"
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -29,6 +29,9 @@
 <h2>CommonJS w/ browser field mapping (axios)</h2>
 <div>This should show pong: <span class="cjs-browser-field"></span></div>
 
+<h2>CommonJS w/ bare id browser field mapping</h2>
+<div>This should show pong: <span class="cjs-browser-field-bare"></span></div>
+
 <h2>Detecting linked src package and optimizing its deps (lodash-es)</h2>
 <div>This should show fooBarBaz: <span class="deps-linked"></span></div>
 
@@ -87,6 +90,9 @@
 <script type="module">
   // test dep detection in globbed files
   const globbed = import.meta.glob('./glob/*.js', { eager: true })
+
+  import cjsBrowerFieldBare from 'dep-cjs-browser-field-bare'
+  text('.cjs-browser-field-bare', cjsBrowerFieldBare)
 
   import { camelCase } from 'dep-linked'
   text('.deps-linked', camelCase('foo-bar-baz'))

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "clipboard": "^2.0.11",
+    "dep-cjs-browser-field-bare": "file:./dep-cjs-browser-field-bare",
     "dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
     "dep-cjs-with-assets": "file:./dep-cjs-with-assets",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,7 @@ importers:
       added-in-entries: file:./added-in-entries
       axios: ^0.27.2
       clipboard: ^2.0.11
+      dep-cjs-browser-field-bare: file:./dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:./dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:./dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:./dep-cjs-with-assets
@@ -600,6 +601,7 @@ importers:
       added-in-entries: file:playground/optimize-deps/added-in-entries
       axios: 0.27.2
       clipboard: 2.0.11
+      dep-cjs-browser-field-bare: file:playground/optimize-deps/dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:playground/optimize-deps/dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:playground/optimize-deps/dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:playground/optimize-deps/dep-cjs-with-assets
@@ -626,6 +628,9 @@ importers:
       '@vitejs/plugin-vue': link:../../packages/plugin-vue
 
   playground/optimize-deps/added-in-entries:
+    specifiers: {}
+
+  playground/optimize-deps/dep-cjs-browser-field-bare:
     specifiers: {}
 
   playground/optimize-deps/dep-cjs-compiled-from-cjs:
@@ -8704,6 +8709,12 @@ packages:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
     name: added-in-entries
     version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-cjs-browser-field-bare:
+    resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
+    name: dep-cjs-browser-field-bare
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR adds a failing test for #4798, #7301, #7576.

These issues are caused by the same reason.
I investigated this but I could not come up with a good solution.

### Additional context
This bug is caused by this line. `idToPkgMap.get(importer)`  is undefined through it should have PackageData.
https://github.com/vitejs/vite/blob/5d6ea8efc36bfdcd8b70afa8e82026ad1ccc0a77/packages/vite/src/node/plugins/resolve.ts#L941-L942
This `tryResolveBrowserMapping` is called from here.
https://github.com/vitejs/vite/blob/5d6ea8efc36bfdcd8b70afa8e82026ad1ccc0a77/packages/vite/src/node/plugins/resolve.ts#L272

I will try to describe why this is happening only when resolver is used with optimizer.

- bare imports goes through vite's resolver. https://github.com/vitejs/vite/blob/5d6ea8efc36bfdcd8b70afa8e82026ad1ccc0a77/packages/vite/src/node/optimizer/esbuildDepPlugin.ts#L107-L149
- non-bare imports does not go through vite's resolver and handled by esbuild's resolver
- when all imports goes through vite's resolver `idToPkgMap` is constructed correctly.

This (https://github.com/sapphi-red/vite/commit/4d7a716d4ae1cf78605af519be77e9730fcb63f1) is the solution I came up with but I think this solution has many problems.

1. It might occur infinite loop. I have set `pluginData` to check whether it is already called but I feel it would not work if there is other plugins.
    - > There is currently no attempt made to detect infinite path resolution loops. Calling resolve from within onResolve with the same parameters is almost certainly a bad idea.
      > https://esbuild.github.io/plugins/#resolve
1. Other plugins' `onResolve` runs two times. For example, if there is a `onResolve` which adds `@`, the id `foo` will become `foo@@`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
