### PR TITLE
feat: optimizeDeps.disabled

### DIFF
--- a/packages/playground/vue-jsx/vite.config.js
+++ b/packages/playground/vue-jsx/vite.config.js
@@ -35,5 +35,8 @@ export default defineComponent(() => {
   build: {
     // to make tests faster
     minify: false
+  },
+  optimizeDeps: {
+    disabled: true
   }
 }

--- a/packages/playground/vue-jsx/vite.config.js
+++ b/packages/playground/vue-jsx/vite.config.js
@@ -36,7 +36,5 @@ export default defineComponent(() => {
     // to make tests faster
     minify: false
   },
-  optimizeDeps: {
-    disabled: true
-  }
+  optimizeDeps: false
 }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -145,8 +145,9 @@ export interface UserConfig {
   preview?: PreviewOptions
   /**
    * Dep optimization options
+   * false disables optimization completely (experimental)
    */
-  optimizeDeps?: DepOptimizationOptions
+  optimizeDeps?: DepOptimizationOptions | false
   /**
    * SSR specific options
    * @alpha
@@ -463,6 +464,8 @@ export async function resolveConfig(
 
   const server = resolveServerOptions(resolvedRoot, config.server)
 
+  const optimizeDeps = config.optimizeDeps || {}
+
   const resolved: ResolvedConfig = {
     ...config,
     configFile: configFile ? normalizePath(configFile) : undefined,
@@ -497,11 +500,12 @@ export async function resolveConfig(
     packageCache: new Map(),
     createResolver,
     optimizeDeps: {
-      ...config.optimizeDeps,
+      disabled: config.optimizeDeps === false,
+      ...optimizeDeps,
       esbuildOptions: {
-        keepNames: config.optimizeDeps?.keepNames,
+        keepNames: optimizeDeps.keepNames,
         preserveSymlinks: config.resolve?.preserveSymlinks,
-        ...config.optimizeDeps?.esbuildOptions
+        ...optimizeDeps.esbuildOptions
       }
     },
     worker: resolvedWorkerOptions
@@ -605,7 +609,7 @@ export async function resolveConfig(
     }
   })
 
-  if (config.optimizeDeps?.keepNames) {
+  if (optimizeDeps.keepNames) {
     logDeprecationWarning(
       'optimizeDeps.keepNames',
       'Use "optimizeDeps.esbuildOptions.keepNames" instead.'

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -145,6 +145,7 @@ export interface UserConfig {
   preview?: PreviewOptions
   /**
    * Dep optimization options
+   *
    * false disables optimization completely (experimental)
    */
   optimizeDeps?: DepOptimizationOptions | false

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -42,6 +42,10 @@ export interface OptimizedDeps {
 
 export interface DepOptimizationOptions {
   /**
+   * @default false
+   */
+  disabled?: boolean
+  /**
    * By default, Vite will crawl your `index.html` to detect dependencies that
    * need to be pre-bundled. If `build.rollupOptions.input` is specified, Vite
    * will crawl those entry points instead.

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -42,10 +42,6 @@ export interface OptimizedDeps {
 
 export interface DepOptimizationOptions {
   /**
-   * @default false
-   */
-  disabled?: boolean
-  /**
    * By default, Vite will crawl your `index.html` to detect dependencies that
    * need to be pre-bundled. If `build.rollupOptions.input` is specified, Vite
    * will crawl those entry points instead.
@@ -105,6 +101,12 @@ export interface DepOptimizationOptions {
    * @experimental
    */
   extensions?: string[]
+  /**
+   * Disables dependencies optimizations
+   * @default false
+   * @experimental
+   */
+  disabled?: boolean
 }
 
 export interface DepOptimizationResult {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -571,6 +571,12 @@ export async function createServer(
   // error handler
   middlewares.use(errorMiddleware(server, !!middlewareMode))
 
+  const initOptimizer = () => {
+    if (!config.optimizeDeps.disabled) {
+      server._optimizedDeps = createOptimizedDeps(server)
+    }
+  }
+
   if (!middlewareMode && httpServer) {
     let isOptimized = false
     // overwrite listen to init optimizer before server start
@@ -579,7 +585,7 @@ export async function createServer(
       if (!isOptimized) {
         try {
           await container.buildStart({})
-          server._optimizedDeps = createOptimizedDeps(server)
+          initOptimizer()
           isOptimized = true
         } catch (e) {
           httpServer.emit('error', e)
@@ -590,7 +596,7 @@ export async function createServer(
     }) as any
   } else {
     await container.buildStart({})
-    server._optimizedDeps = createOptimizedDeps(server)
+    initOptimizer()
   }
 
   return server


### PR DESCRIPTION
### Description

See https://github.com/vitest-dev/vitest/issues/485#issuecomment-1088664771 for context.

Vitest is currently trying to disable deps optimization by using `optimizeDeps: { entries: [] }`, but this only avoids scanning.

I choose `optimizeDeps: { disabled: true }` to avoid a breaking change, but if we want to switch to `optimizeDeps: OptimizeDepsOptions | false` in ResolvedConfig we could do that instead and push this in Vite 3.0.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other