### PR TITLE
fix: improve type signature of mergeConfig

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -112,7 +112,7 @@ describe('mergeConfig', () => {
 
   test('not handles alias not under `resolve`', () => {
     const baseConfig = {
-      custom: {
+      resolve: {
         alias: {
           bar: 'bar-value',
           baz: 'baz-value'
@@ -121,7 +121,7 @@ describe('mergeConfig', () => {
     }
 
     const newConfig = {
-      custom: {
+      resolve: {
         alias: {
           bar: 'bar-value-2',
           foo: 'foo-value'
@@ -130,7 +130,7 @@ describe('mergeConfig', () => {
     }
 
     const mergedConfig = {
-      custom: {
+      resolve: {
         alias: {
           bar: 'bar-value-2',
           baz: 'baz-value',
@@ -144,15 +144,15 @@ describe('mergeConfig', () => {
 
   test('merge array correctly', () => {
     const baseConfig = {
-      foo: null
+      assetsInclude: null
     }
 
     const newConfig = {
-      foo: ['bar']
+      assetsInclude: ['bar']
     }
 
     const mergedConfig = {
-      foo: ['bar']
+      assetsInclude: ['bar']
     }
 
     expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -766,10 +766,10 @@ function mergeConfigRecursively(
 }
 
 export function mergeConfig(
-  defaults: Record<string, any>,
-  overrides: Record<string, any>,
+  defaults: UserConfig,
+  overrides: UserConfig,
   isRoot = true
-): Record<string, any> {
+): UserConfig {
   return mergeConfigRecursively(defaults, overrides, isRoot ? '' : '.')
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

As `mergeConfig` is exported as a public method in Vite's JS API, it would be better to have a strict type signature.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Some test cases are also tweaked for this.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
