### PR TITLE
fix: `$ vite preview` 404 handling

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import fs from 'fs'
 import sirv from 'sirv'
 import connect from 'connect'
 import compression from './server/middlewares/compression'
@@ -90,10 +91,19 @@ export async function preview(
     config.base,
     sirv(distDir, {
       etag: true,
-      dev: true,
-      single: true
+      dev: true
     })
   )
+
+  app.use(config.base, (_, res, next) => {
+    const file = path.join(distDir, './404.html')
+    if (fs.existsSync(file)) {
+      res.statusCode = 404
+      res.end(fs.readFileSync(file))
+    } else {
+      next()
+    }
+  })
 
   const options = config.preview
   const hostname = resolveHostname(options.host)


### PR DESCRIPTION

### Description

When running a production preview with `$ vite preview`, Vite fallbacks 404 pages to the landing page `/`. See the [`dirv`](https://www.npmjs.com/package/sirv) option `single`:

> `opts.single`
> Default: `false`
> 
> Treat the directory as a single-page application.
>
> When true, the directory's index page (default index.html) will be sent if the request asset does not exist.

Currently this option is set to `true` and this PR changes it to `false`.

I guess Vite used to assume that every Vite app was an SPA, but that's not really the case anymore.

For MPA and SSR apps, having a 404 page be the landing page `/` is quite an unexpected behavior.

We could make this a config, but I don't think it's worth it. I think it's fine if `$ vite preview` serves SPAs only at `/`. (I would even argue that it's better, as it's a more truthful representation and preview of production.)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
