### PR TITLE
fix: use NODE_ENV in optimizer

### DIFF
--- a/packages/playground/optimize-deps/.env
+++ b/packages/playground/optimize-deps/.env
@@ -1,0 +1,1 @@
+NODE_ENV=production

--- a/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/packages/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -62,6 +62,10 @@ test('import * from optimized dep', async () => {
   expect(await page.textContent('.import-star')).toMatch(`[success]`)
 })
 
+test('import from dep with process.env.NODE_ENV', async () => {
+  expect(await page.textContent('.node-env')).toMatch(`prod`)
+})
+
 test('import from dep with .notjs files', async () => {
   expect(await page.textContent('.not-js')).toMatch(`[success]`)
 })

--- a/packages/playground/optimize-deps/dep-node-env/index.js
+++ b/packages/playground/optimize-deps/dep-node-env/index.js
@@ -1,0 +1,1 @@
+export const env = process.env.NODE_ENV === 'production' ? 'prod' : 'dev'

--- a/packages/playground/optimize-deps/dep-node-env/package.json
+++ b/packages/playground/optimize-deps/dep-node-env/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep-node-env",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/packages/playground/optimize-deps/index.html
+++ b/packages/playground/optimize-deps/index.html
@@ -38,6 +38,9 @@
 <h2>import * as ...</h2>
 <div class="import-star"></div>
 
+<h2>Import from dependency with process.env.NODE_ENV</h2>
+<div class="node-env"></div>
+
 <h2>Import from dependency with .notjs files</h2>
 <div class="not-js"></div>
 
@@ -87,6 +90,9 @@
   if (keys.length) {
     text('.import-star', `[success] ${keys.join(', ')}`)
   }
+
+  import { env } from 'dep-node-env'
+  text('.node-env', env)
 
   import { notjsValue } from 'dep-not-js'
   text('.not-js', notjsValue)

--- a/packages/playground/optimize-deps/package.json
+++ b/packages/playground/optimize-deps/package.json
@@ -17,6 +17,7 @@
     "dep-esbuild-plugin-transform": "file:./dep-esbuild-plugin-transform",
     "dep-linked": "link:./dep-linked",
     "dep-linked-include": "link:./dep-linked-include",
+    "dep-node-env": "file:./dep-node-env",
     "dep-not-js": "file:./dep-not-js",
     "dep-with-dynamic-import": "file:./dep-with-dynamic-import",
     "lodash-es": "^4.17.21",

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -438,7 +438,7 @@ export async function runOptimizeDeps(
   }
 
   const define: Record<string, string> = {
-    'process.env.NODE_ENV': JSON.stringify(config.mode)
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || config.mode)
   }
   for (const key in config.define) {
     const value = config.define[key]
@@ -783,7 +783,7 @@ export function getDepHash(config: ResolvedConfig): string {
   // only a subset of config options that can affect dep optimization
   content += JSON.stringify(
     {
-      mode: config.mode,
+      mode: process.env.NODE_ENV || config.mode,
       root: config.root,
       define: config.define,
       resolve: config.resolve,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -317,6 +317,7 @@ importers:
       dep-esbuild-plugin-transform: file:./dep-esbuild-plugin-transform
       dep-linked: link:./dep-linked
       dep-linked-include: link:./dep-linked-include
+      dep-node-env: file:./dep-node-env
       dep-not-js: file:./dep-not-js
       dep-with-dynamic-import: file:./dep-with-dynamic-import
       lodash-es: ^4.17.21
@@ -336,6 +337,7 @@ importers:
       dep-esbuild-plugin-transform: link:dep-esbuild-plugin-transform
       dep-linked: link:dep-linked
       dep-linked-include: link:dep-linked-include
+      dep-node-env: link:dep-node-env
       dep-not-js: link:dep-not-js
       dep-with-dynamic-import: link:dep-with-dynamic-import
       lodash-es: 4.17.21
@@ -370,6 +372,9 @@ importers:
       react: 17.0.2
     dependencies:
       react: 17.0.2
+
+  packages/playground/optimize-deps/dep-node-env:
+    specifiers: {}
 
   packages/playground/optimize-deps/dep-not-js:
     specifiers: {}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Use `process.env.NODE_ENV` too for esbuild `define` object. Similar to the define plugin:

https://github.com/vitejs/vite/blob/eb57627a368a5ae0532b5836c176647525d5394f/packages/vite/src/node/plugins/define.ts#L15

### Additional context

Found this issue at https://github.com/vitejs/vite/pull/7246/files#r846999746

While optimizing is for dev only, if we set `mode` to something else, it could affect define `process.env.NODE_ENV` which doesn't seem right to me.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
