### PR TITLE
fix(css): hoist charset

### DIFF
--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -247,6 +247,15 @@ test('inline css modules', async () => {
   expect(css).toMatch(/\.inline-module__apply-color-inline___[\w-]{5}/)
 })
 
+if (isBuild) {
+  test('@charset hoist', async () => {
+    serverLogs.forEach((log) => {
+      // no warning from esbuild css minifier
+      expect(log).not.toMatch('"@charset" must be the first rule in the file')
+    })
+  })
+}
+
 test('@import dependency w/ style entry', async () => {
   expect(await getColor('.css-dep')).toBe('purple')
 })

--- a/packages/playground/css/charset.css
+++ b/packages/playground/css/charset.css
@@ -1,0 +1,5 @@
+@charset "utf-8";
+
+.utf8 {
+  color: green;
+}

--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -96,6 +96,9 @@
   <p>Inline CSS module:</p>
   <pre class="modules-inline"></pre>
 
+  <p>CSS with @charset:</p>
+  <pre class="charset-css"></pre>
+
   <p class="css-dep">
     @import dependency w/ style enrtrypoints: this should be purple
   </p>

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -41,6 +41,9 @@ text(
 import inlineMod from './inline.module.css?inline'
 text('.modules-inline', inlineMod)
 
+import charset from './charset.css'
+text('.charset-css', charset)
+
 import './dep.css'
 import './glob-dep.css'
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #6333

Hoist the first `@charset` found to the top of the css file

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
There could theoretically be two or more charsets in the file, and possibly with different values, but this doesn't seem to be an issue in the past so in this PR we try to suppress the minification warning from esbuild only.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
