### PR TITLE
perf(css): hoist at rules with regex

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -122,7 +122,7 @@ describe('hoist @ rules', () => {
     expect(result).toBe(`@import "bla";.foo{color:red;}`)
   })
 
-  test('hoist @import with semicolon in rl', async () => {
+  test('hoist @import with semicolon in quotes', async () => {
     const css = `.foo{color:red;}@import "bla;bar";`
     const result = await hoistAtRules(css)
     expect(result).toBe(`@import "bla;bar";.foo{color:red;}`)

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -122,6 +122,12 @@ describe('hoist @ rules', () => {
     expect(result).toBe(`@import "bla";.foo{color:red;}`)
   })
 
+  test('hoist @import with semicolon in rl', async () => {
+    const css = `.foo{color:red;}@import "bla;bar";`
+    const result = await hoistAtRules(css)
+    expect(result).toBe(`@import "bla;bar";.foo{color:red;}`)
+  })
+
   test('hoist @charset', async () => {
     const css = `.foo{color:red;}@charset "utf-8";`
     const result = await hoistAtRules(css)

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -1,4 +1,4 @@
-import { cssUrlRE, cssPlugin } from '../../plugins/css'
+import { cssUrlRE, cssPlugin, hoistAtRules } from '../../plugins/css'
 import { resolveConfig } from '../../config'
 import fs from 'fs'
 import path from 'path'
@@ -112,5 +112,33 @@ describe('css path resolutions', () => {
     `)
 
     mockFs.mockReset()
+  })
+})
+
+describe('hoist @ rules', () => {
+  test('hoist @import', async () => {
+    const css = `.foo{color:red;}@import "bla";`
+    const result = await hoistAtRules(css)
+    expect(result).toBe(`@import "bla";.foo{color:red;}`)
+  })
+
+  test('hoist @charset', async () => {
+    const css = `.foo{color:red;}@charset "utf-8";`
+    const result = await hoistAtRules(css)
+    expect(result).toBe(`@charset "utf-8";.foo{color:red;}`)
+  })
+
+  test('hoist one @charset only', async () => {
+    const css = `.foo{color:red;}@charset "utf-8";@charset "utf-8";`
+    const result = await hoistAtRules(css)
+    expect(result).toBe(`@charset "utf-8";.foo{color:red;}`)
+  })
+
+  test('hoist @import and @charset', async () => {
+    const css = `.foo{color:red;}@import "bla";@charset "utf-8";.bar{color:grren;}@import "baz";`
+    const result = await hoistAtRules(css)
+    expect(result).toBe(
+      `@charset "utf-8";@import "bla";@import "baz";.foo{color:red;}.bar{color:grren;}`
+    )
   })
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1106,36 +1106,27 @@ async function minifyCSS(css: string, config: ResolvedConfig) {
   return code
 }
 
-// #1845
-// CSS @import can only appear at top of the file. We need to hoist all @import
-// to top when multiple files are concatenated.
-// #6333
-// CSS @charset must be the top-first in the file, hoist to top too
-async function hoistAtRules(css: string) {
-  const postcss = await import('postcss')
-  return (await postcss.default([AtRuleHoistPlugin]).process(css)).css
-}
-
-const AtRuleHoistPlugin: PostCSS.PluginCreator<any> = () => {
-  return {
-    postcssPlugin: 'vite-hoist-at-rules',
-    Once(root) {
-      const imports: PostCSS.AtRule[] = []
-      let charset: PostCSS.AtRule | undefined
-      root.walkAtRules((rule) => {
-        if (rule.name === 'import') {
-          // record in reverse so that can simply prepend to preserve order
-          imports.unshift(rule)
-        } else if (!charset && rule.name === 'charset') {
-          charset = rule
-        }
-      })
-      imports.forEach((i) => root.prepend(i))
-      if (charset) root.prepend(charset)
+export async function hoistAtRules(css: string) {
+  const s = new MagicString(css)
+  // #1845
+  // CSS @import can only appear at top of the file. We need to hoist all @import
+  // to top when multiple files are concatenated.
+  s.replace(/@import.*?;/g, (match) => {
+    s.appendLeft(0, match)
+    return ''
+  })
+  // #6333
+  // CSS @charset must be the top-first in the file, hoist the first to top
+  let foundCharset = false
+  s.replace(/@charset.*?;/g, (match) => {
+    if (!foundCharset) {
+      s.prepend(match)
+      foundCharset = true
     }
-  }
+    return ''
+  })
+  return s.toString()
 }
-AtRuleHoistPlugin.postcss = true
 
 // Preprocessor support. This logic is largely replicated from @vue/compiler-sfc
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1111,14 +1111,15 @@ export async function hoistAtRules(css: string) {
   // #1845
   // CSS @import can only appear at top of the file. We need to hoist all @import
   // to top when multiple files are concatenated.
-  s.replace(/@import.*?;/g, (match) => {
+  // match until semicolon that's not in quotes
+  s.replace(/@import\s*(?:"[^"]*"|'[^']*'|[^;]*).*?;/gm, (match) => {
     s.appendLeft(0, match)
     return ''
   })
   // #6333
   // CSS @charset must be the top-first in the file, hoist the first to top
   let foundCharset = false
-  s.replace(/@charset.*?;/g, (match) => {
+  s.replace(/@charset\s*(?:"[^"]*"|'[^']*'|[^;]*).*?;/gm, (match) => {
     if (!foundCharset) {
       s.prepend(match)
       foundCharset = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When hoisting the at rules, use regex instead of postcss to do so for speed and reduced memory comsumption.

### Additional context

Noticed this additional optimization in #7678

Did some simple benchmarking on a concatenated 455KB css file.

Before: **202.29ms**
After: **15.519ms**

More than 10x faster (could be more on large file size)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
