### PR TITLE
refactor: esbuild handles `target` and `useDefineForClassFields`

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -81,6 +81,7 @@ export async function transformWithEsbuild(
     // these fields would affect the compilation result
     // https://esbuild.github.io/content-types/#tsconfig-json
     const meaningfulFields: Array<keyof TSCompilerOptions> = [
+      'target',
       'jsxFactory',
       'jsxFragmentFactory',
       'useDefineForClassFields',
@@ -98,17 +99,9 @@ export async function transformWithEsbuild(
           compilerOptionsForFile[field] = loadedCompilerOptions[field]
         }
       }
-
-      // align with TypeScript 4.3
-      // https://github.com/microsoft/TypeScript/pull/42663
-      if (loadedCompilerOptions.target?.toLowerCase() === 'esnext') {
-        compilerOptionsForFile.useDefineForClassFields =
-          loadedCompilerOptions.useDefineForClassFields ?? true
-      }
     }
 
     tsconfigRaw = {
-      ...tsconfigRaw,
       compilerOptions: {
         ...compilerOptionsForFile,
         ...tsconfigRaw?.compilerOptions


### PR DESCRIPTION
esbuild has added the corresponding handling logic in 0.14.0 and 0.14.35:

- https://github.com/evanw/esbuild/releases/tag/v0.14.0
- https://github.com/evanw/esbuild/releases/tag/v0.14.35

So our workaround is no longer needed.


### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
