### PR TITLE
chore: type unknown env as any

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -42,7 +42,7 @@ In addition, environment variables that already exist when Vite is executed have
 `.env` files are loaded at the start of Vite. Restart the server after making changes.
 :::
 
-Loaded env variables are also exposed to your client source code via `import.meta.env`.
+Loaded env variables are also exposed to your client source code via `import.meta.env` as strings.
 
 To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code. e.g. the following file:
 

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -36,7 +36,7 @@ interface ImportMeta {
 }
 
 interface ImportMetaEnv {
-  [key: string]: string | boolean | undefined
+  [key: string]: any
   BASE_URL: string
   MODE: string
   DEV: boolean


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Type `import.meta.env.*` as `any` for unknown keys, as the `define` option can be used to define `import.meta.env.*` too with JS identifiers.

### Additional context

Brought up in #6930 and https://github.com/vitejs/vite/pull/4415#issuecomment-888563775

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
