### PR TITLE
docs: declaration test env different with production

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ test('should work', async () => {
 
 Some common test helpers, e.g. `testDir`, `isBuild` or `editFile` are available in `packages/playground/testUtils.ts`.
 
+Note: test build environment skip transpilation during tests to make it faster, This makes the js files not process by `esbuild` compared to the production environment.
+
 ### Extending the Test Suite
 
 To add new tests, you should find a related playground to the fix or feature (or create a new one). As an example, static assets loading are tested in the [assets playground](https://github.com/vitejs/vite/tree/main/packages/playground/assets). In this Vite App, there is a test for `?raw` imports, with [a section is defined in the `index.html` for it](https://github.com/vitejs/vite/blob/71215533ac60e8ff566dc3467feabfc2c71a01e2/packages/playground/assets/index.html#L121):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,31 @@ test('should work', async () => {
 
 Some common test helpers, e.g. `testDir`, `isBuild` or `editFile` are available in `packages/playground/testUtils.ts`.
 
-Note: test build environment skip transpilation during tests to make it faster, This makes the js files not process by `esbuild` compared to the production environment.
+Note: test build environment uses a different default set of Vite config to skip transpilation during tests to make it faster. But this makes the js files not process by `esbuild` compared to the production environment.
+
+```ts
+export default {
+  root: rootDir,
+  logLevel: 'silent',
+  server: {
+    watch: {
+      // During tests we edit the files too fast and sometimes chokidar
+      // misses change events, so enforce polling for consistency
+      usePolling: true,
+      interval: 100
+    },
+    host: true,
+    fs: {
+      strict: !isBuildTest
+    }
+  },
+  build: {
+    // skip transpilation during tests to make it faster
+    target: 'esnext'
+  },
+  customLogger: createInMemoryLogger(serverLogs)
+}
+```
 
 ### Extending the Test Suite
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ test('should work', async () => {
 
 Some common test helpers, e.g. `testDir`, `isBuild` or `editFile` are available in `packages/playground/testUtils.ts`.
 
-Note: test build environment uses a different default set of Vite config to skip transpilation during tests to make it faster. But this makes the js files not process by `esbuild` compared to the production environment.
+Note: The test build environment uses a [different default set of Vite config](https://github.com/vitejs/vite/blob/9c6501d9c363eaa3c1e7708d531fb2a92b633db6/scripts/jestPerTestSetup.ts#L102-L122) to skip transpilation during tests to make it faster. This may produce a different result compared to the default production build.
 
 ```ts
 export default {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,30 +97,6 @@ Some common test helpers, e.g. `testDir`, `isBuild` or `editFile` are available 
 
 Note: The test build environment uses a [different default set of Vite config](https://github.com/vitejs/vite/blob/9c6501d9c363eaa3c1e7708d531fb2a92b633db6/scripts/jestPerTestSetup.ts#L102-L122) to skip transpilation during tests to make it faster. This may produce a different result compared to the default production build.
 
-```ts
-export default {
-  root: rootDir,
-  logLevel: 'silent',
-  server: {
-    watch: {
-      // During tests we edit the files too fast and sometimes chokidar
-      // misses change events, so enforce polling for consistency
-      usePolling: true,
-      interval: 100
-    },
-    host: true,
-    fs: {
-      strict: !isBuildTest
-    }
-  },
-  build: {
-    // skip transpilation during tests to make it faster
-    target: 'esnext'
-  },
-  customLogger: createInMemoryLogger(serverLogs)
-}
-```
-
 ### Extending the Test Suite
 
 To add new tests, you should find a related playground to the fix or feature (or create a new one). As an example, static assets loading are tested in the [assets playground](https://github.com/vitejs/vite/tree/main/packages/playground/assets). In this Vite App, there is a test for `?raw` imports, with [a section is defined in the `index.html` for it](https://github.com/vitejs/vite/blob/71215533ac60e8ff566dc3467feabfc2c71a01e2/packages/playground/assets/index.html#L121):

--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -115,6 +115,7 @@ beforeAll(async () => {
           }
         },
         build: {
+          // esbuild do not minify ES lib output since that would remove pure annotations and break tree-shaking
           // skip transpilation during tests to make it faster
           target: 'esnext'
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I'm testing `import.meta.url` and I found that there was a difference between my build running results and the running results of the test environment.

I think there is no compressed code. Esbuild does not process JS files, so it leads to the difference, So make a note.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
