### PR TITLE
docs: Use .mjs extension for library ESM bundle

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -127,7 +127,7 @@ module.exports = defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'lib/main.js'),
       name: 'MyLib',
-      fileName: (format) => `my-lib.${format}.js`
+      fileName: (format) => `my-lib.${format}.${format === 'es' ? 'mjs' : 'js'}`
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
@@ -159,7 +159,7 @@ Running `vite build` with this config uses a Rollup preset that is oriented towa
 ```
 $ vite build
 building for production...
-[write] my-lib.es.js 0.08kb, brotli: 0.07kb
+[write] my-lib.es.mjs 0.08kb, brotli: 0.07kb
 [write] my-lib.umd.js 0.30kb, brotli: 0.16kb
 ```
 
@@ -170,10 +170,10 @@ Recommended `package.json` for your lib:
   "name": "my-lib",
   "files": ["dist"],
   "main": "./dist/my-lib.umd.js",
-  "module": "./dist/my-lib.es.js",
+  "module": "./dist/my-lib.es.mjs",
   "exports": {
     ".": {
-      "import": "./dist/my-lib.es.js",
+      "import": "./dist/my-lib.es.mjs",
       "require": "./dist/my-lib.umd.js"
     }
   }


### PR DESCRIPTION
As explained in #7609, when importing an ES module in Node.js, either its package needs to have `"type": "module"` set in its `package.json`, or its file extension needs to be `.mjs`. Otherwise the file will be interpreted as CommonJS and the import will fail.

The [Library](https://vitejs.dev/guide/build.html#library-mode) section of the Vite docs documents how to publish a library and also recommends to add an `exports` section to `package.json`. As far as I am aware, this section tells Node.js which file to import, although I believe some frontend bundlers are also adding support for it these days. The current documentation encourages developers to publish their ESM bundles with a `.es.js` extension, which will make the package impossible to be imported from an ESM Node.js project. Since not many Node.js projects use ESM yet, many developers are not aware of this problem.

This pull request changes the documentation to recommend the use of the `.mjs` extension for the generated bundle. This way the library bundle can be successfully used both in Node.js and in frontend bundlers.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other