### PR TITLE
fix: revert optimizeDeps false, keep optimizedDeps.disabled

### DIFF
--- a/packages/playground/vue-jsx/vite.config.js
+++ b/packages/playground/vue-jsx/vite.config.js
@@ -36,5 +36,7 @@ export default defineComponent(() => {
     // to make tests faster
     minify: false
   },
-  optimizeDeps: false
+  optimizeDeps: {
+    disabled: true
+  }
 }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -145,10 +145,8 @@ export interface UserConfig {
   preview?: PreviewOptions
   /**
    * Dep optimization options
-   *
-   * false disables optimization completely (experimental)
    */
-  optimizeDeps?: DepOptimizationOptions | false
+  optimizeDeps?: DepOptimizationOptions
   /**
    * SSR specific options
    * @alpha
@@ -501,7 +499,7 @@ export async function resolveConfig(
     packageCache: new Map(),
     createResolver,
     optimizeDeps: {
-      disabled: config.optimizeDeps === false,
+      disabled: optimizeDeps.disabled === true,
       ...optimizeDeps,
       esbuildOptions: {
         keepNames: optimizeDeps.keepNames,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -499,7 +499,6 @@ export async function resolveConfig(
     packageCache: new Map(),
     createResolver,
     optimizeDeps: {
-      disabled: optimizeDeps.disabled === true,
       ...optimizeDeps,
       esbuildOptions: {
         keepNames: optimizeDeps.keepNames,


### PR DESCRIPTION
### Description

This feat was never released, it is safe to remove it. See https://github.com/vitejs/vite/pull/7646#issuecomment-1097916379

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other