### PR TITLE
fix(ssr): rewrite dynamic class method name (fix #7751)

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -545,6 +545,45 @@ class A {
   `)
 })
 
+test('class methods', async () => {
+  expect(
+    (
+      await ssrTransform(
+        `
+import foo from 'foo'
+
+const bar = 'bar'
+
+class A {
+  foo() {}
+  [foo]() {}
+  [bar]() {}
+  #foo() {}
+  bar(foo) {}
+}
+`,
+        null,
+        null
+      )
+    ).code
+  ).toMatchInlineSnapshot(`
+    "
+    const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"foo\\");
+
+
+    const bar = 'bar'
+
+    class A {
+      foo() {}
+      [__vite_ssr_import_0__.default]() {}
+      [bar]() {}
+      #foo() {}
+      bar(foo) {}
+    }
+    "
+  `)
+})
+
 test('declare scope', async () => {
   expect(
     (

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -429,7 +429,7 @@ function isRefIdentifier(id: Identifier, parent: _Node, parentStack: _Node[]) {
   }
 
   // class method name
-  if (parent.type === 'MethodDefinition') {
+  if (parent.type === 'MethodDefinition' && !parent.computed) {
     return false
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Fix #7751
Fix https://github.com/vitest-dev/vitest/issues/1155

```js
import { value } from "./const";

describe("test class", () => {
  it("test class", () => {
    console.log("value", value); // this `value` wrote correctly
    class A {
      [value]() {} // this `value` was not rewritten
    }
  });
});
```

### Additional context

Related code of vue/compiler-core: https://github.com/vuejs/core/blob/74d2a76af6e830af5abb8aac8484dc1b3e90a510/packages/compiler-core/src/babelUtils.ts#L288-L297

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
