### PR TITLE
feat(legacy): Add configuration for skip assets emit logic

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -127,6 +127,13 @@ export default {
 
   Defaults to `false`. Enabling this option will exclude `systemjs/dist/s.min.js` inside polyfills-legacy chunk.
 
+### `skipAssetsEmits`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+  Defaults to `true`. This is useful for disabling it by setting it to `false` only if you are using a plugin that requires it.
+
 ## Dynamic Import
 
 The legacy plugin offers a way to use native `import()` in the modern build while falling back to the legacy build in browsers with native ESM but without dynamic import support (e.g. Legacy Edge). This feature works by injecting a runtime check and loading the legacy bundle with SystemJs runtime if needed. There are the following drawbacks:

--- a/packages/plugin-legacy/index.d.ts
+++ b/packages/plugin-legacy/index.d.ts
@@ -26,6 +26,10 @@ export interface Options {
    * default: false
    */
   externalSystemJS?: boolean
+  /**
+   * default: true
+   */
+  skipAssetsEmits?: boolean
 }
 
 declare function createPlugin(options?: Options): Plugin

--- a/packages/plugin-legacy/index.js
+++ b/packages/plugin-legacy/index.js
@@ -39,6 +39,7 @@ function viteLegacyPlugin(options = {}) {
   const targets = options.targets || 'defaults'
   const genLegacy = options.renderLegacyChunks !== false
   const genDynamicFallback = genLegacy
+  const skipAssetsEmit = options.skipAssetsEmits !== false
 
   const debugFlags = (process.env.DEBUG || '').split(',')
   const isDebug =
@@ -293,8 +294,9 @@ function viteLegacyPlugin(options = {}) {
       // In the `generateBundle` hook,
       // we'll delete the assets from the legacy bundle to avoid emitting duplicate assets.
       // But that's still a waste of computing resource.
-      // So we add this flag to avoid emitting the asset in the first place whenever possible.
-      opts.__vite_skip_asset_emit__ = true
+      // By default, we add this flag to true to avoid emitting the asset in the first place whenever possible.
+      // By configuring skipAssetsEmits to false, you can re-enable the asset emit to have compatibility with other plugins that require its use.
+      opts.__vite_skip_asset_emit__ = skipAssetsEmit
 
       // @ts-ignore avoid emitting assets for legacy bundle
       const needPolyfills =


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
closes #7422 
The goal of this PR is to enable the emission of assets in the legacy plugin via a configuration parameter.

### Additional context

This is necessary because in some cases, as specified in the attached issue, this total skip of the issue does not allow the execution of a plugin that I have developed, which has to do with assets. However, this parameter remains true by default, not changing the basic behavior of the plugin. 
This would allow anyone who develops a plugin for `Vite` to have compatibility with the `plugin-legacy` in case they need to access the assets even at the time of the build of the `plugin-legacy` output.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
