### PR TITLE
feat: add configuration option to disable automatic "modulepreloads"

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -726,6 +726,15 @@ export default defineConfig({
 
   Note the build will fail if the code contains features that cannot be safely transpiled by esbuild. See [esbuild docs](https://esbuild.github.io/content-types/#javascript) for more details.
 
+### build.modulePreload
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+  Whether to automatically inject module preloads.
+
+  If set to `true`, the proxy module is injected in each `index.html` entry. If `.js`-chunks are manually resolved (e. g. via Glob Import) this could lead to problems like double fetching or wrong path resolving when linking to the main JavaScript file from other domains.
+
 ### build.polyfillModulePreload
 
 - **Type:** `boolean`

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -280,7 +280,9 @@ for (const path in modules) {
 }
 ```
 
-Matched files are by default lazy loaded via dynamic import and will be split into separate chunks during build. If you'd rather import all the modules directly (e.g. relying on side-effects in these modules to be applied first), you can use `import.meta.globEager` instead:
+Matched files are by default lazy loaded via dynamic import and will be split into separate chunks during build. Be careful with this function, as this can lead to double fetching of files, if `build.modulePreload` is turned on.
+
+If you'd rather import all the modules directly (e.g. relying on side-effects in these modules to be applied first), you can use `import.meta.globEager` instead:
 
 ```js
 const modules = import.meta.globEager('./dir/*.js')

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -65,6 +65,12 @@ export interface BuildOptions {
    */
   target?: 'modules' | TransformOptions['target'] | false
   /**
+   * whether to inject module preload.
+   * Note: does not apply to library mode and SSR.
+   * @default true
+   */
+  modulePreload?: boolean
+  /**
    * whether to inject module preload polyfill.
    * Note: does not apply to library mode.
    * @default true
@@ -236,6 +242,7 @@ export type ResolvedBuildOptions = Required<
 export function resolveBuildOptions(raw?: BuildOptions): ResolvedBuildOptions {
   const resolved: ResolvedBuildOptions = {
     target: 'modules',
+    modulePreload: true,
     polyfillModulePreload: true,
     outDir: 'dist',
     assetsDir: 'assets',

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -85,7 +85,8 @@ function preload(baseModule: () => Promise<{}>, deps?: string[]) {
  */
 export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
   const ssr = !!config.build.ssr
-  const insertPreload = !(ssr || !!config.build.lib)
+  const insertPreload =
+    !(ssr || !!config.build.lib) && !!config.build.modulePreload
   const isWorker = config.isWorker
 
   const scriptRel = config.build.polyfillModulePreload


### PR DESCRIPTION
### Description
When being not in `lib`-mode a script is injected in the main `js`-file which automatically adds chunked files to the html `<head>` and links them with `<link rel="modulepreload">` or `<link rel="preload">`.

The following line is responsible for the injection: https://github.com/vitejs/vite/blob/9a932339aae8bfbb9f3b522706c551a21a1eea3a/packages/vite/src/node/plugins/importAnalysisBuild.ts#L94

In most cases this behaviour is fine, but can lead to problems in combination with glob importing:
1. I'm creating a Web Components library which is used from other domains. I use glob importing to import the components (and maybe will add some lazy loading). Nevertheless the script adds lots of `<link rel="modulepreload">`s to the recipients `<head>` – which leads to overhead in the `main.js` I don't need and want (about 2-3kb uncompressed) AND failing fetches as the links link relatively to the base of the `url`. 
2. When creating a static website within the same repo, using the same Web Component library, this leads to doubled fetches in Safari and FireFox.

The only possibility (which apparently is being used!) is ugly RegEx/replacement to remove the problematic and in that case unneded code after build time.

This PR introduces a build option to completely disable the injection of the script.

The following issues could benefit from this PR:
- https://github.com/vitejs/vite/issues/5532
- https://github.com/vitejs/vite/issues/5214
- https://github.com/vitejs/vite/issues/3133
- https://github.com/vitejs/vite/issues/5120
- https://github.com/vitejs/vite/issues/5991
- https://stackoverflow.com/questions/70980498/disable-preload-in-vite

### Additional context

I didn't add a test – it would be great, if someone with more experience in Vite-development could help out with that! ❤️

---

### What is the purpose of this pull request?

- [x] Bug fix
- [x] New Feature

(I'm not sure whether this is more a bug fix or a feature. 😄)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
