### PR TITLE
feat: support ESM subpath imports

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import type { Exports, Imports } from 'resolve.exports'
 import { createDebugger, createFilter, resolveFrom } from './utils'
 import type { ResolvedConfig } from './config'
 import type { Plugin } from './plugin'
@@ -27,7 +28,8 @@ export interface PackageData {
     main: string
     module: string
     browser: string | Record<string, string | false>
-    exports: string | Record<string, any> | string[]
+    exports: Exports
+    imports: Imports
     dependencies: Record<string, string>
   }
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -156,13 +156,14 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       const resolveSubpathImports = (id: string, importer?: string) => {
         if (!importer || !id.startsWith(subpathImportsPrefix)) return
         const basedir = path.dirname(importer)
-        const importerPkgJson = lookupFile(basedir, ['package.json'], {
-          predicate: (content) => !!JSON.parse(content).name,
+        const pkgJsonPath = lookupFile(basedir, ['package.json'], {
+          pathOnly: true,
         })
-        if (!importerPkgJson) return
+        if (!pkgJsonPath) return
 
+        const pkgData = loadPackageData(pkgJsonPath, options.preserveSymlinks)
         return resolveExportsOrImports(
-          JSON.parse(importerPkgJson),
+          pkgData.data,
           id,
           options,
           targetWeb,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import colors from 'picocolors'
 import type { PartialResolvedId } from 'rollup'
-import { exports } from 'resolve.exports'
+import { exports, imports } from 'resolve.exports'
 import { hasESMSyntax } from 'mlly'
 import type { Plugin } from '../plugin'
 import {
@@ -55,6 +55,7 @@ export const browserExternalId = '__vite-browser-external'
 export const optionalPeerDepId = '__vite-optional-peer-dep'
 
 const nodeModulesInPathRE = /(?:^|\/)node_modules\//
+const subpathImportsPrefix = '#'
 
 const isDebug = process.env.DEBUG
 const debug = createDebugger('vite:resolve-details', {
@@ -150,6 +151,28 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         isRequire,
         ...resolveOptions,
         scan: resolveOpts?.scan ?? resolveOptions.scan,
+      }
+
+      const resolveSubpathImports = (id: string, importer?: string) => {
+        if (!importer || !id.startsWith(subpathImportsPrefix)) return
+        const basedir = path.dirname(importer)
+        const importerPkgJson = lookupFile(basedir, ['package.json'], {
+          predicate: (content) => !!JSON.parse(content).name,
+        })
+        if (!importerPkgJson) return
+
+        return resolveExportsOrImports(
+          JSON.parse(importerPkgJson),
+          id,
+          options,
+          targetWeb,
+          'imports',
+        )
+      }
+
+      const resolvedImports = resolveSubpathImports(id, importer)
+      if (resolvedImports) {
+        id = resolvedImports
       }
 
       if (importer) {
@@ -958,7 +981,13 @@ export function resolvePackageEntry(
     // resolve exports field with highest priority
     // using https://github.com/lukeed/resolve.exports
     if (data.exports) {
-      entryPoint = resolveExports(data, '.', options, targetWeb)
+      entryPoint = resolveExportsOrImports(
+        data,
+        '.',
+        options,
+        targetWeb,
+        'exports',
+      )
     }
 
     const resolvedFromExports = !!entryPoint
@@ -1076,11 +1105,12 @@ function packageEntryFailure(id: string, details?: string) {
 
 const conditionalConditions = new Set(['production', 'development', 'module'])
 
-function resolveExports(
+function resolveExportsOrImports(
   pkg: PackageData['data'],
   key: string,
   options: InternalResolveOptionsWithOverrideConditions,
   targetWeb: boolean,
+  type: 'imports' | 'exports',
 ) {
   const overrideConditions = options.overrideConditions
     ? new Set(options.overrideConditions)
@@ -1115,7 +1145,8 @@ function resolveExports(
     conditions.push(...options.conditions)
   }
 
-  const result = exports(pkg, key, {
+  const fn = type === 'imports' ? imports : exports
+  const result = fn(pkg, key, {
     browser: targetWeb && !conditions.includes('node'),
     require: options.isRequire && !conditions.includes('import'),
     conditions,
@@ -1149,7 +1180,13 @@ function resolveDeepImport(
     if (isObject(exportsField) && !Array.isArray(exportsField)) {
       // resolve without postfix (see #7098)
       const { file, postfix } = splitFileAndPostfix(relativeId)
-      const exportsId = resolveExports(data, file, options, targetWeb)
+      const exportsId = resolveExportsOrImports(
+        data,
+        file,
+        options,
+        targetWeb,
+        'exports',
+      )
       if (exportsId !== undefined) {
         relativeId = exportsId + postfix
       } else {

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -158,3 +158,23 @@ test('resolve package that contains # in path', async () => {
     '[success]',
   )
 })
+
+test('Resolving top level with imports field', async () => {
+  expect(await page.textContent('.imports-top-level')).toMatch('[success]')
+})
+
+test('Resolving nested path with imports field', async () => {
+  expect(await page.textContent('.imports-nested')).toMatch('[success]')
+})
+
+test('Resolving star with imports filed', async () => {
+  expect(await page.textContent('.imports-star')).toMatch('[success]')
+})
+
+test('Resolving slash with imports filed', async () => {
+  expect(await page.textContent('.imports-slash')).toMatch('[success]')
+})
+
+test('Resolving from other package with imports field', async () => {
+  expect(await page.textContent('.imports-pkg-slash')).toMatch('[success]')
+})

--- a/playground/resolve/imports-path/nested-path.js
+++ b/playground/resolve/imports-path/nested-path.js
@@ -1,0 +1,1 @@
+export const msg = '[success] nested path subpath imports'

--- a/playground/resolve/imports-path/other-pkg/nest/index.js
+++ b/playground/resolve/imports-path/other-pkg/nest/index.js
@@ -1,0 +1,1 @@
+export const msg = '[success] subpath imports from other package'

--- a/playground/resolve/imports-path/other-pkg/package.json
+++ b/playground/resolve/imports-path/other-pkg/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@vitejs/test-resolve-imports-pkg",
+  "private": true
+}

--- a/playground/resolve/imports-path/slash/index.js
+++ b/playground/resolve/imports-path/slash/index.js
@@ -1,0 +1,1 @@
+export const msg = '[success] subpath imports with slash'

--- a/playground/resolve/imports-path/star/index.js
+++ b/playground/resolve/imports-path/star/index.js
@@ -1,0 +1,1 @@
+export const msg = '[success] subpath imports with star'

--- a/playground/resolve/imports-path/top-level.js
+++ b/playground/resolve/imports-path/top-level.js
@@ -1,0 +1,1 @@
+export const msg = '[success] top level subpath imports'

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -36,6 +36,21 @@
 <h2>Exports with module</h2>
 <p class="exports-with-module">fail</p>
 
+<h2>Resolving top level with imports field</h2>
+<p class="imports-top-level">fail</p>
+
+<h2>Resolving nested path with imports field</h2>
+<p class="imports-nested">fail</p>
+
+<h2>Resolving star with imports filed</h2>
+<p class="imports-star">fail</p>
+
+<h2>Resolving slash with imports filed</h2>
+<p class="imports-slash">fail</p>
+
+<h2>Resolving from other package with imports field</h2>
+<p class="imports-pkg-slash">fail</p>
+
 <h2>Resolve /index.*</h2>
 <p class="index">fail</p>
 
@@ -186,6 +201,22 @@
 
   import { msg as exportsWithModule } from '@vitejs/test-resolve-exports-with-module'
   text('.exports-with-module', exportsWithModule)
+
+  // imports field
+  import { msg as importsTopLevel } from '#top-level'
+  text('.imports-top-level', importsTopLevel)
+
+  import { msg as importsNested } from '#nested/path.js'
+  text('.imports-nested', importsNested)
+
+  import { msg as importsStar } from '#star/index.js'
+  text('.imports-star', importsStar)
+
+  import { msg as importsSlash } from '#slash/index.js'
+  text('.imports-slash', importsSlash)
+
+  import { msg as importsPkgSlash } from '#other-pkg-slash/index.js'
+  text('.imports-pkg-slash', importsPkgSlash)
 
   // implicit index resolving
   import { foo } from './util'

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -8,6 +8,13 @@
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
   },
+  "imports": {
+    "#top-level": "./imports-path/top-level.js",
+    "#nested/path.js": "./imports-path/nested-path.js",
+    "#star/*": "./imports-path/star/*",
+    "#slash/": "./imports-path/slash/",
+    "#other-pkg-slash/": "@vitejs/test-resolve-imports-pkg/nest/"
+  },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "es5-ext": "0.10.62",
@@ -25,6 +32,7 @@
     "@vitejs/test-resolve-exports-legacy-fallback": "link:./exports-legacy-fallback",
     "@vitejs/test-resolve-exports-path": "link:./exports-path",
     "@vitejs/test-resolve-exports-with-module": "link:./exports-with-module",
-    "@vitejs/test-resolve-linked": "workspace:*"
+    "@vitejs/test-resolve-linked": "workspace:*",
+    "@vitejs/test-resolve-imports-pkg": "link:./imports-path/other-pkg"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,6 +809,7 @@ importers:
       '@vitejs/test-resolve-exports-legacy-fallback': link:./exports-legacy-fallback
       '@vitejs/test-resolve-exports-path': link:./exports-path
       '@vitejs/test-resolve-exports-with-module': link:./exports-with-module
+      '@vitejs/test-resolve-imports-pkg': link:./imports-path/other-pkg
       '@vitejs/test-resolve-linked': workspace:*
       es5-ext: 0.10.62
       normalize.css: ^8.0.1
@@ -827,6 +828,7 @@ importers:
       '@vitejs/test-resolve-exports-legacy-fallback': link:exports-legacy-fallback
       '@vitejs/test-resolve-exports-path': link:exports-path
       '@vitejs/test-resolve-exports-with-module': link:exports-with-module
+      '@vitejs/test-resolve-imports-pkg': link:imports-path/other-pkg
       '@vitejs/test-resolve-linked': link:../resolve-linked
       es5-ext: 0.10.62
       normalize.css: 8.0.1
@@ -880,6 +882,9 @@ importers:
     specifiers: {}
 
   playground/resolve/exports-with-module:
+    specifiers: {}
+
+  playground/resolve/imports-path/other-pkg:
     specifiers: {}
 
   playground/resolve/inline-package:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
resolve #7385 

Vite now uses https://github.com/lukeed/resolve.exports to determine the target file of exports filed. According to the node.js [spec](https://nodejs.org/api/packages.html#subpath-imports) and this https://github.com/lukeed/resolve.exports/issues/14. This PR made a little fork of `resolve.exports` based on https://gist.github.com/okikio/3f07571c7707dc6e6eb4906b951c6bc3 to implement `resolve.imports`. We can remove the code from Vite until `resovle.exports` supports `imports` filed.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

1. 

https://github.com/fi3ework/vite/blob/7acab6a9db3aecb7b11d955598c1b48d58f7956b/packages/vite/src/node/plugins/resolve.ts#L152-L154

This PR re-assign `id` at the beginning for `imports`, I'm not sure is it the best way to do this or we could add another plugin like `pre-alias`? 🤔

2. The test cases referenced https://github.com/evanw/esbuild/commit/62a3943bfc354898442b6cd8b5291c749bebfa05

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
