### PR TITLE
test: fix properly use terser for preload test

### DIFF
--- a/packages/playground/preload/vite.config.js
+++ b/packages/playground/preload/vite.config.js
@@ -3,6 +3,7 @@ const vuePlugin = require('@vitejs/plugin-vue')
 module.exports = {
   plugins: [vuePlugin()],
   build: {
+    minify: 'terser',
     terserOptions: {
       format: {
         beautify: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`build.terserOptions` was set for #4163 but `build.minify` was not set.
This PR simply adds `minify: 'terser'`.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
