### PR TITLE
Revert "chore: add isolatedModules to create-vite > template-vue-ts > tsconfig"

### DIFF
--- a/packages/create-vite/template-vue-ts/tsconfig.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.json
@@ -8,7 +8,6 @@
     "jsx": "preserve",
     "sourceMap": true,
     "resolveJsonModule": true,
-    "isolatedModules": true,
     "esModuleInterop": true,
     "lib": ["esnext", "dom"]
   },


### PR DESCRIPTION
Reverts vitejs/vite#7304

See https://github.com/vuejs/core/issues/1228

Using `npm run build` is broken in a clean `npm create vite@latest` with `vue-ts`. This is the beginning of the error:

```
node_modules/@vue/reactivity/dist/reactivity.d.ts:26:15 - error TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.

26     readonly [ReactiveFlags.IS_READONLY]: boolean;
```