### PR TITLE
chore: worker sourcemap output style

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -184,10 +184,15 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
               }
             } else if (chunk.source) {
               const isCSS = chunk.fileName.endsWith('.css')
+              const isMap = chunk.fileName.endsWith('.js.map')
               printFileInfo(
                 chunk.fileName,
                 chunk.source,
-                isCSS ? WriteType.CSS : WriteType.ASSET,
+                isCSS
+                  ? WriteType.CSS
+                  : isMap
+                  ? WriteType.SOURCE_MAP
+                  : WriteType.ASSET,
                 longest,
                 isCSS ? await getCompressedSize(chunk.source) : undefined
               )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

before:
![image](https://user-images.githubusercontent.com/36070057/163998959-954c96b4-a6b0-48b4-80c1-a65490bb9494.png)


after:
![image](https://user-images.githubusercontent.com/36070057/163998889-d71e8d50-9676-4d39-9c95-3d9452028f11.png)


make worker sourcemap output report color with simple sourcemap color.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
