### PR TITLE
fix: don't transform process.env. when build target is node

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -48,9 +48,12 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     ssr: boolean
   ): [Record<string, string | undefined>, RegExp | null] {
     const processEnv: Record<string, string> = {}
+    const isNodeTarget =
+      typeof config.build.target === 'string' &&
+      config.build.target.startsWith('node')
     const isNeedProcessEnv = !ssr || config.ssr?.target === 'webworker'
 
-    if (isNeedProcessEnv) {
+    if (isNeedProcessEnv && !isNodeTarget) {
       Object.assign(processEnv, {
         'process.env.': `({}).`,
         'global.process.env.': `({}).`,
@@ -59,7 +62,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     }
 
     const replacements: Record<string, string> = {
-      ...(isNeedProcessEnv ? processNodeEnv : {}),
+      ...(isNeedProcessEnv && !isNodeTarget ? processNodeEnv : {}),
       ...userDefine,
       ...importMetaKeys,
       ...processEnv


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When build target is `node`, `process.env. ` will be left as is without transformation. Currently, process.env.FOO will always be transformed as ({}).FOO, which is undesirable when running in node.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
