### PR TITLE
fix: ssr.noExternal with boolean values

### DIFF
--- a/packages/playground/ssr-webworker/vite.config.js
+++ b/packages/playground/ssr-webworker/vite.config.js
@@ -10,9 +10,18 @@ module.exports = {
   },
   ssr: {
     target: 'webworker',
-    noExternal: true
+    noExternal: ['this-should-be-replaced-by-the-boolean']
   },
   plugins: [
+    {
+      config() {
+        return {
+          ssr: {
+            noExternal: true
+          }
+        }
+      }
+    },
     {
       config() {
         return {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -745,7 +745,8 @@ function mergeConfigRecursively(
     } else if (key === 'assetsInclude' && rootPath === '') {
       merged[key] = [].concat(existing, value)
       continue
-    } else if (key === 'noExternal' && existing === true) {
+    } else if (key === 'noExternal' && (existing === true || value === true)) {
+      merged[key] = true
       continue
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It was working when a plugin tried to replace an existing boolean value. However, it failed when a plugin tried to overwrite an array with a boolean value. The test is now checking both situations.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
