### PR TITLE
fix: modulepreload polyfill only during build (fix #4786)

### DIFF
--- a/packages/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/packages/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -32,6 +32,12 @@ if (isBuild) {
     expect(htmlEntry.assets.length).toEqual(1)
   })
 } else {
+  test('No ReferenceError', async () => {
+    browserErrors.forEach((error) => {
+      expect(error.name).not.toBe('ReferenceError')
+    })
+  })
+
   describe('CSS HMR', () => {
     test('preserve the base in CSS HMR', async () => {
       await untilUpdated(() => getColor('body'), 'black') // sanity check

--- a/packages/playground/backend-integration/frontend/entrypoints/main.ts
+++ b/packages/playground/backend-integration/frontend/entrypoints/main.ts
@@ -1,3 +1,5 @@
+import 'vite/modulepreload-polyfill'
+
 export const colorClass = 'text-black'
 
 export function colorHeading() {

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -5,7 +5,8 @@ import { isModernFlag } from './importAnalysisBuild'
 export const modulePreloadPolyfillId = 'vite/modulepreload-polyfill'
 
 export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
-  const skip = config.build.ssr
+  // `isModernFlag` is only available during build since it is resolved by `vite:build-import-analysis`
+  const skip = config.command !== 'build' || config.build.ssr
   let polyfillString: string | undefined
 
   return {

--- a/scripts/jestPerTestSetup.ts
+++ b/scripts/jestPerTestSetup.ts
@@ -24,6 +24,7 @@ declare global {
   const page: Page | undefined
 
   const browserLogs: string[]
+  const browserErrors: Error[]
   const serverLogs: string[]
   const viteTestUrl: string | undefined
   const watcher: RollupWatcher | undefined
@@ -34,6 +35,7 @@ declare const global: {
   page?: Page
 
   browserLogs: string[]
+  browserErrors: Error[]
   serverLogs: string[]
   viteTestUrl?: string
   watcher?: RollupWatcher
@@ -56,6 +58,11 @@ const onConsole = (msg: ConsoleMessage) => {
   logs.push(msg.text())
 }
 
+const errors: Error[] = (global.browserErrors = [])
+const onPageError = (error: Error) => {
+  errors.push(error)
+}
+
 beforeAll(async () => {
   const page = global.page
   if (!page) {
@@ -63,6 +70,7 @@ beforeAll(async () => {
   }
   try {
     page.on('console', onConsole)
+    page.on('pageerror', onPageError)
 
     const testPath = expect.getState().testPath
     const testName = slash(testPath).match(/playground\/([\w-]+)\//)?.[1]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I changed the content of `vite/modulepreload-polyfill` to `''` not during dev.
This will fix #4786.

I think this change can be justified for the following reason.
- polyfill is not necessary during dev
  - also even if this polyfill is not included and modulepreload is not supported, the code works unlike other polyfills
- the current polyfill includes `__VITE_IS_MODERN__` and it only works during build
  - it can be solved by avoiding this by replacing this even not during build, but I don't think it is needed

fixes #4786 
close #6507

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
