### PR TITLE
fix: update sourcemap in importAnalysisBuild

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -22,7 +22,7 @@ export const preloadMarker = `__VITE_PRELOAD__`
 export const preloadBaseMarker = `__VITE_PRELOAD_BASE__`
 
 const preloadHelperId = 'vite/preload-helper'
-const preloadMarkerWithQuote = `"${preloadMarker}"`
+const preloadMarkerWithQuote = `"${preloadMarker}"` as const
 
 /**
  * Helper for preloading CSS and direct imports of async chunks in parallel to
@@ -328,16 +328,16 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 addDeps(normalizedFile)
               }
 
-              let markPos = code.indexOf(preloadMarker, end)
+              let markerStartPos = code.indexOf(preloadMarkerWithQuote, end)
               // fix issue #3051
-              if (markPos === -1 && imports.length === 1) {
-                markPos = code.indexOf(preloadMarker)
+              if (markerStartPos === -1 && imports.length === 1) {
+                markerStartPos = code.indexOf(preloadMarkerWithQuote)
               }
 
-              if (markPos > 0) {
+              if (markerStartPos > 0) {
                 s.overwrite(
-                  markPos - 1,
-                  markPos + preloadMarker.length + 1,
+                  markerStartPos,
+                  markerStartPos + preloadMarkerWithQuote.length,
                   // the dep list includes the main chunk, so only need to
                   // preload when there are actual other deps.
                   deps.size > 1 ||
@@ -347,7 +347,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                     : `[]`,
                   { contentOnly: true }
                 )
-                rewroteMarkerStartPos.add(markPos - 1)
+                rewroteMarkerStartPos.add(markerStartPos)
               }
             }
           }
@@ -359,7 +359,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
             if (!rewroteMarkerStartPos.has(markerStartPos)) {
               s.overwrite(
                 markerStartPos,
-                markerStartPos + 1 + preloadMarker.length + 1,
+                markerStartPos + preloadMarkerWithQuote.length,
                 'void 0',
                 { contentOnly: true }
               )
@@ -367,7 +367,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
             markerStartPos = code.indexOf(
               preloadMarkerWithQuote,
-              markerStartPos + 1 + preloadMarker.length + 1
+              markerStartPos + preloadMarkerWithQuote.length
             )
           } while (markerStartPos >= 0)
 

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -355,7 +355,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           // there may still be markers due to inlined dynamic imports, remove
           // all the markers regardless
           let markerStartPos = code.indexOf(preloadMarkerWithQuote)
-          do {
+          while (markerStartPos >= 0) {
             if (!rewroteMarkerStartPos.has(markerStartPos)) {
               s.overwrite(
                 markerStartPos,
@@ -369,7 +369,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               preloadMarkerWithQuote,
               markerStartPos + preloadMarkerWithQuote.length
             )
-          } while (markerStartPos >= 0)
+          }
 
           if (s.hasChanged()) {
             chunk.code = s.toString()

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -61,7 +61,7 @@ export async function injectSourcesContent(
   }
 }
 
-function genSourceMapUrl(map: SourceMap | string | undefined) {
+export function genSourceMapUrl(map: SourceMap | string | undefined) {
   if (typeof map !== 'string') {
     map = JSON.stringify(map)
   }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -605,7 +605,8 @@ const nullSourceMap: RawSourceMap = {
 }
 export function combineSourcemaps(
   filename: string,
-  sourcemapList: Array<DecodedSourceMap | RawSourceMap>
+  sourcemapList: Array<DecodedSourceMap | RawSourceMap>,
+  excludeContent = true
 ): RawSourceMap {
   if (
     sourcemapList.length === 0 ||
@@ -635,7 +636,7 @@ export function combineSourcemaps(
   const useArrayInterface =
     sourcemapList.slice(0, -1).find((m) => m.sources.length !== 1) === undefined
   if (useArrayInterface) {
-    map = remapping(sourcemapList, () => null, true)
+    map = remapping(sourcemapList, () => null, excludeContent)
   } else {
     map = remapping(
       sourcemapList[0],
@@ -646,7 +647,7 @@ export function combineSourcemaps(
           return null
         }
       },
-      true
+      excludeContent
     )
   }
   if (!map.file) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

importAnalysisBuild was breaking sourcemaps when there is a dynamic import.

This is a reproduction.
https://stackblitz.com/edit/vitejs-vite-ipkqha?file=main.js&terminal=dev
```js
import './style.css';

console.log('1');
import('./dy');
console.log('2');
/* omit below */
```
- Current v2.9.5.
  ![image](https://user-images.githubusercontent.com/49056869/164158964-02d0bddd-b1d6-466e-a1b8-565ee70e1501.png)
- With this PR (The output `2` has changed from line 4 to 5)
  ![image](https://user-images.githubusercontent.com/49056869/164159096-ea0b1a3b-0f9c-4392-896e-308b0f83c4fe.png)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
