### PR TITLE
fix(css): do not clean id when passing to postcss (fix #7822)

### DIFF
--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -409,5 +409,9 @@ test("relative path rewritten in Less's data-uri", async () => {
 test('PostCSS source.input.from includes query', async () => {
   const code = await page.textContent('.postcss-source-input')
   // should resolve assets
-  expect(code).toContain('/postcss-source-input.css?query=foo')
+  expect(code).toContain(
+    isBuild
+      ? '/postcss-source-input.css?used&query=foo'
+      : '/postcss-source-input.css?query=foo'
+  )
 })

--- a/packages/playground/css/__tests__/css.spec.ts
+++ b/packages/playground/css/__tests__/css.spec.ts
@@ -405,3 +405,9 @@ test("relative path rewritten in Less's data-uri", async () => {
     /^url\("data:image\/svg\+xml,%3Csvg/
   )
 })
+
+test('PostCSS source.input.from includes query', async () => {
+  const code = await page.textContent('.postcss-source-input')
+  // should resolve assets
+  expect(code).toContain('/postcss-source-input.css?query=foo')
+})

--- a/packages/playground/css/index.html
+++ b/packages/playground/css/index.html
@@ -135,6 +135,9 @@
 
   <p>Raw Support</p>
   <pre class="raw-imported-css"></pre>
+
+  <p>PostCSS source.input.from. Should include query</p>
+  <pre class="postcss-source-input"></pre>
 </div>
 
 <script type="module" src="./main.js"></script>

--- a/packages/playground/css/main.js
+++ b/packages/playground/css/main.js
@@ -87,3 +87,6 @@ Promise.all(Object.keys(glob).map((key) => glob[key]())).then((res) => {
 // globEager
 const globEager = import.meta.globEager('./glob-import/*.css')
 text('.imported-css-globEager', JSON.stringify(globEager, null, 2))
+
+import postcssSourceInput from './postcss-source-input.css?query=foo'
+text('.postcss-source-input', postcssSourceInput)

--- a/packages/playground/css/postcss-source-input.css
+++ b/packages/playground/css/postcss-source-input.css
@@ -1,0 +1,1 @@
+@source-input;

--- a/packages/playground/css/postcss.config.js
+++ b/packages/playground/css/postcss.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: [require('postcss-nested'), testDirDep]
+  plugins: [require('postcss-nested'), testDirDep, testSourceInput]
 }
 
 const fs = require('fs')
@@ -35,3 +35,16 @@ function testDirDep() {
   }
 }
 testDirDep.postcss = true
+
+function testSourceInput() {
+  return {
+    postcssPlugin: 'source-input',
+    AtRule(atRule) {
+      if (atRule.name === 'source-input') {
+        atRule.after(`/* ${atRule.source.input.from} */`)
+        atRule.remove()
+      }
+    }
+  }
+}
+testSourceInput.postcss = true

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -785,8 +785,8 @@ async function compileCSS(
     .default(postcssPlugins)
     .process(code, {
       ...postcssOptions,
-      to: cleanUrl(id),
-      from: cleanUrl(id),
+      to: id,
+      from: id,
       map: {
         inline: false,
         annotation: false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This change was introduced as a part of #7173. I was struggling with css sourcemaps and supposed that this change was necessary at that time. But now I checked it works without this change.
Because it changes behaviors downstreams (as described in #7822), I think it is better to revert this part.

fix #7822 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
