### PR TITLE
fix: escape character in string regexp match

### DIFF
--- a/packages/vite/src/node/__tests__/cleanString.spec.ts
+++ b/packages/vite/src/node/__tests__/cleanString.spec.ts
@@ -32,11 +32,23 @@ test('strings', () => {
   expect(clean).toMatch('const b = "\0\0\0\0"')
 })
 
-test('Escape character', () => {
+test('escape character', () => {
   const clean = emptyString(`
-    const a = '\''
-    const b = "\""
+    '1\\'1'
+    "1\\"1"
+    "1\\"1\\"1"
+    "1\\'1'\\"1"
+    "1'1'"
+    "1'\\'1\\''\\"1\\"\\""
+    '1"\\"1\\""\\"1\\"\\"'
+    '""1""'
+    '"""1"""'
+    '""""1""""'
+    "''1''"
+    "'''1'''"
+    "''''1''''"
   `)
+  expect(clean).not.toMatch('1')
 })
 
 test('strings comment nested', () => {

--- a/packages/vite/src/node/__tests__/cleanString.spec.ts
+++ b/packages/vite/src/node/__tests__/cleanString.spec.ts
@@ -32,6 +32,13 @@ test('strings', () => {
   expect(clean).toMatch('const b = "\0\0\0\0"')
 })
 
+test('Escape character', () => {
+  const clean = emptyString(`
+    const a = '\''
+    const b = "\""
+  `)
+})
+
 test('strings comment nested', () => {
   expect(
     emptyString(`

--- a/packages/vite/src/node/cleanString.ts
+++ b/packages/vite/src/node/cleanString.ts
@@ -25,9 +25,16 @@ export function emptyString(raw: string): string {
 }
 
 const enum LexerState {
+  // template string
   inTemplateString,
   inInterpolationExpression,
-  inObjectExpression
+  inObjectExpression,
+  // strings
+  inSingleQuoteString,
+  inDoubleQuoteString,
+  // comments
+  inMultilineCommentsRE,
+  inSinglelineCommentsRE
 }
 
 function replaceAt(

--- a/packages/vite/src/node/cleanString.ts
+++ b/packages/vite/src/node/cleanString.ts
@@ -2,7 +2,8 @@ import type { RollupError } from 'rollup'
 // bank on the non-overlapping nature of regex matches and combine all filters into one giant regex
 // /`([^`\$\{\}]|\$\{(`|\g<1>)*\})*`/g can match nested string template
 // but js not support match expression(\g<0>). so clean string template(`...`) in other ways.
-const cleanerRE = /"[^"]*"|'[^']*'|\/\*(.|[\r\n])*?\*\/|\/\/.*/g
+const cleanerRE =
+  /"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|\/\*(.|[\r\n])*?\*\/|\/\/.*/g
 
 const blankReplacer = (s: string) => ' '.repeat(s.length)
 const stringBlankReplacer = (s: string) =>

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1122,7 +1122,7 @@ export async function hoistAtRules(css: string) {
   // to top when multiple files are concatenated.
   // match until semicolon that's not in quotes
   s.replace(
-    /@import\s*(?:url\([^\)]*\)|"[^"]*"|'[^']*'|[^;]*).*?;/gm,
+    /@import\s*(?:url\([^\)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm,
     (match) => {
       s.appendLeft(0, match)
       return ''
@@ -1131,13 +1131,16 @@ export async function hoistAtRules(css: string) {
   // #6333
   // CSS @charset must be the top-first in the file, hoist the first to top
   let foundCharset = false
-  s.replace(/@charset\s*(?:"[^"]*"|'[^']*'|[^;]*).*?;/gm, (match) => {
-    if (!foundCharset) {
-      s.prepend(match)
-      foundCharset = true
+  s.replace(
+    /@charset\s*(?:"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm,
+    (match) => {
+      if (!foundCharset) {
+        s.prepend(match)
+        foundCharset = true
+      }
+      return ''
     }
-    return ''
-  })
+  )
   return s.toString()
 }
 

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -46,7 +46,8 @@ interface ScriptAssetsUrl {
 const htmlProxyRE = /\?html-proxy=?[&inline\-css]*&index=(\d+)\.(js|css)$/
 const inlineCSSRE = /__VITE_INLINE_CSS__([^_]+_\d+)__/g
 // Do not allow preceding '.', but do allow preceding '...' for spread operations
-const inlineImportRE = /(?<!(?<!\.\.)\.)\bimport\s*\(("[^"]*"|'[^']*')\)/g
+const inlineImportRE =
+  /(?<!(?<!\.\.)\.)\bimport\s*\(("([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*')\)/g
 const htmlLangRE = /\.(html|htm)$/
 
 export const isHTMLProxy = (id: string): boolean => htmlProxyRE.test(id)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

escape character in string regexp match.

https://regex101.com/r/fe286c/1

"1\\"1"

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
