### PR TITLE
feat(assets): allow `new URL` to resolve package assets

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -42,7 +42,6 @@ import {
   getDepsCacheDir,
   initDepsOptimizer
 } from './optimizer'
-import { assetImportMetaUrlPlugin } from './plugins/assetImportMetaUrl'
 import { loadFallbackPlugin } from './plugins/loadFallback'
 import type { PackageData } from './packages'
 import { watchPackageDataPlugin } from './packages'
@@ -310,7 +309,6 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
       watchPackageDataPlugin(config),
       ...(usePluginCommonjs ? [commonjsPlugin(options.commonjsOptions)] : []),
       dataURIPlugin(),
-      assetImportMetaUrlPlugin(config),
       ...(options.rollupOptions.plugins
         ? (options.rollupOptions.plugins.filter(Boolean) as Plugin[])
         : [])

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -20,6 +20,7 @@ import { preAliasPlugin } from './preAlias'
 import { definePlugin } from './define'
 import { ssrRequireHookPlugin } from './ssrRequireHook'
 import { workerImportMetaUrlPlugin } from './workerImportMetaUrl'
+import { assetImportMetaUrlPlugin } from './assetImportMetaUrl'
 import { ensureWatchPlugin } from './ensureWatch'
 import { metadataPlugin } from './metadata'
 import { dynamicImportVarsPlugin } from './dynamicImportVars'
@@ -88,6 +89,7 @@ export async function resolvePlugins(
     isBuild && config.build.ssr ? ssrRequireHookPlugin(config) : null,
     isBuild && buildHtmlPlugin(config),
     workerImportMetaUrlPlugin(config),
+    assetImportMetaUrlPlugin(config),
     ...buildPlugins.pre,
     dynamicImportVarsPlugin(config),
     importGlobPlugin(config),

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import JSON5 from 'json5'
 import MagicString from 'magic-string'
 import type { RollupError } from 'rollup'
@@ -8,11 +7,11 @@ import type { Plugin } from '../plugin'
 import {
   cleanUrl,
   injectQuery,
-  normalizePath,
   parseRequest,
   transformStableResult
 } from '../utils'
 import { getDepsOptimizer } from '../optimizer'
+import type { ResolveFn } from '..'
 import type { WorkerType } from './worker'
 import { WORKER_FILE_ID, workerFileToUrl } from './worker'
 import { fileToUrl } from './asset'
@@ -71,6 +70,7 @@ function getWorkerType(raw: string, clean: string, i: number): WorkerType {
 
 export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
+  let workerResolver: ResolveFn
 
   return {
     name: 'vite:worker-import-meta-url',
@@ -112,22 +112,28 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             cleanString,
             index + allExp.length
           )
-          const file = normalizePath(
-            path.resolve(path.dirname(id), rawUrl.slice(1, -1))
-          )
+          const url = rawUrl.slice(1, -1)
+          workerResolver ??= config.createResolver({
+            tryIndex: false,
+            preferRelative: true
+          })
+          const file = (await workerResolver(url, id)) ?? url
 
-          let url: string
+          let builtUrl: string
           if (isBuild) {
             getDepsOptimizer(config, ssr)?.registerWorkersSource(id)
-            url = await workerFileToUrl(config, file, query)
+            builtUrl = await workerFileToUrl(config, file, query)
           } else {
-            url = await fileToUrl(cleanUrl(file), config, this)
-            url = injectQuery(url, WORKER_FILE_ID)
-            url = injectQuery(url, `type=${workerType}`)
+            builtUrl = await fileToUrl(cleanUrl(file), config, this)
+            builtUrl = injectQuery(builtUrl, WORKER_FILE_ID)
+            builtUrl = injectQuery(builtUrl, `type=${workerType}`)
           }
-          s.overwrite(urlIndex, urlIndex + exp.length, JSON.stringify(url), {
-            contentOnly: true
-          })
+          s.overwrite(
+            urlIndex,
+            urlIndex + exp.length,
+            `new URL(${JSON.stringify(builtUrl)}, self.location)`,
+            { contentOnly: true }
+          )
         }
 
         if (s) {

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -281,6 +281,10 @@ test('new URL(..., import.meta.url)', async () => {
   expect(await page.textContent('.import-meta-url')).toMatch(assetMatch)
 })
 
+test('new URL("@/...", import.meta.url)', async () => {
+  expect(await page.textContent('.import-meta-url-dep')).toMatch(assetMatch)
+})
+
 test('new URL("/...", import.meta.url)', async () => {
   expect(await page.textContent('.import-meta-url-base-path')).toMatch(
     iconMatch

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -281,6 +281,12 @@ test('new URL(..., import.meta.url)', async () => {
   expect(await page.textContent('.import-meta-url')).toMatch(assetMatch)
 })
 
+test('new URL("/...", import.meta.url)', async () => {
+  expect(await page.textContent('.import-meta-url-base-path')).toMatch(
+    iconMatch
+  )
+})
+
 test('new URL(`${dynamic}`, import.meta.url)', async () => {
   expect(await page.textContent('.dynamic-import-meta-url-1')).toMatch(
     isBuild ? 'data:image/png;base64' : '/foo/nested/icon.png'

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -182,6 +182,10 @@
 <img class="import-meta-url-img" />
 <code class="import-meta-url"></code>
 
+<h2>new URL('@/...', import.meta.url)</h2>
+<img class="import-meta-url-dep-img" />
+<code class="import-meta-url-dep"></code>
+
 <h2>new URL('/...', import.meta.url)</h2>
 <img class="import-meta-url-base-path-img" />
 <code class="import-meta-url-base-path"></code>
@@ -357,6 +361,10 @@
   const metaUrl = new URL('./nested/asset.png', import.meta.url)
   text('.import-meta-url', metaUrl)
   document.querySelector('.import-meta-url-img').src = metaUrl
+
+  const metaUrlDep = new URL('@/asset.png', import.meta.url)
+  text('.import-meta-url-dep', metaUrlDep)
+  document.querySelector('.import-meta-url-dep-img').src = metaUrlDep
 
   // testing URLs for public assets served at the public base path
   // equivalent to `new URL(`${import.meta.env.BASE_URL}/icon.png`, self.location)

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -182,6 +182,10 @@
 <img class="import-meta-url-img" />
 <code class="import-meta-url"></code>
 
+<h2>new URL('/...', import.meta.url)</h2>
+<img class="import-meta-url-base-path-img" />
+<code class="import-meta-url-base-path"></code>
+
 <h2>new URL('...', import.meta.url,) (with comma)</h2>
 <img class="import-meta-url-img-comma" />
 <code class="import-meta-url-comma"></code>
@@ -353,6 +357,12 @@
   const metaUrl = new URL('./nested/asset.png', import.meta.url)
   text('.import-meta-url', metaUrl)
   document.querySelector('.import-meta-url-img').src = metaUrl
+
+  // testing URLs for public assets served at the public base path
+  // equivalent to `new URL(`${import.meta.env.BASE_URL}/icon.png`, self.location)
+  const metaUrlBasePath = new URL('/icon.png', import.meta.url)
+  text('.import-meta-url-base-path', metaUrlBasePath)
+  document.querySelector('.import-meta-url-base-path-img').src = metaUrlBasePath
 
   // prettier-ignore
   const metaUrlWithComma = new URL('./nested/asset.png', import.meta.url,)

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -93,6 +93,11 @@ describe.runIf(isBuild)('build', () => {
 
 test('module worker', async () => {
   await untilUpdated(
+    () => page.textContent('.worker-import-meta-url'),
+    'A string',
+    true
+  )
+  await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
     true

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -98,6 +98,11 @@ test('module worker', async () => {
     true
   )
   await untilUpdated(
+    () => page.textContent('.worker-import-meta-url-resolve'),
+    'A string',
+    true
+  )
+  await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
     true

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -80,6 +80,10 @@ describe.runIf(isBuild)('build', () => {
 
 test('module worker', async () => {
   await untilUpdated(
+    () => page.textContent('.worker-import-meta-url'),
+    'A string'
+  )
+  await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string'
   )

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -84,6 +84,10 @@ test('module worker', async () => {
     'A string'
   )
   await untilUpdated(
+    () => page.textContent('.worker-import-meta-url-resolve'),
+    'A string'
+  )
+  await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string'
   )

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -45,6 +45,12 @@
 <code class="worker-import-meta-url"></code>
 
 <p>
+  new Worker(new URL('@/url-worker', import.meta.url), { type: 'module' })
+  <span class="classname">.worker-import-meta-url-resolve</span>
+</p>
+<code class="worker-import-meta-url-resolve"></code>
+
+<p>
   new SharedWorker(new URL('./url-shared-worker.js', import.meta.url), { type:
   'module' })
   <span class="classname">.shared-worker-import-meta-url</span>

--- a/playground/worker/vite.config-es.js
+++ b/playground/worker/vite.config-es.js
@@ -4,6 +4,11 @@ const vite = require('vite')
 module.exports = vite.defineConfig({
   base: '/es/',
   enforce: 'pre',
+  resolve: {
+    alias: {
+      '@': __dirname
+    }
+  },
   worker: {
     format: 'es',
     plugins: [vueJsx()],

--- a/playground/worker/vite.config-iife.js
+++ b/playground/worker/vite.config-iife.js
@@ -3,6 +3,11 @@ const vite = require('vite')
 
 module.exports = vite.defineConfig({
   base: '/iife/',
+  resolve: {
+    alias: {
+      '@': __dirname
+    }
+  },
   worker: {
     format: 'iife',
     plugins: [

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -4,6 +4,11 @@ const vite = require('vite')
 
 module.exports = vite.defineConfig({
   base: './',
+  resolve: {
+    alias: {
+      '@': __dirname
+    }
+  },
   worker: {
     format: 'es',
     plugins: [vueJsx()],

--- a/playground/worker/vite.config-sourcemap.js
+++ b/playground/worker/vite.config-sourcemap.js
@@ -10,6 +10,11 @@ module.exports = vite.defineConfig((sourcemap) => {
     base: `/iife-${
       typeof sourcemap === 'boolean' ? 'sourcemap' : 'sourcemap-' + sourcemap
     }/`,
+    resolve: {
+      alias: {
+        '@': __dirname
+      }
+    },
     worker: {
       format: 'iife',
       plugins: [vueJsx()],

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -65,6 +65,15 @@ w.addEventListener('message', (ev) =>
   text('.worker-import-meta-url', JSON.stringify(ev.data))
 )
 
+// url import worker with alias path
+const wResolve = new Worker(
+  new URL('@/url-worker', import.meta.url),
+  /* @vite-ignore */ workerOptions
+)
+wResolve.addEventListener('message', (ev) =>
+  text('.worker-import-meta-url-resolve', JSON.stringify(ev.data))
+)
+
 const genWorkerName = () => 'module'
 const w2 = new SharedWorker(
   new URL('../url-shared-worker.js', import.meta.url),

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -67,7 +67,7 @@ w.addEventListener('message', (ev) =>
 
 // url import worker with alias path
 const wResolve = new Worker(
-  new URL('@/url-worker', import.meta.url),
+  new URL('@/url-worker.js', import.meta.url),
   /* @vite-ignore */ workerOptions
 )
 wResolve.addEventListener('message', (ev) =>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This change allows modules to resolve asset URLs for assets located underneath a package path. E.g. `new URL('@scope/component/assets/logo.png', import.meta.url)`

close #6918 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I Implemented this in a backwards-compatible way by using a resolver which prefers relative paths and makes the root path resolve to the public base path.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
