### PR TITLE
fix(css): var in image-set

### DIFF
--- a/packages/playground/assets/__tests__/assets.spec.ts
+++ b/packages/playground/assets/__tests__/assets.spec.ts
@@ -105,6 +105,13 @@ describe('css url() references', () => {
     })
   })
 
+  test('image-set with var', async () => {
+    const imageSet = await getBg('.css-image-set-with-var')
+    imageSet.split(', ').forEach((s) => {
+      expect(s).toMatch(assetMatch)
+    })
+  })
+
   test('relative in @import', async () => {
     expect(await getBg('.css-url-relative-at-imported')).toMatch(assetMatch)
   })

--- a/packages/playground/assets/css/css-url.css
+++ b/packages/playground/assets/css/css-url.css
@@ -26,6 +26,12 @@
   background-size: 10px;
 }
 
+.css-image-set-with-var {
+  --bg-img: url('../nested/asset.png');
+  background-image: -webkit-image-set(var(--bg-img) 1x, var(--bg-img) 2x);
+  background-size: 10px;
+}
+
 .css-url-public {
   background: url('/icon.png');
   background-size: 10px;

--- a/packages/playground/assets/index.html
+++ b/packages/playground/assets/index.html
@@ -46,6 +46,11 @@
     >CSS background with image-set() (relative)</span
   >
 </div>
+<div class="css-image-set-with-var">
+  <span style="background: #fff">
+    CSS background image-set() (relative in var)
+  </span>
+</div>
 <div class="css-url-relative-at-imported">
   <span style="background: #fff"
     >CSS background (relative from @imported file in different dir)</span

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -102,6 +102,7 @@ const commonjsProxyRE = /\?commonjs-proxy/
 const inlineRE = /(\?|&)inline\b/
 const inlineCSSRE = /(\?|&)inline-css\b/
 const usedRE = /(\?|&)used\b/
+const varRE = /^var/i
 
 const enum PreprocessLang {
   less = 'less',
@@ -968,7 +969,7 @@ export const cssUrlRE =
 export const cssDataUriRE =
   /(?<=^|[^\w\-\u0080-\uffff])data-uri\(\s*('[^']+'|"[^"]+"|[^'")]+)\s*\)/
 export const importCssRE = /@import ('[^']+\.css'|"[^"]+\.css"|[^'")]+\.css)/
-const cssImageSetRE = /image-set\(([^)]+)\)/
+const cssImageSetRE = /(?=image-set)\(([^)]+)\)/
 
 const UrlRewritePostcssPlugin: PostCSS.PluginCreator<{
   replacer: CssUrlReplacer
@@ -1061,7 +1062,13 @@ async function doUrlReplace(
     wrap = first
     rawUrl = rawUrl.slice(1, -1)
   }
-  if (isExternalUrl(rawUrl) || isDataUrl(rawUrl) || rawUrl.startsWith('#')) {
+
+  if (
+    isExternalUrl(rawUrl) ||
+    isDataUrl(rawUrl) ||
+    rawUrl.startsWith('#') ||
+    varRE.test(rawUrl)
+  ) {
     return matched
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #7874 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

the case in #7874
 #### input:
`
background-image: image-set(var(--hero--image-webp) 1x, var(--hero--image-jpg) 1x);
`
#### output:
`
background-image: image-set(url(var(--hero--image-webp) ) 1x, var(--hero--image-jpg) 1x);
`
#### step:
1. `cssImageSetRE` match the `image-set(var(--hero--image-webp)` (note: there only one `)`)
2. replace `var(--hero--image-webp` to `url(var(--hero--image-webp)`

it means that if the css is:
`
.some-class {
 --some-var: './a.png';
 background-image: -webkit-image-set(var(--some-var) 1x, './b.png' 2x)
`
The `cssImageSetRE` will only match `image-set(var(--some-var)` and do not handle `'./b.png'`.

But I think this is OK, because of the demo metioned in #7874. Url like `'./b.png'` in image-set is invalid, only `url('./b.png')` is valid.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
