### PR TITLE
fix(css): clean comments before hoist at rules

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -155,10 +155,54 @@ describe('hoist @ rules', () => {
   })
 
   test('hoist @import and @charset', async () => {
-    const css = `.foo{color:red;}@import "bla";@charset "utf-8";.bar{color:grren;}@import "baz";`
+    const css = `.foo{color:red;}@import "bla";@charset "utf-8";.bar{color:green;}@import "baz";`
     const result = await hoistAtRules(css)
     expect(result).toBe(
-      `@charset "utf-8";@import "bla";@import "baz";.foo{color:red;}.bar{color:grren;}`
+      `@charset "utf-8";@import "bla";@import "baz";.foo{color:red;}.bar{color:green;}`
+    )
+  })
+
+  test('dont hoist @import in comments', async () => {
+    const css = `.foo{color:red;}/* @import "bla"; */@import "bar";`
+    const result = await hoistAtRules(css)
+    expect(result).toBe(`@import "bar";.foo{color:red;}/* @import "bla"; */`)
+  })
+
+  test('dont hoist @charset in comments', async () => {
+    const css = `.foo{color:red;}/* @charset "utf-8"; */@charset "utf-8";`
+    const result = await hoistAtRules(css)
+    expect(result).toBe(
+      `@charset "utf-8";.foo{color:red;}/* @charset "utf-8"; */`
+    )
+  })
+
+  test('dont hoist @import and @charset in comments', async () => {
+    const css = `
+      .foo{color:red;}
+      /*
+        @import "bla";
+      */
+      @charset "utf-8";
+      /*
+        @charset "utf-8";
+        @import "bar";
+      */
+      @import "baz";
+    `
+    const result = await hoistAtRules(css)
+    expect(result).toBe(
+      `@charset "utf-8";@import "baz";
+      .foo{color:red;}
+      /*
+        @import "bla";
+      */
+      
+      /*
+        @charset "utf-8";
+        @import "bar";
+      */
+      
+    `
     )
   })
 })

--- a/packages/vite/src/node/cleanString.ts
+++ b/packages/vite/src/node/cleanString.ts
@@ -1,10 +1,14 @@
 import type { RollupError } from 'rollup'
+import { multilineCommentsRE, singlelineCommentsRE } from './utils'
+
 // bank on the non-overlapping nature of regex matches and combine all filters into one giant regex
 // /`([^`\$\{\}]|\$\{(`|\g<1>)*\})*`/g can match nested string template
 // but js not support match expression(\g<0>). so clean string template(`...`) in other ways.
-const stringsRE = /"([^"\r\n]|(?<=\\)")*"|'([^'\r\n]|(?<=\\)')*'/.source
-const commentsRE = /\/\*(.|[\r\n])*?\*\/|\/\/.*/.source
-const cleanerRE = new RegExp(`${stringsRE}|${commentsRE}`, 'g')
+const stringsRE = /"([^"\r\n]|(?<=\\)")*"|'([^'\r\n]|(?<=\\)')*'/g
+const cleanerRE = new RegExp(
+  `${stringsRE.source}|${multilineCommentsRE.source}|${singlelineCommentsRE.source}`,
+  'g'
+)
 
 const blankReplacer = (s: string) => ' '.repeat(s.length)
 const stringBlankReplacer = (s: string) =>
@@ -24,6 +28,10 @@ export function emptyString(raw: string): string {
   }
 
   return res
+}
+
+export function emptyCssComments(raw: string) {
+  return raw.replace(multilineCommentsRE, blankReplacer)
 }
 
 const enum LexerState {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1128,9 +1128,8 @@ export async function hoistAtRules(css: string) {
   const atImportRE =
     /@import\s*(?:url\([^\)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm
   while ((match = atImportRE.exec(cleanCss))) {
-    s.overwrite(match.index, match.index + match[0].length, '', {
-      contentOnly: true
-    })
+    s.remove(match.index, match.index + match[0].length)
+    // Use `appendLeft` instead of `prepend` to preserve original @import order
     s.appendLeft(0, match[0])
   }
 
@@ -1140,9 +1139,7 @@ export async function hoistAtRules(css: string) {
     /@charset\s*(?:"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm
   let foundCharset = false
   while ((match = atCharsetRE.exec(cleanCss))) {
-    s.overwrite(match.index, match.index + match[0].length, '', {
-      contentOnly: true
-    })
+    s.remove(match.index, match.index + match[0].length)
     if (!foundCharset) {
       s.prepend(match[0])
       foundCharset = true

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -48,6 +48,7 @@ import { transform, formatMessages } from 'esbuild'
 import { addToHTMLProxyTransformResult } from './html'
 import { injectSourcesContent, getCodeWithSourcemap } from '../server/sourcemap'
 import type { RawSourceMap } from '@ampproject/remapping'
+import { emptyCssComments } from '../cleanString'
 
 // const debug = createDebugger('vite:css')
 
@@ -1117,30 +1118,37 @@ async function minifyCSS(css: string, config: ResolvedConfig) {
 
 export async function hoistAtRules(css: string) {
   const s = new MagicString(css)
+  const cleanCss = emptyCssComments(css)
+  let match: RegExpExecArray | null
+
   // #1845
   // CSS @import can only appear at top of the file. We need to hoist all @import
   // to top when multiple files are concatenated.
   // match until semicolon that's not in quotes
-  s.replace(
-    /@import\s*(?:url\([^\)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm,
-    (match) => {
-      s.appendLeft(0, match)
-      return ''
-    }
-  )
+  const atImportRE =
+    /@import\s*(?:url\([^\)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm
+  while ((match = atImportRE.exec(cleanCss))) {
+    s.overwrite(match.index, match.index + match[0].length, '', {
+      contentOnly: true
+    })
+    s.appendLeft(0, match[0])
+  }
+
   // #6333
   // CSS @charset must be the top-first in the file, hoist the first to top
+  const atCharsetRE =
+    /@charset\s*(?:"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm
   let foundCharset = false
-  s.replace(
-    /@charset\s*(?:"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|[^;]*).*?;/gm,
-    (match) => {
-      if (!foundCharset) {
-        s.prepend(match)
-        foundCharset = true
-      }
-      return ''
+  while ((match = atCharsetRE.exec(cleanCss))) {
+    s.overwrite(match.index, match.index + match[0].length, '', {
+      contentOnly: true
+    })
+    if (!foundCharset) {
+      s.prepend(match[0])
+      foundCharset = true
     }
-  )
+  }
+
   return s.toString()
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #7912. Clean `/**/` comments in css string before running regex.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
