### PR TITLE
fix: inject esbuild helpers in IIFE and UMD wrappers

### DIFF
--- a/packages/playground/lib/__tests__/lib.spec.ts
+++ b/packages/playground/lib/__tests__/lib.spec.ts
@@ -9,10 +9,22 @@ if (isBuild) {
 
   test('umd', async () => {
     expect(await page.textContent('.umd')).toBe('It works')
+    const code = fs.readFileSync(
+      path.join(testDir, 'dist/my-lib-custom-filename.umd.js'),
+      'utf-8'
+    )
+    // esbuild helpers are injected inside of the UMD wrapper
+    expect(code).toMatch(/^\(function\(/)
   })
 
   test('iife', async () => {
     expect(await page.textContent('.iife')).toBe('It works')
+    const code = fs.readFileSync(
+      path.join(testDir, 'dist/my-lib-custom-filename.iife.js'),
+      'utf-8'
+    )
+    // esbuild helpers are injected inside of the IIFE wrapper
+    expect(code).toMatch(/^var MyLib=function\(\){"use strict";/)
   })
 
   test('Library mode does not include `preload`', async () => {

--- a/packages/playground/lib/src/main.js
+++ b/packages/playground/lib/src/main.js
@@ -1,3 +1,6 @@
 export default function myLib(sel) {
+  // Force esbuild helpers
+  console.log({ ...'foo' })
+
   document.querySelector(sel).textContent = 'It works'
 }

--- a/packages/playground/lib/src/main.js
+++ b/packages/playground/lib/src/main.js
@@ -1,5 +1,5 @@
 export default function myLib(sel) {
-  // Force esbuild helpers
+  // Force esbuild spread helpers (https://github.com/evanw/esbuild/issues/951)
   console.log({ ...'foo' })
 
   document.querySelector(sel).textContent = 'It works'


### PR DESCRIPTION
fix #5426
fix #7188

### Description

See https://github.com/vitejs/vite/issues/7188#issuecomment-1112049326 for context.

We could search for a better solution later, but I think these issues are important enough that should be fixed even if it means injecting the esbuild helpers as a post processing as done in the PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other