### PR TITLE
fix: index.html inline style content output

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -44,7 +44,7 @@ interface ScriptAssetsUrl {
 }
 
 const htmlProxyRE = /\?html-proxy=?[&inline\-css]*&index=(\d+)\.(js|css)$/
-const inlineCSSRE = /__VITE_INLINE_CSS__([^_]+_\d+)__/g
+const inlineCSSRE = /__VITE_INLINE_CSS__([\s\S]+_\d+)__/g
 // Do not allow preceding '.', but do allow preceding '...' for spread operations
 const inlineImportRE =
   /(?<!(?<!\.\.)\.)\bimport\s*\(("([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*')\)/g


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: [#7966](https://github.com/vitejs/vite/issues/7966)

### Additional context

run yarn build
The contents of html style tags are not output correctly，Check the code and find that vite has a bug in handling underlined paths，It excludes underlined paths.
If the project name is underlined（for example: test_vue）, there will be a bug

![image](https://user-images.githubusercontent.com/17608015/166089580-198c696b-8aa5-4e52-b2d4-54fb6cb48491.png)
![image](https://user-images.githubusercontent.com/17608015/166089579-f98b3485-7a92-4618-b884-bbf3e3e91d53.png)
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
