### PR TITLE
fix(css): sourcemap crash with postcss (fix #7978)

### DIFF
--- a/packages/playground/vue-sourcemap/Css.vue
+++ b/packages/playground/vue-sourcemap/Css.vue
@@ -2,6 +2,7 @@
   <p class="css">&lt;css&gt;</p>
   <p :class="$style['css-module']">&lt;css&gt; module</p>
   <p class="css-scoped">&lt;css&gt; scoped</p>
+  <p class="css-scoped-nested">&lt;css&gt; scoped with nested</p>
 </template>
 
 <style>
@@ -19,5 +20,15 @@
 <style scoped>
 .css-scoped {
   color: red;
+}
+</style>
+
+<style scoped>
+.css-scoped-nested {
+  color: red;
+  .dummy {
+    color: green;
+  }
+  font-weight: bold;
 }
 </style>

--- a/packages/playground/vue-sourcemap/__tests__/serve.spec.ts
+++ b/packages/playground/vue-sourcemap/__tests__/serve.spec.ts
@@ -80,7 +80,7 @@ if (!isBuild) {
     const map = extractSourcemap(css)
     expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
       Object {
-        "mappings": ";AAOA;EACE,UAAU;AACZ",
+        "mappings": ";AAQA;EACE,UAAU;AACZ",
         "sources": Array [
           "/root/Css.vue",
         ],
@@ -89,6 +89,7 @@ if (!isBuild) {
         <p class=\\"css\\">&lt;css&gt;</p>
         <p :class=\\"$style['css-module']\\">&lt;css&gt; module</p>
         <p class=\\"css-scoped\\">&lt;css&gt; scoped</p>
+        <p class=\\"css-scoped-nested\\">&lt;css&gt; scoped with nested</p>
       </template>
 
       <style>
@@ -106,6 +107,16 @@ if (!isBuild) {
       <style scoped>
       .css-scoped {
         color: red;
+      }
+      </style>
+
+      <style scoped>
+      .css-scoped-nested {
+        color: red;
+        .dummy {
+          color: green;
+        }
+        font-weight: bold;
       }
       </style>
       ",
@@ -120,7 +131,7 @@ if (!isBuild) {
     const map = extractSourcemap(css)
     expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
       Object {
-        "mappings": ";AAaA;EACE,UAAU;AACZ",
+        "mappings": ";AAcA;EACE,UAAU;AACZ",
         "sources": Array [
           "/root/Css.vue",
         ],
@@ -129,6 +140,7 @@ if (!isBuild) {
         <p class=\\"css\\">&lt;css&gt;</p>
         <p :class=\\"$style['css-module']\\">&lt;css&gt; module</p>
         <p class=\\"css-scoped\\">&lt;css&gt; scoped</p>
+        <p class=\\"css-scoped-nested\\">&lt;css&gt; scoped with nested</p>
       </template>
 
       <style>
@@ -146,6 +158,16 @@ if (!isBuild) {
       <style scoped>
       .css-scoped {
         color: red;
+      }
+      </style>
+
+      <style scoped>
+      .css-scoped-nested {
+        color: red;
+        .dummy {
+          color: green;
+        }
+        font-weight: bold;
       }
       </style>
       ",
@@ -160,7 +182,7 @@ if (!isBuild) {
     const map = extractSourcemap(css)
     expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
       Object {
-        "mappings": ";AAmBA;EACE,UAAU;AACZ",
+        "mappings": ";AAoBA;EACE,UAAU;AACZ",
         "sources": Array [
           "/root/Css.vue",
         ],
@@ -169,6 +191,7 @@ if (!isBuild) {
         <p class=\\"css\\">&lt;css&gt;</p>
         <p :class=\\"$style['css-module']\\">&lt;css&gt; module</p>
         <p class=\\"css-scoped\\">&lt;css&gt; scoped</p>
+        <p class=\\"css-scoped-nested\\">&lt;css&gt; scoped with nested</p>
       </template>
 
       <style>
@@ -186,6 +209,16 @@ if (!isBuild) {
       <style scoped>
       .css-scoped {
         color: red;
+      }
+      </style>
+
+      <style scoped>
+      .css-scoped-nested {
+        color: red;
+        .dummy {
+          color: green;
+        }
+        font-weight: bold;
       }
       </style>
       ",

--- a/packages/playground/vue-sourcemap/package.json
+++ b/packages/playground/vue-sourcemap/package.json
@@ -11,7 +11,8 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "workspace:*",
     "less": "^4.1.2",
-    "sass": "^1.43.4"
+    "sass": "^1.43.4",
+    "postcss-nested": "^5.0.6"
   },
   "dependencies": {
     "vue": "^3.2.31"

--- a/packages/playground/vue-sourcemap/postcss.config.js
+++ b/packages/playground/vue-sourcemap/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('postcss-nested')]
+}

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -877,32 +877,23 @@ export function formatPostcssSourceMap(
 ): ExistingRawSourceMap {
   const inputFileDir = path.dirname(file)
 
-  const sources: string[] = []
-  const sourcesContent: string[] = []
-  for (const [i, source] of rawMap.sources.entries()) {
-    // remove <no source> from sources, to prevent source map to be combined incorrectly
-    if (source === '<no source>') continue
-
+  const sources = rawMap.sources.map((source) => {
     const cleanSource = cleanUrl(decodeURIComponent(source))
 
     // postcss returns virtual files
     if (/^<.+>$/.test(cleanSource)) {
-      sources.push(`\0${cleanSource}`)
-    } else {
-      sources.push(normalizePath(path.resolve(inputFileDir, cleanSource)))
+      return `\0${cleanSource}`
     }
 
-    if (rawMap.sourcesContent) {
-      sourcesContent.push(rawMap.sourcesContent[i])
-    }
-  }
+    return normalizePath(path.resolve(inputFileDir, cleanSource))
+  })
 
   return {
     file,
     mappings: rawMap.mappings,
     names: rawMap.names,
     sources,
-    sourcesContent,
+    sourcesContent: rawMap.sourcesContent,
     version: rawMap.version
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,6 +730,7 @@ importers:
     specifiers:
       '@vitejs/plugin-vue': workspace:*
       less: ^4.1.2
+      postcss-nested: ^5.0.6
       sass: ^1.43.4
       vue: ^3.2.31
     dependencies:
@@ -737,6 +738,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue': link:../../plugin-vue
       less: 4.1.2
+      postcss-nested: 5.0.6
       sass: 1.45.1
 
   packages/playground/wasm:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This crash occured because removing `<no source>` was illegal.

I wrote this line based on a hypothesis that source maps will be combined incorrectly if multiple `<no source>` exists.
https://github.com/vitejs/vite/pull/7173/files#diff-2cfbd4f4d8c32727cd8e1a561cffbde0b384a3ce0789340440e144f9d64c10f6R834-R835
But since that happens rarely and a crash should be avoided, I think it I should remove this line.

fixes #7978

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
