### PR TITLE
fix: inline proxies for virtual html in transformIndexHtml

### DIFF
--- a/packages/playground/ssr-html/server.js
+++ b/packages/playground/ssr-html/server.js
@@ -58,14 +58,15 @@ async function createServer(
       if (url.startsWith('/favicon.ico')) {
         return res.status(404).end('404')
       }
-      const htmlLoc =
-        url === '/index.html' ? resolve('index.html') : `${url}.html`
+
+      const htmlLoc = resolve(`.${url}`)
       let template = fs.readFileSync(htmlLoc, 'utf-8')
 
       template = template.replace(
         '</body>',
         `${DYNAMIC_SCRIPTS}${DYNAMIC_STYLES}</body>`
       )
+
       const html = await vite.transformIndexHtml(url, template)
 
       res.status(200).set({ 'Content-Type': 'text/html' }).end(html)

--- a/packages/playground/ssr-html/server.js
+++ b/packages/playground/ssr-html/server.js
@@ -52,11 +52,14 @@ async function createServer(
 
   app.use('*', async (req, res) => {
     try {
-      const url = req.originalUrl
+      let [url] = req.originalUrl.split('?')
+      if (url.endsWith('/')) url += 'index.html'
+
       if (url.startsWith('/favicon.ico')) {
         return res.status(404).end('404')
       }
-      const htmlLoc = url === '/' ? resolve('index.html') : `${url}.html`
+      const htmlLoc =
+        url === '/index.html' ? resolve('index.html') : `${url}.html`
       let template = fs.readFileSync(htmlLoc, 'utf-8')
 
       template = template.replace(

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -53,7 +53,7 @@ import {
   optimizedDepNeedsInterop
 } from '../optimizer'
 
-const isDebug = true
+const isDebug = !!process.env.DEBUG
 const debug = createDebugger('vite:import-analysis')
 
 const clientDir = normalizePath(CLIENT_DIR)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -53,7 +53,7 @@ import {
   optimizedDepNeedsInterop
 } from '../optimizer'
 
-const isDebug = !!process.env.DEBUG
+const isDebug = true
 const debug = createDebugger('vite:import-analysis')
 
 const clientDir = normalizePath(CLIENT_DIR)
@@ -167,9 +167,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       const { moduleGraph } = server
-      // since we are already in the transform phase of the importer, it must
-      // have been loaded so its entry is guaranteed in the module graph.
-      const importerModule = moduleGraph.getModuleById(importer)!
+      const importerModule = moduleGraph.getModuleById(importer)
+      if (!importerModule) {
+        return null
+      }
 
       if (!imports.length) {
         importerModule.isSelfAccepting = false

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -167,6 +167,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       const { moduleGraph } = server
+      // since we are already in the transform phase of the importer, it must
+      // have been loaded so its entry is guaranteed in the module graph.
       const importerModule = moduleGraph.getModuleById(importer)!
 
       if (!imports.length) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -167,10 +167,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       const { moduleGraph } = server
-      const importerModule = moduleGraph.getModuleById(importer)
-      if (!importerModule) {
-        return null
-      }
+      const importerModule = moduleGraph.getModuleById(importer)!
 
       if (!imports.length) {
         importerModule.isSelfAccepting = false

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -194,18 +194,9 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
   await Promise.all(
     styleUrl.map(async ({ start, end, code }, index) => {
-      // NOTE: ssr url may be '/' run resolveId to get the real path
-      // let resolvedId: string | undefined
-      // try {
-      //   resolvedId = (await server!.pluginContainer.resolveId(filename))?.id
-      // } catch (err) {
-      //   // If fails to resolve filename, try resolving <filename>/index.html
-      //   resolvedId = (
-      //     await server!.pluginContainer.resolveId(
-      //       path.join(filename, 'index.html')
-      //     )
-      //   )?.id
-      // }
+      if (filename.endsWith('/')) {
+        return
+      }
       const url = `${filename}?html-proxy&${index}.css`
 
       // ensure module in graph after successful load

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -49,8 +49,12 @@ function getHtmlFilename(url: string, server: ViteDevServer) {
   if (url.startsWith(FS_PREFIX)) {
     return decodeURIComponent(fsPathFromId(url))
   } else {
+    let htmlFileName = url.slice(1)
+    if (!htmlFileName) {
+      htmlFileName = 'index.html'
+    }
     return decodeURIComponent(
-      normalizePath(path.join(server.config.root, url.slice(1)))
+      normalizePath(path.join(server.config.root, htmlFileName))
     )
   }
 }
@@ -191,18 +195,18 @@ const devHtmlHook: IndexHtmlTransformHook = async (
   await Promise.all(
     styleUrl.map(async ({ start, end, code }, index) => {
       // NOTE: ssr url may be '/' run resolveId to get the real path
-      let resolvedId: string | undefined
-      try {
-        resolvedId = (await server!.pluginContainer.resolveId(filename))?.id
-      } catch (err) {
-        // If fails to resolve filename, try resolving <filename>/index.html
-        resolvedId = (
-          await server!.pluginContainer.resolveId(
-            path.join(filename, 'index.html')
-          )
-        )?.id
-      }
-      const url = `${resolvedId || filename}?html-proxy&${index}.css`
+      // let resolvedId: string | undefined
+      // try {
+      //   resolvedId = (await server!.pluginContainer.resolveId(filename))?.id
+      // } catch (err) {
+      //   // If fails to resolve filename, try resolving <filename>/index.html
+      //   resolvedId = (
+      //     await server!.pluginContainer.resolveId(
+      //       path.join(filename, 'index.html')
+      //     )
+      //   )?.id
+      // }
+      const url = `${filename}?html-proxy&${index}.css`
 
       // ensure module in graph after successful load
       const mod = await moduleGraph.ensureEntryFromUrl(url, false)

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -190,7 +190,10 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
   await Promise.all(
     styleUrl.map(async ({ start, end, code }, index) => {
-      const url = filename + `?html-proxy&${index}.css`
+      // NOTE: ssr url may be '/' run resolveId to get the real path
+      let url =
+        (await server!.pluginContainer.resolveId(filename))?.id || filename
+      url += `?html-proxy&${index}.css`
 
       // ensure module in graph after successful load
       const mod = await moduleGraph.ensureEntryFromUrl(url, false)


### PR DESCRIPTION
### Description

Fixes #7992 

When inlined css is passed through the `vite.transformIndexHtml` it was failing with `isSelfAccepting` of undefined error on import-analysis plugin.

I added an early null return there which seem to fix the issue. Although I am new to Vite's codebase so I am not sure if this is the right fix.

Let me know if something else is a fix.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
