### PR TITLE
chore(create-vite): update reference to volar vscode extension

### DIFF
--- a/packages/create-vite/template-vue-ts/.vscode/extensions.json
+++ b/packages/create-vite/template-vue-ts/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volar"]
+  "recommendations": ["Vue.volar"]
 }

--- a/packages/create-vite/template-vue-ts/README.md
+++ b/packages/create-vite/template-vue-ts/README.md
@@ -4,7 +4,7 @@ This template should help get you started developing with Vue 3 and TypeScript i
 
 ## Recommended IDE Setup
 
-- [VS Code](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
+- [VS Code](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar)
 
 ## Type Support For `.vue` Imports in TS
 

--- a/packages/create-vite/template-vue/.vscode/extensions.json
+++ b/packages/create-vite/template-vue/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["johnsoncodehk.volar"]
+  "recommendations": ["Vue.volar"]
 }

--- a/packages/create-vite/template-vue/README.md
+++ b/packages/create-vite/template-vue/README.md
@@ -4,4 +4,4 @@ This template should help get you started developing with Vue 3 in Vite. The tem
 
 ## Recommended IDE Setup
 
-- [VS Code](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
+- [VS Code](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar)


### PR DESCRIPTION
### Description

When scaffolding a new project with `npm create vite@latest my-vue-app -- --template vue-ts` or `npm create vite@latest my-vue-app -- --template vue`, opening the project within Visual Studio Code will trigger the following warning because the namespace for the Volar extension moved from `johnsoncodehk.volar` to `Vue.volar`. This PR updates the reference to fix the issue. It also updates the references in the README files.

<img width="467" alt="Screenshot 2022-05-02 at 20 10 56" src="https://user-images.githubusercontent.com/649677/166301676-c7cea364-8ad7-4a1a-b670-a97506222baf.png">

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
