### PR TITLE
feat: import ts with .js in vue

### DIFF
--- a/packages/playground/vue-jsx/TsImport.vue
+++ b/packages/playground/vue-jsx/TsImport.vue
@@ -1,0 +1,8 @@
+<template>
+  <h2>Ts Import</h2>
+  <p class="ts-import">{{ foo }}</p>
+</template>
+
+<script setup lang="tsx">
+import { foo } from './TsImportFile.js'
+</script>

--- a/packages/playground/vue-jsx/TsImportFile.ts
+++ b/packages/playground/vue-jsx/TsImportFile.ts
@@ -1,0 +1,1 @@
+export const foo = 'success'

--- a/packages/playground/vue-jsx/__tests__/vue-jsx.spec.ts
+++ b/packages/playground/vue-jsx/__tests__/vue-jsx.spec.ts
@@ -9,6 +9,7 @@ test('should render', async () => {
   expect(await page.textContent('.src-import')).toMatch('5')
   expect(await page.textContent('.jsx-with-query')).toMatch('6')
   expect(await page.textContent('.other-ext')).toMatch('Other Ext')
+  expect(await page.textContent('.ts-import')).toMatch('success')
 })
 
 test('should update', async () => {

--- a/packages/playground/vue-jsx/main.jsx
+++ b/packages/playground/vue-jsx/main.jsx
@@ -7,6 +7,7 @@ import JsxSrcImport from './SrcImport.vue'
 import JsxSetupSyntax from './setup-syntax-jsx.vue'
 // eslint-disable-next-line
 import JsxWithQuery from './Query.jsx?query=true'
+import TsImport from './TsImport.vue'
 
 function App() {
   return (
@@ -20,6 +21,7 @@ function App() {
       <JsxSrcImport />
       <JsxSetupSyntax />
       <JsxWithQuery />
+      <TsImport />
     </>
   )
 }

--- a/packages/playground/vue/Main.vue
+++ b/packages/playground/vue/Main.vue
@@ -15,6 +15,7 @@
     <div class="slotted">this should be red</div>
   </Slotted>
   <ScanDep />
+  <TsImport />
   <Suspense>
     <AsyncComponent />
   </Suspense>
@@ -33,6 +34,7 @@ import CustomBlock from './CustomBlock.vue'
 import SrcImport from './src-import/SrcImport.vue'
 import Slotted from './Slotted.vue'
 import ScanDep from './ScanDep.vue'
+import TsImport from './TsImport.vue'
 import AsyncComponent from './AsyncComponent.vue'
 import ReactivityTransform from './ReactivityTransform.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'

--- a/packages/playground/vue/TsImport.vue
+++ b/packages/playground/vue/TsImport.vue
@@ -1,0 +1,8 @@
+<template>
+  <h2>Ts Import</h2>
+  <p class="ts-import">{{ foo }}</p>
+</template>
+
+<script setup lang="ts">
+import { foo } from './TsImportFile.js'
+</script>

--- a/packages/playground/vue/TsImportFile.ts
+++ b/packages/playground/vue/TsImportFile.ts
@@ -1,0 +1,1 @@
+export const foo = 'success'

--- a/packages/playground/vue/__tests__/vue.spec.ts
+++ b/packages/playground/vue/__tests__/vue.spec.ts
@@ -14,6 +14,10 @@ test('template/script latest syntax support', async () => {
   expect(await page.textContent('.syntax')).toBe('baz')
 })
 
+test('import ts with .js extension with lang="ts"', async () => {
+  expect(await page.textContent('.ts-import')).toBe('success')
+})
+
 test('should remove comments in prod', async () => {
   expect(await page.innerHTML('.comments')).toBe(isBuild ? `` : `<!--hello-->`)
 })

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -192,13 +192,12 @@ export async function transformMain(
   }
 
   // handle TS transpilation
-  const isTs =
+  let resolvedCode = output.join('\n')
+  if (
     (descriptor.script?.lang === 'ts' ||
       descriptor.scriptSetup?.lang === 'ts') &&
     !descriptor.script?.src // only normal script can have src
-
-  let resolvedCode = output.join('\n')
-  if (isTs) {
+  ) {
     const { code, map } = await transformWithEsbuild(
       resolvedCode,
       filename,
@@ -216,9 +215,7 @@ export async function transformMain(
     },
     meta: {
       vite: {
-        lang: isTs
-          ? 'ts'
-          : descriptor.scriptSetup?.lang || descriptor.script?.lang || 'js'
+        lang: descriptor.script?.lang || descriptor.scriptSetup?.lang || 'js'
       }
     }
   }

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -192,12 +192,13 @@ export async function transformMain(
   }
 
   // handle TS transpilation
-  let resolvedCode = output.join('\n')
-  if (
+  const isTs =
     (descriptor.script?.lang === 'ts' ||
       descriptor.scriptSetup?.lang === 'ts') &&
     !descriptor.script?.src // only normal script can have src
-  ) {
+
+  let resolvedCode = output.join('\n')
+  if (isTs) {
     const { code, map } = await transformWithEsbuild(
       resolvedCode,
       filename,
@@ -212,6 +213,11 @@ export async function transformMain(
     code: resolvedCode,
     map: resolvedMap || {
       mappings: ''
+    },
+    meta: {
+      vite: {
+        isTs
+      }
     }
   }
 }

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -216,7 +216,9 @@ export async function transformMain(
     },
     meta: {
       vite: {
-        isTs
+        lang: isTs
+          ? 'ts'
+          : descriptor.scriptSetup?.lang || descriptor.script?.lang || 'js'
       }
     }
   }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -133,7 +133,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
         isFromTsImporter: !importer
           ? false
           : isTsRequest(importer) ||
-            this.getModuleInfo(importer)?.meta?.vite?.isTs
+            this.getModuleInfo(importer)?.meta?.vite?.lang === 'ts'
       }
 
       let res: string | PartialResolvedId | undefined

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -128,10 +128,12 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
 
       const options: InternalResolveOptions = {
         isRequire,
-
         ...baseOptions,
-        isFromTsImporter: isTsRequest(importer ?? ''),
-        scan: resolveOpts?.scan ?? baseOptions.scan
+        scan: resolveOpts?.scan ?? baseOptions.scan,
+        isFromTsImporter: !importer
+          ? false
+          : isTsRequest(importer) ||
+            this.getModuleInfo(importer)?.meta?.vite?.isTs
       }
 
       let res: string | PartialResolvedId | undefined

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -129,11 +129,16 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
       const options: InternalResolveOptions = {
         isRequire,
         ...baseOptions,
-        scan: resolveOpts?.scan ?? baseOptions.scan,
-        isFromTsImporter: !importer
-          ? false
-          : isTsRequest(importer) ||
-            this.getModuleInfo(importer)?.meta?.vite?.lang === 'ts'
+        scan: resolveOpts?.scan ?? baseOptions.scan
+      }
+
+      if (importer) {
+        if (isTsRequest(importer)) {
+          options.isFromTsImporter = true
+        } else {
+          const moduleLang = this.getModuleInfo(importer)?.meta?.vite?.lang
+          options.isFromTsImporter = moduleLang && isTsRequest(`.${moduleLang}`)
+        }
       }
 
       let res: string | PartialResolvedId | undefined

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -228,7 +228,7 @@ export const isJSRequest = (url: string): boolean => {
 
 const knownTsRE = /\.(ts|mts|cts|tsx)$/
 const knownTsOutputRE = /\.(js|mjs|cjs|jsx)$/
-export const isTsRequest = (url: string) => knownTsRE.test(cleanUrl(url))
+export const isTsRequest = (url: string) => knownTsRE.test(url)
 export const isPossibleTsOutput = (url: string) =>
   knownTsOutputRE.test(cleanUrl(url))
 export function getPotentialTsSrcPaths(filePath: string) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #6671

Support importing `.ts` files via `.js`. Added a new `meta.vite.lang` flag to provide the hint.

### Additional context

~~Initially instead of `.lang` I used `.isTs`, maybe that's desirable?~~

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
