### PR TITLE
fix: only handle merge ssr.noExternal

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -157,6 +157,30 @@ describe('mergeConfig', () => {
 
     expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
   })
+
+  test('handles ssr.noExternal', () => {
+    const baseConfig = {
+      ssr: {
+        noExternal: true
+      }
+    }
+
+    const newConfig = {
+      ssr: {
+        noExternal: ['foo']
+      }
+    }
+
+    const mergedConfig = {
+      ssr: {
+        noExternal: true
+      }
+    }
+
+    // merging either ways, `ssr.noExternal: true` should take highest priority
+    expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+    expect(mergeConfig(newConfig, baseConfig)).toEqual(mergedConfig)
+  })
 })
 
 describe('resolveConfig', () => {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -745,7 +745,11 @@ function mergeConfigRecursively(
     } else if (key === 'assetsInclude' && rootPath === '') {
       merged[key] = [].concat(existing, value)
       continue
-    } else if (key === 'noExternal' && (existing === true || value === true)) {
+    } else if (
+      key === 'noExternal' &&
+      rootPath === 'ssr' &&
+      (existing === true || value === true)
+    ) {
       merged[key] = true
       continue
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Previously `noExternal` in any level of the config would have special `true` handling. Now this is only handled for `ssr.noExternal`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Found this while discussing the potential use of `mergeConfig` in vite-plugin-svelte

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
