### PR TITLE
fix: handle optimize failure

### DIFF
--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -296,7 +296,11 @@ export function createOptimizedDeps(server: ViteDevServer): OptimizedDeps {
 
       // Reset missing deps, let the server rediscover the dependencies
       metadata.discovered = {}
-      fullReload()
+
+      const isEsbuildError = e.errors && e.warnings
+      if (!isEsbuildError) {
+        fullReload()
+      }
     }
 
     currentlyProcessing = false

--- a/packages/vite/src/node/optimizer/registerMissing.ts
+++ b/packages/vite/src/node/optimizer/registerMissing.ts
@@ -296,11 +296,6 @@ export function createOptimizedDeps(server: ViteDevServer): OptimizedDeps {
 
       // Reset missing deps, let the server rediscover the dependencies
       metadata.discovered = {}
-
-      const isEsbuildError = e.errors && e.warnings
-      if (!isEsbuildError) {
-        fullReload()
-      }
     }
 
     currentlyProcessing = false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Stop optimize reload if fail on esbuild bundling.

### Additional context

Looking into #3715 today. With Vite 2.9, when optimization fails (because of named importing a nodejs module, will also look into this soon), vite would reload optimization again, but since it would always fail, it will reload infinitely.

Question: Should we not do a `fullReload` all together?

Note: I also made a repro https://github.com/bluwy/vite-bundle-node-issue

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
