### PR TITLE
docs(plugin-legacy): remove regenerator-runtime note

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -27,22 +27,6 @@ export default {
 }
 ```
 
-When targeting IE11, you also need `regenerator-runtime`:
-
-```js
-// vite.config.js
-import legacy from '@vitejs/plugin-legacy'
-
-export default {
-  plugins: [
-    legacy({
-      targets: ['ie >= 11'],
-      additionalLegacyPolyfills: ['regenerator-runtime/runtime']
-    })
-  ]
-}
-```
-
 ## Options
 
 ### `targets`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This note was added by #3389 for #3362.

But `regenerator-runtime` was included without using `additionalLegacyPolyfills` with vite@2.3.0 + plugin-legacy@1.3.4.
https://stackblitz.com/edit/vitejs-vite-wedvpk?file=package.json&terminal=dev
So I feel #3389 was something like https://github.com/vitejs/vite/issues/7819#issuecomment-1103625188. (There was no reproduction so I cannot confirmed though)

Also `regenerator-runtime` is included without using `additionalLegacyPolyfills` with the latest version as reported by #7987.
I think this note should be removed.

fixes #7987 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
