### PR TITLE
docs: add nodejs buildpack setup in Heroku deploy step

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -270,6 +270,12 @@ You can also deploy to a [custom domain](http://surge.sh/help/adding-a-custom-do
    # set buildpack for static sites
    $ heroku buildpacks:set https://github.com/heroku/heroku-buildpack-static.git
    ```
+   
+7. If you want Heroku to be in charge of the build, add the [nodejs buildpack](https://github.com/heroku/heroku-buildpack-nodejs) to run first:
+
+   ```bash
+   $ heroku buildpacks:add --index 1 heroku/nodejs
+   ```
 
 6. Deploy your site:
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This adds a step to the Heroku deploy so that the Heroku pipeline is in charge of the build step

### Additional context

You may want to have Heroku run the build step, this allows for `dist/` to be on the .gitignore as well as making it a single command to deploy changes

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
