### PR TITLE
feat(resolve): Resolve dependencies that support external injection

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -313,6 +313,12 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
         }
       }
 
+      // injected dependencies
+      const fsPath = path.join(root, fsPathFromId(`/node_modules/${id}`))
+      if ((res = tryFsResolve(fsPath, options))) {
+        return res
+      }
+
       isDebug && debug(`[fallthrough] ${colors.dim(id)}`)
     },
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I tried to directly use the pseudo-dependency written by importing the node.fs module. Vite did not parse this path at runtime.

#### Directory
```bash
node_modules
    .inject
        dep.js
```

#### Code
```js
import module from '.inject/dep'
// [vite] Internal server error: Failed to resolve import ".inject/dep" from "packages\app\view1\index.js". Does the file exist?
```
 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
