### PR TITLE
fix(vue-plugin): support syntax 'export { default } from ...' in vue script block 

### DIFF
--- a/packages/playground/vue/ExportDefault.vue
+++ b/packages/playground/vue/ExportDefault.vue
@@ -1,0 +1,7 @@
+<template>
+  <div class="export-default">{{ count }}</div>
+</template>
+
+<script>
+export { default } from './exportDefaultTest'
+</script>

--- a/packages/playground/vue/Main.vue
+++ b/packages/playground/vue/Main.vue
@@ -21,6 +21,7 @@
   <ReactivityTransform :foo="time" />
   <SetupImportTemplate />
   <WorkerTest />
+  <ExportDefault />
 </template>
 
 <script setup lang="ts">
@@ -37,6 +38,7 @@ import AsyncComponent from './AsyncComponent.vue'
 import ReactivityTransform from './ReactivityTransform.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
 import WorkerTest from './worker.vue'
+import ExportDefault from './ExportDefault.vue'
 import { ref } from 'vue'
 
 const time = ref('loading...')

--- a/packages/playground/vue/__tests__/vue.spec.ts
+++ b/packages/playground/vue/__tests__/vue.spec.ts
@@ -248,3 +248,9 @@ describe('vue worker', () => {
     expect(await page.textContent('.vue-worker')).toMatch('worker load!')
   })
 })
+
+describe('export default', () => {
+  test(`should support the syntax 'export {default} from' in script block`, async () => {
+    expect(await page.textContent('.export-default')).toMatch('1')
+  })
+})

--- a/packages/playground/vue/exportDefaultTest.ts
+++ b/packages/playground/vue/exportDefaultTest.ts
@@ -1,0 +1,10 @@
+import { ref } from 'vue'
+
+export default {
+  setup() {
+    const count = ref(1)
+    return {
+      count
+    }
+  }
+}

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -17,6 +17,8 @@ import { createRollupError } from './utils/error'
 import { transformWithEsbuild } from 'vite'
 import { EXPORT_HELPER_ID } from './helper'
 
+const exportDefaultRE = /(^|\n|;)\s*export\s*\{\s*default\s*\}\s*from/
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function transformMain(
   code: string,
@@ -267,7 +269,11 @@ async function genScriptCode(
   if (script) {
     // If the script is js/ts and has no external src, it can be directly placed
     // in the main module.
-    if ((!script.lang || script.lang === 'ts') && !script.src) {
+    if (
+      (!script.lang || script.lang === 'ts') &&
+      !script.src &&
+      !exportDefaultRE.test(script.content)
+    ) {
       scriptCode = options.compiler.rewriteDefault(
         script.content,
         '_sfc_main',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #8008 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
let vite support syntax 'export { default } from ...' in vue script block.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
