### PR TITLE
fix: externalize dependencies by default during SSR

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -79,9 +79,6 @@ export function resolveSSRExternal(
   return externals
 }
 
-const CJS_CONTENT_RE =
-  /\bmodule\.exports\b|\bexports[.\[]|\brequire\s*\(|\bObject\.(defineProperty|defineProperties|assign)\s*\(\s*exports\b/
-
 // do we need to do this ahead of time or could we do it lazily?
 function collectExternals(
   root: string,
@@ -144,45 +141,35 @@ function collectExternals(
       debug(`Failed to resolve entries for package "${id}"\n`, e)
       continue
     }
-    // no esm entry but has require entry
-    if (!esmEntry) {
-      ssrExternals.add(id)
+
+    const pkgPath = resolveFrom(`${id}/package.json`, root)
+    const pkgContent = fs.readFileSync(pkgPath, 'utf-8')
+
+    if (!pkgContent) {
+      continue
     }
-    // trace the dependencies of linked packages
-    else if (!esmEntry.includes('node_modules')) {
+    const pkg = JSON.parse(pkgContent)
+
+    if (pkg.type === 'module') {
+      if (requireEntry && !requireEntry.endsWith('.cjs')) {
+        logger.warn(
+          `${id} must use a .cjs extension for the CJS entry point when "type": "module" is set. Please contact the package author to fix.`
+        )
+      }
+    } else {
+      if (esmEntry && !esmEntry.endsWith('.mjs')) {
+        logger.warn(
+          `${id} must either set "type": "module" or use an .mjs extension for the ESM entry point. Please contact the package author to fix.`
+        )
+      }
+    }
+
+    if (esmEntry && !esmEntry.includes('node_modules')) {
+      // trace the dependencies of linked packages
       const pkgPath = resolveFrom(`${id}/package.json`, root)
       depsToTrace.add(path.dirname(pkgPath))
-    }
-    // has separate esm/require entry, assume require entry is cjs
-    else if (esmEntry !== requireEntry) {
+    } else {
       ssrExternals.add(id)
-    }
-    // if we're externalizing ESM and CJS should basically just always do it?
-    // or are there others like SystemJS / AMD that we'd need to handle?
-    // for now, we'll just leave this as is
-    else if (/\.m?js$/.test(esmEntry)) {
-      const pkgPath = resolveFrom(`${id}/package.json`, root)
-      const pkgContent = fs.readFileSync(pkgPath, 'utf-8')
-
-      if (!pkgContent) {
-        continue
-      }
-      const pkg = JSON.parse(pkgContent)
-
-      if (pkg.type === 'module' || esmEntry.endsWith('.mjs')) {
-        ssrExternals.add(id)
-        continue
-      }
-      // check if the entry is cjs
-      const content = fs.readFileSync(esmEntry, 'utf-8')
-      if (CJS_CONTENT_RE.test(content)) {
-        ssrExternals.add(id)
-        continue
-      }
-
-      logger.warn(
-        `${id} doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.`
-      )
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Externalize dependencies by default during SSR

### Additional context

We had talked about doing this in https://github.com/vitejs/vite/pull/5544. At the time, I didn't want to change the code more than necessary because we were trying to get 2.7 out the door and we had already made so many SSR changes. But now that SSR has settled down a bit, I do think it'd be a good cleanup to make.

As far as I'm aware, there's really nothing to gain by having complex logic to determine whether to bundle or externalize. I'm not aware of any case where that makes something work that otherwise wouldn't work. Rather, I'm only aware of cases where that breaks things because of incorrect or incomplete bundling logic (e.g. https://github.com/vitejs/vite/issues/2579)

There are libraries that don't work with Node.js because they're incorrectly packaged and would work if they were bundled since the bundler often fixes these issues. However, at the current moment, Vite's SSR bundling doesn't work well enough that bundling solves more problems than it creates. Problems created by bundling bugs are far harder to diagnose than incorrectly packaged Node modules. Even if we did want to bundle more aggressively, we should probably just do it by default for all packages rather than having the complex logic we have now.

One of our users recently reported a problem using `reflect-metadata` (https://github.com/sveltejs/kit/discussions/3334#discussioncomment-2076988). From a quick glance, it looks like the library is essentially a polyfill for a proposed piece of functionality to the ES spec, so it sticks its functionality onto the global scope and doesn't export anything. Because it doesn't export anything, we don't see `exports` or `module.exports`, etc. As a result, we fail to detect that the library is a CJS library and thus fail to externalize the library.

I had tried this earlier in https://github.com/vitejs/vite/pull/6698 but had a failing test. @ygj6 has fixed that in https://github.com/vitejs/vite/pull/8025. Unfortunately I'm unable to reopen the original PR, so am sending this new one

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
