### PR TITLE
chore: remove redundant pnpm version in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
-        with:
-          version: 6
 
       - name: Set node version to ${{ matrix.node_version }}
         uses: actions/setup-node@v3
@@ -85,8 +83,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
-        with:
-          version: 6
 
       - name: Set node version to 16
         uses: actions/setup-node@v3


### PR DESCRIPTION
`pnpm/action-setup@v2` reads the packageManager field in package.json, remove the duplication so we can have single source of the version