### PR TITLE
docs: CSS `?inline` query parameter

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -215,8 +215,8 @@ You can also use CSS modules combined with pre-processors by prepending `.module
 If you want to turn off the automatic injection of CSS contents, you can do via the `?inline` query parameter:
 
 ```js
-import styles from './foo.js'; // will be injected into the page
-import otherStyles from './bar.js?inline'; // will not be injected into the page
+import styles from './foo.css'; // will be injected into the page
+import otherStyles from './bar.css?inline'; // will not be injected into the page
 ```
 
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -210,15 +210,14 @@ Vite improves `@import` resolving for Sass and Less so that Vite aliases are als
 
 You can also use CSS modules combined with pre-processors by prepending `.module` to the file extension, for example `style.module.scss`.
 
-### Disabling injection into the page
+### Disabling CSS injection into the page
 
-If you want to turn off the automatic injection of CSS contents, you can do via the `?inline` query parameter:
+The automatic injection of CSS contents can be turned off via the `?inline` query parameter. In this case, the processed CSS string is returned as the module's default export as usual, but the styles aren't injected to the page.
 
 ```js
-import styles from './foo.css'; // will be injected into the page
-import otherStyles from './bar.css?inline'; // will not be injected into the page
+import styles from './foo.css' // will be injected into the page
+import otherStyles from './bar.css?inline' // will not be injected into the page
 ```
-
 
 ## Static Assets
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -210,6 +210,16 @@ Vite improves `@import` resolving for Sass and Less so that Vite aliases are als
 
 You can also use CSS modules combined with pre-processors by prepending `.module` to the file extension, for example `style.module.scss`.
 
+### Disabling injection into the page
+
+If you want to turn off the automatic injection of CSS contents, you can do via the `?inline` query parameter:
+
+```js
+import styles from './foo.js'; // will be injected into the page
+import otherStyles from './bar.js?inline'; // will not be injected into the page
+```
+
+
 ## Static Assets
 
 Importing a static asset will return the resolved public URL when it is served:


### PR DESCRIPTION
### Description

I spent ages hunting for this feature to turn off CSS content injection
and then found the [GitHub
commit](https://github.com/vitejs/vite/commit/e1de8a888ea9adb9dc415cf74aec43dfa83aa526)
which I couldn't find mentioned in the docs at all, so I thought I'd add
a brief mention.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
