### PR TITLE
feat: option to disable SPA catch-all

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -69,6 +69,14 @@ export interface CommonServerOptions {
    * Specify server response headers.
    */
   headers?: HttpServerHeaders
+  /**
+   * Disable SPA catch-all routing.
+   *
+   * By default, Vite's dev/preview server redirects all routes to the root
+   * URL `/`. (In order to enable client-side routed SPAs.) For SSR or MPA apps,
+   * this behavior should be disabled and this option allows you to do so.
+   */
+  disableSPACatchAll?: boolean
 }
 
 /**

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -524,7 +524,10 @@ export async function createServer(
   middlewares.use(serveStaticMiddleware(root, server))
 
   // spa fallback
-  if (!middlewareMode || middlewareMode === 'html') {
+  if (
+    !serverConfig.disableSPACatchAll &&
+    (!middlewareMode || middlewareMode === 'html')
+  ) {
     middlewares.use(spaFallbackMiddleware(root))
   }
 


### PR DESCRIPTION

### Description

Resurrection of https://github.com/vitejs/vite/pull/7665: it was merged but later reverted because SPAs should be able to do client-side routing and catch-all routing is needed for that.

Such catch-all routing doesn't make sense for MPAs or SSR apps. Hence this new option to disable it.

@benmccann This removes the SPA fallback middleware, so this may be a solution for your problem.

The name `disableSPACatchAll` is fairly long for Vite's standards. But I think it's worth it. I think it's pretty clear and considerably increases the probability of understanding what `disableSPACatchAll` is about without having to look up documentation.

### Additional context

This will be used by Vike Frameworks (frameworks based on Vike tools such as `vite-plugin-ssr` 0.4).

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

I considered adding a test, but I realized that it would require a whole new playground setup. I'm thinking that adding a playground just for this would add too much bloat to be worth it. Note that vite-plugin-ssr will have tests for this, so we'll catch any problems at latest when running vite-plugin-ssr's test suite.
