### PR TITLE
feat(glob-import): support `{ import: '*' }`

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
@@ -38,6 +38,10 @@ export const eagerAs = {
 \\"./modules/a.ts\\": __vite_glob_5_0,
 \\"./modules/b.ts\\": __vite_glob_5_1
 };
+export const rawImportModule = {
+\\"./modules/a.ts\\": () => import(\\"./modules/a.ts?raw\\"),
+\\"./modules/b.ts\\": () => import(\\"./modules/b.ts?raw\\")
+};
 export const excludeSelf = {
 \\"./sibling.ts\\": () => import(\\"./sibling.ts\\")
 };
@@ -107,6 +111,10 @@ export const namedDefault = {
 export const eagerAs = {
 \\"./modules/a.ts\\": __vite_glob_5_0,
 \\"./modules/b.ts\\": __vite_glob_5_1
+};
+export const rawImportModule = {
+\\"./modules/a.ts\\": () => import(\\"./modules/a.ts?raw\\"),
+\\"./modules/b.ts\\": () => import(\\"./modules/b.ts?raw\\")
 };
 export const excludeSelf = {
 \\"./sibling.ts\\": () => import(\\"./sibling.ts\\")

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
@@ -27,6 +27,11 @@ export const eagerAs = import.meta.glob<ModuleType>(
   { eager: true, as: 'raw' }
 )
 
+export const rawImportModule = import.meta.glob(
+  ['./modules/*.ts', '!**/index.ts'],
+  { as: 'raw', import: '*' }
+)
+
 export const excludeSelf = import.meta.glob(
   './*.ts'
   // for test: annotation contain ")"

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -217,11 +217,15 @@ export async function parseImportGlob(
     }
 
     if (options.as && forceDefaultAs.includes(options.as)) {
-      if (options.import && options.import !== 'default')
+      if (
+        options.import &&
+        options.import !== 'default' &&
+        options.import !== '*'
+      )
         throw err(
-          `Option "export" can only be "default" when "as" is "${options.as}", but got "${options.import}"`
+          `Option "import" can only be "default" or "*" when "as" is "${options.as}", but got "${options.import}"`
         )
-      options.import = 'default'
+      options.import = options.import || 'default'
     }
 
     if (options.as && options.query)
@@ -358,10 +362,15 @@ export async function transformGlobImport(
 
             importPath = `${importPath}${importQuery}`
 
+            const importKey =
+              options.import && options.import !== '*'
+                ? options.import
+                : undefined
+
             if (options.eager) {
               const variableName = `${importPrefix}${index}_${i}`
-              const expression = options.import
-                ? `{ ${options.import} as ${variableName} }`
+              const expression = importKey
+                ? `{ ${importKey} as ${variableName} }`
                 : `* as ${variableName}`
               staticImports.push(
                 `import ${expression} from ${JSON.stringify(importPath)}`
@@ -369,10 +378,8 @@ export async function transformGlobImport(
               objectProps.push(`${JSON.stringify(filePath)}: ${variableName}`)
             } else {
               let importStatement = `import(${JSON.stringify(importPath)})`
-              if (options.import)
-                importStatement += `.then(m => m[${JSON.stringify(
-                  options.import
-                )}])`
+              if (importKey)
+                importStatement += `.then(m => m[${JSON.stringify(importKey)}])`
               objectProps.push(
                 `${JSON.stringify(filePath)}: () => ${importStatement}`
               )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

By default, when `as: 'raw'` is specified, the glob will interpret to import the `default` entry for convenience.

```ts
import.meta.glob('pattern', { as: 'raw' }) // Record<string, () => Promise<string>>
```

With this PR, it will allow to specify `{ import: '*' }` to force import as the whole module

```ts
import.meta.glob('pattern', { as: 'raw', import: '*' }) // Record<string, () => Promise<Module>>
```

### Additional context

Unblock https://github.com/vitejs/vite/pull/7756#discussion_r867641769

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
