### PR TITLE
chore: enable renovate for playground

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,11 +1,7 @@
 {
   "extends": ["config:base", "schedule:weekly", "group:allNonMajor"],
   "labels": ["dependencies"],
-  "ignorePaths": [
-    "packages/playground/**",
-    "packages/create-vite/template-*/**",
-    "**/__tests__/**"
-  ],
+  "ignorePaths": ["**/__tests__/**"],
   "pin": false,
   "rangeStrategy": "bump",
   "node": false,


### PR DESCRIPTION
Related to #8074 

Actually I can't remember why we had had them disabled at the beginning. I guess keeping them up to date would also help us to identify early bugs.