### PR TITLE
chore(plugin-react): add vite peer dep

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -41,5 +41,8 @@
     "@rollup/pluginutils": "^4.2.1",
     "react-refresh": "^0.13.0",
     "resolve": "^1.22.0"
+  },
+  "peerDependencies": {
+    "vite": "^2.0.0"
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #8058

### Additional context

Set as `^2.0.0`. It doesn't seem like it's using features that requires a specific minor version.

`vite` is only used in the exported types now, but it makes sense to me to specify a version to show that it doesn't work with Vite v1 (for example)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
