### PR TITLE
chore: bump Vitest timeout

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
       '**/dist/**',
       './playground/**/*.*',
       './playground-temp/**/*.*'
-    ]
+    ],
+    testTimeout: 20000
   },
   esbuild: {
     target: 'node14'


### PR DESCRIPTION
### Description

There is a unit test [that took >6 seconds](https://github.com/vitejs/vite/runs/6353755050?check_suite_focus=true#step:9:33). Bump the timeout to 20 seconds, to start testing how it behaves. We would probably need a higher timeout if we end up using Vitest for e2e

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other