### PR TITLE
fix: add direct query to html-proxy css (fixes #8091)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -223,7 +223,8 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
         const thisModule = moduleGraph.getModuleById(id)
         if (thisModule) {
           // CSS modules cannot self-accept since it exports values
-          const isSelfAccepting = !modules && !inlineRE.test(id)
+          const isSelfAccepting =
+            !modules && !inlineRE.test(id) && !htmlProxyRE.test(id)
           if (deps) {
             // record deps in the module graph so edits to @import css can trigger
             // main import to hot update

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -217,7 +217,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
   await Promise.all(
     styleUrl.map(async ({ start, end, code }, index) => {
-      const url = `${proxyModulePath}?html-proxy&index=${index}.css`
+      const url = `${proxyModulePath}?html-proxy&direct&index=${index}.css`
 
       // ensure module in graph after successful load
       const mod = await moduleGraph.ensureEntryFromUrl(url, false)

--- a/playground/css-sourcemap/__tests__/serve.spec.ts
+++ b/playground/css-sourcemap/__tests__/serve.spec.ts
@@ -27,8 +27,22 @@ if (!isBuild) {
       }
     )
     const css = await res.text()
-    const lines = css.split('\n')
-    expect(lines[lines.length - 1].includes('/*')).toBe(false) // expect no sourcemap
+    const map = extractSourcemap(css)
+    expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
+      Object {
+        "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACT,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACb,CAAC;",
+        "sources": Array [
+          "/root/linked.css",
+        ],
+        "sourcesContent": Array [
+          ".linked {
+        color: red;
+      }
+      ",
+        ],
+        "version": 3,
+      }
+    `)
   })
 
   test('linked css with import', async () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The error was happening here.
https://github.com/vitejs/vite/blob/780b4f5cdf02adb4ce42c283b60a4d4bb06b8440/packages/vite/src/node/plugins/importAnalysis.ts#L142
Adding direct query will make this condition `true` and `vite:import-analysis` will be skipped.
https://github.com/vitejs/vite/blob/780b4f5cdf02adb4ce42c283b60a4d4bb06b8440/packages/vite/src/node/plugins/importAnalysis.ts#L129

fixes #8091 
refs #7869

### Additional context

#8091 will be fixed by 1285ff5907282fda460705f80783d3f71b11f2a9.
But this commit will drop sourcemap support because `?direct` condition comes before `?html-proxy` condition.
https://github.com/vitejs/vite/blob/780b4f5cdf02adb4ce42c283b60a4d4bb06b8440/packages/vite/src/node/plugins/css.ts#L317-L337

I noticed sourcemap support for `<link type="style" href="./foo.css">` is lacking. In most cases `./foo.css` does not get transformed but it might be transformed by postcss.
I fixed this (03861ebf) along fixing sourcemap support for inline style tag which I dropped at 1285ff5907282fda460705f80783d3f71b11f2a9.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
