### PR TITLE
fix: make html-proxy css request pass `importAnalysis`

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -121,8 +121,10 @@ type CssLang = keyof typeof PureCssLang | keyof typeof PreprocessLang
 export const isCSSRequest = (request: string): boolean =>
   cssLangRE.test(request)
 
+// htmlProxyRE is used to check if the request is a html proxy request and it will return css.
 export const isDirectCSSRequest = (request: string): boolean =>
-  cssLangRE.test(request) && directRequestRE.test(request)
+  cssLangRE.test(request) &&
+  (directRequestRE.test(request) || htmlProxyRE.test(request))
 
 export const isDirectRequest = (request: string): boolean =>
   directRequestRE.test(request)

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -1,5 +1,14 @@
 <link rel="stylesheet" href="./linked.css" />
-
+<style>
+  /* latin */
+  @font-face {
+    font-family: 'Roboto';
+    src: url(https://abc.woff2) format('woff2');
+  }
+  body {
+    font-family: Roboto, sans-serif;
+  }
+</style>
 <div class="wrapper">
   <h1>CSS</h1>
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixs: #8091 
fixs: #7869

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
