### PR TITLE
fix: call warning for asset what it is not exist and import by js

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -6,7 +6,7 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "rimraf dist && run-p dev-types dev-watch",

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -53,6 +53,8 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       if (publicFile) {
         return id
       }
+
+      return id
     },
 
     async load(id) {
@@ -76,7 +78,12 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       }
 
       id = id.replace(urlRE, '$1').replace(/[\?&]$/, '')
-      const url = await fileToUrl(id, config, this)
+      const url = await fileToUrl(id, config, this).catch(() => {
+        config.logger.warnOnce(
+          `\n${id} doesn't exist at build time, it will remain unchanged to be resolved at runtime`
+        )
+        return id
+      })
       return `export default ${JSON.stringify(url)}`
     },
 

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -53,8 +53,6 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       if (publicFile) {
         return id
       }
-
-      return id
     },
 
     async load(id) {
@@ -78,12 +76,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       }
 
       id = id.replace(urlRE, '$1').replace(/[\?&]$/, '')
-      const url = await fileToUrl(id, config, this).catch(() => {
-        config.logger.warnOnce(
-          `\n${id} doesn't exist at build time, it will remain unchanged to be resolved at runtime`
-        )
-        return id
-      })
+      const url = await fileToUrl(id, config, this)
       return `export default ${JSON.stringify(url)}`
     },
 

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -22,7 +22,8 @@
   <ReactivityTransform :foo="time" />
   <SetupImportTemplate />
   <WorkerTest />
-  <img alt="smpte bars" class="logo" src="/img/aaaSMPTE-color-bars.png" />
+  <img :src="noExistImg" alt="noExistImg" />
+  <img alt="noExistImg" src="/img/aaaSMPTE-color-bars.png" />
 </template>
 
 <script setup lang="ts">
@@ -41,6 +42,7 @@ import ReactivityTransform from './ReactivityTransform.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
 import WorkerTest from './worker.vue'
 import { ref } from 'vue'
+import noExistImg from './img/aaaSMPTE-color-bars.png'
 
 const time = ref('loading...')
 

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -22,6 +22,7 @@
   <ReactivityTransform :foo="time" />
   <SetupImportTemplate />
   <WorkerTest />
+  <img alt="smpte bars" class="logo" src="/img/aaaSMPTE-color-bars.png" />
 </template>
 
 <script setup lang="ts">

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -26,7 +26,11 @@ export default defineConfig({
             return 'src-import'
           }
         }
-      }
+      },
+      external: [
+        '/img/aaaSMPTE-color-bars.png',
+        './img/aaaSMPTE-color-bars.png'
+      ]
     }
   },
   css: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #8047

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

`config.assetsInclude`'s assets load error, but I think this is expect? because vue make the asset import like
```js
import noExistImg from "/img/aaaSMPTE-color-bars.png"
```

if `/img/aaaSMPTE-color-bars.png` no exist I think call error is better. 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
