### PR TITLE
test: set global hookTimeout

### DIFF
--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -200,7 +200,7 @@ beforeAll(async (s) => {
       throw beforeAllError
     }
   }
-}, 30000)
+})
 
 function startStaticServer(config?: InlineConfig): Promise<string> {
   if (!config) {

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -1,6 +1,8 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vitest/config'
 
+const timeout = process.env.CI ? 50000 : 30000
+
 export default defineConfig({
   resolve: {
     alias: {
@@ -11,7 +13,8 @@ export default defineConfig({
     include: ['./playground/**/*.spec.[tj]s'],
     setupFiles: ['./playground/vitestSetup.ts'],
     globalSetup: ['./playground/vitestGlobalSetup.ts'],
-    testTimeout: process.env.CI ? 50000 : 20000,
+    testTimeout: timeout,
+    hookTimeout: timeout,
     globals: true,
     reporters: 'dot',
     onConsoleLog(log) {


### PR DESCRIPTION
### Description

We missed a 30sec timeout in a `beforeAll` hook that was sometimes surpassed. Move the value to a global `hookTimeout` and bump it to 50secs.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other