### PR TITLE
fix: remove ssrError when invalidating a module

### DIFF
--- a/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
+++ b/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ModuleGraph } from '../moduleGraph'
+let moduleGraph: ModuleGraph
+
+describe('moduleGraph', () => {
+  describe('invalidateModule', () => {
+    beforeEach(() => {
+      moduleGraph = new ModuleGraph((id) => Promise.resolve({ id }))
+    })
+
+    it('removes an ssrError', async () => {
+      const entryUrl = '/x.js'
+
+      const entryModule = await moduleGraph.ensureEntryFromUrl(entryUrl, false)
+      entryModule.ssrError = new Error(`unable to execute module`)
+
+      expect(entryModule.ssrError).to.be.a('error')
+      moduleGraph.invalidateModule(entryModule)
+      expect(entryModule.ssrError).toBe(null)
+    })
+  })
+})

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -55,6 +55,7 @@ function invalidateSSRModule(mod: ModuleNode, seen: Set<ModuleNode>) {
   }
   seen.add(mod)
   mod.ssrModule = null
+  mod.ssrError = null
   mod.importers.forEach((importer) => invalidateSSRModule(importer, seen))
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This removes `ssrError` when invalidating a module from the graph (which happens when a module is changed).

### Additional context

This is a follow up to https://github.com/vitejs/vite/pull/8052 which partially fixed the problem.

This fixes a bug in Astro: https://github.com/withastro/astro/issues/3263

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
