### PR TITLE
fix(lib): enable inlineDynamicImports for umd and iife

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -441,7 +441,10 @@ async function doBuild(
         // #764 add `Symbol.toStringTag` when build es module into cjs chunk
         // #1048 add `Symbol.toStringTag` for module default export
         namespaceToStringTag: true,
-        inlineDynamicImports: ssr && typeof input === 'string',
+        inlineDynamicImports:
+          output.format === 'umd' ||
+          output.format === 'iife' ||
+          (ssr && typeof input === 'string'),
         ...output
       }
     }

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -40,7 +40,7 @@ describe.runIf(isBuild)('build', () => {
       'hello vite'
     )
     const code = fs.readFileSync(
-      path.join(testDir(), 'dist/lib/dynamic-import-message.js'),
+      path.join(testDir(), 'dist/lib/dynamic-import-message.es.js'),
       'utf-8'
     )
     expect(code).not.toMatch('__vitePreload')

--- a/playground/lib/vite.dyimport.config.js
+++ b/playground/lib/vite.dyimport.config.js
@@ -8,9 +8,9 @@ module.exports = {
   build: {
     lib: {
       entry: path.resolve(__dirname, 'src/main2.js'),
-      formats: ['es'],
+      formats: ['es', 'iife'],
       name: 'message',
-      fileName: () => 'dynamic-import-message.js'
+      fileName: (format) => `dynamic-import-message.${format}.js`
     },
     outDir: 'dist/lib'
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #2982. Set `inlineDynamicImports: true` by default when building for umd and iife

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
