### PR TITLE
test: refactor test utils and setup

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -120,7 +120,8 @@ module.exports = defineConfig({
         'node/no-extraneous-import': 'off',
         'node/no-extraneous-require': 'off',
         'node/no-missing-import': 'off',
-        'node/no-missing-require': 'off'
+        'node/no-missing-require': 'off',
+        'no-undef': 'off'
       }
     },
     {

--- a/playground/cli-module/__tests__/serve.ts
+++ b/playground/cli-module/__tests__/serve.ts
@@ -78,7 +78,7 @@ export async function serve() {
     if (serverProcess) {
       const timeoutError = `server process still alive after 3s`
       try {
-        killProcess(serverProcess)
+        await killProcess(serverProcess)
         await resolvedOrTimeout(serverProcess, 10000, timeoutError)
       } catch (e) {
         if (e === timeoutError || (!serverProcess.killed && !isWindows)) {

--- a/playground/cli-module/__tests__/serve.ts
+++ b/playground/cli-module/__tests__/serve.ts
@@ -3,11 +3,18 @@
 
 import execa from 'execa'
 import kill from 'kill-port'
-import { isWindows, ports, viteBinPath } from '~utils'
+import {
+  isBuild,
+  isWindows,
+  killProcess,
+  ports,
+  rootDir,
+  viteBinPath
+} from '~utils'
 
 export const port = ports['cli-module']
 
-export async function serve(root: string, isProd: boolean) {
+export async function serve() {
   // collect stdout and stderr streams from child processes here to avoid interfering with regular vitest output
   const streams = {
     build: { out: [], err: [] },
@@ -35,11 +42,11 @@ export async function serve(root: string, isProd: boolean) {
   }
 
   // only run `vite build` when needed
-  if (isProd) {
+  if (isBuild) {
     const buildCommand = `${viteBinPath} build`
     try {
       const buildProcess = execa.command(buildCommand, {
-        cwd: root,
+        cwd: rootDir,
         stdio: 'pipe'
       })
       collectStreams('build', buildProcess)
@@ -56,12 +63,12 @@ export async function serve(root: string, isProd: boolean) {
 
   // run `vite --port x` or `vite preview --port x` to start server
   const viteServerArgs = ['--port', `${port}`, '--strict-port']
-  if (isProd) {
+  if (isBuild) {
     viteServerArgs.unshift('preview')
   }
   const serverCommand = `${viteBinPath} ${viteServerArgs.join(' ')}`
   const serverProcess = execa.command(serverCommand, {
-    cwd: root,
+    cwd: rootDir,
     stdio: 'pipe'
   })
   collectStreams('server', serverProcess)
@@ -130,19 +137,6 @@ async function startedOnPort(serverProcess, port, timeout) {
     timeout,
     `failed to start within ${timeout}ms`
   ).finally(() => serverProcess.stdout.off('data', checkPort))
-}
-
-// helper function to kill process, uses taskkill on windows to ensure child process is killed too
-function killProcess(serverProcess) {
-  if (isWindows) {
-    try {
-      execa.commandSync(`taskkill /pid ${serverProcess.pid} /T /F`)
-    } catch (e) {
-      console.error('failed to taskkill:', e)
-    }
-  } else {
-    serverProcess.kill('SIGTERM', { forceKillAfterTimeout: 2000 })
-  }
 }
 
 // helper function that rejects with errorMessage if promise isn't settled within ms

--- a/playground/cli/__tests__/serve.ts
+++ b/playground/cli/__tests__/serve.ts
@@ -78,7 +78,7 @@ export async function serve() {
     if (serverProcess) {
       const timeoutError = `server process still alive after 3s`
       try {
-        killProcess(serverProcess)
+        await killProcess(serverProcess)
         await resolvedOrTimeout(serverProcess, 3000, timeoutError)
       } catch (e) {
         if (e === timeoutError || (!serverProcess.killed && !isWindows)) {

--- a/playground/cli/__tests__/serve.ts
+++ b/playground/cli/__tests__/serve.ts
@@ -3,11 +3,18 @@
 
 import execa from 'execa'
 import kill from 'kill-port'
-import { isWindows, ports, viteBinPath } from '~utils'
+import {
+  isBuild,
+  isWindows,
+  killProcess,
+  ports,
+  rootDir,
+  viteBinPath
+} from '~utils'
 
 export const port = ports.cli
 
-export async function serve(root: string, isProd: boolean) {
+export async function serve() {
   // collect stdout and stderr streams from child processes here to avoid interfering with regular vitest output
   const streams = {
     build: { out: [], err: [] },
@@ -35,11 +42,11 @@ export async function serve(root: string, isProd: boolean) {
   }
 
   // only run `vite build` when needed
-  if (isProd) {
+  if (isBuild) {
     const buildCommand = `${viteBinPath} build`
     try {
       const buildProcess = execa.command(buildCommand, {
-        cwd: root,
+        cwd: rootDir,
         stdio: 'pipe'
       })
       collectStreams('build', buildProcess)
@@ -56,12 +63,12 @@ export async function serve(root: string, isProd: boolean) {
 
   // run `vite --port x` or `vite preview --port x` to start server
   const viteServerArgs = ['--port', `${port}`, '--strict-port']
-  if (isProd) {
+  if (isBuild) {
     viteServerArgs.unshift('preview')
   }
   const serverCommand = `${viteBinPath} ${viteServerArgs.join(' ')}`
   const serverProcess = execa.command(serverCommand, {
-    cwd: root,
+    cwd: rootDir,
     stdio: 'pipe'
   })
   collectStreams('server', serverProcess)
@@ -130,19 +137,6 @@ async function startedOnPort(serverProcess, port, timeout) {
     timeout,
     `failed to start within ${timeout}ms`
   ).finally(() => serverProcess.stdout.off('data', checkPort))
-}
-
-// helper function to kill process, uses taskkill on windows to ensure child process is killed too
-function killProcess(serverProcess) {
-  if (isWindows) {
-    try {
-      execa.commandSync(`taskkill /pid ${serverProcess.pid} /T /F`)
-    } catch (e) {
-      console.error('failed to taskkill:', e)
-    }
-  } else {
-    serverProcess.kill('SIGTERM', { forceKillAfterTimeout: 2000 })
-  }
 }
 
 // helper function that rejects with errorMessage if promise isn't settled within ms

--- a/playground/legacy/__tests__/ssr/serve.ts
+++ b/playground/legacy/__tests__/ssr/serve.ts
@@ -1,14 +1,14 @@
 // this is automatically detected by playground/vitestSetup.ts and will replace
 // the default e2e test serve behavior
 import path from 'path'
-import { ports } from '~utils'
+import { ports, rootDir } from '~utils'
 
 export const port = ports['legacy/ssr']
 
-export async function serve(root: string, _isProd: boolean) {
+export async function serve() {
   const { build } = require('vite')
   await build({
-    root,
+    root: rootDir,
     logLevel: 'silent',
     build: {
       target: 'esnext',
@@ -22,7 +22,7 @@ export async function serve(root: string, _isProd: boolean) {
 
   app.use('/', async (_req, res) => {
     const { render } = require(path.resolve(
-      root,
+      rootDir,
       './dist/server/entry-server.js'
     ))
     const html = await render()

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -17,7 +17,7 @@ describe.runIf(isBuild)('build', () => {
   test('umd', async () => {
     expect(await page.textContent('.umd')).toBe('It works')
     const code = fs.readFileSync(
-      path.join(testDir(), 'dist/my-lib-custom-filename.umd.js'),
+      path.join(testDir, 'dist/my-lib-custom-filename.umd.js'),
       'utf-8'
     )
     // esbuild helpers are injected inside of the UMD wrapper
@@ -27,7 +27,7 @@ describe.runIf(isBuild)('build', () => {
   test('iife', async () => {
     expect(await page.textContent('.iife')).toBe('It works')
     const code = fs.readFileSync(
-      path.join(testDir(), 'dist/my-lib-custom-filename.iife.js'),
+      path.join(testDir, 'dist/my-lib-custom-filename.iife.js'),
       'utf-8'
     )
     // esbuild helpers are injected inside of the IIFE wrapper
@@ -40,7 +40,7 @@ describe.runIf(isBuild)('build', () => {
       'hello vite'
     )
     const code = fs.readFileSync(
-      path.join(testDir(), 'dist/lib/dynamic-import-message.js'),
+      path.join(testDir, 'dist/lib/dynamic-import-message.js'),
       'utf-8'
     )
     expect(code).not.toMatch('__vitePreload')

--- a/playground/lib/__tests__/serve.ts
+++ b/playground/lib/__tests__/serve.ts
@@ -4,19 +4,27 @@
 import path from 'path'
 import http from 'http'
 import sirv from 'sirv'
-import { page, ports, serverLogs, setViteUrl, viteTestUrl } from '~utils'
+import {
+  isBuild,
+  page,
+  ports,
+  rootDir,
+  serverLogs,
+  setViteUrl,
+  viteTestUrl
+} from '~utils'
 
 export const port = ports.lib
 
-export async function serve(root, isBuildTest) {
+export async function serve() {
   setupConsoleWarnCollector()
 
-  if (!isBuildTest) {
+  if (!isBuild) {
     const { createServer } = require('vite')
     process.env.VITE_INLINE = 'inline-serve'
     const viteServer = await (
       await createServer({
-        root: root,
+        root: rootDir,
         logLevel: 'silent',
         server: {
           watch: {
@@ -25,7 +33,7 @@ export async function serve(root, isBuildTest) {
           },
           host: true,
           fs: {
-            strict: !isBuildTest
+            strict: !isBuild
           }
         },
         build: {
@@ -42,19 +50,19 @@ export async function serve(root, isBuildTest) {
   } else {
     const { build } = require('vite')
     await build({
-      root,
+      root: rootDir,
       logLevel: 'silent',
       configFile: path.resolve(__dirname, '../vite.config.js')
     })
 
     await build({
-      root,
+      root: rootDir,
       logLevel: 'warn', // output esbuild warns
       configFile: path.resolve(__dirname, '../vite.dyimport.config.js')
     })
 
     // start static file server
-    const serve = sirv(path.resolve(root, 'dist'))
+    const serve = sirv(path.resolve(rootDir, 'dist'))
     const httpServer = http.createServer((req, res) => {
       if (req.url === '/ping') {
         res.statusCode = 200

--- a/playground/optimize-missing-deps/__test__/serve.ts
+++ b/playground/optimize-missing-deps/__test__/serve.ts
@@ -2,13 +2,13 @@
 // the default e2e test serve behavior
 
 import path from 'path'
-import { ports } from '~utils'
+import { isBuild, ports, rootDir } from '~utils'
 
 export const port = ports['optimize-missing-deps']
 
-export async function serve(root: string, isProd: boolean) {
-  const { createServer } = require(path.resolve(root, 'server.js'))
-  const { app, vite } = await createServer(root, isProd)
+export async function serve() {
+  const { createServer } = require(path.resolve(rootDir, 'server.js'))
+  const { app, vite } = await createServer(rootDir, isBuild)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/resolve-config/__tests__/resolve-config.spec.ts
+++ b/playground/resolve-config/__tests__/resolve-config.spec.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { commandSync } from 'execa'
 import { isBuild, testDir, viteBinPath } from '~utils'
 
-const fromTestDir = (...p: string[]) => path.resolve(testDir(), ...p)
+const fromTestDir = (...p: string[]) => path.resolve(testDir, ...p)
 
 const build = (configName: string) => {
   commandSync(`${viteBinPath} build`, { cwd: fromTestDir(configName) })

--- a/playground/resolve-config/__tests__/serve.ts
+++ b/playground/resolve-config/__tests__/serve.ts
@@ -3,13 +3,14 @@
 
 import path from 'path'
 import fs from 'fs-extra'
+import { isBuild, rootDir } from '~utils'
 
 const configNames = ['js', 'cjs', 'mjs', 'ts']
 
-export async function serve(root: string, isProd: boolean) {
-  if (!isProd) return
+export async function serve() {
+  if (!isBuild) return
 
-  const fromTestDir = (...p: string[]) => path.resolve(root, '..', ...p)
+  const fromTestDir = (...p: string[]) => path.resolve(rootDir, '..', ...p)
 
   // create separate directories for all config types:
   // ./{js,cjs,mjs,ts} and ./{js,cjs,mjs,ts}-module (with package#type)

--- a/playground/ssr-deps/__tests__/serve.ts
+++ b/playground/ssr-deps/__tests__/serve.ts
@@ -3,15 +3,15 @@
 
 import path from 'path'
 import kill from 'kill-port'
-import { ports } from '~utils'
+import { isBuild, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-deps']
 
-export async function serve(root, isProd) {
+export async function serve() {
   await kill(port)
 
-  const { createServer } = require(path.resolve(root, 'server.js'))
-  const { app, vite } = await createServer(root, isProd)
+  const { createServer } = require(path.resolve(rootDir, 'server.js'))
+  const { app, vite } = await createServer(rootDir, isBuild)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/ssr-html/__tests__/serve.ts
+++ b/playground/ssr-html/__tests__/serve.ts
@@ -3,15 +3,15 @@
 
 import path from 'path'
 import kill from 'kill-port'
-import { ports } from '~utils'
+import { isBuild, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-html']
 
-export async function serve(root, isProd) {
+export async function serve() {
   await kill(port)
 
-  const { createServer } = require(path.resolve(root, 'server.js'))
-  const { app, vite } = await createServer(root, isProd)
+  const { createServer } = require(path.resolve(rootDir, 'server.js'))
+  const { app, vite } = await createServer(rootDir, isBuild)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/ssr-pug/__tests__/serve.ts
+++ b/playground/ssr-pug/__tests__/serve.ts
@@ -3,15 +3,15 @@
 
 import path from 'path'
 import kill from 'kill-port'
-import { ports } from '~utils'
+import { isBuild, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-pug']
 
-export async function serve(root, isProd) {
+export async function serve() {
   await kill(port)
 
-  const { createServer } = require(path.resolve(root, 'server.js'))
-  const { app, vite } = await createServer(root, isProd)
+  const { createServer } = require(path.resolve(rootDir, 'server.js'))
+  const { app, vite } = await createServer(rootDir, isBuild)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/ssr-react/__tests__/serve.ts
+++ b/playground/ssr-react/__tests__/serve.ts
@@ -3,17 +3,17 @@
 
 import path from 'path'
 import kill from 'kill-port'
-import { ports } from '~utils'
+import { isBuild, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-react']
 
-export async function serve(root: string, isProd: boolean) {
-  if (isProd) {
+export async function serve() {
+  if (isBuild) {
     // build first
     const { build } = require('vite')
     // client build
     await build({
-      root,
+      root: rootDir,
       logLevel: 'silent', // exceptions are logged by Vitest
       build: {
         target: 'esnext',
@@ -24,7 +24,7 @@ export async function serve(root: string, isProd: boolean) {
     })
     // server build
     await build({
-      root,
+      root: rootDir,
       logLevel: 'silent',
       build: {
         target: 'esnext',
@@ -36,8 +36,8 @@ export async function serve(root: string, isProd: boolean) {
 
   await kill(port)
 
-  const { createServer } = require(path.resolve(root, 'server.js'))
-  const { app, vite } = await createServer(root, isProd)
+  const { createServer } = require(path.resolve(rootDir, 'server.js'))
+  const { app, vite } = await createServer(rootDir, isBuild)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/ssr-vue/__tests__/serve.ts
+++ b/playground/ssr-vue/__tests__/serve.ts
@@ -3,17 +3,17 @@
 
 import path from 'path'
 import kill from 'kill-port'
-import { ports } from '~utils'
+import { isBuild, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-vue']
 
-export async function serve(root, isProd) {
-  if (isProd) {
+export async function serve() {
+  if (isBuild) {
     // build first
     const { build } = require('vite')
     // client build
     await build({
-      root,
+      root: rootDir,
       logLevel: 'silent', // exceptions are logged by Vitest
       build: {
         target: 'esnext',
@@ -24,7 +24,7 @@ export async function serve(root, isProd) {
     })
     // server build
     await build({
-      root,
+      root: rootDir,
       logLevel: 'silent',
       build: {
         target: 'esnext',
@@ -36,8 +36,8 @@ export async function serve(root, isProd) {
 
   await kill(port)
 
-  const { createServer } = require(path.resolve(root, 'server.js'))
-  const { app, vite } = await createServer(root, isProd)
+  const { createServer } = require(path.resolve(rootDir, 'server.js'))
+  const { app, vite } = await createServer(rootDir, isBuild)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/ssr-webworker/__tests__/serve.ts
+++ b/playground/ssr-webworker/__tests__/serve.ts
@@ -3,11 +3,11 @@
 
 import path from 'path'
 import kill from 'kill-port'
-import { ports } from '~utils'
+import { isBuild, ports, rootDir } from '~utils'
 
 export const port = ports['ssr-webworker']
 
-export async function serve(root: string, isProd: boolean) {
+export async function serve() {
   await kill(port)
 
   // we build first, regardless of whether it's prod/build mode
@@ -16,7 +16,7 @@ export async function serve(root: string, isProd: boolean) {
 
   // worker build
   await build({
-    root,
+    root: rootDir,
     logLevel: 'silent',
     build: {
       target: 'esnext',
@@ -25,8 +25,8 @@ export async function serve(root: string, isProd: boolean) {
     }
   })
 
-  const { createServer } = require(path.resolve(root, 'worker.js'))
-  const { app } = await createServer(root, isProd)
+  const { createServer } = require(path.resolve(rootDir, 'worker.js'))
+  const { app } = await createServer(rootDir, isBuild)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/tsconfig-json-load-error/__tests__/serve.ts
+++ b/playground/tsconfig-json-load-error/__tests__/serve.ts
@@ -1,0 +1,21 @@
+import { startDefaultServe } from '~utils'
+
+export let serveError: Error | undefined
+
+export async function serve(root: string, isBuild: boolean) {
+  try {
+    await startDefaultServe(root, isBuild)
+  } catch (e) {
+    serveError = e
+  }
+}
+
+export function clearServeError() {
+  serveError = undefined
+}
+
+afterAll(() => {
+  if (serveError) {
+    throw serveError
+  }
+})

--- a/playground/tsconfig-json-load-error/__tests__/serve.ts
+++ b/playground/tsconfig-json-load-error/__tests__/serve.ts
@@ -2,9 +2,9 @@ import { startDefaultServe } from '~utils'
 
 export let serveError: Error | undefined
 
-export async function serve(root: string, isBuild: boolean) {
+export async function serve() {
   try {
-    await startDefaultServe(root, isBuild)
+    await startDefaultServe()
   } catch (e) {
     serveError = e
   }

--- a/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
+++ b/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
@@ -1,7 +1,6 @@
+import { clearServeError, serveError } from './serve'
 import {
-  beforeAllError,
   browserLogs,
-  clearBeforeAllError,
   editFile,
   isBuild,
   isServe,
@@ -12,12 +11,11 @@ import {
 
 describe.runIf(isBuild)('build', () => {
   test('should throw an error on build', () => {
-    const buildError = beforeAllError
-    expect(buildError).toBeTruthy()
-    expect(buildError.message).toMatch(
+    expect(serveError).toBeTruthy()
+    expect(serveError.message).toMatch(
       /^parsing .* failed: SyntaxError: Unexpected token } in JSON at position \d+$/
     )
-    clearBeforeAllError() // got expected error, null it here so testsuite does not fail from rethrow in afterAll
+    clearServeError() // got expected error, null it here so testsuite does not fail from rethrow in afterAll
   })
 
   test('should not output files to dist', () => {

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -24,25 +24,30 @@ export const workspaceRoot = path.resolve(__dirname, '../')
 
 export const isBuild = !!process.env.VITE_TEST_BUILD
 export const isServe = !isBuild
-
 export const isWindows = process.platform === 'win32'
-export const viteBinPath = path.join(
-  workspaceRoot,
-  'packages',
-  'vite',
-  'bin',
-  'vite.js'
-)
+export const viteBinPath = path.join(workspaceRoot, 'packages/vite/bin/vite.js')
 
 // #endregion
 
 // #region context
 
 let server: ViteDevServer | http.Server
-let tempDir: string
 
+/**
+ * Root of the Vite fixture
+ */
 export let rootDir: string
+/**
+ * Path to the current test file
+ */
 export let testPath: string
+/**
+ * Path to the test folder
+ */
+export let testDir: string
+/**
+ * Test folder name
+ */
 export let testName: string
 
 export const serverLogs: string[] = []
@@ -56,10 +61,6 @@ export let watcher: RollupWatcher | undefined = undefined
 
 export function setViteUrl(url: string) {
   viteTestUrl = url
-}
-
-export function slash(p: string): string {
-  return p.replace(/\\/g, '/')
 }
 
 // #endregion
@@ -100,15 +101,16 @@ beforeAll(async (s) => {
 
     testPath = suite.filepath!
     testName = slash(testPath).match(/playground\/([\w-]+)\//)?.[1]
+    testDir = dirname(testPath)
 
     // if this is a test placed under playground/xxx/__tests__
     // start a vite server in that directory.
     if (testName) {
-      tempDir = resolve(__dirname, '../playground-temp/', testName)
+      testDir = resolve(workspaceRoot, 'playground-temp', testName)
 
       // when `root` dir is present, use it as vite's root
-      const testCustomRoot = resolve(tempDir, 'root')
-      rootDir = fs.existsSync(testCustomRoot) ? testCustomRoot : tempDir
+      const testCustomRoot = resolve(testDir, 'root')
+      rootDir = fs.existsSync(testCustomRoot) ? testCustomRoot : testDir
 
       const testCustomServe = [
         resolve(dirname(testPath), 'serve.ts'),
@@ -320,4 +322,8 @@ function setupConsoleWarnCollector(logs: string[]) {
     serverLogs.push(args.join(' '))
     return warn.call(console, ...args)
   }
+}
+
+export function slash(p: string): string {
+  return p.replace(/\\/g, '/')
 }

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -62,7 +62,7 @@ test('worker emitted and import.meta.url in nested worker (serve)', async () => 
 describe.runIf(isBuild)('build', () => {
   // assert correct files
   test('inlined code generation', async () => {
-    const assetsDir = path.resolve(testDir(), 'dist/es/assets')
+    const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
     expect(files.length).toBe(26)
     const index = files.find((f) => f.includes('main-module'))

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -106,10 +106,10 @@ test('classic worker', async () => {
 })
 
 test('emit chunk', async () => {
-  expect(await page.textContent('.emti-chunk-worker')).toMatch(
+  expect(await page.textContent('.emit-chunk-worker')).toMatch(
     '["A string",{"type":"emit-chunk-sub-worker","data":"A string"},{"type":"module-and-worker:worker","data":"A string"},{"type":"module-and-worker:module","data":"module and worker"},{"type":"emit-chunk-sub-worker","data":{"module":"module and worker","msg1":"module1","msg2":"module2","msg3":"module3"}}]'
   )
-  expect(await page.textContent('.emti-chunk-dynamic-import-worker')).toMatch(
+  expect(await page.textContent('.emit-chunk-dynamic-import-worker')).toMatch(
     '"A string/es/"'
   )
 })

--- a/playground/worker/__tests__/iife/worker.spec.ts
+++ b/playground/worker/__tests__/iife/worker.spec.ts
@@ -63,7 +63,7 @@ test('worker emitted and import.meta.url in nested worker (serve)', async () => 
 describe.runIf(isBuild)('build', () => {
   // assert correct files
   test('inlined code generation', async () => {
-    const assetsDir = path.resolve(testDir(), 'dist/iife/assets')
+    const assetsDir = path.resolve(testDir, 'dist/iife/assets')
     const files = fs.readdirSync(assetsDir)
     expect(files.length).toBe(13)
     const index = files.find((f) => f.includes('main-module'))

--- a/playground/worker/__tests__/sourcemap-hidden/sourcemap-hidden-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/sourcemap-hidden-worker.spec.ts
@@ -5,10 +5,7 @@ import { isBuild, testDir } from '~utils'
 describe.runIf(isBuild)('build', () => {
   // assert correct files
   test('sourcemap generation for web workers', async () => {
-    const assetsDir = path.resolve(
-      testDir(),
-      'dist/iife-sourcemap-hidden/assets'
-    )
+    const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap-hidden/assets')
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk

--- a/playground/worker/__tests__/sourcemap-inline/sourcemap-inline-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/sourcemap-inline-worker.spec.ts
@@ -5,10 +5,7 @@ import { isBuild, testDir } from '~utils'
 describe.runIf(isBuild)('build', () => {
   // assert correct files
   test('sourcemap generation for web workers', async () => {
-    const assetsDir = path.resolve(
-      testDir(),
-      'dist/iife-sourcemap-inline/assets'
-    )
+    const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap-inline/assets')
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk

--- a/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
@@ -5,7 +5,7 @@ import { isBuild, testDir } from '~utils'
 describe.runIf(isBuild)('build', () => {
   // assert correct files
   test('sourcemap generation for web workers', async () => {
-    const assetsDir = path.resolve(testDir(), 'dist/iife-sourcemap/assets')
+    const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap/assets')
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
     expect(files.length).toBe(26)

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -92,15 +92,15 @@
   worker emit chunk <br />
   module and worker:worker in worker file <br />
   module and worker:module in worker file <br />
-  <span class="classname">.emti-chunk-worker</span>
+  <span class="classname">.emit-chunk-worker</span>
 </p>
-<code class="emti-chunk-worker"></code>
+<code class="emit-chunk-worker"></code>
 
 <p>
   worker dynamic import to emit chunk
-  <span class="classname">.emti-chunk-dynamic-import-worker</span>
+  <span class="classname">.emit-chunk-dynamic-import-worker</span>
 </p>
-<code class="emti-chunk-dynamic-import-worker"></code>
+<code class="emit-chunk-dynamic-import-worker"></code>
 
 <p>
   module and worker:worker in simple file

--- a/playground/worker/worker/main-format-es.js
+++ b/playground/worker/worker/main-format-es.js
@@ -13,7 +13,7 @@ const dataList = []
 nestedWorker.addEventListener('message', (ev) => {
   dataList.push(ev.data)
   text(
-    '.emti-chunk-worker',
+    '.emit-chunk-worker',
     JSON.stringify(
       dataList.sort(
         (a, b) => JSON.stringify(a).length - JSON.stringify(b).length
@@ -29,7 +29,7 @@ const dynamicImportWorker = new Worker(
   }
 )
 dynamicImportWorker.addEventListener('message', (ev) => {
-  text('.emti-chunk-dynamic-import-worker', JSON.stringify(ev.data))
+  text('.emit-chunk-dynamic-import-worker', JSON.stringify(ev.data))
 })
 
 const moduleWorker = new Worker(


### PR DESCRIPTION
This is more like a DX thing.

Currently, we shallow the `beforeAll` setup error deferring to `afterAll` to throw. It's for the `tsconfig` to test the expected failure. However, this allows the test to run with a broken state, which leads to a lot of misleading errors until the real error gets displayed in `afterAll`. This PR make the error throw on eager, only do the error tolerance in the tsconfig test.