### PR TITLE
feat: treat Astro file scripts as TS

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -277,6 +277,8 @@ function esbuildScanPlugin(
             let loader: Loader = 'js'
             if (lang === 'ts' || lang === 'tsx' || lang === 'jsx') {
               loader = lang
+            } else if (path.endsWith('.astro')) {
+              loader = 'ts'
             }
             const srcMatch = openTag.match(srcRE)
             if (srcMatch) {

--- a/playground/optimize-deps/index.astro
+++ b/playground/optimize-deps/index.astro
@@ -1,0 +1,4 @@
+<script>
+  type Foo = 'bar';
+  console.log("stuff");
+</script>

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -119,6 +119,8 @@
 
   import { parse } from 'node:url'
   text('.url', parse('https://vitejs.dev').hostname)
+
+  import './index.astro'
 </script>
 
 <script type="module">

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -50,6 +50,15 @@ module.exports = {
           res.end('pong')
         })
       }
+    },
+    {
+      name: 'test-astro',
+      transform(code, id) {
+        if (id.endsWith('.astro')) {
+          code = `export default {}`
+          return { code }
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

This updates the import scanner to treat `<script>` tags inside of `.astro` files as TypeScript and not JS. In Astro plain scripts can contain TypeScript and this changes prevents error messages coming from the import scanner.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
