### PR TITLE
chore(plugin-vue): change @rollup/pluginutils to dep from devDep

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -39,12 +39,14 @@
     "vue": "^3.2.25"
   },
   "devDependencies": {
-    "@rollup/pluginutils": "^4.2.1",
     "debug": "^4.3.4",
     "rollup": "^2.72.1",
     "slash": "^4.0.0",
     "source-map": "^0.6.1",
-    "vue": "^3.2.33",
-    "vite": "workspace:*"
+    "vite": "workspace:*",
+    "vue": "^3.2.33"
+  },
+  "dependencies": {
+    "@rollup/pluginutils": "^4.2.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,9 @@ importers:
       source-map: ^0.6.1
       vite: workspace:*
       vue: ^3.2.33
-    devDependencies:
+    dependencies:
       '@rollup/pluginutils': 4.2.1
+    devDependencies:
       debug: 4.3.4
       rollup: 2.72.1
       slash: 4.0.0


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
All other plugins in this repo has `@rollup/pluginutils` in dep instead of devDep.
https://github.com/vitejs/vite/blob/2289d04af5398791c3a01c9e597dc976e593c852/packages/plugin-react/package.json#L47

`@rollup/pluginutils` is a quite common dep among rollup plugins so I think it is better to have this not bundled to dedupe it.
Maybe it should be a dep also with Vite?

In addition, `@rollup/pluginutils` don't have many deps, only 2.
https://npm.anvaka.com/#/view/2d/%2540rollup%252Fpluginutils

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
