### PR TITLE
chore(plugin-vue): replace source-map with gen/trace-mapping

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -39,6 +39,8 @@
     "vue": "^3.2.25"
   },
   "devDependencies": {
+    "@jridgewell/gen-mapping": "^0.3.1",
+    "@jridgewell/trace-mapping": "^0.3.10",
     "debug": "^4.3.4",
     "rollup": "^2.72.1",
     "slash": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,8 @@ importers:
 
   packages/plugin-vue:
     specifiers:
+      '@jridgewell/gen-mapping': ^0.3.1
+      '@jridgewell/trace-mapping': ^0.3.10
       '@rollup/pluginutils': ^4.2.1
       debug: ^4.3.4
       rollup: ^2.72.1
@@ -182,6 +184,8 @@ importers:
     dependencies:
       '@rollup/pluginutils': 4.2.1
     devDependencies:
+      '@jridgewell/gen-mapping': 0.3.1
+      '@jridgewell/trace-mapping': 0.3.11
       debug: 4.3.4
       rollup: 2.72.1
       slash: 4.0.0
@@ -1640,6 +1644,15 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.1
       '@jridgewell/sourcemap-codec': 1.4.13
+
+  /@jridgewell/gen-mapping/0.3.1:
+    resolution: {integrity: sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.1
+      '@jridgewell/sourcemap-codec': 1.4.13
+      '@jridgewell/trace-mapping': 0.3.11
+    dev: true
 
   /@jridgewell/resolve-uri/3.0.7:
     resolution: {integrity: sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR replaces `source-map` with `@jridgewell/gen-mapping` and `@jridgewell/trace-mapping`.
This reduces package size.

|                     |before|after|diff| (%)|
|--------------|-------:|------:|---:|----:|
|package size|79.8kB|44.7kB|-35.1kB | -43.98%|
|unpacked size|311.0kB|155.9kB|-155.1kB | -49.87%|

Simillar to #6746.

### Additional context

Another approach is to turn `source-map` into dep. `source-map` is a dep of `@vue/compiler-core`/`@vue/compiler-sfc`.
Or `source-map-js` which is a dep of `postcss` (`@vue/compiler-sfc`).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
