### PR TITLE
ci: remove mac node18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,11 @@ jobs:
         os: [ubuntu-latest]
         node_version: [14, 16, 18]
         include:
+          # Active LTS + other OS
           - os: macos-latest
             node_version: 16
-          - os: macos-latest
-            node_version: 18
           - os: windows-latest
             node_version: 16
-          # Maybe bug with jest on windows and node-v18
-          # - os: windows-latest
-          #   node_version: 18
       fail-fast: false
 
     env:


### PR DESCRIPTION
### Description
This PR removes mac + node18 CI to reduce build minutes.

close #7868
close #8164

### Additional context

If this PR is going to be merged, mac + node18 needs to be removed from required CI checks.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
