### PR TITLE
chore: show ws port conflict error

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -160,7 +160,12 @@ export function createWebSocketServer(
   })
 
   wss.on('error', (e: Error & { code: string }) => {
-    if (e.code !== 'EADDRINUSE') {
+    if (e.code === 'EADDRINUSE') {
+      config.logger.error(
+        colors.red(`WebSocket server: Port is already in use`),
+        { error: e }
+      )
+    } else {
       config.logger.error(
         colors.red(`WebSocket server error:\n${e.stack || e.message}`),
         { error: e }

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -162,7 +162,7 @@ export function createWebSocketServer(
   wss.on('error', (e: Error & { code: string }) => {
     if (e.code === 'EADDRINUSE') {
       config.logger.error(
-        colors.red(`WebSocket server: Port is already in use`),
+        colors.red(`WebSocket server error: Port is already in use`),
         { error: e }
       )
     } else {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Show error when ws port conflicts.
Reproduction is written in #8197.

refs #8197

### Additional context
There might be a reason?
https://github.com/vitejs/vite/commit/c6bb3e4338e5edf999acdcd491981e10eae0298b#diff-7ea20ab586e000d69e1adb4aeb7e126745c763f6d15f30e09f8ca2149722e6f1R27-R32

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
