### PR TITLE
fix: support set NODE_ENV in scripts when custom mode option

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -395,7 +395,9 @@ export async function resolveConfig(
   // Note it is possible for user to have a custom mode, e.g. `staging` where
   // production-like behavior is expected. This is indicated by NODE_ENV=production
   // loaded from `.staging.env` and set by us as VITE_USER_NODE_ENV
-  const isProduction = (process.env.VITE_USER_NODE_ENV || mode) === 'production'
+  const isProduction =
+    (process.env.NODE_ENV || process.env.VITE_USER_NODE_ENV || mode) ===
+    'production'
   if (isProduction) {
     // in case default mode was not production and is overwritten
     process.env.NODE_ENV = 'production'

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const vue = require('@vitejs/plugin-vue')
 
+process.env.NODE_ENV = ''
+
 /**
  * @type {import('vite').UserConfig}
  */

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const vue = require('@vitejs/plugin-vue')
 
+// Overriding the NODE_ENV set by vitest
 process.env.NODE_ENV = ''
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Support set NODE_ENV in scripts when custom mode option, e.g:
```shell
NODE_ENV=production vite build --mode custom && vite preview
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

close: #8192

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
