### PR TITLE
fix: EPERM error on Windows when processing dependencies

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -15,6 +15,7 @@ import {
   lookupFile,
   normalizeId,
   normalizePath,
+  removeDir,
   removeDirSync,
   renameDir,
   writeFile
@@ -534,7 +535,7 @@ export async function runOptimizeDeps(
   async function commitProcessingDepsCacheSync() {
     // Processing is done, we can now replace the depsCacheDir with processingCacheDir
     // Rewire the file paths from the temporal processing dir to the final deps cache dir
-    removeDirSync(depsCacheDir)
+    await removeDir(depsCacheDir)
     await renameDir(processingCacheDir, depsCacheDir)
   }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -534,8 +534,9 @@ export function removeDirSync(dir: string) {
   }
 }
 
-const rmdirSync = fs.rmSync ?? fs.rmdirSync // TODO: Remove after support for Node 12 is dropped
-export const removeDir = isWindows ? promisify(gracefulRemoveDir) : rmdirSync
+export const removeDir = isWindows
+  ? promisify(gracefulRemoveDir)
+  : removeDirSync
 export const renameDir = isWindows ? promisify(gracefulRename) : fs.renameSync
 
 export function ensureWatchedFile(

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -538,7 +538,9 @@ const REMOVE_DIR_TIMEOUT = 5000
 const rmdir = promisify(fs.rm ?? fs.rmdir) // TODO: Remove after support for Node 12 is dropped
 export async function removeDir(dir: string) {
   const t0 = Date.now()
+  let backoff = 0
   const attempt = async () => {
+    const attemptStart = Date.now()
     try {
       await rmdir(dir, { recursive: true })
     } catch (e) {
@@ -546,11 +548,13 @@ export async function removeDir(dir: string) {
         return
       }
       if (e.code === 'ENOTEMPTY' || e.code === 'EPERM') {
-        if (Date.now() - t0 < REMOVE_DIR_TIMEOUT) {
-          // There's no delay here, testing showed it wasn't required.
-          // If the remove doesn't succeed the first time, it almost always succeed immediately afterwards.
-          // In rare cases two or three attempts are needed before the dir is successfully removed,
-          // typically taking <1s total.
+        const now = Date.now()
+        if (now - t0 < REMOVE_DIR_TIMEOUT) {
+          const delay = backoff - (now - attemptStart)
+          if (delay > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delay))
+          }
+          backoff = Math.min(backoff + 10, 100)
           await attempt()
           return
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix a rare for people but consistent for me issue that results in an EPERM error when renaming the `.vite/processing` dir to `.vite/deps`. See #7939 for a discussion of the issue.

This PR adds retries to the _remove dst_ step of the _remove dst, rename src->dst_ process used when processing dependencies. 

During testing I observed that as part of loading a page, the dependency processing/optimisation logic in vite can be invoked more than once, this resulted in the following flow

1. Page requests a dependency file
2. Vite optimises the dependency
   1. uses `processing` for working files
   2. delete `deps`
   3. rename `processing` to `deps`
3. Page requests another dependency file
4. Vite optimises the new dependency
   1. uses `processing` for working files
   2. delete `deps`
   3. rename `processing` to `deps`

The error mentioned in [the issue](#7939) is triggered at step 4.iii, but during testing I've identified that the underlying problem is actually a race/conflict between steps 2.iii and 4.ii - effectively deleting `deps` can sometimes fail without saying it has failed, it can say the dir is deleted when there are still files, or the dir itself, on the FS.

If logging is added to print each time the `removeDir` in this PR errors I see output like the following
```
calling removeDir [...]/node_modules/.vite/deps
retrying removeDir because ENOTEMPTY: ["vuetify.js"]
retrying removeDir because EPERM
retrying removeDir because EPERM
removeDir done in 530ms
```

Fixes #7939 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
