### PR TITLE
fix(plugin-legacy): disable babel.compact when minify is disabled

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -309,7 +309,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       const { code, map } = babel.transform(raw, {
         babelrc: false,
         configFile: false,
-        compact: true,
+        compact: !!config.build.minify,
         sourceMaps,
         inputSourceMap: sourceMaps ? chunk.map : undefined,
         presets: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
[`compact`](https://babeljs.io/docs/en/options#compact) was set to `true` always.
This PR changes it to `false` when `build.minify` is `false`.

It might be slightly faster when `compact` is `true` than `false`. So ones who is setting `build.minify` to `false` with intention to reduce build time will get a negative effect from this change.

I tested this by setting `build.minify` to `false` at `playground/legacy/vite.config.js`.

close #8180

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
