### PR TITLE
fix(plugin-legacy): respect `entryFileNames` for polyfill chunks

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -131,11 +131,12 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
             modernPolyfills
           )
         await buildPolyfillChunk(
-          'polyfills-modern',
           modernPolyfills,
           bundle,
           facadeToModernPolyfillMap,
           config.build,
+          'es',
+          opts,
           options.externalSystemJS
         )
         return
@@ -160,13 +161,14 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           )
 
         await buildPolyfillChunk(
-          'polyfills-legacy',
           legacyPolyfills,
           bundle,
           facadeToLegacyPolyfillMap,
           // force using terser for legacy polyfill minification, since esbuild
           // isn't legacy-safe
           config.build,
+          'iife',
+          opts,
           options.externalSystemJS
         )
       }
@@ -549,11 +551,12 @@ export async function detectPolyfills(
 }
 
 async function buildPolyfillChunk(
-  name: string,
   imports: Set<string>,
   bundle: OutputBundle,
   facadeToChunkMap: Map<string, string>,
   buildOptions: BuildOptions,
+  format: 'iife' | 'es',
+  rollupOutputOptions: NormalizedOutputOptions,
   externalSystemJS?: boolean
 ) {
   let { minify, assetsDir } = buildOptions
@@ -571,10 +574,11 @@ async function buildPolyfillChunk(
       assetsDir,
       rollupOptions: {
         input: {
-          [name]: polyfillId
+          polyfills: polyfillId
         },
         output: {
-          format: name.includes('legacy') ? 'iife' : 'es',
+          format,
+          entryFileNames: rollupOutputOptions.entryFileNames,
           manualChunks: undefined
         }
       }

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -37,7 +37,8 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
           )
           if (format === 'system' && !chunk.name.includes('-legacy')) {
             const ext = path.extname(name)
-            name = name.slice(0, -ext.length) + `-legacy` + ext
+            const endPos = ext.length !== 0 ? -ext.length : undefined
+            name = name.slice(0, endPos) + `-legacy` + ext
           }
           return name.replace(/\0/g, '')
         } else {

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -71,6 +71,12 @@ test('should load dynamic import with css', async () => {
 describe.runIf(isBuild)('build', () => {
   test('should generate correct manifest', async () => {
     const manifest = readManifest()
+    // legacy polyfill
+    expect(manifest['../../vite/legacy-polyfills-legacy']).toBeDefined()
+    expect(manifest['../../vite/legacy-polyfills-legacy'].src).toBe(
+      '../../vite/legacy-polyfills-legacy'
+    )
+    // modern polyfill
     expect(manifest['../../vite/legacy-polyfills']).toBeDefined()
     expect(manifest['../../vite/legacy-polyfills'].src).toBe(
       '../../vite/legacy-polyfills'

--- a/playground/legacy/vite.config-custom-filename.js
+++ b/playground/legacy/vite.config-custom-filename.js
@@ -1,7 +1,7 @@
 const legacy = require('@vitejs/plugin-legacy').default
 
 module.exports = {
-  plugins: [legacy()],
+  plugins: [legacy({ modernPolyfills: true })],
   build: {
     manifest: true,
     minify: false,

--- a/playground/legacy/vite.config.js
+++ b/playground/legacy/vite.config.js
@@ -6,7 +6,8 @@ module.exports = {
   base: './',
   plugins: [
     legacy({
-      targets: 'IE 11'
+      targets: 'IE 11',
+      modernPolyfills: true
     })
   ],
 


### PR DESCRIPTION
***Potentially breaking change: `vite/legacy-polyfills` in manifest is now `vite/legacy-polyfills-legacy`. `polyfills-modern.hash.js` is now `polyfills.hash.js`.***

### Description
legacy and modern polyfill chunk file names now respect `entryFileNames`.
As a byproduct, conflicted entry in manifest was solved. I will describe this in the additional context.

I tested with `pnpm build:custom-filename` in `playground/legacy`.

close #4221
refs #8180

### Additional context
When [modernPolyfill](https://github.com/vitejs/vite/blob/main/packages/plugin-legacy/README.md#modernpolyfills) is enabled, `vite/legacy-polyfills` in `manifest.json` points to modern polyfill chunk. Also there was no entry pointing to legacy polyfill chunk.
When it is disabled, it points to legacy polyfill chunk.

It was like this.
```json
  "vite/legacy-polyfills": {
    "file": "assets/polyfills-modern.792b0ede.js",
    "src": "vite/legacy-polyfills",
    "isEntry": true
  },
```

This PR changes it to
```json
  "vite/legacy-polyfills-legacy": {
    "file": "assets/polyfills-legacy.378fc635.js",
    "src": "vite/legacy-polyfills-legacy",
    "isEntry": true
  },
  "vite/legacy-polyfills": {
    "file": "assets/polyfills.4dce788d.js",
    "src": "vite/legacy-polyfills",
    "isEntry": true
  }
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

(maybe it's a feat than a fix?)

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
