### PR TITLE
chore: use 'new URL' instead of 'url.parse'

### DIFF
--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -1,4 +1,3 @@
-import { parse as parseUrl } from 'url'
 import type { Connect } from 'types/connect'
 import type { ViteDevServer } from '..'
 
@@ -12,7 +11,7 @@ export function baseMiddleware({
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteBaseMiddleware(req, res, next) {
     const url = req.url!
-    const parsed = parseUrl(url)
+    const parsed = new URL(url)
     const path = parsed.pathname || '/'
 
     if (path.startsWith(base)) {

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -11,7 +11,7 @@ export function baseMiddleware({
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteBaseMiddleware(req, res, next) {
     const url = req.url!
-    const parsed = new URL(url)
+    const parsed = new URL(url, 'http://vitejs.dev')
     const path = parsed.pathname || '/'
 
     if (path.startsWith(base)) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`url.parse` has been depreciated, so use `new URL` instead it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
