### PR TITLE
fix: dev sourcemap

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -206,10 +206,7 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
         }
         return {
           code: s.toString(),
-          map:
-            !isBuild || config.build.sourcemap
-              ? s.generateMap({ hires: true })
-              : null
+          map: config.build.sourcemap ? s.generateMap({ hires: true }) : null
         }
       }
     }

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -117,7 +117,7 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
   const { include, exclude, warnOnError } =
     config.build.dynamicImportVarsOptions
   const filter = createFilter(include, exclude)
-  const isBuild = config.command === 'build'
+
   return {
     name: 'vite:dynamic-import-vars',
 

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -75,7 +75,7 @@ export function importGlobPlugin(config: ResolvedConfig): Plugin {
         }
         return {
           code: result.s.toString(),
-          map: result.s.generateMap()
+          map: config.build.sourcemap ? result.s.generateMap() : null
         }
       }
     }

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -71,7 +71,7 @@ test('should load dynamic import with vars', async () => {
 test('should load dynamic import with vars alias', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-alias'),
-    'hello',
+    'hi',
     true
   )
 })

--- a/playground/dynamic-import/alias/hello.js
+++ b/playground/dynamic-import/alias/hello.js
@@ -1,3 +1,4 @@
 export function hello() {
   return 'hello'
 }
+console.log('hello.js')

--- a/playground/dynamic-import/alias/hi.js
+++ b/playground/dynamic-import/alias/hi.js
@@ -1,3 +1,4 @@
 export function hi() {
   return 'hi'
 }
+console.log('hi.js')

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -79,16 +79,19 @@ function text(el, text) {
   document.querySelector(el).textContent = text
 }
 
-const base = 'hello'
+let base = 'hello'
 
 import(`../alias/${base}.js`).then((mod) => {
   text('.dynamic-import-with-vars', mod.hello())
 })
 
-import(`@/${base}.js`).then((mod) => {
-  text('.dynamic-import-with-vars-alias', mod.hello())
-})
-
 import(`../alias/${base}.js?raw`).then((mod) => {
   text('.dynamic-import-with-vars-raw', JSON.stringify(mod))
 })
+
+base = 'hi'
+import(`@/${base}.js`).then((mod) => {
+  text('.dynamic-import-with-vars-alias', mod.hi())
+})
+
+console.log('index.js')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

in dev mode, we don't need to generate sourcemap, if generate a sourcemap will point to a null file.
this PR will clean `importGlob` and `dynamicImport` generate sourcemap in dev.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

config.build had value when mode === 'build' 

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
