### PR TITLE
fix(css): remove `?used` hack (fixes #6421, #8245)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -108,7 +108,6 @@ const htmlProxyRE = /(\?|&)html-proxy\b/
 const commonjsProxyRE = /\?commonjs-proxy/
 const inlineRE = /(\?|&)inline\b/
 const inlineCSSRE = /(\?|&)inline-css\b/
-const usedRE = /(\?|&)used\b/
 const varRE = /^var\(/i
 
 const cssBundleName = 'style.css'
@@ -406,18 +405,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       }
 
       let code: string
-      if (usedRE.test(id)) {
-        if (modulesCode) {
-          code = modulesCode
-        } else {
-          let content = css
-          if (config.build.minify) {
-            content = await minifyCSS(content, config)
-          }
-          code = `export default ${JSON.stringify(content)}`
-        }
+      if (modulesCode) {
+        code = modulesCode
       } else {
-        code = `export default ''`
+        let content = css
+        if (config.build.minify) {
+          content = await minifyCSS(content, config)
+        }
+        code = `export default ${JSON.stringify(content)}`
       }
 
       return {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -412,7 +412,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         if (config.build.minify) {
           content = await minifyCSS(content, config)
         }
-        code = `export default ${JSON.stringify(content)}`
+        // marking as pure to make it tree-shakable by minifier
+        // but the module itself is still treated as a non tree-shakable module
+        // because moduleSideEffects is 'no-treeshake'
+        code = `export default /* #__PURE__ */ (() => ${JSON.stringify(
+          content
+        )})()`
       }
 
       return {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -4,11 +4,11 @@ import type { ImportSpecifier } from 'es-module-lexer'
 import { init, parse as parseImports } from 'es-module-lexer'
 import type { OutputChunk, SourceMap } from 'rollup'
 import type { RawSourceMap } from '@ampproject/remapping'
-import { bareImportRE, combineSourcemaps, isRelativeBase } from '../utils'
+import { combineSourcemaps, isRelativeBase } from '../utils'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
 import { genSourceMapUrl } from '../server/sourcemap'
-import { isCSSRequest, removedPureCssFilesCache } from './css'
+import { removedPureCssFilesCache } from './css'
 
 /**
  * A flag for injected helpers. This flag will be set to `false` if the output
@@ -145,14 +145,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       let needPreloadHelper = false
 
       for (let index = 0; index < imports.length; index++) {
-        const {
-          s: start,
-          e: end,
-          ss: expStart,
-          se: expEnd,
-          n: specifier,
-          d: dynamicIndex
-        } = imports[index]
+        const { ss: expStart, se: expEnd, d: dynamicIndex } = imports[index]
 
         const isDynamic = dynamicIndex > -1
 
@@ -165,27 +158,6 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               relativeBase ? ',import.meta.url' : ''
             })`
           )
-        }
-
-        // Differentiate CSS imports that use the default export from those that
-        // do not by injecting a ?used query - this allows us to avoid including
-        // the CSS string when unnecessary (esbuild has trouble tree-shaking
-        // them)
-        if (
-          specifier &&
-          isCSSRequest(specifier) &&
-          // always inject ?used query when it is a dynamic import
-          // because there is no way to check whether the default export is used
-          (source.slice(expStart, start).includes('from') || isDynamic) &&
-          // already has ?used query (by import.meta.glob)
-          !specifier.match(/\?used(&|$)/) &&
-          // edge case for package names ending with .css (e.g normalize.css)
-          !(bareImportRE.test(specifier) && !specifier.includes('/'))
-        ) {
-          const url = specifier.replace(/\?|$/, (m) => `?used${m ? '&' : ''}`)
-          str().overwrite(start, end, isDynamic ? `'${url}'` : url, {
-            contentOnly: true
-          })
         }
       }
 

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -18,7 +18,6 @@ import type { ViteDevServer } from '../server'
 import type { ModuleNode } from '../server/moduleGraph'
 import type { ResolvedConfig } from '../config'
 import { normalizePath, slash } from '../utils'
-import { isCSSRequest } from './css'
 
 const { isMatch, scan } = micromatch
 
@@ -392,9 +391,6 @@ export async function transformGlobImport(
             const filePath = paths.filePath
             let importPath = paths.importPath
             let importQuery = query
-
-            if (isCSSRequest(file))
-              importQuery = importQuery ? `${importQuery}&used` : '?used'
 
             if (importQuery && importQuery !== '?raw') {
               const fileExtension = basename(file).split('.').slice(-1)[0]

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -415,9 +415,5 @@ test("relative path rewritten in Less's data-uri", async () => {
 test('PostCSS source.input.from includes query', async () => {
   const code = await page.textContent('.postcss-source-input')
   // should resolve assets
-  expect(code).toContain(
-    isBuild
-      ? '/postcss-source-input.css?used&query=foo'
-      : '/postcss-source-input.css?query=foo'
-  )
+  expect(code).toContain('/postcss-source-input.css?query=foo')
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This `?used` hack was introduced by https://github.com/vitejs/vite/commit/3e3c20364d6c065026f7362bbcb7094099705cc9.

At that time, esbuild v0.12.25 was used. This version of esbuild had trouble with tree-shaking.
[This is the reproduction with esbuild repl](https://hyrious.me/esbuild-repl/?version=0.12.25&mode=transform&input=const+p+%3D+function+polyfill%28%29+%7B%0A++++const+relList+%3D+document.createElement%28%27link%27%29.relList%3B%0A++++if+%28relList+%26%26+relList.supports+%26%26+relList.supports%28%27modulepreload%27%29%29+%7B%0A++++++++return%3B%0A++++%7D%0A++++for+%28const+link+of+document.querySelectorAll%28%27link%5Brel%3D%22modulepreload%22%5D%27%29%29+%7B%0A++++++++processPreload%28link%29%3B%0A++++%7D%0A++++new+MutationObserver%28%28mutations%29+%3D%3E+%7B%0A++++++++for+%28const+mutation+of+mutations%29+%7B%0A++++++++++++if+%28mutation.type+%21%3D%3D+%27childList%27%29+%7B%0A++++++++++++++++continue%3B%0A++++++++++++%7D%0A++++++++++++for+%28const+node+of+mutation.addedNodes%29+%7B%0A++++++++++++++++if+%28node.tagName+%3D%3D%3D+%27LINK%27+%26%26+node.rel+%3D%3D%3D+%27modulepreload%27%29%0A++++++++++++++++++++processPreload%28node%29%3B%0A++++++++++++%7D%0A++++++++%7D%0A++++%7D%29.observe%28document%2C+%7B+childList%3A+true%2C+subtree%3A+true+%7D%29%3B%0A++++function+getFetchOpts%28script%29+%7B%0A++++++++const+fetchOpts+%3D+%7B%7D%3B%0A++++++++if+%28script.integrity%29%0A++++++++++++fetchOpts.integrity+%3D+script.integrity%3B%0A++++++++if+%28script.referrerpolicy%29%0A++++++++++++fetchOpts.referrerPolicy+%3D+script.referrerpolicy%3B%0A++++++++if+%28script.crossorigin+%3D%3D%3D+%27use-credentials%27%29%0A++++++++++++fetchOpts.credentials+%3D+%27include%27%3B%0A++++++++else+if+%28script.crossorigin+%3D%3D%3D+%27anonymous%27%29%0A++++++++++++fetchOpts.credentials+%3D+%27omit%27%3B%0A++++++++else%0A++++++++++++fetchOpts.credentials+%3D+%27same-origin%27%3B%0A++++++++return+fetchOpts%3B%0A++++%7D%0A++++function+processPreload%28link%29+%7B%0A++++++++if+%28link.ep%29%0A++++++++++++%2F%2F+ep+marker+%3D+processed%0A++++++++++++return%3B%0A++++++++link.ep+%3D+true%3B%0A++++++++%2F%2F+prepopulate+the+load+record%0A++++++++const+fetchOpts+%3D+getFetchOpts%28link%29%3B%0A++++++++fetch%28link.href%2C+fetchOpts%29%3B%0A++++%7D%0A%7D%3Btrue%26%26p%28%29%3B%0A%0Aconst+linked+%3D+%22.linked-at-import%7Bcolor%3Ared%7D.wrapper+.linked%7Bcolor%3A%2300f%7D%5Cn%22%3B%0A%0Aconst+imported+%3D+%22.imported-at-import%7Bcolor%3Apurple%7D.import-with-space%7Bcolor%3Agreen%3Bbackground%3Aurl%28%22%2Bnew+URL%28%22ok.5aa0ddc0.png%22%2Cimport.meta.url%29.href%2B%22%29%3Bbackground-position%3Acenter%7D.imported%7Bcolor%3Agreen%7Dpre%7Bbackground-color%3A%23eee%3Bwidth%3A500px%3Bpadding%3A1em+1.5em%3Bborder-radius%3A10px%7D.postcss+.nesting%7Bcolor%3Apink%7D.url-separated%7Bbackground-image%3Aurl%28images%2Fcat.webp%29%2Curl%28images%2Fdog.webp%29%7D%5Cn%22%3B%0A&options=--minify+--tree-shaking+--format%3Desm+--target%3Des2020%2Cedge88%2Cfirefox78%2Cchrome87%2Csafari13). You can see `linked` variable and `imported` variable exists in the output.

But now Vite uses esbuild v0.14.38 and tree-shake works. [This is the reproduction with esbuild repl](https://hyrious.me/esbuild-repl/?version=0.14.38&mode=transform&input=const+p+%3D+function+polyfill%28%29+%7B%0A++++const+relList+%3D+document.createElement%28%27link%27%29.relList%3B%0A++++if+%28relList+%26%26+relList.supports+%26%26+relList.supports%28%27modulepreload%27%29%29+%7B%0A++++++++return%3B%0A++++%7D%0A++++for+%28const+link+of+document.querySelectorAll%28%27link%5Brel%3D%22modulepreload%22%5D%27%29%29+%7B%0A++++++++processPreload%28link%29%3B%0A++++%7D%0A++++new+MutationObserver%28%28mutations%29+%3D%3E+%7B%0A++++++++for+%28const+mutation+of+mutations%29+%7B%0A++++++++++++if+%28mutation.type+%21%3D%3D+%27childList%27%29+%7B%0A++++++++++++++++continue%3B%0A++++++++++++%7D%0A++++++++++++for+%28const+node+of+mutation.addedNodes%29+%7B%0A++++++++++++++++if+%28node.tagName+%3D%3D%3D+%27LINK%27+%26%26+node.rel+%3D%3D%3D+%27modulepreload%27%29%0A++++++++++++++++++++processPreload%28node%29%3B%0A++++++++++++%7D%0A++++++++%7D%0A++++%7D%29.observe%28document%2C+%7B+childList%3A+true%2C+subtree%3A+true+%7D%29%3B%0A++++function+getFetchOpts%28script%29+%7B%0A++++++++const+fetchOpts+%3D+%7B%7D%3B%0A++++++++if+%28script.integrity%29%0A++++++++++++fetchOpts.integrity+%3D+script.integrity%3B%0A++++++++if+%28script.referrerpolicy%29%0A++++++++++++fetchOpts.referrerPolicy+%3D+script.referrerpolicy%3B%0A++++++++if+%28script.crossorigin+%3D%3D%3D+%27use-credentials%27%29%0A++++++++++++fetchOpts.credentials+%3D+%27include%27%3B%0A++++++++else+if+%28script.crossorigin+%3D%3D%3D+%27anonymous%27%29%0A++++++++++++fetchOpts.credentials+%3D+%27omit%27%3B%0A++++++++else%0A++++++++++++fetchOpts.credentials+%3D+%27same-origin%27%3B%0A++++++++return+fetchOpts%3B%0A++++%7D%0A++++function+processPreload%28link%29+%7B%0A++++++++if+%28link.ep%29%0A++++++++++++%2F%2F+ep+marker+%3D+processed%0A++++++++++++return%3B%0A++++++++link.ep+%3D+true%3B%0A++++++++%2F%2F+prepopulate+the+load+record%0A++++++++const+fetchOpts+%3D+getFetchOpts%28link%29%3B%0A++++++++fetch%28link.href%2C+fetchOpts%29%3B%0A++++%7D%0A%7D%3Btrue%26%26p%28%29%3B%0A%0Aconst+linked+%3D+%22.linked-at-import%7Bcolor%3Ared%7D.wrapper+.linked%7Bcolor%3A%2300f%7D%5Cn%22%3B%0A%0Aconst+imported+%3D+%22.imported-at-import%7Bcolor%3Apurple%7D.import-with-space%7Bcolor%3Agreen%3Bbackground%3Aurl%28%22%2Bnew+URL%28%22ok.5aa0ddc0.png%22%2Cimport.meta.url%29.href%2B%22%29%3Bbackground-position%3Acenter%7D.imported%7Bcolor%3Agreen%7Dpre%7Bbackground-color%3A%23eee%3Bwidth%3A500px%3Bpadding%3A1em+1.5em%3Bborder-radius%3A10px%7D.postcss+.nesting%7Bcolor%3Apink%7D.url-separated%7Bbackground-image%3Aurl%28images%2Fcat.webp%29%2Curl%28images%2Fdog.webp%29%7D%5Cn%22%3B%0A&options=--minify+--tree-shaking+--format%3Desm+--target%3Des2020%2Cedge88%2Cfirefox78%2Cchrome87%2Csafari13). You can see `linked` is removed from output. `imported` is still included because of `new URL('---', import.meta.url).href`.
So here it needs to be marked as pure.
esbuild 0.13.0+ supports `/* #__PURE__ */` and it worked if I marked by using it ([esbuild repl](https://hyrious.me/esbuild-repl/?version=0.14.38&mode=transform&input=const+p+%3D+function+polyfill%28%29+%7B%0A++++const+relList+%3D+document.createElement%28%27link%27%29.relList%3B%0A++++if+%28relList+%26%26+relList.supports+%26%26+relList.supports%28%27modulepreload%27%29%29+%7B%0A++++++++return%3B%0A++++%7D%0A++++for+%28const+link+of+document.querySelectorAll%28%27link%5Brel%3D%22modulepreload%22%5D%27%29%29+%7B%0A++++++++processPreload%28link%29%3B%0A++++%7D%0A++++new+MutationObserver%28%28mutations%29+%3D%3E+%7B%0A++++++++for+%28const+mutation+of+mutations%29+%7B%0A++++++++++++if+%28mutation.type+%21%3D%3D+%27childList%27%29+%7B%0A++++++++++++++++continue%3B%0A++++++++++++%7D%0A++++++++++++for+%28const+node+of+mutation.addedNodes%29+%7B%0A++++++++++++++++if+%28node.tagName+%3D%3D%3D+%27LINK%27+%26%26+node.rel+%3D%3D%3D+%27modulepreload%27%29%0A++++++++++++++++++++processPreload%28node%29%3B%0A++++++++++++%7D%0A++++++++%7D%0A++++%7D%29.observe%28document%2C+%7B+childList%3A+true%2C+subtree%3A+true+%7D%29%3B%0A++++function+getFetchOpts%28script%29+%7B%0A++++++++const+fetchOpts+%3D+%7B%7D%3B%0A++++++++if+%28script.integrity%29%0A++++++++++++fetchOpts.integrity+%3D+script.integrity%3B%0A++++++++if+%28script.referrerpolicy%29%0A++++++++++++fetchOpts.referrerPolicy+%3D+script.referrerpolicy%3B%0A++++++++if+%28script.crossorigin+%3D%3D%3D+%27use-credentials%27%29%0A++++++++++++fetchOpts.credentials+%3D+%27include%27%3B%0A++++++++else+if+%28script.crossorigin+%3D%3D%3D+%27anonymous%27%29%0A++++++++++++fetchOpts.credentials+%3D+%27omit%27%3B%0A++++++++else%0A++++++++++++fetchOpts.credentials+%3D+%27same-origin%27%3B%0A++++++++return+fetchOpts%3B%0A++++%7D%0A++++function+processPreload%28link%29+%7B%0A++++++++if+%28link.ep%29%0A++++++++++++%2F%2F+ep+marker+%3D+processed%0A++++++++++++return%3B%0A++++++++link.ep+%3D+true%3B%0A++++++++%2F%2F+prepopulate+the+load+record%0A++++++++const+fetchOpts+%3D+getFetchOpts%28link%29%3B%0A++++++++fetch%28link.href%2C+fetchOpts%29%3B%0A++++%7D%0A%7D%3Btrue%26%26p%28%29%3B%0A%0Aconst+linked+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%22.linked-at-import%7Bcolor%3Ared%7D.wrapper+.linked%7Bcolor%3A%2300f%7D%5Cn%22%29%28%29%3B%0A%0Aconst+imported+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%22.imported-at-import%7Bcolor%3Apurple%7D.import-with-space%7Bcolor%3Agreen%3Bbackground%3Aurl%28%22%2Bnew+URL%28%22ok.5aa0ddc0.png%22%2Cimport.meta.url%29.href%2B%22%29%3Bbackground-position%3Acenter%7D.imported%7Bcolor%3Agreen%7Dpre%7Bbackground-color%3A%23eee%3Bwidth%3A500px%3Bpadding%3A1em+1.5em%3Bborder-radius%3A10px%7D.postcss+.nesting%7Bcolor%3Apink%7D.url-separated%7Bbackground-image%3Aurl%28images%2Fcat.webp%29%2Curl%28images%2Fdog.webp%29%7D%5Cn%22%29%28%29%3B%0A&options=--minify+--tree-shaking+--format%3Desm+--target%3Des2020%2Cedge88%2Cfirefox78%2Cchrome87%2Csafari13)).
The same code worked successfully with terser too.

This PR removes the `?used` hack and changes the css default export to `export default /* #__PURE__ */ (() => ${JSON.stringify(content)})()` which I showed above.
I also tested with [this project (stackblitz)](https://stackblitz.com/edit/vitejs-vite-rj91sc?terminal=dev).

|commit|index.js size|tree-shake|notes|
|---|---|---|---|
|67743a3c4|872B|⭕|the parent commit of this PR|
|a49bd36b8|13984B|❌|because I removed `?used` hack|
|197253e06|872B|⭕|because I added pure comment|

fixes #6421
fixes #8245

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
