### PR TITLE
fix: correctly replace process.env.NODE_ENV

### DIFF
--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -55,7 +55,8 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
         // avoiding inconsistencies between dev and build
         return code.replace(
           /\bprocess\.env\.NODE_ENV\b/g,
-          JSON.stringify(config.mode)
+          config.define?.['process.env.NODE_ENV'] ||
+            JSON.stringify(process.env.NODE_ENV || config.mode)
         )
       }
     }

--- a/playground/define/__tests__/define.spec.ts
+++ b/playground/define/__tests__/define.spec.ts
@@ -14,6 +14,9 @@ test('string', async () => {
   expect(await page.textContent('.object')).toBe(
     JSON.stringify(defines.__OBJ__, null, 2)
   )
+  expect(await page.textContent('.process-node-env')).toBe(
+    JSON.parse(defines['process.env.NODE_ENV'])
+  )
   expect(await page.textContent('.env-var')).toBe(
     JSON.parse(defines['process.env.SOMEVAR'])
   )

--- a/playground/define/index.html
+++ b/playground/define/index.html
@@ -6,6 +6,7 @@
 <p>Boolean <code class="boolean"></code></p>
 <p>Object <span class="pre object"></span></p>
 <p>Env Var <code class="env-var"></code></p>
+<p>process node env: <code class="process-node-env"></code></p>
 <p>process as property: <code class="process-as-property"></code></p>
 <p>spread object: <code class="spread-object"></code></p>
 <p>spread array: <code class="spread-array"></code></p>
@@ -23,6 +24,7 @@
   text('.number', __NUMBER__)
   text('.boolean', __BOOLEAN__)
   text('.object', JSON.stringify(__OBJ__, null, 2))
+  text('.process-node-env', process.env.NODE_ENV)
   text('.env-var', process.env.SOMEVAR)
   text('.process-as-property', __OBJ__.process.env.SOMEVAR)
   text(

--- a/playground/define/vite.config.js
+++ b/playground/define/vite.config.js
@@ -15,6 +15,7 @@ module.exports = {
         }
       }
     },
+    'process.env.NODE_ENV': '"dev"',
     'process.env.SOMEVAR': '"SOMEVAR"',
     $DOLLAR: 456,
     ÖUNICODE_LETTERɵ: 789,

--- a/playground/env/__tests__/env.spec.ts
+++ b/playground/env/__tests__/env.spec.ts
@@ -37,7 +37,7 @@ test('inline variables', async () => {
 })
 
 test('NODE_ENV', async () => {
-  expect(await page.textContent('.node-env')).toBe(mode)
+  expect(await page.textContent('.node-env')).toBe(process.env.NODE_ENV)
 })
 
 test('env object', async () => {

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -8,7 +8,7 @@ test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong')
   await untilUpdated(
     () => page.textContent('.mode'),
-    isBuild ? 'production' : 'development'
+    process.env.NODE_ENV // match workerImport.js
   )
   await untilUpdated(
     () => page.textContent('.bundle-with-plugin'),

--- a/playground/worker/__tests__/iife/worker.spec.ts
+++ b/playground/worker/__tests__/iife/worker.spec.ts
@@ -9,7 +9,7 @@ test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong')
   await untilUpdated(
     () => page.textContent('.mode'),
-    isBuild ? 'production' : 'development'
+    process.env.NODE_ENV // match workerImport.js
   )
   await untilUpdated(
     () => page.textContent('.bundle-with-plugin'),

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -8,7 +8,7 @@ test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong')
   await untilUpdated(
     () => page.textContent('.mode'),
-    isBuild ? 'production' : 'development'
+    process.env.NODE_ENV // match workerImport.js
   )
   await untilUpdated(
     () => page.textContent('.bundle-with-plugin'),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #8210 

Use same logic as `definePlugin` when resolving the value of `process.env.NODE_ENV` when replacing.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
