### PR TITLE
refactor(plugin-legacy): improve default polyfill

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -63,8 +63,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   const modernPolyfills = new Set<string>()
   // System JS relies on the Promise interface. It needs to be polyfilled for IE 11. (array.iterator is mandatory for supporting Promise.all)
   const DEFAULT_LEGACY_POLYFILL = [
-    'core-js/modules/es.promise',
-    'core-js/modules/es.array.iterator'
+    'core-js/modules/es.promise.js',
+    'core-js/modules/es.array.iterator.js'
   ]
   const legacyPolyfills = new Set(DEFAULT_LEGACY_POLYFILL)
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -61,12 +61,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   const facadeToLegacyPolyfillMap = new Map()
   const facadeToModernPolyfillMap = new Map()
   const modernPolyfills = new Set<string>()
-  // System JS relies on the Promise interface. It needs to be polyfilled for IE 11. (array.iterator is mandatory for supporting Promise.all)
-  const DEFAULT_LEGACY_POLYFILL = [
-    'core-js/modules/es.promise.js',
-    'core-js/modules/es.array.iterator.js'
-  ]
-  const legacyPolyfills = new Set(DEFAULT_LEGACY_POLYFILL)
+  const legacyPolyfills = new Set<string>()
 
   if (Array.isArray(options.modernPolyfills)) {
     options.modernPolyfills.forEach((i) => {
@@ -148,6 +143,14 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
 
       // legacy bundle
       if (legacyPolyfills.size || genDynamicFallback) {
+        // check if the target needs Promise polyfill because SystemJS relies on it
+        // https://github.com/systemjs/systemjs#ie11-support
+        await detectPolyfills(
+          `Promise.resolve(); Promise.all();`,
+          targets,
+          legacyPolyfills
+        )
+
         isDebug &&
           console.log(
             `[@vitejs/plugin-legacy] legacy polyfills:`,

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -148,12 +148,6 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
 
       // legacy bundle
       if (legacyPolyfills.size || genDynamicFallback) {
-        if (!legacyPolyfills.has('es.promise')) {
-          // check if the target needs Promise polyfill because SystemJS relies
-          // on it
-          await detectPolyfills(`Promise.resolve()`, targets, legacyPolyfills)
-        }
-
         isDebug &&
           console.log(
             `[@vitejs/plugin-legacy] legacy polyfills:`,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR fixes the following things.

- reverts #4440 and reapply b72db4e with fix 
  - now it injects polyfill only if it is needed
- dedupe `[@vitejs/plugin-legacy] legacy polyfills:` output (indirectly): https://github.com/vitejs/vite/issues/8287#issuecomment-1135869096
  - actually it does not affect anything but it is confusing

I tested this with create-vite (vanilla-js) with IE 11.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
