### PR TITLE
chore: add type module to ESM internal test packages

### DIFF
--- a/playground/alias/dir/module/package.json
+++ b/playground/alias/dir/module/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@vite/aliased-module",
   "private": true,
+  "type": "module",
   "version": "0.0.0"
 }

--- a/playground/nested-deps/test-package-a/package.json
+++ b/playground/nested-deps/test-package-a/package.json
@@ -1,6 +1,7 @@
 {
   "name": "test-package-a",
   "private": true,
-  "version": "2.0.0",
+  "version": "1.0.0",
+  "type": "module",
   "main": "index.js"
 }

--- a/playground/nested-deps/test-package-b/package.json
+++ b/playground/nested-deps/test-package-b/package.json
@@ -2,5 +2,6 @@
   "name": "test-package-b",
   "private": true,
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js"
 }

--- a/playground/nested-deps/test-package-c/package.json
+++ b/playground/nested-deps/test-package-c/package.json
@@ -2,6 +2,7 @@
   "name": "test-package-c",
   "private": true,
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "module": "index-es.js"
 }

--- a/playground/nested-deps/test-package-d/package.json
+++ b/playground/nested-deps/test-package-d/package.json
@@ -2,6 +2,7 @@
   "name": "test-package-d",
   "private": true,
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "dependencies": {
     "test-package-d-nested": "link:./test-package-d-nested"

--- a/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
+++ b/playground/nested-deps/test-package-e/test-package-e-excluded/package.json
@@ -2,5 +2,6 @@
   "name": "test-package-e-excluded",
   "private": true,
   "version": "0.1.0",
+  "type": "module",
   "main": "index.js"
 }

--- a/playground/nested-deps/test-package-e/test-package-e-included/package.json
+++ b/playground/nested-deps/test-package-e/test-package-e-included/package.json
@@ -2,6 +2,7 @@
   "name": "test-package-e-included",
   "private": true,
   "version": "0.1.0",
+  "type": "module",
   "main": "index.js",
   "dependencies": {
     "test-package-e-excluded": "link:../test-package-e-excluded"

--- a/playground/optimize-deps/dep-esbuild-plugin-transform/package.json
+++ b/playground/optimize-deps/dep-esbuild-plugin-transform/package.json
@@ -2,5 +2,6 @@
   "name": "dep-esbuild-plugin-transform",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "main": "index.js"
 }

--- a/playground/optimize-deps/dep-linked/package.json
+++ b/playground/optimize-deps/dep-linked/package.json
@@ -2,6 +2,7 @@
   "name": "dep-linked",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "main": "index.js",
   "dependencies": {
     "lodash-es": "^4.17.21"

--- a/playground/optimize-deps/dep-node-env/package.json
+++ b/playground/optimize-deps/dep-node-env/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dep-node-env",
   "private": true,
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "type": "module"
 }

--- a/playground/optimize-deps/dep-with-dynamic-import/package.json
+++ b/playground/optimize-deps/dep-with-dynamic-import/package.json
@@ -2,5 +2,6 @@
   "name": "dep-with-dynamic-import",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "main": "index.js"
 }

--- a/playground/optimize-deps/nested-exclude/package.json
+++ b/playground/optimize-deps/nested-exclude/package.json
@@ -2,6 +2,7 @@
   "name": "nested-exclude",
   "private": true,
   "version": "1.0.0",
+  "type": "module",
   "main": "index.js",
   "dependencies": {
     "nested-include": "file:../nested-include"


### PR DESCRIPTION
### Description

Internal packages where using ESM in `.js` without `"type": "module"`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other