### PR TITLE
fix: expose client dist in `exports`

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -20,6 +20,7 @@
     "./client": {
       "types": "./client.d.ts"
     },
+    "./dist/client/*": "./dist/client/*",
     "./terser": {
       "require": "./dist/node-cjs/terser.cjs"
     }


### PR DESCRIPTION
Fix `Missing "./dist/client/client.mjs" export in "vite"` error @Shinigami92 