### PR TITLE
fix: HMR Break when using context in react templates - Issues: #3301 and #2624

### DIFF
--- a/packages/create-vite/template-react-ts/src/main.tsx
+++ b/packages/create-vite/template-react-ts/src/main.tsx
@@ -3,8 +3,15 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-)
+let rootElement: HTMLElement | null;
+
+document.addEventListener("DOMContentLoaded", () => {
+  if (!rootElement) {
+    rootElement = document.getElementById("root");
+    ReactDOM.createRoot(rootElement as HTMLElement).render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    );
+  }
+});

--- a/packages/create-vite/template-react/src/main.jsx
+++ b/packages/create-vite/template-react/src/main.jsx
@@ -3,8 +3,15 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-)
+let rootElement;
+
+document.addEventListener("DOMContentLoaded", function () {
+  if (!rootElement) {
+    rootElement = document.getElementById("root");
+    ReactDOM.createRoot(rootElement).render(
+      <React.StrictMode>
+            <App />
+      </React.StrictMode>
+    );
+  }
+});


### PR DESCRIPTION
When using `createContext` and wrap elements with `context.provider`, hmr breaks and the context tries to access disposed object.

This new template avoid the problem by creating one react root per model, and it makes loading page faster too.

<!-- Thank you for contributing! -->

### Description

HMR breaks in react templates when using contexts and wrap the `<App />` with any context provider.

I found this error in console:

```
You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before.
```

so it seems that in the current template, the root is being recreated with each Hot Reload leading to the dispose of old one, which made contexts stores throw `can't access lexical declaration 'SomeContext' before initialization`.

So the new main.jsx and main.tsx address this problem in general.
It makes sure that the root is created only once. 
I also noticed pages are loading faster after using this method.

BTW, the react error appears in the console anyway after each Hot Reload, whether using context or not.

### Additional context

This PR for the new template is a work around for issues #3301 and #2624.
It doesn't doesn't address the problem itself in the `react-vite` plugin.

Even though the problem doesn't persist, this solution creates a new issue. 
The context resets with every new change, which means it loses all its data;
but still better than just seeing an empty white screen.

So until the issue is fixed in the plugin, this workaround does the job.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
