### PR TITLE
fix(optimizer): transpile before calling `transformGlobImport`

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -299,10 +299,14 @@ function esbuildScanPlugin(
 
               const key = `${path}?id=${scriptId++}`
               if (contents.includes('import.meta.glob')) {
+                let transpiledContents
                 // transpile because `transformGlobImport` only expects js
-                const transpiledContents = (
-                  await transform(contents, { loader })
-                ).code
+                if (loader !== 'js') {
+                  transpiledContents = (await transform(contents, { loader }))
+                    .code
+                } else {
+                  transpiledContents = contents
+                }
 
                 scripts[key] = {
                   loader: 'js', // since it is transpiled

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -318,7 +318,7 @@ function esbuildScanPlugin(
                         config.root,
                         resolve
                       )
-                    )?.s.toString() || contents
+                    )?.s.toString() || transpiledContents
                 }
               } else {
                 scripts[key] = {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { performance } from 'perf_hooks'
 import glob from 'fast-glob'
 import type { Loader, OnLoadResult, Plugin } from 'esbuild'
-import { build } from 'esbuild'
+import { build, transform } from 'esbuild'
 import colors from 'picocolors'
 import type { ResolvedConfig } from '..'
 import {
@@ -299,12 +299,17 @@ function esbuildScanPlugin(
 
               const key = `${path}?id=${scriptId++}`
               if (contents.includes('import.meta.glob')) {
+                // transpile because `transformGlobImport` only expects js
+                const transpiledContents = (
+                  await transform(contents, { loader })
+                ).code
+
                 scripts[key] = {
-                  loader: 'js',
+                  loader: 'js', // since it is transpiled
                   contents:
                     (
                       await transformGlobImport(
-                        contents,
+                        transpiledContents,
                         path,
                         config.root,
                         resolve

--- a/playground/optimize-deps/index.astro
+++ b/playground/optimize-deps/index.astro
@@ -1,4 +1,6 @@
 <script>
   type Foo = 'bar';
   console.log("stuff");
+
+  import.meta.glob('./dedupe.*', { eager: true })
 </script>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When `import.meta.glob` is used inside Vue SFC with TypeScript, optimizer fails with error.
[Minimal reproduction (stackblitz). Run `npx vite optimize` to reproduce.](https://stackblitz.com/edit/vitejs-vite-dqwcpe?file=src%2FApp.vue)

Before #7537, TypeScript was transpiled to JavaScript before passing to `es-module-lexer`.
https://github.com/vitejs/vite/blob/b215493b6c01d9d299094e27a0f6bae694b71eff/packages/vite/src/node/optimizer/scan.ts#L304-L317
https://github.com/vitejs/vite/blob/b215493b6c01d9d299094e27a0f6bae694b71eff/packages/vite/src/node/optimizer/scan.ts#L493-L507
After #7537, the transpilation was removed.
https://github.com/vitejs/vite/blob/330e0a90988509454e31067984bf0cdbe2465325/packages/vite/src/node/optimizer/scan.ts#L302-L313
But  `parseImportGlob` which is called from `transformGlobImport` assumes the code as JavaScript. So that transpilation is still needed.
https://github.com/vitejs/vite/blob/330e0a90988509454e31067984bf0cdbe2465325/packages/vite/src/node/plugins/importMetaGlob.ts#L116-L122

### Additional context
Found while testing alpha.4 with my project.😄

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
