### PR TITLE
fix: remove empty chunk css imports when using esnext

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -560,8 +560,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           .replace(/\./g, '\\.')
         const emptyChunkRE = new RegExp(
           opts.format === 'es' || opts.format === 'system'
-            ? `\\bimport\\s*["'][^"]*(?:${emptyChunkFiles})["'];\n?`
-            : `\\brequire\\(\\s*"[^"]*(?:${emptyChunkFiles})"\\);\n?`,
+            ? `\\bimport\\s*["'][^"']*(?:${emptyChunkFiles})["'];\n?`
+            : `\\brequire\\(\\s*["'][^"']*(?:${emptyChunkFiles})["']\\);\n?`,
           'g'
         )
         for (const file in bundle) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -560,7 +560,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           .replace(/\./g, '\\.')
         const emptyChunkRE = new RegExp(
           opts.format === 'es' || opts.format === 'system'
-            ? `\\bimport\\s*"[^"]*(?:${emptyChunkFiles})";\n?`
+            ? `\\bimport\\s*["'][^"]*(?:${emptyChunkFiles})["'];\n?`
             : `\\brequire\\(\\s*"[^"]*(?:${emptyChunkFiles})"\\);\n?`,
           'g'
         )


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/issues/8330

- When building to `esnext` a single quote rather than double quote is used. Fixing the regex causes it to remove the empty chunk import statement correctly.

### Additional context

This fixes a bug in Astro and Sveltekit (see https://github.com/sveltejs/kit/issues/5052)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
