### PR TITLE
fix: preserve annotations during build deps optimization

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -485,7 +485,7 @@ export async function runOptimizeDeps(
     splitting: true,
     sourcemap: true,
     outdir: processingCacheDir,
-    ignoreAnnotations: true,
+    ignoreAnnotations: resolvedConfig.command !== 'build',
     metafile: true,
     define,
     plugins: [


### PR DESCRIPTION
### Description

fix {issue that @userquin is creating}

See context on:
- https://github.com/vitejs/vite/pull/8280

During dev bundling with esbuild passed `ignoreAnnotations` to speed up optimization, as they weren't used. At build time we need them to allow proper tree-shaking.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other