### PR TITLE
fix: fix type of `files` in `.eslintrc` overrides

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -150,7 +150,7 @@ module.exports = defineConfig({
       }
     },
     {
-      files: 'packages/vite/**/*.*',
+      files: ['packages/vite/**/*.*'],
       rules: {
         'no-restricted-globals': ['error', 'require', '__dirname', '__filename']
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes the type of `files` in `.eslintrc` overrides.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

My VSCode warns:

![スクリーンショット 2022-05-29 1 36 49](https://user-images.githubusercontent.com/14838850/170834606-b363a7cd-2529-47a3-b4c1-7fd6c64f369e.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
