### PR TITLE
chore: enable `@typescript-eslint/explicit-module-boundary-types`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -73,6 +73,10 @@ module.exports = defineConfig({
 
     '@typescript-eslint/ban-ts-comment': 'off', // TODO: we should turn this on in a new PR
     '@typescript-eslint/ban-types': 'off', // TODO: we should turn this on in a new PR
+    '@typescript-eslint/explicit-module-boundary-types': [
+      'error',
+      { allowArgumentsExplicitlyTypedAsAny: true }
+    ],
     '@typescript-eslint/no-empty-function': [
       'error',
       { allow: ['arrowFunctions'] }

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -517,7 +517,7 @@ export async function detectPolyfills(
   code: string,
   targets: any,
   list: Set<string>
-) {
+): Promise<void> {
   const babel = await loadBabel()
   const { ast } = babel.transform(code, {
     ast: true,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -861,7 +861,7 @@ async function loadConfigFromBundledFile(
   return config
 }
 
-export function isDepsOptimizerEnabled(config: ResolvedConfig) {
+export function isDepsOptimizerEnabled(config: ResolvedConfig): boolean {
   const { command, optimizeDeps } = config
   const { disabled } = optimizeDeps
   return !(

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -595,19 +595,22 @@ export function newDepOptimizationProcessing(): DepOptimizationProcessing {
 // Convert to { id: src }
 export function depsFromOptimizedDepInfo(
   depsInfo: Record<string, OptimizedDepInfo>
-) {
+): Record<string, string> {
   return Object.fromEntries(
     Object.entries(depsInfo).map((d) => [d[0], d[1].src!])
   )
 }
 
-export function getOptimizedDepPath(id: string, config: ResolvedConfig) {
+export function getOptimizedDepPath(
+  id: string,
+  config: ResolvedConfig
+): string {
   return normalizePath(
     path.resolve(getDepsCacheDir(config), flattenId(id) + '.js')
   )
 }
 
-export function getDepsCacheDir(config: ResolvedConfig) {
+export function getDepsCacheDir(config: ResolvedConfig): string {
   const dirName = config.command === 'build' ? 'depsBuild' : 'deps'
   return normalizePath(path.resolve(config.cacheDir, dirName))
 }
@@ -617,11 +620,16 @@ function getProcessingDepsCacheDir(config: ResolvedConfig) {
   return normalizePath(path.resolve(config.cacheDir, dirName))
 }
 
-export function isOptimizedDepFile(id: string, config: ResolvedConfig) {
+export function isOptimizedDepFile(
+  id: string,
+  config: ResolvedConfig
+): boolean {
   return id.startsWith(getDepsCacheDir(config))
 }
 
-export function createIsOptimizedDepUrl(config: ResolvedConfig) {
+export function createIsOptimizedDepUrl(
+  config: ResolvedConfig
+): (url: string) => boolean {
   const { root } = config
   const depsCacheDir = getDepsCacheDir(config)
 

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -34,7 +34,9 @@ const debounceMs = 100
 
 const depsOptimizerMap = new WeakMap<ResolvedConfig, DepsOptimizer>()
 
-export function getDepsOptimizer(config: ResolvedConfig) {
+export function getDepsOptimizer(
+  config: ResolvedConfig
+): DepsOptimizer | undefined {
   // Workers compilation shares the DepsOptimizer from the main build
   return depsOptimizerMap.get(config.mainConfig || config)
 }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1197,7 +1197,7 @@ async function minifyCSS(css: string, config: ResolvedConfig) {
   }
 }
 
-export async function hoistAtRules(css: string) {
+export async function hoistAtRules(css: string): Promise<string> {
   const s = new MagicString(css)
   const cleanCss = emptyCssComments(css)
   let match: RegExpExecArray | null

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -61,7 +61,7 @@ const debug = createDebugger('vite:import-analysis')
 const clientDir = normalizePath(CLIENT_DIR)
 
 const skipRE = /\.(map|json)$/
-export const canSkipImportAnalysis = (id: string) =>
+export const canSkipImportAnalysis = (id: string): boolean =>
   skipRE.test(id) || isDirectCSSRequest(id)
 
 const optimizedDepChunkRE = /\/chunk-[A-Z0-9]{8}\.js/

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -33,7 +33,10 @@ export interface ParsedImportGlob {
   end: number
 }
 
-export function getAffectedGlobModules(file: string, server: ViteDevServer) {
+export function getAffectedGlobModules(
+  file: string,
+  server: ViteDevServer
+): ModuleNode[] {
   const modules: ModuleNode[] = []
   for (const [id, allGlobs] of server._importGlobMap!) {
     if (allGlobs.some((glob) => isMatch(file, glob)))
@@ -501,7 +504,7 @@ export function getCommonBase(globsResolved: string[]): null | string {
   return commonAncestor
 }
 
-export function isVirtualModule(id: string) {
+export function isVirtualModule(id: string): boolean {
   // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
   return id.startsWith('virtual:') || id.startsWith('\0') || !id.includes('/')
 }

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -43,7 +43,10 @@ function getRunProcessingInfo(config: ResolvedConfig): RunProcessingInfo {
   )
 }
 
-export function registerWorkersSource(config: ResolvedConfig, id: string) {
+export function registerWorkersSource(
+  config: ResolvedConfig,
+  id: string
+): void {
   const info = getRunProcessingInfo(config)
   info.workersSources.add(id)
   if (info.waitingOn === id) {
@@ -55,7 +58,7 @@ export function delayDepsOptimizerUntil(
   config: ResolvedConfig,
   id: string,
   done: () => Promise<any>
-) {
+): void {
   const info = getRunProcessingInfo(config)
   if (
     !getDepsOptimizer(config)?.isOptimizedDepFile(id) &&

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -27,7 +27,7 @@ export class SplitVendorChunkCache {
   constructor() {
     this.cache = new Map<string, boolean>()
   }
-  reset() {
+  reset(): void {
     this.cache = new Map<string, boolean>()
   }
 }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -34,7 +34,7 @@ export interface HmrContext {
   server: ViteDevServer
 }
 
-export function getShortName(file: string, root: string) {
+export function getShortName(file: string, root: string): string {
   return file.startsWith(root + '/') ? path.posix.relative(root, file) : file
 }
 
@@ -130,7 +130,7 @@ export function updateModules(
   modules: ModuleNode[],
   timestamp: number,
   { config, ws }: ViteDevServer
-) {
+): void {
   const updates: Update[] = []
   const invalidatedModules = new Set<ModuleNode>()
   let needFullReload = false

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -59,7 +59,7 @@ export async function injectSourcesContent(
   }
 }
 
-export function genSourceMapUrl(map: SourceMap | string | undefined) {
+export function genSourceMapUrl(map: SourceMap | string | undefined): string {
   if (typeof map !== 'string') {
     map = JSON.stringify(map)
   }
@@ -70,7 +70,7 @@ export function getCodeWithSourcemap(
   type: 'js' | 'css',
   code: string,
   map: SourceMap | null
-) {
+): string {
   if (isDebug) {
     code += `\n/*${JSON.stringify(map, null, 2).replace(/\*\//g, '*\\/')}*/\n`
   }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -18,7 +18,7 @@ const debug = createDebugger('vite:ssr-external')
 /**
  * Converts "parent > child" syntax to just "child"
  */
-export function stripNesting(packages: string[]) {
+export function stripNesting(packages: string[]): string[] {
   return packages.map((s) => {
     const arr = s.split('>')
     return arr[arr.length - 1].trim()

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -234,10 +234,10 @@ export const isJSRequest = (url: string): boolean => {
 
 const knownTsRE = /\.(ts|mts|cts|tsx)$/
 const knownTsOutputRE = /\.(js|mjs|cjs|jsx)$/
-export const isTsRequest = (url: string) => knownTsRE.test(url)
-export const isPossibleTsOutput = (url: string) =>
+export const isTsRequest = (url: string): boolean => knownTsRE.test(url)
+export const isPossibleTsOutput = (url: string): boolean =>
   knownTsOutputRE.test(cleanUrl(url))
-export function getPotentialTsSrcPaths(filePath: string) {
+export function getPotentialTsSrcPaths(filePath: string): string[] {
   const [name, type, query = ''] = filePath.split(/(\.(?:[cm]?js|jsx))(\?.*)?$/)
   const paths = [name + type.replace('js', 'ts') + query]
   if (!type.endsWith('x')) {
@@ -781,7 +781,7 @@ export function parseRequest(id: string): Record<string, string> | null {
   return Object.fromEntries(new URLSearchParams(search))
 }
 
-export const blankReplacer = (match: string) => ' '.repeat(match.length)
+export const blankReplacer = (match: string): string => ' '.repeat(match.length)
 
 export function getHash(text: Buffer | string): string {
   return createHash('sha256').update(text).digest('hex').substring(0, 8)
@@ -856,7 +856,7 @@ function gracefulRemoveDir(
   })
 }
 
-export function emptyCssComments(raw: string) {
+export function emptyCssComments(raw: string): string {
   return raw.replace(multilineCommentsRE, (s) => ' '.repeat(s.length))
 }
 

--- a/playground/legacy/__tests__/ssr/serve.ts
+++ b/playground/legacy/__tests__/ssr/serve.ts
@@ -5,7 +5,7 @@ import { ports, rootDir } from '~utils'
 
 export const port = ports['legacy/ssr']
 
-export async function serve() {
+export async function serve(): Promise<{ close(): Promise<void> }> {
   const { build } = await import('vite')
   await build({
     root: rootDir,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR does not touch the logic, only fixes types.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Looking at `.eslintrc`, I noticed that `@typescript-eslint/explicit-module-boundary-types` was previously enabled in this repository.

It used to be included in typescript-eslint's recommended rules, but has been removed since v5.

Maybe forgot to enable it manually at that time.

This PR re-enables `@typescript-eslint/explicit-module-boundary-types` and fixes errors.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
