### PR TITLE
chore: set node/no-unsupported-features version

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -132,7 +132,20 @@ module.exports = defineConfig({
         'node/no-extraneous-require': 'off',
         'node/no-missing-import': 'off',
         'node/no-missing-require': 'off',
-        'no-undef': 'off'
+        'no-undef': 'off',
+        // engine field doesn't exist in playgrounds
+        'node/no-unsupported-features/es-builtins': [
+          'error',
+          {
+            version: '>=14.6.0'
+          }
+        ],
+        'node/no-unsupported-features/node-builtins': [
+          'error',
+          {
+            version: '>=14.6.0'
+          }
+        ]
       }
     },
     {

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -48,7 +48,6 @@ document.querySelector('.mxdjson').addEventListener('click', async () => {
 // data URLs (`blob:`)
 const code1 = 'export const msg = "blob"'
 const blob = new Blob([code1], { type: 'text/javascript;charset=UTF-8' })
-// eslint-disable-next-line node/no-unsupported-features/node-builtins
 const blobURL = URL.createObjectURL(blob)
 document.querySelector('.issue-2658-1').addEventListener('click', async () => {
   const { msg } = await import(/*@vite-ignore*/ blobURL)

--- a/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable node/no-unsupported-features/node-builtins */
 import fs from 'fs'
 import path from 'path'
 import {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Set `node/no-unsupported-features/*` version because `playground/*` does not have `engines` field.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
