### PR TITLE
fix: resolve relative root from config file path

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -383,9 +383,20 @@ export async function resolveConfig(
   }
 
   // resolve root
-  const resolvedRoot = normalizePath(
-    config.root ? path.resolve(config.root) : process.cwd()
-  )
+  let resolvedRoot: string
+  if (!config.root) {
+    resolvedRoot = process.cwd()
+  } else if (path.isAbsolute(config.root)) {
+    resolvedRoot = config.root
+  } else {
+    if (typeof configFile !== 'string') {
+      throw new Error(
+        `"config.root" cannot be relative when config file is not used.`
+      )
+    }
+    resolvedRoot = path.resolve(path.dirname(configFile), config.root)
+  }
+  resolvedRoot = normalizePath(resolvedRoot)
 
   const clientAlias = [
     { find: /^[\/]?@vite\/env/, replacement: () => ENV_ENTRY },


### PR DESCRIPTION
***Potentially breaking change: relative root is now resolved from config file path instead of `process.cwd()`***

### Description

Changed resolution of relative `config.root` as said in https://github.com/vitejs/vite/pull/7291#issuecomment-1133148148

refs #4151 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
