### PR TITLE
feat: ssr build using optimized deps

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -306,7 +306,7 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
     pre: [
       ...(options.watch ? [ensureWatchPlugin()] : []),
       watchPackageDataPlugin(config),
-      ...(!isDepsOptimizerEnabled(config) || options.ssr
+      ...(!isDepsOptimizerEnabled(config)
         ? [commonjsPlugin(options.commonjsOptions)]
         : []),
       dataURIPlugin(),
@@ -402,7 +402,7 @@ async function doBuild(
     external = await cjsSsrResolveExternal(config, userExternal)
   }
 
-  if (isDepsOptimizerEnabled(config) && !ssr) {
+  if (isDepsOptimizerEnabled(config)) {
     await initDepsOptimizer(config)
   }
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -610,13 +610,23 @@ export function getOptimizedDepPath(
   )
 }
 
+function getDepsCacheSuffix(config: ResolvedConfig): string {
+  let suffix = ''
+  if (config.command === 'build') {
+    suffix += '_build'
+    if (config.build.ssr) {
+      suffix += '_ssr'
+    }
+  }
+  return suffix
+}
 export function getDepsCacheDir(config: ResolvedConfig): string {
-  const dirName = config.command === 'build' ? 'depsBuild' : 'deps'
+  const dirName = 'deps' + getDepsCacheSuffix(config)
   return normalizePath(path.resolve(config.cacheDir, dirName))
 }
 
 function getProcessingDepsCacheDir(config: ResolvedConfig) {
-  const dirName = config.command === 'build' ? 'processingBuild' : 'processing'
+  const dirName = 'deps' + getDepsCacheSuffix(config) + '_temp'
   return normalizePath(path.resolve(config.cacheDir, dirName))
 }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -89,6 +89,7 @@ export interface InternalResolveOptions extends ResolveOptions {
 export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
   const {
     root,
+    isBuild,
     isProduction,
     asSrc,
     ssrConfig,
@@ -266,7 +267,7 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
           !external &&
           asSrc &&
           depsOptimizer &&
-          !ssr &&
+          (isBuild || !ssr) &&
           !options.scan &&
           (res = await tryOptimizedResolve(depsOptimizer, id, importer))
         ) {
@@ -668,7 +669,7 @@ export function tryNodeResolve(
     exclude?.includes(pkgId) ||
     exclude?.includes(nestedPath) ||
     SPECIAL_QUERY_RE.test(resolved) ||
-    ssr
+    (!isBuild && ssr)
   ) {
     // excluded from optimization
     // Inject a version query to npm deps so that the browser
@@ -682,7 +683,6 @@ export function tryNodeResolve(
       }
     }
   } else {
-    // TODO: depsBuild
     // this is a missing import, queue optimize-deps re-run and
     // get a resolved its optimized info
     const optimizedInfo = depsOptimizer.registerMissingImport(id, resolved)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -320,18 +320,7 @@ export async function createServer(
     },
     transformIndexHtml: null!, // to be immediately set
     async ssrLoadModule(url, opts?: { fixStacktrace?: boolean }) {
-      if (!server._ssrExternals) {
-        let knownImports: string[] = []
-        const depsOptimizer = getDepsOptimizer(config)
-        if (depsOptimizer) {
-          await depsOptimizer.scanProcessing
-          knownImports = [
-            ...Object.keys(depsOptimizer.metadata.optimized),
-            ...Object.keys(depsOptimizer.metadata.discovered)
-          ]
-        }
-        server._ssrExternals = cjsSsrResolveExternals(config, knownImports)
-      }
+      await updateCjsSsrExternals(server)
       return ssrLoadModule(
         url,
         server,
@@ -754,4 +743,19 @@ async function restartServer(server: ViteDevServer) {
 
   // new server (the current server) can restart now
   newServer._restartPromise = null
+}
+
+async function updateCjsSsrExternals(server: ViteDevServer) {
+  if (!server._ssrExternals) {
+    let knownImports: string[] = []
+    const depsOptimizer = getDepsOptimizer(server.config)
+    if (depsOptimizer) {
+      await depsOptimizer.scanProcessing
+      knownImports = [
+        ...Object.keys(depsOptimizer.metadata.optimized),
+        ...Object.keys(depsOptimizer.metadata.discovered)
+      ]
+    }
+    server._ssrExternals = cjsSsrResolveExternals(server.config, knownImports)
+  }
 }


### PR DESCRIPTION
### Description

Follow up to:
- https://github.com/vitejs/vite/pull/8280
- https://github.com/vitejs/vite/pull/8319
- https://github.com/vitejs/vite/pull/8348

This PR removes the need for `@rollup/plugin-commonjs` for SSR builds, enabling dep optimization using esbuild by default for them.

After this PR, if the user doesn't use `optimizeDeps.disabled: 'build'` or `optimizeDeps.devScan: true` then Vite isn't using `plugin-commonjs` or the esbuild scanner. In the same way we are doing with terser, we could decide in Vite v3 to avoid `@rollup/plugin-commonjs` as a dependency and ask users to add it to the project themselves if they need it. It isn't a big dep though, so probably not worthy.

There is a new deps cache for SSR. We could discuss if the build cache could be reused, but given that most deps will be externalized, I think a separate cache wouldn't affect performance. It will allow users to avoid busting the cache if there is a conditional change for the config depending on if we are building for SSR.
Given that we have more caches now, this PRs renames them to be more future proof:

- `deps`
- `deps_build`
- `deps_build_ssr`
 
And the prev `processingDeps` are now the same as above but with a `_temp` suffix. About using a flat structure instead of `deps/build`, we discussed in a previous PR with Anthony and Blu that this structure is easier to work with.

I thought about renaming `deps` to `deps_dev`, but I left it as `deps` because it is shorter and this dir is seen in the browser network tab.

@benmccann @brillout I would need some help with testing and validating here. Tests are passing on Vite's side, but maybe we should expand them.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other