### PR TITLE
fix: not match \n when injecting esbuild helpers

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -27,9 +27,9 @@ import { searchForWorkspaceRoot } from '..'
 const debug = createDebugger('vite:esbuild')
 
 const INJECT_HELPERS_IIFE_RE =
-  /(.*)((?:const|var) [^\s]+=function\([^)]*?\){"use strict";)(.*)/
+  /(.*)((?:const|var) [^\s]+=function\([^)]*?\){"use strict";)(.*)/s
 const INJECT_HELPERS_UMD_RE =
-  /(.*)(\(function\([^)]*?\){.+amd.+function\([^)]*?\){"use strict";)(.*)/
+  /(.*)(\(function\([^)]*?\){.+amd.+function\([^)]*?\){"use strict";)(.*)/s
 
 let server: ViteDevServer
 

--- a/playground/lib/vite.config.js
+++ b/playground/lib/vite.config.js
@@ -6,6 +6,11 @@ const path = require('path')
  */
 module.exports = {
   build: {
+    rollupOptions: {
+      output: {
+        banner: `/*!\nMayLib\n*/`
+      }
+    },
     lib: {
       entry: path.resolve(__dirname, 'src/main.js'),
       name: 'MyLib',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #8412

### Additional context

[A plugin like this could be used to workaround it.](https://github.com/vitejs/vite/issues/8412#issuecomment-1142037893)

But, I found that the key to the bug was not `rollupOptions.output.banner`, but `\n`, the following code does not match `\n` correctly:

```ts
const INJECT_HELPERS_UMD_RE =
  /(.*)(\(function\([^)]*?\){.+amd.+function\([^)]*?\){"use strict";)(.*)/
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
