### PR TITLE
docs: improve migration from v2 guide

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -68,6 +68,21 @@ If using ESM for SSR isn't possible in your project, you can set `ssr.format: 'c
 - When using an alias with `import.meta.glob`, the keys are always absolute.
 - `import.meta.globEager` is now deprecated. Use `import.meta.glob('*', { eager: true })` instead.
 
+### WebAssembly support
+
+`import init from 'example.wasm'` syntax is dropped to prevent future collision with ["ESM integration for Wasm"](https://github.com/WebAssembly/esm-integration).
+You can use `?init` which is similar to the previous behavior.
+
+```diff
+-import init from 'example.wasm'
++import init from 'example.wasm?init'
+
+-init().then((instance) => {
++init().then(({ exports }) => {
+  exports.test()
+})
+```
+
 ## Migration from v1
 
 Check the [Migration from v1 Guide](https://v2.vitejs.dev/guide/migration.html) in the Vite v2 docs first to see the needed changes to port your app to Vite v2, and then proceed with the changes on this page.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -19,11 +19,13 @@ A small fraction of users will now require using [@vitejs/plugin-legacy](https:/
 
 - The following options that were already deprecated in v2 have been removed:
 
-  - `optimizeDeps.keepNames` (switch to [`optimizeDeps.esbuildOptions.keepNames`](../config/dep-optimization-options.md#optimizedepsesbuildoptions))
-  - `build.base` (switch to [`base`](../config/shared-options.md#base))
   - `alias` (switch to [`resolve.alias`](../config/shared-options.md#resolvealias))
   - `dedupe` (switch to [`resolve.dedupe`](../config/shared-options.md#resolvededupe))
-  - `polyfillDynamicImport` (use [`@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) for browsers without dynamic import support)
+  - `build.base` (switch to [`base`](../config/shared-options.md#base))
+  - `build.brotliSize` (switch to [`build.reportCompressedSize`](../config/build-options.md#build-reportcompressedsize))
+  - `build.cleanCssOptions` (Vite now uses esbuild for CSS minification)
+  - `build.polyfillDynamicImport` (use [`@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) for browsers without dynamic import support)
+  - `optimizeDeps.keepNames` (switch to [`optimizeDeps.esbuildOptions.keepNames`](../config/dep-optimization-options.md#optimizedepsesbuildoptions))
 
 ## Dev Server Changes
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -45,9 +45,26 @@ If using ESM for SSR isn't possible in your project, you can set `ssr.format: 'c
 
 ## General Changes
 
-- [Raw `import.meta.glob`](features.md#glob-import-as) switched from `{ assert: { type: 'raw' }}` to `{ as: 'raw' }`
-
 - JS file extensions in SSR and lib mode now use a valid extension (`js`, `mjs`, or `cjs`) for output JS entries and chunks based on their format and the package type.
+
+### `import.meta.glob`
+
+- [Raw `import.meta.glob`](features.md#glob-import-as) switched from `{ assert: { type: 'raw' }}` to `{ as: 'raw' }`
+- Keys of `import.meta.glob` are now relative to the current module.
+
+  ```diff
+  // file: /foo/index.js
+  const modules = import.meta.glob('../foo/*.js')
+
+  // transformed:
+  const modules = {
+  -  '../foo/bar.js': () => {}
+  +  './bar.js': () => {}
+  }
+  ```
+
+- When using an alias with `import.meta.glob`, the keys are always absolute.
+- `import.meta.globEager` is now deprecated. Use `import.meta.glob('*', { eager: true })` instead.
 
 ## Migration from v1
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -27,6 +27,8 @@ A small fraction of users will now require using [@vitejs/plugin-legacy](https:/
 
 ## Dev Server Changes
 
+Vite's default dev server port is now 5173. You can use [`server.port`](../config/server-options.md#server-port) to set it to 3000.
+
 Vite optimizes dependencies with esbuild to both convert CJS-only deps to ESM and to reduce the number of modules the browser needs to request. In v3, the default strategy to discover and batch dependencies has changed. Vite no longer pre-scans user code with esbuild to get an initial list of dependencies on cold start. Instead, it delays the first dependency optimization run until every imported user module on load is processed.
 
 To get back the v2 strategy, you can use [`optimizeDeps.devScan`](../config/dep-optimization-options.md#optimizedepsdevscan).


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I checked the commit log from 2.9.8 and added descriptions for breaking changes which was missing.

There are potentially breaking changes which I didn't include.

- #5018
  - Transpile to ES5 is now necessary even if the user code only includes ES5. This is unlikely to happen.
- #7877
  - `/// <reference lib="dom" />` is removed from `vite/client.d.ts`. This only affects users who does not have either `{"lib": ["dom"]}` nor `{"lib": ["webworker"]}` in `tsconfig.json`.
- #8139 
  - `exports` field now exists. For example, it breaks if someone is importing `vite/dist/node/cli.js` directly which rarely happens.
- #8280
  - `server.force` option was removed in favor of `force` option.

And some which only affects plugin/tool creators which I didn't include.

- #5868 
  - `printHttpServerUrls` is removed
  - `server.app`, `server.transformWithEsbuild` are removed
  - `import.meta.hot.acceptDeps` is removed
- #7995
  - `ssrLoadModule`'s `fixStacktrace` option's default is now `false`
- #8178
  - `formatPostcssSourceMap` is now async
  - `resolvePackageEntry`, `resolvePackageData` are no longer available from CJS build (dynamic import is needed to use in CJS)

Also I didn't include breaking changes of plugins.

- #5868
  - `options.parserPlugins` is removed
- #8247
  - *potentially*: `vite/legacy-polyfills` in manifest is now `vite/legacy-polyfills-legacy`.
  - *potentially*: `polyfills-modern.hash.js` is now `polyfills.hash.js`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
