### PR TITLE
refactor: rename `force` to `optimizeDeps.force`

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -50,4 +50,4 @@ Certain options are omitted since changing them would not be compatible with Vit
 
 - **Type:** `boolean`
 
-Set to `true` to force dependency pre-bundling.
+Set to `true` to force dependency pre-bundling, ignoring previously cached optimized dependencies.

--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -45,3 +45,9 @@ Certain options are omitted since changing them would not be compatible with Vit
 
 - `external` is also omitted, use Vite's `optimizeDeps.exclude` option
 - `plugins` are merged with Vite's dep plugin
+
+## optimizeDeps.force
+
+- **Type:** `boolean`
+
+Set to `true` to force dependency pre-bundling.

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -107,13 +107,6 @@ Configure CORS for the dev server. This is enabled by default and allows any ori
 
 Specify server response headers.
 
-## server.force
-
-- **Type:** `boolean`
-- **Related:** [Dependency Pre-Bundling](/guide/dep-pre-bundling)
-
-Set to `true` to force dependency pre-bundling.
-
 ## server.hmr
 
 - **Type:** `boolean | { protocol?: string, host?: string, port?: number, path?: string, timeout?: number, overlay?: boolean, clientPort?: number, server?: Server }`

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -116,7 +116,7 @@ Also there are other breaking changes which only affect few users.
 - [[#8090] feat: preserve process env vars in lib build](https://github.com/vitejs/vite/pull/8090)
   - `process.env.*` is now preserved in library mode
 - [[#8280] feat: non-blocking esbuild optimization at build time](https://github.com/vitejs/vite/pull/8280)
-  - `server.force` option was removed in favor of `force` option.
+  - `server.force` option was removed in favor of `optimizeDeps.force` option.
 - [[#8550] fix: dont handle sigterm in middleware mode](https://github.com/vitejs/vite/pull/8550)
   - When running in middleware mode, Vite no longer kills process on `SIGTERM`.
 

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -87,6 +87,7 @@ cli
         configFile: options.config,
         logLevel: options.logLevel,
         clearScreen: options.clearScreen,
+        optimizeDeps: { force: options.force },
         server: cleanOptions(options)
       })
 
@@ -174,7 +175,7 @@ cli
         configFile: options.config,
         logLevel: options.logLevel,
         clearScreen: options.clearScreen,
-        force: options.force,
+        optimizeDeps: { force: options.force },
         build: buildOptions
       })
     } catch (e) {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -147,11 +147,6 @@ export interface UserConfig {
    */
   preview?: PreviewOptions
   /**
-   * Force dep pre-optimization regardless of whether deps have changed.
-   * @experimental
-   */
-  force?: boolean
-  /**
    * Dep optimization options
    */
   optimizeDeps?: DepOptimizationOptions

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -137,6 +137,11 @@ export interface DepOptimizationOptions {
    * @experimental
    */
   disabled?: boolean | 'build' | 'dev'
+  /**
+   * Force dep pre-optimization regardless of whether deps have changed.
+   * @experimental
+   */
+  force?: boolean
 }
 
 export interface DepOptimizationResult {
@@ -209,7 +214,7 @@ export interface DepOptimizationMetadata {
  */
 export async function optimizeDeps(
   config: ResolvedConfig,
-  force = config.force,
+  force = config.optimizeDeps.force,
   asCommand = false
 ): Promise<DepOptimizationMetadata> {
   const log = asCommand ? config.logger.info : debug
@@ -265,7 +270,7 @@ export function addOptimizedDepInfo(
  */
 export function loadCachedDepOptimizationMetadata(
   config: ResolvedConfig,
-  force = config.force,
+  force = config.optimizeDeps.force,
   asCommand = false
 ): DepOptimizationMetadata | undefined {
   const log = asCommand ? config.logger.info : debug


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`server.force` was removed in #8280.

refs #8398

### Additional context
The following options were missing from docs. Most of them are experimental, so it is intended?

- `optimizeDeps.needsInterop` => experimental
- `optimizeDeps.devScan` => #8623
- `optimizeDeps.extensions` => experimental
- `optimizeDeps.disabled` => experimental (#8623)
- `server.preTransformRequests`
- `experimental.importGlobRestoreExtension` => experimental
- `customLogger`
- `configFile`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
