### PR TITLE
fix: SSR deep imports externalization (fixes #8420)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -636,8 +636,14 @@ export function tryNodeResolve(
       return resolved
     }
     const resolvedExt = path.extname(resolved.id)
-    const resolvedId =
-      isDeepImport && path.extname(id) !== resolvedExt ? id + resolvedExt : id
+    let resolvedId = id
+    if (
+      isDeepImport &&
+      !pkg?.data.exports &&
+      path.extname(id) !== resolvedExt
+    ) {
+      resolvedId += resolvedExt
+    }
     return { ...resolved, id: resolvedId, external: true }
   }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -262,7 +262,6 @@ export function resolvePlugin(baseOptions: InternalResolveOptions): Plugin {
       // bare package imports, perform node resolve
       if (bareImportRE.test(id)) {
         const external = options.shouldExternalize?.(id)
-
         if (
           !external &&
           asSrc &&
@@ -637,12 +636,15 @@ export function tryNodeResolve(
     }
     const resolvedExt = path.extname(resolved.id)
     let resolvedId = id
-    if (
-      isDeepImport &&
-      !pkg?.data.exports &&
-      path.extname(id) !== resolvedExt
-    ) {
-      resolvedId += resolvedExt
+    if (isDeepImport) {
+      // check ext before externalizing - only externalize
+      // extension-less imports and explicit .js imports
+      if (resolvedExt && !resolved.id.match(/(.js|.mjs|.cjs)$/)) {
+        return
+      }
+      if (!pkg?.data.exports && path.extname(id) !== resolvedExt) {
+        resolvedId += resolvedExt
+      }
     }
     return { ...resolved, id: resolvedId, external: true }
   }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -139,29 +139,19 @@ function createIsSsrExternal(
     isBuild: true
   }
 
-  const isPackageEntry = (id: string) => {
+  const isValidPackageEntry = (id: string) => {
     if (!bareImportRE.test(id) || id.includes('\0')) {
       return false
     }
-    if (
-      tryNodeResolve(
-        id,
-        undefined,
-        resolveOptions,
-        ssr?.target === 'webworker',
-        undefined,
-        true
-      )
-    ) {
-      return true
-    }
-    try {
-      // no main entry, but deep imports may be allowed
-      if (resolveFrom(`${id}/package.json`, root)) {
-        return true
-      }
-    } catch {}
-    return false
+    return !!tryNodeResolve(
+      id,
+      undefined,
+      resolveOptions,
+      ssr?.target === 'webworker',
+      undefined,
+      true,
+      true // try to externalize, will return undefined if not possible
+    )
   }
 
   return (id: string) => {
@@ -171,7 +161,7 @@ function createIsSsrExternal(
     const external =
       !id.startsWith('.') &&
       !path.isAbsolute(id) &&
-      (isBuiltin(id) || (isConfiguredAsExternal(id) && isPackageEntry(id)))
+      (isBuiltin(id) || (isConfiguredAsExternal(id) && isValidPackageEntry(id)))
     processedIds.set(id, external)
     return external
   }


### PR DESCRIPTION
### Description

Fixes the error reported by @benmccann here https://github.com/vitejs/vite/issues/8420

But after this fix, SvelteKit is still not building as there is an issue with .css imports
```
kit.svelte.dev:build: TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".css" for /Users/patak/ecosystem/kit/node_modules/.pnpm/@sveltejs+site-kit@2.1.0/node_modules/@sveltejs/site-kit/base.css
```

We can still merge this one while we work on the other issue.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other