### PR TITLE
test: guard against ssr-vue hmr in CI flakiness

### DIFF
--- a/playground/ssr-vue/__tests__/ssr-vue.spec.ts
+++ b/playground/ssr-vue/__tests__/ssr-vue.spec.ts
@@ -160,7 +160,8 @@ test('hydration', async () => {
 
 test('hmr', async () => {
   // This is test is flaky in Mac CI, but can't be reproduced locally. Wait until
-  // network idle to avoid the issue
+  // network idle to avoid the issue. TODO: This may be caused by a bug when
+  // modifying a file while loading, we should remove this guard
   await page.goto(url, { waitUntil: 'networkidle' })
   editFile('src/pages/Home.vue', (code) => code.replace('Home', 'changed'))
   await untilUpdated(() => page.textContent('h1'), 'changed')

--- a/playground/ssr-vue/__tests__/ssr-vue.spec.ts
+++ b/playground/ssr-vue/__tests__/ssr-vue.spec.ts
@@ -159,7 +159,9 @@ test('hydration', async () => {
 })
 
 test('hmr', async () => {
-  await page.goto(url)
+  // This is test is flaky in Mac CI, but can't be reproduced locally. Wait until
+  // network idle to avoid the issue
+  await page.goto(url, { waitUntil: 'networkidle' })
   editFile('src/pages/Home.vue', (code) => code.replace('Home', 'changed'))
   await untilUpdated(() => page.textContent('h1'), 'changed')
 })


### PR DESCRIPTION
### Description

Trying to fix https://github.com/vitejs/vite/runs/6683267477?check_suite_focus=true#step:9:85
I can't reproduce this locally.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other