### PR TITLE
feat: better config `__dirname` support

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -24,14 +24,14 @@ vite --config my-config.js
 ```
 
 ::: tip NOTE
-Vite will replace `__filename`, `__dirname`, and `import.meta.url` in config files and its deps. Using these as variable names or passing as a parameter to a function with string double quote (example `console.log`) will result in an error:
+Vite will inject `__filename`, `__dirname` in config files and its deps. Declaring these variables at top level will result in an error:
 
 ```js
-const __filename = "value"
-// will be transformed to
-const "path/vite.config.js" = "value"
+const __filename = 'value' // SyntaxError: Identifier '__filename' has already been declared
 
-console.log("import.meta.url") // break error on build
+const func = () => {
+  const __filename = 'value' // no error
+}
 ```
 
 :::

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -790,6 +790,7 @@ async function bundleConfigFile(
   fileName: string,
   isESM = false
 ): Promise<{ code: string; dependencies: string[] }> {
+  const importMetaUrlVarName = '__vite_injected_original_import_meta_url'
   const result = await build({
     absWorkingDir: process.cwd(),
     entryPoints: [fileName],
@@ -800,6 +801,9 @@ async function bundleConfigFile(
     format: isESM ? 'esm' : 'cjs',
     sourcemap: 'inline',
     metafile: true,
+    define: {
+      'import.meta.url': importMetaUrlVarName
+    },
     plugins: [
       {
         name: 'externalize-deps',
@@ -815,22 +819,20 @@ async function bundleConfigFile(
         }
       },
       {
-        name: 'replace-import-meta',
+        name: 'inject-file-scope-variables',
         setup(build) {
           build.onLoad({ filter: /\.[jt]s$/ }, async (args) => {
             const contents = await fs.promises.readFile(args.path, 'utf8')
+            const injectValues =
+              `const __dirname = ${JSON.stringify(path.dirname(args.path))};` +
+              `const __filename = ${JSON.stringify(args.path)};` +
+              `const ${importMetaUrlVarName} = ${JSON.stringify(
+                pathToFileURL(args.path).href
+              )};`
+
             return {
               loader: args.path.endsWith('.ts') ? 'ts' : 'js',
-              contents: contents
-                .replace(
-                  /\bimport\.meta\.url\b/g,
-                  JSON.stringify(pathToFileURL(args.path).href)
-                )
-                .replace(
-                  /\b__dirname\b/g,
-                  JSON.stringify(path.dirname(args.path))
-                )
-                .replace(/\b__filename\b/g, JSON.stringify(args.path))
+              contents: injectValues + contents
             }
           })
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR changes the way to implement `__dirname`/`__filename`/`import.meta.url` support in config files.

Before this PR, those values were replaced. But now it is injected at each files.
This will avoid some strange errors.

I tested this with the files below.
```js
// vite.config.js
import './dep'

console.log('__dirname', __dirname)
console.log('__filename', __filename)
console.log('import.meta.url', import.meta.url)

;(() => {
  const __dirname = 'd'
  const __filename = 'f'
  console.log(__dirname, __filename)
})()

export default {}
```
```js
// dep.js
console.log('[dep] __dirname', __dirname)
console.log('[dep] __filename', __filename)
console.log('[dep] import.meta.url', import.meta.url)
```

refs: https://github.com/vitejs/vite/pull/7846#issuecomment-1120676802

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
