### PR TITLE
fix: opt out of direct import in SSR when the file is not JS

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -690,7 +690,7 @@ export function tryNodeResolve(
     // otherwise we may introduce duplicated modules for externalized files
     // from pre-bundled deps.
     if (!isBuild) {
-      const versionHash = depsOptimizer.metadata({ ssr }).browserHash
+      const versionHash = depsOptimizer.metadata({ ssr })?.browserHash
       if (versionHash && isJsType) {
         resolved = injectQuery(resolved, `v=${versionHash}`)
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently importing external CSS files in SSR throws `ERR_UNKNOWN_FILE_EXTENSION` unless those modules are marked as external ([reproduction](https://github.com/cyco130/vite-ssr-react/tree/ssr-css-bug), [StackBlitz](https://stackblitz.com/github/cyco130/vite-ssr-react/tree/ssr-css-bug)). This PR solves it by opting out of direct Node import if the resolved file has a non-JS extension.

### Additional context

The regex testing if a file is a non-JS file (which I copied from the optimizer code) may require some more thinking.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
