### PR TITLE
chore: resolve ssr options

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -41,6 +41,8 @@ import type { PluginContainer } from './server/pluginContainer'
 import { createPluginContainer } from './server/pluginContainer'
 import type { PackageCache } from './packages'
 import { loadEnv, resolveEnvPrefix } from './env'
+import type { ResolvedSSROptions, SSROptions } from './ssr'
+import { resolveSSROptions } from './ssr'
 
 const debug = createDebugger('vite:config')
 
@@ -228,29 +230,6 @@ export interface ExperimentalOptions {
   importGlobRestoreExtension?: boolean
 }
 
-export type SSRTarget = 'node' | 'webworker'
-
-export type SSRFormat = 'esm' | 'cjs'
-
-export interface SSROptions {
-  external?: string[]
-  noExternal?: string | RegExp | (string | RegExp)[] | true
-  /**
-   * Define the target for the ssr build. The browser field in package.json
-   * is ignored for node but used if webworker is the target
-   * Default: 'node'
-   */
-  target?: SSRTarget
-  /**
-   * Define the format for the ssr build. Since Vite v3 the SSR build generates ESM by default.
-   * `'cjs'` can be selected to generate a CJS build, but it isn't recommended. This option is
-   * left marked as experimental to give users more time to update to ESM. CJS builds requires
-   * complex externalization heuristics that aren't present in the ESM format.
-   * @experimental
-   */
-  format?: SSRFormat
-}
-
 export interface ResolveWorkerOptions {
   format: 'es' | 'iife'
   plugins: Plugin[]
@@ -285,6 +264,7 @@ export type ResolvedConfig = Readonly<
     server: ResolvedServerOptions
     build: ResolvedBuildOptions
     preview: ResolvedPreviewOptions
+    ssr: ResolvedSSROptions | undefined
     assetsInclude: (file: string) => boolean
     logger: Logger
     createResolver: (options?: Partial<InternalResolveOptions>) => ResolveFn
@@ -491,6 +471,7 @@ export async function resolveConfig(
       : ''
 
   const server = resolveServerOptions(resolvedRoot, config.server, logger)
+  const ssr = resolveSSROptions(config.ssr)
 
   const optimizeDeps = config.optimizeDeps || {}
 
@@ -508,6 +489,7 @@ export async function resolveConfig(
     cacheDir,
     command,
     mode,
+    ssr,
     isWorker: false,
     mainConfig: null,
     isProduction,

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -39,6 +39,12 @@ export type {
   DepsOptimizer,
   ExportsData
 } from './optimizer'
+export type {
+  ResolvedSSROptions,
+  SSROptions,
+  SSRFormat,
+  SSRTarget
+} from './ssr'
 export type { Plugin } from './plugin'
 export type { PackageCache, PackageData } from './packages'
 export type {

--- a/packages/vite/src/node/ssr/index.ts
+++ b/packages/vite/src/node/ssr/index.ts
@@ -1,0 +1,39 @@
+export type SSRTarget = 'node' | 'webworker'
+export type SSRFormat = 'esm' | 'cjs'
+
+export interface SSROptions {
+  external?: string[]
+  noExternal?: string | RegExp | (string | RegExp)[] | true
+  /**
+   * Define the target for the ssr build. The browser field in package.json
+   * is ignored for node but used if webworker is the target
+   * Default: 'node'
+   */
+  target?: SSRTarget
+  /**
+   * Define the format for the ssr build. Since Vite v3 the SSR build generates ESM by default.
+   * `'cjs'` can be selected to generate a CJS build, but it isn't recommended. This option is
+   * left marked as experimental to give users more time to update to ESM. CJS builds requires
+   * complex externalization heuristics that aren't present in the ESM format.
+   * @experimental
+   */
+  format?: SSRFormat
+}
+
+export interface ResolvedSSROptions extends SSROptions {
+  target: SSRTarget
+  format: SSRFormat
+}
+
+export function resolveSSROptions(
+  ssr: SSROptions | undefined
+): ResolvedSSROptions | undefined {
+  if (ssr === undefined) {
+    return undefined
+  }
+  return {
+    format: 'esm',
+    target: 'node',
+    ...ssr
+  }
+}


### PR DESCRIPTION
This PR adds a resolve function for SSR options to set the default. It allows plugin to know the target format:

```ts
const myPlugin = {
  configResolved(config) {
    const isESM = config.ssr?.format === 'esm'
  }
}
```

Otherwise, it was always `undefined` unless explicitly set, but the default is different in v2 and v3. This PR makes it easier for plugins to get the format without relying on checking Vite's version.