### PR TITLE
feat: expose `version`

### DIFF
--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -3,6 +3,7 @@
  * This file will be bundled to ESM and CJS and redirected by ../index.cjs
  * Please control the side-effects by checking the ./dist/node-cjs/publicUtils.cjs bundle
  */
+export { VERSION as version } from './constants'
 export {
   splitVendorChunkPlugin,
   splitVendorChunk


### PR DESCRIPTION
Allows 

```ts
import { version } from 'vite'
```

Similiar to what we had for

```ts
import { version } from 'vue'
```