### PR TITLE
fix(optimizer): external require-import conversion (fixes #2492, #3409, #5308)

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -13,6 +13,10 @@ import {
 import { browserExternalId } from '../plugins/resolve'
 import type { ExportsData } from '.'
 
+const externalWithConversionNamespace =
+  'vite:dep-pre-bundle:external-conversion'
+const convertedExternalPrefix = 'vite-dep-pre-bundle-external:'
+
 const externalTypes = [
   'css',
   // supported pre-processor types
@@ -79,10 +83,6 @@ export function esbuildDepPlugin(
   return {
     name: 'vite:dep-pre-bundle',
     setup(build) {
-      const externalWithConversionNamespace =
-        'vite:dep-pre-bundle:external-conversion'
-      const convertedExternalPrefix = 'vite-dep-pre-bundle-external:'
-
       // externalize assets and commonly known non-js file types
       // See #8459 for more details about this require-import conversion
       build.onResolve(

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -77,7 +77,11 @@ test('dep with dynamic import', async () => {
 })
 
 test('dep with css import', async () => {
-  expect(await getColor('h1')).toBe('red')
+  expect(await getColor('.dep-linked-include')).toBe('red')
+})
+
+test('CJS dep with css import', async () => {
+  expect(await getColor('.cjs-with-assets')).toBe('blue')
 })
 
 test('dep w/ non-js files handled via plugin', async () => {

--- a/playground/optimize-deps/dep-cjs-with-assets/foo.css
+++ b/playground/optimize-deps/dep-cjs-with-assets/foo.css
@@ -1,0 +1,3 @@
+.cjs-with-assets {
+  color: blue;
+}

--- a/playground/optimize-deps/dep-cjs-with-assets/index.js
+++ b/playground/optimize-deps/dep-cjs-with-assets/index.js
@@ -1,0 +1,3 @@
+require('./foo.css')
+
+exports.a = 11

--- a/playground/optimize-deps/dep-cjs-with-assets/package.json
+++ b/playground/optimize-deps/dep-cjs-with-assets/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep-cjs-with-assets",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/playground/optimize-deps/dep-linked-include/test.css
+++ b/playground/optimize-deps/dep-linked-include/test.css
@@ -1,3 +1,3 @@
-body {
+.dep-linked-include {
   color: red;
 }

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -35,6 +35,12 @@
 <h2>Optimizing force included dep even when it's linked</h2>
 <div class="force-include"></div>
 
+<h2>Dep with CSS</h2>
+<div class="dep-linked-include">This should be red</div>
+
+<h2>CJS Dep with CSS</h2>
+<div class="cjs-with-assets">This should be blue</div>
+
 <h2>import * as ...</h2>
 <div class="import-star"></div>
 
@@ -90,6 +96,8 @@
   if (keys.length) {
     text('.import-star', `[success] ${keys.join(', ')}`)
   }
+
+  import 'dep-cjs-with-assets'
 
   import { env } from 'dep-node-env'
   text('.node-env', env)

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -13,6 +13,7 @@
     "clipboard": "^2.0.11",
     "dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
+    "dep-cjs-with-assets": "file:./dep-cjs-with-assets",
     "dep-esbuild-plugin-transform": "file:./dep-esbuild-plugin-transform",
     "dep-linked": "link:./dep-linked",
     "dep-linked-include": "link:./dep-linked-include",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,7 @@ importers:
       clipboard: ^2.0.11
       dep-cjs-compiled-from-cjs: file:./dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:./dep-cjs-compiled-from-esm
+      dep-cjs-with-assets: file:./dep-cjs-with-assets
       dep-esbuild-plugin-transform: file:./dep-esbuild-plugin-transform
       dep-linked: link:./dep-linked
       dep-linked-include: link:./dep-linked-include
@@ -596,6 +597,7 @@ importers:
       clipboard: 2.0.11
       dep-cjs-compiled-from-cjs: file:playground/optimize-deps/dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:playground/optimize-deps/dep-cjs-compiled-from-esm
+      dep-cjs-with-assets: file:playground/optimize-deps/dep-cjs-with-assets
       dep-esbuild-plugin-transform: file:playground/optimize-deps/dep-esbuild-plugin-transform
       dep-linked: link:dep-linked
       dep-linked-include: link:dep-linked-include
@@ -618,6 +620,9 @@ importers:
     specifiers: {}
 
   playground/optimize-deps/dep-cjs-compiled-from-esm:
+    specifiers: {}
+
+  playground/optimize-deps/dep-cjs-with-assets:
     specifiers: {}
 
   playground/optimize-deps/dep-esbuild-plugin-transform:
@@ -8807,6 +8812,12 @@ packages:
   file:playground/optimize-deps/dep-cjs-compiled-from-esm:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-esm, type: directory}
     name: dep-cjs-compiled-from-esm
+    version: 0.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-cjs-with-assets:
+    resolution: {directory: playground/optimize-deps/dep-cjs-with-assets, type: directory}
+    name: dep-cjs-with-assets
     version: 0.0.0
     dev: false
 


### PR DESCRIPTION
### Description
This PR uses esbuild's plugin hook to convert `require` into `import` even if it is externalized. (refs: https://github.com/vitejs/vite/issues/2492#issuecomment-855196704)

a minimal require-import conversion plugin: https://stackblitz.com/edit/node-xh6pvc?file=build.js

fixes #2492
fixes #3409
fixes #5308

I tested with #3409's repro.

### Additional context
I think this approach is faster and less-fragile than regex or parsing + replacing. But it heavily depends on esbuild's plugin behavior and it might unveil an edge case bug of esbuild.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
