### PR TITLE
fix: respect server.headers in static middlewares

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -477,7 +477,9 @@ export async function createServer(
   // this applies before the transform middleware so that these files are served
   // as-is without transforms.
   if (config.publicDir) {
-    middlewares.use(servePublicMiddleware(config.publicDir))
+    middlewares.use(
+      servePublicMiddleware(config.publicDir, config.server.headers)
+    )
   }
 
   // main transform middleware


### PR DESCRIPTION
### Description

@jrvidal is working in a downstream integration and noticed that `server.headers` aren't being respected for several middlewares.

This change seems correct to me given Vite's docs: https://vitejs.dev/config/#server-headers
We may need to explore giving a functional form to define headers dynamically, but if a static list is exposed, they should be applied to all responses.

We should also review how headers are being respected in `vite preview`, but this is out of the scope of the PR

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other