### PR TITLE
fix: respect optimize deps entries

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -45,11 +45,18 @@ export type ExportsData = {
 export interface DepsOptimizer {
   metadata: DepOptimizationMetadata
   scanProcessing?: Promise<void>
+
   registerMissingImport: (id: string, resolved: string) => OptimizedDepInfo
   run: () => void
+
   isOptimizedDepFile: (id: string) => boolean
   isOptimizedDepUrl: (url: string) => boolean
   getOptimizedDepId: (depInfo: OptimizedDepInfo) => string
+
+  delayDepsOptimizerUntil: (id: string, done: () => Promise<any>) => void
+  registerWorkersSource: (id: string) => void
+  resetRegisteredIds: () => void
+
   options: DepOptimizationOptions
 }
 

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -534,7 +534,7 @@ export async function initDepsOptimizer(
     }
     if (server && !optimizeDepsEntriesVisited) {
       optimizeDepsEntriesVisited = true
-      pretransformOptimizeDepsEntries(server)
+      preTransformOptimizeDepsEntries(server)
     }
   }
 
@@ -567,7 +567,7 @@ export async function initDepsOptimizer(
   return depsOptimizer
 }
 
-export async function pretransformOptimizeDepsEntries(
+export async function preTransformOptimizeDepsEntries(
   server: ViteDevServer
 ): Promise<void> {
   const { config } = server

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -1,6 +1,8 @@
 import colors from 'picocolors'
 import _debug from 'debug'
+import glob from 'fast-glob'
 import { getHash } from '../utils'
+import { transformRequest } from '../server/transformRequest'
 import type { ResolvedConfig, ViteDevServer } from '..'
 import {
   addOptimizedDepInfo,
@@ -65,6 +67,9 @@ export async function initDepsOptimizer(
     isOptimizedDepUrl: createIsOptimizedDepUrl(config),
     getOptimizedDepId: (depInfo: OptimizedDepInfo) =>
       isBuild ? depInfo.file : `${depInfo.file}?v=${depInfo.browserHash}`,
+    registerWorkersSource,
+    delayDepsOptimizerUntil,
+    resetRegisteredIds,
     options: config.optimizeDeps
   }
 
@@ -101,8 +106,12 @@ export async function initDepsOptimizer(
   let enqueuedRerun: (() => void) | undefined
   let currentlyProcessing = false
 
+  // Only pretransform optimizeDeps.entries on cold start
+  let optimizeDepsEntriesVisited = !!cachedMetadata
+
   // If there wasn't a cache or it is outdated, we need to prepare a first run
   let firstRunCalled = !!cachedMetadata
+
   if (!cachedMetadata) {
     if (!scan) {
       // Initialize discovered deps with manually added optimizeDeps.include info
@@ -496,5 +505,85 @@ export async function initDepsOptimizer(
     }, timeout)
   }
 
+  const runOptimizerIfIdleAfterMs = 100
+
+  let registeredIds: { id: string; done: () => Promise<any> }[] = []
+  let seenIds = new Set<string>()
+  let workersSources = new Set<string>()
+  let waitingOn: string | undefined
+
+  function resetRegisteredIds() {
+    registeredIds = []
+    seenIds = new Set<string>()
+    workersSources = new Set<string>()
+    waitingOn = undefined
+  }
+
+  function registerWorkersSource(id: string): void {
+    workersSources.add(id)
+    if (waitingOn === id) {
+      waitingOn = undefined
+    }
+  }
+
+  function delayDepsOptimizerUntil(id: string, done: () => Promise<any>): void {
+    if (!depsOptimizer.isOptimizedDepFile(id) && !seenIds.has(id)) {
+      seenIds.add(id)
+      registeredIds.push({ id, done })
+      runOptimizerWhenIdle()
+    }
+    if (server && !optimizeDepsEntriesVisited) {
+      optimizeDepsEntriesVisited = true
+      pretransformOptimizeDepsEntries(server)
+    }
+  }
+
+  function runOptimizerWhenIdle() {
+    if (!waitingOn) {
+      const next = registeredIds.pop()
+      if (next) {
+        waitingOn = next.id
+        const afterLoad = () => {
+          waitingOn = undefined
+          if (registeredIds.length > 0) {
+            runOptimizerWhenIdle()
+          } else if (!workersSources.has(next.id)) {
+            getDepsOptimizer(config)?.run()
+          }
+        }
+        next
+          .done()
+          .then(() => {
+            setTimeout(
+              afterLoad,
+              registeredIds.length > 0 ? 0 : runOptimizerIfIdleAfterMs
+            )
+          })
+          .catch(afterLoad)
+      }
+    }
+  }
+
   return depsOptimizer
+}
+
+export async function pretransformOptimizeDepsEntries(
+  server: ViteDevServer
+): Promise<void> {
+  const { config } = server
+  const { entries } = config.optimizeDeps
+  if (entries) {
+    const explicitEntries = await glob(entries, {
+      cwd: config.root,
+      ignore: ['**/node_modules/**', `**/${config.build.outDir}/**`],
+      absolute: true
+    })
+    // TODO: should we restrict the entries to JS and HTML like the
+    // scanner did? I think we can let the user chose any entry
+    for (const entry of explicitEntries) {
+      transformRequest(entry, server, { ssr: false }).catch((e) => {
+        config.logger.error(e.message)
+      })
+    }
+  }
 }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -53,10 +53,7 @@ import {
   optimizedDepNeedsInterop
 } from '../optimizer'
 import { checkPublicFile } from './asset'
-import {
-  ERR_OUTDATED_OPTIMIZED_DEP,
-  delayDepsOptimizerUntil
-} from './optimizedDeps'
+import { ERR_OUTDATED_OPTIMIZED_DEP } from './optimizedDeps'
 import { isCSSRequest, isDirectCSSRequest } from './css'
 import { browserExternalId } from './resolve'
 
@@ -616,8 +613,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             // Unexpected error, log the issue but avoid an unhandled exception
             config.logger.error(e.message)
           })
-          if (!config.optimizeDeps.devScan) {
-            delayDepsOptimizerUntil(config, id, () => request)
+          if (depsOptimizer && !config.optimizeDeps.devScan) {
+            depsOptimizer.delayDepsOptimizerUntil(id, () => request)
           }
         })
       }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -599,7 +599,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         )
 
       // pre-transform known direct imports
-      // TODO: we should also crawl dynamic imports
+      // TODO: should we also crawl dynamic imports? or the experience is good enough to allow
+      // users to chose their tradeoffs by explicitily setting optimizeDeps.entries for the
+      // most common dynamic imports
       if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach(({ url, id }) => {
           url = unwrapId(removeImportQuery(url)).replace(

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -13,8 +13,8 @@ import {
   parseRequest
 } from '../utils'
 import { onRollupWarning } from '../build'
+import { getDepsOptimizer } from '../optimizer'
 import { fileToUrl } from './asset'
-import { registerWorkersSource } from './optimizedDeps'
 
 interface WorkerCache {
   // save worker all emit chunk avoid rollup make the same asset unique.
@@ -269,7 +269,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         : 'module'
       const workerOptions = workerType === 'classic' ? '' : ',{type: "module"}'
       if (isBuild) {
-        registerWorkersSource(config, id)
+        getDepsOptimizer(config)?.registerWorkersSource(id)
         if (query.inline != null) {
           const chunk = await bundleWorkerEntry(config, id, query)
           // inline as blob data url

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -12,10 +12,10 @@ import {
   parseRequest,
   transformResult
 } from '../utils'
+import { getDepsOptimizer } from '../optimizer'
 import type { WorkerType } from './worker'
 import { WORKER_FILE_ID, workerFileToUrl } from './worker'
 import { fileToUrl } from './asset'
-import { registerWorkersSource } from './optimizedDeps'
 
 const ignoreFlagRE = /\/\*\s*@vite-ignore\s*\*\//
 
@@ -123,7 +123,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
           let url: string
           if (isBuild) {
-            registerWorkersSource(config, id)
+            getDepsOptimizer(config)?.registerWorkersSource(id)
             url = await workerFileToUrl(config, file, query)
           } else {
             url = await fileToUrl(cleanUrl(file), config, this)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -7,7 +7,6 @@ import connect from 'connect'
 import corsMiddleware from 'cors'
 import colors from 'picocolors'
 import chokidar from 'chokidar'
-import glob from 'fast-glob'
 import type { FSWatcher, WatchOptions } from 'types/chokidar'
 import type { Connect } from 'types/connect'
 import launchEditorMiddleware from 'launch-editor-middleware'
@@ -522,7 +521,6 @@ export async function createServer(
   const initOptimizer = async () => {
     if (isDepsOptimizerEnabled(config)) {
       await initDepsOptimizer(config, server)
-      pretransformOptimizeDepsEntries(server)
     }
   }
 
@@ -761,26 +759,5 @@ async function updateCjsSsrExternals(server: ViteDevServer) {
       ]
     }
     server._ssrExternals = cjsSsrResolveExternals(server.config, knownImports)
-  }
-}
-
-export async function pretransformOptimizeDepsEntries(
-  server: ViteDevServer
-): Promise<void> {
-  const { config } = server
-  const { entries } = config.optimizeDeps
-  if (entries) {
-    const explicitEntries = await glob(entries, {
-      cwd: config.root,
-      ignore: ['**/node_modules/**', `**/${config.build.outDir}/**`],
-      absolute: true
-    })
-    // TODO: should we restrict the entries to JS and HTML like the
-    // scanner did? I think we can let the user chose any entry
-    for (const entry of explicitEntries) {
-      transformRequest(entry, server, { ssr: false }).catch((e) => {
-        config.logger.error(e.message)
-      })
-    }
   }
 }

--- a/playground/optimize-deps/added-in-entries/index.js
+++ b/playground/optimize-deps/added-in-entries/index.js
@@ -1,0 +1,2 @@
+// written in cjs, optimization should convert this to esm
+module.exports = 'added-in-entries'

--- a/playground/optimize-deps/added-in-entries/package.json
+++ b/playground/optimize-deps/added-in-entries/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "added-in-entries",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/playground/optimize-deps/entry.js
+++ b/playground/optimize-deps/entry.js
@@ -1,0 +1,11 @@
+import msg from 'added-in-entries'
+
+// This is an entry file that is added to optimizeDeps.entries
+// When the deps aren't cached, these entries are also processed
+// to discover dependencies in them. This should only be needed
+// for code splitted sections that are commonly visited after
+// first load where a full-reload wants to be avoided at the expense
+// of extra processing on cold start. Another option is to add
+// the missing dependencies to optimizeDeps.include directly
+
+console.log(msg)

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -22,6 +22,7 @@
     "dep-with-builtin-module-cjs": "file:./dep-with-builtin-module-cjs",
     "dep-with-builtin-module-esm": "file:./dep-with-builtin-module-esm",
     "dep-with-dynamic-import": "file:./dep-with-dynamic-import",
+    "added-in-entries": "file:./added-in-entries",
     "lodash-es": "^4.17.21",
     "nested-exclude": "file:./nested-exclude",
     "phoenix": "^1.6.10",

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -33,7 +33,8 @@ module.exports = {
           }
         }
       ]
-    }
+    },
+    entries: ['entry.js']
   },
 
   build: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,6 +572,7 @@ importers:
   playground/optimize-deps:
     specifiers:
       '@vitejs/plugin-vue': workspace:*
+      added-in-entries: file:./added-in-entries
       axios: ^0.27.2
       clipboard: ^2.0.11
       dep-cjs-compiled-from-cjs: file:./dep-cjs-compiled-from-cjs
@@ -595,6 +596,7 @@ importers:
       vue: ^3.2.37
       vuex: ^4.0.2
     dependencies:
+      added-in-entries: file:playground/optimize-deps/added-in-entries
       axios: 0.27.2
       clipboard: 2.0.11
       dep-cjs-compiled-from-cjs: file:playground/optimize-deps/dep-cjs-compiled-from-cjs
@@ -619,6 +621,9 @@ importers:
       vuex: 4.0.2_vue@3.2.37
     devDependencies:
       '@vitejs/plugin-vue': link:../../packages/plugin-vue
+
+  playground/optimize-deps/added-in-entries:
+    specifiers: {}
 
   playground/optimize-deps/dep-cjs-compiled-from-cjs:
     specifiers: {}
@@ -8852,6 +8857,12 @@ packages:
     name: json-module
     version: 0.0.0
     dev: true
+
+  file:playground/optimize-deps/added-in-entries:
+    resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
+    name: added-in-entries
+    version: 1.0.0
+    dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-cjs, type: directory}


### PR DESCRIPTION
### Description

Once we merged:
- https://github.com/vitejs/vite/pull/8319

We stopped respecting `optimizeDeps.entries`. This PR uses this config option to let users be explicit about which extra entries should be processed before the first deps optimization step. 

Right now, the optimization is run after every static import (+ dynamic imports that are triggered by the browser while loading the first visited page) are processed. This seems like a good default because processing every dynamic import may be more costly now that we don't do it with the esbuild scanner, especially for apps like StoryBook-like apps.

After this PR, the user should add to entries every dynamic import entry that is commonly used after the first load.

TODO: Tests.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other