### PR TITLE
fix(dev): avoid FOUC when swapping out link tag (fix #7973)

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -101,7 +101,16 @@ async function handleMessage(payload: HMRPayload) {
             const newPath = `${base}${searchUrl.slice(1)}${
               searchUrl.includes('?') ? '&' : '?'
             }t=${timestamp}`
-            el.href = new URL(newPath, el.href).href
+
+            // rather than swapping the href on the existing tag, we will
+            // create a new link tag. Once the new stylesheet has loaded we
+            // will remove the existing link tag. This removes a Flash Of
+            // Unstyled Content that can occur when swapping out the tag href
+            // directly, as the new stylesheet has not yet been loaded.
+            const newLinkTag = el.cloneNode() as HTMLLinkElement
+            newLinkTag.href = new URL(newPath, el.href).href
+            newLinkTag.addEventListener('load', () => el.remove())
+            el.after(newLinkTag)
           }
           console.log(`[vite] css hot updated: ${searchUrl}`)
         }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -109,7 +109,9 @@ async function handleMessage(payload: HMRPayload) {
             // directly, as the new stylesheet has not yet been loaded.
             const newLinkTag = el.cloneNode() as HTMLLinkElement
             newLinkTag.href = new URL(newPath, el.href).href
-            newLinkTag.addEventListener('load', () => el.remove())
+            const removeOldEl = () => el.remove()
+            newLinkTag.addEventListener('load', removeOldEl)
+            newLinkTag.addEventListener('error', removeOldEl)
             el.after(newLinkTag)
           }
           console.log(`[vite] css hot updated: ${searchUrl}`)

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -169,6 +169,20 @@ if (!isBuild) {
     expect(textpost).not.toMatch('direct')
   })
 
+  test('it swaps out link tags', async () => {
+    await page.goto(viteTestUrl)
+
+    editFile('global.css', (code) => code.replace('white', 'tomato'))
+
+    let el = await page.$('.link-tag-added')
+    await untilUpdated(() => el.textContent(), 'yes')
+
+    el = await page.$('.link-tag-removed')
+    await untilUpdated(() => el.textContent(), 'yes')
+
+    expect((await page.$$('link')).length).toBe(1)
+  })
+
   test('not loaded dynamic import', async () => {
     await page.goto(viteTestUrl + '/counter/index.html')
 

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -46,8 +46,8 @@ if (import.meta.hot) {
         (document.querySelector('.global-css') as HTMLLinkElement).href
       )
 
-      // We don't have a vite:afterUpdate event, but updates are currently
-      // sync. We need to wait until the tag has been swapped out, which
+      // We don't have a vite:afterUpdate event.
+      // We need to wait until the tag has been swapped out, which
       // includes the time taken to download and parse the new stylesheet.
       const observer = new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -41,12 +41,42 @@ if (import.meta.hot) {
         update.type === 'css-update' && update.path.match('global.css')
     )
     if (cssUpdate) {
-      const el = document.querySelector('#global-css') as HTMLLinkElement
-      text('.css-prev', el.href)
-      // We don't have a vite:afterUpdate event, but updates are currently sync
-      setTimeout(() => {
-        text('.css-post', el.href)
-      }, 0)
+      text(
+        '.css-prev',
+        (document.querySelector('.global-css') as HTMLLinkElement).href
+      )
+
+      // We don't have a vite:afterUpdate event, but updates are currently
+      // sync. We need to wait until the tag has been swapped out, which
+      // includes the time taken to download and parse the new stylesheet.
+      const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+          mutation.addedNodes.forEach((node) => {
+            if (
+              node.nodeType === Node.ELEMENT_NODE &&
+              (node as Element).tagName === 'LINK'
+            ) {
+              text('.link-tag-added', 'yes')
+            }
+          })
+          mutation.removedNodes.forEach((node) => {
+            if (
+              node.nodeType === Node.ELEMENT_NODE &&
+              (node as Element).tagName === 'LINK'
+            ) {
+              text('.link-tag-removed', 'yes')
+              text(
+                '.css-post',
+                (document.querySelector('.global-css') as HTMLLinkElement).href
+              )
+            }
+          })
+        })
+      })
+
+      observer.observe(document.querySelector('#style-tags-wrapper'), {
+        childList: true
+      })
     }
   })
 

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -1,4 +1,10 @@
-<link id="global-css" rel="stylesheet" href="./global.css?param=required" />
+<div id="style-tags-wrapper">
+  <link
+    class="global-css"
+    rel="stylesheet"
+    href="./global.css?param=required"
+  />
+</div>
 <script type="module" src="./hmr.ts"></script>
 <style>
   .import-image {
@@ -16,4 +22,6 @@
 <div class="custom-communication"></div>
 <div class="css-prev"></div>
 <div class="css-post"></div>
+<div class="link-tag-added">no</div>
+<div class="link-tag-removed">no</div>
 <div class="import-image"></div>


### PR DESCRIPTION
### Description

Assuming we have a CSS file at the following path...

```
/resources/css/app.css
```

When adding a link tag to the DOM manually (i.e. via Server Side Rendering)...

```html
<link rel="stylesheet" href="{DEV_SERVER_URL}/resources/css/app.css">
```

Vite will now watch this file and hot reload changes in the browser for this asset (very sweet!). When we update `app.css` Vite will update the link tag's `href` attribute like so...

```diff
- <link rel="stylesheet" href="{DEV_SERVER_URL}/resources/css/app.css?">
+ <link rel="stylesheet" href="{DEV_SERVER_URL}/resources/css/app.css?t={TIMESTAMP}">
```

This is great, but for a split moment there is a flash of unstyled content as the asset has not loaded yet. The browser unloads the styles from the original stylesheet and waits until the new stylesheet has loaded and been parsed before it will show the new stylings.

This PR addresses this problem. Now the process is as follows..

First the client adds a second (cloned) link tag to the DOM, leaving the original in place and still loaded by the browser...

```diff
<link rel="stylesheet" href="{DEV_SERVER_URL}/resources/css/app.css?">
+ <link rel="stylesheet" href="{DEV_SERVER_URL}/resources/css/app.css?t={TIMESTAMP}">
```

Once the new stylesheet has loaded, the browser will remove the original stylesheet from the DOM, leaving the new _loaded_ stylesheet in the DOM.

```diff
- <link rel="stylesheet" href="{DEV_SERVER_URL}/resources/css/app.css?">
<link rel="stylesheet" href="{DEV_SERVER_URL}/resources/css/app.css?t={TIMESTAMP}">
```

This process then continues for future updates to the CSS file.

### Additional context

~I have no idea where to start with adding a unit test for this. I'm a dumb back-end developer. Send help! (I've read the guides - I just don't know how to actually write the test itself for something like this, sorry!).~

I added a test. I have no idea if it is good or not!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.