### PR TITLE
docs(plugin-vue-jsx): update the options

### DIFF
--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -17,7 +17,7 @@ export default {
 
 ## Options
 
-There has been a few own plugins.
+There has been a few own options.
 
 ### include
 

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -23,7 +23,7 @@ Type: `(string | RegExp)[] | string | RegExp | null;`
 
 Default: `/\.[jt]sx$/`
 
-if you want to add extensions option to vue-jsx plugin, you can use `include`
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files the plugin should operate on.
 
 ### exclude
 

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -17,8 +17,6 @@ export default {
 
 ## Options
 
-There has been a few own options.
-
 ### include
 
 Type: `<string | RegExp> | string | RegExp | null;`

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -19,7 +19,7 @@ export default {
 
 ### include
 
-Type: `(string | RegExp)[] | string | RegExp | null;`
+Type: `(string | RegExp)[] | string | RegExp | null`
 
 Default: `/\.[jt]sx$/`
 
@@ -27,7 +27,7 @@ A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patt
 
 ### exclude
 
-Type: `(string | RegExp)[] | string | RegExp | null;`
+Type: `(string | RegExp)[] | string | RegExp | null`
 
 Default: `undefined`
 

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -17,7 +17,23 @@ export default {
 
 ## Options
 
-See [@vue/babel-plugin-jsx](https://github.com/vuejs/jsx-next).
+There has been a few own plugins.
+
+### include
+
+Type: `<string | RegExp> | string | RegExp | null;`
+
+Default: `/\.[jt]sx$/`
+
+if you want to add extensions option to vue-jsx plugin, you can use `include`
+
+### exclude
+
+Type: `<string | RegExp> | string | RegExp | null;`
+
+Default: `undefined`
+
+See [@vue/babel-plugin-jsx](https://github.com/vuejs/jsx-next) for other plugins.
 
 ## HMR Detection
 

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -33,7 +33,7 @@ Type: `<string | RegExp> | string | RegExp | null;`
 
 Default: `undefined`
 
-See [@vue/babel-plugin-jsx](https://github.com/vuejs/jsx-next) for other plugins.
+> See [@vue/babel-plugin-jsx](https://github.com/vuejs/jsx-next) for other options.
 
 ## HMR Detection
 

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -33,6 +33,8 @@ Type: `<string | RegExp> | string | RegExp | null;`
 
 Default: `undefined`
 
+A [picomatch pattern](https://github.com/micromatch/picomatch), or array of patterns, which specifies the files to be ignored by the plugin.
+
 > See [@vue/babel-plugin-jsx](https://github.com/vuejs/jsx-next) for other options.
 
 ## HMR Detection

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -19,7 +19,7 @@ export default {
 
 ### include
 
-Type: `<string | RegExp> | string | RegExp | null;`
+Type: `(string | RegExp)[] | string | RegExp | null;`
 
 Default: `/\.[jt]sx$/`
 

--- a/packages/plugin-vue-jsx/README.md
+++ b/packages/plugin-vue-jsx/README.md
@@ -27,7 +27,7 @@ if you want to add extensions option to vue-jsx plugin, you can use `include`
 
 ### exclude
 
-Type: `<string | RegExp> | string | RegExp | null;`
+Type: `(string | RegExp)[] | string | RegExp | null;`
 
 Default: `undefined`
 


### PR DESCRIPTION
I try to use [mdx](https://mdxjs.com/) in vite and I found that [@vitejs/plugin-vue-jsx](https://github.com/vitejs/vite/tree/main/packages/plugin-vue-jsx) provides `include/exclude` options to extend the functionality of vue-jsx, but it is not listed in the README - Options, So I added these two Option descriptions。