### PR TITLE
fix: outdated optimized dep removed from module graph

### DIFF
--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -139,7 +139,7 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
-function throwProcessingError(id: string) {
+function throwProcessingError(id: string): never {
   const err: any = new Error(
     `Something unexpected happened while optimizing "${id}". ` +
       `The current page should have reloaded by now`
@@ -150,7 +150,7 @@ function throwProcessingError(id: string) {
   throw err
 }
 
-function throwOutdatedRequest(id: string) {
+export function throwOutdatedRequest(id: string): never {
   const err: any = new Error(
     `There is a new version of the pre-bundle for "${id}", ` +
       `a page reload is going to ask for it.`


### PR DESCRIPTION
### Description

Context: https://github.com/withastro/astro/pull/3568#issuecomment-1152324146

@matthewp uncovered a race condition when an optimized dep is invalidated and removed from the module graph and an outdated request for it is still on-fly (this request should be discarded, a new one is being requested by the browser)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other