### PR TITLE
test: fix style link after HMR

### DIFF
--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -52,7 +52,7 @@ describe.runIf(isServe)('serve', () => {
     await untilUpdated(() => getColor('body'), 'red') // successful HMR
 
     // Verify that the base (/dev/) was added during the css-update
-    const link = await page.$('link[rel="stylesheet"]')
+    const link = (await page.$$('link[rel="stylesheet"]')).at(-1)
     expect(await link.getAttribute('href')).toContain('/dev/global.css?t=')
   })
 

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -52,7 +52,7 @@ describe.runIf(isServe)('serve', () => {
     await untilUpdated(() => getColor('body'), 'red') // successful HMR
 
     // Verify that the base (/dev/) was added during the css-update
-    const link = (await page.$$('link[rel="stylesheet"]')).at(-1)
+    const link = await page.$('link[rel="stylesheet"]:last-of-type')
     expect(await link.getAttribute('href')).toContain('/dev/global.css?t=')
   })
 


### PR DESCRIPTION
### Description

A CSS HMR test was expecting a single <link> tag to be present, but that isn't longer the case after:
- https://github.com/vitejs/vite/pull/8495

Fixes https://github.com/vitejs/vite/runs/6826881245?check_suite_focus=true#step:9:19

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other