### PR TITLE
chore: refactor interop named imports

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -638,12 +638,12 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
-function interopNamedImports(
+export function interopNamedImports(
   str: MagicString,
   importSpecifier: ImportSpecifier,
   rewrittenUrl: string,
   importIndex: number
-) {
+): void {
   const source = str.original
   const {
     s: start,


### PR DESCRIPTION
Small refactor in `importAnalysisBuild` to reuse `interopNamedImports`, which is an extraction of the code being replaced from `importAnalysis`