### PR TITLE
fix(plugin-react): apply manual runtime interop

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -45,8 +45,7 @@
     "@babel/plugin-transform-react-jsx-self": "^7.17.12",
     "@babel/plugin-transform-react-jsx-source": "^7.16.7",
     "@rollup/pluginutils": "^4.2.1",
-    "react-refresh": "^0.13.0",
-    "resolve": "^1.22.0"
+    "react-refresh": "^0.13.0"
   },
   "peerDependencies": {
     "vite": "^3.0.0-alpha"

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -361,7 +361,9 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     }
   }
 
-  // const runtimeId = 'react/jsx-runtime'
+  const reactJsxRuntime = 'react/jsx-runtime'
+  const reactJsxDevRuntime = 'react/jsx-dev-runtime'
+  const virtualPrefix = 'virtual:'
   // Adapted from https://github.com/alloc/vite-react-jsx
   const viteReactJsx: Plugin = {
     name: 'vite:react-jsx',
@@ -369,32 +371,41 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     config() {
       return {
         optimizeDeps: {
-          include: ['react/jsx-dev-runtime']
+          include: [reactJsxRuntime, reactJsxDevRuntime]
         }
       }
-    }
-    // TODO: this optimization may not be necesary and it is breacking esbuild+rollup compat,
-    // see https://github.com/vitejs/vite/pull/7246#discussion_r861552185
-    // We could still do the same trick and resolve to the optimized dependency here
-    /*
-    resolveId(id: string) {
-      return id === runtimeId ? id : null
     },
-    load(id: string) {
-      if (id === runtimeId) {
-        const runtimePath = resolve.sync(runtimeId, {
-          basedir: projectRoot
-        })
-        const exports = ['jsx', 'jsxs', 'Fragment']
+    resolveId(id, importer) {
+      // Resolve runtime to a virtual path to be interoped.
+      // Since the interop code re-imports `id`, we need to prevent re-setting
+      // the virtual id if the importer is already the virtual id.
+      if (
+        importer &&
+        !importer.startsWith(virtualPrefix) &&
+        (id === reactJsxRuntime || id === reactJsxDevRuntime)
+      ) {
+        return virtualPrefix + id
+      }
+    },
+    load(id) {
+      if (!id.startsWith(virtualPrefix)) return
+      id = id.slice(virtualPrefix.length)
+      // Apply manual interop
+      if (id === reactJsxRuntime) {
         return [
-          `import * as jsxRuntime from ${JSON.stringify(runtimePath)}`,
-          // We can't use `export * from` or else any callsite that uses
-          // this module will be compiled to `jsxRuntime.exports.jsx`
-          // instead of the more concise `jsx` alias.
-          ...exports.map((name) => `export const ${name} = jsxRuntime.${name}`)
+          `import * as jsxRuntime from ${JSON.stringify(id)}`,
+          `export const Fragment = jsxRuntime.Fragment`,
+          `export const jsx = jsxRuntime.jsx`,
+          `export const jsxs = jsxRuntime.jsxs`
+        ].join('\n')
+      } else if (id === reactJsxDevRuntime) {
+        return [
+          `import * as jsxRuntime from ${JSON.stringify(id)}`,
+          `export const Fragment = jsxRuntime.Fragment`,
+          `export const jsxDEV = jsxRuntime.jsxDEV`
         ].join('\n')
       }
-    } */
+    }
   }
 
   return [viteBabel, viteReactRefresh, useAutomaticRuntime && viteReactJsx]

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -363,8 +363,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
   const reactJsxRuntimeId = 'react/jsx-runtime'
   const reactJsxDevRuntimeId = 'react/jsx-dev-runtime'
-  const virtualReactJsxRuntimeId = '\0virtual:react/jsx-runtime'
-  const virtualReactJsxDevRuntimeId = '\0virtual:react/jsx-dev-runtime'
+  const virtualReactJsxRuntimeId = '\0' + reactJsxRuntimeId
+  const virtualReactJsxDevRuntimeId = '\0' + reactJsxDevRuntimeId
   // Adapted from https://github.com/alloc/vite-react-jsx
   const viteReactJsx: Plugin = {
     name: 'vite:react-jsx',

--- a/playground/react/App.jsx
+++ b/playground/react/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import Dummy from './components/Dummy?qs-should-not-break-plugin-react'
+import Button from 'jsx-entry'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -26,6 +27,7 @@ function App() {
       </header>
 
       <Dummy />
+      <Button>button</Button>
     </div>
   )
 }

--- a/playground/react/jsx-entry/Button.jsx
+++ b/playground/react/jsx-entry/Button.jsx
@@ -1,0 +1,5 @@
+const Button = ({ children }) => {
+  return <button>{children}</button>
+}
+
+export default Button

--- a/playground/react/jsx-entry/package.json
+++ b/playground/react/jsx-entry/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "jsx-entry",
+  "private": true,
+  "version": "0.0.0",
+  "main": "Button.jsx"
+}

--- a/playground/react/package.json
+++ b/playground/react/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "jsx-entry": "file:./jsx-entry",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/playground/react/vite.config.ts
+++ b/playground/react/vite.config.ts
@@ -2,6 +2,7 @@ import react from '@vitejs/plugin-react'
 import type { UserConfig } from 'vite'
 
 const config: UserConfig = {
+  mode: 'development',
   plugins: [react()],
   build: {
     // to make tests faster

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,7 +164,6 @@ importers:
       '@babel/plugin-transform-react-jsx-source': ^7.16.7
       '@rollup/pluginutils': ^4.2.1
       react-refresh: ^0.13.0
-      resolve: ^1.22.0
       vite: workspace:*
     dependencies:
       '@babel/core': 7.18.2
@@ -174,7 +173,6 @@ importers:
       '@babel/plugin-transform-react-jsx-source': 7.16.7_@babel+core@7.18.2
       '@rollup/pluginutils': 4.2.1
       react-refresh: 0.13.0
-      resolve: 1.22.0
     devDependencies:
       vite: link:../vite
 
@@ -720,9 +718,11 @@ importers:
   playground/react:
     specifiers:
       '@vitejs/plugin-react': workspace:*
+      jsx-entry: file:./jsx-entry
       react: ^17.0.2
       react-dom: ^17.0.2
     dependencies:
+      jsx-entry: file:playground/react/jsx-entry
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -746,6 +746,9 @@ importers:
       '@babel/plugin-proposal-pipeline-operator': 7.18.2
       '@emotion/babel-plugin': 11.9.2
       '@vitejs/plugin-react': link:../../packages/plugin-react
+
+  playground/react/jsx-entry:
+    specifiers: {}
 
   playground/resolve:
     specifiers:
@@ -8959,6 +8962,12 @@ packages:
   file:playground/optimize-missing-deps/multi-entry-dep:
     resolution: {directory: playground/optimize-missing-deps/multi-entry-dep, type: directory}
     name: multi-entry-dep
+    version: 0.0.0
+    dev: false
+
+  file:playground/react/jsx-entry:
+    resolution: {directory: playground/react/jsx-entry, type: directory}
+    name: jsx-entry
     version: 0.0.0
     dev: false
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/vitejs/vite/issues/8468
Fix https://github.com/vitejs/vite/issues/5885

Supersedes https://github.com/vitejs/vite/pull/7246, though didn't implement deduping `react/jsx-runtime` and `react/jsx-dev-runtime` as I think that's a risky optimization.

### Additional context

The esbuild+rollup issue arise because the old interop code depends on `@rollup/plugin-commonjs` to handle the CJS code. Without it, the interop failed, and without interop it caused #8468.

Interop can't be applied with `importAnalysisBuild` because the JSX code in question is in `node_modules`, and `importAnalysisBuild` don't handle both JSX files (es-module-lexer) and those inside `node_modules`.

This PR implements a virtual proxy file for the react runtime import that implements interop, working with esbuild. ~~(I have not tested without esbuild optimization in build)~~ works

I think the issue at the start would've been better resolved with `optimizeDeps.extensions`. I'd love to start implementing it for plugin-vue and plugin-react, but there's one more piece I haven't implement in core. 

All-in-all, this PR helps prevent the regression at the meantime.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
