### PR TITLE
feat: expose createFilter util

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -517,6 +517,10 @@ normalizePath('foo\\bar') // 'foo/bar'
 normalizePath('foo/bar') // 'foo/bar'
 ```
 
+## Filtering, include/exclude pattern
+
+Vite exposes [`@rollup/pluginutils`'s `createFilter`](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter) function to encourage Vite specific plugins and integrations to use the standard include/exclude filtering pattern, which is also used in Vite core itself.
+
 ## Client-server Communication
 
 Since Vite 2.9, we provide some utilities for plugins to help handle the communication with clients.

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -44,7 +44,6 @@
     "@babel/plugin-transform-react-jsx-development": "^7.16.7",
     "@babel/plugin-transform-react-jsx-self": "^7.17.12",
     "@babel/plugin-transform-react-jsx-source": "^7.16.7",
-    "@rollup/pluginutils": "^4.2.1",
     "react-refresh": "^0.13.0"
   },
   "peerDependencies": {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,8 +1,7 @@
 import path from 'path'
 import type { ParserOptions, TransformOptions, types as t } from '@babel/core'
 import * as babel from '@babel/core'
-import { createFilter } from '@rollup/pluginutils'
-import { normalizePath } from 'vite'
+import { createFilter, normalizePath } from 'vite'
 import type { Plugin, PluginOption, ResolvedConfig } from 'vite'
 import {
   addRefreshWrapper,

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -38,7 +38,6 @@
     "@babel/core": "^7.18.2",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-transform-typescript": "^7.18.4",
-    "@rollup/pluginutils": "^4.2.1",
     "@vue/babel-plugin-jsx": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -5,7 +5,7 @@ import * as babel from '@babel/core'
 import jsx from '@vue/babel-plugin-jsx'
 // @ts-expect-error missing type
 import importMeta from '@babel/plugin-syntax-import-meta'
-import { createFilter, normalizePath } from '@rollup/pluginutils'
+import { createFilter, normalizePath } from 'vite'
 import type { ComponentOptions } from 'vue'
 import type { Plugin } from 'vite'
 import type { Options } from './types'

--- a/packages/plugin-vue-jsx/src/types.ts
+++ b/packages/plugin-vue-jsx/src/types.ts
@@ -1,5 +1,5 @@
 import type { VueJSXPluginOptions } from '@vue/babel-plugin-jsx'
-import type { FilterPattern } from '@rollup/pluginutils'
+import type { FilterPattern } from 'vite'
 
 export interface FilterOptions {
   include?: FilterPattern

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -47,8 +47,5 @@
     "source-map": "^0.6.1",
     "vite": "workspace:*",
     "vue": "^3.2.37"
-  },
-  "dependencies": {
-    "@rollup/pluginutils": "^4.2.1"
   }
 }

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import type { Plugin, ViteDevServer } from 'vite'
-import { createFilter } from '@rollup/pluginutils'
+import { createFilter } from 'vite'
 /* eslint-disable import/no-duplicates */
 import type {
   SFCBlock,

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -1,13 +1,12 @@
 import path from 'path'
 import type { SFCBlock, SFCDescriptor } from 'vue/compiler-sfc'
 import type { PluginContext, SourceMap, TransformPluginContext } from 'rollup'
-import { normalizePath } from '@rollup/pluginutils'
 import type { RawSourceMap } from 'source-map'
 import type { EncodedSourceMap as TraceEncodedSourceMap } from '@jridgewell/trace-mapping'
 import { TraceMap, eachMapping } from '@jridgewell/trace-mapping'
 import type { EncodedSourceMap as GenEncodedSourceMap } from '@jridgewell/gen-mapping'
 import { addMapping, fromMap, toEncodedMap } from '@jridgewell/gen-mapping'
-import { transformWithEsbuild } from 'vite'
+import { normalizePath, transformWithEsbuild } from 'vite'
 import {
   createDescriptor,
   getPrevDescriptor,

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -535,6 +535,28 @@ License: MIT
 By: Rich Harris
 Repository: rollup/plugins
 
+> The MIT License (MIT)
+> 
+> Copyright (c) 2019 RollupJS Plugin Contributors (https://github.com/rollup/plugins/graphs/contributors)
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
 ---------------------------------------
 
 ## @vue/compiler-core

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -208,7 +208,7 @@ function createCjsConfig(isProduction: boolean) {
       ...Object.keys(pkg.dependencies),
       ...(isProduction ? [] : Object.keys(pkg.devDependencies))
     ],
-    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(55)]
+    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(120)]
   })
 }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -5,7 +5,6 @@ import { performance } from 'perf_hooks'
 import { createRequire } from 'module'
 import colors from 'picocolors'
 import type { Alias, AliasOptions } from 'types/alias'
-import { createFilter } from '@rollup/pluginutils'
 import aliasPlugin from '@rollup/plugin-alias'
 import { build } from 'esbuild'
 import type { RollupOptions } from 'rollup'
@@ -19,6 +18,7 @@ import { resolvePreviewOptions } from './preview'
 import type { CSSOptions } from './plugins/css'
 import {
   createDebugger,
+  createFilter,
   dynamicImport,
   isExternalUrl,
   isObject,

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -10,6 +10,7 @@ export { resolvePackageData } from './packages'
 export * from './publicUtils'
 
 // additional types
+export type { FilterPattern } from './utils'
 export type { CorsOptions, CorsOrigin, CommonServerOptions } from './http'
 export type {
   ViteDevServer,

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import { createFilter } from '@rollup/pluginutils'
-import { createDebugger, resolveFrom } from './utils'
+import { createDebugger, createFilter, resolveFrom } from './utils'
 import type { ResolvedConfig } from './config'
 import type { Plugin } from './plugin'
 

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -3,11 +3,11 @@ import MagicString from 'magic-string'
 import { init, parse as parseImports } from 'es-module-lexer'
 import type { ImportSpecifier } from 'es-module-lexer'
 import { parse as parseJS } from 'acorn'
-import { createFilter } from '@rollup/pluginutils'
 import { dynamicImportToGlob } from '@rollup/plugin-dynamic-import-vars'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
 import {
+  createFilter,
   normalizePath,
   parseRequest,
   requestQuerySplitRE,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -9,13 +9,13 @@ import type {
 import { transform } from 'esbuild'
 import type { RawSourceMap } from '@ampproject/remapping'
 import type { SourceMap } from 'rollup'
-import { createFilter } from '@rollup/pluginutils'
 import type { TSConfckParseOptions, TSConfckParseResult } from 'tsconfck'
 import { TSConfckParseError, findAll, parse } from 'tsconfck'
 import {
   cleanUrl,
   combineSourcemaps,
   createDebugger,
+  createFilter,
   ensureWatchedFile,
   generateCodeFrame,
   toUpperCaseDriveLetter

--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -8,7 +8,7 @@ export {
   splitVendorChunkPlugin,
   splitVendorChunk
 } from './plugins/splitVendorChunk'
-export { normalizePath, mergeConfig, mergeAlias } from './utils'
+export { normalizePath, mergeConfig, mergeAlias, createFilter } from './utils'
 export { send } from './server/send'
 export { createLogger } from './logger'
 export { searchForWorkspaceRoot } from './server/searchRoot'

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -1,12 +1,12 @@
 import fs from 'fs'
 import path from 'path'
 import { createRequire } from 'module'
-import { createFilter } from '@rollup/pluginutils'
 import type { InternalResolveOptions } from '../plugins/resolve'
 import { tryNodeResolve } from '../plugins/resolve'
 import {
   bareImportRE,
   createDebugger,
+  createFilter,
   isBuiltin,
   isDefined,
   lookupFile,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -35,13 +35,11 @@ export type FilterPattern =
   | string
   | RegExp
   | null
-export function createFilter(
+export const createFilter = _createFilter as (
   include?: FilterPattern,
   exclude?: FilterPattern,
   options?: { resolve?: string | false | null }
-): (id: string | unknown) => boolean {
-  return _createFilter(include, exclude, options)
-}
+) => (id: string | unknown) => boolean
 
 export function slash(p: string): string {
   return p.replace(/\\/g, '/')

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -27,7 +27,6 @@ import {
 } from './constants'
 import type { ResolvedConfig } from '.'
 
-
 /**
  * Inlined to keep `@rollup/pluginutils` in devDependencies
  */

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -16,6 +16,7 @@ import type { Alias, AliasOptions } from 'types/alias'
 import type MagicString from 'magic-string'
 
 import type { TransformResult } from 'rollup'
+import { createFilter as _createFilter } from '@rollup/pluginutils'
 import {
   CLIENT_ENTRY,
   CLIENT_PUBLIC_PATH,
@@ -25,6 +26,23 @@ import {
   VALID_ID_PREFIX
 } from './constants'
 import type { ResolvedConfig } from '.'
+
+
+/**
+ * Inlined to keep `@rollup/pluginutils` in devDependencies
+ */
+export type FilterPattern =
+  | ReadonlyArray<string | RegExp>
+  | string
+  | RegExp
+  | null
+export function createFilter(
+  include?: FilterPattern,
+  exclude?: FilterPattern,
+  options?: { resolve?: string | false | null }
+): (id: string | unknown) => boolean {
+  return _createFilter(include, exclude, options)
+}
 
 export function slash(p: string): string {
   return p.replace(/\\/g, '/')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,7 +162,6 @@ importers:
       '@babel/plugin-transform-react-jsx-development': ^7.16.7
       '@babel/plugin-transform-react-jsx-self': ^7.17.12
       '@babel/plugin-transform-react-jsx-source': ^7.16.7
-      '@rollup/pluginutils': ^4.2.1
       react-refresh: ^0.13.0
       vite: workspace:*
     dependencies:
@@ -171,7 +170,6 @@ importers:
       '@babel/plugin-transform-react-jsx-development': 7.16.7_@babel+core@7.18.2
       '@babel/plugin-transform-react-jsx-self': 7.17.12_@babel+core@7.18.2
       '@babel/plugin-transform-react-jsx-source': 7.16.7_@babel+core@7.18.2
-      '@rollup/pluginutils': 4.2.1
       react-refresh: 0.13.0
     devDependencies:
       vite: link:../vite
@@ -180,15 +178,12 @@ importers:
     specifiers:
       '@jridgewell/gen-mapping': ^0.3.1
       '@jridgewell/trace-mapping': ^0.3.13
-      '@rollup/pluginutils': ^4.2.1
       debug: ^4.3.4
       rollup: ^2.72.1
       slash: ^4.0.0
       source-map: ^0.6.1
       vite: workspace:*
       vue: ^3.2.37
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
     devDependencies:
       '@jridgewell/gen-mapping': 0.3.1
       '@jridgewell/trace-mapping': 0.3.13
@@ -204,14 +199,12 @@ importers:
       '@babel/core': ^7.18.2
       '@babel/plugin-syntax-import-meta': ^7.10.4
       '@babel/plugin-transform-typescript': ^7.18.4
-      '@rollup/pluginutils': ^4.2.1
       '@vue/babel-plugin-jsx': ^1.1.1
       vite: workspace:*
     dependencies:
       '@babel/core': 7.18.2
       '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.18.2
       '@babel/plugin-transform-typescript': 7.18.4_@babel+core@7.18.2
-      '@rollup/pluginutils': 4.2.1
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.18.2
     devDependencies:
       vite: link:../vite
@@ -2168,6 +2161,7 @@ packages:
     dependencies:
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    dev: true
 
   /@rushstack/node-core-library/3.45.5:
     resolution: {integrity: sha512-KbN7Hp9vH3bD3YJfv6RnVtzzTAwGYIBl7y2HQLY4WEQqRbvE3LgI78W9l9X+cTAXCX//p0EeoiUYNTFdqJrMZg==}


### PR DESCRIPTION
### Description

We are already exposing `normalizePath`, another `@rollup/pluginutils` function. `createFilter` is used internally and in the plugins in the monorepo. Exposing it in Vite may encourage more people to follow the recommended include/exclude pattern. 

Reference discussion with @sheremet-va for Vitest: https://github.com/vitest-dev/vitest/pull/1467#discussion_r895442501

@antfu I needed to bump the size limit of the CJS build. I tried to avoid exposing `createFilter` in publicUtils but we are ourselves using the CJS build for plugins internally. Do you think the extra 50kb is an issue here? The other option is to avoid its use in our plugins for the moment.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other