### PR TITLE
fix: add missed JPEG file extensions to `KNOWN_ASSET_TYPES`

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -74,6 +74,18 @@ declare module '*.jpeg' {
   const src: string
   export default src
 }
+declare module '*.jfif' {
+  const src: string
+  export default src
+}
+declare module '*.pjpeg' {
+  const src: string
+  export default src
+}
+declare module '*.pjp' {
+  const src: string
+  export default src
+}
 declare module '*.png' {
   const src: string
   export default src

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -67,6 +67,9 @@ export const KNOWN_ASSET_TYPES = [
   // images
   'png',
   'jpe?g',
+  'jfif',
+  'pjpeg',
+  'pjp',
   'gif',
   'svg',
   'ico',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add more JPEG file extensions to `KNOWN_ASSET_TYPES`. I get extensions from MDN https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
