### PR TITLE
chore: tweak server start output

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -248,6 +248,6 @@ function printServerUrls(
     print(colors.green('➜'), label, text)
   })
   notes.forEach(({ label, message: text }) => {
-    print(colors.blue('❖'), label, text)
+    print(colors.white('❖'), label, text)
   })
 }

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -173,6 +173,7 @@ function printServerUrls(
   info: Logger['info']
 ): void {
   const urls: Array<{ label: string; url: string }> = []
+  const notes: Array<{ label: string; message: string }> = []
 
   if (hostname.host && loopbackHosts.has(hostname.host)) {
     let hostnameName = hostname.name
@@ -191,9 +192,11 @@ function printServerUrls(
     })
 
     if (hostname.name === 'localhost') {
-      urls.push({
-        label: 'Network',
-        url: colors.dim(`use ${colors.white(colors.bold('--host'))} to expose`)
+      notes.push({
+        label: 'Hint',
+        message: colors.dim(
+          `Use ${colors.white(colors.bold('--host'))} to expose to network.`
+        )
       })
     }
   } else {
@@ -217,9 +220,17 @@ function printServerUrls(
       })
   }
 
-  const length = urls.reduce(
-    (length, { label }) => Math.max(length, label.length),
-    0
+  if (!hostname.host || wildcardHosts.has(hostname.host)) {
+    notes.push({
+      label: 'Note',
+      message: colors.dim(
+        'You are using a wildcard host. Ports might be overriden.'
+      )
+    })
+  }
+
+  const length = Math.max(
+    ...[...urls, ...notes].map(({ label }) => label.length)
   )
   const print = (
     iconWithColor: string,
@@ -236,11 +247,7 @@ function printServerUrls(
   urls.forEach(({ label, url: text }) => {
     print(colors.green('➜'), label, text)
   })
-  if (!hostname.host || wildcardHosts.has(hostname.host)) {
-    print(
-      colors.bold(colors.blue('ⓘ')),
-      'Note',
-      colors.dim('You are using a wildcard host. Ports might be overriden.')
-    )
-  }
+  notes.forEach(({ label, message: text }) => {
+    print(colors.blue('❖'), label, text)
+  })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`ⓘ` has a different width with `➜` depending on fonts. This PR replaces that letter and tweaks some messages.

![image](https://user-images.githubusercontent.com/49056869/173575637-2989e350-67be-466a-9da3-0bc32d9d5f0a.png)
![image](https://user-images.githubusercontent.com/49056869/173575826-93b56f66-457c-4ce5-8a9e-a4848904aeb5.png)

@patak-dev You suggested `➜` (U+279C) but how about `❖` (U+2756)? It has the same width ([East Asian Width](http://www.unicode.org/reports/tr11/), [East Asian Width data](https://unicode.org/Public/14.0.0/ucd/EastAsianWidth.txt)).

|letter|width|
|---|---|
|ⓘ (U+24BE)|East Asian Ambiguous (A)|
|➜ (U+279C)|Neutral (N)|
|❖ (U+2756)|Neutral (N)|

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
