### PR TITLE
ci: only install chromium for playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,9 @@ jobs:
       - name: Install deps
         run: pnpm install
 
+      # This could be removed when https://github.com/pnpm/pnpm/issues/4888 is resolved
       - name: Install Playwright
-        run: pnpm playwright install
+        run: pnpm playwright install chromium
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`playwright install` installs all default browsers (https://github.com/microsoft/playwright/issues/14862).
But as we are using `playwight-chromium`, other browsers are not needed.
This PR changes the command to explicitly install chromium only.

Also this part is needed because of https://github.com/pnpm/pnpm/issues/4888.

refs #8041

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
