### PR TITLE
docs: update config jsdoc style

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -41,14 +41,10 @@ const func = () => {
 Since Vite ships with TypeScript typings, you can leverage your IDE's intellisense with jsdoc type hints:
 
 ```js
-/**
- * @type {import('vite').UserConfig}
- */
-const config = {
+/** @type {import('vite').UserConfig} */
+export default {
   // ...
 }
-
-export default config
 ```
 
 Alternatively, you can use the `defineConfig` helper which should provide intellisense without the need for jsdoc annotations:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Looks like jsdoc/ts supports annotating types on `export default` and `module.exports` now. Updated to reflect a shorter syntax.

### Additional context

Note: From my experience, this used to not work, that's why it's using the more verbose syntax.

A kind fellow on Discord pointed this.

Also there's https://twitter.com/adamwathan/status/1532154415561449472

Placed the jsdoc as one line as it's usually common to do so for `@type` only

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
