### PR TITLE
fix: allow cache overlap in parallel builds

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -620,7 +620,11 @@ export function getOptimizedDepPath(
 function getDepsCacheSuffix(config: ResolvedConfig): string {
   let suffix = ''
   if (config.command === 'build') {
-    suffix += '_build'
+    // Differentiate build caches depending on outDir to allow parallel builds
+    const { outDir } = config.build
+    const buildId =
+      outDir.length > 8 || outDir.includes('/') ? getHash(outDir) : outDir
+    suffix += `_build-${buildId}`
     if (config.build.ssr) {
       suffix += '_ssr'
     }

--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -22,6 +22,5 @@ module.exports = {
   },
   testConfig: {
     baseRoute: '/relative-base/'
-  },
-  cacheDir: 'node_modules/.vite/relative-base'
+  }
 }

--- a/playground/assets/vite.config.js
+++ b/playground/assets/vite.config.js
@@ -17,6 +17,5 @@ module.exports = {
     assetsInlineLimit: 8192, // 8kb
     manifest: true,
     watch: {}
-  },
-  cacheDir: 'node_modules/.vite/foo'
+  }
 }

--- a/playground/worker/vite.config-es.js
+++ b/playground/worker/vite.config-es.js
@@ -38,6 +38,5 @@ module.exports = vite.defineConfig({
         }
       }
     }
-  ],
-  cacheDir: 'node_modules/.vite/es'
+  ]
 })

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -40,6 +40,5 @@ module.exports = vite.defineConfig({
         }
       }
     }
-  ],
-  cacheDir: 'node_modules/.vite/relative-base'
+  ]
 })

--- a/playground/worker/vite.config-sourcemap.js
+++ b/playground/worker/vite.config-sourcemap.js
@@ -21,9 +21,6 @@ module.exports = vite.defineConfig((sourcemap) => {
         }
       }
     },
-    cacheDir: `node_modules/.vite/iife-${
-      typeof sourcemap === 'boolean' ? 'sourcemap' : 'sourcemap-' + sourcemap
-    }`,
     build: {
       outDir: `dist/iife-${
         typeof sourcemap === 'boolean' ? 'sourcemap' : 'sourcemap-' + sourcemap

--- a/playground/worker/vite.config.js
+++ b/playground/worker/vite.config.js
@@ -23,6 +23,5 @@ module.exports = vite.defineConfig({
         entryFileNames: 'assets/[name].js'
       }
     }
-  },
-  cacheDir: 'node_modules/.vite/iife'
+  }
 })


### PR DESCRIPTION
### Description

We found out why the worker tests were failing after:
- https://github.com/vitejs/vite/pull/8280

We now have deps caches during build that can't be used in parallel. @poyoho manually configured the worker (and assets) playground to have different caches (see https://github.com/vitejs/vite/pull/8541/commits/c9b185c7b7a428e99b82be0885b89f3bdaf9d522), so tests are now stable again.

We discussed that we need to implement something here because before building in parallel was possible. This PR implements a possible way forward, adding an id to the build deps cache based on the `outputDir`

I think this may be enough. We can't use a general config hash, because it isn't easy to know when a dir could be removed. I don't think users would call vite build in parallel over the same outputDir, but we need to keep an eye to check if this is really enough.

The PR avoids the use of a hash if the dir name is small enough so it is easier to debug for the default `dist` or other dirs like `output`. The custom `cacheDir`s in the playground are no longer needed so they are removed (and this serves as a test for the PR)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
