### PR TITLE
ci: cache playwright binary correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
       # Install playwright's binary under custom directory to cache
       - name: Set Playwright path (non-windows)
         if: runner.os != 'Windows'
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=~/.cache/playwright-bin" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
       - name: Set Playwright path (windows)
         if: runner.os == 'Windows'
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=~/.cache/playwright-bin" >> $GITHUB_ENV
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $env:GITHUB_ENV
 
       - name: Cache Playwright's binary
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ env:
   # 7 GiB by default on GitHub, setting to 6 GiB
   # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
   NODE_OPTIONS: --max-old-space-size=6144
+  # install playwright binary manually (because pnpm only runs install script once)
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
 on:
   push:
@@ -39,8 +41,8 @@ jobs:
       fail-fast: false
 
     env:
-      # Install playwright's binray under node_modules so it will be cached together
-      PLAYWRIGHT_BROWSERS_PATH: "0"
+      # Install playwright's binary under custom directory to cache
+      PLAYWRIGHT_BROWSERS_PATH: "~/.cache/playwright-bin"
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:
@@ -59,8 +61,16 @@ jobs:
       - name: Install deps
         run: pnpm install
 
-      # This could be removed when https://github.com/pnpm/pnpm/issues/4888 is resolved
+      - name: Cache Playwright's binary
+        uses: actions/cache@v3
+        with:
+          # Playwright removes unused browsers automatically
+          # So does not need to add playwright version to key
+          key: ${{ runner.os }}-playwright-bin-v1
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+
       - name: Install Playwright
+        # does not need to explictly set chromium after https://github.com/microsoft/playwright/issues/14862 is solved
         run: pnpm playwright install chromium
 
       - name: Build
@@ -98,8 +108,6 @@ jobs:
 
       - name: Install deps
         run: pnpm install
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     env:
       # Install playwright's binary under custom directory to cache
-      PLAYWRIGHT_BROWSERS_PATH: "~/.cache/playwright-bin"
+      PLAYWRIGHT_BROWSERS_PATH: "/.cache/playwright-bin"
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
             node_version: 16
       fail-fast: false
 
-    env:
-      # Install playwright's binary under custom directory to cache
-      PLAYWRIGHT_BROWSERS_PATH: "$HOME/.cache/playwright-bin"
-
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:
       - name: Checkout
@@ -60,6 +56,14 @@ jobs:
 
       - name: Install deps
         run: pnpm install
+
+      # Install playwright's binary under custom directory to cache
+      - name: Set Playwright path (non-windows)
+        if: runner.os != 'Windows'
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
+      - name: Set Playwright path (windows)
+        if: runner.os == 'Windows'
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $env:GITHUB_ENV
 
       - name: Cache Playwright's binary
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
       - name: Set Playwright path (windows)
         if: runner.os == 'Windows'
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $env:GITHUB_ENV
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME\.cache\playwright-bin" >> $env:GITHUB_ENV
 
       - name: Cache Playwright's binary
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
             node_version: 16
       fail-fast: false
 
-    env:
-      # Install playwright's binary under custom directory to cache
-      PLAYWRIGHT_BROWSERS_PATH: "/.cache/playwright-bin"
-
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:
       - name: Checkout
@@ -60,6 +56,14 @@ jobs:
 
       - name: Install deps
         run: pnpm install
+
+      # Install playwright's binary under custom directory to cache
+      - name: Set Playwright path (non-windows)
+        if: runner.os != 'Windows'
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=~/.cache/playwright-bin" >> $GITHUB_ENV
+      - name: Set Playwright path (windows)
+        if: runner.os == 'Windows'
+        run: echo "PLAYWRIGHT_BROWSERS_PATH=~/.cache/playwright-bin" >> $GITHUB_ENV
 
       - name: Cache Playwright's binary
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
             node_version: 16
       fail-fast: false
 
+    env:
+      # Install playwright's binary under custom directory to cache
+      PLAYWRIGHT_BROWSERS_PATH: "$HOME/.cache/playwright-bin"
+
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:
       - name: Checkout
@@ -56,14 +60,6 @@ jobs:
 
       - name: Install deps
         run: pnpm install
-
-      # Install playwright's binary under custom directory to cache
-      - name: Set Playwright path (non-windows)
-        if: runner.os != 'Windows'
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
-      - name: Set Playwright path (windows)
-        if: runner.os == 'Windows'
-        run: echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $env:GITHUB_ENV
 
       - name: Cache Playwright's binary
         uses: actions/cache@v3


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Follow up #8589. See https://github.com/pnpm/pnpm/issues/4888#issuecomment-1156110439 for the reason.

This PR changes the following:

- don't install playwright binary while `pnpm i`
- use `actions/cache` to cache playwright binary

refs https://github.com/vitejs/vite/pull/8041

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
