### PR TITLE
fix: avoid replacing defines and NODE_ENV in optimized deps (fix #8593)

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -888,7 +888,7 @@ export function getDepHash(config: ResolvedConfig): string {
   // only a subset of config options that can affect dep optimization
   content += JSON.stringify(
     {
-      mode: (config.command !== 'build' && process.env.NODE_ENV) || config.mode,
+      mode: process.env.NODE_ENV || config.mode,
       root: config.root,
       resolve: config.resolve,
       buildTarget: config.build.target,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -888,9 +888,8 @@ export function getDepHash(config: ResolvedConfig): string {
   // only a subset of config options that can affect dep optimization
   content += JSON.stringify(
     {
-      mode: process.env.NODE_ENV || config.mode,
+      mode: (config.command !== 'build' && process.env.NODE_ENV) || config.mode,
       root: config.root,
-      define: config.define,
       resolve: config.resolve,
       buildTarget: config.build.target,
       assetsInclude: config.assetsInclude,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -472,22 +472,15 @@ export async function runOptimizeDeps(
     flatIdToExports[flatId] = exportsData
   }
 
-  const define = {
-    'process.env.NODE_ENV': isBuild
-      ? '__vite_process_env_NODE_ENV'
-      : JSON.stringify(process.env.NODE_ENV || config.mode)
-  }
-
   const start = performance.now()
 
   const result = await build({
     absWorkingDir: process.cwd(),
     entryPoints: Object.keys(flatIdDeps),
     bundle: true,
-    platform:
-      config.build.ssr && config.ssr?.target !== 'webworker'
-        ? 'node'
-        : undefined,
+    // Ensure resolution is handled by esbuildDepPlugin and
+    // avoid replacing `process.env.NODE_ENV` for 'browser'
+    platform: 'neutral',
     format: 'esm',
     target: config.build.target || undefined,
     external: config.optimizeDeps?.exclude,
@@ -497,7 +490,6 @@ export async function runOptimizeDeps(
     outdir: processingCacheDir,
     ignoreAnnotations: !isBuild,
     metafile: true,
-    define,
     plugins: [
       ...plugins,
       esbuildDepPlugin(flatIdDeps, flatIdToExports, config)

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -385,7 +385,6 @@ export async function runOptimizeDeps(
   resolvedConfig: ResolvedConfig,
   depsInfo: Record<string, OptimizedDepInfo>
 ): Promise<DepOptimizationResult> {
-  const isBuild = resolvedConfig.command === 'build'
   const config: ResolvedConfig = {
     ...resolvedConfig,
     command: 'build'
@@ -472,19 +471,12 @@ export async function runOptimizeDeps(
     flatIdToExports[flatId] = exportsData
   }
 
-  let define: Record<string, string> | undefined
-  if (!isBuild) {
-    // We only use define for dev optimized deps. During build we let the define keys
-    // unchanged as the define plugin will process them
-    define = {
-      'process.env.NODE_ENV': JSON.stringify(
-        process.env.NODE_ENV || config.mode
-      )
-    }
-    for (const key in config.define) {
-      const value = config.define[key]
-      define[key] = typeof value === 'string' ? value : JSON.stringify(value)
-    }
+  const define: Record<string, string> = {
+    'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || config.mode)
+  }
+  for (const key in config.define) {
+    const value = config.define[key]
+    define[key] = typeof value === 'string' ? value : JSON.stringify(value)
   }
 
   const start = performance.now()

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -2,6 +2,7 @@ import MagicString from 'magic-string'
 import type { TransformResult } from 'rollup'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
+import { getDepsOptimizer } from '../optimizer'
 import { isCSSRequest } from './css'
 import { isHTMLRequest } from './html'
 
@@ -107,6 +108,15 @@ export function definePlugin(config: ResolvedConfig): Plugin {
         isNonJsRequest(id) ||
         config.assetsInclude(id)
       ) {
+        return
+      }
+
+      if (getDepsOptimizer(config)?.isOptimizedDepFile(id)) {
+        // The esbuild optimizer already replaced these variables
+        // Avoid re-processing for performance and also to avoid breaking
+        // with object values which end up generating a variable in esbuild
+        // that isn't removed in commonjs deps
+        //   "<define:__DEFINE_KEY__>"() {
         return
       }
 

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -25,8 +25,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     Object.assign(processNodeEnv, {
       'process.env.NODE_ENV': JSON.stringify(nodeEnv),
       'global.process.env.NODE_ENV': JSON.stringify(nodeEnv),
-      'globalThis.process.env.NODE_ENV': JSON.stringify(nodeEnv),
-      __vite_process_env_NODE_ENV: JSON.stringify(nodeEnv)
+      'globalThis.process.env.NODE_ENV': JSON.stringify(nodeEnv)
     })
   }
 
@@ -64,9 +63,6 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       ...userDefine,
       ...importMetaKeys,
       ...(replaceProcessEnv ? processEnv : {})
-    }
-    if (isBuild && !replaceProcessEnv) {
-      replacements['__vite_process_env_NODE_ENV'] = 'process.env.NODE_ENV'
     }
 
     const replacementsKeys = Object.keys(replacements)

--- a/playground/define/__tests__/define.spec.ts
+++ b/playground/define/__tests__/define.spec.ts
@@ -40,4 +40,7 @@ test('string', async () => {
   // html would't need to define replacement
   expect(await page.textContent('.exp-define')).toBe('__EXP__')
   expect(await page.textContent('.import-json')).toBe('__EXP__')
+  expect(await page.textContent('.define-in-dep')).toBe(
+    defines.__STRINGIFIED_OBJ__
+  )
 })

--- a/playground/define/commonjs-dep/index.js
+++ b/playground/define/commonjs-dep/index.js
@@ -1,0 +1,1 @@
+module.exports = { defined: __STRINGIFIED_OBJ__ }

--- a/playground/define/commonjs-dep/package.json
+++ b/playground/define/commonjs-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "commonjs-dep",
+  "private": true,
+  "version": "1.0.0",
+  "type": "commonjs"
+}

--- a/playground/define/index.html
+++ b/playground/define/index.html
@@ -16,6 +16,7 @@
 <p>no identifier substring: <span class="no-identifier-substring"></span></p>
 <p>define variable in html: <code class="exp-define">__EXP__</code></p>
 <p>import json: <code class="import-json"></code></p>
+<p>define in dep: <code class="define-in-dep"></code></p>
 
 <script type="module">
   const __VAR_NAME__ = true // ensure define doesn't replace var name
@@ -50,6 +51,9 @@
   function text(el, text) {
     document.querySelector(el).textContent = text
   }
+
+  import { defined } from 'dep'
+  text('.define-in-dep', JSON.stringify(defined))
 </script>
 
 <style>

--- a/playground/define/package.json
+++ b/playground/define/package.json
@@ -7,5 +7,8 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "dep": "file:./commonjs-dep"
   }
 }

--- a/playground/define/vite.config.js
+++ b/playground/define/vite.config.js
@@ -19,6 +19,7 @@ module.exports = {
     'process.env.SOMEVAR': '"SOMEVAR"',
     $DOLLAR: 456,
     ÖUNICODE_LETTERɵ: 789,
-    __VAR_NAME__: false
+    __VAR_NAME__: false,
+    __STRINGIFIED_OBJ__: JSON.stringify({ foo: true })
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,6 +423,12 @@ importers:
     specifiers: {}
 
   playground/define:
+    specifiers:
+      dep: file:./commonjs-dep
+    dependencies:
+      dep: file:playground/define/commonjs-dep
+
+  playground/define/commonjs-dep:
     specifiers: {}
 
   playground/dynamic-import:
@@ -8655,6 +8661,12 @@ packages:
     resolution: {directory: playground/alias/dir/module, type: directory}
     name: '@vite/aliased-module'
     version: 0.0.0
+    dev: false
+
+  file:playground/define/commonjs-dep:
+    resolution: {directory: playground/define/commonjs-dep, type: directory}
+    name: commonjs-dep
+    version: 1.0.0
     dev: false
 
   file:playground/dynamic-import/pkg:


### PR DESCRIPTION
### Description

When we use `define` for build optimized deps and there is CJS interop, the defined keys end up being used as part of the interop. In the define playground, it looks like:
```js
// <define:__OBJ__>
var init_define_OBJ = __esm({
  "<define:__OBJ__>"() {
  }
});

// <define:__STRINGIFIED_OBJ__>
var foo, define_STRINGIFIED_OBJ_default;
var init_define_STRINGIFIED_OBJ = __esm({
  "<define:__STRINGIFIED_OBJ__>"() {
    foo = true;
    define_STRINGIFIED_OBJ_default = { foo };
  }
});
```

So if we don't skip these files in the define plugin, then the keys are re-replaced and there is an error.

We have two ways to fix this:

1. the first commit
  - we don't use define in esbuild optimization during build
  - we let the define plugin process this
  
cons: 
 - there is a failing test, I don't understand why

2. the second commit
  - we let define in esbuild untouched
  - we skip the optimized deps in the define plugin
  
pro:
 - dev and prod are more similar

cons:
 - the define keys appear in the optimize dep, and also in the final output?
 - the failing test is gone

Pushing so we can continue the discussion here

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other