### PR TITLE
fix(optimizer): use simple browser external shim in prod

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -224,24 +224,29 @@ export function esbuildDepPlugin(
       build.onLoad(
         { filter: /.*/, namespace: 'browser-external' },
         ({ path }) => {
-          return {
-            // Return in CJS to intercept named imports. Use `Object.create` to
-            // create the Proxy in the prototype to workaround esbuild issue. Why?
-            //
-            // In short, esbuild cjs->esm flow:
-            // 1. Create empty object using `Object.create(Object.getPrototypeOf(module.exports))`.
-            // 2. Assign props of `module.exports` to the object.
-            // 3. Return object for ESM use.
-            //
-            // If we do `module.exports = new Proxy({}, {})`, step 1 returns empty object,
-            // step 2 does nothing as there's no props for `module.exports`. The final object
-            // is just an empty object.
-            //
-            // Creating the Proxy in the prototype satisfies step 1 immediately, which means
-            // the returned object is a Proxy that we can intercept.
-            //
-            // Note: Skip keys that are accessed by esbuild and browser devtools.
-            contents: `\
+          if (config.isProduction) {
+            return {
+              contents: 'module.exports = {}'
+            }
+          } else {
+            return {
+              // Return in CJS to intercept named imports. Use `Object.create` to
+              // create the Proxy in the prototype to workaround esbuild issue. Why?
+              //
+              // In short, esbuild cjs->esm flow:
+              // 1. Create empty object using `Object.create(Object.getPrototypeOf(module.exports))`.
+              // 2. Assign props of `module.exports` to the object.
+              // 3. Return object for ESM use.
+              //
+              // If we do `module.exports = new Proxy({}, {})`, step 1 returns empty object,
+              // step 2 does nothing as there's no props for `module.exports`. The final object
+              // is just an empty object.
+              //
+              // Creating the Proxy in the prototype satisfies step 1 immediately, which means
+              // the returned object is a Proxy that we can intercept.
+              //
+              // Note: Skip keys that are accessed by esbuild and browser devtools.
+              contents: `\
 module.exports = Object.create(new Proxy({}, {
   get(_, key) {
     if (
@@ -254,6 +259,7 @@ module.exports = Object.create(new Proxy({}, {
     }
   }
 }))`
+            }
           }
         }
       )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Simpley return `module.exports = {}` for `browser-external` modules in esbuild prod since it's now used for builds.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
