### PR TITLE
feat: cleaner default dev output

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -172,8 +172,8 @@ function printServerUrls(
   base: string,
   info: Logger['info']
 ): void {
-  const urls: Array<{ label: string; url: string }> = []
-  const notes: Array<{ label?: string; message: string }> = []
+  const urls: Array<{ label: string; url: string; disabled?: boolean }> = []
+  const notes: Array<{ label: string; message: string }> = []
 
   if (hostname.host && loopbackHosts.has(hostname.host)) {
     let hostnameName = hostname.name
@@ -192,10 +192,10 @@ function printServerUrls(
     })
 
     if (hostname.name === 'localhost') {
-      notes.push({
-        message: colors.dim(
-          `Use ${colors.white(colors.bold('--host'))} to expose to network`
-        )
+      urls.push({
+        label: 'Network',
+        url: `Use ${colors.white(colors.bold('--host'))} to expose`,
+        disabled: true
       })
     }
   } else {
@@ -234,17 +234,17 @@ function printServerUrls(
   const print = (
     iconWithColor: string,
     label: string | undefined,
-    messageWithColor: string
+    messageWithColor: string,
+    disabled?: boolean
   ) => {
-    info(
-      `  ${iconWithColor}  ${
-        label ? colors.bold(label) + ':' : ' '
-      } ${' '.repeat(length - (label?.length ?? 0))}${messageWithColor}`
-    )
+    const message = `  ${iconWithColor}  ${
+      label ? colors.bold(label) + ':' : ' '
+    } ${' '.repeat(length - (label?.length ?? 0))}${messageWithColor}`
+    info(disabled ? colors.dim(message) : message)
   }
 
-  urls.forEach(({ label, url: text }) => {
-    print(colors.green('➜'), label, text)
+  urls.forEach(({ label, url: text, disabled }) => {
+    print(colors.green('➜'), label, text, disabled)
   })
   notes.forEach(({ label, message: text }) => {
     print(colors.white('❖'), label, text)

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -194,7 +194,7 @@ function printServerUrls(
     if (hostname.name === 'localhost') {
       urls.push({
         label: 'Network',
-        url: `Use ${colors.white(colors.bold('--host'))} to expose`,
+        url: `use ${colors.white(colors.bold('--host'))} to expose`,
         disabled: true
       })
     }
@@ -229,17 +229,17 @@ function printServerUrls(
   }
 
   const length = Math.max(
-    ...[...urls, ...notes].map(({ label }) => label?.length ?? 0)
+    ...[...urls, ...notes].map(({ label }) => label.length)
   )
   const print = (
     iconWithColor: string,
-    label: string | undefined,
+    label: string,
     messageWithColor: string,
     disabled?: boolean
   ) => {
     const message = `  ${iconWithColor}  ${
       label ? colors.bold(label) + ':' : ' '
-    } ${' '.repeat(length - (label?.length ?? 0))}${messageWithColor}`
+    } ${' '.repeat(length - label.length)}${messageWithColor}`
     info(disabled ? colors.dim(message) : message)
   }
 

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -173,7 +173,7 @@ function printServerUrls(
   info: Logger['info']
 ): void {
   const urls: Array<{ label: string; url: string }> = []
-  const notes: Array<{ label: string; message: string }> = []
+  const notes: Array<{ label?: string; message: string }> = []
 
   if (hostname.host && loopbackHosts.has(hostname.host)) {
     let hostnameName = hostname.name
@@ -193,9 +193,8 @@ function printServerUrls(
 
     if (hostname.name === 'localhost') {
       notes.push({
-        label: 'Hint',
         message: colors.dim(
-          `Use ${colors.white(colors.bold('--host'))} to expose to network.`
+          `Use ${colors.white(colors.bold('--host'))} to expose to network`
         )
       })
     }
@@ -230,17 +229,17 @@ function printServerUrls(
   }
 
   const length = Math.max(
-    ...[...urls, ...notes].map(({ label }) => label.length)
+    ...[...urls, ...notes].map(({ label }) => label?.length ?? 0)
   )
   const print = (
     iconWithColor: string,
-    label: string,
+    label: string | undefined,
     messageWithColor: string
   ) => {
     info(
-      `  ${iconWithColor}  ${colors.bold(label)}: ${' '.repeat(
-        length - label.length
-      )}${messageWithColor}`
+      `  ${iconWithColor}  ${
+        label ? colors.bold(label) + ':' : ' '
+      } ${' '.repeat(length - (label?.length ?? 0))}${messageWithColor}`
     )
   }
 


### PR DESCRIPTION
### Description

Around ~2.4 we stopped exposing to the network by default. As this was a big change, we added a big `Hint:` note so people will know that they can still use `--host` to expose to the network

In v3, I think we can already clean up a bit the output and at least remove the bright `Hint: `  label. We can still leave the message as it is dimmed and helpful

Before:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/583075/174283955-3ce01ed8-121d-42f1-9458-3c143fac4d8d.png">

After (initial commit):

<img width="423" alt="image" src="https://user-images.githubusercontent.com/583075/174283991-6956ed31-9063-4650-99f5-48b19d70771e.png">

After (version after @bluwy's suggestions)

<img width="423" alt="image" src="https://user-images.githubusercontent.com/583075/174298534-49b9c07b-d8b8-4d4a-9666-a93a4758b323.png">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
