### PR TITLE
fix: disable inlineDynamicImports for ssr.target = node

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -62,6 +62,8 @@ Vite v3 uses ESM for the SSR build by default. When using ESM, the [SSR external
 
 If using ESM for SSR isn't possible in your project, you can set `legacy.buildSsrCjsExternalHeuristics` to generate a CJS bundle using the same externalization strategy of Vite v2.
 
+Also [`build.rollupOptions.output.inlineDynamicImports`](https://rollupjs.org/guide/en/#outputinlinedynamicimports) now defaults to `false` when `ssr.target` is `'node'`. `inlineDynamicImports` changes execution order and bundling to a single file is not needed for node builds.
+
 ## General Changes
 
 - JS file extensions in SSR and lib mode now use a valid extension (`js`, `mjs`, or `cjs`) for output JS entries and chunks based on their format and the package type.

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -447,10 +447,11 @@ async function doBuild(
         )
       }
 
+      const ssrWorkerBuild = ssr && config.ssr?.target !== 'webworker'
       const cjsSsrBuild = ssr && config.ssr?.format === 'cjs'
       const format = output.format || (cjsSsrBuild ? 'cjs' : 'es')
       const jsExt =
-        (ssr && config.ssr?.target !== 'webworker') || libOptions
+        ssrWorkerBuild || libOptions
           ? resolveOutputJsExtension(format, getPkgJson(config.root)?.type)
           : 'js'
       return {
@@ -478,7 +479,7 @@ async function doBuild(
         inlineDynamicImports:
           output.format === 'umd' ||
           output.format === 'iife' ||
-          (ssr && typeof input === 'string'),
+          (ssrWorkerBuild && typeof input === 'string'),
         ...output
       }
     }


### PR DESCRIPTION
### Description

`inlineDynamicImports` was enabled for both `ssr.target = 'node'` and `ssr.target = 'webworker'`.

AFAIK there's no reason to force the output to be a single file when `ssr.target` is node and [`inlineDynamicImports` option has a caveat](https://rollupjs.org/guide/en/#outputinlinedynamicimports).
So I think we should not enable `inlineDynamicImports` for `ssr.target = 'node'` by default.

~~WIP: I need to check if it does not affect ssr manifest because this commit (https://github.com/vitejs/vite/commit/107e79e7b7d422f0d1dbe8b7b435636df7c6281c) introduced this change.~~ `playground/ssr-vue` seems to work.
~~WIP: add docs~~

fixes #7356
fixes #8571

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
