### PR TITLE
fix(server): skip localhost verbatim dns lookup

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -187,10 +187,8 @@ export async function httpServerStart(
 ): Promise<number> {
   let { port, strictPort, host, logger } = serverOptions
 
-  // This could be removed when Vite only supports Node 17+ because verbatim=true is default
-  // https://github.com/nodejs/node/pull/39987
   if (host === 'localhost') {
-    const addr = await dns.lookup('localhost', { verbatim: true })
+    const addr = await dns.lookup('localhost')
     host = addr.address
   }
 

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -5,7 +5,6 @@ import type {
   OutgoingHttpHeaders as HttpServerHeaders
 } from 'http'
 import type { ServerOptions as HttpsServerOptions } from 'https'
-import { promises as dns } from 'dns'
 import type { Connect } from 'types/connect'
 import { isObject } from './utils'
 import type { ProxyOptions } from './server/middlewares/proxy'
@@ -186,11 +185,6 @@ export async function httpServerStart(
   }
 ): Promise<number> {
   let { port, strictPort, host, logger } = serverOptions
-
-  if (host === 'localhost') {
-    const addr = await dns.lookup('localhost')
-    host = addr.address
-  }
 
   return new Promise((resolve, reject) => {
     const onError = (e: Error & { code?: string }) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Based on discussion in discord, we should `dns.lookup` with the default options so that other tools can lookup `localhost` equally too.

### Additional context

@sapphi-red will update the docs in https://github.com/vitejs/vite/pull/8634

I'm not sure why the tests pass before.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
