### PR TITLE
fix(plugin-legacy): prevent esbuild injecting arrow function (fixes #8651)

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -578,7 +578,8 @@ async function buildPolyfillChunk(
     plugins: [polyfillsPlugin(imports, excludeSystemJS)],
     build: {
       write: false,
-      target: false,
+      // if a value above 'es5' is set, esbuild injects helper functions which uses es2015 features
+      target: 'es5',
       minify,
       assetsDir,
       rollupOptions: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Previously core-js was bundled by `@rollup/plugin-commonjs` but now it is bundled by esbuild.
esbuild injects helper functions and it uses ES2015 features when target is above ES5.

fixes #8651

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
