### PR TITLE
fix(plugin-react): set `this-is-undefined-in-esm` to silent if classic runtime (fixes #8644)

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -47,7 +47,7 @@
     "react-refresh": "^0.13.0"
   },
   "peerDependencies": {
-    "vite": "^3.0.0-alpha"
+    "vite": "^3.0.0-alpha.11"
   },
   "devDependencies": {
     "vite": "workspace:*"

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -117,6 +117,17 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   const viteBabel: Plugin = {
     name: 'vite:react-babel',
     enforce: 'pre',
+    config() {
+      if (opts.jsxRuntime === 'classic') {
+        return {
+          esbuild: {
+            logOverride: {
+              'this-is-undefined-in-esm': 'silent'
+            }
+          }
+        }
+      }
+    },
     configResolved(config) {
       base = config.base
       projectRoot = config.root


### PR DESCRIPTION
### Description
For automatic runtime it was fixed upstream (https://github.com/evanw/esbuild/commit/0905d851eca6666bc606ff719450336ab868c547).
But for classic runtime it still happens (https://github.com/evanw/esbuild/issues/2328#issuecomment-1159314915).

This PR sets `esbuild.logOverride['this-is-undefined-in-esm'] = 'silent'` automatically when classic runtime is used.

This PR only works with esbuild 0.14.42+.
Vite 3.0.0-alpha.11+ requires 0.14.43 so it is safe.
https://github.com/vitejs/vite/blob/afe88ff6a31243dd5efbfa3a83693ae0c1d1d3b3/packages/vite/package.json#L60

fixes #8644

### Additional context

related: https://github.com/evanw/esbuild/issues/2328

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
