### PR TITLE
feat: export esbuildVersion and rollupVersion

### DIFF
--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -4,6 +4,7 @@
  * Please control the side-effects by checking the ./dist/node-cjs/publicUtils.cjs bundle
  */
 export { VERSION as version } from './constants'
+export { version as esbuildVersion } from 'esbuild'
 export {
   splitVendorChunkPlugin,
   splitVendorChunk

--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -5,6 +5,7 @@
  */
 export { VERSION as version } from './constants'
 export { version as esbuildVersion } from 'esbuild'
+export { VERSION as rollupVersion } from 'rollup'
 export {
   splitVendorChunkPlugin,
   splitVendorChunk


### PR DESCRIPTION
### Description
esbuild does not accept passing unknown options.
For example, #8674 does not work with 0.14.41 or below because `logOverride` does not exist.

By exporting this, plugins can use it to conditionally set esbuild options.
This will reduce peer dependency bumps.

AFAIK it could also be obtained by the code below, but it is complicated.

```js
import { createRequire } from 'node:module'

const _require = createRequire(import.meta.url)
const vitePath = _require.resolve('vite')
const _viteRequire = createRequire(vitePath)
const { version: esbuildVersion } = _viteRequire('esbuild')
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
