### PR TITLE
fix: respect `rollupOptions.external` for transitive dependencies

### DIFF
--- a/playground/external/__tests__/external.spec.ts
+++ b/playground/external/__tests__/external.spec.ts
@@ -1,8 +1,13 @@
 import { isBuild, page } from '~utils'
 
 describe.runIf(isBuild)('build', () => {
-  test('should not include vue source code in the bundle', async () => {
+  test('should externalize imported packages', async () => {
     // If `vue` is successfully externalized, the page should use the version from the import map
     expect(await page.textContent('#imported-vue-version')).toBe('3.2.0')
+  })
+
+  test('should externalize required packages', async () => {
+    // If `vue` is successfully externalized, the page should use the version from the import map
+    expect(await page.textContent('#required-vue-version')).toBe('3.2.0')
   })
 })

--- a/playground/external/__tests__/external.spec.ts
+++ b/playground/external/__tests__/external.spec.ts
@@ -1,0 +1,8 @@
+import { isBuild, page } from '~utils'
+
+describe.runIf(isBuild)('build', () => {
+  test('should not include vue source code in the bundle', async () => {
+    // If `vue` is successfully externalized, the page should use the version from the import map
+    expect(await page.textContent('#imported-vue-version')).toBe('3.2.0')
+  })
+})

--- a/playground/external/dep-that-imports-vue/index.js
+++ b/playground/external/dep-that-imports-vue/index.js
@@ -1,5 +1,3 @@
 import { version } from 'vue'
 
-export default function foo() {
-  document.querySelector('#imported-vue-version').textContent = version
-}
+document.querySelector('#imported-vue-version').textContent = version

--- a/playground/external/dep-that-imports-vue/index.js
+++ b/playground/external/dep-that-imports-vue/index.js
@@ -1,0 +1,5 @@
+import { version } from 'vue'
+
+export default function foo() {
+  document.querySelector('#imported-vue-version').textContent = version
+}

--- a/playground/external/dep-that-imports-vue/package.json
+++ b/playground/external/dep-that-imports-vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dep-that-imports-vue",
+  "name": "@vitejs/dep-that-imports-vue",
   "version": "0.0.1",
   "dependencies": {
     "vue": "^3.2.37"

--- a/playground/external/dep-that-imports-vue/package.json
+++ b/playground/external/dep-that-imports-vue/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "dep-that-imports-vue",
+  "version": "0.0.1",
+  "dependencies": {
+    "vue": "^3.2.37"
+  }
+}

--- a/playground/external/dep-that-requires-vue/index.js
+++ b/playground/external/dep-that-requires-vue/index.js
@@ -1,0 +1,3 @@
+const { version } = require('vue')
+
+document.querySelector('#required-vue-version').textContent = version

--- a/playground/external/dep-that-requires-vue/package.json
+++ b/playground/external/dep-that-requires-vue/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/dep-that-requires-vue",
+  "version": "0.0.1",
+  "dependencies": {
+    "vue": "^3.2.37"
+  }
+}

--- a/playground/external/index.html
+++ b/playground/external/index.html
@@ -13,7 +13,8 @@
     </script>
   </head>
   <body>
-    <div id="imported-vue-version"></div>
+    <p>Imported Vue version: <span id="imported-vue-version"></span></p>
+    <p>Required Vue version: <span id="required-vue-version"></span></p>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>

--- a/playground/external/index.html
+++ b/playground/external/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite App</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "vue": "https://unpkg.com/vue@3.2.0/dist/vue.runtime.esm-browser.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="imported-vue-version"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/playground/external/package.json
+++ b/playground/external/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "external-test",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "dep-that-imports-vue": "file:./dep-that-imports-vue"
+  },
+  "devDependencies": {
+    "vite": "workspace:*",
+    "vue": "^3.2.37"
+  }
+}

--- a/playground/external/package.json
+++ b/playground/external/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "dep-that-imports-vue": "file:./dep-that-imports-vue"
+    "@vitejs/dep-that-imports-vue": "file:./dep-that-imports-vue"
   },
   "devDependencies": {
     "vite": "workspace:*",

--- a/playground/external/package.json
+++ b/playground/external/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@vitejs/dep-that-imports-vue": "file:./dep-that-imports-vue"
+    "@vitejs/dep-that-imports-vue": "file:./dep-that-imports-vue",
+    "@vitejs/dep-that-requires-vue": "file:./dep-that-requires-vue"
   },
   "devDependencies": {
     "vite": "workspace:*",

--- a/playground/external/src/main.js
+++ b/playground/external/src/main.js
@@ -1,3 +1,1 @@
-import foo from '@vitejs/dep-that-imports-vue'
-
-foo()
+import '@vitejs/dep-that-imports-vue'

--- a/playground/external/src/main.js
+++ b/playground/external/src/main.js
@@ -1,1 +1,2 @@
 import '@vitejs/dep-that-imports-vue'
+import '@vitejs/dep-that-requires-vue'

--- a/playground/external/src/main.js
+++ b/playground/external/src/main.js
@@ -1,0 +1,3 @@
+import foo from 'dep-that-imports-vue'
+
+foo()

--- a/playground/external/src/main.js
+++ b/playground/external/src/main.js
@@ -1,3 +1,3 @@
-import foo from 'dep-that-imports-vue'
+import foo from '@vitejs/dep-that-imports-vue'
 
 foo()

--- a/playground/external/vite.config.js
+++ b/playground/external/vite.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    minify: false,
+    rollupOptions: {
+      external: ['vue']
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,23 @@ importers:
     dependencies:
       vue: 3.2.37
 
+  playground/external:
+    specifiers:
+      dep-that-imports-vue: file:./dep-that-imports-vue
+      vite: workspace:*
+      vue: ^3.2.37
+    dependencies:
+      dep-that-imports-vue: file:playground/external/dep-that-imports-vue
+    devDependencies:
+      vite: link:../../packages/vite
+      vue: 3.2.37
+
+  playground/external/dep-that-imports-vue:
+    specifiers:
+      vue: ^3.2.37
+    dependencies:
+      vue: 3.2.37
+
   playground/file-delete-restore:
     specifiers:
       '@vitejs/plugin-react': workspace:*
@@ -8674,6 +8691,14 @@ packages:
     resolution: {directory: playground/dynamic-import/pkg, type: directory}
     name: pkg
     version: 1.0.0
+    dev: false
+
+  file:playground/external/dep-that-imports-vue:
+    resolution: {directory: playground/external/dep-that-imports-vue, type: directory}
+    name: dep-that-imports-vue
+    version: 0.0.1
+    dependencies:
+      vue: 3.2.37
     dev: false
 
   file:playground/json/json-module:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,11 +457,11 @@ importers:
 
   playground/external:
     specifiers:
-      dep-that-imports-vue: file:./dep-that-imports-vue
+      '@vitejs/dep-that-imports-vue': file:./dep-that-imports-vue
       vite: workspace:*
       vue: ^3.2.37
     dependencies:
-      dep-that-imports-vue: file:playground/external/dep-that-imports-vue
+      '@vitejs/dep-that-imports-vue': file:playground/external/dep-that-imports-vue
     devDependencies:
       vite: link:../../packages/vite
       vue: 3.2.37

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,15 +458,23 @@ importers:
   playground/external:
     specifiers:
       '@vitejs/dep-that-imports-vue': file:./dep-that-imports-vue
+      '@vitejs/dep-that-requires-vue': file:./dep-that-requires-vue
       vite: workspace:*
       vue: ^3.2.37
     dependencies:
       '@vitejs/dep-that-imports-vue': file:playground/external/dep-that-imports-vue
+      '@vitejs/dep-that-requires-vue': file:playground/external/dep-that-requires-vue
     devDependencies:
       vite: link:../../packages/vite
       vue: 3.2.37
 
   playground/external/dep-that-imports-vue:
+    specifiers:
+      vue: ^3.2.37
+    dependencies:
+      vue: 3.2.37
+
+  playground/external/dep-that-requires-vue:
     specifiers:
       vue: ^3.2.37
     dependencies:
@@ -8695,7 +8703,15 @@ packages:
 
   file:playground/external/dep-that-imports-vue:
     resolution: {directory: playground/external/dep-that-imports-vue, type: directory}
-    name: dep-that-imports-vue
+    name: '@vitejs/dep-that-imports-vue'
+    version: 0.0.1
+    dependencies:
+      vue: 3.2.37
+    dev: false
+
+  file:playground/external/dep-that-requires-vue:
+    resolution: {directory: playground/external/dep-that-requires-vue, type: directory}
+    name: '@vitejs/dep-that-requires-vue'
     version: 0.0.1
     dependencies:
       vue: 3.2.37


### PR DESCRIPTION
### Description

The regression was brought in by https://github.com/vitejs/vite/pull/8280

To be compatible with Vite 2.x behavior:
When `rollupOptions.external` is set to `['vue']`,
- `import ... from 'vue'` in dependencies should be preserved;
- `const Vue = require('vue')` in dependencies should be transformed to `import * as Vue from 'vue'` and be preserved;

Ideally, we need a first-class `build.external` option, but that belongs to another issue/PR. It's fine to postpone it after 3.0 stable is out.

---

Remaining issues in this PR:
- `rollupOptions.external` only accepts `string[] | string` in the current implementation
  - this is because `optimizeDeps.exclude` only supports `string[]`
  - Rollup supports `RegExp | RegExp[]` and function formats https://rollupjs.org/guide/en/#external
  - If we want to support all these types, we need to extend the ability of `optimizeDeps.exclude`, either exposing it internally, or open to all end users.
  - Do we really want to do that? Or we can do that in 3.1 or later…
- The CJS `external` implementation is naive, there could potentially be more edge cases than in v2. But I think it's acceptable, because this use case shouldn't be encouraged at all.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
