### PR TITLE
fix: SSR with relative base

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -486,7 +486,7 @@ export async function resolveConfig(
 
   // During dev, we ignore relative base and fallback to '/'
   // For the SSR build, relative base isn't possible by means
-  // of import.meta.url. The user will be able to work out a setup 
+  // of import.meta.url. The user will be able to work out a setup
   // using experimental.buildAdvancedBaseOptions
   const base =
     relativeBaseShortcut && (!isBuild || config.build?.ssr)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -483,7 +483,15 @@ export async function resolveConfig(
   // resolve public base url
   const isBuild = command === 'build'
   const relativeBaseShortcut = config.base === '' || config.base === './'
-  const base = relativeBaseShortcut && !isBuild ? '/' : config.base ?? '/'
+
+  // During dev, we ignore relative base and fallback to '/'
+  // For the SSR build, relative base isn't possible by means
+  // of import.meta.url. The user will be able to work out a setup 
+  // using experimental.buildAdvancedBaseOptions
+  const base =
+    relativeBaseShortcut && (!isBuild || config.build?.ssr)
+      ? '/'
+      : config.base ?? '/'
   let resolvedBase = relativeBaseShortcut
     ? base
     : resolveBaseUrl(base, isBuild, logger, 'base')

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -105,7 +105,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       ) => {
         return base.runtime
           ? `"+${base.runtime(JSON.stringify(filename))}+"`
-          : base.relative
+          : base.relative && !config.build.ssr
           ? absoluteUrlPathInterpolation(filename)
           : JSON.stringify((base.url ?? config.base) + filename).slice(1, -1)
       }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -469,7 +469,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         chunkCSS = chunkCSS.replace(assetUrlRE, (_, fileHash, postfix = '') => {
           const filename = getAssetFilename(fileHash, config) + postfix
           chunk.viteMetadata.importedAssets.add(cleanUrl(filename))
-          if (assetsBase.relative) {
+          if (assetsBase.relative && !config.build.ssr) {
             // relative base + extracted CSS
             const relativePath = path.posix.relative(cssAssetDirname!, filename)
             return relativePath.startsWith('.')
@@ -488,7 +488,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           )
           chunkCSS = chunkCSS.replace(publicAssetUrlRE, (_, hash) => {
             const publicUrl = publicAssetUrlMap.get(hash)!
-            if (publicBase.relative) {
+            if (publicBase.relative && !config.build.ssr) {
               return relativePathToPublicFromCSS + publicUrl
             } else {
               // publicBase.runtime has no effect for assets in CSS

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -338,7 +338,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           } else {
             // Relative base
             let outputFilepath: string
-            if (assetsBase.relative) {
+            if (assetsBase.relative && !config.build.ssr) {
               outputFilepath = path.posix.relative(
                 path.dirname(chunk.fileName),
                 filename


### PR DESCRIPTION
### Description

We discussed with @danielroe, using his vote to merge this one so we can release an alpha. 

During SSR with relative base, we were generating paths using `import.meta.url`. Relative base should be applied only for client code. This PR disables it in SSR so `runtime` and `url` from advanced base options will be used. And if the relative base shortcut is used, the global base fallbacks to `/`. 

The API for `experimental.buildAdvancedBaseOptions` may need to be expanded to accommodate SSR. We would discuss this in other PRs and it isn't blocking the beta.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other