### PR TITLE
chore: fix "remove pending triage label" action

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -20,7 +20,7 @@ jobs:
           labels: "pending triage, need reproduction"
 
       - name: remove pending
-        if: contains(github.event.label.description, '(priority)') == true && contains(github.event.issue.labels.*.name, 'pending triage') == true
+        if: contains(github.event.label.description, '(priority)') && contains(github.event.issue.labels.*.name, 'pending triage')
         uses: actions-cool/issues-helper@v3
         with:
           actions: "remove-labels"
@@ -29,7 +29,7 @@ jobs:
           labels: "pending triage"
 
       - name: remove enhancement pending
-        if: "(github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)') == true) && contains(github.event.issue.labels.*.name, 'enhancement: pending triage') == true"
+        if: "(github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)')) && contains(github.event.issue.labels.*.name, 'enhancement: pending triage')"
         uses: actions-cool/issues-helper@v3
         with:
           actions: "remove-labels"

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -28,6 +28,15 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           labels: "pending triage"
 
+      - name: remove enhancement pending
+        if: "(github.event.label.name == 'enhancement' || startsWith(github.event.label.name, 'p:') == true) && contains(github.event.issue.labels.*.name, 'enhancement: pending triage') == true"
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: "remove-labels"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          labels: "enhancement: pending triage"
+
       - name: need reproduction
         if: github.event.label.name == 'need reproduction'
         uses: actions-cool/issues-helper@v3

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -20,7 +20,7 @@ jobs:
           labels: "pending triage, need reproduction"
 
       - name: remove pending
-        if: startsWith(github.event.label.name, 'p:') == true && contains(github.event.issue.labels.*.name, 'pending triage') == true
+        if: contains(github.event.label.description, '(priority)') == true && contains(github.event.issue.labels.*.name, 'pending triage') == true
         uses: actions-cool/issues-helper@v3
         with:
           actions: "remove-labels"
@@ -29,7 +29,7 @@ jobs:
           labels: "pending triage"
 
       - name: remove enhancement pending
-        if: "(github.event.label.name == 'enhancement' || startsWith(github.event.label.name, 'p:') == true) && contains(github.event.issue.labels.*.name, 'enhancement: pending triage') == true"
+        if: "(github.event.label.name == 'enhancement' || contains(github.event.label.description, '(priority)') == true) && contains(github.event.issue.labels.*.name, 'enhancement: pending triage') == true"
         uses: actions-cool/issues-helper@v3
         with:
           actions: "remove-labels"

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -20,7 +20,7 @@ jobs:
           labels: "pending triage, need reproduction"
 
       - name: remove pending
-        if: github.event.label.name == 'enhancement' || github.event.label.name == 'bug' || (contains(github.event.label.name, 'pending triage') == false && startsWith(github.event.label.name, 'bug:') == true)
+        if: startsWith(github.event.label.name, 'p:') == true && contains(github.event.issue.labels.*.name, 'pending triage') == true
         uses: actions-cool/issues-helper@v3
         with:
           actions: "remove-labels"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
There is a action which removes `pending triage` when some label is added.
But this was only working in some cases.

~~**labels `p-*` needs to be renamed to `p:*`** to make this PR work.~~

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
