### PR TITLE
fix: avoid type mismatch with Rollup (fix #7843)

### DIFF
--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -37,7 +37,8 @@ import type { ConfigEnv, ResolvedConfig } from './'
  * If a plugin should be applied only for server or build, a function format
  * config file can be used to conditional determine the plugins to use.
  */
-export interface Plugin extends RollupPlugin {
+export interface Plugin
+  extends Omit<RollupPlugin, 'resolveId' | 'load' | 'transform'> {
   /**
    * Enforce plugin invocation tier similar to webpack loaders.
    *

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -37,8 +37,7 @@ import type { ConfigEnv, ResolvedConfig } from './'
  * If a plugin should be applied only for server or build, a function format
  * config file can be used to conditional determine the plugins to use.
  */
-export interface Plugin
-  extends Omit<RollupPlugin, 'resolveId' | 'load' | 'transform'> {
+export interface Plugin extends RollupPlugin {
   /**
    * Enforce plugin invocation tier similar to webpack loaders.
    *
@@ -129,7 +128,7 @@ export interface Plugin
   /**
    * extend hooks with ssr flag
    */
-  resolveId?(
+  resolveId?: (
     this: PluginContext,
     source: string,
     importer: string | undefined,
@@ -140,17 +139,18 @@ export interface Plugin
        * @internal
        */
       scan?: boolean
+      isEntry: boolean
     }
-  ): Promise<ResolveIdResult> | ResolveIdResult
-  load?(
+  ) => Promise<ResolveIdResult> | ResolveIdResult
+  load?: (
     this: PluginContext,
     id: string,
     options?: { ssr?: boolean }
-  ): Promise<LoadResult> | LoadResult
-  transform?(
+  ) => Promise<LoadResult> | LoadResult
+  transform?: (
     this: TransformPluginContext,
     code: string,
     id: string,
     options?: { ssr?: boolean }
-  ): Promise<TransformResult> | TransformResult
+  ) => Promise<TransformResult> | TransformResult
 }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -97,6 +97,7 @@ export interface PluginContainer {
        * @internal
        */
       scan?: boolean
+      isEntry?: boolean
     }
   ): Promise<PartialResolvedId | null>
   transform(
@@ -527,6 +528,7 @@ export async function createPluginContainer(
       const skip = options?.skip
       const ssr = options?.ssr
       const scan = !!options?.scan
+      const isEntry = !!options?.isEntry
       const ctx = new Context()
       ctx.ssr = !!ssr
       ctx._scan = scan
@@ -546,7 +548,7 @@ export async function createPluginContainer(
           ctx as any,
           rawId,
           importer,
-          { ssr, scan }
+          { ssr, scan, isEntry }
         )
         if (!result) continue
 

--- a/packages/vite/tsconfig.check.json
+++ b/packages/vite/tsconfig.check.json
@@ -14,7 +14,9 @@
       // indirect: postcss depends on it
       "source-map-js": ["./node_modules/source-map-js/source-map.d.ts"]
     },
-    "typeRoots": []
+    "typeRoots": [],
+    "strict": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["dist/**/*.d.ts"]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

TS2430 appears when using `skipLibCheck: false`

I have some React projects. Sometimes I would like to configure `skipLibCheck: false`, however it makes errors only here.

fixes #7843

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Initially tried to merge original types more, but I've given up 🙇‍♂️ 

I don't have confident for below points.

* Wihch option should be preferred between `strictNullChecks: true` and `strict: true` in the `tsconfig.check.json`?
* Wihch prefix should be preferred between `fix:` and `types:` in the commit message?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
