### PR TITLE
refactor(plugin-vue): reuse sfc code from load() result in transform()

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -20,7 +20,7 @@ export async function handleHotUpdate(
   { file, modules, read, server }: HmrContext,
   options: ResolvedOptions
 ): Promise<ModuleNode[] | void> {
-  const prevDescriptor = getDescriptor(file, options, undefined)
+  const prevDescriptor = getDescriptor(file, options, false)
   if (!prevDescriptor) {
     // file hasn't been requested yet (e.g. async component)
     return

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -20,7 +20,7 @@ export async function handleHotUpdate(
   { file, modules, read, server }: HmrContext,
   options: ResolvedOptions
 ): Promise<ModuleNode[] | void> {
-  const prevDescriptor = getDescriptor(file, options, false)
+  const prevDescriptor = getDescriptor(file, options, undefined)
   if (!prevDescriptor) {
     // file hasn't been requested yet (e.g. async component)
     return

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -198,7 +198,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
       const { filename, query } = parseVueRequest(id)
       if (filter(filename) && Object.keys(query).length === 0) {
         // pre-cache sfc file from load() result from other plugins without fs.readFileSync
-        getDescriptor(filename, options, () => code)
+        getDescriptor(filename, options, true, () => code)
       }
       if (query.raw) {
         return

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -172,9 +172,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
         if (query.src) {
           return fs.readFileSync(filename, 'utf-8')
         }
-        const descriptor = getDescriptor(filename, options, () =>
-          fs.readFileSync(filename, 'utf-8')
-        )!
+        const descriptor = getDescriptor(filename, options)!
         let block: SFCBlock | null | undefined
         if (query.type === 'script') {
           // handle <scrip> + <script setup> merge via compileScript()
@@ -233,9 +231,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
         // sub block request
         const descriptor = query.src
           ? getSrcDescriptor(filename, query)!
-          : getDescriptor(filename, options, () =>
-              fs.readFileSync(filename, 'utf-8')
-            )!
+          : getDescriptor(filename, options)!
 
         if (query.type === 'template') {
           return transformTemplateAsModule(code, descriptor, options, this, ssr)

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -47,13 +47,13 @@ export function setPrevDescriptor(
 export function getDescriptor(
   filename: string,
   options: ResolvedOptions,
-  readFile: (() => string) | undefined = () =>
-    fs.readFileSync(filename, 'utf-8')
+  createIfNotFound = true,
+  readFile = () => fs.readFileSync(filename, 'utf-8')
 ): SFCDescriptor | undefined {
   if (cache.has(filename)) {
     return cache.get(filename)!
   }
-  if (readFile) {
+  if (createIfNotFound) {
     const { descriptor, errors } = createDescriptor(
       filename,
       readFile(),

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -47,7 +47,8 @@ export function setPrevDescriptor(
 export function getDescriptor(
   filename: string,
   options: ResolvedOptions,
-  readFile: (() => string) | undefined
+  readFile: (() => string) | undefined = () =>
+    fs.readFileSync(filename, 'utf-8')
 ): SFCDescriptor | undefined {
   if (cache.has(filename)) {
     return cache.get(filename)!

--- a/packages/plugin-vue/src/utils/descriptorCache.ts
+++ b/packages/plugin-vue/src/utils/descriptorCache.ts
@@ -47,15 +47,15 @@ export function setPrevDescriptor(
 export function getDescriptor(
   filename: string,
   options: ResolvedOptions,
-  createIfNotFound = true
+  readFile: (() => string) | undefined
 ): SFCDescriptor | undefined {
   if (cache.has(filename)) {
     return cache.get(filename)!
   }
-  if (createIfNotFound) {
+  if (readFile) {
     const { descriptor, errors } = createDescriptor(
       filename,
-      fs.readFileSync(filename, 'utf-8'),
+      readFile(),
       options
     )
     if (errors.length) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If other vite plugin try provide vue code from virtual file name, @vitejs/plugin-vue throw because it try to load the virtual vue file path with `fs.readFileSync` and caching.

This PR try reuse vue code load result from other plugins.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
