### PR TITLE
fix(optimizer): browser field bare import

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -149,35 +149,35 @@ export function esbuildDepPlugin(
         }
       }
 
-      build.onResolve(
-        { filter: /^[\w@][^:]/ },
-        async ({ path: id, importer, kind }) => {
-          if (moduleListContains(config.optimizeDeps?.exclude, id)) {
-            return {
-              path: id,
-              external: true
-            }
-          }
-
-          // ensure esbuild uses our resolved entries
-          let entry: { path: string; namespace: string } | undefined
-          // if this is an entry, return entry namespace resolve result
-          if (!importer) {
-            if ((entry = resolveEntry(id))) return entry
-            // check if this is aliased to an entry - also return entry namespace
-            const aliased = await _resolve(id, undefined, true)
-            if (aliased && (entry = resolveEntry(aliased))) {
-              return entry
-            }
-          }
-
-          // use vite's own resolver
-          const resolved = await resolve(id, importer, kind)
-          if (resolved) {
-            return resolveResult(id, resolved)
+      build.onResolve({ filter: /./ }, async ({ path: id, importer, kind }) => {
+        if (
+          /^[\w@][^:]/.test(id) &&
+          moduleListContains(config.optimizeDeps?.exclude, id)
+        ) {
+          return {
+            path: id,
+            external: true
           }
         }
-      )
+
+        // ensure esbuild uses our resolved entries
+        let entry: { path: string; namespace: string } | undefined
+        // if this is an entry, return entry namespace resolve result
+        if (!importer) {
+          if ((entry = resolveEntry(id))) return entry
+          // check if this is aliased to an entry - also return entry namespace
+          const aliased = await _resolve(id, undefined, true)
+          if (aliased && (entry = resolveEntry(aliased))) {
+            return entry
+          }
+        }
+
+        // use vite's own resolver
+        const resolved = await resolve(id, importer, kind)
+        if (resolved) {
+          return resolveResult(id, resolved)
+        }
+      })
 
       // For entry files, we'll read it ourselves and construct a proxy module
       // to retain the entry's raw id instead of file path so that esbuild

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -71,13 +71,13 @@ export function esbuildDepPlugin(
     // explicit resolveDir - this is passed only during yarn pnp resolve for
     // entries
     if (resolveDir) {
-      _importer = normalizePath(path.join(resolveDir, '*'))
+      _importer = path.join(resolveDir, '*')
     } else {
       // map importer ids to file paths for correct resolution
       _importer = importer in qualified ? qualified[importer] : importer
     }
     const resolver = kind.startsWith('require') ? _resolveRequire : _resolve
-    return resolver(id, _importer, undefined)
+    return resolver(id, normalizePath(_importer), undefined)
   }
 
   const resolveResult = (id: string, resolved: string) => {

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -77,6 +77,10 @@ test('import from dep with .notjs files', async () => {
   expect(await page.textContent('.not-js')).toMatch(`[success]`)
 })
 
+test('Import from dependency which uses relative path which needs to be resolved by main field', async () => {
+  expect(await page.textContent('.relative-to-main')).toMatch(`[success]`)
+})
+
 test('dep with dynamic import', async () => {
   expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
     `[success]`

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -57,6 +57,10 @@ test('cjs browser field (axios)', async () => {
   expect(await page.textContent('.cjs-browser-field')).toBe('pong')
 })
 
+test('cjs browser field bare', async () => {
+  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
+})
+
 test('dep from linked dep (lodash-es)', async () => {
   expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
 })

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: 'foo'
+}

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const internal = require('./internal')
+
+module.exports = internal

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const events = require('events')
+
+module.exports = 'foo' in events ? 'pong' : ''

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dep-cjs-browser-field-bare",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "browser": {
+    "events": "./events-shim.js"
+  }
+}

--- a/playground/optimize-deps/dep-relative-to-main/entry.js
+++ b/playground/optimize-deps/dep-relative-to-main/entry.js
@@ -1,0 +1,1 @@
+module.exports = require('./')

--- a/playground/optimize-deps/dep-relative-to-main/lib/main.js
+++ b/playground/optimize-deps/dep-relative-to-main/lib/main.js
@@ -1,0 +1,1 @@
+module.exports = '[success] imported from main'

--- a/playground/optimize-deps/dep-relative-to-main/package.json
+++ b/playground/optimize-deps/dep-relative-to-main/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep-relative-to-main",
+  "private": true,
+  "version": "1.0.0",
+  "main": "lib/main.js"
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -50,6 +50,12 @@
 <h2>Import from dependency with .notjs files</h2>
 <div class="not-js"></div>
 
+<h2>
+  Import from dependency which uses relative path which needs to be resolved by
+  main field
+</h2>
+<div class="relative-to-main"></div>
+
 <h2>Import from dependency with dynamic import</h2>
 <div class="dep-with-dynamic-import"></div>
 
@@ -108,6 +114,9 @@
 
   import { notjsValue } from 'dep-not-js'
   text('.not-js', notjsValue)
+
+  import foo from 'dep-relative-to-main/entry'
+  text('.relative-to-main', foo)
 
   import { lazyFoo } from 'dep-with-dynamic-import'
   lazyFoo().then((foo) => {

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -29,6 +29,9 @@
 <h2>CommonJS w/ browser field mapping (axios)</h2>
 <div>This should show pong: <span class="cjs-browser-field"></span></div>
 
+<h2>CommonJS w/ bare id browser field mapping</h2>
+<div>This should show pong: <span class="cjs-browser-field-bare"></span></div>
+
 <h2>Detecting linked src package and optimizing its deps (lodash-es)</h2>
 <div>This should show fooBarBaz: <span class="deps-linked"></span></div>
 
@@ -93,6 +96,9 @@
 <script type="module">
   // test dep detection in globbed files
   const globbed = import.meta.glob('./glob/*.js', { eager: true })
+
+  import cjsBrowerFieldBare from 'dep-cjs-browser-field-bare'
+  text('.cjs-browser-field-bare', cjsBrowerFieldBare)
 
   import { camelCase } from 'dep-linked'
   text('.deps-linked', camelCase('foo-bar-baz'))

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "clipboard": "^2.0.11",
+    "dep-cjs-browser-field-bare": "file:./dep-cjs-browser-field-bare",
     "dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
     "dep-cjs-with-assets": "file:./dep-cjs-with-assets",

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -19,6 +19,7 @@
     "dep-linked-include": "link:./dep-linked-include",
     "dep-node-env": "file:./dep-node-env",
     "dep-not-js": "file:./dep-not-js",
+    "dep-relative-to-main": "file:./dep-relative-to-main",
     "dep-with-builtin-module-cjs": "file:./dep-with-builtin-module-cjs",
     "dep-with-builtin-module-esm": "file:./dep-with-builtin-module-esm",
     "dep-with-dynamic-import": "file:./dep-with-dynamic-import",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,7 @@ importers:
       dep-linked-include: link:./dep-linked-include
       dep-node-env: file:./dep-node-env
       dep-not-js: file:./dep-not-js
+      dep-relative-to-main: file:./dep-relative-to-main
       dep-with-builtin-module-cjs: file:./dep-with-builtin-module-cjs
       dep-with-builtin-module-esm: file:./dep-with-builtin-module-esm
       dep-with-dynamic-import: file:./dep-with-dynamic-import
@@ -608,6 +609,7 @@ importers:
       dep-linked-include: link:dep-linked-include
       dep-node-env: file:playground/optimize-deps/dep-node-env
       dep-not-js: file:playground/optimize-deps/dep-not-js
+      dep-relative-to-main: file:playground/optimize-deps/dep-relative-to-main
       dep-with-builtin-module-cjs: file:playground/optimize-deps/dep-with-builtin-module-cjs
       dep-with-builtin-module-esm: file:playground/optimize-deps/dep-with-builtin-module-esm
       dep-with-dynamic-import: file:playground/optimize-deps/dep-with-dynamic-import
@@ -656,6 +658,9 @@ importers:
     specifiers: {}
 
   playground/optimize-deps/dep-not-js:
+    specifiers: {}
+
+  playground/optimize-deps/dep-relative-to-main:
     specifiers: {}
 
   playground/optimize-deps/dep-with-builtin-module-cjs:
@@ -8739,6 +8744,12 @@ packages:
   file:playground/optimize-deps/dep-not-js:
     resolution: {directory: playground/optimize-deps/dep-not-js, type: directory}
     name: dep-not-js
+    version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-relative-to-main:
+    resolution: {directory: playground/optimize-deps/dep-relative-to-main, type: directory}
+    name: dep-relative-to-main
     version: 1.0.0
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,7 @@ importers:
       added-in-entries: file:./added-in-entries
       axios: ^0.27.2
       clipboard: ^2.0.11
+      dep-cjs-browser-field-bare: file:./dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:./dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:./dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:./dep-cjs-with-assets
@@ -601,6 +602,7 @@ importers:
       added-in-entries: file:playground/optimize-deps/added-in-entries
       axios: 0.27.2
       clipboard: 2.0.11
+      dep-cjs-browser-field-bare: file:playground/optimize-deps/dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:playground/optimize-deps/dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:playground/optimize-deps/dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:playground/optimize-deps/dep-cjs-with-assets
@@ -628,6 +630,9 @@ importers:
       '@vitejs/plugin-vue': link:../../packages/plugin-vue
 
   playground/optimize-deps/added-in-entries:
+    specifiers: {}
+
+  playground/optimize-deps/dep-cjs-browser-field-bare:
     specifiers: {}
 
   playground/optimize-deps/dep-cjs-compiled-from-cjs:
@@ -8709,6 +8714,12 @@ packages:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
     name: added-in-entries
     version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-cjs-browser-field-bare:
+    resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
+    name: dep-cjs-browser-field-bare
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
based on #8706

See #7599 for why these did not work.

close #7599 (this PR includes it)
fixes #4798: another error happens but updating `socket.io-client` to 4.3.0+ will fix.
```
[plugin vite:dep-pre-bundle] Missing "./wrapper.mjs" export in "socket.io-client" package
    dep:socket__io-client:1:14:
      1 │ import d from "./node_modules/socket.io-client/wrapper.mjs";export default d;
```
fixes #7301
fixes #7576

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
