### PR TITLE
fix: use esbuild platform browser/node instead of neutral

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -149,35 +149,35 @@ export function esbuildDepPlugin(
         }
       }
 
-      build.onResolve(
-        { filter: /^[\w@][^:]/ },
-        async ({ path: id, importer, kind }) => {
-          if (moduleListContains(config.optimizeDeps?.exclude, id)) {
-            return {
-              path: id,
-              external: true
-            }
-          }
-
-          // ensure esbuild uses our resolved entries
-          let entry: { path: string; namespace: string } | undefined
-          // if this is an entry, return entry namespace resolve result
-          if (!importer) {
-            if ((entry = resolveEntry(id))) return entry
-            // check if this is aliased to an entry - also return entry namespace
-            const aliased = await _resolve(id, undefined, true)
-            if (aliased && (entry = resolveEntry(aliased))) {
-              return entry
-            }
-          }
-
-          // use vite's own resolver
-          const resolved = await resolve(id, importer, kind)
-          if (resolved) {
-            return resolveResult(id, resolved)
+      build.onResolve({ filter: /./ }, async ({ path: id, importer, kind }) => {
+        if (
+          /^[\w@][^:]/.test(id) &&
+          moduleListContains(config.optimizeDeps?.exclude, id)
+        ) {
+          return {
+            path: id,
+            external: true
           }
         }
-      )
+
+        // ensure esbuild uses our resolved entries
+        let entry: { path: string; namespace: string } | undefined
+        // if this is an entry, return entry namespace resolve result
+        if (!importer) {
+          if ((entry = resolveEntry(id))) return entry
+          // check if this is aliased to an entry - also return entry namespace
+          const aliased = await _resolve(id, undefined, true)
+          if (aliased && (entry = resolveEntry(aliased))) {
+            return entry
+          }
+        }
+
+        // use vite's own resolver
+        const resolved = await resolve(id, importer, kind)
+        if (resolved) {
+          return resolveResult(id, resolved)
+        }
+      })
 
       // For entry files, we'll read it ourselves and construct a proxy module
       // to retain the entry's raw id instead of file path so that esbuild

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -149,35 +149,35 @@ export function esbuildDepPlugin(
         }
       }
 
-      build.onResolve({ filter: /./ }, async ({ path: id, importer, kind }) => {
-        if (
-          /^[\w@][^:]/.test(id) &&
-          moduleListContains(config.optimizeDeps?.exclude, id)
-        ) {
-          return {
-            path: id,
-            external: true
+      build.onResolve(
+        { filter: /^[\w@][^:]/ },
+        async ({ path: id, importer, kind }) => {
+          if (moduleListContains(config.optimizeDeps?.exclude, id)) {
+            return {
+              path: id,
+              external: true
+            }
+          }
+
+          // ensure esbuild uses our resolved entries
+          let entry: { path: string; namespace: string } | undefined
+          // if this is an entry, return entry namespace resolve result
+          if (!importer) {
+            if ((entry = resolveEntry(id))) return entry
+            // check if this is aliased to an entry - also return entry namespace
+            const aliased = await _resolve(id, undefined, true)
+            if (aliased && (entry = resolveEntry(aliased))) {
+              return entry
+            }
+          }
+
+          // use vite's own resolver
+          const resolved = await resolve(id, importer, kind)
+          if (resolved) {
+            return resolveResult(id, resolved)
           }
         }
-
-        // ensure esbuild uses our resolved entries
-        let entry: { path: string; namespace: string } | undefined
-        // if this is an entry, return entry namespace resolve result
-        if (!importer) {
-          if ((entry = resolveEntry(id))) return entry
-          // check if this is aliased to an entry - also return entry namespace
-          const aliased = await _resolve(id, undefined, true)
-          if (aliased && (entry = resolveEntry(aliased))) {
-            return entry
-          }
-        }
-
-        // use vite's own resolver
-        const resolved = await resolve(id, importer, kind)
-        if (resolved) {
-          return resolveResult(id, resolved)
-        }
-      })
+      )
 
       // For entry files, we'll read it ourselves and construct a proxy module
       // to retain the entry's raw id instead of file path so that esbuild

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -533,6 +533,10 @@ export async function runOptimizeDeps(
     flatIdToExports[flatId] = exportsData
   }
 
+  // esbuild automatically replaces process.env.NODE_ENV for platform 'browser'
+  // In lib mode, we need to keep process.env.NODE_ENV untouched, so to at build
+  // time we replace it by __vite_process_env_NODE_ENV. This placeholder will be 
+  // later replaced by the define plugin
   const define = {
     'process.env.NODE_ENV': isBuild
       ? '__vite_process_env_NODE_ENV'

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -546,7 +546,7 @@ export async function runOptimizeDeps(
     entryPoints: Object.keys(flatIdDeps),
     bundle: true,
     // We can't use platform 'neutral', as esbuild has custom handling
-    // when the platform is 'node' or 'browser' that can be emulated
+    // when the platform is 'node' or 'browser' that can't be emulated
     // by using mainFields and conditions
     platform:
       config.build.ssr && config.ssr?.target !== 'webworker'

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -533,15 +533,26 @@ export async function runOptimizeDeps(
     flatIdToExports[flatId] = exportsData
   }
 
+  const define = {
+    'process.env.NODE_ENV': isBuild
+      ? '__vite_process_env_NODE_ENV'
+      : JSON.stringify(process.env.NODE_ENV || config.mode)
+  }
+
   const start = performance.now()
 
   const result = await build({
     absWorkingDir: process.cwd(),
     entryPoints: Object.keys(flatIdDeps),
     bundle: true,
-    // Ensure resolution is handled by esbuildDepPlugin and
-    // avoid replacing `process.env.NODE_ENV` for 'browser'
-    platform: 'neutral',
+    // We can't use platform 'neutral', as esbuild has custom handling
+    // when the platform is 'node' or 'browser' that can be emulated
+    // by using mainFields and conditions
+    platform:
+      config.build.ssr && config.ssr?.target !== 'webworker'
+        ? 'node'
+        : 'browser',
+    define,
     format: 'esm',
     target: config.build.target || undefined,
     external: config.optimizeDeps?.exclude,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -535,7 +535,7 @@ export async function runOptimizeDeps(
 
   // esbuild automatically replaces process.env.NODE_ENV for platform 'browser'
   // In lib mode, we need to keep process.env.NODE_ENV untouched, so to at build
-  // time we replace it by __vite_process_env_NODE_ENV. This placeholder will be 
+  // time we replace it by __vite_process_env_NODE_ENV. This placeholder will be
   // later replaced by the define plugin
   const define = {
     'process.env.NODE_ENV': isBuild

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -25,7 +25,8 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     Object.assign(processNodeEnv, {
       'process.env.NODE_ENV': JSON.stringify(nodeEnv),
       'global.process.env.NODE_ENV': JSON.stringify(nodeEnv),
-      'globalThis.process.env.NODE_ENV': JSON.stringify(nodeEnv)
+      'globalThis.process.env.NODE_ENV': JSON.stringify(nodeEnv),
+      __vite_process_env_NODE_ENV: JSON.stringify(nodeEnv)
     })
   }
 
@@ -63,6 +64,10 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       ...userDefine,
       ...importMetaKeys,
       ...(replaceProcessEnv ? processEnv : {})
+    }
+
+    if (isBuild && !replaceProcessEnv) {
+      replacements['__vite_process_env_NODE_ENV'] = 'process.env.NODE_ENV'
     }
 
     const replacementsKeys = Object.keys(replacements)

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -77,6 +77,10 @@ test('import from dep with .notjs files', async () => {
   expect(await page.textContent('.not-js')).toMatch(`[success]`)
 })
 
+test('Import from dependency which uses relative path which needs to be resolved by main field', async () => {
+  expect(await page.textContent('.relative-to-main')).toMatch(`[success]`)
+})
+
 test('dep with dynamic import', async () => {
   expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
     `[success]`

--- a/playground/optimize-deps/dep-relative-to-main/entry.js
+++ b/playground/optimize-deps/dep-relative-to-main/entry.js
@@ -1,0 +1,1 @@
+module.exports = require('./')

--- a/playground/optimize-deps/dep-relative-to-main/lib/main.js
+++ b/playground/optimize-deps/dep-relative-to-main/lib/main.js
@@ -1,0 +1,1 @@
+module.exports = '[success] imported from main'

--- a/playground/optimize-deps/dep-relative-to-main/package.json
+++ b/playground/optimize-deps/dep-relative-to-main/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep-relative-to-main",
+  "private": true,
+  "version": "1.0.0",
+  "main": "lib/main.js"
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -50,6 +50,12 @@
 <h2>Import from dependency with .notjs files</h2>
 <div class="not-js"></div>
 
+<h2>
+  Import from dependency which uses relative path which needs to be resolved by
+  main field
+</h2>
+<div class="relative-to-main"></div>
+
 <h2>Import from dependency with dynamic import</h2>
 <div class="dep-with-dynamic-import"></div>
 
@@ -108,6 +114,9 @@
 
   import { notjsValue } from 'dep-not-js'
   text('.not-js', notjsValue)
+
+  import foo from 'dep-relative-to-main/entry'
+  text('.relative-to-main', foo)
 
   import { lazyFoo } from 'dep-with-dynamic-import'
   lazyFoo().then((foo) => {

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -19,6 +19,7 @@
     "dep-linked-include": "link:./dep-linked-include",
     "dep-node-env": "file:./dep-node-env",
     "dep-not-js": "file:./dep-not-js",
+    "dep-relative-to-main": "file:./dep-relative-to-main",
     "dep-with-builtin-module-cjs": "file:./dep-with-builtin-module-cjs",
     "dep-with-builtin-module-esm": "file:./dep-with-builtin-module-esm",
     "dep-with-dynamic-import": "file:./dep-with-dynamic-import",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,7 @@ importers:
       dep-linked-include: link:./dep-linked-include
       dep-node-env: file:./dep-node-env
       dep-not-js: file:./dep-not-js
+      dep-relative-to-main: file:./dep-relative-to-main
       dep-with-builtin-module-cjs: file:./dep-with-builtin-module-cjs
       dep-with-builtin-module-esm: file:./dep-with-builtin-module-esm
       dep-with-dynamic-import: file:./dep-with-dynamic-import
@@ -608,6 +609,7 @@ importers:
       dep-linked-include: link:dep-linked-include
       dep-node-env: file:playground/optimize-deps/dep-node-env
       dep-not-js: file:playground/optimize-deps/dep-not-js
+      dep-relative-to-main: file:playground/optimize-deps/dep-relative-to-main
       dep-with-builtin-module-cjs: file:playground/optimize-deps/dep-with-builtin-module-cjs
       dep-with-builtin-module-esm: file:playground/optimize-deps/dep-with-builtin-module-esm
       dep-with-dynamic-import: file:playground/optimize-deps/dep-with-dynamic-import
@@ -656,6 +658,9 @@ importers:
     specifiers: {}
 
   playground/optimize-deps/dep-not-js:
+    specifiers: {}
+
+  playground/optimize-deps/dep-relative-to-main:
     specifiers: {}
 
   playground/optimize-deps/dep-with-builtin-module-cjs:
@@ -8739,6 +8744,12 @@ packages:
   file:playground/optimize-deps/dep-not-js:
     resolution: {directory: playground/optimize-deps/dep-not-js, type: directory}
     name: dep-not-js
+    version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-relative-to-main:
+    resolution: {directory: playground/optimize-deps/dep-relative-to-main, type: directory}
+    name: dep-relative-to-main
     version: 1.0.0
     dev: false
 


### PR DESCRIPTION
### Description

fixes https://github.com/vitejs/vite/issues/8704
fixes https://github.com/vitejs/vite/discussions/8702
fixes https://github.com/vitejs/vite/issues/8712

Alternative to:
- https://github.com/vitejs/vite/pull/8706

We discussed with @bluwy and @sapphi-red that it is better to use esbuild resolution if possible.

Also, looks like we will need to use 'browser'/'node' instead of 'neutral', I'm seeing code that won't run even with the `mainFields` defined IIUC in esbuild: https://github.com/evanw/esbuild/blob/79975460813c6765de1df858efd671ea5e7e6897/internal/resolver/package_json.go#L349. Later we could ask a feature to disable the automatic replacement of `process.env.NODE_ENV`, but seems that it is safer to use the right platform

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other