### PR TITLE
feat: enable tree-shaking for lib es

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -237,12 +237,7 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
       }
 
       const target = config.build.target
-      const minify =
-        config.build.minify === 'esbuild' &&
-        // Do not minify ES lib output since that would remove pure annotations
-        // and break tree-shaking
-        // https://github.com/vuejs/core/issues/2860#issuecomment-926882793
-        !(config.build.lib && opts.format === 'es')
+      const minify = config.build.minify === 'esbuild'
 
       if ((!target || target === 'esnext') && !minify) {
         return null
@@ -253,7 +248,10 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
         target: target || undefined,
         ...(minify
           ? {
-              minify,
+              // Do not minify ES lib output since that would remove pure annotations
+              // and break tree-shaking
+              // https://github.com/vuejs/core/issues/2860#issuecomment-926882793
+              minify: !(config.build.lib && opts.format === 'es'),
               treeShaking: true,
               format: rollupToEsbuildFormatMap[opts.format]
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR enables `treeShaking` for lib es output. This will reduce output size.
`minify` removes pure annotations but `treeShaking` does not remove them.

[before (esbuild repl)](https://hyrious.me/esbuild-repl/?version=0.14.47&mode=transform&input=const+css0+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%27.some-css-code%7Bcolor%3Ared%7D%27%29%28%29%0Aconst+css1+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%27.some-css-code%7Bcolor%3Ablue%7D%27%29%28%29%0A%0Aexport+%7B+css1+%7D&options=--target%3Dchrome100)
[`--minify` + `--tree-shaking` (esbuild repl)](https://hyrious.me/esbuild-repl/?version=0.14.47&mode=transform&input=const+css0+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%27.some-css-code%7Bcolor%3Ared%7D%27%29%28%29%0Aconst+css1+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%27.some-css-code%7Bcolor%3Ablue%7D%27%29%28%29%0A%0Aexport+%7B+css1+%7D&options=--minify+--tree-shaking+--format%3Desm+--target%3Dchrome100)
[this PR: `--tree-shaking` (esbuild repl)](https://hyrious.me/esbuild-repl/?version=0.14.47&mode=transform&input=const+css0+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%27.some-css-code%7Bcolor%3Ared%7D%27%29%28%29%0Aconst+css1+%3D+%2F*+%40__PURE__+*%2F+%28%28%29+%3D%3E+%27.some-css-code%7Bcolor%3Ablue%7D%27%29%28%29%0A%0Aexport+%7B+css1+%7D&options=--tree-shaking+--format%3Desm+--target%3Dchrome100)

close #8728

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
