### PR TITLE
feat!: worker bundle in dev mode

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -13,6 +13,7 @@ import {
   createDebugger,
   emptyDir,
   flattenId,
+  getDepsCacheSuffix,
   getHash,
   lookupFile,
   normalizeId,
@@ -674,21 +675,6 @@ export function getOptimizedDepPath(
   return normalizePath(
     path.resolve(getDepsCacheDir(config, ssr), flattenId(id) + '.js')
   )
-}
-
-function getDepsCacheSuffix(config: ResolvedConfig, ssr: boolean): string {
-  let suffix = ''
-  if (config.command === 'build') {
-    // Differentiate build caches depending on outDir to allow parallel builds
-    const { outDir } = config.build
-    const buildId =
-      outDir.length > 8 || outDir.includes('/') ? getHash(outDir) : outDir
-    suffix += `_build-${buildId}`
-  }
-  if (ssr) {
-    suffix += '_ssr'
-  }
-  return suffix
 }
 
 export function getDepsCacheDir(config: ResolvedConfig, ssr: boolean): string {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1056,3 +1056,21 @@ export function stripBomTag(content: string): string {
 
   return content
 }
+
+export function getDepsCacheSuffix(
+  config: ResolvedConfig,
+  ssr: boolean
+): string {
+  let suffix = ''
+  if (config.command === 'build') {
+    // Differentiate build caches depending on outDir to allow parallel builds
+    const { outDir } = config.build
+    const buildId =
+      outDir.length > 8 || outDir.includes('/') ? getHash(outDir) : outDir
+    suffix += `_build-${buildId}`
+  }
+  if (ssr) {
+    suffix += '_ssr'
+  }
+  return suffix
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

use rollup cache improves rollup bundle time. and make worker bundle in dev mode.


I found that rollup can accept cache parameters, that is, if we cache the cache results of rollup, rollup can reduce the compile of a lot of entries, similar to the watch mode of lib mode.

If we cache the packaged caches of all workers, it may be relatively slow to warm up the cache when starting vite for the first time. Later in the dev mode we use the rollup cache for bundles, I guess the speed should still be acceptable.

This way our build and development process will be exactly the same. 

some issues like 
* iife worker does not support static import syntax
* user plugin affect worker plugin in dev

can be resolved

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
