### PR TITLE
feat: respect esbuild minify config

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -145,7 +145,7 @@ Produce SSR-oriented build. The value can be a string to directly specify the SS
 
 Set to `false` to disable minification, or specify the minifier to use. The default is [esbuild](https://github.com/evanw/esbuild) which is 20 ~ 40x faster than terser and only 1 ~ 2% worse compression. [Benchmarks](https://github.com/privatenumber/minification-benchmarks)
 
-Note the `build.minify` option is not available when using the `'es'` format in lib mode.
+Note the `build.minify` option does not minify whitespaces when using the `'es'` format in lib mode, as it removes pure annotations and break tree-shaking.
 
 Terser must be installed when it is set to `'terser'`.
 

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -280,7 +280,7 @@ export default defineConfig({
 })
 ```
 
-When `build.minify` is `true`, you can configure to only minify certain aspects of the code by setting either of `esbuild.minifyIdentifiers`, `esbuild.minifySyntax`, and `esbuild.minifyWhitespace` to `true`. Note the `esbuild.minify` option can't be used to override `build.minify`.
+When [`build.minify`](./build-options.md#build-minify) is `true`, you can configure to only minify [certain aspects](https://esbuild.github.io/api/#minify) of the code by setting either of `esbuild.minifyIdentifiers`, `esbuild.minifySyntax`, and `esbuild.minifyWhitespace` to `true`. Note the `esbuild.minify` option can't be used to override `build.minify`.
 
 Set to `false` to disable esbuild transforms.
 

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -280,6 +280,8 @@ export default defineConfig({
 })
 ```
 
+When `build.minify` is `true`, you can configure to only minify certain aspects of the code by setting either of `esbuild.minifyIdentifiers`, `esbuild.minifySyntax`, and `esbuild.minifyWhitespace` to `true`. Note the `esbuild.minify` option can't be used to override `build.minify`.
+
 Set to `false` to disable esbuild transforms.
 
 ## assetsInclude

--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -89,7 +89,6 @@ describe('resolveEsbuildTranspileOptions', () => {
       minifyIdentifiers: true,
       minifySyntax: true,
       minifyWhitespace: false,
-
       treeShaking: true
     })
   })

--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'vitest'
+import type { ResolvedConfig, UserConfig } from '../../config'
+import { resolveEsbuildTranspileOptions } from '../../plugins/esbuild'
+
+describe('resolveEsbuildTranspileOptions', () => {
+  test('resolve default', () => {
+    const options = resolveEsbuildTranspileOptions(
+      defineResolvedConfig({
+        build: {
+          target: 'es2020',
+          minify: 'esbuild'
+        },
+        esbuild: {
+          keepNames: true
+        }
+      }),
+      'es'
+    )
+    expect(options).toEqual({
+      target: 'es2020',
+      format: 'esm',
+      keepNames: true,
+      minify: true,
+      treeShaking: true
+    })
+  })
+
+  test('resolve esnext no minify', () => {
+    const options = resolveEsbuildTranspileOptions(
+      defineResolvedConfig({
+        build: {
+          target: 'esnext',
+          minify: false
+        },
+        esbuild: {
+          keepNames: true
+        }
+      }),
+      'es'
+    )
+    expect(options).toEqual(null)
+  })
+
+  test('resolve no minify', () => {
+    const options = resolveEsbuildTranspileOptions(
+      defineResolvedConfig({
+        build: {
+          target: 'es2020',
+          minify: false
+        },
+        esbuild: {
+          keepNames: true
+        }
+      }),
+      'es'
+    )
+    expect(options).toEqual({
+      target: 'es2020',
+      format: 'esm',
+      keepNames: true,
+      minify: false,
+      minifyIdentifiers: false,
+      minifySyntax: false,
+      minifyWhitespace: false,
+      treeShaking: false
+    })
+  })
+
+  test('resolve es lib', () => {
+    const options = resolveEsbuildTranspileOptions(
+      defineResolvedConfig({
+        build: {
+          minify: 'esbuild',
+          lib: {
+            entry: './somewhere.js'
+          }
+        },
+        esbuild: {
+          keepNames: true
+        }
+      }),
+      'es'
+    )
+    expect(options).toEqual({
+      target: undefined,
+      format: 'esm',
+      keepNames: true,
+      minify: false,
+      minifyIdentifiers: true,
+      minifySyntax: true,
+      minifyWhitespace: false,
+
+      treeShaking: true
+    })
+  })
+
+  test('resolve cjs lib', () => {
+    const options = resolveEsbuildTranspileOptions(
+      defineResolvedConfig({
+        build: {
+          minify: 'esbuild',
+          lib: {
+            entry: './somewhere.js'
+          }
+        },
+        esbuild: {
+          keepNames: true
+        }
+      }),
+      'cjs'
+    )
+    expect(options).toEqual({
+      target: undefined,
+      format: 'cjs',
+      keepNames: true,
+      minify: true,
+      treeShaking: true
+    })
+  })
+
+  test('resolve es lib with specific minify options', () => {
+    const options = resolveEsbuildTranspileOptions(
+      defineResolvedConfig({
+        build: {
+          minify: 'esbuild',
+          lib: {
+            entry: './somewhere.js'
+          }
+        },
+        esbuild: {
+          keepNames: true,
+          minifyIdentifiers: true,
+          minifyWhitespace: true
+        }
+      }),
+      'es'
+    )
+    expect(options).toEqual({
+      target: undefined,
+      format: 'esm',
+      keepNames: true,
+      minify: false,
+      minifyIdentifiers: true,
+      minifyWhitespace: false,
+      treeShaking: true
+    })
+  })
+
+  test('resolve cjs lib with specific minify options', () => {
+    const options = resolveEsbuildTranspileOptions(
+      defineResolvedConfig({
+        build: {
+          minify: 'esbuild',
+          lib: {
+            entry: './somewhere.js'
+          }
+        },
+        esbuild: {
+          keepNames: true,
+          minifyIdentifiers: true,
+          minifyWhitespace: true,
+          treeShaking: true
+        }
+      }),
+      'cjs'
+    )
+    expect(options).toEqual({
+      target: undefined,
+      format: 'cjs',
+      keepNames: true,
+      minify: false,
+      minifyIdentifiers: true,
+      minifyWhitespace: true,
+      treeShaking: true
+    })
+  })
+})
+
+/**
+ * Helper for `resolveEsbuildTranspileOptions` to created resolved config with types.
+ * Note: The function only uses `build.target`, `build.minify` and `esbuild` options.
+ */
+function defineResolvedConfig(config: UserConfig): ResolvedConfig {
+  return config as any
+}

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
@@ -57,6 +57,7 @@ export const parent = Object.assign({
 export const rootMixedRelative = Object.assign({
 \\"/css.spec.ts\\": () => import(\\"../../css.spec.ts?url\\").then(m => m[\\"default\\"]),
 \\"/define.spec.ts\\": () => import(\\"../../define.spec.ts?url\\").then(m => m[\\"default\\"]),
+\\"/esbuild.spec.ts\\": () => import(\\"../../esbuild.spec.ts?url\\").then(m => m[\\"default\\"]),
 \\"/import.spec.ts\\": () => import(\\"../../import.spec.ts?url\\").then(m => m[\\"default\\"]),
 \\"/importGlob/fixture-b/a.ts\\": () => import(\\"../fixture-b/a.ts?url\\").then(m => m[\\"default\\"]),
 \\"/importGlob/fixture-b/b.ts\\": () => import(\\"../fixture-b/b.ts?url\\").then(m => m[\\"default\\"]),
@@ -131,6 +132,7 @@ export const parent = Object.assign({
 export const rootMixedRelative = Object.assign({
 \\"/css.spec.ts\\": () => import(\\"../../css.spec.ts?url&lang.ts\\").then(m => m[\\"default\\"]),
 \\"/define.spec.ts\\": () => import(\\"../../define.spec.ts?url&lang.ts\\").then(m => m[\\"default\\"]),
+\\"/esbuild.spec.ts\\": () => import(\\"../../esbuild.spec.ts?url&lang.ts\\").then(m => m[\\"default\\"]),
 \\"/import.spec.ts\\": () => import(\\"../../import.spec.ts?url&lang.ts\\").then(m => m[\\"default\\"]),
 \\"/importGlob/fixture-b/a.ts\\": () => import(\\"../fixture-b/a.ts?url&lang.ts\\").then(m => m[\\"default\\"]),
 \\"/importGlob/fixture-b/b.ts\\": () => import(\\"../fixture-b/b.ts?url&lang.ts\\").then(m => m[\\"default\\"]),

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -255,7 +255,7 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
       }
 
       const isEsLibBuild = config.build.lib && opts.format === 'es'
-      const options: TransformOptions = {
+      let options: TransformOptions = {
         ...config.esbuild,
         target: target || undefined,
         format: rollupToEsbuildFormatMap[opts.format]
@@ -268,29 +268,38 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
           options.minifySyntax === true ||
           options.minifyWhitespace === true
         ) {
-          options.treeShaking = true
+          options = { ...options, treeShaking: true }
           // Do not minify whitespace for ES lib output since that would remove
           // pure annotations and break tree-shaking
           // https://github.com/vuejs/core/issues/2860#issuecomment-926882793
           if (isEsLibBuild) {
-            options.minifyWhitespace = false
+            options = { ...options, minifyWhitespace: true }
           }
         } else if (isEsLibBuild) {
           // Enable all minify except whitespace, which doesn't work
-          options.minify = false
-          options.minifyIdentifiers = true
-          options.minifySyntax = true
-          options.treeShaking = true
+          options = {
+            ...options,
+            minify: false,
+            minifyIdentifiers: true,
+            minifySyntax: true,
+            treeShaking: true
+          }
         } else {
-          options.minify = true
-          options.treeShaking = true
+          options = {
+            ...options,
+            minify: true,
+            treeShaking: true
+          }
         }
       } else {
-        options.minify = false
-        options.minifyIdentifiers = false
-        options.minifySyntax = false
-        options.minifyWhitespace = false
-        options.treeShaking = false
+        options = {
+          ...options,
+          minify: false,
+          minifyIdentifiers: false,
+          minifySyntax: false,
+          minifyWhitespace: false,
+          treeShaking: false
+        }
       }
 
       const res = await transformWithEsbuild(code, chunk.fileName, options)

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -277,7 +277,7 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
           // pure annotations and break tree-shaking
           // https://github.com/vuejs/core/issues/2860#issuecomment-926882793
           if (isEsLibBuild) {
-            options = { ...options, minifyWhitespace: true }
+            options = { ...options, minifyWhitespace: false }
           }
         } else if (isEsLibBuild) {
           // Enable all minify except whitespace, which doesn't work

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -37,6 +37,10 @@ export interface ESBuildOptions extends TransformOptions {
   include?: string | RegExp | string[] | RegExp[]
   exclude?: string | RegExp | string[] | RegExp[]
   jsxInject?: string
+  /**
+   * This option is not respected. Use `build.minify` instead.
+   */
+  minify?: never
 }
 
 export type ESBuildTransformResult = Omit<TransformResult, 'map'> & {
@@ -172,7 +176,7 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
 
   // Remove optimization options for dev as we only need to transpile them,
   // and for build as the final optimization is in `buildEsbuildPlugin`
-  options = {
+  const transformOptions: TransformOptions = {
     ...options,
     minify: false,
     minifyIdentifiers: false,
@@ -199,7 +203,7 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
     },
     async transform(code, id) {
       if (filter(id) || filter(cleanUrl(id))) {
-        const result = await transformWithEsbuild(code, id, options)
+        const result = await transformWithEsbuild(code, id, transformOptions)
         if (result.warnings.length) {
           result.warnings.forEach((m) => {
             this.warn(prettifyMessage(m, code))

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -280,14 +280,17 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
           options.minify = false
           options.minifyIdentifiers = true
           options.minifySyntax = true
+          options.treeShaking = true
         } else {
           options.minify = true
+          options.treeShaking = true
         }
       } else {
         options.minify = false
         options.minifyIdentifiers = false
         options.minifySyntax = false
         options.minifyWhitespace = false
+        options.treeShaking = false
       }
 
       const res = await transformWithEsbuild(code, chunk.fileName, options)

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -268,9 +268,9 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
       if (minify) {
         // If user enable fine-grain minify options, minify with their options instead
         if (
-          options.minifyIdentifiers === true ||
-          options.minifySyntax === true ||
-          options.minifyWhitespace === true
+          options.minifyIdentifiers ||
+          options.minifySyntax ||
+          options.minifyWhitespace
         ) {
           options = { ...options, treeShaking: true }
           // Do not minify whitespace for ES lib output since that would remove


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/vitejs/vite/issues/6065

### Additional context

Been thinking about the issue, and maybe it make sense to scope minify to certain aspects only.

Logic:

1. If `minify*` options are specified, use them instead of `minify: true` (which overrides all the specific options to `true`)
2. Otherwise we force `minify: true`
3. Lastly, also ensure that `minifyWhitespace` is false for es library build.

#### Other improvements

1. ES library build will not completely skip minify, it would run `minifySyntax` and `minifyIdentifiers` as those are safe.
2. Ensure minification is totally off if `build.minify: false`, regardless of `esbuild.minify` and `esbuild.minify*`
3. Ensure minification is totally off when transforming tsx/jsx files

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
