### PR TITLE
fix(optimizer): always queue run at least once (fixes #8750)

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -58,6 +58,7 @@ export interface DepsOptimizer {
   isOptimizedDepUrl: (url: string) => boolean
   getOptimizedDepId: (depInfo: OptimizedDepInfo) => string
 
+  queueFirstOptimizerRun: () => void
   delayDepsOptimizerUntil: (id: string, done: () => Promise<any>) => void
   registerWorkersSource: (id: string) => void
   resetRegisteredIds: () => void

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -86,10 +86,11 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
     buildStart() {
       if (!config.isWorker) {
         getDepsOptimizer(config)?.resetRegisteredIds()
+        getDepsOptimizer(config)?.queueFirstOptimizerRun()
       }
     },
 
-    async resolveId(id) {
+    resolveId(id) {
       if (getDepsOptimizer(config)?.isOptimizedDepFile(id)) {
         return id
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`getDepsOptimizer(config)?.run()` is added to queue by `runOptimizerWhenIdle` through `delayDepsOptimizerUntil`.
But when entrypoints are all going to be optimized, all `load` hooks won't end so none of the `transform` hook will be called. This means that `delayDepsOptimizerUntil` is never called.

This PR adds `queueFirstOptimizerRun` function and call that on `buildStart` hook. This will ensure `runOptimizerWhenIdle` to be called at least once.

fixes #8750

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
