### PR TITLE
fix(hmr): __HMR_PORT__ should not be `'undefined'`

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -9,7 +9,7 @@ import '@vite/env'
 declare const __BASE__: string
 declare const __HMR_PROTOCOL__: string | null
 declare const __HMR_HOSTNAME__: string | null
-declare const __HMR_PORT__: string | null
+declare const __HMR_PORT__: number | null
 declare const __HMR_DIRECT_TARGET__: string
 declare const __HMR_BASE__: string
 declare const __HMR_TIMEOUT__: number

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -26,11 +26,9 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
 
         // hmr.clientPort -> hmr.port
         // -> (24678 if middleware mode) -> new URL(import.meta.url).port
-        let port = hmrConfig
-          ? String(hmrConfig.clientPort || hmrConfig.port)
-          : null
+        let port = hmrConfig?.clientPort || hmrConfig?.port || null
         if (config.server.middlewareMode) {
-          port ||= '24678'
+          port ||= 24678
         }
 
         const devBase = config.base


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When `config.server.hmr` exsits and both `config.server.hmr.clientPort` and `config.server.hmr.port` does not exist, `__HMR_PORT__` was injected as `'undefined'` instead of `null`.

For example a config like this:
```js
export default {
  server: {
    hmr: {}
  }
}
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
