### PR TITLE
feat: restart server with overwritten configuration

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -111,9 +111,9 @@ interface ViteDevServer {
   /**
    * Restart the server.
    *
-   * @param forceOptimize - force the optimizer to re-bundle, same as --force cli flag
+   * @param overwritesConfig - configurations that need to be overridden
    */
-  restart(forceOptimize?: boolean): Promise<void>
+  restart(overwritesConfig?: InlineConfig): Promise<void>
   /**
    * Stop the server.
    */


### PR DESCRIPTION
### Description

Provide a programming way to modify configuration like `base/port`.

### Additional context

_HAS BREAKING CHANGE!_

Remove the `forceOptimize` arg, so user need manually pass `{ server: { force: true } }` to keep the previous behavior

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
