### PR TITLE
fix: always remove temp config

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -887,9 +887,12 @@ export async function loadConfigFromFile(
         // bundle the config file w/ ts transforms first, write it to disk,
         // load it with native Node ESM, then delete the file.
         fs.writeFileSync(resolvedPath + '.mjs', bundled.code)
-        userConfig = (await dynamicImport(`${fileUrl}.mjs?t=${Date.now()}`))
-          .default
-        fs.unlinkSync(resolvedPath + '.mjs')
+        try {
+          userConfig = (await dynamicImport(`${fileUrl}.mjs?t=${Date.now()}`))
+            .default
+        } finally {
+          fs.unlinkSync(resolvedPath + '.mjs')
+        }
         debug(`TS + native esm config loaded in ${getTime()}`, fileUrl)
       } else {
         // using Function to avoid this from being compiled away by TS/Rollup


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
A temporary file which contains bundled config result was not removed when an error happened during dynamic importing that.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
