### PR TITLE
fix: remove buildTimeImportMetaUrl

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-restricted-globals */
 import fs from 'node:fs'
 import path from 'node:path'
-import url from 'node:url'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import typescript from '@rollup/plugin-typescript'
 import commonjs from '@rollup/plugin-commonjs'

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -140,8 +140,6 @@ function createNodePlugins(
         }
       }),
 
-    buildTimeImportMetaUrl(),
-
     commonjs({
       extensions: ['.js'],
       // Optional peer deps of ws. Native deps that are mostly for performance.
@@ -281,21 +279,6 @@ function shimDepsPlugin(deps: Record<string, ShimOptions>): Plugin {
             )
           }
         }
-      }
-    }
-  }
-}
-
-// The use of `import.meta.url` in source code is not reliable after bundling.
-// For example, it is affected by the `isEntry` bug brought in by the Rollup CJS plugin
-// https://github.com/rollup/plugins/pull/1180
-// The better way is to resolve it at build time.
-function buildTimeImportMetaUrl(): Plugin {
-  return {
-    name: 'buildTimeImportMetaUrl',
-    resolveImportMeta: (property, chunk) => {
-      if (property === 'url') {
-        return `'${url.pathToFileURL(chunk.moduleId).href}'`
       }
     }
   }

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -61,6 +61,7 @@ export const NULL_BYTE_PLACEHOLDER = `__x00__`
 export const CLIENT_PUBLIC_PATH = `/@vite/client`
 export const ENV_PUBLIC_PATH = `/@vite/env`
 export const VITE_PACKAGE_DIR = resolve(
+  // import.meta.url is `dist/node/constants.js` after bundle
   fileURLToPath(import.meta.url),
   '../../..'
 )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This error happens for **almost all users**.
```text
Error: cannot test case insensitive FS, CLIENT_ENTRY does not point to an existing file: D:\documents\GitHub\vite\packages\vite\dist\client\client.mjs
```
This does not happen **only** for a user which is using self-built Vite and the generated `dist` directory is not removed.

It is p5 but since #8743 is not released yet, a new release is not urgent.

refs #8743
refs https://github.com/vitejs/vite-ecosystem-ci/pull/83

### Additional context
https://github.com/vitejs/vite/blob/f018f135ffa5a2885c063d4509d39958c788120c/packages/vite/src/node/constants.ts#L63-L70
https://github.com/vitejs/vite/blob/c2b09db1bf78c09df20d209a28568b0851ce5c31/packages/vite/src/node/utils.ts#L171-L186

This is the code throwing the error.

Also IIUC a code like this will be broken if it is replaced on build time.
https://github.com/vitejs/vite/blob/c2b09db1bf78c09df20d209a28568b0851ce5c31/packages/vite/src/node/config.ts#L988

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
