### PR TITLE
fix: skip inline html

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -383,6 +383,7 @@ async function fileToBuiltUrl(
   if (
     config.build.lib ||
     (!file.endsWith('.svg') &&
+      !file.endsWith('.html') &&
       content.length < Number(config.build.assetsInlineLimit))
   ) {
     const mimeType = mrmime.lookup(file) ?? 'application/octet-stream'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/vitejs/vite/issues/5238

### Additional context

I'm not sure if there are cases where you want to get the html url as base64

I also found https://github.com/vitejs/vite/pull/2909, which I can rebase later as it seems like a useful addition. Don't think it needs to apply to html files though.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
