### PR TITLE
chore: bump minmum node version to v14.9

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -137,13 +137,13 @@ module.exports = defineConfig({
         'node/no-unsupported-features/es-builtins': [
           'error',
           {
-            version: '>=14.18.0'
+            version: '>=14.19.0'
           }
         ],
         'node/no-unsupported-features/node-builtins': [
           'error',
           {
-            version: '>=14.18.0'
+            version: '>=14.19.0'
           }
         ]
       }

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -38,7 +38,7 @@ The supported template presets are:
 ## Scaffolding Your First Vite Project
 
 ::: tip Compatibility Note
-Vite requires [Node.js](https://nodejs.org/en/) version >=14.18.0. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
+Vite requires [Node.js](https://nodejs.org/en/) version >=14.19.0. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
 :::
 
 With NPM:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vite-monorepo",
   "private": true,
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=14.19.0"
   },
   "homepage": "https://vitejs.dev/",
   "keywords": [

--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -3,7 +3,7 @@
 ## Scaffolding Your First Vite Project
 
 > **Compatibility Note:**
-> Vite requires [Node.js](https://nodejs.org/en/) version >=14.18.0. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
+> Vite requires [Node.js](https://nodejs.org/en/) version >=14.19.0. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
 
 With NPM:
 

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -14,7 +14,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=14.19.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=14.19.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=14.19.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=14.19.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=14.19.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -31,7 +31,7 @@
     "types"
   ],
   "engines": {
-    "node": ">=14.18.0"
+    "node": ">=14.19.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

the corepack minmum version is v14.9
https://github.com/nodejs/corepack#default-installs

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
