### PR TITLE
fix: consistent module graph IDs during transform

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -36,9 +36,7 @@ import {
   moduleListContains,
   normalizePath,
   prettifyUrl,
-  removeImportQuery,
-  timeFrom,
-  unwrapId
+  timeFrom
 } from '../utils'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
@@ -673,10 +671,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // pre-transform known direct imports
       if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach((url) => {
-          url = unwrapId(removeImportQuery(url)).replace(
-            NULL_BYTE_PLACEHOLDER,
-            '\0'
-          )
           transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors

--- a/packages/vite/src/node/server/__tests__/fixtures/dependency.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/dependency.js
@@ -1,0 +1,1 @@
+export const foo = 'bar'

--- a/packages/vite/src/node/server/__tests__/fixtures/entry.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/entry.js
@@ -1,0 +1,3 @@
+import { fooReexported } from 'virtual:a-module'
+
+console.log('value of foo:', fooReexported)

--- a/packages/vite/src/node/server/__tests__/transformRequest.spec.ts
+++ b/packages/vite/src/node/server/__tests__/transformRequest.spec.ts
@@ -1,0 +1,57 @@
+import { resolve } from 'path'
+import { createServer } from '../index'
+
+const ENTRY_MODULE_URL = '/entry.js'
+const DEPENDENCY_MODULE_PATH = resolve(__dirname, './fixtures/dependency.js')
+
+/**
+ * Construct a simple dependency chain:
+ * entry.js -> <virtual module> -> dependency.js
+ *
+ * The test will check for integrity in the module graph after a request is transformed.
+ */
+test('virtual modules participate in a continuous module graph', async () => {
+  const viteServer = await createServer({
+    root: resolve(__dirname, 'fixtures'),
+    plugins: [
+      {
+        name: 'virtual-module-test-plugin',
+        resolveId(id) {
+          if (id === 'virtual:a-module') {
+            return '\0virtual:a-module'
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:a-module') {
+            return `import { foo as fooReexported } from '${DEPENDENCY_MODULE_PATH}';\nexport { fooReexported };`
+          }
+        }
+      }
+    ]
+  })
+
+  await viteServer.transformRequest(ENTRY_MODULE_URL)
+
+  // Wait for all requests to finish
+  while (viteServer._pendingRequests.size) {
+    await Promise.all(
+      Array.from(viteServer._pendingRequests.values()).map(
+        (entry) => entry.request
+      )
+    )
+  }
+
+  const entry = (await viteServer.moduleGraph.getModuleByUrl(ENTRY_MODULE_URL))!
+  expect(entry).toBeTruthy()
+
+  // Find each link in the import chain to ensure the graph is contiguous
+  ;['virtual:a-module', 'dependency.js'].reduce((module, url) => {
+    const child = Array.from(module.importedModules.entries()).find(
+      ([module]) => module.url.includes(url)
+    )?.[0]
+
+    expect(child).toBeTruthy()
+
+    return child!
+  }, entry)
+})

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -141,7 +141,9 @@ async function doTransform(
 
   // resolve
   const id =
-    (await pluginContainer.resolveId(url, undefined, { ssr }))?.id || url
+    (module && module.id) ||
+    (await pluginContainer.resolveId(url, undefined, { ssr }))?.id ||
+    url
   const file = cleanUrl(id)
 
   let code: string | null = null


### PR DESCRIPTION
### Description

I was noticing that certain modules weren't updating when saving a change to their dependencies, and traced it back to this recent addition:
https://github.com/vitejs/vite/blob/v2/packages/vite/src/node/plugins/importAnalysis.ts#L676-L679

What's happening is some modules are given a browser-safe URL with the `/@id/` prefix before they're added to the module graph.  Then the above code strips the prefix and the imports are sent back through the transform pipeline, which adds duplicate modules _without_ the prefix.  This has the effect of creating a discontinuous module graph.

I would expect it to look like this:
```
entry.js -> /@id/__x00__virtual:my-module -> dependency.js
```

But instead the graph looks like this:

```
entry.js -> /@id/__x00__virtual:my-module
virtual:my-module -> dependency.js
```

Thus any changes made to `dependency.js` don't properly trickle down when purging the module cache and I must restart the server to see the changes.

I've been running this fix in an internal project for a few weeks via a yarn patch.  Wanted to contribute the fix and a failing test.

### Additional context

The fix essentially moves the `/@id/` unwrapping to a more-central location alongside a tiny change to re-use module IDs if they already exist in the graph.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
