### PR TITLE
fix: incorrectly resolving `knownJsSrcRE` files from root (fixes #4161)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -24,6 +24,7 @@ import {
   isDataUrl,
   isExternalUrl,
   isFileReadable,
+  isNonDriveRelativeAbsolutePath,
   isObject,
   isPossibleTsOutput,
   isTsRequest,
@@ -172,8 +173,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       // relative
       if (
         id.startsWith('.') ||
-        (preferRelative && /^\w/.test(id)) ||
-        importer?.endsWith('.html')
+        ((preferRelative || importer?.endsWith('.html')) && /^\w/.test(id))
       ) {
         const basedir = importer ? path.dirname(importer) : process.cwd()
         const fsPath = path.resolve(basedir, id)
@@ -239,7 +239,10 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       }
 
       // absolute fs paths
-      if (path.isAbsolute(id) && (res = tryFsResolve(id, options))) {
+      if (
+        isNonDriveRelativeAbsolutePath(id) &&
+        (res = tryFsResolve(id, options))
+      ) {
         isDebug && debug(`[fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         return res
       }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1064,8 +1064,11 @@ export function stripBomTag(content: string): string {
 
 export const isTS = (filename: string): boolean => /\.[cm]?ts$/.test(filename)
 
+/**
+ * path.isAbsolute also returns true for drive relative paths on windows (e.g. /something)
+ * this function returns false for them but true for absolute paths (e.g. C:/something)
+ */
 export const isNonDriveRelativeAbsolutePath = (p: string): boolean => {
   if (!isWindows) return p.startsWith('/')
-
   return /^[A-Za-z]:[/\\]/.test(p)
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1064,11 +1064,13 @@ export function stripBomTag(content: string): string {
 
 export const isTS = (filename: string): boolean => /\.[cm]?ts$/.test(filename)
 
+const windowsDrivePathPrefixRE = /^[A-Za-z]:[/\\]/
+
 /**
  * path.isAbsolute also returns true for drive relative paths on windows (e.g. /something)
  * this function returns false for them but true for absolute paths (e.g. C:/something)
  */
 export const isNonDriveRelativeAbsolutePath = (p: string): boolean => {
   if (!isWindows) return p.startsWith('/')
-  return /^[A-Za-z]:[/\\]/.test(p)
+  return windowsDrivePathPrefixRE.test(p)
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1063,3 +1063,9 @@ export function stripBomTag(content: string): string {
 }
 
 export const isTS = (filename: string): boolean => /\.[cm]?ts$/.test(filename)
+
+export const isNonDriveRelativeAbsolutePath = (p: string): boolean => {
+  if (!isWindows) return p.startsWith('/')
+
+  return /^[A-Za-z]:[/\\]/.test(p)
+}


### PR DESCRIPTION
### Description
`path.isAbsolute` return true for `/something` also on windows.
https://nodejs.org/api/path.html#pathisabsolutepath

If the working directory is `C:\Users\green`, `/something` means `C:\something`.

fixes #4161 
refs #8122

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
