### PR TITLE
chore: use tsconfig for client build

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -89,12 +89,7 @@ function createNodePlugins(
     }),
     nodeResolve({ preferBuiltins: true }),
     typescript({
-      tsconfig: 'src/node/tsconfig.json',
-      module: 'esnext',
-      target: 'es2020',
-      include: ['src/**/*.ts', 'types/**'],
-      exclude: ['src/**/__tests__/**'],
-      esModuleInterop: true,
+      tsconfig: path.resolve(__dirname, 'src/node/tsconfig.json'),
       sourceMap,
       declaration: declarationDir !== false,
       declarationDir: declarationDir !== false ? declarationDir : undefined

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -19,14 +19,7 @@ const envConfig = defineConfig({
   input: path.resolve(__dirname, 'src/client/env.ts'),
   plugins: [
     typescript({
-      tsconfig: false,
-      target: 'es2020',
-      module: 'esnext',
-      include: ['src/client/env.ts'],
-      baseUrl: path.resolve(__dirname, 'src/env'),
-      paths: {
-        'types/*': ['../../types/*']
-      }
+      tsconfig: path.resolve(__dirname, 'src/client/tsconfig.json')
     })
   ],
   output: {
@@ -40,13 +33,7 @@ const clientConfig = defineConfig({
   external: ['./env', '@vite/env'],
   plugins: [
     typescript({
-      tsconfig: false,
-      target: 'es2020',
-      include: ['src/client/**/*.ts'],
-      baseUrl: path.resolve(__dirname, 'src/client'),
-      paths: {
-        'types/*': ['../../types/*']
-      }
+      tsconfig: path.resolve(__dirname, 'src/client/tsconfig.json')
     })
   ],
   output: {

--- a/packages/vite/src/client/tsconfig.json
+++ b/packages/vite/src/client/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "include": ["./", "../../types"],
   "compilerOptions": {
-    "outDir": "../../dist/client",
-    "module": "ESNext",
     "types": [],
     "lib": ["ESNext", "DOM"],
     "declaration": false

--- a/packages/vite/src/node/tsconfig.json
+++ b/packages/vite/src/node/tsconfig.json
@@ -3,10 +3,6 @@
   "include": ["./", "../../types"],
   "exclude": ["**/__tests__"],
   "compilerOptions": {
-    "target": "ES2020",
-    "outDir": "../../dist/node",
-    "module": "ESNext",
-    "lib": ["ESNext", "DOM"],
-    "sourceMap": true
+    "lib": ["ESNext", "DOM"]
   }
 }


### PR DESCRIPTION
### Description
This warning was shown when building `vite`.
```text
(!) Plugin typescript: @rollup/plugin-typescript TS2339: Property 'innerHTML' does not exist on type 'HTMLStyleElement | CSSStyleSheet'.
  Property 'innerHTML' does not exist on type 'CSSStyleSheet'.
src/client/client.ts: (338:13)
leElement | CSSStyleSheet'.
  Property 'innerHTML' does not exist on type 'CSSStyleSheet'.

338       style.innerHTML = content
```

I checked this doesn't change output by `diff` command.
```sh
$ diff -r dist-prod dist-old-prod # no diff between prod dist
$ diff -r dist-dev dist-old-dev # no diff between dev dist
```


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
