### PR TITLE
fix: deps optimizer waits for every requested module

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -696,7 +696,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             NULL_BYTE_PLACEHOLDER,
             '\0'
           )
-          const request = transformRequest(url, server, { ssr }).catch((e) => {
+          transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors
               return
@@ -704,9 +704,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             // Unexpected error, log the issue but avoid an unhandled exception
             config.logger.error(e.message)
           })
-          if (depsOptimizer && !config.legacy?.devDepsScanner) {
-            depsOptimizer.delayDepsOptimizerUntil(id, () => request)
-          }
         })
       }
 


### PR DESCRIPTION
### Description

We were only registering ids statically imported. This PR moves the registration after resolving the id `transformRequest` ensuring that we wait on every module the browser is loading.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other