### PR TITLE
fix(vite): can not resolve node_module package which has a query surfix

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -530,7 +530,7 @@ function tryResolveFile(
 export const idToPkgMap = new Map<string, PackageData>()
 
 export function tryNodeResolve(
-  id: string,
+  nodeId: string,
   importer: string | null | undefined,
   options: InternalResolveOptions,
   targetWeb: boolean,
@@ -538,6 +538,7 @@ export function tryNodeResolve(
   ssr?: boolean,
   externalize?: boolean
 ): PartialResolvedId | undefined {
+  const [id, idSurfix] = nodeId.split('?')
   const { root, dedupe, isBuild, preserveSymlinks, packageCache } = options
 
   ssr ??= false
@@ -630,6 +631,9 @@ export function tryNodeResolve(
   }
   if (!resolved) {
     return
+  }
+  if (idSurfix) {
+    resolved = injectQuery(resolved, idSurfix)
   }
 
   const processResult = (resolved: PartialResolvedId) => {


### PR DESCRIPTION
### Description
When I import a node_module package with query surfix, vite can't resolve it and give me a error:
````
const Vue3Lottie = async () => (await import( "vue3-lottie?chunkName=vue-lottie")).Vue3Lottie;
````
error logs:
````
[vite]: Rollup failed to resolve import "vue3-lottie?chunkName=vue-lottie" from "src/pages/demo/demo.vue".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
error during build:
Error: [vite]: Rollup failed to resolve import "vue3-lottie?chunkName=vue-lottie" from "src/pages/demo/demo.vue".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at onRollupWarning (D:\work\ytt-pc-1\node_modules\vite\dist\node\chunks\dep-8f5c9290.js:41772:19)
    at onwarn (D:\work\ytt-pc-1\node_modules\vite\dist\node\chunks\dep-8f5c9290.js:41588:13)
    at Object.onwarn (D:\work\ytt-pc-1\node_modules\rollup\dist\shared\rollup.js:23224:13)
    at ModuleLoader.handleResolveId (D:\work\ytt-pc-1\node_modules\rollup\dist\shared\rollup.js:22508:26)
    at ModuleLoader.resolveDynamicImport (D:\work\ytt-pc-1\node_modules\rollup\dist\shared\rollup.js:22560:120)
    at D:\work\ytt-pc-1\node_modules\rollup\dist\shared\rollup.js:22455:32
````
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
