### PR TITLE
test: fix tailwind playground `server.origin`

### DIFF
--- a/playground/tailwind/vite.config.ts
+++ b/playground/tailwind/vite.config.ts
@@ -15,6 +15,6 @@ export default defineConfig({
   server: {
     // This option caused issues with HMR,
     // although it should not affect the build
-    origin: 'http://localhost:8080/'
+    origin: 'http://localhost:8080'
   }
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The warning below was happening.
```
(!) server.origin should not end with "/". Using "http://localhost:8080" instead.
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
