### PR TITLE
chore: remove duplicated virtual-module plugin from ssr-vue

### DIFF
--- a/playground/ssr-vue/vite.config.js
+++ b/playground/ssr-vue/vite.config.js
@@ -45,23 +45,6 @@ export default defineConfig({
         }
       }
     },
-    {
-      name: 'virtual-module',
-      resolveId(id) {
-        if (id === virtualFile) {
-          return virtualId
-        } else if (id === nestedVirtualFile) {
-          return nestedVirtualId
-        }
-      },
-      load(id) {
-        if (id === virtualId) {
-          return `export { msg } from "@nested-virtual-file";`
-        } else if (id === nestedVirtualId) {
-          return `export const msg = "[success] from conventional virtual file"`
-        }
-      }
-    },
     // Example of a plugin that injects a helper from a virtual module that can
     // be used in renderBuiltUrl
     (function () {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`ssr-vue` example from playground had defined same plugin 2 times in its config

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
