### PR TITLE
chore: add package.json to export map

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -20,7 +20,8 @@
     "./client": {
       "types": "./client.d.ts"
     },
-    "./dist/client/*": "./dist/client/*"
+    "./dist/client/*": "./dist/client/*",
+    "./package.json": "./package.json"
   },
   "files": [
     "bin",


### PR DESCRIPTION
### Description

We've only exposed the `version` field since https://github.com/vitejs/vite/pull/8456
Before that, users can only get the version number from `package.json`.

This fixes compatibility issue with iles:
https://github.com/ElMassimo/iles/blob/4618f4be7118c06324d74d87d35ba73c0767369b/packages/iles/src/node/cli.ts#L11

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
