### PR TITLE
fix: server.force deprecation and force on restart API

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -648,6 +648,19 @@ export async function resolveConfig(
     )
   }
 
+  if (
+    config.server?.force &&
+    !isBuild &&
+    config.optimizeDeps?.force === undefined
+  ) {
+    resolved.optimizeDeps.force = true
+    logger.warn(
+      colors.yellow(
+        `server.force is deprecated, use optimizeDeps.force instead`
+      )
+    )
+  }
+
   if (resolved.legacy?.buildRollupPluginCommonjs) {
     const optimizerDisabled = resolved.optimizeDeps.disabled
     if (!optimizerDisabled) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -96,6 +96,13 @@ export interface ServerOptions extends CommonServerOptions {
    * @default true
    */
   preTransformRequests?: boolean
+  /**
+   * Force dep pre-optimization regardless of whether deps have changed.
+   * Use optimizeDeps.force instead, this option may be removed in a future
+   * minor version without following semver
+   * @deprecated
+   */
+  force?: boolean
 }
 
 export interface ResolvedServerOptions extends ServerOptions {
@@ -697,7 +704,7 @@ async function restartServer(server: ViteDevServer) {
   let inlineConfig = server.config.inlineConfig
   if (server._forceOptimizeOnRestart) {
     inlineConfig = mergeConfig(inlineConfig, {
-      server: {
+      optimizeDeps: {
         force: true
       }
     })

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -98,9 +98,9 @@ export interface ServerOptions extends CommonServerOptions {
   preTransformRequests?: boolean
   /**
    * Force dep pre-optimization regardless of whether deps have changed.
-   * Use optimizeDeps.force instead, this option may be removed in a future
-   * minor version without following semver
-   * @deprecated
+   *
+   * @deprecated Use optimizeDeps.force instead, this option may be removed
+   * in a future minor version without following semver
    */
   force?: boolean
 }


### PR DESCRIPTION
### Description

`force` on server restart was broken.

And adds back `server.force` as deprecated, the ecosystem is using this config in CI. We should at least keep it for a few minors.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
