### PR TITLE
feat: `build.target: ['nodeXX']` ignore replace process.env

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -11,6 +11,19 @@ const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
   const isBuildLib = isBuild && config.build.lib
+  let isTargetNode: boolean | undefined
+
+  if (
+    Array.isArray(config.build.target) &&
+    config.build.target.find((e) => e.startsWith('node'))
+  ) {
+    isTargetNode = true
+  } else if (
+    typeof config.build.target === 'string' &&
+    config.build.target.startsWith('node')
+  ) {
+    isTargetNode = true
+  }
 
   // ignore replace process.env in lib build
   const processEnv: Record<string, string> = {}
@@ -58,7 +71,8 @@ export function definePlugin(config: ResolvedConfig): Plugin {
   function generatePattern(
     ssr: boolean
   ): [Record<string, string | undefined>, RegExp | null] {
-    const replaceProcessEnv = !ssr || config.ssr?.target === 'webworker'
+    const replaceProcessEnv =
+      !(ssr || isTargetNode) || config.ssr?.target === 'webworker'
 
     const replacements: Record<string, string> = {
       ...(replaceProcessEnv ? processNodeEnv : {}),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When I use Vite and explicitly specify that the build target is `node`(Electron App), I hope to bypass the `definePlugin`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
