### PR TITLE
docs: fix the wasm example in "migration from v2"

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -100,7 +100,7 @@ You can use `?init` which is similar to the previous behavior.
 -import init from 'example.wasm'
 +import init from 'example.wasm?init'
 
--init().then((instance) => {
+-init().then((exports) => {
 +init().then(({ exports }) => {
   exports.test()
 })


### PR DESCRIPTION
### Description

The returned promise of `init()` function was fulfilled with an
`exports` object, not `instance`, in v2:
https://github.com/vitejs/vite/blob/d93ac8eca16534eb5474c19899bc130019b30a71/docs/guide/features.md?plain=1#L334

It was only changed in v3.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
