### PR TITLE
feat(client): use debug channel on hot updates

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -166,7 +166,7 @@ async function handleMessage(payload: HMRPayload) {
             newLinkTag.addEventListener('error', removeOldEl)
             el.after(newLinkTag)
           }
-          console.log(`[vite] css hot updated: ${searchUrl}`)
+          console.debug(`[vite] css hot updated: ${searchUrl}`)
         }
       })
       break
@@ -413,7 +413,7 @@ async function fetchUpdate({ path, acceptedPath, timestamp }: Update) {
       fn(deps.map((dep) => moduleMap.get(dep)))
     }
     const loggedPath = isSelfUpdate ? path : `${acceptedPath} via ${path}`
-    console.log(`[vite] hot updated: ${loggedPath}`)
+    console.debug(`[vite] hot updated: ${loggedPath}`)
   }
 }
 


### PR DESCRIPTION
### Description

This PR changes the `console.log` related to HMR updated from the client to `console.debug`, in order to avoid getting spammed in the console.

Recently, `[vite] connecting...` and `[vite] connected.` have been moved to the `debug` channel as well in https://github.com/vitejs/vite/pull/7733. 

![image](https://user-images.githubusercontent.com/16060559/176445050-02bf6c67-aa47-4272-b35d-f27497e4597f.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
