### PR TITLE
test: use ES syntax in vite.config.noexternal.js

### DIFF
--- a/playground/ssr-vue/vite.config.noexternal.js
+++ b/playground/ssr-vue/vite.config.noexternal.js
@@ -1,8 +1,6 @@
-const config = require('./vite.config.js')
-/**
- * @type {import('vite').UserConfig}
- */
-module.exports = Object.assign(config, {
+import config from './vite.config.js'
+
+export default Object.assign(config, {
   ssr: {
     noExternal: /./
   },

--- a/playground/ssr-vue/vite.config.noexternal.js
+++ b/playground/ssr-vue/vite.config.noexternal.js
@@ -1,5 +1,8 @@
 import config from './vite.config.js'
 
+/**
+ * @type {import('vite').UserConfig}
+ */
 export default Object.assign(config, {
   ssr: {
     noExternal: /./

--- a/playground/ssr-vue/vite.config.noexternal.js
+++ b/playground/ssr-vue/vite.config.noexternal.js
@@ -1,5 +1,4 @@
 import config from './vite.config.js'
-
 /**
  * @type {import('vite').UserConfig}
  */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Running `pnpm run build:noExternal` in `ssr-vue` playground results require/module is not defined errors, e.g.:
```
> test-ssr-vue@0.0.0 build:server:noExternal
> vite build --config vite.config.noexternal.js --ssr src/entry-server.js --outDir dist/server

▲ [WARNING] The CommonJS "module" variable is treated as a global variable in an ECMAScript module and may not work as expected [commonjs-variable-in-esm]

    vite.config.noexternal.js:5:0:
      5 │ module.exports = Object.assign(config, {
        ╵ ~~~~~~

  This file is considered to be an ECMAScript module because the enclosing "package.json"
  file sets the type of this file to "module":

    package.json:5:10:
      5 │   "type": "module",
        ╵           ~~~~~~~~

failed to load config from /home/stefan/Projects/vite/playground/ssr-vue/vite.config.noexternal.js
error during build:
ReferenceError: module is not defined in ES module scope
This file is being treated as an ES module because it has a '.js' file extension and '/home/stefan/Projects/vite/playground/ssr-vue/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///home/stefan/Projects/vite/playground/ssr-vue/vite.config.noexternal.js?t=1656524183085:5:1
    at ModuleJob.run (node:internal/modules/esm/module_job:198:25)
    at async Promise.all (index 0)
    at ESMLoader.import (node:internal/modules/esm/loader:409:24)
    at loadConfigFromFile (file:///home/stefan/Projects/vite/packages/vite/dist/node/chunks/dep-e7bffd95.js:62313:31)
    at resolveConfig (file:///home/stefan/Projects/vite/packages/vite/dist/node/chunks/dep-e7bffd95.js:61928:28)
    at doBuild (file:///home/stefan/Projects/vite/packages/vite/dist/node/chunks/dep-e7bffd95.js:43024:20)
    at build (file:///home/stefan/Projects/vite/packages/vite/dist/node/chunks/dep-e7bffd95.js:43013:16)
    at CAC.<anonymous> (file:///home/stefan/Projects/vite/packages/vite/dist/node/cli.js:747:9)
 ELIFECYCLE  Command failed with exit code 1.
```

Converting `vite.config.noexternal.js` to ES syntax fixes this.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
