### PR TITLE
fix: avoid optimizing non-optimizable external deps

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -41,7 +41,7 @@ export const DEFAULT_CONFIG_FILES = [
 
 export const JS_TYPES_RE = /\.(?:j|t)sx?$|\.mjs$/
 
-export const OPTIMIZABLE_ENTRY_RE = /\.(?:m?js|ts)$/
+export const OPTIMIZABLE_ENTRY_RE = /\.(?:(m|c)?js|ts)$/
 
 export const SPECIAL_QUERY_RE = /[\?&](?:worker|sharedworker|raw|url)\b/
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -259,7 +259,7 @@ export async function optimizeServerSsrDeps(
   const noExternal = config.ssr?.noExternal
   if (noExternal) {
     alsoInclude = arraify(noExternal).filter(
-      (ne) => typeof ne === 'string' && isOptimizable(ne, config.optimizeDeps)
+      (ne) => typeof ne === 'string'
     ) as string[]
     noExternalFilter =
       noExternal === true
@@ -661,7 +661,11 @@ async function addManuallyIncludedOptimizeDeps(
       if (!deps[normalizedId] && filter?.(normalizedId) !== false) {
         const entry = await resolve(id)
         if (entry) {
-          deps[normalizedId] = entry
+          if (isOptimizable(entry, config.optimizeDeps)) {
+            deps[normalizedId] = entry
+          } else {
+            config.logger.warn(`Cannot optimize entry ${entry}`)
+          }
         } else {
           throw new Error(
             `Failed to resolve force included dependency: ${colors.cyan(id)}`

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -14,6 +14,7 @@ import {
   emptyDir,
   flattenId,
   getHash,
+  isOptimizable,
   lookupFile,
   normalizeId,
   normalizePath,
@@ -258,7 +259,7 @@ export async function optimizeServerSsrDeps(
   const noExternal = config.ssr?.noExternal
   if (noExternal) {
     alsoInclude = arraify(noExternal).filter(
-      (ne) => typeof ne === 'string'
+      (ne) => typeof ne === 'string' && isOptimizable(ne, config.optimizeDeps)
     ) as string[]
     noExternalFilter =
       noExternal === true

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -6,11 +6,7 @@ import type { Loader, OnLoadResult, Plugin } from 'esbuild'
 import { build, transform } from 'esbuild'
 import colors from 'picocolors'
 import type { ResolvedConfig } from '..'
-import {
-  JS_TYPES_RE,
-  KNOWN_ASSET_TYPES,
-  SPECIAL_QUERY_RE
-} from '../constants'
+import { JS_TYPES_RE, KNOWN_ASSET_TYPES, SPECIAL_QUERY_RE } from '../constants'
 import {
   cleanUrl,
   createDebugger,
@@ -231,7 +227,11 @@ function esbuildScanPlugin(
         // It is possible for the scanner to scan html types in node_modules.
         // If we can optimize this html type, skip it so it's handled by the
         // bare import resolve, and recorded as optimization dep.
-        if (resolved.includes('node_modules') && isOptimizable(resolved, config.optimizeDeps)) return
+        if (
+          resolved.includes('node_modules') &&
+          isOptimizable(resolved, config.optimizeDeps)
+        )
+          return
         return {
           path: resolved,
           namespace: 'html'

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -92,8 +92,14 @@ export function moduleListContains(
   return moduleList?.some((m) => m === id || id.startsWith(m + '/'))
 }
 
-export function isOptimizable (id: string, optimizeDepsConfig: ResolvedConfig['optimizeDeps']) {
-  return OPTIMIZABLE_ENTRY_RE.test(id) || optimizeDepsConfig.extensions?.some((ext) => id.endsWith(ext))
+export function isOptimizable(
+  id: string,
+  optimizeDepsConfig: ResolvedConfig['optimizeDeps']
+): boolean {
+  return (
+    OPTIMIZABLE_ENTRY_RE.test(id) ||
+    (optimizeDepsConfig.extensions?.some((ext) => id.endsWith(ext)) ?? false)
+  )
 }
 
 export const bareImportRE = /^[\w@](?!.*:\/\/)/

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_EXTENSIONS,
   ENV_PUBLIC_PATH,
   FS_PREFIX,
+  OPTIMIZABLE_ENTRY_RE,
   VALID_ID_PREFIX,
   wildcardHosts
 } from './constants'
@@ -89,6 +90,10 @@ export function moduleListContains(
   id: string
 ): boolean | undefined {
   return moduleList?.some((m) => m === id || id.startsWith(m + '/'))
+}
+
+export function isOptimizable (id: string, optimizeDepsConfig: ResolvedConfig['optimizeDeps']) {
+  return OPTIMIZABLE_ENTRY_RE.test(id) || optimizeDepsConfig.extensions?.some((ext) => id.endsWith(ext))
 }
 
 export const bareImportRE = /^[\w@](?!.*:\/\/)/

--- a/playground/optimize-deps/non-optimizable-include/index.css
+++ b/playground/optimize-deps/non-optimizable-include/index.css
@@ -1,0 +1,4 @@
+@font-face {
+  font-family: 'Not Real Sans';
+  src: url('./i-throw-if-you-optimize-this-file.woff') format('woff');
+}

--- a/playground/optimize-deps/non-optimizable-include/package.json
+++ b/playground/optimize-deps/non-optimizable-include/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "no-external-css",
+  "name": "non-optimizable-include",
   "private": true,
   "type": "module",
   "version": "0.0.0",

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -16,7 +16,12 @@ module.exports = {
   },
 
   optimizeDeps: {
-    include: ['dep-linked-include', 'nested-exclude > nested-include'],
+    include: [
+      'dep-linked-include',
+      'nested-exclude > nested-include',
+      // will throw if optimized (should log warning instead)
+      'non-optimizable-include'
+    ],
     exclude: ['nested-exclude'],
     esbuildOptions: {
       plugins: [

--- a/playground/ssr-deps/no-external-css/index.css
+++ b/playground/ssr-deps/no-external-css/index.css
@@ -1,0 +1,4 @@
+@font-face {
+  font-family: 'Not Real Sans';
+  src: url('./i-throw-if-you-optimize-this-file.woff') format('woff');
+}

--- a/playground/ssr-deps/no-external-css/package.json
+++ b/playground/ssr-deps/no-external-css/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "primitive-export-css",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "exports": {
+    ".": "./index.css"
+  }
+}

--- a/playground/ssr-deps/package.json
+++ b/playground/ssr-deps/package.json
@@ -19,7 +19,8 @@
     "read-file-content": "file:./read-file-content",
     "require-absolute": "file:./require-absolute",
     "ts-transpiled-exports": "file:./ts-transpiled-exports",
-    "no-external-cjs": "file:./no-external-cjs"
+    "no-external-cjs": "file:./no-external-cjs",
+    "no-external-css": "file:./no-external-css"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -35,7 +35,7 @@ export async function createServer(root = process.cwd(), hmrPort) {
     },
     appType: 'custom',
     ssr: {
-      noExternal: ['no-external-cjs']
+      noExternal: ['no-external-cjs', 'no-external-css']
     }
   })
   // use vite's connect instance as middleware

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,9 @@ importers:
   playground/lib:
     specifiers: {}
 
+  playground/minify:
+    specifiers: {}
+
   playground/multiple-entrypoints:
     specifiers:
       fast-glob: ^3.2.11
@@ -854,6 +857,7 @@ importers:
       express: ^4.18.1
       forwarded-export: file:./forwarded-export
       no-external-cjs: file:./no-external-cjs
+      no-external-css: file:./no-external-css
       object-assigned-exports: file:./object-assigned-exports
       only-object-assigned-exports: file:./only-object-assigned-exports
       primitive-export: file:./primitive-export
@@ -866,6 +870,7 @@ importers:
       define-property-exports: file:playground/ssr-deps/define-property-exports
       forwarded-export: file:playground/ssr-deps/forwarded-export
       no-external-cjs: file:playground/ssr-deps/no-external-cjs
+      no-external-css: file:playground/ssr-deps/no-external-css
       object-assigned-exports: file:playground/ssr-deps/object-assigned-exports
       only-object-assigned-exports: file:playground/ssr-deps/only-object-assigned-exports
       primitive-export: file:playground/ssr-deps/primitive-export
@@ -889,6 +894,9 @@ importers:
       object-assigned-exports: file:playground/ssr-deps/object-assigned-exports
 
   playground/ssr-deps/no-external-cjs:
+    specifiers: {}
+
+  playground/ssr-deps/no-external-css:
     specifiers: {}
 
   playground/ssr-deps/object-assigned-exports:
@@ -8666,6 +8674,12 @@ packages:
   file:playground/ssr-deps/no-external-cjs:
     resolution: {directory: playground/ssr-deps/no-external-cjs, type: directory}
     name: primitive-export
+    version: 0.0.0
+    dev: false
+
+  file:playground/ssr-deps/no-external-css:
+    resolution: {directory: playground/ssr-deps/no-external-css, type: directory}
+    name: primitive-export-css
     version: 0.0.0
     dev: false
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We discovered that Vite 3 will optimize deps added to `ssr.noExternal`, even when those deps are _not_ optimizable. This change will check whether a dependency is optimizable before attempting to optimize.
- if you include a non-optimizable dep in `ssr.noExternal` 👉 don't optimize, don't log a warning
- if you include a non-optimizable dep in `optimizeDeps.include` 👉 don't optimize, DO log a warning

### Additional context

- adds non-optimizable dependency to the `optimize-deps` playground test
- adds non-optimizable dependency to the `ssr-deps` playground test

☝️ Note: no unit tests were added to the `.spec.ts` files! This is because we're just checking whether your Vite config causes the test suite to bomb. By adding `non-optimizable-dep` to `optimizeDeps.include`, for example, we're implicitly checking whether Vite will (wrongly) attempt to optimize.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
