### PR TITLE
chore: update deprecation warnings for improved migration DX

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -636,16 +636,16 @@ export async function resolveConfig(
   if (middlewareMode === 'ssr') {
     logger.warn(
       colors.yellow(
-        `server.middlewareMode 'ssr' is now deprecated, use server.middlewareMode true${
-          config.appType === 'custom' ? '' : ` and appType 'custom'`
-        }`
+        `Setting server.middlewareMode to 'ssr' is deprecated, set server.middlewareMode to \`true\`${
+          config.appType === 'custom' ? '' : ` and appType to 'custom'`
+        } instead`
       )
     )
   }
   if (middlewareMode === 'html') {
     logger.warn(
       colors.yellow(
-        `server.middlewareMode 'html' is now deprecated, use server.middlewareMode true`
+        `Setting server.middlewareMode to 'html' is deprecated, set server.middlewareMode to \`true\` instead`
       )
     )
   }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -636,7 +636,9 @@ export async function resolveConfig(
   if (middlewareMode === 'ssr') {
     logger.warn(
       colors.yellow(
-        `server.middlewareMode 'ssr' is now deprecated, use server.middlewareMode true and appType 'custom'`
+        `server.middlewareMode 'ssr' is now deprecated, use server.middlewareMode true${
+          config.appType === 'custom' ? '' : ` and appType 'custom'`
+        }`
       )
     )
   }


### PR DESCRIPTION

### Description

If the user uses a plugin that sets `config.appType` to `'custom'` on behalf of the user (for example vite-plugin-ssr), then the current deprecation warning message is confusing.

The main thing here is the first commit https://github.com/vitejs/vite/commit/d30389013c1cc9f35805b0964ff3716bffba3ef4.

The second commit https://github.com/vitejs/vite/commit/3d0028ddc0cef64e90326f23af40289d36209850 is only aesthetics. I'm totally fine reverting it.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
