### PR TITLE
test: fix flaky glob test

### DIFF
--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -81,11 +81,15 @@ const relativeRawResult = {
 }
 
 test('should work', async () => {
-  expect(await page.textContent('.result')).toBe(
-    JSON.stringify(allResult, null, 2)
+  await untilUpdated(
+    () => page.textContent('.result'),
+    JSON.stringify(allResult, null, 2),
+    true
   )
-  expect(await page.textContent('.result-node_modules')).toBe(
-    JSON.stringify(nodeModulesResult, null, 2)
+  await untilUpdated(
+    () => page.textContent('.result-node_modules'),
+    JSON.stringify(nodeModulesResult, null, 2),
+    true
   )
 })
 


### PR DESCRIPTION
### Description
https://github.com/vitejs/vite/blob/09742e21dc8d59c57d82e384fd58f7da3c08cd74/playground/glob-import/index.html#L9-L28
`useImports` sets `textContent` asynchronously.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
