### PR TITLE
fix(optimizer): hash by config mode only

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -993,7 +993,7 @@ export function getDepHash(config: ResolvedConfig): string {
   // only a subset of config options that can affect dep optimization
   content += JSON.stringify(
     {
-      mode: process.env.NODE_ENV || config.mode,
+      mode: config.mode,
       root: config.root,
       resolve: config.resolve,
       buildTarget: config.build.target,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix regression from https://github.com/vitejs/vite/pull/7673

When hashing the `mode`, use `config.mode` only. `process.env.NODE_ENV` is different than `mode`.

Otherwise this could cause unnecessary reloads on warm starts.

### Additional context

I think past me made a brain-fart.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
