### PR TITLE
Dedicated H3 to accessing Env Vars

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -44,14 +44,18 @@ In addition, environment variables that already exist when Vite is executed have
 
 Loaded env variables are also exposed to your client source code via `import.meta.env` as strings.
 
-To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code. e.g. the following file:
+### Accessing Environment Variables in Application Code
+
+To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code.
+
+For example, consider the following file:
 
 ```
 DB_PASSWORD=foobar
 VITE_SOME_KEY=123
 ```
 
-Only `VITE_SOME_KEY` will be exposed as `import.meta.env.VITE_SOME_KEY` to your client source code, but `DB_PASSWORD` will not.
+The `VITE_SOME_KEY` will be accessible at `import.meta.env.VITE_SOME_KEY` to your client source code because it is prefixed with `VITE_`. The `DB_PASSWORD` will not be accessible in the cliect source code.
 
 If you want to customize env variables prefix, see [envPrefix](/config/index#envprefix) option.
 


### PR DESCRIPTION
### Description

I propose dedicating a h3 section to "Accessing Environment Variables in Application Code" that more clearly calls out how env vars need to be prefixed with `VUE_` to be accessed via `import.meta.env` in client source code.

### Additional context

I felt that this information was hidden within the **.env Files** section when it deserves its own nested section. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
