### PR TITLE
fix: don't count class declarations as react fast refresh boundry (fixes #3675)

### DIFF
--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -92,6 +92,7 @@ export function isRefreshBoundary(ast: t.File): boolean {
     }
     const { declaration, specifiers } = node
     if (declaration) {
+      if (declaration.type === 'ClassDeclaration') return false
       if (declaration.type === 'VariableDeclaration') {
         return declaration.declarations.every((variable) =>
           isComponentLikeIdentifier(variable.id)


### PR DESCRIPTION
### Description

This addresses https://github.com/vitejs/vite-plugin-react/issues/8 especially: https://github.com/vitejs/vite-plugin-react/issues/8

If an export in a Vite React project is a React class component, editing the contents of the components and then saving the file will not cause any updates in the browser during development (neither a fast refresh nor a full refresh). I fixed this by checking for class components in the `isRefreshBoundary` and returning false if one is found.

### Additional context

I'm pretty sure this will work but I wasn't able to test locally. I tried adding the follow to my package.json in a test React project:

``` json
"pnpm": {
    "overrides": {
      "vite": "link:../vite/packages/vite",
      "@vitejs/plugin-react": "link:../vite/packages/plugin-react"
    }
  }
```
however the changes in the `plugin-react` didn't seem to be reflected in my project.

If we could merge this into v2 of vite as well, that would be appreciated since this bug is creating a worse dev experience for many projects on v2.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
