### PR TITLE
fix(hmr): set isSelfAccepting unless it is delayed

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -356,7 +356,12 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // its last updated timestamp to force the browser to fetch the most
           // up-to-date version of this module.
           try {
-            const depModule = await moduleGraph.ensureEntryFromUrl(url, ssr)
+            // delay setting `isSelfAccepting` until the file is actually used (#7870)
+            const depModule = await moduleGraph.ensureEntryFromUrl(
+              url,
+              ssr,
+              canSkipImportAnalysis(url)
+            )
             if (depModule.lastHMRTimestamp > 0) {
               url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)
             }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -169,18 +169,24 @@ export function updateModules(
     ws.send({
       type: 'full-reload'
     })
-  } else {
-    config.logger.info(
-      updates
-        .map(({ path }) => colors.green(`hmr update `) + colors.dim(path))
-        .join('\n'),
-      { clear: true, timestamp: true }
-    )
-    ws.send({
-      type: 'update',
-      updates
-    })
+    return
   }
+
+  if (updates.length === 0) {
+    debugHmr(colors.yellow(`no update happened `) + colors.dim(file))
+    return
+  }
+
+  config.logger.info(
+    updates
+      .map(({ path }) => colors.green(`hmr update `) + colors.dim(path))
+      .join('\n'),
+    { clear: true, timestamp: true }
+  )
+  ws.send({
+    type: 'update',
+    updates
+  })
 }
 
 export async function handleFileAddUnlink(


### PR DESCRIPTION
### Description
In the following situation, a full reload should happen.

- `main.css` depends on `index.liquid` by tailwind.
- `index.liquid`'s hmr is not handled by anything
- edited `index.liquid`

The full reload was not happening because `isSelfAccepting` was `undefined`.

This PR changes `isSelfAccepting` to be set unless `ensureEntryFromUrl` is called from `import-analysis`.
The old behavior is to set `isSelfAccepting` if `isHTMLRequest(url) || canSkipImportAnalysis(url)` is `true`.

refs #7561 #7895 #7898

### Additional context
Found while checking #8890.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
