### PR TITLE
refactor: remove ?used inject in glob plugin

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -18,7 +18,6 @@ import type { ViteDevServer } from '../server'
 import type { ModuleNode } from '../server/moduleGraph'
 import type { ResolvedConfig } from '../config'
 import { normalizePath, slash, transformStableResult } from '../utils'
-import { isCSSRequest } from './css'
 
 const { isMatch, scan } = micromatch
 
@@ -392,9 +391,6 @@ export async function transformGlobImport(
             const filePath = paths.filePath
             let importPath = paths.importPath
             let importQuery = query
-
-            if (isCSSRequest(file))
-              importQuery = importQuery ? `${importQuery}&used` : '?used'
 
             if (importQuery && importQuery !== '?raw') {
               const fileExtension = basename(file).split('.').slice(-1)[0]

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -32,6 +32,14 @@ const json = isBuild
       msg: 'baz'
     }
 
+const css = isBuild
+  ? {
+      default: '.foo{color:#00f}\n'
+    }
+  : {
+      default: '.foo {\n  color: blue;\n}\n'
+    }
+
 const globWithAlias = {
   '/dir/alias.js': {
     default: 'hi'
@@ -44,6 +52,7 @@ const allResult = {
     default: 'hi'
   },
   '/dir/baz.json': json,
+  '/dir/foo.css': css,
   '/dir/foo.js': {
     msg: 'foo'
   },
@@ -83,6 +92,11 @@ const relativeRawResult = {
 test('should work', async () => {
   await untilUpdated(
     () => page.textContent('.result'),
+    JSON.stringify(allResult, null, 2),
+    true
+  )
+  await untilUpdated(
+    () => page.textContent('.result-eager'),
     JSON.stringify(allResult, null, 2),
     true
   )

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -148,21 +148,7 @@ if (!isBuild) {
     removeFile('dir/a.js')
     await withRetry(async () => {
       const actualRemove = await resultElement.textContent()
-      expect(JSON.parse(actualRemove)).toStrictEqual({
-        '/dir/a.js': {
-          msg: 'a'
-        },
-        ...allResult,
-        '/dir/index.js': {
-          ...allResult['/dir/index.js'],
-          modules: {
-            './a.js': {
-              msg: 'a'
-            },
-            ...allResult['/dir/index.js'].modules
-          }
-        }
-      })
+      expect(JSON.parse(actualRemove)).toStrictEqual(allResult)
     })
   })
 }

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -1,11 +1,4 @@
-import {
-  addFile,
-  editFile,
-  isBuild,
-  page,
-  removeFile,
-  untilUpdated
-} from '~utils'
+import { addFile, editFile, isBuild, page, removeFile, withRetry } from '~utils'
 
 const filteredResult = {
   './alias.js': {
@@ -16,29 +9,12 @@ const filteredResult = {
   }
 }
 
-// json exports key order is altered during build, but it doesn't matter in
-// terms of behavior since module exports are not ordered anyway
-const json = isBuild
-  ? {
-      msg: 'baz',
-      default: {
-        msg: 'baz'
-      }
-    }
-  : {
-      default: {
-        msg: 'baz'
-      },
-      msg: 'baz'
-    }
-
-const css = isBuild
-  ? {
-      default: '.foo{color:#00f}\n'
-    }
-  : {
-      default: '.foo {\n  color: blue;\n}\n'
-    }
+const json = {
+  msg: 'baz',
+  default: {
+    msg: 'baz'
+  }
+}
 
 const globWithAlias = {
   '/dir/alias.js': {
@@ -52,7 +28,13 @@ const allResult = {
     default: 'hi'
   },
   '/dir/baz.json': json,
-  '/dir/foo.css': css,
+  '/dir/foo.css': isBuild
+    ? {
+        default: '.foo{color:#00f}\n'
+      }
+    : {
+        default: '.foo {\n  color: blue;\n}\n'
+      },
   '/dir/foo.js': {
     msg: 'foo'
   },
@@ -90,21 +72,18 @@ const relativeRawResult = {
 }
 
 test('should work', async () => {
-  await untilUpdated(
-    () => page.textContent('.result'),
-    JSON.stringify(allResult, null, 2),
-    true
-  )
-  await untilUpdated(
-    () => page.textContent('.result-eager'),
-    JSON.stringify(allResult, null, 2),
-    true
-  )
-  await untilUpdated(
-    () => page.textContent('.result-node_modules'),
-    JSON.stringify(nodeModulesResult, null, 2),
-    true
-  )
+  await withRetry(async () => {
+    const actual = await page.textContent('.result')
+    expect(JSON.parse(actual)).toStrictEqual(allResult)
+  }, true)
+  await withRetry(async () => {
+    const actualEager = await page.textContent('.result-eager')
+    expect(JSON.parse(actualEager)).toStrictEqual(allResult)
+  }, true)
+  await withRetry(async () => {
+    const actualNodeModules = await page.textContent('.result-node_modules')
+    expect(JSON.parse(actualNodeModules)).toStrictEqual(nodeModulesResult)
+  }, true)
 })
 
 test('import glob raw', async () => {
@@ -127,55 +106,63 @@ test('unassigned import processes', async () => {
 
 if (!isBuild) {
   test('hmr for adding/removing files', async () => {
+    const resultElement = page.locator('.result')
+
     addFile('dir/a.js', '')
-    await untilUpdated(
-      () => page.textContent('.result'),
-      JSON.stringify(
-        {
-          '/dir/a.js': {},
-          ...allResult,
-          '/dir/index.js': {
-            ...allResult['/dir/index.js'],
-            modules: {
-              './a.js': {},
-              ...allResult['/dir/index.js'].modules
-            }
+    await withRetry(async () => {
+      const actualAdd = await resultElement.textContent()
+      expect(JSON.parse(actualAdd)).toStrictEqual({
+        '/dir/a.js': {},
+        ...allResult,
+        '/dir/index.js': {
+          ...allResult['/dir/index.js'],
+          modules: {
+            './a.js': {},
+            ...allResult['/dir/index.js'].modules
           }
-        },
-        null,
-        2
-      )
-    )
+        }
+      })
+    })
 
     // edit the added file
     editFile('dir/a.js', () => 'export const msg ="a"')
-    await untilUpdated(
-      () => page.textContent('.result'),
-      JSON.stringify(
-        {
-          '/dir/a.js': {
-            msg: 'a'
-          },
-          ...allResult,
-          '/dir/index.js': {
-            ...allResult['/dir/index.js'],
-            modules: {
-              './a.js': {
-                msg: 'a'
-              },
-              ...allResult['/dir/index.js'].modules
-            }
-          }
+    await withRetry(async () => {
+      const actualEdit = await resultElement.textContent()
+      expect(JSON.parse(actualEdit)).toStrictEqual({
+        '/dir/a.js': {
+          msg: 'a'
         },
-        null,
-        2
-      )
-    )
+        ...allResult,
+        '/dir/index.js': {
+          ...allResult['/dir/index.js'],
+          modules: {
+            './a.js': {
+              msg: 'a'
+            },
+            ...allResult['/dir/index.js'].modules
+          }
+        }
+      })
+    })
 
     removeFile('dir/a.js')
-    await untilUpdated(
-      () => page.textContent('.result'),
-      JSON.stringify(allResult, null, 2)
-    )
+    await withRetry(async () => {
+      const actualRemove = await resultElement.textContent()
+      expect(JSON.parse(actualRemove)).toStrictEqual({
+        '/dir/a.js': {
+          msg: 'a'
+        },
+        ...allResult,
+        '/dir/index.js': {
+          ...allResult['/dir/index.js'],
+          modules: {
+            './a.js': {
+              msg: 'a'
+            },
+            ...allResult['/dir/index.js'].modules
+          }
+        }
+      })
+    })
   })
 }

--- a/playground/glob-import/dir/foo.css
+++ b/playground/glob-import/dir/foo.css
@@ -1,0 +1,3 @@
+.foo {
+  color: blue;
+}

--- a/playground/glob-import/index.html
+++ b/playground/glob-import/index.html
@@ -1,4 +1,5 @@
 <pre class="result"></pre>
+<pre class="result-eager"></pre>
 <pre class="result-node_modules"></pre>
 <pre class="globraw"></pre>
 <pre class="relative-glob-raw"></pre>
@@ -35,6 +36,12 @@
      * */
   )
   useImports(modules, '.result')
+  const eagerModules = import.meta.glob('/dir/**', { eager: true })
+  document.querySelector('.result-eager').textContent = JSON.stringify(
+    eagerModules,
+    null,
+    2
+  )
 
   const nodeModules = import.meta.glob('/dir/node_modules/**')
   useImports(nodeModules, '.result-node_modules')

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -162,6 +162,25 @@ export async function untilUpdated(
   }
 }
 
+/**
+ * Poll a getter until the value it returns includes the expected value.
+ */
+export async function withRetry(
+  func: () => Promise<void>,
+  runInBuild = false
+): Promise<void> {
+  if (isBuild && !runInBuild) return
+  const maxTries = process.env.CI ? 200 : 50
+  for (let tries = 0; tries < maxTries; tries++) {
+    try {
+      await func()
+      return
+    } catch {}
+    await timeout(50)
+  }
+  await func()
+}
+
 export async function untilBrowserLogAfter(
   operation: () => any,
   target: string | RegExp | Array<string | RegExp>,

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -163,7 +163,7 @@ export async function untilUpdated(
 }
 
 /**
- * Poll a getter until the value it returns includes the expected value.
+ * Retry `func` until it does not throw error.
  */
 export async function withRetry(
   func: () => Promise<void>,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This code was added by https://github.com/antfu/vite-plugin-glob/commit/00a82b76ef1eb0a82c84ee4cf13adb86e7a6e51d.
But it is not needed because `?used` is injected by `import-analysis` which runs at the end.

### Additional context
To fix_ #8245, `import-analysis-build` needs to resolve id before deciding to inject `?used`.
This PR is needed to dedupe that logic.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
