### PR TITLE
fix: ssrBuild is optional, avoid breaking VitePress

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -80,7 +80,7 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
 
 It is important to note that in Vite's API the `command` value is `serve` during dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases), and `build` when building for production (`vite build`).
 
-Only `ssrBuild` is included instead of a more general `ssr` flag because, during dev, the config is shared by the single server handling SSR and non-SSR requests.
+`ssrBuild` is experimental. It is only available during build instead of a more general `ssr` flag because, during dev, the config is shared by the single server handling SSR and non-SSR requests. The value could be `undefined` for tools that don't have separate commands for the browser and SSR build, so use explicit comparison against `true` and `false`.
 
 ## Async Config
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -66,7 +66,10 @@ export type { RenderBuiltAssetUrl } from './build'
 export interface ConfigEnv {
   command: 'build' | 'serve'
   mode: string
-  ssrBuild: boolean
+  /**
+   * @experimental
+   */
+  ssrBuild?: boolean
 }
 
 /**


### PR DESCRIPTION
### Description

Follow up on:
- https://github.com/vitejs/vite/pull/8863

It is breaking VitePress. The PR makes it optional, and experimental, I think more discussion is needed around DX of this flag when we have CLIs based on Vite that don't have separate commands for SSR build.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other