### PR TITLE
feat: ssr.optimizeDeps

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -398,7 +398,7 @@ async function doBuild(
     external = await cjsSsrResolveExternal(config, userExternal)
   }
 
-  if (isDepsOptimizerEnabled(config)) {
+  if (isDepsOptimizerEnabled(config, ssr)) {
     await initDepsOptimizer(config)
   }
 
@@ -739,7 +739,7 @@ async function cjsSsrResolveExternal(
   } catch (e) {}
   if (!knownImports) {
     // no dev deps optimization data, do a fresh scan
-    knownImports = await findKnownImports(config)
+    knownImports = await findKnownImports(config, false) // needs to use non-ssr
   }
   const ssrExternals = cjsSsrResolveExternals(config, knownImports)
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -7,7 +7,6 @@ import colors from 'picocolors'
 import type { Alias, AliasOptions } from 'types/alias'
 import aliasPlugin from '@rollup/plugin-alias'
 import { build } from 'esbuild'
-import type { Plugin as ESBuildPlugin } from 'esbuild'
 import type { RollupOptions } from 'rollup'
 import type { Plugin } from './plugin'
 import type {
@@ -565,7 +564,6 @@ export async function resolveConfig(
 
   const middlewareMode = config?.server?.middlewareMode
 
-  config = mergeConfig(config, externalConfigCompat(config, configEnv))
   const optimizeDeps = config.optimizeDeps || {}
 
   if (process.env.VITE_TEST_LEGACY_CJS_PLUGIN) {
@@ -1024,86 +1022,4 @@ export function isDepsOptimizerEnabled(
     (command === 'build' && disabled === 'build') ||
     (command === 'serve' && disabled === 'dev')
   )
-}
-
-// esbuild doesn't transpile `require('foo')` into `import` statements if 'foo' is externalized
-// https://github.com/evanw/esbuild/issues/566#issuecomment-735551834
-function esbuildCjsExternalPlugin(externals: string[]): ESBuildPlugin {
-  return {
-    name: 'cjs-external',
-    setup(build) {
-      const escape = (text: string) =>
-        `^${text.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}$`
-      const filter = new RegExp(externals.map(escape).join('|'))
-
-      build.onResolve({ filter: /.*/, namespace: 'external' }, (args) => ({
-        path: args.path,
-        external: true
-      }))
-
-      build.onResolve({ filter }, (args) => ({
-        path: args.path,
-        namespace: 'external'
-      }))
-
-      build.onLoad({ filter: /.*/, namespace: 'external' }, (args) => ({
-        contents: `export * from ${JSON.stringify(args.path)}`
-      }))
-    }
-  }
-}
-
-// TODO: optimizeDeps
-
-// Support `rollupOptions.external` when `legacy.buildRollupPluginCommonjs` is disabled
-function externalConfigCompat(config: UserConfig, { command }: ConfigEnv) {
-  // Only affects the build command
-  if (command !== 'build') {
-    return {}
-  }
-
-  // Skip if using Rollup CommonJS plugin
-  if (
-    config.legacy?.buildRollupPluginCommonjs ||
-    config.optimizeDeps?.disabled === 'build'
-  ) {
-    return {}
-  }
-
-  // Skip if no `external` configured
-  const external = config?.build?.rollupOptions?.external
-  if (!external) {
-    return {}
-  }
-
-  let normalizedExternal = external
-  if (typeof external === 'string') {
-    normalizedExternal = [external]
-  }
-
-  // TODO: decide whether to support RegExp and function options
-  // They're not supported yet because `optimizeDeps.exclude` currently only accepts strings
-  if (
-    !Array.isArray(normalizedExternal) ||
-    normalizedExternal.some((ext) => typeof ext !== 'string')
-  ) {
-    throw new Error(
-      `[vite] 'build.rollupOptions.external' can only be an array of strings or a string.\n` +
-        `You can turn on 'legacy.buildRollupPluginCommonjs' to support more advanced options.`
-    )
-  }
-
-  const additionalConfig: UserConfig = {
-    optimizeDeps: {
-      exclude: normalizedExternal as string[],
-      esbuildOptions: {
-        plugins: [
-          // TODO: maybe it can be added globally/unconditionally?
-          esbuildCjsExternalPlugin(normalizedExternal as string[])
-        ]
-      }
-    }
-  }
-
-  return additionalConfig
 }

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -35,6 +35,7 @@ export type {
 export type {
   DepOptimizationMetadata,
   DepOptimizationOptions,
+  DepOptimizationConfig,
   DepOptimizationResult,
   DepOptimizationProcessing,
   OptimizedDepInfo,
@@ -43,6 +44,7 @@ export type {
 } from './optimizer'
 export type {
   ResolvedSSROptions,
+  SsrDepOptimizationOptions,
   SSROptions,
   SSRFormat,
   SSRTarget

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -44,10 +44,11 @@ const externalTypes = [
 export function esbuildDepPlugin(
   qualified: Record<string, string>,
   exportsData: Record<string, ExportsData>,
+  external: string[],
   config: ResolvedConfig,
   ssr: boolean
 ): Plugin {
-  const { extensions, exclude } = getDepOptimizationConfig(config, ssr)
+  const { extensions } = getDepOptimizationConfig(config, ssr)
 
   // remove optimizable extensions from `externalTypes` list
   const allExternalTypes = extensions
@@ -164,7 +165,7 @@ export function esbuildDepPlugin(
       build.onResolve(
         { filter: /^[\w@][^:]/ },
         async ({ path: id, importer, kind }) => {
-          if (moduleListContains(exclude, id)) {
+          if (moduleListContains(external, id)) {
             return {
               path: id,
               external: true
@@ -299,6 +300,33 @@ module.exports = Object.create(new Proxy({}, {
           loader: 'default'
         }))
       }
+    }
+  }
+}
+
+// esbuild doesn't transpile `require('foo')` into `import` statements if 'foo' is externalized
+// https://github.com/evanw/esbuild/issues/566#issuecomment-735551834
+export function esbuildCjsExternalPlugin(externals: string[]): Plugin {
+  return {
+    name: 'cjs-external',
+    setup(build) {
+      const escape = (text: string) =>
+        `^${text.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')}$`
+      const filter = new RegExp(externals.map(escape).join('|'))
+
+      build.onResolve({ filter: /.*/, namespace: 'external' }, (args) => ({
+        path: args.path,
+        external: true
+      }))
+
+      build.onResolve({ filter }, (args) => ({
+        path: args.path,
+        namespace: 'external'
+      }))
+
+      build.onLoad({ filter: /.*/, namespace: 'external' }, (args) => ({
+        contents: `export * from ${JSON.stringify(args.path)}`
+      }))
     }
   }
 }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -7,6 +7,7 @@ import type { BuildOptions as EsbuildBuildOptions } from 'esbuild'
 import { build } from 'esbuild'
 import { init, parse } from 'es-module-lexer'
 import { createFilter } from '@rollup/pluginutils'
+import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig } from '../config'
 import {
   arraify,
@@ -71,18 +72,7 @@ export interface DepsOptimizer {
   options: DepOptimizationOptions
 }
 
-export interface DepOptimizationOptions {
-  /**
-   * By default, Vite will crawl your `index.html` to detect dependencies that
-   * need to be pre-bundled. If `build.rollupOptions.input` is specified, Vite
-   * will crawl those entry points instead.
-   *
-   * If neither of these fit your needs, you can specify custom entries using
-   * this option - the value should be a fast-glob pattern or array of patterns
-   * (https://github.com/mrmlnc/fast-glob#basic-syntax) that are relative from
-   * vite project root. This will overwrite default entries inference.
-   */
-  entries?: string | string[]
+export interface DepOptimizationConfig {
   /**
    * Force optimize listed dependencies (must be resolvable import paths,
    * cannot be globs).
@@ -141,6 +131,20 @@ export interface DepOptimizationOptions {
    * @experimental
    */
   disabled?: boolean | 'build' | 'dev'
+}
+
+export type DepOptimizationOptions = DepOptimizationConfig & {
+  /**
+   * By default, Vite will crawl your `index.html` to detect dependencies that
+   * need to be pre-bundled. If `build.rollupOptions.input` is specified, Vite
+   * will crawl those entry points instead.
+   *
+   * If neither of these fit your needs, you can specify custom entries using
+   * this option - the value should be a fast-glob pattern or array of patterns
+   * (https://github.com/mrmlnc/fast-glob#basic-syntax) that are relative from
+   * vite project root. This will overwrite default entries inference.
+   */
+  entries?: string | string[]
   /**
    * Force dep pre-optimization regardless of whether deps have changed.
    * @experimental
@@ -223,22 +227,26 @@ export async function optimizeDeps(
 ): Promise<DepOptimizationMetadata> {
   const log = asCommand ? config.logger.info : debug
 
+  const ssr = !!config.build.ssr
+
   const cachedMetadata = loadCachedDepOptimizationMetadata(
     config,
+    ssr,
     force,
     asCommand
   )
   if (cachedMetadata) {
     return cachedMetadata
   }
+
   const deps = await discoverProjectDependencies(config)
 
   const depsString = depsLogString(Object.keys(deps))
   log(colors.green(`Optimizing dependencies:\n  ${depsString}`))
 
-  await addManuallyIncludedOptimizeDeps(deps, config)
+  await addManuallyIncludedOptimizeDeps(deps, config, ssr)
 
-  const depsInfo = toDiscoveredDependencies(config, deps, !!config.build.ssr)
+  const depsInfo = toDiscoveredDependencies(config, deps, ssr)
 
   const result = await runOptimizeDeps(config, depsInfo)
 
@@ -250,11 +258,12 @@ export async function optimizeDeps(
 export async function optimizeServerSsrDeps(
   config: ResolvedConfig
 ): Promise<DepOptimizationMetadata> {
+  const ssr = true
   const cachedMetadata = loadCachedDepOptimizationMetadata(
     config,
+    ssr,
     config.optimizeDeps.force,
-    false,
-    true // ssr
+    false
   )
   if (cachedMetadata) {
     return cachedMetadata
@@ -262,6 +271,8 @@ export async function optimizeServerSsrDeps(
 
   let alsoInclude: string[] | undefined
   let noExternalFilter: ((id: unknown) => boolean) | undefined
+
+  const { exclude } = getDepOptimizationConfig(config, ssr)
 
   const noExternal = config.ssr?.noExternal
   if (noExternal) {
@@ -271,7 +282,7 @@ export async function optimizeServerSsrDeps(
     noExternalFilter =
       noExternal === true
         ? (dep: unknown) => false
-        : createFilter(noExternal, config.optimizeDeps?.exclude, {
+        : createFilter(noExternal, exclude, {
             resolve: false
           })
   }
@@ -281,6 +292,7 @@ export async function optimizeServerSsrDeps(
   await addManuallyIncludedOptimizeDeps(
     deps,
     config,
+    ssr,
     alsoInclude,
     noExternalFilter
   )
@@ -296,9 +308,10 @@ export async function optimizeServerSsrDeps(
 
 export function initDepsOptimizerMetadata(
   config: ResolvedConfig,
+  ssr: boolean,
   timestamp?: string
 ): DepOptimizationMetadata {
-  const hash = getDepHash(config)
+  const hash = getDepHash(config, ssr)
   return {
     hash,
     browserHash: getOptimizedBrowserHash(hash, {}, timestamp),
@@ -325,9 +338,9 @@ export function addOptimizedDepInfo(
  */
 export function loadCachedDepOptimizationMetadata(
   config: ResolvedConfig,
+  ssr: boolean,
   force = config.optimizeDeps.force,
-  asCommand = false,
-  ssr = !!config.build.ssr
+  asCommand = false
 ): DepOptimizationMetadata | undefined {
   const log = asCommand ? config.logger.info : debug
 
@@ -349,7 +362,7 @@ export function loadCachedDepOptimizationMetadata(
       )
     } catch (e) {}
     // hash is consistent, no need to re-bundle
-    if (cachedMetadata && cachedMetadata.hash === getDepHash(config)) {
+    if (cachedMetadata && cachedMetadata.hash === getDepHash(config, ssr)) {
       log('Hash is consistent. Skipping. Use --force to override.')
       // Nothing to commit or cancel as we are using the cache, we only
       // need to resolve the processing promise so requests can move on
@@ -396,7 +409,7 @@ export function toDiscoveredDependencies(
   timestamp?: string
 ): Record<string, OptimizedDepInfo> {
   const browserHash = getOptimizedBrowserHash(
-    getDepHash(config),
+    getDepHash(config, ssr),
     deps,
     timestamp
   )
@@ -408,7 +421,7 @@ export function toDiscoveredDependencies(
       file: getOptimizedDepPath(id, config, ssr),
       src,
       browserHash: browserHash,
-      exportsData: extractExportsData(src, config)
+      exportsData: extractExportsData(src, config, ssr)
     }
   }
   return discovered
@@ -463,7 +476,7 @@ export async function runOptimizeDeps(
     JSON.stringify({ type: 'module' })
   )
 
-  const metadata = initDepsOptimizerMetadata(config)
+  const metadata = initDepsOptimizerMetadata(config, ssr)
 
   metadata.browserHash = getOptimizedBrowserHash(
     metadata.hash,
@@ -504,13 +517,14 @@ export async function runOptimizeDeps(
   const idToExports: Record<string, ExportsData> = {}
   const flatIdToExports: Record<string, ExportsData> = {}
 
-  const { plugins = [], ...esbuildOptions } =
-    config.optimizeDeps?.esbuildOptions ?? {}
+  const optimizeDeps = getDepOptimizationConfig(config, ssr)
+
+  const { plugins = [], ...esbuildOptions } = optimizeDeps?.esbuildOptions ?? {}
 
   for (const id in depsInfo) {
     const src = depsInfo[id].src!
     const exportsData = await (depsInfo[id].exportsData ??
-      extractExportsData(src, config))
+      extractExportsData(src, config, ssr))
     if (exportsData.jsxLoader) {
       // Ensure that optimization won't fail by defaulting '.js' to the JSX parser.
       // This is useful for packages such as Gatsby.
@@ -558,7 +572,7 @@ export async function runOptimizeDeps(
           }
         : undefined,
     target: isBuild ? config.build.target || undefined : ESBUILD_MODULES_TARGET,
-    external: config.optimizeDeps?.exclude,
+    external: optimizeDeps?.exclude,
     logLevel: 'error',
     splitting: true,
     sourcemap: true,
@@ -599,7 +613,7 @@ export async function runOptimizeDeps(
       browserHash: metadata.browserHash,
       // After bundling we have more information and can warn the user about legacy packages
       // that require manual configuration
-      needsInterop: needsInterop(config, id, idToExports[id], output)
+      needsInterop: needsInterop(config, ssr, id, idToExports[id], output)
     })
   }
 
@@ -634,20 +648,23 @@ export async function runOptimizeDeps(
 }
 
 export async function findKnownImports(
-  config: ResolvedConfig
+  config: ResolvedConfig,
+  ssr: boolean
 ): Promise<string[]> {
   const deps = (await scanImports(config)).deps
-  await addManuallyIncludedOptimizeDeps(deps, config)
+  await addManuallyIncludedOptimizeDeps(deps, config, ssr)
   return Object.keys(deps)
 }
 
 export async function addManuallyIncludedOptimizeDeps(
   deps: Record<string, string>,
   config: ResolvedConfig,
+  ssr: boolean,
   extra: string[] = [],
   filter?: (id: string) => boolean
 ): Promise<void> {
-  const optimizeDepsInclude = config.optimizeDeps?.include ?? []
+  const optimizeDeps = getDepOptimizationConfig(config, ssr)
+  const optimizeDepsInclude = optimizeDeps?.include ?? []
   if (optimizeDepsInclude.length || extra.length) {
     const resolve = config.createResolver({ asSrc: false, scan: true })
     for (const id of [...optimizeDepsInclude, ...extra]) {
@@ -657,7 +674,7 @@ export async function addManuallyIncludedOptimizeDeps(
       if (!deps[normalizedId] && filter?.(normalizedId) !== false) {
         const entry = await resolve(id)
         if (entry) {
-          if (isOptimizable(entry, config.optimizeDeps)) {
+          if (isOptimizable(entry, optimizeDeps)) {
             deps[normalizedId] = entry
           } else if (optimizeDepsInclude.includes(id)) {
             config.logger.warn(
@@ -865,12 +882,15 @@ function esbuildOutputFromId(
 
 export async function extractExportsData(
   filePath: string,
-  config: ResolvedConfig
+  config: ResolvedConfig,
+  ssr: boolean
 ): Promise<ExportsData> {
   await init
 
-  const esbuildOptions = config.optimizeDeps?.esbuildOptions ?? {}
-  if (config.optimizeDeps.extensions?.some((ext) => filePath.endsWith(ext))) {
+  const optimizeDeps = getDepOptimizationConfig(config, ssr)
+
+  const esbuildOptions = optimizeDeps?.esbuildOptions ?? {}
+  if (optimizeDeps.extensions?.some((ext) => filePath.endsWith(ext))) {
     // For custom supported extensions, build the entry file to transform it into JS,
     // and then parse with es-module-lexer. Note that the `bundle` option is not `true`,
     // so only the entry file is being transformed.
@@ -933,12 +953,13 @@ const KNOWN_INTEROP_IDS = new Set(['moment'])
 
 function needsInterop(
   config: ResolvedConfig,
+  ssr: boolean,
   id: string,
   exportsData: ExportsData,
   output?: { exports: string[] }
 ): boolean {
   if (
-    config.optimizeDeps?.needsInterop?.includes(id) ||
+    getDepOptimizationConfig(config, ssr)?.needsInterop?.includes(id) ||
     KNOWN_INTEROP_IDS.has(id)
   ) {
     return true
@@ -972,10 +993,11 @@ function isSingleDefaultExport(exports: readonly string[]) {
 
 const lockfileFormats = ['package-lock.json', 'yarn.lock', 'pnpm-lock.yaml']
 
-export function getDepHash(config: ResolvedConfig): string {
+export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
   let content = lookupFile(config.root, lockfileFormats) || ''
   // also take config into account
   // only a subset of config options that can affect dep optimization
+  const optimizeDeps = getDepOptimizationConfig(config, ssr)
   content += JSON.stringify(
     {
       mode: process.env.NODE_ENV || config.mode,
@@ -985,13 +1007,11 @@ export function getDepHash(config: ResolvedConfig): string {
       assetsInclude: config.assetsInclude,
       plugins: config.plugins.map((p) => p.name),
       optimizeDeps: {
-        include: config.optimizeDeps?.include,
-        exclude: config.optimizeDeps?.exclude,
+        include: optimizeDeps?.include,
+        exclude: optimizeDeps?.exclude,
         esbuildOptions: {
-          ...config.optimizeDeps?.esbuildOptions,
-          plugins: config.optimizeDeps?.esbuildOptions?.plugins?.map(
-            (p) => p.name
-          )
+          ...optimizeDeps?.esbuildOptions,
+          plugins: optimizeDeps?.esbuildOptions?.plugins?.map((p) => p.name)
         }
       }
     },
@@ -1044,13 +1064,15 @@ function findOptimizedDepInfoInRecord(
 export async function optimizedDepNeedsInterop(
   metadata: DepOptimizationMetadata,
   file: string,
-  config: ResolvedConfig
+  config: ResolvedConfig,
+  ssr: boolean
 ): Promise<boolean | undefined> {
   const depInfo = optimizedDepInfoFromFile(metadata, file)
   if (depInfo?.src && depInfo.needsInterop === undefined) {
-    depInfo.exportsData ??= extractExportsData(depInfo.src, config)
+    depInfo.exportsData ??= extractExportsData(depInfo.src, config, ssr)
     depInfo.needsInterop = needsInterop(
       config,
+      ssr,
       depInfo.id,
       await depInfo.exportsData
     )

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -692,6 +692,7 @@ export async function addManuallyIncludedOptimizeDeps(
   extra: string[] = [],
   filter?: (id: string) => boolean
 ): Promise<void> {
+  const { logger } = config
   const optimizeDeps = getDepOptimizationConfig(config, ssr)
   const optimizeDepsInclude = optimizeDeps?.include ?? []
   if (optimizeDepsInclude.length || extra.length) {
@@ -706,13 +707,20 @@ export async function addManuallyIncludedOptimizeDeps(
           if (isOptimizable(entry, optimizeDeps)) {
             deps[normalizedId] = entry
           } else if (optimizeDepsInclude.includes(id)) {
-            config.logger.warn(
-              `Cannot optimize included dependency: ${colors.cyan(id)}`
+            logger.warn(
+              `Cannot optimize dependency: ${colors.cyan(
+                id
+              )}, present in 'include'`
             )
           }
         } else {
-          throw new Error(
-            `Failed to resolve force included dependency: ${colors.cyan(id)}`
+          const configOptionName = optimizeDepsInclude.includes(id)
+            ? 'include'
+            : 'noExternal'
+          logger.warn(
+            `Failed to resolve dependency: ${colors.cyan(
+              id
+            )}, present in '${configOptionName}'`
           )
         }
       }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -44,6 +44,8 @@ export async function scanImports(config: ResolvedConfig): Promise<{
   deps: Record<string, string>
   missing: Record<string, string>
 }> {
+  // Only used to scan non-ssr code
+
   const start = performance.now()
 
   let entries: string[] = []

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -9,6 +9,7 @@ import { parse as parseJS } from 'acorn'
 import type { Node } from 'estree'
 import { findStaticImports, parseStaticImport } from 'mlly'
 import { makeLegalIdentifier } from '@rollup/pluginutils'
+import { getDepOptimizationConfig } from '..'
 import type { ViteDevServer } from '..'
 import {
   CLIENT_DIR,
@@ -214,7 +215,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         )
       }
 
-      const depsOptimizer = getDepsOptimizer(config, { ssr })
+      const depsOptimizer = getDepsOptimizer(config, ssr)
 
       const { moduleGraph } = server
       // since we are already in the transform phase of the importer, it must
@@ -267,7 +268,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
 
         let importerFile = importer
-        if (moduleListContains(config.optimizeDeps?.exclude, url)) {
+
+        const optimizeDeps = getDepOptimizationConfig(config, ssr)
+        if (moduleListContains(optimizeDeps?.exclude, url)) {
           if (depsOptimizer) {
             await depsOptimizer.scanProcessing
 
@@ -485,7 +488,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               const needsInterop = await optimizedDepNeedsInterop(
                 depsOptimizer.metadata,
                 file,
-                config
+                config,
+                ssr
               )
 
               if (needsInterop === undefined) {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -14,6 +14,7 @@ import {
   moduleListContains
 } from '../utils'
 import type { Plugin } from '../plugin'
+import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig } from '../config'
 import { genSourceMapUrl } from '../server/sourcemap'
 import { getDepsOptimizer, optimizedDepNeedsInterop } from '../optimizer'
@@ -155,7 +156,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       const { root } = config
-      const depsOptimizer = getDepsOptimizer(config, { ssr })
+      const depsOptimizer = getDepsOptimizer(config, ssr)
 
       const normalizeUrl = async (
         url: string,
@@ -163,7 +164,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       ): Promise<[string, string]> => {
         let importerFile = importer
 
-        if (moduleListContains(config.optimizeDeps?.exclude, url)) {
+        const optimizeDeps = getDepOptimizationConfig(config, ssr)
+        if (moduleListContains(optimizeDeps?.exclude, url)) {
           if (depsOptimizer) {
             await depsOptimizer.scanProcessing
 
@@ -260,7 +262,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               const needsInterop = await optimizedDepNeedsInterop(
                 depsOptimizer.metadata,
                 file,
-                config
+                config,
+                ssr
               )
 
               let rewriteDone = false

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -33,7 +33,6 @@ export async function resolvePlugins(
 ): Promise<Plugin[]> {
   const isBuild = config.command === 'build'
   const isWatch = isBuild && !!config.build.watch
-
   const buildPlugins = isBuild
     ? (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
@@ -47,7 +46,8 @@ export async function resolvePlugins(
     config.build.polyfillModulePreload
       ? modulePreloadPolyfillPlugin(config)
       : null,
-    ...(isDepsOptimizerEnabled(config)
+    ...(isDepsOptimizerEnabled(config, false) ||
+    isDepsOptimizerEnabled(config, true)
       ? [
           isBuild
             ? optimizedDepsBuildPlugin(config)
@@ -62,8 +62,7 @@ export async function resolvePlugins(
       packageCache: config.packageCache,
       ssrConfig: config.ssr,
       asSrc: true,
-      getDepsOptimizer: (type: { ssr?: boolean }) =>
-        getDepsOptimizer(config, type),
+      getDepsOptimizer: (ssr: boolean) => getDepsOptimizer(config, ssr),
       shouldExternalize:
         isBuild && config.build.ssr && config.ssr?.format !== 'cjs'
           ? (id) => shouldExternalizeForSSR(id, config)

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -18,7 +18,7 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:optimized-deps',
 
     async resolveId(id, source, { ssr }) {
-      if (getDepsOptimizer(config, { ssr })?.isOptimizedDepFile(id)) {
+      if (getDepsOptimizer(config, ssr)?.isOptimizedDepFile(id)) {
         return id
       }
     },
@@ -29,7 +29,7 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
 
     async load(id, options) {
       const ssr = options?.ssr === true
-      const depsOptimizer = getDepsOptimizer(config, { ssr })
+      const depsOptimizer = getDepsOptimizer(config, ssr)
       if (depsOptimizer?.isOptimizedDepFile(id)) {
         const metadata = depsOptimizer.metadata
         const file = cleanUrl(id)
@@ -85,29 +85,26 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
       if (!config.isWorker) {
         // This will be run for the current active optimizer, during build
         // it will be the SSR optimizer if config.build.ssr is defined
-        getDepsOptimizer(config, { ssr: undefined })?.resetRegisteredIds()
+        getDepsOptimizer(config)?.resetRegisteredIds()
       }
     },
 
     async resolveId(id, importer, { ssr }) {
-      if (getDepsOptimizer(config, { ssr })?.isOptimizedDepFile(id)) {
+      if (getDepsOptimizer(config, ssr)?.isOptimizedDepFile(id)) {
         return id
       }
     },
 
     transform(_code, id, options) {
       const ssr = options?.ssr === true
-      getDepsOptimizer(config, { ssr })?.delayDepsOptimizerUntil(
-        id,
-        async () => {
-          await this.load({ id })
-        }
-      )
+      getDepsOptimizer(config, ssr)?.delayDepsOptimizerUntil(id, async () => {
+        await this.load({ id })
+      })
     },
 
     async load(id, options) {
       const ssr = options?.ssr === true
-      const depsOptimizer = getDepsOptimizer(config, { ssr })
+      const depsOptimizer = getDepsOptimizer(config, ssr)
       if (!depsOptimizer?.isOptimizedDepFile(id)) {
         return
       }

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -13,7 +13,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:pre-alias',
     async resolveId(id, importer, options) {
       const ssr = options?.ssr === true
-      const depsOptimizer = getDepsOptimizer(config, { ssr })
+      const depsOptimizer = getDepsOptimizer(config, ssr)
       if (
         importer &&
         depsOptimizer &&

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -83,7 +83,7 @@ export interface InternalResolveOptions extends ResolveOptions {
   // True when resolving during the scan phase to discover dependencies
   scan?: boolean
   // Resolve using esbuild deps optimization
-  getDepsOptimizer?: (type: { ssr?: boolean }) => DepsOptimizer | undefined
+  getDepsOptimizer?: (ssr: boolean) => DepsOptimizer | undefined
   shouldExternalize?: (id: string) => boolean | undefined
 }
 
@@ -106,7 +106,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
       // We need to delay depsOptimizer until here instead of passing it as an option
       // the resolvePlugin because the optimizer is created on server listen during dev
-      const depsOptimizer = resolveOptions.getDepsOptimizer?.({ ssr })
+      const depsOptimizer = resolveOptions.getDepsOptimizer?.(ssr)
 
       if (id.startsWith(browserExternalId)) {
         return id

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -270,7 +270,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         : 'module'
       const workerOptions = workerType === 'classic' ? '' : ',{type: "module"}'
       if (isBuild) {
-        getDepsOptimizer(config, { ssr })?.registerWorkersSource(id)
+        getDepsOptimizer(config, ssr)?.registerWorkersSource(id)
         if (query.inline != null) {
           const chunk = await bundleWorkerEntry(config, id, query)
           // inline as blob data url

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -118,7 +118,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
           let url: string
           if (isBuild) {
-            getDepsOptimizer(config, { ssr })?.registerWorkersSource(id)
+            getDepsOptimizer(config, ssr)?.registerWorkersSource(id)
             url = await workerFileToUrl(config, file, query)
           } else {
             url = await fileToUrl(cleanUrl(file), config, this)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -329,7 +329,7 @@ export async function createServer(
     },
     transformIndexHtml: null!, // to be immediately set
     async ssrLoadModule(url, opts?: { fixStacktrace?: boolean }) {
-      if (isDepsOptimizerEnabled(config)) {
+      if (isDepsOptimizerEnabled(config, true)) {
         await initDevSsrDepsOptimizer(config, server)
       }
       await updateCjsSsrExternals(server)
@@ -539,7 +539,8 @@ export async function createServer(
     }
     initingServer = (async function () {
       await container.buildStart({})
-      if (isDepsOptimizerEnabled(config)) {
+      if (isDepsOptimizerEnabled(config, false)) {
+        // non-ssr
         await initDepsOptimizer(config, server)
       }
       initingServer = undefined
@@ -776,7 +777,7 @@ async function updateCjsSsrExternals(server: ViteDevServer) {
     // This is part of the v2 externalization heuristics and it is kept
     // for backwards compatibility in case user needs to fallback to the
     // legacy scheme. It may be removed in a future v3 minor.
-    const depsOptimizer = getDepsOptimizer(server.config, { ssr: false })
+    const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
 
     if (depsOptimizer) {
       await depsOptimizer.scanProcessing

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -71,11 +71,8 @@ export function transformMiddleware(
       const isSourceMap = withoutQuery.endsWith('.map')
       // since we generate source map references, handle those requests here
       if (isSourceMap) {
-        if (
-          getDepsOptimizer(server.config, { ssr: false })?.isOptimizedDepUrl(
-            url
-          )
-        ) {
+        const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
+        if (depsOptimizer?.isOptimizedDepUrl(url)) {
           // If the browser is requesting a source map for an optimized dep, it
           // means that the dependency has already been pre-bundled and loaded
           const mapFile = url.startsWith(FS_PREFIX)
@@ -189,12 +186,10 @@ export function transformMiddleware(
           html: req.headers.accept?.includes('text/html')
         })
         if (result) {
+          const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
           const type = isDirectCSSRequest(url) ? 'css' : 'js'
           const isDep =
-            DEP_VERSION_RE.test(url) ||
-            getDepsOptimizer(server.config, { ssr: false })?.isOptimizedDepUrl(
-              url
-            )
+            DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
           return send(req, res, result.code, type, {
             etag: result.etag,
             // allow browser to cache npm deps!

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -145,7 +145,7 @@ async function doTransform(
 
   const result = loadAndTransform(id, url, server, options, timestamp)
 
-  getDepsOptimizer(config, { ssr })?.delayDepsOptimizerUntil(id, () => result)
+  getDepsOptimizer(config, ssr)?.delayDepsOptimizerUntil(id, () => result)
 
   return result
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -28,6 +28,7 @@ import {
   VALID_ID_PREFIX,
   wildcardHosts
 } from './constants'
+import type { DepOptimizationConfig } from './optimizer'
 import type { ResolvedConfig } from '.'
 
 /**
@@ -94,11 +95,12 @@ export function moduleListContains(
 
 export function isOptimizable(
   id: string,
-  optimizeDepsConfig: ResolvedConfig['optimizeDeps']
+  optimizeDeps: DepOptimizationConfig
 ): boolean {
+  const { extensions } = optimizeDeps
   return (
     OPTIMIZABLE_ENTRY_RE.test(id) ||
-    (optimizeDepsConfig.extensions?.some((ext) => id.endsWith(ext)) ?? false)
+    (extensions?.some((ext) => id.endsWith(ext)) ?? false)
   )
 }
 


### PR DESCRIPTION
### Description

#### Context:
- Comments here https://github.com/vitejs/vite/pull/8869#issuecomment-1173191643
- And [in discord with @bluwy](https://discord.com/channels/804011606160703521/993159290116390912/993425842980003850)

##### Build SSR

We were using `@rollup/plugin-commonjs`, needed for `noExternal` CJS deps in Vite v2. For `external` deps nothing is needed. In v3 we replace the plugin with esbuild deps optimization. Implemented in:
- https://github.com/vitejs/vite/pull/8403

##### Dev SSR

There is already interop, but it isn't perfect. Allowing users to optimize explicitly defined deps is a way to deal with problematic CJS deps in the SSR dev server. Implemented in:
- https://github.com/vitejs/vite/pull/8430
- https://github.com/vitejs/vite/pull/8854

#### Issue

In the PRs above we optimized every `noExternal` dep by default (during build we have the complete list, during dev only the explicit ones, but SSR dev interop is normally enough)

We also made `optimizeDeps.include/exclude` configure the way SSR optimization works. The problem is that the client env is quite different from the SSR env. @brillout, @benmccann, and others have been pushing hard for deps to be `external` by default (that we got done in v3).

We have conflicting requirements here, we have recommended people to use both `include` and `external`.

For the client, we need to optimize deps because:
- Interop with CJS
- Dependencies can end up sending too many files to the browser (lodash/es, etc), so we need to pre-bundle them

For SSR, we want to optimize deps only because:
- They were set as `noExternal` and they are CJS

So for the browser, we want people to add things to `include`, but we don't want all these deps to be optimized during SSR. The best is to leave ESM deps untouched.

This PRs allows us to avoid the conflict by introducing a new `ssr.optimizeDeps` experimental option. So users can continue to use `config.optimizeDeps` for client only. esbuildOptions modifications are also specific to the client or ssr.

There are no overrides from `optimizeDeps` to `ssr.optimizeDeps`, both are independent for the reasons above.

```js
ssr: {
  noExternal: [...],
  external: [...], <- by default, only useful to overwrite a noExternal pattern
  optimizeDeps: {
    exclude: [...], <- no external deps are optimized by default, use exclude to bail out
    esbuildOptions: { ... } <- custom config for SSR
  }
}
```

#### Fixes

The PR also takes into account `exclude` to define the `external` scheme started by @sodatea. Soda, I moved the plugin from config to the optimizer because we have the context needed (dev/build, ssr/non-ssr needed).

#### Refactor

- `getDepsOptimizer(config, { ssr })` => `getDepsOptimizer(config, ssr)`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other