### PR TITLE
feat: avoid scanner during build and only optimize CJS in SSR

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,21 +1,15 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-  optimizeDeps: {
-    // vitepress is an aliased with replacement `join(DIST_CLIENT_PATH, '/index')`
-    // This needs to be excluded from optimization
-    exclude: ['vitepress']
-  },
   ssr: {
-    // And it is also marked as noExternal, so it is safer to exclude it in SSR too
-    // Right now in Vite we are bailing out for aliased deps during SSR by default
-    // but this may change in the future
-    optimizeDeps: {
-      exclude: ['vitepress']
-    },
     format: 'cjs'
   },
   legacy: {
     buildSsrCjsExternalHeuristics: true
+  },
+  optimizeDeps: {
+    // vitepress is aliased with replacement `join(DIST_CLIENT_PATH, '/index')`
+    // This needs to be excluded from optimization
+    exclude: ['vitepress']
   }
 })

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,7 +1,18 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  optimizeDeps: {
+    // vitepress is an aliased with replacement `join(DIST_CLIENT_PATH, '/index')`
+    // This needs to be excluded from optimization
+    exclude: ['vitepress']
+  },
   ssr: {
+    // And it is also marked as noExternal, so it is safer to exclude it in SSR too
+    // Right now in Vite we are bailing out for aliased deps during SSR by default
+    // but this may change in the future
+    optimizeDeps: {
+      exclude: ['vitepress']
+    },
     format: 'cjs'
   },
   legacy: {

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -975,7 +975,7 @@ Repository: http://github.com/bripkens/connect-history-api-fallback.git
 
 > The MIT License
 > 
-> Copyright (c) 2012 Ben Ripkens http://bripkens.de
+> Copyright (c) 2022 Ben Blackmore and contributors
 > 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -545,7 +545,9 @@ export async function resolveConfig(
             ]
           }))
       }
-      return (await container.resolveId(id, importer, { ssr }))?.id
+      return (
+        await container.resolveId(id, importer, { ssr, scan: options?.scan })
+      )?.id
     }
   }
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -277,7 +277,7 @@ export async function optimizeServerSsrDeps(
     ) as string[]
     noExternalFilter =
       noExternal === true
-        ? (dep: unknown) => false
+        ? (dep: unknown) => true
         : createFilter(undefined, exclude, {
             resolve: false
           })
@@ -701,16 +701,22 @@ export async function addManuallyIncludedOptimizeDeps(
         )
       }
     }
-    const resolve = config.createResolver({ asSrc: false, scan: true })
+    const resolve = config.createResolver({
+      asSrc: false,
+      scan: true,
+      ssrOptimizeCheck: ssr
+    })
     for (const id of [...optimizeDepsInclude, ...extra]) {
       // normalize 'foo   >bar` as 'foo > bar' to prevent same id being added
       // and for pretty printing
       const normalizedId = normalizeId(id)
       if (!deps[normalizedId] && filter?.(normalizedId) !== false) {
-        const entry = await resolve(id)
+        const entry = await resolve(id, undefined, undefined, ssr)
         if (entry) {
           if (isOptimizable(entry, optimizeDeps)) {
-            deps[normalizedId] = entry
+            if (!entry.endsWith('?__vite_skip_optimization')) {
+              deps[normalizedId] = entry
+            }
           } else {
             unableToOptimize(entry, 'Cannot optimize dependency')
           }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -54,11 +54,7 @@ export type ExportsData = {
 export interface DepsOptimizer {
   metadata: DepOptimizationMetadata
   scanProcessing?: Promise<void>
-  registerMissingImport: (
-    id: string,
-    resolved: string,
-    ssr?: boolean
-  ) => OptimizedDepInfo
+  registerMissingImport: (id: string, resolved: string) => OptimizedDepInfo
   run: () => void
 
   isOptimizedDepFile: (id: string) => boolean

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -183,11 +183,10 @@ async function createDepsOptimizer(
       newDepsDiscovered = true
     }
 
-    // TODO: We need the scan during build time, until preAliasPlugin
-    // is refactored to work without the scanned deps. We could skip
-    // this for build later.
-
-    runScanner()
+    if (!isBuild) {
+      // The scanner is dev only
+      runScanner()
+    }
   }
 
   async function runScanner() {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -184,7 +184,7 @@ async function createDepsOptimizer(
     }
 
     if (!isBuild) {
-      // The scanner is dev only
+      // Important, the scanner is dev only
       runScanner()
     }
   }

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -28,7 +28,9 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
         importer &&
         depsOptimizer &&
         bareImportRE.test(id) &&
-        !options?.scan
+        !options?.scan &&
+        id !== '@vite/client' &&
+        id !== '@vite/env'
       ) {
         if (findPatterns.find((pattern) => matches(pattern, id))) {
           const optimizedId = await tryOptimizedResolve(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -698,7 +698,7 @@ export function tryNodeResolve(
   } else {
     // this is a missing import, queue optimize-deps re-run and
     // get a resolved its optimized info
-    const optimizedInfo = depsOptimizer.registerMissingImport(id, resolved, ssr)
+    const optimizedInfo = depsOptimizer.registerMissingImport(id, resolved)
     resolved = depsOptimizer.getOptimizedDepId(optimizedInfo)
   }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -82,6 +82,8 @@ export interface InternalResolveOptions extends ResolveOptions {
   tryEsmOnly?: boolean
   // True when resolving during the scan phase to discover dependencies
   scan?: boolean
+  // Appends ?__vite_skip_optimization to the resolved id if shouldn't be optimized
+  ssrOptimizeCheck?: boolean
   // Resolve using esbuild deps optimization
   getDepsOptimizer?: (ssr: boolean) => DepsOptimizer | undefined
   shouldExternalize?: (id: string) => boolean | undefined
@@ -665,32 +667,57 @@ export function tryNodeResolve(
     })
   }
 
+  const ext = path.extname(resolved)
+  const isCJS = ext === '.cjs' || (ext === '.js' && pkg.data.type !== 'module')
+
   if (
-    !resolved.includes('node_modules') || // linked
-    !depsOptimizer || // resolving before listening to the server
-    options.scan // initial esbuild scan phase
+    !options.ssrOptimizeCheck &&
+    (!resolved.includes('node_modules') || // linked
+      !depsOptimizer || // resolving before listening to the server
+      options.scan) // initial esbuild scan phase
   ) {
     return { id: resolved }
   }
+
   // if we reach here, it's a valid dep import that hasn't been optimized.
   const isJsType = OPTIMIZABLE_ENTRY_RE.test(resolved)
 
-  const exclude = depsOptimizer.options.exclude
-  if (
+  let exclude = depsOptimizer?.options.exclude
+  let include = depsOptimizer?.options.exclude
+  if (options.ssrOptimizeCheck) {
+    // we don't have the depsOptimizer
+    exclude = options.ssrConfig?.optimizeDeps?.exclude
+    include = options.ssrConfig?.optimizeDeps?.exclude
+  }
+
+  const skipOptimization =
     !isJsType ||
     importer?.includes('node_modules') ||
     exclude?.includes(pkgId) ||
     exclude?.includes(nestedPath) ||
     SPECIAL_QUERY_RE.test(resolved) ||
-    (!isBuild && ssr)
-  ) {
+    (!isBuild && ssr) ||
+    // Only optimize non-external CJS deps during SSR by default
+    (ssr &&
+      !isCJS &&
+      !(include?.includes(pkgId) || include?.includes(nestedPath)))
+
+  if (options.ssrOptimizeCheck) {
+    return {
+      id: skipOptimization
+        ? injectQuery(resolved, `__vite_skip_optimization`)
+        : resolved
+    }
+  }
+
+  if (skipOptimization) {
     // excluded from optimization
     // Inject a version query to npm deps so that the browser
     // can cache it without re-validation, but only do so for known js types.
     // otherwise we may introduce duplicated modules for externalized files
     // from pre-bundled deps.
     if (!isBuild) {
-      const versionHash = depsOptimizer.metadata.browserHash
+      const versionHash = depsOptimizer!.metadata.browserHash
       if (versionHash && isJsType) {
         resolved = injectQuery(resolved, `v=${versionHash}`)
       }
@@ -698,8 +725,8 @@ export function tryNodeResolve(
   } else {
     // this is a missing import, queue optimize-deps re-run and
     // get a resolved its optimized info
-    const optimizedInfo = depsOptimizer.registerMissingImport(id, resolved)
-    resolved = depsOptimizer.getOptimizedDepId(optimizedInfo)
+    const optimizedInfo = depsOptimizer!.registerMissingImport(id, resolved)
+    resolved = depsOptimizer!.getOptimizedDepId(optimizedInfo)
   }
 
   if (isBuild) {

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -105,20 +105,17 @@ export function shouldExternalizeForSSR(
   return isSsrExternal(id)
 }
 
-function createIsSsrExternal(
+export function createIsConfiguredAsSsrExternal(
   config: ResolvedConfig
-): (id: string) => boolean | undefined {
-  const processedIds = new Map<string, boolean | undefined>()
-
-  const { ssr, root } = config
-
+): (id: string) => boolean {
+  const { ssr } = config
   const noExternal = ssr?.noExternal
   const noExternalFilter =
     noExternal !== 'undefined' &&
     typeof noExternal !== 'boolean' &&
     createFilter(undefined, noExternal, { resolve: false })
 
-  const isConfiguredAsExternal = (id: string) => {
+  return (id: string) => {
     const { ssr } = config
     if (!ssr || ssr.external?.includes(id)) {
       return true
@@ -131,6 +128,16 @@ function createIsSsrExternal(
     }
     return true
   }
+}
+
+function createIsSsrExternal(
+  config: ResolvedConfig
+): (id: string) => boolean | undefined {
+  const processedIds = new Map<string, boolean | undefined>()
+
+  const { ssr, root } = config
+
+  const isConfiguredAsExternal = createIsConfiguredAsSsrExternal(config)
 
   const resolveOptions: InternalResolveOptions = {
     root,


### PR DESCRIPTION
### Description

Follow up to:
- https://github.com/vitejs/vite/pull/8869

That enabled back the scanner also during build to fix:
- https://github.com/vitejs/vite/issues/8867

This PR avoids the scanner by refactoring preAlias to register the aliased dependency when needed.

With this, we also now support aliased optimized deps when added in an import by a plugin. This was failing before because they were invisible to the scanner

The PR now also implements the change in heuristics to what needs to be optimized during SSR. Only no-external CJS deps will be optimized during SSR, the user can opt-in using `ssr.optimizeDeps.include`

Some details:
- If a dependency is aliased, it isn't optimized by default even if the replacement is CJS. Users can include it to be optimized. We could support this by loading the entry and using mlly, or by recursively finding the package.json to see if the replacement is in a commonjs or module context. I don't know if the complexity is worth it.
- Added `'vitepress'` to `optimizeDeps.exclude` since it is aliased with replacement `join(DIST_CLIENT_PATH, '/index')`, and in it a virtual module is used. This was not a problem with commonjs during build, but now dependencies need to be excluded if they are using Vite features.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other