### PR TITLE
feat: skip css and json transform for \0

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -192,6 +192,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       if (
         !isCSSRequest(id) ||
         commonjsProxyRE.test(id) ||
+        id.startsWith('\0') ||
         SPECIAL_QUERY_RE.test(id)
       ) {
         return
@@ -340,6 +341,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       if (
         !isCSSRequest(id) ||
         commonjsProxyRE.test(id) ||
+        id.startsWith('\0') ||
         SPECIAL_QUERY_RE.test(id)
       ) {
         return

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -42,7 +42,7 @@ export function jsonPlugin(
 
     transform(json, id) {
       if (!jsonExtRE.test(id)) return null
-      if (SPECIAL_QUERY_RE.test(id)) return null
+      if (id.startsWith('\0') || SPECIAL_QUERY_RE.test(id)) return null
 
       json = stripBomTag(json)
 

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -443,3 +443,7 @@ test.skip('aliased css has content', async () => {
   expect(await page.textContent('.aliased-content')).toMatch('.aliased')
   expect(await getColor('.aliased-module')).toBe('blue')
 })
+
+test('css plugin skip when id starts with null byte', async () => {
+  expect(await page.textContent('.null-byte')).toBe('i_am_special')
+})

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -153,6 +153,9 @@
   <p class="aliased">import '#alias': this should be blue</p>
   <pre class="aliased-content"></pre>
   <p class="aliased-module">import '#alias-module': this should be blue</p>
+
+  <p>Null byte</p>
+  <pre class="null-byte"></pre>
 </div>
 
 <script type="module" src="./main.js"></script>

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -104,3 +104,6 @@ import aliasModule from '#alias-module'
 document
   .querySelector('.aliased-module')
   .classList.add(aliasModule.aliasedModule)
+
+import special from 'special.css'
+text('.null-byte', special)

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -4,6 +4,7 @@ const path = require('path')
  * @type {import('vite').UserConfig}
  */
 module.exports = {
+  plugins: [specialCssPlugin()],
   build: {
     cssTarget: 'chrome61'
   },
@@ -50,6 +51,26 @@ module.exports = {
           './options/relative-import.styl',
           path.join(__dirname, 'options/absolute-import.styl')
         ]
+      }
+    }
+  }
+}
+
+/**
+ * @returns {import('vite').Plugin}
+ */
+function specialCssPlugin() {
+  return {
+    name: 'special-css-plugin',
+    enforce: 'pre',
+    resolveId(id) {
+      if (id === 'special.css') {
+        return '\0special.css'
+      }
+    },
+    load(id) {
+      if (id === '\0special.css') {
+        return `export default 'i_am_special'`
       }
     }
   }

--- a/playground/json/__tests__/json.spec.ts
+++ b/playground/json/__tests__/json.spec.ts
@@ -45,3 +45,7 @@ test('?raw', async () => {
     readFileSync(require.resolve('../test.json'), 'utf-8')
   )
 })
+
+test('json plugin skip when id starts with null byte', async () => {
+  expect(await page.textContent('.null-byte')).toBe('i_am_special')
+})

--- a/playground/json/index.html
+++ b/playground/json/index.html
@@ -25,6 +25,9 @@
 <h2>Has BOM Tag</h2>
 <pre class="bom"></pre>
 
+<p>Null byte</p>
+<pre class="null-byte"></pre>
+
 <script type="module">
   import json, { hello } from './test.json'
   import deepJson, { name } from 'vue/package.json'
@@ -57,6 +60,9 @@
 
   import hasBomJson from './json-bom/has-bom.json'
   text('.bom', JSON.stringify(hasBomJson))
+
+  import special from 'special.json'
+  text('.null-byte', special)
 
   function text(sel, text) {
     document.querySelector(sel).textContent = text

--- a/playground/json/vite.config.js
+++ b/playground/json/vite.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from 'rollup'
+
+export default defineConfig({
+  plugins: [speciaJsonPlugin()]
+})
+
+/**
+ * @returns {import('vite').Plugin}
+ */
+function speciaJsonPlugin() {
+  return {
+    name: 'special-json-plugin',
+    enforce: 'pre',
+    resolveId(id) {
+      if (id === 'special.json') {
+        return '\0special.json'
+      }
+    },
+    load(id) {
+      if (id === '\0special.json') {
+        return `export default 'i_am_special'`
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #8523 

Skip css and json plugin handling when id starts with `\0`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I think this should be safe. It will error if previously people use `\0` and still want the results to be transformed by Vite's css plugin, but I think it's rare.

May be worth running vite-ecosystem-ci against this just in case.

cc @hl037

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
