### PR TITLE
fix(css): always use css module content

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -975,7 +975,7 @@ Repository: http://github.com/bripkens/connect-history-api-fallback.git
 
 > The MIT License
 > 
-> Copyright (c) 2012 Ben Ripkens http://bripkens.de
+> Copyright (c) 2022 Ben Blackmore and contributors
 > 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -426,7 +426,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           code = `export default ${JSON.stringify(content)}`
         }
       } else {
-        code = `export default ''`
+        // if moduleCode exists return it **even if** it does not have `?used`
+        // this will disable tree-shake to work with `import './foo.module.css'` but this usually does not happen
+        // this is a limitation of the current approach by `?used` to make tree-shake work
+        // See #8936 for more details
+        code = modulesCode || `export default ''`
       }
 
       return {

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -349,8 +349,7 @@ test('PostCSS dir-dependency', async () => {
   }
 })
 
-// skip because #8278 is reverted
-test.skip('import dependency includes css import', async () => {
+test('import dependency includes css import', async () => {
   expect(await getColor('.css-js-dep')).toBe('green')
   expect(await getColor('.css-js-dep-module')).toBe('green')
 })
@@ -437,9 +436,9 @@ test('PostCSS source.input.from includes query', async () => {
   )
 })
 
-// skip because #8278 is reverted
-test.skip('aliased css has content', async () => {
+test('aliased css has content', async () => {
   expect(await getColor('.aliased')).toBe('blue')
-  expect(await page.textContent('.aliased-content')).toMatch('.aliased')
+  // skipped: currently not supported see #8936
+  // expect(await page.textContent('.aliased-content')).toMatch('.aliased')
   expect(await getColor('.aliased-module')).toBe('blue')
 })


### PR DESCRIPTION
### Description
Unfortunately I failed to implement what I said at #8900 and ended up reverting https://github.com/vitejs/vite/pull/7591#pullrequestreview-929719208. 😞

This will cause the following code **not to be tree-shaked**.
```js
/* input */
import './foo.module.css' // note that default export is not used

/* output(old) */
// none

/* output(new) */
var foo_module_css = { foo: 'foo_hash' }
```
But because this code usually does not happen, I think it is not so bad.

Also this PR does **not** fix https://github.com/vitejs/vite/issues/8245#issuecomment-1133203490.

For better or worse, this PR could be backported to v2 since this is a simple partial revert of #7591. I'll create it later if we are going this way.

fixes #8245
fixes #8461
refs #8874, #8896

### Additional context

The fix I said at #8900 is to resolve id before injecting `?used`.
But this faced to some issues:

1. `normalize.css` will be `normalize.css?used`.
    - This is correct but the current vite resolver does not handle this case. Handling this case is very difficult and a lot of work will be needed. Previous attempt by other person: https://github.com/vitejs/vite/pull/8824#issuecomment-1173104990
1. `#alias` will be `#alias?used`.
    - This is not safe. `#alias` might be perfect matching like `/^#alias$/`. Replacing to `#alias?used` makes it not to be resolved.

We could use `${resolvedId}?used` (`/path/to/node_modules/normalize.css/normalize.css`) instead. But if there is a `exports` field and `normalize.css` is not included, it will fail to resolve.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
