### PR TITLE
docs: fix `build.chunkSizeWarningLimit` heading level

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -180,12 +180,12 @@ By default, Vite will empty the `outDir` on build if it is inside project root. 
 
 Enable/disable gzip-compressed size reporting. Compressing large output files can be slow, so disabling this may increase build performance for large projects.
 
-### build.chunkSizeWarningLimit
+## build.chunkSizeWarningLimit
 
 - **Type:** `number`
 - **Default:** `500`
 
-  Limit for chunk size warnings (in kbs).
+Limit for chunk size warnings (in kbs).
 
 ## build.watch
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`build.chunkSizeWarningLimit` was the only one using h3.

https://main.vitejs.dev/config/build-options.html#build-reportcompressedsize

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
