### PR TITLE
fix: re-encode url to prevent fs.allow bypass (fixes #8498)

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -109,16 +109,11 @@ export function serveStaticMiddleware(
     }
 
     if (redirected) {
-      req.url = encodePercent(redirected)
+      req.url = encodeURIComponent(redirected)
     }
 
     serve(req, res, next)
   }
-}
-
-const percentRe = /%/g
-function encodePercent(url: string) {
-  return url.includes('%') ? url.replace(percentRe, '%25') : url
 }
 
 export function serveRawFsMiddleware(
@@ -149,7 +144,7 @@ export function serveRawFsMiddleware(
       url = url.slice(FS_PREFIX.length)
       if (isWindows) url = url.replace(/^[A-Z]:/i, '')
 
-      req.url = encodePercent(url)
+      req.url = encodeURIComponent(url)
       serveFromRoot(req, res, next)
     } else {
       next()

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -109,11 +109,16 @@ export function serveStaticMiddleware(
     }
 
     if (redirected) {
-      req.url = redirected
+      req.url = encodePercent(redirected)
     }
 
     serve(req, res, next)
   }
+}
+
+const percentRe = /%/g
+function encodePercent(url: string) {
+  return url.includes('%') ? url.replace(percentRe, '%25') : url
 }
 
 export function serveRawFsMiddleware(
@@ -144,7 +149,7 @@ export function serveRawFsMiddleware(
       url = url.slice(FS_PREFIX.length)
       if (isWindows) url = url.replace(/^[A-Z]:/i, '')
 
-      req.url = url
+      req.url = encodePercent(url)
       serveFromRoot(req, res, next)
     } else {
       next()

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -42,6 +42,11 @@ describe.runIf(isServe)('main', () => {
     expect(await page.textContent('.unsafe-fetch-8498-status')).toBe('403')
   })
 
+  test('unsafe fetch with special characters 2 (#8498)', async () => {
+    expect(await page.textContent('.unsafe-fetch-8498-2')).toMatch('')
+    expect(await page.textContent('.unsafe-fetch-8498-2-status')).toBe('404')
+  })
+
   test('safe fs fetch', async () => {
     expect(await page.textContent('.safe-fs-fetch')).toBe(stringified)
     expect(await page.textContent('.safe-fs-fetch-status')).toBe('200')
@@ -62,6 +67,11 @@ describe.runIf(isServe)('main', () => {
   test('unsafe fs fetch with special characters (#8498)', async () => {
     expect(await page.textContent('.unsafe-fs-fetch-8498')).toBe('')
     expect(await page.textContent('.unsafe-fs-fetch-8498-status')).toBe('403')
+  })
+
+  test('unsafe fs fetch with special characters 2 (#8498)', async () => {
+    expect(await page.textContent('.unsafe-fs-fetch-8498-2')).toBe('')
+    expect(await page.textContent('.unsafe-fs-fetch-8498-2-status')).toBe('404')
   })
 
   test('nested entry', async () => {

--- a/playground/fs-serve/root/src/index.html
+++ b/playground/fs-serve/root/src/index.html
@@ -19,6 +19,8 @@
 <pre class="unsafe-fetch"></pre>
 <pre class="unsafe-fetch-8498-status"></pre>
 <pre class="unsafe-fetch-8498"></pre>
+<pre class="unsafe-fetch-8498-2-status"></pre>
+<pre class="unsafe-fetch-8498-2"></pre>
 
 <h2>Safe /@fs/ Fetch</h2>
 <pre class="safe-fs-fetch-status"></pre>
@@ -31,6 +33,8 @@
 <pre class="unsafe-fs-fetch"></pre>
 <pre class="unsafe-fs-fetch-8498-status"></pre>
 <pre class="unsafe-fs-fetch-8498"></pre>
+<pre class="unsafe-fs-fetch-8498-2-status"></pre>
+<pre class="unsafe-fs-fetch-8498-2"></pre>
 
 <h2>Nested Entry</h2>
 <pre class="nested-entry"></pre>
@@ -100,6 +104,19 @@
       console.error(e)
     })
 
+  // outside of allowed dir with special characters 2 #8498
+  fetch('/src/%252e%252e%252funsafe%252etxt')
+    .then((r) => {
+      text('.unsafe-fetch-8498-2-status', r.status)
+      return r.text()
+    })
+    .then((data) => {
+      text('.unsafe-fetch-8498-2', data)
+    })
+    .catch((e) => {
+      console.error(e)
+    })
+
   // imported before, should be treated as safe
   fetch('/@fs/' + ROOT + '/safe.json')
     .then((r) => {
@@ -131,6 +148,18 @@
     })
     .then((data) => {
       text('.unsafe-fs-fetch-8498', JSON.stringify(data))
+    })
+
+  // outside root with special characters 2 #8498
+  fetch(
+    '/@fs/' + ROOT + '/root/src/%252e%252e%252f%252e%252e%252funsafe%252ejson'
+  )
+    .then((r) => {
+      text('.unsafe-fs-fetch-8498-2-status', r.status)
+      return r.json()
+    })
+    .then((data) => {
+      text('.unsafe-fs-fetch-8498-2', JSON.stringify(data))
     })
 
   // not imported before, inside root with special characters, treated as safe


### PR DESCRIPTION
### Description
I think this fix is not the ideal way but at least it works.

The reason why https://github.com/vitejs/vite/issues/8498#issuecomment-1170079570 was happening is:

1. Vite decodes URL (`%252ffoo.txt` => `%2ffoo.txt`)
2. Vite filters URL (`%2ffoo.txt`)
3. sirv decodes URL (`%2ffoo.txt` => `/foo.txt`)
4. sirv reponses (`/foo.txt`)

The file path mapped from URL is different between 2 and 4.

This PR adds encode after 2. (`%2ffoo.txt` => `%252ffoo.txt`)

fixes #8498
refs #8804
refs https://github.com/lukeed/sirv/issues/139

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
