### PR TITLE
feat: expose server resolved urls

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -85,11 +85,6 @@ interface ViteDevServer {
    */
   moduleGraph: ModuleGraph
   /**
-   * The resolved urls Vite prints on the CLI. null in middleware mode or
-   * before `server.listen` is called.
-   */
-  resolvedUrls: ResolvedServerUrls | null
-  /**
    * Programmatically resolve, load and transform a URL and get the result
    * without going through the http request pipeline.
    */

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -82,6 +82,10 @@ interface ViteDevServer {
    */
   moduleGraph: ModuleGraph
   /**
+   * The resolved urls Vite prints on the CLI. null in middleware mode.
+   */
+  resolvedUrls: ResolvedServerUrls | null
+  /**
    * Programmatically resolve, load and transform a URL and get the result
    * without going through the http request pipeline.
    */

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -85,7 +85,8 @@ interface ViteDevServer {
    */
   moduleGraph: ModuleGraph
   /**
-   * The resolved urls Vite prints on the CLI. null in middleware mode.
+   * The resolved urls Vite prints on the CLI. null in middleware mode or
+   * before `server.listen` is called.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -144,8 +144,6 @@ Also there are other breaking changes which only affect few users.
   - `server.force` option was removed in favor of `optimizeDeps.force` option.
 - [[#8550] fix: dont handle sigterm in middleware mode](https://github.com/vitejs/vite/pull/8550)
   - When running in middleware mode, Vite no longer kills process on `SIGTERM`.
-- [[#8647] feat: print resolved address for localhost](https://github.com/vitejs/vite/pull/8647)
-  - `server.printUrls` and `previewServer.printUrls` are now async
 
 ## Migration from v1
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -56,8 +56,7 @@ describe('resolveHostname', () => {
 
     expect(await resolveHostname(undefined)).toEqual({
       host: 'localhost',
-      name: resolved ?? 'localhost',
-      implicit: true
+      name: resolved ?? 'localhost'
     })
   })
 
@@ -66,24 +65,21 @@ describe('resolveHostname', () => {
 
     expect(await resolveHostname('localhost')).toEqual({
       host: 'localhost',
-      name: resolved ?? 'localhost',
-      implicit: false
+      name: resolved ?? 'localhost'
     })
   })
 
   test('accepts 0.0.0.0', async () => {
     expect(await resolveHostname('0.0.0.0')).toEqual({
       host: '0.0.0.0',
-      name: 'localhost',
-      implicit: false
+      name: 'localhost'
     })
   })
 
   test('accepts ::', async () => {
     expect(await resolveHostname('::')).toEqual({
       host: '::',
-      name: 'localhost',
-      implicit: false
+      name: 'localhost'
     })
   })
 
@@ -92,8 +88,7 @@ describe('resolveHostname', () => {
       await resolveHostname('0000:0000:0000:0000:0000:0000:0000:0000')
     ).toEqual({
       host: '0000:0000:0000:0000:0000:0000:0000:0000',
-      name: 'localhost',
-      implicit: false
+      name: 'localhost'
     })
   })
 })

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -17,7 +17,8 @@ export type {
   ServerOptions,
   FileSystemServeOptions,
   ServerHook,
-  ResolvedServerOptions
+  ResolvedServerOptions,
+  ResolvedServerUrls
 } from './server'
 export type {
   BuildOptions,

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -1,15 +1,9 @@
 /* eslint no-console: 0 */
 
-import type { AddressInfo, Server } from 'node:net'
-import os from 'node:os'
 import readline from 'readline'
 import colors from 'picocolors'
 import type { RollupError } from 'rollup'
-import type { CommonServerOptions } from './http'
-import type { Hostname } from './utils'
-import { resolveHostname } from './utils'
-import { loopbackHosts } from './constants'
-import type { ResolvedConfig } from '.'
+import type { ResolvedServerUrls } from './server'
 
 export type LogType = 'error' | 'warn' | 'info'
 export type LogLevel = LogType | 'silent'
@@ -145,94 +139,23 @@ export function createLogger(
   return logger
 }
 
-export async function printCommonServerUrls(
-  server: Server,
-  options: CommonServerOptions,
-  config: ResolvedConfig
-): Promise<void> {
-  const address = server.address()
-  const isAddressInfo = (x: any): x is AddressInfo => x?.address
-  if (isAddressInfo(address)) {
-    const hostname = await resolveHostname(options.host)
-    const protocol = options.https ? 'https' : 'http'
-    const base = config.base === './' || config.base === '' ? '/' : config.base
-    printServerUrls(hostname, protocol, address.port, base, config.logger.info)
-  }
-}
-
-function printServerUrls(
-  hostname: Hostname,
-  protocol: string,
-  port: number,
-  base: string,
+export function printServerUrls(
+  urls: ResolvedServerUrls,
+  optionsHost: string | boolean | undefined,
   info: Logger['info']
 ): void {
-  const urls: Array<{ label: string; url: string; disabled?: boolean }> = []
-  const notes: Array<{ label: string; message: string }> = []
-
-  if (hostname.host && loopbackHosts.has(hostname.host)) {
-    let hostnameName = hostname.name
-    if (
-      hostnameName === '::1' ||
-      hostnameName === '0000:0000:0000:0000:0000:0000:0000:0001'
-    ) {
-      hostnameName = `[${hostnameName}]`
-    }
-
-    urls.push({
-      label: 'Local',
-      url: colors.cyan(
-        `${protocol}://${hostnameName}:${colors.bold(port)}${base}`
-      )
-    })
-
-    if (hostname.implicit) {
-      urls.push({
-        label: 'Network',
-        url: `use ${colors.white(colors.bold('--host'))} to expose`,
-        disabled: true
-      })
-    }
-  } else {
-    Object.values(os.networkInterfaces())
-      .flatMap((nInterface) => nInterface ?? [])
-      .filter(
-        (detail) =>
-          detail &&
-          detail.address &&
-          // Node < v18
-          ((typeof detail.family === 'string' && detail.family === 'IPv4') ||
-            // Node >= v18
-            (typeof detail.family === 'number' && detail.family === 4))
-      )
-      .forEach((detail) => {
-        const host = detail.address.replace('127.0.0.1', hostname.name)
-        const url = `${protocol}://${host}:${colors.bold(port)}${base}`
-        const label = detail.address.includes('127.0.0.1') ? 'Local' : 'Network'
-
-        urls.push({ label, url: colors.cyan(url) })
-      })
+  const colorUrl = (url: string) =>
+    colors.cyan(url.replace(/:(\d+)\//, (_, port) => `:${colors.bold(port)}/`))
+  for (const url of urls.local) {
+    info(`  ${colors.green('➜')}  ${colors.bold('Local')}:   ${colorUrl(url)}`)
   }
-
-  const length = Math.max(
-    ...[...urls, ...notes].map(({ label }) => label.length)
-  )
-  const print = (
-    iconWithColor: string,
-    label: string,
-    messageWithColor: string,
-    disabled?: boolean
-  ) => {
-    const message = `  ${iconWithColor}  ${
-      label ? colors.bold(label) + ':' : ' '
-    } ${' '.repeat(length - label.length)}${messageWithColor}`
-    info(disabled ? colors.dim(message) : message)
+  for (const url of urls.network) {
+    info(`  ${colors.green('➜')}  ${colors.bold('Network')}: ${colorUrl(url)}`)
   }
-
-  urls.forEach(({ label, url: text, disabled }) => {
-    print(colors.green('➜'), label, text, disabled)
-  })
-  notes.forEach(({ label, message: text }) => {
-    print(colors.white('❖'), label, text)
-  })
+  if (urls.network.length === 0 && optionsHost === undefined) {
+    const note = `use ${colors.white(colors.bold('--host'))} to expose`
+    info(
+      colors.dim(`  ${colors.green('➜')}  ${colors.bold('Network')}: ${note}`)
+    )
+  }
 }

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -4,14 +4,14 @@ import sirv from 'sirv'
 import connect from 'connect'
 import type { Connect } from 'types/connect'
 import corsMiddleware from 'cors'
-import type { ResolvedServerOptions } from './server'
+import type { ResolvedServerOptions, ResolvedServerUrls } from './server'
 import type { CommonServerOptions } from './http'
 import { httpServerStart, resolveHttpServer, resolveHttpsConfig } from './http'
 import { openBrowser } from './server/openBrowser'
 import compression from './server/middlewares/compression'
 import { proxyMiddleware } from './server/middlewares/proxy'
-import { resolveHostname } from './utils'
-import { printCommonServerUrls } from './logger'
+import { resolveHostname, resolveServerUrls } from './utils'
+import { printServerUrls } from './logger'
 import { resolveConfig } from '.'
 import type { InlineConfig, ResolvedConfig } from '.'
 
@@ -48,9 +48,13 @@ export interface PreviewServer {
    */
   httpServer: http.Server
   /**
+   * The resolved urls Vite prints on the CLI
+   */
+  resolvedUrls: ResolvedServerUrls
+  /**
    * Print server urls
    */
-  printUrls: () => Promise<void>
+  printUrls(): void
 }
 
 export type PreviewServerHook = (server: {
@@ -127,6 +131,12 @@ export async function preview(
     logger
   })
 
+  const resolvedUrls = await resolveServerUrls(
+    httpServer,
+    config.preview,
+    config
+  )
+
   if (options.open) {
     const path = typeof options.open === 'string' ? options.open : previewBase
     openBrowser(
@@ -141,8 +151,9 @@ export async function preview(
   return {
     config,
     httpServer,
-    async printUrls() {
-      await printCommonServerUrls(httpServer, config.preview, config)
+    resolvedUrls,
+    printUrls() {
+      printServerUrls(resolvedUrls, options.host, logger.info)
     }
   }
 }

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -48,7 +48,9 @@ export interface PreviewServer {
    */
   httpServer: http.Server
   /**
-   * The resolved urls Vite prints on the CLI
+   * The resolved urls Vite prints on the
+   *
+   * @experimental
    */
   resolvedUrls: ResolvedServerUrls
   /**

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -399,7 +399,7 @@ export async function createServer(
         throw new Error('cannot print server URLs in middleware mode.')
       } else {
         throw new Error(
-          'cannot print server URLs before server.listen is called'
+          'cannot print server URLs before server.listen is called.'
         )
       }
     },

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -186,7 +186,8 @@ export interface ViteDevServer {
    */
   moduleGraph: ModuleGraph
   /**
-   * The resolved urls Vite prints on the CLI. null in middleware mode.
+   * The resolved urls Vite prints on the CLI. null in middleware mode or
+   * before `server.listen` is called.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**
@@ -394,8 +395,12 @@ export async function createServer(
           serverConfig.host,
           config.logger.info
         )
-      } else {
+      } else if (middlewareMode) {
         throw new Error('cannot print server URLs in middleware mode.')
+      } else {
+        throw new Error(
+          'cannot print server URLs before server.listen is called'
+        )
       }
     },
     async restart(forceOptimize?: boolean) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -188,6 +188,8 @@ export interface ViteDevServer {
   /**
    * The resolved urls Vite prints on the CLI. null in middleware mode or
    * before `server.listen` is called.
+   *
+   * @experimental
    */
   resolvedUrls: ResolvedServerUrls | null
   /**

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -380,13 +380,13 @@ export async function createServer(
           process.stdin.off('end', exitProcess)
         }
       }
-
       await Promise.all([
         watcher.close(),
         ws.close(),
         container.close(),
         closeHttpServer()
       ])
+      server.resolvedUrls = null
     },
     printUrls() {
       if (server.resolvedUrls) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -35,7 +35,7 @@ import {
   initDevSsrDepsOptimizer
 } from '../optimizer'
 import { CLIENT_DIR } from '../constants'
-import type { Logger} from '../logger';
+import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
 import { invalidatePackageData } from '../packages'
 import type { PluginContainer } from './pluginContainer'
@@ -329,7 +329,7 @@ export async function createServer(
     pluginContainer: container,
     ws,
     moduleGraph,
-    resolvedUrls: null,
+    resolvedUrls: null, // will be set on listen
     ssrTransform(code: string, inMap: SourceMap | null, url: string) {
       return ssrTransform(code, inMap, url, {
         json: { stringify: server.config.json?.stringify }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Implements https://github.com/vitejs/vite/discussions/8891

Expose `devServer.resolvedUrls` and `previewServer.resolvedUrls`.

This PR also removes a breaking change in Vite 3 where `printUrls` are async, now they are back as sync.

### Additional context

This mostly refactors on how we resolve urls and print them.

Previously, `printUrls` handle the entire resolve and print flow. Now, we break it into two parts. Whenever the server starts/restarts, we resolve `resolvedUrls`. This usually happens in the `listen()` function which is async and we lend to avoid `printUrls` becoming async. Then, `printUrls` become a basic function that only reads `resolvedUrls` and prints it.

Not sure how to add tests to this, but works locally for me and for vite-plugin-qrcode.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
