### PR TITLE
chore: use vite-env.d.ts convention

### DIFF
--- a/packages/create-vite/template-vue-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-vue-ts/src/vite-env.d.ts
@@ -2,7 +2,7 @@
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+   
   const component: DefineComponent<{}, {}, any>
   export default component
 }

--- a/packages/create-vite/template-vue-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-vue-ts/src/vite-env.d.ts
@@ -2,7 +2,6 @@
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
-   
   const component: DefineComponent<{}, {}, any>
   export default component
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The vue template is the only one not using `vite-env.d.ts`. Thought we should make it consistent.


<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

