### PR TITLE
fix(react): sourcemap incorrect warning and classic runtime sourcemap

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -44,6 +44,7 @@
     "@babel/plugin-transform-react-jsx-development": "^7.18.6",
     "@babel/plugin-transform-react-jsx-self": "^7.18.6",
     "@babel/plugin-transform-react-jsx-source": "^7.18.6",
+    "magic-string": "^0.26.2",
     "react-refresh": "^0.14.0"
   },
   "peerDependencies": {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -90,6 +90,8 @@ declare module 'vite' {
   }
 }
 
+const prependReactImportCode = "import React from 'react'; "
+
 export default function viteReact(opts: Options = {}): PluginOption[] {
   // Provide default values for Rollup compat.
   let devBase = '/'
@@ -274,10 +276,10 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
         let inputMap: SourceMap | undefined
         if (prependReactImport) {
-          const s = new MagicString(code)
-          s.prepend("import React from 'react'; ")
-          code = s.toString()
+          code = prependReactImportCode + code
           if (needHiresSourcemap) {
+            const s = new MagicString(code)
+            s.prepend(prependReactImportCode)
             inputMap = s.generateMap({ hires: true, source: id })
           }
         }

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -276,11 +276,13 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
         let inputMap: SourceMap | undefined
         if (prependReactImport) {
-          code = prependReactImportCode + code
           if (needHiresSourcemap) {
             const s = new MagicString(code)
             s.prepend(prependReactImportCode)
+            code = s.toString()
             inputMap = s.generateMap({ hires: true, source: id })
+          } else {
+            code = prependReactImportCode + code
           }
         }
 

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -278,7 +278,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
         if (shouldSkip) {
           // Avoid parsing if no plugins exist.
           return {
-            code
+            code,
+            map: null
           }
         }
 

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -274,7 +274,6 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
 
         let inputMap: SourceMap | undefined
         if (prependReactImport) {
-          console.log('prepend')
           const s = new MagicString(code)
           s.prepend("import React from 'react'; ")
           code = s.toString()

--- a/playground/react-sourcemap/App.jsx
+++ b/playground/react-sourcemap/App.jsx
@@ -1,0 +1,7 @@
+function App() {
+  return <div>foo</div>
+}
+
+console.log('App.jsx') // for sourcemap
+
+export default App

--- a/playground/react-sourcemap/App.jsx
+++ b/playground/react-sourcemap/App.jsx
@@ -1,7 +1,8 @@
+console.log('App.jsx 1') // for sourcemap
 function App() {
   return <div>foo</div>
 }
 
-console.log('App.jsx') // for sourcemap
+console.log('App.jsx 2') // for sourcemap
 
 export default App

--- a/playground/react-sourcemap/__tests__/react-sourcemap.spec.ts
+++ b/playground/react-sourcemap/__tests__/react-sourcemap.spec.ts
@@ -1,0 +1,7 @@
+import { isBuild, serverLogs } from '~utils'
+
+test.runIf(isBuild)('should not output sourcemap warning', () => {
+  serverLogs.forEach((log) => {
+    expect(log).not.toMatch('Sourcemap is likely to be incorrect')
+  })
+})

--- a/playground/react-sourcemap/index.html
+++ b/playground/react-sourcemap/index.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+<script type="module" src="main.jsx"></script>

--- a/playground/react-sourcemap/main.jsx
+++ b/playground/react-sourcemap/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App.jsx'
+
+ReactDOM.createRoot(document.getElementById('app')).render(
+  React.createElement(App)
+)
+
+console.log('main.jsx') // for sourcemap

--- a/playground/react-sourcemap/package.json
+++ b/playground/react-sourcemap/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test-react-sourcemap",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "workspace:*"
+  }
+}

--- a/playground/react-sourcemap/package.json
+++ b/playground/react-sourcemap/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",
+    "dev:classic": "cross-env USE_CLASSIC=1 vite",
     "build": "vite build",
+    "build:classic": "cross-env USE_CLASSIC=1 vite build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
   },
@@ -13,6 +15,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "workspace:*"
+    "@vitejs/plugin-react": "workspace:*",
+    "cross-env": "^7.0.3"
   }
 }

--- a/playground/react-sourcemap/vite.config.ts
+++ b/playground/react-sourcemap/vite.config.ts
@@ -1,0 +1,11 @@
+import react from '@vitejs/plugin-react'
+import type { UserConfig } from 'vite'
+
+const config: UserConfig = {
+  plugins: [react()],
+  build: {
+    sourcemap: true
+  }
+}
+
+export default config

--- a/playground/react-sourcemap/vite.config.ts
+++ b/playground/react-sourcemap/vite.config.ts
@@ -2,7 +2,11 @@ import react from '@vitejs/plugin-react'
 import type { UserConfig } from 'vite'
 
 const config: UserConfig = {
-  plugins: [react()],
+  plugins: [
+    react({
+      jsxRuntime: process.env.USE_CLASSIC === '1' ? 'classic' : 'automatic'
+    })
+  ],
   build: {
     sourcemap: true
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -821,6 +821,17 @@ importers:
       '@emotion/babel-plugin': 11.9.2
       '@vitejs/plugin-react': link:../../packages/plugin-react
 
+  playground/react-sourcemap:
+    specifiers:
+      '@vitejs/plugin-react': workspace:*
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@vitejs/plugin-react': link:../../packages/plugin-react
+
   playground/react/jsx-entry:
     specifiers: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,7 @@ importers:
       '@babel/plugin-transform-react-jsx-development': ^7.18.6
       '@babel/plugin-transform-react-jsx-self': ^7.18.6
       '@babel/plugin-transform-react-jsx-source': ^7.18.6
+      magic-string: ^0.26.2
       react-refresh: ^0.14.0
       vite: workspace:*
     dependencies:
@@ -170,6 +171,7 @@ importers:
       '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.18.6
       '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.18.6
       '@babel/plugin-transform-react-jsx-source': 7.18.6_@babel+core@7.18.6
+      magic-string: 0.26.2
       react-refresh: 0.14.0
     devDependencies:
       vite: link:../vite
@@ -824,6 +826,7 @@ importers:
   playground/react-sourcemap:
     specifiers:
       '@vitejs/plugin-react': workspace:*
+      cross-env: ^7.0.3
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
@@ -831,6 +834,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@vitejs/plugin-react': link:../../packages/plugin-react
+      cross-env: 7.0.3
 
   playground/react/jsx-entry:
     specifiers: {}
@@ -5721,7 +5725,7 @@ packages:
     dev: true
 
   /isexe/2.0.0:
-    resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
 
   /jiti/1.13.0:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
From plugin-react 2.0.0-beta.1, the following warning was happening. This PR fixes that.
```
Sourcemap is likely to be incorrect: a plugin (vite:react-babel) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

Reproduction: https://stackblitz.com/edit/vitejs-vite-g4zebx

Also this PR fixes classic runtime sourcemap which was incorrect in some cases.

refs #8676

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
