### PR TITLE
feat: show ws connection error and don't reload if ws connection did not success

### DIFF
--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -17,6 +17,14 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:client-inject',
     async transform(code, id, options) {
       if (id === normalizedClientEntry || id === normalizedEnvEntry) {
+        const resolvedServerHostname = (
+          await resolveHostname(config.server.host)
+        ).name
+        const resolvedServerPort = config.server.port!
+        const devBase = config.base
+
+        const serverHost = `${resolvedServerHostname}:${resolvedServerPort}${devBase}`
+
         let hmrConfig = config.server.hmr
         hmrConfig = isObject(hmrConfig) ? hmrConfig : undefined
         const host = hmrConfig?.host || null
@@ -31,10 +39,8 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
           port ||= 24678
         }
 
-        const devBase = config.base
-        let directTarget =
-          hmrConfig?.host || (await resolveHostname(config.server.host)).name
-        directTarget += `:${hmrConfig?.port || config.server.port!}`
+        let directTarget = hmrConfig?.host || resolvedServerHostname
+        directTarget += `:${hmrConfig?.port || resolvedServerPort}`
         directTarget += devBase
 
         let hmrBase = devBase
@@ -46,6 +52,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
           .replace(`__MODE__`, JSON.stringify(config.mode))
           .replace(`__BASE__`, JSON.stringify(devBase))
           .replace(`__DEFINES__`, serializeDefine(config.define || {}))
+          .replace(`__SERVER_HOST__`, JSON.stringify(serverHost))
           .replace(`__HMR_PROTOCOL__`, JSON.stringify(protocol))
           .replace(`__HMR_HOSTNAME__`, JSON.stringify(host))
           .replace(`__HMR_PORT__`, JSON.stringify(port))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#8650 introduced a fallback mechanism when the connection did not success.
This PR uses that to prevent reload if ws connection did not success.
Also this PR adds an error output when that happened.

![image](https://user-images.githubusercontent.com/49056869/178105192-47c4f06a-8897-435a-a3ba-b5b3d1df4c66.png)

fixes #8861 (because this PR will prevent reload if ws did not connect)
fixes #6089, close #6090 (because this PR will prevent reload if ws did not connect)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
