### PR TITLE
fix: stop running into null pathname errors

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -1,5 +1,5 @@
 import { extname } from 'node:path'
-import { parse as parseUrl } from 'node:url'
+import { URL } from 'node:url'
 import type { ModuleInfo, PartialResolvedId } from 'rollup'
 import { isDirectCSSRequest } from '../plugins/css'
 import {
@@ -238,9 +238,9 @@ export class ModuleGraph {
     const resolved = await this.resolveId(url, !!ssr)
     const resolvedId = resolved?.id || url
     const ext = extname(cleanUrl(resolvedId))
-    const { pathname, search, hash } = parseUrl(url)
-    if (ext && !pathname!.endsWith(ext)) {
-      url = pathname + ext + (search || '') + (hash || '')
+    const { path, query, fragment } = new URL(url)
+    if (ext && !path!.endsWith(ext)) {
+      url = path + ext + (query ? `?${query} `: '') + (fragment ? `#${fragment}` : '')
     }
     return [url, resolvedId, resolved?.meta]
   }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -238,7 +238,7 @@ export class ModuleGraph {
     const resolved = await this.resolveId(url, !!ssr)
     const resolvedId = resolved?.id || url
     const ext = extname(cleanUrl(resolvedId))
-    const { pathname, search, hash } = new URL(url)
+    const { pathname, search, hash } = new URL(url, 'relative://')
     if (ext && !pathname!.endsWith(ext)) {
       url = pathname + ext + (search || '') + (hash || '')
     }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -238,9 +238,9 @@ export class ModuleGraph {
     const resolved = await this.resolveId(url, !!ssr)
     const resolvedId = resolved?.id || url
     const ext = extname(cleanUrl(resolvedId))
-    const { path, query, fragment } = new URL(url)
-    if (ext && !path!.endsWith(ext)) {
-      url = path + ext + (query ? `?${query} `: '') + (fragment ? `#${fragment}` : '')
+    const { pathname, search, hash } = new URL(url)
+    if (ext && !pathname!.endsWith(ext)) {
+      url = pathname + ext + (search || '') + (hash || '')
     }
     return [url, resolvedId, resolved?.meta]
   }


### PR DESCRIPTION
Replace `url.parse` (legacy) with `new URL`

<!-- Thank you for contributing! -->

### Description

Starting from node `16.15.0` (see https://github.com/nodejs/node/pull/42196), `url.parse` now trims leading and trailing C0 control characters. leading C0 control characters are recommended to be prefixed for resolved virtual module ids (see https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention).

This means that if we use an URL like `\0virtual:mypackage-somedata` from a plugins `resolveId` method, pathname will be null and you will run into an error like this starting from node `16.15.0`:

![image](https://user-images.githubusercontent.com/603683/178346314-63a1c51f-394e-4793-aab9-ff622978fb8e.png)

This was also noted by @bjuriewicz in discussions: https://github.com/vitejs/vite/discussions/8967

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other