### PR TITLE
docs: fix link a11y

### DIFF
--- a/docs/.vitepress/theme/styles/vars.css
+++ b/docs/.vitepress/theme/styles/vars.css
@@ -94,6 +94,7 @@
   over scoped class data attribute.
 */
 .dark .vp-doc a,
+.dark .vp-doc a > code,
 .dark .VPNavBarMenuLink.VPNavBarMenuLink:hover,
 .dark .VPNavBarMenuLink.VPNavBarMenuLink.active,
 .dark .link.link:hover,
@@ -103,7 +104,8 @@
   color: var(--vp-c-brand-lighter);
 }
 
-.dark .vp-doc a:hover {
+.dark .vp-doc a:hover,
+.dark .vp-doc a > code:hover {
   color: var(--vp-c-brand-lightest);
   opacity: 1;
 }

--- a/docs/.vitepress/theme/styles/vars.css
+++ b/docs/.vitepress/theme/styles/vars.css
@@ -6,6 +6,7 @@
   --vp-c-brand: #646cff;
   --vp-c-brand-light: #747bff;
   --vp-c-brand-lighter: #9499ff;
+  --vp-c-brand-lightest: #bcc0ff;
   --vp-c-brand-dark: #535bf2;
   --vp-c-brand-darker: #454ce1;
   --vp-c-brand-dimm: rgba(100, 108, 255, 0.08);
@@ -71,7 +72,7 @@
 
 .dark {
   --vp-custom-block-tip-border: var(--vp-c-brand);
-  --vp-custom-block-tip-text: var(--vp-c-brand-lighter);
+  --vp-custom-block-tip-text: var(--vp-c-brand-lightest);
   --vp-custom-block-tip-bg: var(--vp-c-brand-dimm);
 }
 
@@ -81,4 +82,29 @@
 
 .DocSearch {
   --docsearch-primary-color: var(--vp-c-brand) !important;
+}
+
+/**
+ * VitePress: Custom fix
+ * -------------------------------------------------------------------------- */
+
+/* a11y: use lighter colors for links in dark mode */
+.dark .vp-doc a,
+.dark .VPNavBarMenuLink.VPNavBarMenuLink:hover,
+.dark .VPNavBarMenuLink.VPNavBarMenuLink.active,
+.dark .link.link:hover,
+.dark .link.link.active,
+.dark .edit-link-button.edit-link-button,
+.dark .pager-link .title {
+  color: var(--vp-c-brand-lighter);
+}
+
+.dark .vp-doc a:hover {
+  color: var(--vp-c-brand-lightest);
+  opacity: 1;
+}
+
+/* transition by color instead of opacity */
+.dark .vp-doc .custom-block a {
+  transition: color 0.25s;
 }

--- a/docs/.vitepress/theme/styles/vars.css
+++ b/docs/.vitepress/theme/styles/vars.css
@@ -90,7 +90,7 @@
 
 /*
   Use lighter colors for links in dark mode for a11y.
-  Also specify some class twice to have higer specificity
+  Also specify some classes twice to have higher specificity
   over scoped class data attribute.
 */
 .dark .vp-doc a,

--- a/docs/.vitepress/theme/styles/vars.css
+++ b/docs/.vitepress/theme/styles/vars.css
@@ -88,7 +88,11 @@
  * VitePress: Custom fix
  * -------------------------------------------------------------------------- */
 
-/* a11y: use lighter colors for links in dark mode */
+/*
+  Use lighter colors for links in dark mode for a11y.
+  Also specify some class twice to have higer specificity
+  over scoped class data attribute.
+*/
 .dark .vp-doc a,
 .dark .VPNavBarMenuLink.VPNavBarMenuLink:hover,
 .dark .VPNavBarMenuLink.VPNavBarMenuLink.active,
@@ -104,7 +108,7 @@
   opacity: 1;
 }
 
-/* transition by color instead of opacity */
+/* Transition by color instead of opacity */
 .dark .vp-doc .custom-block a {
   transition: color 0.25s;
 }


### PR DESCRIPTION
Updated links to use `--vp-c-brand-lighter`. Added `--vp-c-brand-lightest` to have a whiter text for blockquotes, and for docs link hover.