### PR TITLE
fix: reset NODE_ENV on production build end

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -339,10 +339,14 @@ const parallelBuilds: RollupBuild[] = []
 export async function build(
   inlineConfig: InlineConfig = {}
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
+  // NODE_ENV may be used as an "isProduction" flag for plugins
+  // Be sure to reset on exit (see finally block)
+  const initialNodeEnv = process.env.NODE_ENV
   parallelCallCounts++
   try {
     return await doBuild(inlineConfig)
   } finally {
+    process.env.NODE_ENV = initialNodeEnv
     parallelCallCounts--
     if (parallelCallCounts <= 0) {
       await Promise.all(parallelBuilds.map((bundle) => bundle.close()))

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -1,9 +1,6 @@
 const fs = require('fs')
 const vue = require('@vitejs/plugin-vue')
 
-// Overriding the NODE_ENV set by vitest
-process.env.NODE_ENV = ''
-
 /**
  * @type {import('vite').UserConfig}
  */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Resolves #9057 
- Reset `NODE_ENV` to its initial value when a production build ends. This prevents `NODE_ENV` from leaking to subsequent Vite runs.

### Additional context

It seems this issue was introduced by https://github.com/vitejs/vite/pull/8218 (cc @sapphi-red and @bluwy). I'd suggest investigating other options to flip `isProduction` beyond environment variables, since they can easily leak between Vite builds (ex. the parallel CI suites we use at Astro). Perhaps a new CLI flag, or exposing `isProduction` as an inline config option separate from `mode`?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
