### PR TITLE
fix: avoid errors when loading the overlay code in workers

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -115,6 +115,9 @@ code {
 const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
 const codeframeRE = /^(?:>?\s+\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
+// Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
+// `HTMLElement` was not originally defined.
+const { HTMLElement = class { } } = globalThis;
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot
 
@@ -184,6 +187,7 @@ export class ErrorOverlay extends HTMLElement {
 }
 
 export const overlayId = 'vite-error-overlay'
+const { customElements } = globalThis; // Ensure `customElements` is defined before the next line.
 if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay)
 }

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -117,7 +117,7 @@ const codeframeRE = /^(?:>?\s+\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
 // Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
 // `HTMLElement` was not originally defined.
-const { HTMLElement = class { } } = globalThis;
+const { HTMLElement = class {} } = globalThis
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot
 
@@ -187,7 +187,7 @@ export class ErrorOverlay extends HTMLElement {
 }
 
 export const overlayId = 'vite-error-overlay'
-const { customElements } = globalThis; // Ensure `customElements` is defined before the next line.
+const { customElements } = globalThis // Ensure `customElements` is defined before the next line.
 if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay)
 }


### PR DESCRIPTION
### Description

`HTMLElement` and `customElements` are not defined in e.g. web workers. However, Vite sometimes tries to inject the overlay into such workers. Ideally, it would not do so (and would e.g. find another way to notify the developer about issues). But this PR offers a change that allows such workers to run, by avoiding crashes in `overlay.ts` when it does.

### Additional context

Vite 3 requires this fix to successfully run module workers:

```js
import { randomScrambleForEvent } from "cubing/scramble";

(async () => {
  (await randomScrambleForEvent("333")).log();
})();
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
