### PR TITLE
fix: prevent production node_env in serve

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -360,6 +360,10 @@ export async function resolveConfig(
   if (mode === 'production') {
     process.env.NODE_ENV = 'production'
   }
+  // production env would not work in serve, fallback to development
+  if (command === 'serve' && process.env.NODE_ENV === 'production') {
+    process.env.NODE_ENV = 'development'
+  }
 
   const configEnv = {
     mode,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Alternative to https://github.com/vitejs/vite/pull/9058
Fix https://github.com/vitejs/vite/issues/9057

### Additional context

Make sure `process.env.NODE_ENV` is not `production` in dev. Some plugins may rely on this behaviour for hmr / improved perf for example, so we can't have production-like behaviours in dev.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
