### PR TITLE
fix(create-vite): remove import from public

### DIFF
--- a/packages/create-vite/template-lit-ts/src/my-element.ts
+++ b/packages/create-vite/template-lit-ts/src/my-element.ts
@@ -1,6 +1,5 @@
 import { html, css, LitElement } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
-import viteLogo from '/vite.svg'
 import litLogo from './assets/lit.svg'
 
 /**
@@ -27,7 +26,7 @@ export class MyElement extends LitElement {
     return html`
       <div>
         <a href="https://vitejs.dev" target="_blank">
-          <img src="${viteLogo}" class="logo" alt="Vite logo" />
+          <img src="/vite.svg" class="logo" alt="Vite logo" />
         </a>
         <a href="https://lit.dev" target="_blank">
           <img src=${litLogo} class="logo lit" alt="Lit logo" />

--- a/packages/create-vite/template-lit/src/my-element.js
+++ b/packages/create-vite/template-lit/src/my-element.js
@@ -1,5 +1,4 @@
 import { html, css, LitElement } from 'lit'
-import viteLogo from '/vite.svg'
 import litLogo from './assets/lit.svg'
 
 /**
@@ -33,7 +32,7 @@ export class MyElement extends LitElement {
     return html`
       <div>
         <a href="https://vitejs.dev" target="_blank">
-          <img src="${viteLogo}" class="logo" alt="Vite logo" />
+          <img src="/vite.svg" class="logo" alt="Vite logo" />
         </a>
         <a href="https://lit.dev" target="_blank">
           <img src=${litLogo} class="logo lit" alt="Lit logo" />

--- a/packages/create-vite/template-preact-ts/src/app.tsx
+++ b/packages/create-vite/template-preact-ts/src/app.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'preact/hooks'
-import viteLogo from '/vite.svg'
 import preactLogo from './assets/preact.svg'
 import './app.css'
 
@@ -10,7 +9,7 @@ export function App() {
     <>
       <div>
         <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} class="logo" alt="Vite logo" />
+          <img src="/vite.svg" class="logo" alt="Vite logo" />
         </a>
         <a href="https://preactjs.com" target="_blank">
           <img src={preactLogo} class="logo preact" alt="Preact logo" />

--- a/packages/create-vite/template-preact/src/app.jsx
+++ b/packages/create-vite/template-preact/src/app.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'preact/hooks'
-import viteLogo from '/vite.svg'
 import preactLogo from './assets/preact.svg'
 import './app.css'
 
@@ -10,7 +9,7 @@ export function App() {
     <>
       <div>
         <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} class="logo" alt="Vite logo" />
+          <img src="/vite.svg" class="logo" alt="Vite logo" />
         </a>
         <a href="https://preactjs.com" target="_blank">
           <img src={preactLogo} class="logo preact" alt="Preact logo" />

--- a/packages/create-vite/template-react-ts/src/App.tsx
+++ b/packages/create-vite/template-react-ts/src/App.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import viteLogo from '/vite.svg'
 import reactLogo from './assets/react.svg'
 import './App.css'
 
@@ -10,7 +9,7 @@ function App() {
     <div className="App">
       <div>
         <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
+          <img src="/vite.svg" className="logo" alt="Vite logo" />
         </a>
         <a href="https://reactjs.org" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />

--- a/packages/create-vite/template-react/src/App.jsx
+++ b/packages/create-vite/template-react/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import viteLogo from '/vite.svg'
 import reactLogo from './assets/react.svg'
 import './App.css'
 
@@ -10,7 +9,7 @@ function App() {
     <div className="App">
       <div>
         <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
+          <img src="/vite.svg" className="logo" alt="Vite logo" />
         </a>
         <a href="https://reactjs.org" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />

--- a/packages/create-vite/template-svelte-ts/src/App.svelte
+++ b/packages/create-vite/template-svelte-ts/src/App.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import viteLogo from '/vite.svg'
   import svelteLogo from './assets/svelte.svg'
   import Counter from './lib/Counter.svelte'
 </script>
@@ -7,7 +6,7 @@
 <main>
   <div>
     <a href="https://vitejs.dev" target="_blank"> 
-      <img src={viteLogo} class="logo" alt="Vite Logo" />
+      <img src="/vite.svg" class="logo" alt="Vite Logo" />
     </a>
     <a href="https://svelte.dev" target="_blank"> 
       <img src={svelteLogo} class="logo svelte" alt="Svelte Logo" />

--- a/packages/create-vite/template-svelte/src/App.svelte
+++ b/packages/create-vite/template-svelte/src/App.svelte
@@ -1,5 +1,4 @@
 <script>
-  import viteLogo from '/vite.svg'
   import svelteLogo from './assets/svelte.svg'
   import Counter from './lib/Counter.svelte'
 </script>
@@ -7,7 +6,7 @@
 <main>
   <div>
     <a href="https://vitejs.dev" target="_blank"> 
-      <img src={viteLogo} class="logo" alt="Vite Logo" />
+      <img src="/vite.svg" class="logo" alt="Vite Logo" />
     </a>
     <a href="https://svelte.dev" target="_blank"> 
       <img src={svelteLogo} class="logo svelte" alt="Svelte Logo" />

--- a/packages/create-vite/template-vanilla-ts/src/main.ts
+++ b/packages/create-vite/template-vanilla-ts/src/main.ts
@@ -1,12 +1,11 @@
 import './style.css'
-import viteLogo from '/vite.svg'
 import typescriptLogo from './typescript.svg'
 import { setupCounter } from './counter'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
     <a href="https://vitejs.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
+      <img src="/vite.svg" class="logo" alt="Vite logo" />
     </a>
     <a href="https://www.typescriptlang.org/" target="_blank">
       <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />

--- a/packages/create-vite/template-vanilla/main.js
+++ b/packages/create-vite/template-vanilla/main.js
@@ -1,12 +1,11 @@
 import './style.css'
-import viteLogo from '/vite.svg'
 import javascriptLogo from './javascript.svg'
 import { setupCounter } from './counter.js'
 
 document.querySelector('#app').innerHTML = `
   <div>
     <a href="https://vitejs.dev" target="_blank">
-      <img src="${viteLogo}" class="logo" alt="Vite logo" />
+      <img src="/vite.svg" class="logo" alt="Vite logo" />
     </a>
     <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript" target="_blank">
       <img src="${javascriptLogo}" class="logo vanilla" alt="JavaScript logo" />


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We can't import `vite.svg` from the public folder, even though it works, as the [docs](https://vitejs.dev/guide/assets.html#the-public-directory) don't guarantee it.

### Additional context

We should probably report a warning.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

