### PR TITLE
chore: remove note about v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,6 @@ In addition, Vite is highly extensible via its [Plugin API](https://vitejs.dev/g
 
 [Read the Docs to Learn More](https://vitejs.dev).
 
-## v3.0
-
-Current Status: **Beta** (for internal testing, not recommended for production)
-
-The `main` branch is now for v3.0, if you are looking for current stable releases, check the [`v2` branch](https://github.com/vitejs/vite/tree/v2) branch instead.
-
-We will start drafting release notes and migration guide for v3.0 when we enter the beta stage. Before that you can check:
-
-- [v3.0 Milestone](https://github.com/vitejs/vite/milestone/5)
-- [Breaking Change List](https://github.com/vitejs/vite/issues?q=label%3A%22breaking+change%22+is%3Aclosed+milestone%3A3.0)
-
 ## Packages
 
 | Package                                           | Version (click for changelogs)                                                                                                       |


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR removes the note section about v3 on README which was added by #8171.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
