### PR TITLE
fix: resolve drive relative path

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -28,6 +28,7 @@ import {
   isObject,
   isPossibleTsOutput,
   isTsRequest,
+  isWindows,
   nestedResolveFrom,
   normalizePath,
   resolveFrom,
@@ -239,6 +240,17 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
               moduleSideEffects: pkg.hasSideEffects(res)
             }
           }
+          return res
+        }
+      }
+
+      // drive relative fs paths (only windows)
+      if (isWindows && id.startsWith('/')) {
+        const basedir = importer ? path.dirname(importer) : process.cwd()
+        const fsPath = path.resolve(basedir, id)
+        if ((res = tryFsResolve(fsPath, options))) {
+          isDebug &&
+            debug(`[drive-relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           return res
         }
       }

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -1,4 +1,4 @@
-import { isBuild, page } from '~utils'
+import { isBuild, isWindows, page } from '~utils'
 
 test('bom import', async () => {
   expect(await page.textContent('.utf8-bom')).toMatch('[success]')
@@ -73,6 +73,10 @@ test('a ts module can import another ts module using its corresponding js file n
 
 test('filename with dot', async () => {
   expect(await page.textContent('.dot')).toMatch('[success]')
+})
+
+test.runIf(isWindows)('drive-relative path', async () => {
+  expect(await page.textContent('.drive-relative')).toMatch('[success]')
 })
 
 test('browser field', async () => {

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -79,6 +79,10 @@ test.runIf(isWindows)('drive-relative path', async () => {
   expect(await page.textContent('.drive-relative')).toMatch('[success]')
 })
 
+test('absolute path', async () => {
+  expect(await page.textContent('.absolute')).toMatch('[success]')
+})
+
 test('browser field', async () => {
   expect(await page.textContent('.browser')).toMatch('[success]')
 })

--- a/playground/resolve/absolute.js
+++ b/playground/resolve/absolute.js
@@ -1,0 +1,1 @@
+export default '[success] absolute'

--- a/playground/resolve/drive-relative.js
+++ b/playground/resolve/drive-relative.js
@@ -1,0 +1,1 @@
+export default '[success] drive relative'

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -55,6 +55,9 @@
 <h2>Resolve file name containing dot</h2>
 <p class="dot">fail</p>
 
+<h2>Resolve drive-relative path (Windows only)</h2>
+<p class="drive-relative">fail</p>
+
 <h2>Browser Field</h2>
 <p class="browser">fail</p>
 
@@ -89,6 +92,7 @@
 <p class="path-contains-sharp-symbol"></p>
 
 <script type="module">
+  import '@generated-content-virtual-file'
   function text(selector, text) {
     document.querySelector(selector).textContent = text
   }

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -58,6 +58,9 @@
 <h2>Resolve drive-relative path (Windows only)</h2>
 <p class="drive-relative">fail</p>
 
+<h2>Resolve absolute path</h2>
+<p class="absolute">fail</p>
+
 <h2>Browser Field</h2>
 <p class="browser">fail</p>
 

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -1,8 +1,21 @@
+const path = require('node:path')
+const { normalizePath } = require('vite')
+
 const virtualFile = '@virtual-file'
 const virtualId = '\0' + virtualFile
 
 const customVirtualFile = '@custom-virtual-file'
 const { a } = require('./config-dep')
+
+const generatedContentVirtualFile = '@generated-content-virtual-file'
+const generatedContentImports = [
+  {
+    specifier: normalizePath(
+      path.resolve(__dirname, './drive-relative.js').replace(/^[a-zA-Z]:/, '')
+    ),
+    elementQuery: '.drive-relative'
+  }
+]
 
 module.exports = {
   resolve: {
@@ -37,6 +50,32 @@ module.exports = {
       load(id) {
         if (id === customVirtualFile) {
           return `export const msg = "[success] from custom virtual file"`
+        }
+      }
+    },
+    {
+      name: 'generated-content',
+      resolveId(id) {
+        if (id === generatedContentVirtualFile) {
+          return id
+        }
+      },
+      load(id) {
+        if (id === generatedContentVirtualFile) {
+          const tests = generatedContentImports
+            .map(
+              ({ specifier, elementQuery }, i) =>
+                `import content${i} from ${JSON.stringify(specifier)}\n` +
+                `text(${JSON.stringify(elementQuery)}, content${i})`
+            )
+            .join('\n')
+
+          return (
+            'function text(selector, text) {\n' +
+            '  document.querySelector(selector).textContent = text\n' +
+            '}\n\n' +
+            tests
+          )
         }
       }
     }

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -14,6 +14,10 @@ const generatedContentImports = [
       path.resolve(__dirname, './drive-relative.js').replace(/^[a-zA-Z]:/, '')
     ),
     elementQuery: '.drive-relative'
+  },
+  {
+    specifier: normalizePath(path.resolve(__dirname, './absolute.js')),
+    elementQuery: '.absolute'
   }
 ]
 


### PR DESCRIPTION
### Description
#8808 completely removed drive-relative path resolution behavior.
I removed this because I thought it was not intended: it was resolving using `process.cwd()` as a base, not the importer.

But I found that node.js supports drive-relative path resolution (https://github.com/nodejs/node/issues/31710) and now I think this should be implemented.

This PR implements drive-relative path resolution (with the correct base). In addition, this PR adds absolute path resolution test.

### Additional context
I tested the behavior of drive-relative path by:
`$ node D:\foo.mjs` on `pwd = C:\`

`D:\foo.mjs`
```js
import '/bar.mjs'

console.log('foo.mjs')
```

`D:\bar.js`
```js
console.log('bar.mjs')
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
