### PR TITLE
fix: print error file path when using `rollupOptions.output.dir` (fix #9100)

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -47,14 +47,12 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
     content: string | Uint8Array,
     type: WriteType,
     maxLength: number,
+    outDir = config.build.outDir,
     compressedSize = ''
   ) {
-    const outDir =
+    outDir =
       normalizePath(
-        path.relative(
-          config.root,
-          path.resolve(config.root, config.build.outDir)
-        )
+        path.relative(config.root, path.resolve(config.root, outDir))
       ) + '/'
     const kibs = content.length / 1024
     const sizeColor = kibs > chunkLimit ? colors.yellow : colors.dim
@@ -137,7 +135,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       }
     },
 
-    async writeBundle(_, output) {
+    async writeBundle({ dir: outDir }, output) {
       let hasLargeChunks = false
 
       if (shouldLogInfo) {
@@ -161,6 +159,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                   chunk.code,
                   WriteType.JS,
                   longest,
+                  outDir,
                   await getCompressedSize(chunk.code)
                 )
                 if (chunk.map) {
@@ -168,7 +167,8 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                     chunk.fileName + '.map',
                     chunk.map.toString(),
                     WriteType.SOURCE_MAP,
-                    longest
+                    longest,
+                    outDir
                   )
                 }
               }
@@ -190,6 +190,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                   ? WriteType.SOURCE_MAP
                   : WriteType.ASSET,
                 longest,
+                outDir,
                 isCSS ? await getCompressedSize(chunk.source) : undefined
               )
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix #9110

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Current prints:

![image](https://user-images.githubusercontent.com/40221744/178963179-7e27e6e4-7279-40c3-9322-1141561a3f93.png)

I think it's better to improve to print for each dir by groups, like the following:

```
lib/
  test.js ...
  other.js ...

es/
  test.mjs ...
  other.mjs ...
```

Should I do this?

One more point:

![image](https://user-images.githubusercontent.com/40221744/178965199-7703e48f-82b4-4c4f-8e08-c92381f4defa.png)

`prepareOutDir` only process the `outDir` and ignored `dir` in `output` config, is this expected?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
