### PR TITLE
fix: mention that Node.js 13/15 support is dropped (fixes #9113)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -137,13 +137,13 @@ module.exports = defineConfig({
         'node/no-unsupported-features/es-builtins': [
           'error',
           {
-            version: '>=14.18.0'
+            version: '^14.18.0 || >=16.0.0'
           }
         ],
         'node/no-unsupported-features/node-builtins': [
           'error',
           {
-            version: '>=14.18.0'
+            version: '^14.18.0 || >=16.0.0'
           }
         ]
       }

--- a/docs/blog/announcing-vite3.md
+++ b/docs/blog/announcing-vite3.md
@@ -223,7 +223,7 @@ A triaging marathon was spearheaded by [@bluwyoo](https://twitter.com/bluwyoo), 
 
 ## Compatibility Notes
 
-- Vite no longer supports Node.js 12, which reached its EOL. Node.js 14.18+ is now required.
+- Vite no longer supports Node.js 12 and 15, which reached its EOL. Node.js 14.18+, 16+ is now required.
 - Vite is now published as ESM, with a CJS proxy to the ESM entry for compatibility.
 - The Modern Browser Baseline now targets browsers which support the [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_statements_import_meta) features.
 - JS file extensions in SSR and library mode now use a valid extension (`js`, `mjs`, or `cjs`) for output JS entries and chunks based on their format and the package type.

--- a/docs/blog/announcing-vite3.md
+++ b/docs/blog/announcing-vite3.md
@@ -223,7 +223,7 @@ A triaging marathon was spearheaded by [@bluwyoo](https://twitter.com/bluwyoo), 
 
 ## Compatibility Notes
 
-- Vite no longer supports Node.js 12 and 15, which reached its EOL. Node.js 14.18+, 16+ is now required.
+- Vite no longer supports Node.js 12 / 13 / 15, which reached its EOL. Node.js 14.18+ / 16+ is now required.
 - Vite is now published as ESM, with a CJS proxy to the ESM entry for compatibility.
 - The Modern Browser Baseline now targets browsers which support the [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_statements_import_meta) features.
 - JS file extensions in SSR and library mode now use a valid extension (`js`, `mjs`, or `cjs`) for output JS entries and chunks based on their format and the package type.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -38,7 +38,7 @@ The supported template presets are:
 ## Scaffolding Your First Vite Project
 
 ::: tip Compatibility Note
-Vite requires [Node.js](https://nodejs.org/en/) version >=14.18.0. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
+Vite requires [Node.js](https://nodejs.org/en/) version 14.18+, 16+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
 :::
 
 With NPM:

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -2,7 +2,7 @@
 
 ## Node.js Support
 
-Vite no longer supports Node.js 12 and 15, which reached its EOL. Node.js 14.18+, 16+ is now required.
+Vite no longer supports Node.js 12 / 13 / 15, which reached its EOL. Node.js 14.18+ / 16+ is now required.
 
 ## Modern Browser Baseline change
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -2,7 +2,7 @@
 
 ## Node.js Support
 
-Vite no longer supports Node.js 12, which reached its EOL. Node.js 14.18+ is now required.
+Vite no longer supports Node.js 12 and 15, which reached its EOL. Node.js 14.18+, 16+ is now required.
 
 ## Modern Browser Baseline change
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vite-monorepo",
   "private": true,
   "engines": {
-    "node": ">=14.18.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "homepage": "https://vitejs.dev/",
   "keywords": [

--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -3,7 +3,7 @@
 ## Scaffolding Your First Vite Project
 
 > **Compatibility Note:**
-> Vite requires [Node.js](https://nodejs.org/en/) version >=14.18.0. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
+> Vite requires [Node.js](https://nodejs.org/en/) version 14.18+, 16+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
 
 With NPM:
 

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -14,7 +14,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=14.18.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": ">=14.18.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -32,7 +32,7 @@
     "types"
   ],
   "engines": {
-    "node": ">=14.18.0"
+    "node": "^14.18.0 || >=16.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Node.js 13 / 15 is already EOL and does not work with Vite 3. This was intended to drop but this was forgotten to mention.

fixes #9113

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
