### PR TITLE
fix: use correct require extension to load config

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -978,9 +978,11 @@ async function loadConfigFromBundledFile(
   fileName: string,
   bundledCode: string
 ): Promise<UserConfig> {
+  const extension = path.extname(fileName)
   const realFileName = fs.realpathSync(fileName)
-  const defaultLoader = _require.extensions['.js']
-  _require.extensions['.js'] = (module: NodeModule, filename: string) => {
+  const loaderExt = extension in _require.extensions ? extension : '.js'
+  const defaultLoader = _require.extensions[loaderExt]!
+  _require.extensions[loaderExt] = (module: NodeModule, filename: string) => {
     if (filename === realFileName) {
       ;(module as NodeModuleWithCompile)._compile(bundledCode, filename)
     } else {
@@ -990,7 +992,7 @@ async function loadConfigFromBundledFile(
   // clear cache in case of server restart
   delete _require.cache[_require.resolve(fileName)]
   const raw = _require(fileName)
-  _require.extensions['.js'] = defaultLoader
+  _require.extensions[loaderExt] = defaultLoader
   return raw.__esModule ? raw.default : raw
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #9112

Check in `_require.extensions` for `.ts` added by `ts-node` before falling back to `.js`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
