### PR TITLE
refactor: always load config with esbuild bundled code

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1130,8 +1130,6 @@ export function stripBomTag(content: string): string {
   return content
 }
 
-export const isTS = (filename: string): boolean => /\.[cm]?ts$/.test(filename)
-
 const windowsDrivePathPrefixRE = /^[A-Za-z]:[/\\]/
 
 /**

--- a/playground/ssr-vue/vite.config.js
+++ b/playground/ssr-vue/vite.config.js
@@ -10,6 +10,11 @@ const nestedVirtualId = '\0' + nestedVirtualFile
 
 const base = '/test/'
 
+// preserve this to test loading __filename & __dirname in ESM as Vite polyfills them.
+// if Vite incorrectly load this file, node.js would error out.
+globalThis.__vite_test_filename = __filename
+globalThis.__vite_test_dirname = __dirname
+
 export default defineConfig(({ command, ssrBuild }) => ({
   base,
   plugins: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #9109

ESM config files can be loaded by node directly, but this has the caveat of not being able to use `__filename`, `__dirname` which we document do support. Since we're already always bundling the config (to track dependencies), this PR uses the bundled code when loading them in ESM too.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
