### PR TITLE
fix(ssr): strip NULL_BYTE_PLACEHOLDER before import

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -38,11 +38,9 @@ import {
   moduleListContains,
   normalizePath,
   prettifyUrl,
-  removeImportQuery,
   stripBomTag,
   timeFrom,
-  transformStableResult,
-  unwrapId
+  transformStableResult
 } from '../utils'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
@@ -706,10 +704,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // by the deps optimizer
       if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach(({ url, id }) => {
-          url = unwrapId(removeImportQuery(url)).replace(
-            NULL_BYTE_PLACEHOLDER,
-            '\0'
-          )
           transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -38,9 +38,11 @@ import {
   moduleListContains,
   normalizePath,
   prettifyUrl,
+  removeImportQuery,
   stripBomTag,
   timeFrom,
-  transformStableResult
+  transformStableResult,
+  unwrapId
 } from '../utils'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
@@ -704,6 +706,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // by the deps optimizer
       if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach(({ url, id }) => {
+          url = unwrapId(removeImportQuery(url)).replace(
+            NULL_BYTE_PLACEHOLDER,
+            '\0'
+          )
           transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -137,7 +137,8 @@ async function instantiateModule(
     if (dep[0] !== '.' && dep[0] !== '/') {
       return nodeImport(dep, mod.file!, resolveOptions)
     }
-    dep = unwrapId(dep)
+    // convert to rollup URL because `pendingImports`, `moduleGraph.urlToModuleMap` requires that
+    dep = unwrapId(dep).replace(NULL_BYTE_PLACEHOLDER, '\0')
     if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
       pendingDeps.push(dep)
       if (pendingDeps.length === 1) {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -38,7 +38,7 @@ export async function ssrLoadModule(
   urlStack: string[] = [],
   fixStacktrace?: boolean
 ): Promise<SSRModule> {
-  url = unwrapId(url)
+  url = unwrapId(url).replace(NULL_BYTE_PLACEHOLDER, '\0')
 
   // when we instantiate multiple dependency modules in parallel, they may
   // point to shared modules. We need to avoid duplicate instantiation attempts
@@ -137,7 +137,7 @@ async function instantiateModule(
     if (dep[0] !== '.' && dep[0] !== '/') {
       return nodeImport(dep, mod.file!, resolveOptions)
     }
-    dep = unwrapId(dep).replace(NULL_BYTE_PLACEHOLDER, '\0')
+    dep = unwrapId(dep)
     if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
       pendingDeps.push(dep)
       if (pendingDeps.length === 1) {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -38,7 +38,7 @@ export async function ssrLoadModule(
   urlStack: string[] = [],
   fixStacktrace?: boolean
 ): Promise<SSRModule> {
-  url = unwrapId(url).replace(NULL_BYTE_PLACEHOLDER, '\0')
+  url = unwrapId(url)
 
   // when we instantiate multiple dependency modules in parallel, they may
   // point to shared modules. We need to avoid duplicate instantiation attempts
@@ -137,7 +137,7 @@ async function instantiateModule(
     if (dep[0] !== '.' && dep[0] !== '/') {
       return nodeImport(dep, mod.file!, resolveOptions)
     }
-    dep = unwrapId(dep)
+    dep = unwrapId(dep).replace(NULL_BYTE_PLACEHOLDER, '\0')
     if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
       pendingDeps.push(dep)
       if (pendingDeps.length === 1) {


### PR DESCRIPTION
### Description
This PR revises #6390. That implementation might duplicate moduleGraph entry (not sure if it happens).

~~Maybe it is safer to go with #9036 for 3.0 and merge this PR in 3.1.~~

reverts #6390
~~fixes the issue described at #9036~~ (it's still worth to merge that PR because it replaces the deprecated `url.parse`)

### Additional context
This line `import 'id'` becomes `import 'resolvedId'`.
https://github.com/vitejs/vite/blob/0cb4b2550fa44a1c7bf5e37c70d7654627ea840e/packages/vite/src/node/ssr/ssrModuleLoader.ts#L87-L89
Then, that `resolvedId` is passed to `ssrLoadModule` here.
https://github.com/vitejs/vite/blob/0cb4b2550fa44a1c7bf5e37c70d7654627ea840e/packages/vite/src/node/ssr/ssrModuleLoader.ts#L136-L162

So for the first `instantiateModule` call by `ssrLoadModule`, the raw url is passed to `instantiateModule`. But for other calls, the resolvedId is passed as url to `instantiateModule`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
    - covered by #6390's test