### PR TITLE
docs: note library mode process.env.* replacement

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -189,6 +189,10 @@ Recommended `package.json` for your lib:
 If the `package.json` does not contain `"type": "module"`, Vite will generate different file extensions for Node.js compatibility. `.js` will become `.mjs` and `.cjs` will become `.js`.
 :::
 
+::: tip Environment Variables
+In library mode, all `import.meta.env.*` usage are statically replaced when building for production. However, `process.env.*` usage are not, so that consumers of your library can dynamically change it. If this is undesirable, you can use `define: { 'process.env.`<wbr>`NODE_ENV': '"production"' }` for example to statically replace them.
+:::
+
 ## Advanced Base Options
 
 ::: warning


### PR DESCRIPTION
Add a note for those who wish to replace `process.env.NODE_ENV` for library mode.