### PR TITLE
fix(types): fix type checking error with eslint

### DIFF
--- a/packages/create-vite/template-vue-ts/src/vite-env.d.ts
+++ b/packages/create-vite/template-vue-ts/src/vite-env.d.ts
@@ -2,6 +2,6 @@
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
-  const component: DefineComponent<{}, {}, any>
+  const component: DefineComponent
   export default component
 }


### PR DESCRIPTION
pass any to DefineComponent occurs typescript eslint type checking error

### Description
passing `any` to `DefineComponent` occurs typescript eslint type checking error, remove to fix this error.

![image](https://user-images.githubusercontent.com/4933537/179196434-2de9e435-885b-4447-8b3c-1cb57a06ff47.png)
referrence: https://github.com/typescript-eslint/typescript-eslint/issues/5292

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
