### PR TITLE
fix: externalize workspace relative import when bundle config

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -901,14 +901,14 @@ async function bundleConfigFile(
         name: 'externalize-deps',
         setup(build) {
           build.onResolve({ filter: /.*/ }, ({ path: id, importer }) => {
-            // bundle all relative paths
+            // externalize bare imports
             if (id[0] !== '.' && !path.isAbsolute(id)) {
               return {
                 external: true
               }
             }
-            // if the file is outside of a vite project, make sure that the we can
-            // also access it's third-party dependencies. externalize if not.
+            // bundle the rest and make sure that the we can also access
+            // it's third-party dependencies. externalize if not.
             // monorepo/
             // ├─ package.json
             // ├─ utils.js -----------> bundle (share same node_modules)
@@ -918,21 +918,19 @@ async function bundleConfigFile(
             // ├─ foo-project/
             // │  ├─ utils.js --------> external (has own node_modules)
             // │  ├─ package.json
-            if (id.startsWith('..')) {
-              const idFsPath = path.resolve(path.dirname(importer), id)
-              const idPkgPath = lookupFile(idFsPath, [`package.json`], {
-                pathOnly: true
-              })
-              if (idPkgPath) {
-                const idPkgDir = path.dirname(idPkgPath)
-                // if this file needs to go up one or more directory to reach the vite config,
-                // that means it has it's own node_modules (e.g. foo-project)
-                if (path.relative(idPkgDir, fileName).startsWith('..')) {
-                  return {
-                    // normalize actual relative import after bundled as a single vite config
-                    path: path.relative(path.dirname(fileName), idFsPath),
-                    external: true
-                  }
+            const idFsPath = path.resolve(path.dirname(importer), id)
+            const idPkgPath = lookupFile(idFsPath, [`package.json`], {
+              pathOnly: true
+            })
+            if (idPkgPath) {
+              const idPkgDir = path.dirname(idPkgPath)
+              // if this file needs to go up one or more directory to reach the vite config,
+              // that means it has it's own node_modules (e.g. foo-project)
+              if (path.relative(idPkgDir, fileName).startsWith('..')) {
+                return {
+                  // normalize actual import after bundled as a single vite config
+                  path: idFsPath,
+                  external: true
                 }
               }
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes failing sveltekit test in ecosystem-ci.



### Additional context

The issue is that in [this config file](https://github.com/sveltejs/kit/blob/master/packages/adapter-static/test/apps/prerendered/vite.config.js). It's importing `../../utils.js`, which imports from another workspace package (`kit`). If we bundle the files and leave bare imports externalized, the bundled code can't import deps from that other workspace package, leading to a runtime error.

This PR makes sure that for files in another package, we should externalize them so that they can require the deps themselves. However, this may regress the second workaround for https://github.com/vitejs/vite/issues/5370 if the file from another package doesn't import anything, but I don't think that it's good to allow it in the first place (?).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
