### PR TITLE
fix: ssr.external/noExternal should apply to packageName

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -120,13 +120,17 @@ export function createIsConfiguredAsSsrExternal(
   return (id: string) => {
     const { ssr } = config
     if (ssr) {
-      if (ssr.external?.includes(id)) {
+      const pkgName = getNpmPackageName(id)
+      if (!pkgName) {
+        return undefined
+      }
+      if (ssr.external?.includes(pkgName)) {
         return true
       }
       if (typeof noExternal === 'boolean') {
         return !noExternal
       }
-      if (noExternalFilter && !noExternalFilter(id)) {
+      if (noExternalFilter && !noExternalFilter(pkgName)) {
         return false
       }
     }


### PR DESCRIPTION
### Description

Fixes
- https://github.com/sveltejs/kit/issues/5549

Also fixes https://github.com/Cluster2a/chartjsError, where we need now to add because of deps being external by default:
```js 
  ssr: {
    noExternal: ['chart.js']
  }
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other