### PR TITLE
docs: __dirname is not available in ES modules

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -64,11 +64,11 @@ When building an SSR app, you likely want to have full control over your main se
 ```js{17-19}
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 import express from 'express'
-import { fileURLToPath } from "url";
-import { createServer as createViteServer } from "vite";
+import { createServer as createViteServer } from 'vite'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 async function createServer() {
   const app = express()

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -65,7 +65,10 @@ When building an SSR app, you likely want to have full control over your main se
 import fs from 'fs'
 import path from 'path'
 import express from 'express'
-import {createServer as createViteServer} from 'vite'
+import { fileURLToPath } from "url";
+import { createServer as createViteServer } from "vite";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 async function createServer() {
   const app = express()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

the sample code of SSR guide using `__dirname` which is not available in ES modules. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
