### PR TITLE
feat: allow declaring `__dirname` in config

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -23,19 +23,6 @@ You can also explicitly specify a config file to use with the `--config` CLI opt
 vite --config my-config.js
 ```
 
-::: tip NOTE
-Vite will inject `__filename`, `__dirname` in config files and its deps. Declaring these variables at top level will result in an error:
-
-```js
-const __filename = 'value' // SyntaxError: Identifier '__filename' has already been declared
-
-const func = () => {
-  const __filename = 'value' // no error
-}
-```
-
-:::
-
 ## Config Intellisense
 
 Since Vite ships with TypeScript typings, you can leverage your IDE's intellisense with jsdoc type hints:

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -882,6 +882,8 @@ async function bundleConfigFile(
   fileName: string,
   isESM: boolean
 ): Promise<{ code: string; dependencies: string[] }> {
+  const dirnameVarName = '__vite_injected_original_dirname'
+  const filenameVarName = '__vite_injected_original_filename'
   const importMetaUrlVarName = '__vite_injected_original_import_meta_url'
   const result = await build({
     absWorkingDir: process.cwd(),
@@ -894,6 +896,8 @@ async function bundleConfigFile(
     sourcemap: 'inline',
     metafile: true,
     define: {
+      __dirname: dirnameVarName,
+      __filename: filenameVarName,
       'import.meta.url': importMetaUrlVarName
     },
     plugins: [
@@ -943,8 +947,10 @@ async function bundleConfigFile(
           build.onLoad({ filter: /\.[cm]?[jt]s$/ }, async (args) => {
             const contents = await fs.promises.readFile(args.path, 'utf8')
             const injectValues =
-              `const __dirname = ${JSON.stringify(path.dirname(args.path))};` +
-              `const __filename = ${JSON.stringify(args.path)};` +
+              `const ${dirnameVarName} = ${JSON.stringify(
+                path.dirname(args.path)
+              )};` +
+              `const ${filenameVarName} = ${JSON.stringify(args.path)};` +
               `const ${importMetaUrlVarName} = ${JSON.stringify(
                 pathToFileURL(args.path).href
               )};`


### PR DESCRIPTION
### Description
Currently `__dirname`/`__filename` cannot be declared at top level in config files since Vite injects those variables.
The code below is a common pattern but an error will happen.
```js
import path from 'node:path'
import { defineConfig } from 'vite'

const __dirname = path.dirname(new URL(import.meta.url).pathname)

export default defineConfig({})
```

This PR makes it possible to declare those at top level.
esbuild's define only replaces top-level values (it's not a static replace) so this works.

refs #9147

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
