### PR TITLE
fix: disable keepNames in `vite:esbuild` (fixes #9164)

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -182,7 +182,11 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
     minifyIdentifiers: false,
     minifySyntax: false,
     minifyWhitespace: false,
-    treeShaking: false
+    treeShaking: false,
+    // keepNames is not needed when minify is disabled.
+    // Also transforming multiple times with keepNames enabled breaks
+    // tree-shaking. (#9164)
+    keepNames: false
   }
 
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Transforming a function by esbuild with `keepNames` enabled multiple times will break tree-shaking.

Example:
```js
// Input
function a() {}

// After `--tree-shaking`
/* empty */

// After `--keep-names`
var __defProp = Object.defineProperty;
var __name = (target, value) => __defProp(target, "name", { value, configurable: true });
function a() {
}
__name(a, "a");

// After `--keep-names` => `--tree-shaking --minify`
var __defProp=Object.defineProperty,__name=(e,r)=>__defProp(e,"name",{value:r,configurable:!0});function a(){}__name(a,"a");
```

This PR disables `keepNames` in `vite:esbuild` because `keepNames` is only needed when minify is enabled.

> However, [minification](https://esbuild.github.io/api/#minify) renames symbols to reduce code size and [bundling](https://esbuild.github.io/api/#bundle) sometimes need to rename symbols to avoid collisions. That changes value of the `name` property for many of these cases.
> https://esbuild.github.io/api/#keep-names

fixes #9164

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
