### PR TITLE
fix(resolve): make tryNodeResolve more robust

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -110,7 +110,7 @@
     "postcss-import": "^15.0.0",
     "postcss-load-config": "^4.0.1",
     "postcss-modules": "^5.0.0",
-    "resolve.exports": "^1.1.0",
+    "resolve.exports": "npm:@alloc/resolve.exports@^1.1.0",
     "sirv": "^2.0.2",
     "source-map-js": "^1.0.2",
     "source-map-support": "^0.5.21",

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -48,11 +48,7 @@ import {
   DEFAULT_MAIN_FIELDS,
   ENV_ENTRY
 } from './constants'
-import type {
-  InternalResolveOptions,
-  InternalResolveOptionsWithOverrideConditions,
-  ResolveOptions
-} from './plugins/resolve'
+import type { InternalResolveOptions, ResolveOptions } from './plugins/resolve'
 import { resolvePlugin, tryNodeResolve } from './plugins/resolve'
 import type { LogLevel, Logger } from './logger'
 import { createLogger } from './logger'
@@ -958,7 +954,7 @@ async function bundleConfigFile(
       {
         name: 'externalize-deps',
         setup(build) {
-          const options: InternalResolveOptionsWithOverrideConditions = {
+          const options: InternalResolveOptions = {
             root: path.dirname(fileName),
             isBuild: true,
             isProduction: true,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -968,7 +968,7 @@ async function bundleConfigFile(
             mainFields: [],
             browserField: false,
             conditions: [],
-            overrideConditions: ['node'],
+            overrideConditions: ['node', 'require'],
             dedupe: [],
             extensions: DEFAULT_EXTENSIONS,
             preserveSymlinks: false

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -163,3 +163,16 @@ export function watchPackageDataPlugin(config: ResolvedConfig): Plugin {
     }
   }
 }
+
+export function findPackageJson(dir: string): string | null {
+  // Stop looking at node_modules directory.
+  if (path.basename(dir) === 'node_modules') {
+    return null
+  }
+  const pkgPath = path.join(dir, 'package.json')
+  if (fs.existsSync(pkgPath)) {
+    return pkgPath
+  }
+  const parentDir = path.dirname(dir)
+  return parentDir !== dir ? findPackageJson(parentDir) : null
+}

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -176,3 +176,27 @@ export function findPackageJson(dir: string): string | null {
   const parentDir = path.dirname(dir)
   return parentDir !== dir ? findPackageJson(parentDir) : null
 }
+
+const workspaceRootFiles = ['lerna.json', 'pnpm-workspace.yaml', '.git']
+
+export function isWorkspaceRoot(
+  dir: string,
+  preserveSymlinks?: boolean,
+  packageCache?: PackageCache
+): boolean {
+  const files = fs.readdirSync(dir)
+  if (files.some((file) => workspaceRootFiles.includes(file))) {
+    return true // Found a lerna/pnpm workspace or git repository.
+  }
+  if (files.includes('package.json')) {
+    const workspacePkg = loadPackageData(
+      path.join(dir, 'package.json'),
+      preserveSymlinks,
+      packageCache
+    )
+    if (workspacePkg?.data.workspaces) {
+      return true // Found a npm/yarn workspace.
+    }
+  }
+  return false
+}

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -579,21 +579,19 @@ function tryResolveFile(
   }
 }
 
-export type InternalResolveOptionsWithOverrideConditions =
-  InternalResolveOptions & {
-    /**
-     * @deprecated In future, `conditions` will work like this.
-     * @internal
-     */
-    overrideConditions?: string[]
-  }
+export interface InternalNodeResolveOptions extends InternalResolveOptions {
+  /**
+   * When defined, only conditions defined in this array will be used.
+   */
+  overrideConditions?: string[]
+}
 
 export const idToPkgMap = new Map<string, PackageData>()
 
 export function tryNodeResolve(
   id: string,
   importer: string | null | undefined,
-  options: InternalResolveOptionsWithOverrideConditions,
+  options: InternalNodeResolveOptions,
   targetWeb: boolean,
   depsOptimizer?: DepsOptimizer,
   ssr?: boolean,
@@ -1053,7 +1051,7 @@ function resolveDeepImport(
     data
   }: PackageData,
   targetWeb: boolean,
-  options: InternalResolveOptionsWithOverrideConditions
+  options: InternalNodeResolveOptions
 ): string | undefined {
   const cache = getResolvedCache(id, targetWeb)
   if (cache) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -737,9 +737,11 @@ export function tryNodeResolve(
         }
       }
 
-      // Reset the `pkgId` variable since we use it later on
-      // and the package.json didn't help us find the module.
+      // Reset the resolvedPkg variables to avoid false positives as we
+      // continue our search.
+      resolvedPkg = undefined
       resolvedPkgId = undefined
+      resolvedPkgType = undefined
       continue
     }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -43,13 +43,13 @@ import {
 import { optimizedDepInfoFromFile, optimizedDepInfoFromId } from '../optimizer'
 import type { DepsOptimizer } from '../optimizer'
 import type { SSROptions } from '..'
+import type { PackageCache, PackageData } from '../packages'
 import {
   findPackageJson,
   isWorkspaceRoot,
-  PackageCache,
-  PackageData
+  loadPackageData,
+  resolvePackageData
 } from '../packages'
-import { loadPackageData, resolvePackageData } from '../packages'
 import { isWorkerRequest } from './worker'
 
 const normalizedClientEntry = normalizePath(CLIENT_ENTRY)
@@ -765,9 +765,7 @@ export function tryNodeResolve(
       }
     } catch {}
 
-    // In case a file extension is missing, we need to try calling the
-    // `tryFsResolve` function.
-    let entryDir = path.dirname(entryPath)
+    const entryDir = path.dirname(entryPath)
     let entryDirExists = false
     if (entryDir === nodeModulesDir) {
       entryDirExists = true
@@ -779,6 +777,8 @@ export function tryNodeResolve(
     }
 
     if (entryDirExists) {
+      // In case a file extension is missing, we need to try calling the
+      // `tryFsResolve` function.
       resolvedId = tryFsResolve(
         entryPath,
         { ...options, skipPackageJson: true },

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -43,7 +43,12 @@ import {
 import { optimizedDepInfoFromFile, optimizedDepInfoFromId } from '../optimizer'
 import type { DepsOptimizer } from '../optimizer'
 import type { SSROptions } from '..'
-import { findPackageJson, PackageCache, PackageData } from '../packages'
+import {
+  findPackageJson,
+  isWorkspaceRoot,
+  PackageCache,
+  PackageData
+} from '../packages'
 import { loadPackageData, resolvePackageData } from '../packages'
 import { isWorkerRequest } from './worker'
 
@@ -784,6 +789,16 @@ export function tryNodeResolve(
         break
       }
     }
+
+    // Stop looking if we're at the workspace root directory.
+    if (
+      isWorkspaceRoot(
+        path.dirname(nodeModulesDir),
+        preserveSymlinks,
+        packageCache
+      )
+    )
+      break
   }
 
   if (!resolvedId) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1038,7 +1038,14 @@ function packageEntryFailure(id: string, details?: string) {
 }
 
 function getInlineConditions(conditions: string[], targetWeb: boolean) {
-  return targetWeb && !conditions.includes('node') ? ['browser'] : ['node']
+  const inlineConditions =
+    targetWeb && !conditions.includes('node') ? ['browser'] : ['node']
+
+  // The "module" condition is no longer recommended, but some older
+  // packages may still use it.
+  inlineConditions.push('module')
+
+  return inlineConditions
 }
 
 function resolveDeepImport(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { Module } from 'node:module'
 import colors from 'picocolors'
 import type { PartialResolvedId } from 'rollup'
 import { resolveExports } from 'resolve.exports'
@@ -42,7 +43,7 @@ import {
 import { optimizedDepInfoFromFile, optimizedDepInfoFromId } from '../optimizer'
 import type { DepsOptimizer } from '../optimizer'
 import type { SSROptions } from '..'
-import type { PackageCache, PackageData } from '../packages'
+import { findPackageJson, PackageCache, PackageData } from '../packages'
 import { loadPackageData, resolvePackageData } from '../packages'
 import { isWorkerRequest } from './worker'
 
@@ -495,13 +496,17 @@ function tryFsResolve(
     }
   }
 
+  if (!tryIndex) {
+    return
+  }
+
   if (
     postfix &&
     (res = tryResolveFile(
       fsPath,
       '',
       options,
-      tryIndex,
+      true,
       targetWeb,
       options.tryPrefix,
       options.skipPackageJson
@@ -515,7 +520,7 @@ function tryFsResolve(
       file,
       postfix,
       options,
-      tryIndex,
+      true,
       targetWeb,
       options.tryPrefix,
       options.skipPackageJson
@@ -551,8 +556,10 @@ function tryResolveFile(
           }
         }
       }
-      const index = tryFsResolve(file + '/index', options)
-      if (index) return index + postfix
+      const indexFile = tryIndexFile(file, targetWeb, options)
+      if (indexFile) {
+        return indexFile + postfix
+      }
     }
   }
 
@@ -580,7 +587,22 @@ function tryResolveFile(
   }
 }
 
+function tryIndexFile(
+  dir: string,
+  targetWeb: boolean,
+  options: InternalResolveOptions
+) {
+  if (!options.skipPackageJson) {
+    options = { ...options, skipPackageJson: true }
+  }
+  return tryFsResolve(dir + '/index', options, false, targetWeb)
+}
+
 export const idToPkgMap = new Map<string, PackageData>()
+
+const lookupNodeModules = (Module as any)._nodeModulePaths as {
+  (cwd: string): string[]
+}
 
 export function tryNodeResolve(
   id: string,
@@ -601,37 +623,15 @@ export function tryNodeResolve(
   // 'foo'             => ''          & 'foo'
   const lastArrowIndex = id.lastIndexOf('>')
   const nestedRoot = id.substring(0, lastArrowIndex).trim()
-  const nestedPath = id.substring(lastArrowIndex + 1).trim()
 
-  const possiblePkgIds: string[] = []
-  for (let prevSlashIndex = -1; ; ) {
-    let slashIndex = nestedPath.indexOf('/', prevSlashIndex + 1)
-    if (slashIndex < 0) {
-      slashIndex = nestedPath.length
-    }
-
-    const part = nestedPath.slice(
-      prevSlashIndex + 1,
-      (prevSlashIndex = slashIndex)
-    )
-    if (!part) {
-      break
-    }
-
-    // Assume path parts with an extension are not package roots, except for the
-    // first path part (since periods are sadly allowed in package names).
-    // At the same time, skip the first path part if it begins with "@"
-    // (since "@foo/bar" should be treated as the top-level path).
-    if (possiblePkgIds.length ? path.extname(part) : part[0] === '@') {
-      continue
-    }
-
-    const possiblePkgId = nestedPath.slice(0, slashIndex)
-    possiblePkgIds.push(possiblePkgId)
+  if (lastArrowIndex !== -1) {
+    id = id.substring(lastArrowIndex + 1).trim()
   }
 
+  const basePkgId = id.split('/', id[0] === '@' ? 2 : 1).join('/')
+
   let basedir: string
-  if (dedupe?.some((id) => possiblePkgIds.includes(id))) {
+  if (dedupe?.includes(basePkgId)) {
     basedir = root
   } else if (
     importer &&
@@ -643,95 +643,190 @@ export function tryNodeResolve(
     basedir = root
   }
 
-  // nested node module, step-by-step resolve to the basedir of the nestedPath
+  // resolve a chain of packages notated by '>' in the id
   if (nestedRoot) {
     basedir = nestedResolveFrom(nestedRoot, basedir, preserveSymlinks)
   }
 
-  // nearest package.json
-  let nearestPkg: PackageData | undefined
-  // nearest package.json that may have the `exports` field
-  let pkg: PackageData | undefined
+  let resolvedPkg: PackageData | undefined
+  let resolvedPkgId: string | undefined
+  let resolvedPkgType: string | undefined
+  let resolvedId: string | undefined
+  let resolver: typeof resolvePackageEntry
 
-  let pkgId = possiblePkgIds.reverse().find((pkgId) => {
-    nearestPkg = resolvePackageData(
-      pkgId,
-      basedir,
-      preserveSymlinks,
-      packageCache
-    )!
-    return nearestPkg
-  })!
+  const nodeModules = lookupNodeModules(basedir)
+  for (const nodeModulesDir of nodeModules) {
+    if (!fs.existsSync(nodeModulesDir)) {
+      continue
+    }
 
-  const rootPkgId = possiblePkgIds[0]
-  const rootPkg = resolvePackageData(
-    rootPkgId,
-    basedir,
-    preserveSymlinks,
-    packageCache
-  )!
-  if (rootPkg?.data?.exports) {
-    pkg = rootPkg
-    pkgId = rootPkgId
-  } else {
-    pkg = nearestPkg
-  }
+    const entryPath = path.join(nodeModulesDir, id)
+    const nearestPkgPath = findPackageJson(entryPath)
+    if (nearestPkgPath) {
+      resolvedPkg = loadPackageData(
+        nearestPkgPath,
+        preserveSymlinks,
+        packageCache
+      )
+      resolvedPkgId = path.dirname(
+        path.relative(nodeModulesDir, nearestPkgPath)
+      )
 
-  if (!pkg || !nearestPkg) {
-    // if import can't be found, check if it's an optional peer dep.
-    // if so, we can resolve to a special id that errors only when imported.
-    if (
-      !options.isHookNodeResolve &&
-      basedir !== root && // root has no peer dep
-      !isBuiltin(nestedPath) &&
-      !nestedPath.includes('\0') &&
-      bareImportRE.test(nestedPath)
-    ) {
-      // find package.json with `name` as main
-      const mainPackageJson = lookupFile(basedir, ['package.json'], {
-        predicate: (content) => !!JSON.parse(content).name
-      })
-      if (mainPackageJson) {
-        const mainPkg = JSON.parse(mainPackageJson)
-        if (
-          mainPkg.peerDependencies?.[nestedPath] &&
-          mainPkg.peerDependenciesMeta?.[nestedPath]?.optional
-        ) {
-          return {
-            id: `${optionalPeerDepId}:${nestedPath}:${mainPkg.name}`
+      // Always use the nearest package.json to determine whether a
+      // ".js" module is ESM or CJS.
+      resolvedPkgType = resolvedPkg.data.type
+
+      // If the nearest package.json has no "exports" field, then we
+      // need to check the dependency's root directory for an exports
+      // field, since that should take precedence (see #10371).
+      if (resolvedPkgId !== basePkgId) {
+        try {
+          const basePkgPath = path.join(
+            nodeModulesDir,
+            basePkgId,
+            'package.json'
+          )
+          const basePkg = loadPackageData(
+            basePkgPath,
+            preserveSymlinks,
+            packageCache
+          )
+          if (basePkg.data.exports) {
+            resolvedPkg = basePkg
+            resolvedPkgId = path.dirname(
+              path.relative(nodeModulesDir, basePkgPath)
+            )
+          }
+        } catch (e) {
+          if (e.code !== 'ENOENT') {
+            throw e
           }
         }
       }
+
+      let usedId: string
+      if (resolvedPkgId === id) {
+        // Use the main entry point
+        resolver = resolvePackageEntry
+        usedId = id
+      } else {
+        // Use a deep entry point
+        resolver = resolveDeepImport
+        usedId = '.' + id.slice(resolvedPkgId.length)
+      }
+
+      try {
+        resolvedId = resolver(usedId, resolvedPkg, targetWeb, options)
+        if (resolvedId) {
+          break
+        }
+      } catch (err) {
+        if (!options.tryEsmOnly) {
+          throw err
+        }
+      }
+      if (options.tryEsmOnly) {
+        resolvedId = resolver(usedId, resolvedPkg, targetWeb, {
+          ...options,
+          isRequire: false,
+          mainFields: DEFAULT_MAIN_FIELDS,
+          extensions: DEFAULT_EXTENSIONS
+        })
+        if (resolvedId) {
+          break
+        }
+      }
+
+      // Reset the `pkgId` variable since we use it later on
+      // and the package.json didn't help us find the module.
+      resolvedPkgId = undefined
+      continue
     }
-    return
+
+    // No package.json was found, but there could still be a module
+    // here. To match Node's behavior, we must be able to resolve a
+    // module without a package.json file helping us out.
+    try {
+      const stat = fs.statSync(entryPath)
+      if (stat.isFile()) {
+        resolvedId = entryPath
+        break
+      }
+      resolvedId = tryIndexFile(entryPath, targetWeb, options)
+      if (resolvedId) {
+        break
+      }
+    } catch {}
+
+    // In case a file extension is missing, we need to try calling the
+    // `tryFsResolve` function.
+    try {
+      const stat = fs.statSync(path.dirname(entryPath))
+      if (stat.isDirectory()) {
+        resolvedId = tryFsResolve(
+          entryPath,
+          { ...options, skipPackageJson: true },
+          false,
+          targetWeb
+        )
+        if (resolvedId) {
+          break
+        }
+      }
+    } catch {}
   }
 
-  let resolveId = resolvePackageEntry
-  let unresolvedId = pkgId
-  const isDeepImport = unresolvedId !== nestedPath
-  if (isDeepImport) {
-    resolveId = resolveDeepImport
-    unresolvedId = '.' + nestedPath.slice(pkgId.length)
-  }
+  if (!resolvedId) {
+    const mayBeOptionalPeerDep =
+      !options.isHookNodeResolve &&
+      basedir !== root &&
+      !isBuiltin(basePkgId) &&
+      !basePkgId.includes('\0') &&
+      bareImportRE.test(basePkgId)
 
-  let resolved: string | undefined
-  try {
-    resolved = resolveId(unresolvedId, pkg, targetWeb, options)
-  } catch (err) {
-    if (!options.tryEsmOnly) {
-      throw err
+    if (!mayBeOptionalPeerDep) {
+      return // Module not found.
     }
-  }
-  if (!resolved && options.tryEsmOnly) {
-    resolved = resolveId(unresolvedId, pkg, targetWeb, {
-      ...options,
-      isRequire: false,
-      mainFields: DEFAULT_MAIN_FIELDS,
-      extensions: DEFAULT_EXTENSIONS
+
+    // Find the importer's nearest package.json with a "name" field.
+    // Some projects (like Svelte) have nameless package.json files to
+    // appease older Node.js versions and they don't have the list of
+    // optional peer dependencies like the root package.json does.
+    let basePkg: PackageData | undefined
+    lookupFile(basedir, ['package.json'], {
+      pathOnly: true,
+      predicate(pkgPath) {
+        basePkg = loadPackageData(pkgPath, preserveSymlinks, packageCache)
+        return !!basePkg.data.name
+      }
     })
+
+    if (!basePkg) {
+      return // Module not found.
+    }
+
+    const { peerDependencies, peerDependenciesMeta } = basePkg.data
+    const optionalPeerDep =
+      peerDependenciesMeta?.[basePkgId]?.optional &&
+      peerDependencies?.[basePkgId]
+
+    if (!optionalPeerDep) {
+      return // Module not found.
+    }
+
+    return {
+      id: `${optionalPeerDepId}:${basePkgId}:${basePkg.data.name}`
+    }
   }
-  if (!resolved) {
-    return
+
+  if (!resolvedPkg) {
+    const pkgPath = lookupFile(path.dirname(resolvedId), ['package.json'], {
+      pathOnly: true
+    })
+    if (!pkgPath) {
+      return // Resolved module must be within a package.
+    }
+    resolvedPkg = loadPackageData(pkgPath, preserveSymlinks, packageCache)
   }
 
   const processResult = (resolved: PartialResolvedId) => {
@@ -753,8 +848,8 @@ export function tryNodeResolve(
       return resolved
     }
     let resolvedId = id
-    if (isDeepImport) {
-      if (!pkg?.data.exports && path.extname(id) !== resolvedExt) {
+    if (resolver === resolveDeepImport) {
+      if (!resolvedPkg?.data.exports && path.extname(id) !== resolvedExt) {
         resolvedId = resolved.id.slice(resolved.id.indexOf(id))
         isDebug &&
           debug(
@@ -766,33 +861,33 @@ export function tryNodeResolve(
   }
 
   // link id to pkg for browser field mapping check
-  idToPkgMap.set(resolved, pkg)
+  idToPkgMap.set(resolvedId, resolvedPkg)
   if ((isBuild && !depsOptimizer) || externalize) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return processResult({
-      id: resolved,
-      moduleSideEffects: pkg.hasSideEffects(resolved)
+      id: resolvedId,
+      moduleSideEffects: resolvedPkg.hasSideEffects(resolvedId)
     })
   }
 
-  const ext = path.extname(resolved)
+  const ext = path.extname(resolvedId)
   const isCJS =
-    ext === '.cjs' || (ext === '.js' && nearestPkg.data.type !== 'module')
+    ext === '.cjs' || (ext === '.js' && resolvedPkgType !== 'module')
 
   if (
     !options.ssrOptimizeCheck &&
-    (!resolved.includes('node_modules') || // linked
+    (!resolvedId.includes('node_modules') || // linked
       !depsOptimizer || // resolving before listening to the server
       options.scan) // initial esbuild scan phase
   ) {
-    return { id: resolved }
+    return { id: resolvedId }
   }
 
   // if we reach here, it's a valid dep import that hasn't been optimized.
   const isJsType = depsOptimizer
-    ? isOptimizable(resolved, depsOptimizer.options)
-    : OPTIMIZABLE_ENTRY_RE.test(resolved)
+    ? isOptimizable(resolvedId, depsOptimizer.options)
+    : OPTIMIZABLE_ENTRY_RE.test(resolvedId)
 
   let exclude = depsOptimizer?.options.exclude
   let include = depsOptimizer?.options.exclude
@@ -803,22 +898,28 @@ export function tryNodeResolve(
   }
 
   const skipOptimization =
+    !resolvedPkgId ||
     !isJsType ||
     importer?.includes('node_modules') ||
-    exclude?.includes(pkgId) ||
-    exclude?.includes(nestedPath) ||
-    SPECIAL_QUERY_RE.test(resolved) ||
+    exclude?.includes(resolvedPkgId) ||
+    exclude?.includes(basePkgId) ||
+    exclude?.includes(id) ||
+    SPECIAL_QUERY_RE.test(resolvedId) ||
     (!isBuild && ssr) ||
     // Only optimize non-external CJS deps during SSR by default
     (ssr &&
       !isCJS &&
-      !(include?.includes(pkgId) || include?.includes(nestedPath)))
+      !(
+        include?.includes(resolvedPkgId) ||
+        include?.includes(basePkgId) ||
+        include?.includes(id)
+      ))
 
   if (options.ssrOptimizeCheck) {
     return {
       id: skipOptimization
-        ? injectQuery(resolved, `__vite_skip_optimization`)
-        : resolved
+        ? injectQuery(resolvedId, `__vite_skip_optimization`)
+        : resolvedId
     }
   }
 
@@ -831,25 +932,25 @@ export function tryNodeResolve(
     if (!isBuild) {
       const versionHash = depsOptimizer!.metadata.browserHash
       if (versionHash && isJsType) {
-        resolved = injectQuery(resolved, `v=${versionHash}`)
+        resolvedId = injectQuery(resolvedId, `v=${versionHash}`)
       }
     }
   } else {
     // this is a missing import, queue optimize-deps re-run and
     // get a resolved its optimized info
-    const optimizedInfo = depsOptimizer!.registerMissingImport(id, resolved)
-    resolved = depsOptimizer!.getOptimizedDepId(optimizedInfo)
+    const optimizedInfo = depsOptimizer!.registerMissingImport(id, resolvedId)
+    resolvedId = depsOptimizer!.getOptimizedDepId(optimizedInfo)
   }
 
   if (isBuild) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return {
-      id: resolved,
-      moduleSideEffects: pkg.hasSideEffects(resolved)
+      id: resolvedId,
+      moduleSideEffects: resolvedPkg.hasSideEffects(resolvedId)
     }
   } else {
-    return { id: resolved! }
+    return { id: resolvedId }
   }
 }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1099,6 +1099,19 @@ function resolveDeepImport(
       getInlineConditions(options, targetWeb),
       options.overrideConditions
     )
+    if (postfix) {
+      if (possibleFiles.length) {
+        possibleFiles = possibleFiles.map((f) => f + postfix)
+      } else {
+        possibleFiles = resolveExports(
+          data,
+          file + postfix,
+          options,
+          getInlineConditions(options, targetWeb),
+          options.overrideConditions
+        )
+      }
+    }
     if (!possibleFiles.length) {
       throw new Error(
         `Package subpath '${file}' is not defined by "exports" in ` +
@@ -1108,7 +1121,7 @@ function resolveDeepImport(
   } else if (targetWeb && options.browserField && isObject(browserField)) {
     const mapped = mapWithBrowserField(file, browserField)
     if (mapped) {
-      possibleFiles = [mapped]
+      possibleFiles = [mapped + postfix]
     } else if (mapped === false) {
       return (webResolvedImports[id] = browserExternalId)
     }
@@ -1127,7 +1140,6 @@ function resolveDeepImport(
         ))
     )
     if (resolved) {
-      resolved += postfix
       isDebug &&
         debug(
           `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -144,3 +144,12 @@ test('resolve package that contains # in path', async () => {
     '[success]'
   )
 })
+
+// Support this so we can add symlinks to local directories without
+// creating a package.json file (and because Node.js also supports
+// this).
+test('unpackaged modules in node_modules', async () => {
+  expect(await page.textContent('.unpackaged-file')).toMatch('[success]')
+  expect(await page.textContent('.unpackaged-index-file')).toMatch('[success]')
+  expect(await page.textContent('.unpackaged-deep-import')).toMatch('[success]')
+})

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -121,6 +121,15 @@
 <h2>resolve package that contains # in path</h2>
 <p class="path-contains-sharp-symbol"></p>
 
+<h2>unpackaged file in node_modules</h2>
+<p class="unpackaged-file"></p>
+
+<h2>index file from unpackaged directory in node_modules</h2>
+<p class="unpackaged-index-file"></p>
+
+<h2>deep import of unpackaged directory in node_modules</h2>
+<p class="unpackaged-deep-import"></p>
+
 <script type="module">
   import '@generated-content-virtual-file'
   function text(selector, text) {
@@ -277,6 +286,15 @@
 
   import es5Ext from 'es5-ext'
   text('.path-contains-sharp-symbol', '[success]')
+
+  import unpackagedFile from 'pr-9170/unpackaged-file'
+  text('.unpackaged-file', unpackagedFile)
+
+  import unpackagedIndexFile from 'pr-9170/unpackaged-index-file'
+  text('.unpackaged-index-file', unpackagedIndexFile)
+
+  import unpackagedDeepImport from 'pr-9170/unpackaged-deep-import'
+  text('.unpackaged-deep-import', unpackagedDeepImport)
 </script>
 
 <style>

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -12,6 +12,7 @@
     "@babel/runtime": "^7.20.1",
     "es5-ext": "0.10.62",
     "normalize.css": "^8.0.1",
+    "pr-9170": "link:./pr-9170/node_modules/pr-9170",
     "require-pkg-with-module-field": "link:./require-pkg-with-module-field",
     "resolve-browser-field": "link:./browser-field",
     "resolve-browser-module-field1": "link:./browser-module-field1",

--- a/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-deep-import.js
+++ b/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-deep-import.js
@@ -1,0 +1,1 @@
+export default '[success]'

--- a/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-file.js
+++ b/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-file.js
@@ -1,0 +1,1 @@
+export { default } from 'unpackaged-file'

--- a/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-index-file/index.js
+++ b/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-index-file/index.js
@@ -1,0 +1,1 @@
+export default '[success]'

--- a/playground/resolve/pr-9170/node_modules/unpackaged-file.js
+++ b/playground/resolve/pr-9170/node_modules/unpackaged-file.js
@@ -1,0 +1,1 @@
+export default '[success]'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,6 +896,7 @@ importers:
       '@babel/runtime': ^7.20.1
       es5-ext: 0.10.62
       normalize.css: ^8.0.1
+      pr-9170: link:./pr-9170/node_modules/pr-9170
       require-pkg-with-module-field: link:./require-pkg-with-module-field
       resolve-browser-field: link:./browser-field
       resolve-browser-module-field1: link:./browser-module-field1
@@ -911,6 +912,7 @@ importers:
       '@babel/runtime': 7.20.1
       es5-ext: 0.10.62
       normalize.css: 8.0.1
+      pr-9170: link:pr-9170/node_modules/pr-9170
       require-pkg-with-module-field: link:require-pkg-with-module-field
       resolve-browser-field: link:browser-field
       resolve-browser-module-field1: link:browser-module-field1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
       postcss-load-config: ^4.0.1
       postcss-modules: ^5.0.0
       resolve: ^1.22.1
-      resolve.exports: ^1.1.0
+      resolve.exports: npm:@alloc/resolve.exports@^1.1.0
       rollup: ~3.3.0
       sirv: ^2.0.2
       source-map-js: ^1.0.2
@@ -323,7 +323,7 @@ importers:
       postcss-import: 15.0.0_postcss@8.4.19
       postcss-load-config: 4.0.1_postcss@8.4.19
       postcss-modules: 5.0.0_postcss@8.4.19
-      resolve.exports: 1.1.0
+      resolve.exports: /@alloc/resolve.exports/1.1.0
       sirv: 2.0.2
       source-map-js: 1.0.2
       source-map-support: 0.5.21
@@ -1418,6 +1418,11 @@ packages:
       '@algolia/cache-common': 4.13.1
       '@algolia/logger-common': 4.13.1
       '@algolia/requester-common': 4.13.1
+    dev: true
+
+  /@alloc/resolve.exports/1.1.0:
+    resolution: {integrity: sha512-daZJ4gBXxPUgjWjtxRp+5mU9tV6k7cSG2iKFyiPZOTxRzMRFPEe8dcTuqP+zIVSTfFpN1/SCIOMMYeYA7GwQvQ==}
+    engines: {node: '>=10'}
     dev: true
 
   /@ampproject/remapping/2.2.0:
@@ -7771,11 +7776,6 @@ packages:
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  /resolve.exports/1.1.0:
-    resolution: {integrity: sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==}
-    engines: {node: '>=10'}
-    dev: true
 
   /resolve/1.17.0:
     resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}


### PR DESCRIPTION
# ⚠️ Merge #10504 before this

### Description

The `"{id}/package.json"` lookup done by `resolvePackageData` is insufficient for certain edge cases, like when `"node_modules/{dep}"` is linked to a directory without a package.json in it. With this PR, you can now import any file from node_modules even if it has no package.json file associated with it. This mirrors the same capability in Node's resolution algorithm.

Probably fixes #6061 as reported by @sodatea [here](https://github.com/vitejs/vite/pull/5665#discussion_r774594149), since the `getPossibleModuleIds` function now includes the full module ID (even if it has an extension) in the returned array.

### Additional context

<s>Help wanted with testing...</s>

Here's a (non-exhaustive?) list of cases that should be supported now:
- import `foo/bar` when `node_modules/foo/bar.js` exists without package.json
- import `xyz` when `node_modules/xyz.js` exists
- import `xyz` when `node_modules/xyz/index.js` exists without package.json

*edit:* Tests added!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
