### PR TITLE
fix: fs serve only edit pathname (fixes #9148)

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -81,7 +81,7 @@ export function serveStaticMiddleware(
     }
 
     const url = new URL(req.url!, 'http://example.com')
-    const pathname = getDecodedPathname(url)
+    const pathname = decodeURIComponent(url.pathname)
 
     // apply aliases to static requests as well
     let redirectedPathname: string | undefined
@@ -133,7 +133,7 @@ export function serveRawFsMiddleware(
     // the paths are rewritten to `/@fs/` prefixed paths and must be served by
     // searching based from fs root.
     if (url.pathname.startsWith(FS_PREFIX)) {
-      const pathname = getDecodedPathname(url)
+      const pathname = decodeURIComponent(url.pathname)
       // restrict files outside of `fs.allow`
       if (
         !ensureServingAccess(
@@ -156,12 +156,6 @@ export function serveRawFsMiddleware(
       next()
     }
   }
-}
-
-function getDecodedPathname(url: URL) {
-  return url.pathname.includes('%')
-    ? decodeURIComponent(url.pathname)
-    : url.pathname
 }
 
 const _matchOptions = { matchBase: true }

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -80,36 +80,40 @@ export function serveStaticMiddleware(
       return next()
     }
 
-    const url = decodeURIComponent(req.url!)
+    const url = new URL(req.url!, 'http://example.com')
+    const pathname = getDecodedPathname(url)
 
     // apply aliases to static requests as well
-    let redirected: string | undefined
+    let redirectedPathname: string | undefined
     for (const { find, replacement } of server.config.resolve.alias) {
       const matches =
-        typeof find === 'string' ? url.startsWith(find) : find.test(url)
+        typeof find === 'string'
+          ? pathname.startsWith(find)
+          : find.test(pathname)
       if (matches) {
-        redirected = url.replace(find, replacement)
+        redirectedPathname = pathname.replace(find, replacement)
         break
       }
     }
-    if (redirected) {
+    if (redirectedPathname) {
       // dir is pre-normalized to posix style
-      if (redirected.startsWith(dir)) {
-        redirected = redirected.slice(dir.length)
+      if (redirectedPathname.startsWith(dir)) {
+        redirectedPathname = redirectedPathname.slice(dir.length)
       }
     }
 
-    const resolvedUrl = redirected || url
-    let fileUrl = path.resolve(dir, resolvedUrl.replace(/^\//, ''))
-    if (resolvedUrl.endsWith('/') && !fileUrl.endsWith('/')) {
+    const resolvedPathname = redirectedPathname || pathname
+    let fileUrl = path.resolve(dir, resolvedPathname.replace(/^\//, ''))
+    if (resolvedPathname.endsWith('/') && !fileUrl.endsWith('/')) {
       fileUrl = fileUrl + '/'
     }
     if (!ensureServingAccess(fileUrl, server, res, next)) {
       return
     }
 
-    if (redirected) {
-      req.url = encodeURIComponent(redirected)
+    if (redirectedPathname) {
+      url.pathname = encodeURIComponent(redirectedPathname)
+      req.url = url.href.slice(url.origin.length)
     }
 
     serve(req, res, next)
@@ -123,16 +127,17 @@ export function serveRawFsMiddleware(
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteServeRawFsMiddleware(req, res, next) {
-    let url = decodeURIComponent(req.url!)
+    const url = new URL(req.url!, 'http://example.com')
     // In some cases (e.g. linked monorepos) files outside of root will
     // reference assets that are also out of served root. In such cases
     // the paths are rewritten to `/@fs/` prefixed paths and must be served by
     // searching based from fs root.
-    if (url.startsWith(FS_PREFIX)) {
+    if (url.pathname.startsWith(FS_PREFIX)) {
+      const pathname = getDecodedPathname(url)
       // restrict files outside of `fs.allow`
       if (
         !ensureServingAccess(
-          slash(path.resolve(fsPathFromId(url))),
+          slash(path.resolve(fsPathFromId(pathname))),
           server,
           res,
           next
@@ -141,15 +146,22 @@ export function serveRawFsMiddleware(
         return
       }
 
-      url = url.slice(FS_PREFIX.length)
-      if (isWindows) url = url.replace(/^[A-Z]:/i, '')
+      let newPathname = pathname.slice(FS_PREFIX.length)
+      if (isWindows) newPathname = newPathname.replace(/^[A-Z]:/i, '')
 
-      req.url = encodeURIComponent(url)
+      url.pathname = encodeURIComponent(newPathname)
+      req.url = url.href.slice(url.origin.length)
       serveFromRoot(req, res, next)
     } else {
       next()
     }
   }
+}
+
+function getDecodedPathname(url: URL) {
+  return url.pathname.includes('%')
+    ? decodeURIComponent(url.pathname)
+    : url.pathname
 }
 
 const _matchOptions = { matchBase: true }

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -21,6 +21,11 @@ describe.runIf(isServe)('main', () => {
     expect(await page.textContent('.safe-fetch-status')).toBe('200')
   })
 
+  test('safe fetch with query', async () => {
+    expect(await page.textContent('.safe-fetch-query')).toMatch('KEY=safe')
+    expect(await page.textContent('.safe-fetch-query-status')).toBe('200')
+  })
+
   test('safe fetch with special characters', async () => {
     expect(
       await page.textContent('.safe-fetch-subdir-special-characters')
@@ -50,6 +55,11 @@ describe.runIf(isServe)('main', () => {
   test('safe fs fetch', async () => {
     expect(await page.textContent('.safe-fs-fetch')).toBe(stringified)
     expect(await page.textContent('.safe-fs-fetch-status')).toBe('200')
+  })
+
+  test('safe fs fetch', async () => {
+    expect(await page.textContent('.safe-fs-fetch-query')).toBe(stringified)
+    expect(await page.textContent('.safe-fs-fetch-query-status')).toBe('200')
   })
 
   test('safe fs fetch with special characters', async () => {

--- a/playground/fs-serve/root/src/index.html
+++ b/playground/fs-serve/root/src/index.html
@@ -7,6 +7,8 @@
 <h2>Safe Fetch</h2>
 <pre class="safe-fetch-status"></pre>
 <pre class="safe-fetch"></pre>
+<pre class="safe-fetch-query-status"></pre>
+<pre class="safe-fetch-query"></pre>
 
 <h2>Safe Fetch Subdirectory</h2>
 <pre class="safe-fetch-subdir-status"></pre>
@@ -25,6 +27,8 @@
 <h2>Safe /@fs/ Fetch</h2>
 <pre class="safe-fs-fetch-status"></pre>
 <pre class="safe-fs-fetch"></pre>
+<pre class="safe-fs-fetch-query-status"></pre>
+<pre class="safe-fs-fetch-query"></pre>
 <pre class="safe-fs-fetch-special-characters-status"></pre>
 <pre class="safe-fs-fetch-special-characters"></pre>
 
@@ -58,6 +62,17 @@
     .then((data) => {
       text('.safe-fetch', JSON.stringify(data))
     })
+
+  // inside allowed dir with query, safe fetch
+  fetch('/src/safe.txt?query')
+    .then((r) => {
+      text('.safe-fetch-query-status', r.status)
+      return r.text()
+    })
+    .then((data) => {
+      text('.safe-fetch-query', JSON.stringify(data))
+    })
+
   // inside allowed dir, safe fetch
   fetch('/src/subdir/safe.txt')
     .then((r) => {
@@ -125,6 +140,16 @@
     })
     .then((data) => {
       text('.safe-fs-fetch', JSON.stringify(data))
+    })
+
+  // imported before with query, should be treated as safe
+  fetch('/@fs/' + ROOT + '/safe.json?query')
+    .then((r) => {
+      text('.safe-fs-fetch-query-status', r.status)
+      return r.json()
+    })
+    .then((data) => {
+      text('.safe-fs-fetch-query', JSON.stringify(data))
     })
 
   // not imported before, outside of root, treated as unsafe


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I should have only encode/decode `pathname` and leave other parts as-is.
#9148 was happening because `encodeURIComponent(decodeURIComponent('?'))` is `%3F`.

fixes #9148 
refs #8804

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
