### PR TITLE
fix: prevent null pathname error

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -237,10 +237,16 @@ export class ModuleGraph {
     url = removeImportQuery(removeTimestampQuery(url))
     const resolved = await this.resolveId(url, !!ssr)
     const resolvedId = resolved?.id || url
-    const ext = extname(cleanUrl(resolvedId))
-    const { pathname, search, hash } = parseUrl(url)
-    if (ext && !pathname!.endsWith(ext)) {
-      url = pathname + ext + (search || '') + (hash || '')
+    if (
+      url !== resolvedId &&
+      !url.includes('\0') &&
+      !url.startsWith(`virtual:`)
+    ) {
+      const ext = extname(cleanUrl(resolvedId))
+      const { pathname, search, hash } = parseUrl(url)
+      if (ext && !pathname!.endsWith(ext)) {
+        url = pathname + ext + (search || '') + (hash || '')
+      }
     }
     return [url, resolvedId, resolved?.meta]
   }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -1,5 +1,4 @@
 import { extname } from 'node:path'
-import { parse as parseUrl } from 'node:url'
 import type { ModuleInfo, PartialResolvedId } from 'rollup'
 import { isDirectCSSRequest } from '../plugins/css'
 import {
@@ -243,9 +242,9 @@ export class ModuleGraph {
       !url.startsWith(`virtual:`)
     ) {
       const ext = extname(cleanUrl(resolvedId))
-      const { pathname, search, hash } = parseUrl(url)
+      const { pathname, search, hash } = new URL(url, 'relative://')
       if (ext && !pathname!.endsWith(ext)) {
-        url = pathname + ext + (search || '') + (hash || '')
+        url = pathname + ext + search + hash
       }
     }
     return [url, resolvedId, resolved?.meta]

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -76,6 +76,9 @@
 <h2>Plugin resolved virtual file</h2>
 <p class="virtual"></p>
 
+<h2>Plugin resolved virtual file (#9036)</h2>
+<p class="virtual-9036"></p>
+
 <h2>Plugin resolved custom virtual file</h2>
 <p class="custom-virtual"></p>
 
@@ -220,6 +223,9 @@
 
   import { msg as virtualMsg } from '@virtual-file'
   text('.virtual', virtualMsg)
+
+  import { msg as virtualMsg9036 } from 'virtual:file-9036.js'
+  text('.virtual-9036', virtualMsg9036)
 
   import { msg as customVirtualMsg } from '@custom-virtual-file'
   text('.custom-virtual', customVirtualMsg)

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -4,6 +4,9 @@ const { normalizePath } = require('vite')
 const virtualFile = '@virtual-file'
 const virtualId = '\0' + virtualFile
 
+const virtualFile9036 = 'virtual:file-9036.js'
+const virtualId9036 = '\0' + virtualFile9036
+
 const customVirtualFile = '@custom-virtual-file'
 const { a } = require('./config-dep')
 
@@ -41,6 +44,19 @@ module.exports = {
       load(id) {
         if (id === virtualId) {
           return `export const msg = "[success] from conventional virtual file"`
+        }
+      }
+    },
+    {
+      name: 'virtual-module-9036',
+      resolveId(id) {
+        if (id === virtualFile9036) {
+          return virtualId9036
+        }
+      },
+      load(id) {
+        if (id === virtualId9036) {
+          return `export const msg = "[success] from virtual file #9036"`
         }
       }
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR fixes the issue described at #9036.

The issue happens when

- the resolved id starts with `\0virtual:`
- the resolved id ends with an extension

close #9036

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
