### PR TITLE
docs(migration): include Safari 12 to baseline

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -10,7 +10,7 @@ The production bundle assumes support for modern JavaScript. By default, Vite ta
 
 - Chrome >=87
 - Firefox >=78
-- Safari >=13
+- Safari >=12
 - Edge >=88
 
 A small fraction of users will now require using [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy), which will automatically generate legacy chunks and corresponding ES language feature polyfills.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

By given links to caniuse, safari 12 is included in modern baseline, as it supports all needed ESM features.

It matters for me, because safari 12 is the last available browser on old iPhones, which is pinned to ios 12 (like iPhone 6+, which is our work device for checking bottom end devices).

So it's even not needed to use legacy build for it, and so it should be fixed in docs.

If there is some another reasons to starts official support with Safari 13, they really should be covered in docs.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
