### PR TITLE
fix: return 500 on proxy error only if possible (fixes #9172)

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -55,7 +55,7 @@ export function proxyMiddleware(
             error: err
           }
         )
-        if (!res.writableEnded) {
+        if (!res.headersSent && !res.writableEnded) {
           res
             .writeHead(500, {
               'Content-Type': 'text/plain'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Revises #9175.
I should have used `res.headersSent`.
I'm not sure if I should check `res.writableEnded` too. So I left that.

fixes #9172 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
