### PR TITLE
fix: worker relative base should use import.meta.url

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -843,7 +843,7 @@ export function toOutputFilePathInString(
   toRelative: (
     filename: string,
     hostType: string
-  ) => string | { runtime: string }
+  ) => string | { runtime: string } = toImportMetaURLBasedRelativePath
 ): string | { runtime: string } {
   const { renderBuiltUrl } = config.experimental
   let relative = config.base === '' || config.base === './'
@@ -869,6 +869,17 @@ export function toOutputFilePathInString(
     return toRelative(filename, hostId)
   }
   return config.base + filename
+}
+
+function toImportMetaURLBasedRelativePath(
+  filename: string,
+  importer: string
+): { runtime: string } {
+  return {
+    runtime: `new URL(${JSON.stringify(
+      path.posix.relative(path.dirname(importer), filename)
+    )},import.meta.url).href`
+  }
 }
 
 export function toOutputFilePathWithoutRuntime(

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -94,14 +94,6 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       let match: RegExpExecArray | null
       let s: MagicString | undefined
 
-      const toRelative = (filename: string, importer: string) => {
-        return {
-          runtime: `new URL(${JSON.stringify(
-            path.posix.relative(path.dirname(importer), filename)
-          )},import.meta.url).href`
-        }
-      }
-
       // Urls added with JS using e.g.
       // imgElement.src = "__VITE_ASSET__5aa0ddc0__" are using quotes
 
@@ -123,8 +115,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
           'asset',
           chunk.fileName,
           'js',
-          config,
-          toRelative
+          config
         )
         const replacementString =
           typeof replacement === 'string'
@@ -147,8 +138,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
           'public',
           chunk.fileName,
           'js',
-          config,
-          toRelative
+          config
         )
         const replacementString =
           typeof replacement === 'string'

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -144,15 +144,6 @@ function emitSourcemapForWorkerEntry(
   return chunk
 }
 
-// TODO:base review why we aren't using import.meta.url here
-function toStaticRelativePath(filename: string, importer: string) {
-  let outputFilepath = path.posix.relative(path.dirname(importer), filename)
-  if (!outputFilepath.startsWith('.')) {
-    outputFilepath = './' + outputFilepath
-  }
-  return outputFilepath
-}
-
 export const workerAssetUrlRE = /__VITE_WORKER_ASSET__([a-z\d]{8})__/g
 
 function encodeWorkerAssetFileName(
@@ -343,8 +334,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             'asset',
             chunk.fileName,
             'js',
-            config,
-            toStaticRelativePath
+            config
           )
           const replacementString =
             typeof replacement === 'string'

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -68,8 +68,9 @@ describe.runIf(isBuild)('build', () => {
     expect(workerContent).not.toMatch(`import`)
     expect(workerContent).not.toMatch(`export`)
     // chunk
-    expect(content).toMatch(`new Worker("../worker-entries/`)
-    expect(content).toMatch(`new SharedWorker("../worker-entries/`)
+    console.log(content)
+    expect(content).toMatch(`new Worker(""+new URL("../worker-entries/`)
+    expect(content).toMatch(`new SharedWorker(""+new URL("../worker-entries/`)
     // inlined
     expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
     expect(content).toMatch(`window.Blob`)

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -68,7 +68,6 @@ describe.runIf(isBuild)('build', () => {
     expect(workerContent).not.toMatch(`import`)
     expect(workerContent).not.toMatch(`export`)
     // chunk
-    console.log(content)
     expect(content).toMatch(`new Worker(""+new URL("../worker-entries/`)
     expect(content).toMatch(`new SharedWorker(""+new URL("../worker-entries/`)
     // inlined


### PR DESCRIPTION
### Description

Fixes bug report 2. at:
- https://github.com/sveltejs/kit/pull/4250#issuecomment-1185676982

From that comment:
> When building with `base: './'`, workers are instantiated with `new Worker('../../path/to/worker.js')`, rather than with a root-relative path beginning with base. But that's wrong — the path will be relative to the document, not the module instantiating the worker. I think it should be something like this:
```js
new Worker(new URL('../../path/to/worker.js', import.meta.url).href)
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other