### PR TITLE
feat(css): use esbuild.log* options when minifying (fixes #9196)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1249,18 +1249,25 @@ async function minifyCSS(css: string, config: ResolvedConfig) {
 function resolveEsbuildMinifyOptions(
   options: ESBuildOptions
 ): TransformOptions {
+  const base: TransformOptions = {
+    logLevel: options.logLevel,
+    logLimit: options.logLimit,
+    logOverride: options.logOverride
+  }
+
   if (
     options.minifyIdentifiers != null ||
     options.minifySyntax != null ||
     options.minifyWhitespace != null
   ) {
     return {
+      ...base,
       minifyIdentifiers: options.minifyIdentifiers ?? true,
       minifySyntax: options.minifySyntax ?? true,
       minifyWhitespace: options.minifyWhitespace ?? true
     }
   } else {
-    return { minify: true }
+    return { ...base, minify: true }
   }
 }
 

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -442,3 +442,10 @@ test('aliased css has content', async () => {
   // expect(await page.textContent('.aliased-content')).toMatch('.aliased')
   expect(await getColor('.aliased-module')).toBe('blue')
 })
+
+test.runIf(isBuild)('warning can be suppressed by esbuild.logOverride', () => {
+  serverLogs.forEach((log) => {
+    // no warning from esbuild css minifier
+    expect(log).not.toMatch('unsupported-css-property')
+  })
+})

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -104,3 +104,5 @@ import aliasModule from '#alias-module'
 document
   .querySelector('.aliased-module')
   .classList.add(aliasModule.aliasedModule)
+
+import './unsupported.css'

--- a/playground/css/unsupported.css
+++ b/playground/css/unsupported.css
@@ -1,0 +1,3 @@
+.unsupported {
+  overflow-x: hidden;
+}

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -7,6 +7,11 @@ module.exports = {
   build: {
     cssTarget: 'chrome61'
   },
+  esbuild: {
+    logOverride: {
+      'unsupported-css-property': 'silent'
+    }
+  },
   resolve: {
     alias: {
       '@': __dirname,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
There is currently no way to suppress warnings during minifying CSS.
This PR makes `esbuild.logLevel`, `esbuild.logLimit`, `esbuild.logOverride` applied when minifying CSS.

With this PR, the warning shown at #9196 could be suppressed with the config below.
```js
export default {
  esbuild: {
    logOverride: {
      'unsupported-css-property': 'silent'
    }
  }
}
```

fixes #9196

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
