### PR TITLE
fix: make `resolveConfig()` concurrent safe

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1020,12 +1020,14 @@ async function loadConfigFromBundledFile(
   // with --experimental-loader themselves, we have to do a hack here:
   // write it to disk, load it with native Node ESM, then delete the file.
   if (isESM) {
-    const fileUrl = pathToFileURL(fileName)
-    fs.writeFileSync(fileName + '.mjs', bundledCode)
+    const fileBase = `${fileName}.timestamp-${Date.now()}`
+    const fileNameTmp = `${fileBase}.mjs`
+    const fileUrl = `${pathToFileURL(fileBase)}.mjs`
+    fs.writeFileSync(fileNameTmp, bundledCode)
     try {
-      return (await dynamicImport(`${fileUrl}.mjs?t=${Date.now()}`)).default
+      return (await dynamicImport(fileUrl)).default
     } finally {
-      fs.unlinkSync(fileName + '.mjs')
+      fs.unlinkSync(fileNameTmp)
     }
   }
   // for cjs, we can register a custom loader via `_require.extensions`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Makes `resolveConfig()` concurrent safe.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

It's a blocker for `vite-plugin-vercel`.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
