### PR TITLE
fix: __VITE_PUBLIC_ASSET__hash__ in HTML

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -239,6 +239,13 @@ export function getAssetFilename(
   return assetHashToFilenameMap.get(config)?.get(hash)
 }
 
+export function getPublicAssetFilename(
+  hash: string,
+  config: ResolvedConfig
+): string | undefined {
+  return publicAssetUrlCache.get(config)?.get(hash)
+}
+
 export function resolveAssetFileNames(
   config: ResolvedConfig
 ): string | ((chunkInfo: PreRenderedAsset) => string) {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -34,6 +34,8 @@ import {
   assetUrlRE,
   checkPublicFile,
   getAssetFilename,
+  getPublicAssetFilename,
+  publicAssetUrlRE,
   urlToBuiltUrl
 } from './asset'
 import { isCSSRequest } from './css'
@@ -606,13 +608,16 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       for (const [id, html] of processedHtml) {
         const relativeUrlPath = path.posix.relative(config.root, id)
         const assetsBase = getBaseInHTML(relativeUrlPath, config)
-        const toOutputAssetFilePath = (filename: string) => {
+        const toOutputAssetFilePath = (
+          filename: string,
+          type: 'asset' | 'public' = 'asset'
+        ) => {
           if (isExternalUrl(filename)) {
             return filename
           } else {
             return toOutputFilePathInHtml(
               filename,
-              'asset',
+              type,
               relativeUrlPath,
               'html',
               config,
@@ -706,6 +711,15 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         result = result.replace(assetUrlRE, (_, fileHash, postfix = '') => {
           return (
             toOutputAssetFilePath(getAssetFilename(fileHash, config)!) + postfix
+          )
+        })
+
+        result = result.replace(publicAssetUrlRE, (_, fileHash) => {
+          return normalizePath(
+            toOutputAssetFilePath(
+              getPublicAssetFilename(fileHash, config)!,
+              'public'
+            )
           )
         })
 

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -608,9 +608,9 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       for (const [id, html] of processedHtml) {
         const relativeUrlPath = path.posix.relative(config.root, id)
         const assetsBase = getBaseInHTML(relativeUrlPath, config)
-        const toOutputAssetFilePath = (
+        const toOutputFilePath = (
           filename: string,
-          type: 'asset' | 'public' = 'asset'
+          type: 'asset' | 'public'
         ) => {
           if (isExternalUrl(filename)) {
             return filename
@@ -625,6 +625,12 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             )
           }
         }
+
+        const toOutputAssetFilePath = (filename: string) =>
+          toOutputFilePath(filename, 'asset')
+
+        const toOutputPublicAssetFilePath = (filename: string) =>
+          toOutputFilePath(filename, 'public')
 
         const isAsync = isAsyncScriptMap.get(config)!.get(id)!
 
@@ -716,9 +722,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
         result = result.replace(publicAssetUrlRE, (_, fileHash) => {
           return normalizePath(
-            toOutputAssetFilePath(
-              getPublicAssetFilename(fileHash, config)!,
-              'public'
+            toOutputPublicAssetFilePath(
+              getPublicAssetFilename(fileHash, config)!
             )
           )
         })

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -365,8 +365,11 @@ test('relative path in html asset', async () => {
   expect(await getColor('.relative-css')).toMatch('red')
 })
 
-test('url to public folder', async () => {
+test('url() contains file in publicDir, in <style> tag', async () => {
   expect(await getBg('.style-public-assets')).toContain(iconMatch)
+})
+
+test.skip('url() contains file in publicDir, as inline style', async () => {
   // TODO: To investigate why `await getBg('.inline-style-public') === "url("http://localhost:5173/icon.png")"`
   // It supposes to be `url("http://localhost:5173/foo/icon.png")`
   // (I built the playground to verify)

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -364,3 +364,11 @@ test('relative path in html asset', async () => {
   expect(await page.textContent('.relative-js')).toMatch('hello')
   expect(await getColor('.relative-css')).toMatch('red')
 })
+
+test('url to public folder', async () => {
+  expect(await getBg('.style-public-assets')).toContain(iconMatch)
+  // TODO: To investigate why `await getBg('.inline-style-public') === "url("http://localhost:5173/icon.png")"`
+  // It supposes to be `url("http://localhost:5173/foo/icon.png")`
+  // (I built the playground to verify)
+  expect(await getBg('.inline-style-public')).toContain(iconMatch)
+})

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -266,6 +266,14 @@
   inline style
 </p>
 <p class="style-base64-assets">use style class</p>
+<h3>from public folder</h3>
+<style>
+  .style-public-assets {
+    background: url('/icon.png');
+  }
+</style>
+<p style="background: url(/icon.png)">inline style</p>
+<p class="style-public-assets">use style class</p>
 
 <h3 class="import-css">@import</h3>
 <style class="style-import">

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -266,7 +266,7 @@
   inline style
 </p>
 <p class="style-base64-assets">use style class</p>
-<h3>from public folder</h3>
+<h3>from publicDir</h3>
 <style>
   .style-public-assets {
     background: url('/icon.png');

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -272,7 +272,9 @@
     background: url('/icon.png');
   }
 </style>
-<p style="background: url(/icon.png)">inline style</p>
+<p class="inline-style-public" style="background: url(/icon.png)">
+  inline style
+</p>
 <p class="style-public-assets">use style class</p>
 
 <h3 class="import-css">@import</h3>


### PR DESCRIPTION
### Description

- In Vite 3, in `index.html`, if we refer to a file in `publicDir` inside `url()` (e.g: `style="background: url(/icon.png)"`), it becomes `__VITE_PUBLIC_ASSET__hash__` after building (e.g: `style="background: url(__VITE_PUBLIC_ASSET__018698dc__)"`).
- For more details, see #9174
- This PR updates the `playground/assets` to reproduce this bug
- This PR is trying to replace `__VITE_PUBLIC_ASSET__hash__` with the actual file in `publicDir`. (`packages/vite/src/node/plugins/html.ts`)
- This PR add tests in `playground/assets/__tests__/assets.spec.ts` to cover changes. (not passed all yet)

### Related PR
- #7644

### Additional context

- We are migrating to Vite 3 for [bestofjs.org](https://bestofjs.org/) then encounter an issue that fonts inside `publicDir` does not load https://github.com/bestofjs/bestofjs-webui/pull/148#issuecomment-1183834415

You can see the preview at https://bestofjs-68pbasy3a-bestofjs.vercel.app/
There is no file such as `https://bestofjs-68pbasy3a-bestofjs.vercel.app/__VITE_PUBLIC_ASSET__03d6a1cf__`

![image](https://user-images.githubusercontent.com/8603085/179815883-fbd4f8b3-3635-4776-a963-3e825eaf35de.png)


### Questions
- There is one test not passed yet. However, I tried to build it then it work fine. Not sure what makes this inconsistent yet.

https://github.com/vitejs/vite/pull/9247/files#diff-be0c593011deabf61343720611c7586df51ddc269f187678cdbf85ff72a7973bR370-R373

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests 
  - [x] that fail without this PR but pass with it.
  - [x] but pass with it.
- [ ] Discovered another bug in DEV mode https://github.com/vitejs/vite/pull/9247#discussion_r925633791, @sapphi-red to refer issue number here
