### PR TITLE
fix(create-vite): update vanilla-ts brand color

### DIFF
--- a/packages/create-vite/template-vanilla-ts/src/style.css
+++ b/packages/create-vite/template-vanilla-ts/src/style.css
@@ -53,7 +53,7 @@ h1 {
   filter: drop-shadow(0 0 2em #646cffaa);
 }
 .logo.vanilla:hover {
-  filter: drop-shadow(0 0 2em #f7df1eaa);
+  filter: drop-shadow(0 0 2em #3178c6aa);
 }
 
 .card {


### PR DESCRIPTION
It was yellow like JavaScript but it should be blue instead:

<img width="570" alt="image" src="https://user-images.githubusercontent.com/34116392/180027982-2dc690d1-de15-4286-98b8-ae58720ccf3f.png">
