### PR TITLE
fix: don't modify config

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -663,7 +663,7 @@ export async function resolveConfig(
       ...config.experimental
     }
   }
-  const resolved: ResolvedConfig = Object.assign(config, resolvedConfig)
+  const resolved: ResolvedConfig = Object.assign({}, config, resolvedConfig)
 
   if (middlewareMode === 'ssr') {
     logger.warn(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
```
build.terserOptions is specified but build.minify is not set to use Terser. Note Vite now defaults to use esbuild for minification. If you still prefer Terser, set build.minify to "terser".
```
This warning was shown even if `build.terserOptions` was not set.
https://github.com/vitejs/vite/runs/7440261696?check_suite_focus=true#step:13:78

This was happening because of `Object.assign(config, resolvedConfig)`. This PR changes that to `Object.assign({}, config, resolvedConfig)` to avoid modifing `config`.

refs #9212

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
