### PR TITLE
fix(glob): handle glob prop access

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -5,6 +5,7 @@ import type {
   ArrayExpression,
   CallExpression,
   Literal,
+  MemberExpression,
   Node,
   SequenceExpression
 } from 'estree'
@@ -118,7 +119,7 @@ export async function parseImportGlob(
       return e
     }
 
-    let ast: CallExpression | SequenceExpression
+    let ast: CallExpression | SequenceExpression | MemberExpression
     let lastTokenPos: number | undefined
 
     try {
@@ -156,6 +157,10 @@ export async function parseImportGlob(
 
     if (ast.type === 'SequenceExpression')
       ast = ast.expressions[0] as CallExpression
+
+    // immediate property access, call expression is nested
+    // import.meta.glob(...)['prop']
+    if (ast.type === 'MemberExpression') ast = ast.object as CallExpression
 
     if (ast.type !== 'CallExpression')
       throw err(`Expect CallExpression, got ${ast.type}`)

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -92,6 +92,12 @@ test('import glob raw', async () => {
   )
 })
 
+test('import property access', async () => {
+  expect(await page.textContent('.property-access')).toBe(
+    JSON.stringify(rawResult['/dir/baz.json'], null, 2)
+  )
+})
+
 test('import relative glob raw', async () => {
   expect(await page.textContent('.relative-glob-raw')).toBe(
     JSON.stringify(relativeRawResult, null, 2)

--- a/playground/glob-import/index.html
+++ b/playground/glob-import/index.html
@@ -1,8 +1,17 @@
+<h1>Glob import</h1>
+<h2>Normal</h2>
 <pre class="result"></pre>
+<h2>Eager</h2>
 <pre class="result-eager"></pre>
+<h2>node_modules</h2>
 <pre class="result-node_modules"></pre>
+<h2>Raw</h2>
 <pre class="globraw"></pre>
+<h2>Property access</h2>
+<pre class="property-access"></pre>
+<h2>Relative raw</h2>
 <pre class="relative-glob-raw"></pre>
+<h2>Side effect</h2>
 <pre class="side-effect-result"></pre>
 
 <script type="module" src="./dir/index.js"></script>
@@ -58,6 +67,18 @@
   })
   document.querySelector('.globraw').textContent = JSON.stringify(
     globraw,
+    null,
+    2
+  )
+</script>
+
+<script type="module">
+  const bazJson = import.meta.glob('/dir/*.json', {
+    as: 'raw',
+    eager: true
+  })['/dir/baz.json']
+  document.querySelector('.property-access').textContent = JSON.stringify(
+    JSON.parse(bazJson),
     null,
     2
   )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #9237

If we do `import.meta.glob('...')['prop']`, the ast is slightly different which this pr handles.

### Additional context

You can paste `import.meta.glob('/dir/*.json')['/dir/baz.json']` in https://astexplorer.net to try out.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
