### PR TITLE
fix(scan): handle .ts import as .js alias

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -379,14 +379,18 @@ function esbuildScanPlugin(
           // avoid matching windows volume
           filter: /^[\w@][^:]/
         },
-        async ({ path: id, importer }) => {
+        async ({ path: id, importer, pluginData }) => {
           if (moduleListContains(exclude, id)) {
             return externalUnlessEntry({ path: id })
           }
           if (depImports[id]) {
             return externalUnlessEntry({ path: id })
           }
-          const resolved = await resolve(id, importer)
+          const resolved = await resolve(id, importer, {
+            custom: {
+              depScan: { loader: pluginData?.htmlType?.loader }
+            }
+          })
           if (resolved) {
             if (shouldExternalizeDep(resolved, id)) {
               return externalUnlessEntry({ path: id })

--- a/playground/vue/TsImport.vue
+++ b/playground/vue/TsImport.vue
@@ -6,5 +6,5 @@
 
 <script setup lang="ts">
 import { foo } from '@/TsImportFile.js'
-import { foo2 } from '/@/TsImportFile.js'
+import { foo as foo2 } from '/@/TsImportFile.js'
 </script>

--- a/playground/vue/TsImport.vue
+++ b/playground/vue/TsImport.vue
@@ -1,8 +1,10 @@
 <template>
   <h2>Ts Import</h2>
   <p class="ts-import">{{ foo }}</p>
+  <p class="ts-import2">{{ foo2 }}</p>
 </template>
 
 <script setup lang="ts">
-import { foo } from '/@/TsImportFile.js'
+import { foo } from '@/TsImportFile.js'
+import { foo2 } from '/@/TsImportFile.js'
 </script>

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -25,6 +25,7 @@ test('template/script latest syntax support', async () => {
 
 test('import ts with .js extension with lang="ts"', async () => {
   expect(await page.textContent('.ts-import')).toBe('success')
+  expect(await page.textContent('.ts-import2')).toBe('success')
 })
 
 test('should remove comments in prod', async () => {

--- a/playground/vue/vite.config.ts
+++ b/playground/vue/vite.config.ts
@@ -5,7 +5,8 @@ import { vueI18nPlugin } from './CustomBlockPlugin'
 export default defineConfig({
   resolve: {
     alias: {
-      '/@': __dirname
+      '/@': __dirname,
+      '@': __dirname
     }
   },
   plugins: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #9198

### Additional context

I thought I captured this before, but it wasn't accurate as `/@/` doesn't match the `/^[\w@][^:]/` filter, `@/` does because it looks package-ish. However, the scanner is handling fine for this, just that we also need to pass the ts heuristic into it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
