### PR TITLE
fix: entries in ssr.external

### DIFF
--- a/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -91,3 +91,10 @@ test('msg from optimized cjs with nested external', async () => {
     'Hello World!'
   )
 })
+
+test('msg from external using external entry', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.external-using-external-entry')).toMatch(
+    'Hello World!'
+  )
+})

--- a/playground/ssr-deps/external-entry/entry.js
+++ b/playground/ssr-deps/external-entry/entry.js
@@ -1,0 +1,9 @@
+// Module with state, to check that it is properly externalized and
+// not bundled in the optimized deps
+let msg
+export function setMessage(externalMsg) {
+  msg = externalMsg
+}
+export default function getMessage() {
+  return msg
+}

--- a/playground/ssr-deps/external-entry/index.js
+++ b/playground/ssr-deps/external-entry/index.js
@@ -1,0 +1,1 @@
+export default undefined

--- a/playground/ssr-deps/external-entry/package.json
+++ b/playground/ssr-deps/external-entry/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "external-entry",
+  "private": true,
+  "version": "0.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./entry": "./entry.js"
+  },
+  "type": "module"
+}

--- a/playground/ssr-deps/external-using-external-entry/index.js
+++ b/playground/ssr-deps/external-using-external-entry/index.js
@@ -1,0 +1,7 @@
+import getMessage from 'external-entry/entry'
+
+export default {
+  hello() {
+    return getMessage()
+  }
+}

--- a/playground/ssr-deps/external-using-external-entry/package.json
+++ b/playground/ssr-deps/external-using-external-entry/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "external-using-external-entry",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "external-entry": "file:../external-entry"
+  }
+}

--- a/playground/ssr-deps/package.json
+++ b/playground/ssr-deps/package.json
@@ -24,7 +24,9 @@
     "no-external-css": "file:./no-external-css",
     "non-optimized-with-nested-external": "file:./non-optimized-with-nested-external",
     "optimized-with-nested-external": "file:./optimized-with-nested-external",
-    "optimized-cjs-with-nested-external": "file:./optimized-with-nested-external"
+    "optimized-cjs-with-nested-external": "file:./optimized-with-nested-external",
+    "external-using-external-entry": "file:./external-using-external-entry",
+    "external-entry": "file:./external-entry"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -35,8 +35,13 @@ export async function createServer(root = process.cwd(), hmrPort) {
     },
     appType: 'custom',
     ssr: {
-      noExternal: ['no-external-cjs', 'import-builtin-cjs', 'no-external-css'],
-      external: ['nested-external'],
+      noExternal: [
+        'no-external-cjs',
+        'import-builtin-cjs',
+        'no-external-css',
+        'external-entry'
+      ],
+      external: ['nested-external', 'external-entry/entry'],
       optimizeDeps: {
         disabled: 'build'
       }

--- a/playground/ssr-deps/src/app.js
+++ b/playground/ssr-deps/src/app.js
@@ -20,6 +20,10 @@ import 'non-optimized-with-nested-external'
 import optimizedWithNestedExternal from 'optimized-with-nested-external'
 import optimizedCjsWithNestedExternal from 'optimized-cjs-with-nested-external'
 
+import { setMessage } from 'external-entry/entry'
+setMessage('Hello World!')
+import externalUsingExternalEntry from 'external-using-external-entry'
+
 export async function render(url, rootDir) {
   let html = ''
 
@@ -67,6 +71,9 @@ export async function render(url, rootDir) {
   const optimizedCjsWithNestedExternalMessage =
     optimizedCjsWithNestedExternal.hello()
   html += `\n<p class="optimized-cjs-with-nested-external">message from optimized-cjs-with-nested-external: ${optimizedCjsWithNestedExternalMessage}</p>`
+
+  const externalUsingExternalEntryMessage = externalUsingExternalEntry.hello()
+  html += `\n<p class="external-using-external-entry">message from external-using-external-entry: ${externalUsingExternalEntryMessage}</p>`
 
   return html + '\n'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -903,6 +903,8 @@ importers:
       define-properties-exports: file:./define-properties-exports
       define-property-exports: file:./define-property-exports
       express: ^4.18.1
+      external-entry: file:./external-entry
+      external-using-external-entry: file:./external-using-external-entry
       forwarded-export: file:./forwarded-export
       import-builtin-cjs: file:./import-builtin-cjs
       no-external-cjs: file:./no-external-cjs
@@ -920,6 +922,8 @@ importers:
       bcrypt: 5.0.1
       define-properties-exports: file:playground/ssr-deps/define-properties-exports
       define-property-exports: file:playground/ssr-deps/define-property-exports
+      external-entry: file:playground/ssr-deps/external-entry
+      external-using-external-entry: file:playground/ssr-deps/external-using-external-entry
       forwarded-export: file:playground/ssr-deps/forwarded-export
       import-builtin-cjs: file:playground/ssr-deps/import-builtin-cjs
       no-external-cjs: file:playground/ssr-deps/no-external-cjs
@@ -942,6 +946,15 @@ importers:
 
   playground/ssr-deps/define-property-exports:
     specifiers: {}
+
+  playground/ssr-deps/external-entry:
+    specifiers: {}
+
+  playground/ssr-deps/external-using-external-entry:
+    specifiers:
+      external-entry: file:../external-entry
+    dependencies:
+      external-entry: file:playground/ssr-deps/external-entry
 
   playground/ssr-deps/forwarded-export:
     specifiers:
@@ -9032,6 +9045,20 @@ packages:
     version: 0.0.0
     dev: false
 
+  file:playground/ssr-deps/external-entry:
+    resolution: {directory: playground/ssr-deps/external-entry, type: directory}
+    name: external-entry
+    version: 0.0.0
+    dev: false
+
+  file:playground/ssr-deps/external-using-external-entry:
+    resolution: {directory: playground/ssr-deps/external-using-external-entry, type: directory}
+    name: external-using-external-entry
+    version: 0.0.0
+    dependencies:
+      external-entry: file:playground/ssr-deps/external-entry
+    dev: false
+
   file:playground/ssr-deps/forwarded-export:
     resolution: {directory: playground/ssr-deps/forwarded-export, type: directory}
     name: forwarded-export
@@ -9043,6 +9070,12 @@ packages:
   file:playground/ssr-deps/import-builtin-cjs:
     resolution: {directory: playground/ssr-deps/import-builtin-cjs, type: directory}
     name: import-builtin
+    version: 0.0.0
+    dev: false
+
+  file:playground/ssr-deps/mixed-nested-external:
+    resolution: {directory: playground/ssr-deps/mixed-nested-external, type: directory}
+    name: mixed-nested-external
     version: 0.0.0
     dev: false
 
@@ -9069,6 +9102,7 @@ packages:
     name: non-optimized-with-nested-external
     version: 0.0.0
     dependencies:
+      mixed-nested-external: file:playground/ssr-deps/mixed-nested-external
       nested-external: file:playground/ssr-deps/nested-external
     dev: false
 
@@ -9089,6 +9123,7 @@ packages:
     name: optimized-with-nested-external
     version: 0.0.0
     dependencies:
+      mixed-nested-external: file:playground/ssr-deps/mixed-nested-external
       nested-external: file:playground/ssr-deps/nested-external
     dev: false
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9073,12 +9073,6 @@ packages:
     version: 0.0.0
     dev: false
 
-  file:playground/ssr-deps/mixed-nested-external:
-    resolution: {directory: playground/ssr-deps/mixed-nested-external, type: directory}
-    name: mixed-nested-external
-    version: 0.0.0
-    dev: false
-
   file:playground/ssr-deps/nested-external:
     resolution: {directory: playground/ssr-deps/nested-external, type: directory}
     name: nested-external
@@ -9102,7 +9096,6 @@ packages:
     name: non-optimized-with-nested-external
     version: 0.0.0
     dependencies:
-      mixed-nested-external: file:playground/ssr-deps/mixed-nested-external
       nested-external: file:playground/ssr-deps/nested-external
     dev: false
 
@@ -9123,7 +9116,6 @@ packages:
     name: optimized-with-nested-external
     version: 0.0.0
     dependencies:
-      mixed-nested-external: file:playground/ssr-deps/mixed-nested-external
       nested-external: file:playground/ssr-deps/nested-external
     dev: false
 


### PR DESCRIPTION
Fixes #9275

### Description

Fixes a regression introduced by:
- https://github.com/vitejs/vite/pull/9146

Only package names are valid in `ssr.noExternal`, as #9146 corrected, but `ssr.external` allows defining package names and also individual entries.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
