### PR TITLE
fix: gracefully ignore unlink errors

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1034,7 +1034,9 @@ async function loadConfigFromBundledFile(
     try {
       return (await dynamicImport(fileUrl)).default
     } finally {
-      fs.unlinkSync(fileNameTmp)
+      try {
+        fs.unlinkSync(fileNameTmp)
+      } catch {}
     }
   }
   // for cjs, we can register a custom loader via `_require.extensions`


### PR DESCRIPTION
### Description

I'm seeing intermittent build failures relating to deletion of a temporary file `vite.config.js.mjs` which is generated by `loadConfigFromBundledFile`:

```
failed to load config from vite.config.js
error during build:
Error: ENOENT: no such file or directory, unlink 'vite.config.js.mjs'
    at Object.unlinkSync (node:fs:1780:3)
    at loadConfigFromBundledFile (node_modules/vite/dist/node/chunks/dep-1513d487.js:62806:18)
    at async loadConfigFromFile (node_modules/vite/dist/node/chunks/dep-1513d487.js:62692:28)
    at async resolveConfig (node_modules/vite/dist/node/chunks/dep-1513d487.js:62344:28)
    at async doBuild (node_modules/vite/dist/node/chunks/dep-1513d487.js:43308:20)
    at async build (node_modules/vite/dist/node/chunks/dep-1513d487.js:43297:16)
    at async CAC.<anonymous> (node_modules/vite/dist/node/cli.js:747:9)
```

I'm not sure why it fails exactly, but I'm sure that these unlink errors can be gracefully ignored, which I did here.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix