### PR TITLE
docs: fix deploy type var again

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -11,7 +11,7 @@ const commitRef = process.env.COMMIT_REF?.slice(0, 8) || 'dev'
 
 const deployType = (() => {
   switch (deployURL) {
-    case 'https://main--vitejs.netlify.app':
+    case 'https://main--vite-docs-main.netlify.app':
       return 'main'
     case '':
       return 'local'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`process.env.DEPLOY_PRIME_URL` is not working as expected.
This PR fixes that.

#9290 used `https://main--vitejs.netlify.app` but this seems to be a different one... (the one used for vitejs.dev?)
This PR uses `https://main--vite-docs-main.netlify.app` which I obtained from https://app.netlify.com/sites/vite-docs-main/deploys/62da46dbfdf2ad0009d76075.

netlify env docs: https://docs.netlify.com/configure-builds/environment-variables/#build-metadata

refs #9263 
refs #9290

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
