### PR TITLE
fix: support vite client in safari 13

### DIFF
--- a/packages/vite/src/client/tsconfig.json
+++ b/packages/vite/src/client/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["./", "../../types"],
   "compilerOptions": {
     "types": [],
+    "target": "ES2019",
     "lib": ["ESNext", "DOM"],
     "declaration": false
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/vitejs/vite/pull/9190#issuecomment-1192452877

Our baseline supports Safari 13, which doesn't support optional chaining. Since `vite/client` is served unbundled, we should also support Safari 13. Changing the typescript compile target to `es2019` from `es2020` (declared in `tsconfig.base.json`), transpile the optional chaining usage.

cc @Amareis

### Additional context

Diff of new vs old `client.mjs`:

```
bjorn@Bjorns-MacBook-Pro vite % diff client.mjs client2.mjs
122d121
<         var _a;
135c134
<         const [file] = (((_a = err.loc) === null || _a === void 0 ? void 0 : _a.file) || err.id || 'unknown file').split(`?`);
---
>         const [file] = (err.loc?.file || err.id || 'unknown file').split(`?`);
179,180c178
<         var _a;
<         (_a = this.parentNode) === null || _a === void 0 ? void 0 : _a.removeChild(this);
---
>         this.parentNode?.removeChild(this);
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
