### PR TITLE
fix: handle resolve optional peer deps

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -12,7 +12,7 @@ import {
   moduleListContains,
   normalizePath
 } from '../utils'
-import { browserExternalId } from '../plugins/resolve'
+import { browserExternalId, optionalPeerDepId } from '../plugins/resolve'
 import type { ExportsData } from '.'
 
 const externalWithConversionNamespace =
@@ -91,6 +91,12 @@ export function esbuildDepPlugin(
       return {
         path: id,
         namespace: 'browser-external'
+      }
+    }
+    if (resolved.startsWith(optionalPeerDepId)) {
+      return {
+        path: id,
+        namespace: 'optional-peer-dep'
       }
     }
     if (ssr && isBuiltin(resolved)) {
@@ -274,6 +280,22 @@ module.exports = Object.create(new Proxy({}, {
     }
   }
 }))`
+            }
+          }
+        }
+      )
+
+      build.onLoad(
+        { filter: /.*/, namespace: 'optional-peer-dep' },
+        ({ path }) => {
+          if (config.isProduction) {
+            return {
+              contents: 'module.exports = {}'
+            }
+          } else {
+            const [, peerDep, parentDep] = path.split(':')
+            return {
+              contents: `throw new Error(\`Could not resolve "${peerDep}" imported by "${parentDep}". Is it installed?\`)`
             }
           }
         }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -95,7 +95,7 @@ export function esbuildDepPlugin(
     }
     if (resolved.startsWith(optionalPeerDepId)) {
       return {
-        path: id,
+        path: resolved,
         namespace: 'optional-peer-dep'
       }
     }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -29,6 +29,7 @@ import {
   isPossibleTsOutput,
   isTsRequest,
   isWindows,
+  lookupFile,
   nestedResolveFrom,
   normalizePath,
   resolveFrom,
@@ -43,6 +44,8 @@ import { loadPackageData, resolvePackageData } from '../packages'
 // special id for paths marked with browser: false
 // https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module
 export const browserExternalId = '__vite-browser-external'
+// special id for packages that are optional peer deps
+export const optionalPeerDepId = '__vite-optional-peer-dep'
 
 const isDebug = process.env.DEBUG
 const debug = createDebugger('vite:resolve-details', {
@@ -369,6 +372,14 @@ export default new Proxy({}, {
 })`
         }
       }
+      if (id.startsWith(optionalPeerDepId)) {
+        if (isProduction) {
+          return `export default {}`
+        } else {
+          const [, peerDep, parentDep] = id.split(':')
+          return `throw new Error(\`Could not resolve "${peerDep}" imported by "${parentDep}". Is it installed?\`)`
+        }
+      }
     }
   }
 }
@@ -621,6 +632,30 @@ export function tryNodeResolve(
   })!
 
   if (!pkg) {
+    // if import can't be found, check if it's an optional peer dep.
+    // if so, we can resolve to a special id that errors only when imported.
+    if (
+      basedir !== root && // root has no peer dep
+      !isBuiltin(id) &&
+      !id.includes('\0') &&
+      bareImportRE.test(id)
+    ) {
+      // find package.json with `name` as main
+      const mainPackageJson = lookupFile(basedir, ['package.json'], {
+        predicate: (content) => !!JSON.parse(content).name
+      })
+      if (mainPackageJson) {
+        const mainPkg = JSON.parse(mainPackageJson)
+        if (
+          mainPkg.peerDependencies?.[id] &&
+          mainPkg.peerDependenciesMeta?.[id]?.optional
+        ) {
+          return {
+            id: `${optionalPeerDepId}:${id}:${mainPkg.name}`
+          }
+        }
+      }
+    }
     return
   }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -390,6 +390,7 @@ export function isDefined<T>(value: T | undefined | null): value is T {
 interface LookupFileOptions {
   pathOnly?: boolean
   rootDir?: string
+  predicate?: (file: string) => boolean
 }
 
 export function lookupFile(
@@ -400,7 +401,12 @@ export function lookupFile(
   for (const format of formats) {
     const fullPath = path.join(dir, format)
     if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
-      return options?.pathOnly ? fullPath : fs.readFileSync(fullPath, 'utf-8')
+      const result = options?.pathOnly
+        ? fullPath
+        : fs.readFileSync(fullPath, 'utf-8')
+      if (!options?.predicate || options.predicate(result)) {
+        return result
+      }
     }
   }
   const parentDir = path.dirname(dir)

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -87,6 +87,19 @@ test('dep with dynamic import', async () => {
   )
 })
 
+test('dep with optional peer dep', async () => {
+  expect(await page.textContent('.dep-with-optional-peer-dep')).toMatch(
+    `[success]`
+  )
+  if (isServe) {
+    expect(browserErrors.map((error) => error.message)).toEqual(
+      expect.arrayContaining([
+        'Could not resolve "undefined" imported by "undefined". Is it installed?'
+      ])
+    )
+  }
+})
+
 test('dep with css import', async () => {
   expect(await getColor('.dep-linked-include')).toBe('red')
 })

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -94,7 +94,7 @@ test('dep with optional peer dep', async () => {
   if (isServe) {
     expect(browserErrors.map((error) => error.message)).toEqual(
       expect.arrayContaining([
-        'Could not resolve "undefined" imported by "undefined". Is it installed?'
+        'Could not resolve "foobar" imported by "dep-with-optional-peer-dep". Is it installed?'
       ])
     )
   }

--- a/playground/optimize-deps/dep-with-optional-peer-dep/index.js
+++ b/playground/optimize-deps/dep-with-optional-peer-dep/index.js
@@ -1,0 +1,7 @@
+export function callItself() {
+  return '[success]'
+}
+
+export async function callPeerDep() {
+  return await import('foobar')
+}

--- a/playground/optimize-deps/dep-with-optional-peer-dep/package.json
+++ b/playground/optimize-deps/dep-with-optional-peer-dep/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dep-with-optional-peer-dep",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "type": "module",
+  "peerDependencies": {
+    "foobar": "0.0.0"
+  },
+  "peerDependenciesMeta": {
+    "foobar": {
+      "optional": true
+    }
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -59,6 +59,9 @@
 <h2>Import from dependency with dynamic import</h2>
 <div class="dep-with-dynamic-import"></div>
 
+<h2>Import from dependency with optional peer dep</h2>
+<div class="dep-with-optional-peer-dep"></div>
+
 <h2>Dep w/ special file format supported via plugins</h2>
 <div class="plugin"></div>
 
@@ -150,6 +153,13 @@
 <script type="module">
   const reusedName = 'reused'
   text('.reused-variable-names', reusedName)
+</script>
+
+<script type="module">
+  import { callItself, callPeerDep } from 'dep-with-optional-peer-dep'
+  text('.dep-with-optional-peer-dep', callItself())
+  // expect error as optional peer dep not installed
+  callPeerDep()
 </script>
 
 <script type="module">

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -23,6 +23,7 @@
     "dep-with-builtin-module-cjs": "file:./dep-with-builtin-module-cjs",
     "dep-with-builtin-module-esm": "file:./dep-with-builtin-module-esm",
     "dep-with-dynamic-import": "file:./dep-with-dynamic-import",
+    "dep-with-optional-peer-dep": "file:./dep-with-optional-peer-dep",
     "added-in-entries": "file:./added-in-entries",
     "lodash-es": "^4.17.21",
     "nested-exclude": "file:./nested-exclude",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,7 @@ importers:
       dep-with-builtin-module-cjs: file:./dep-with-builtin-module-cjs
       dep-with-builtin-module-esm: file:./dep-with-builtin-module-esm
       dep-with-dynamic-import: file:./dep-with-dynamic-import
+      dep-with-optional-peer-dep: file:./dep-with-optional-peer-dep
       lodash: ^4.17.21
       lodash-es: ^4.17.21
       lodash.clonedeep: ^4.5.0
@@ -659,6 +660,7 @@ importers:
       dep-with-builtin-module-cjs: file:playground/optimize-deps/dep-with-builtin-module-cjs
       dep-with-builtin-module-esm: file:playground/optimize-deps/dep-with-builtin-module-esm
       dep-with-dynamic-import: file:playground/optimize-deps/dep-with-dynamic-import
+      dep-with-optional-peer-dep: file:playground/optimize-deps/dep-with-optional-peer-dep_vue@3.2.37
       lodash: 4.17.21
       lodash-es: 4.17.21
       lodash.clonedeep: 4.5.0
@@ -716,6 +718,9 @@ importers:
     specifiers: {}
 
   playground/optimize-deps/dep-with-dynamic-import:
+    specifiers: {}
+
+  playground/optimize-deps/dep-with-optional-peer-dep:
     specifiers: {}
 
   playground/optimize-deps/nested-exclude:
@@ -8989,6 +8994,21 @@ packages:
     resolution: {directory: playground/optimize-deps/dep-with-dynamic-import, type: directory}
     name: dep-with-dynamic-import
     version: 0.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-with-optional-peer-dep_vue@3.2.37:
+    resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep, type: directory}
+    id: file:playground/optimize-deps/dep-with-optional-peer-dep
+    name: dep-with-optional-peer-dep
+    version: 0.0.0
+    peerDependencies:
+      test: '*'
+      vue: ^3.2.37
+    peerDependenciesMeta:
+      test:
+        optional: true
+    dependencies:
+      vue: 3.2.37
     dev: false
 
   file:playground/optimize-deps/nested-exclude:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #6007

Introduce `__vite-optional-peer-dep` prefix (similar to `__vite-browser-external) for packages that are optional peer dependencies. 

### Additional context

Since knowing optional peer dep requires traversing the parent for `package.json`, this may incur a small perf cost. But from what I can tell, the logic where I added is rarely called during testing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
