### PR TITLE
feat: show warning on 431 response

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -50,10 +50,9 @@ When the server / WebSocket server receives a large HTTP header, the request wil
 
 > Server responded with status code 431. See https://vitejs.dev/guide/troubleshooting.html#_431-request-header-fields-too-large.
 
-This is because Node.js limits request header size to mitigate CVE-2018-12121.
+This is because Node.js limits request header size to mitigate [CVE-2018-12121](https://www.cve.org/CVERecord?id=CVE-2018-12121).
 
-To avoid this, try to reduce your request header size. For example, if the cookie is long, delete it.
-Or you can use [`--max-http-header-size`](https://nodejs.org/api/cli.html#--max-http-header-sizesize) to change max header size.
+To avoid this, try to reduce your request header size. For example, if the cookie is long, delete it. Or you can use [`--max-http-header-size`](https://nodejs.org/api/cli.html#--max-http-header-sizesize) to change max header size.
 
 ## HMR
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -44,6 +44,17 @@ To solve this:
   $ sudo sysctl fs.inotify.max_user_watches=524288
   ```
 
+### 431 Request Header Fields Too Large
+
+When the server / WebSocket server receives a large HTTP header, the request will be dropped and the following warning will be shown.
+
+> Server responded with status code 431. See https://vitejs.dev/guide/troubleshooting.html#_431-request-header-fields-too-large.
+
+This is because Node.js limits request header size to mitigate CVE-2018-12121.
+
+To avoid this, try to reduce your request header size. For example, if the cookie is long, delete it.
+Or you can use [`--max-http-header-size`](https://nodejs.org/api/cli.html#--max-http-header-sizesize) to change max header size.
+
 ## HMR
 
 ### Vite detects a file change but the HMR is not working

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -191,18 +191,10 @@ export function setClientErrorHandler(
 ): void {
   server.on('clientError', (err, socket) => {
     if ((err as any).code === 'HPE_HEADER_OVERFLOW') {
-      if (!socket.writableEnded) {
-        socket.end(
-          'HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n' +
-            'Request Header was too large. Node.js limits request header size. ' +
-            'Use https://nodejs.org/api/cli.html#--max-http-header-sizesize to change max header size.'
-        )
-      }
       logger.warn(
         colors.yellow(
-          'Server / WS server responded with "431 Request Header Fields Too Large." ' +
-            'Node.js limits request header size and the request was dropped. ' +
-            'Use https://nodejs.org/api/cli.html#--max-http-header-sizesize to change max header size.'
+          'Server responded with status code 431. ' +
+            'See https://vitejs.dev/guide/troubleshooting.html#_431-request-header-fields-too-large.'
         )
       )
     }

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -6,7 +6,12 @@ import type { Connect } from 'types/connect'
 import corsMiddleware from 'cors'
 import type { ResolvedServerOptions, ResolvedServerUrls } from './server'
 import type { CommonServerOptions } from './http'
-import { httpServerStart, resolveHttpServer, resolveHttpsConfig } from './http'
+import {
+  httpServerStart,
+  resolveHttpServer,
+  resolveHttpsConfig,
+  setClientErrorHandler
+} from './http'
 import { openBrowser } from './server/openBrowser'
 import compression from './server/middlewares/compression'
 import { proxyMiddleware } from './server/middlewares/proxy'
@@ -78,6 +83,7 @@ export async function preview(
     app,
     await resolveHttpsConfig(config.preview?.https, config.cacheDir)
   )
+  setClientErrorHandler(httpServer, config.logger)
 
   // apply server hooks from plugins
   const postHooks: ((() => void) | void)[] = []

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -12,7 +12,12 @@ import type { Connect } from 'types/connect'
 import launchEditorMiddleware from 'launch-editor-middleware'
 import type { SourceMap } from 'rollup'
 import type { CommonServerOptions } from '../http'
-import { httpServerStart, resolveHttpServer, resolveHttpsConfig } from '../http'
+import {
+  httpServerStart,
+  resolveHttpServer,
+  resolveHttpsConfig,
+  setClientErrorHandler
+} from '../http'
 import type { InlineConfig, ResolvedConfig } from '../config'
 import { isDepsOptimizerEnabled, resolveConfig } from '../config'
 import {
@@ -300,6 +305,10 @@ export async function createServer(
     ? null
     : await resolveHttpServer(serverConfig, middlewares, httpsOptions)
   const ws = createWebSocketServer(httpServer, config, httpsOptions)
+
+  if (httpServer) {
+    setClientErrorHandler(httpServer, config.logger)
+  }
 
   const { ignored = [], ...watchOptions } = serverConfig.watch || {}
   const watcher = chokidar.watch(path.resolve(root), {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
![image](https://user-images.githubusercontent.com/49056869/180612768-a0abc403-7185-47d5-a322-aa7629979e1b.png)
![image](https://user-images.githubusercontent.com/49056869/180612778-ce6b84d8-f40c-4e57-bff5-f0d3c5554ed9.png)

Show warnings when `HPE_HEADER_OVERFLOW` error happened. Currently the server does not output any errors or warnings.

close #547

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
