### PR TITLE
feat: preCloseBundle hook

### DIFF
--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -156,7 +156,5 @@ export interface Plugin extends RollupPlugin {
   /**
    * Invoked between `writeBundle` and `closeBundle` hooks.
    */
-  preCloseBundle?: (
-    this: PluginContext,
-  ) => void | Promise<void>
+  preCloseBundle?: (this: PluginContext) => void | Promise<void>
 }

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -153,4 +153,10 @@ export interface Plugin extends RollupPlugin {
     id: string,
     options?: { ssr?: boolean }
   ) => Promise<TransformResult> | TransformResult
+  /**
+   * Invoked between `writeBundle` and `closeBundle` hooks.
+   */
+  preCloseBundle?: (
+    this: PluginContext,
+  ) => void | Promise<void>
 }

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -24,7 +24,7 @@ import { ensureWatchPlugin } from './ensureWatch'
 import { metadataPlugin } from './metadata'
 import { dynamicImportVarsPlugin } from './dynamicImportVars'
 import { importGlobPlugin } from './importMetaGlob'
-import { preCloseBundlePlugin } from './preCloseBundle';
+import { preCloseBundlePlugin } from './preCloseBundle'
 
 export async function resolvePlugins(
   config: ResolvedConfig,
@@ -37,7 +37,6 @@ export async function resolvePlugins(
   const buildPlugins = isBuild
     ? (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
-
 
   const plugins: Plugin[] = [
     isWatch ? ensureWatchPlugin() : null,
@@ -101,13 +100,13 @@ export async function resolvePlugins(
       : [clientInjectionsPlugin(config), importAnalysisPlugin(config)])
   ].filter(Boolean) as Plugin[]
 
-  if (!isBuild)
-    return plugins
+  if (!isBuild) return plugins
 
-  const preClosePlugins = plugins.filter(p => typeof (p as any).preCloseBundle === 'function')
+  const preClosePlugins = plugins.filter(
+    (p) => typeof (p as any).preCloseBundle === 'function'
+  )
 
   return preClosePlugins.length > 0
     ? preCloseBundlePlugin(plugins, preClosePlugins)
     : plugins
-
 }

--- a/packages/vite/src/node/plugins/preCloseBundle.ts
+++ b/packages/vite/src/node/plugins/preCloseBundle.ts
@@ -1,0 +1,17 @@
+import type { Plugin } from 'rollup';
+
+export function preCloseBundlePlugin(plugins: Plugin[], preClosePlugins: Plugin[]): Plugin[] {
+  plugins.filter(p => typeof p.closeBundle === 'function').forEach(p => {
+    const _closeBundle = p.closeBundle
+    delete p.closeBundle
+    ;(p as any)._closeBundle = _closeBundle
+  })
+  plugins.push({
+    name: 'vite:pre-close-bundle',
+    async closeBundle() {
+      await Promise.all(preClosePlugins.map(p => (p as any).preCloseBundle?.apply(this)))
+      await Promise.all(plugins.map(p => (p as any)._closeBundle?.apply(this)))
+    }
+  })
+  return plugins;
+}

--- a/packages/vite/src/node/plugins/preCloseBundle.ts
+++ b/packages/vite/src/node/plugins/preCloseBundle.ts
@@ -1,17 +1,28 @@
-import type { Plugin } from 'rollup';
+import type { Plugin as RollupPlugin } from 'rollup'
+import type { Plugin } from '../plugin'
 
-export function preCloseBundlePlugin(plugins: Plugin[], preClosePlugins: Plugin[]): Plugin[] {
-  plugins.filter(p => typeof p.closeBundle === 'function').forEach(p => {
-    const _closeBundle = p.closeBundle
-    delete p.closeBundle
-    ;(p as any)._closeBundle = _closeBundle
-  })
-  plugins.push({
+export function preCloseBundlePlugin(
+  plugins: RollupPlugin[],
+  preClosePlugins: RollupPlugin[]
+): RollupPlugin[] {
+  plugins
+    .filter((p) => typeof p.closeBundle === 'function')
+    .forEach((p) => {
+      const _closeBundle = p.closeBundle
+      delete p.closeBundle
+      ;(p as any)._closeBundle = _closeBundle
+    })
+  plugins.push(<Plugin>{
     name: 'vite:pre-close-bundle',
+    apply: 'build',
     async closeBundle() {
-      await Promise.all(preClosePlugins.map(p => (p as any).preCloseBundle?.apply(this)))
-      await Promise.all(plugins.map(p => (p as any)._closeBundle?.apply(this)))
+      await Promise.all(
+        preClosePlugins.map((p) => (p as any).preCloseBundle?.apply(this))
+      )
+      await Promise.all(
+        plugins.map((p) => (p as any)._closeBundle?.apply(this))
+      )
     }
   })
-  return plugins;
+  return plugins
 }

--- a/playground/pre-close-bundle-hook/index.html
+++ b/playground/pre-close-bundle-hook/index.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+<h1>Hello</h1>
+</body>
+</html>
+

--- a/playground/pre-close-bundle-hook/index.html
+++ b/playground/pre-close-bundle-hook/index.html
@@ -1,6 +1,5 @@
 <html>
-<body>
-<h1>Hello</h1>
-</body>
+  <body>
+    <h1>Hello</h1>
+  </body>
 </html>
-

--- a/playground/pre-close-bundle-hook/package.json
+++ b/playground/pre-close-bundle-hook/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-pre-close-bundle-hook",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "vite build"
+  }
+}

--- a/playground/pre-close-bundle-hook/vite.config.js
+++ b/playground/pre-close-bundle-hook/vite.config.js
@@ -1,0 +1,70 @@
+const { resolve } = require('path')
+
+async function awaiting(timeout = 1000) {
+  await new Promise(resolve => setTimeout(resolve, timeout))
+}
+
+let called1 = false
+let called2 = false
+let called3 = false
+
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = {
+  base: './',
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html')
+      }
+    }
+  },
+  plugins: [
+    {
+      name: 'pre-close-bundle-1',
+      enforce: 'pre',
+      apply: 'build',
+      async preCloseBundle() {
+        await awaiting(1200)
+        called1 = true
+      }
+    },
+    {
+      name: 'pre-close-bundle-2',
+      async preCloseBundle() {
+        await awaiting(1100)
+        called2 = true
+      }
+    },
+    {
+      name: 'pre-close-bundle-2',
+      enforce: 'post',
+      apply: 'build',
+      async preCloseBundle() {
+        await awaiting()
+        called3 = true
+      }
+    },
+    {
+      name: 'close-bundle-pre',
+      enforce: 'pre',
+      apply: 'build',
+      closeBundle() {
+        if (!called1 || !called2 || !called3) {
+          throw new Error('some pre-close-bundle not being called!')
+        }
+      }
+    },
+    {
+      name: 'close-bundle-post',
+      enforce: 'post',
+      apply: 'build',
+      closeBundle() {
+        if (!called1 || !called2 || !called3) {
+          throw new Error('some pre-close-bundle not being called!')
+        }
+      }
+    }
+  ]
+}

--- a/playground/pre-close-bundle-hook/vite.config.js
+++ b/playground/pre-close-bundle-hook/vite.config.js
@@ -1,7 +1,7 @@
 const { resolve } = require('path')
 
 async function awaiting(timeout = 1000) {
-  await new Promise(resolve => setTimeout(resolve, timeout))
+  await new Promise((resolve) => setTimeout(resolve, timeout))
 }
 
 let called1 = false

--- a/scripts/patchCJS.ts
+++ b/scripts/patchCJS.ts
@@ -41,7 +41,7 @@ if (matchMixed) {
   writeFileSync(indexPath, lines.join('\n'))
 
   console.log(colors.bold(`${indexPath} CJS patched`))
-  process.exit()
+  process.exit(0)
 }
 
 const matchDefault = code.match(/\nmodule.exports = (\w+);/)
@@ -50,7 +50,7 @@ if (matchDefault) {
   code += `module.exports["default"] = ${matchDefault[1]};\n`
   writeFileSync(indexPath, code)
   console.log(colors.bold(`${indexPath} CJS patched`))
-  process.exit()
+  process.exit(0)
 }
 
 console.error(colors.red(`${indexPath} CJS patch failed`))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add a new `preCloseBundle` hook to allow run build plugins hooks between Rollup `writeBundle` and `closeBundle` hooks.

**EDIT**: we need it also in Vite 2  :pray: .

I changed also `scripts/patchCJS.ts` module to allow build in Windows: I just change `process.exit()` call with `process.exit(0)`: sent another PR for this.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Trying to integrate with SvelteKit the `vite-plugin-pwa` plugin, we have found a problem about a race condition using both plugins with Vite 3 (also with Vite 2, right now latest SvelteKit version will work only with Vite 3).

SvelteKit uses the `writeBundle` to call the `prerender` process (SSG). In the `closeBundle` hook, it calls the `adapter` logic, the adapter gets the `prerender` output and copy the content to the `adapter` output folder (it can do more things).

`vite-plugin-pwa` uses `closeBundle` hook in its build plugin to generate the service worker, it has `enforce: ' post'`, and so will be called by Vite/Rollup after SvelteKit `closeBundle` hook.

We need to invert the `closeBundle` hook call, that's, `vite-plugin-pwa` first and then SvelteKit`.

We can reverse the order just changing the `vite-plugin-pwa` build plugin with `enforce: 'pre'`, but then we have a race condition: since the `closeBundle` hook will be called in parallel, both plugins need to be called in a `sequential` order; why? because the `adapter` needs to copy also the service worker generated by the `vite-plugin-pwa` build plugin.

Can we move the `vite-plugin-pwa` build plugin to the `writeBundle` hook: the answer is no; the `vite-plugin-pwa` will need the `prerender` output, and so we have the another race condition, since SvelteKit and `vite-plugin-pwa` build plugin will run in parallel.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
