### PR TITLE
fix: build command fails in Windows

### DIFF
--- a/scripts/patchCJS.ts
+++ b/scripts/patchCJS.ts
@@ -41,7 +41,7 @@ if (matchMixed) {
   writeFileSync(indexPath, lines.join('\n'))
 
   console.log(colors.bold(`${indexPath} CJS patched`))
-  process.exit()
+  process.exit(0)
 }
 
 const matchDefault = code.match(/\nmodule.exports = (\w+);/)
@@ -50,7 +50,7 @@ if (matchDefault) {
   code += `module.exports["default"] = ${matchDefault[1]};\n`
   writeFileSync(indexPath, code)
   console.log(colors.bold(`${indexPath} CJS patched`))
-  process.exit()
+  process.exit(0)
 }
 
 console.error(colors.red(`${indexPath} CJS patch failed`))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Running `pnpm run build` in Windows fails: the `scripts/patchCJS.ts` module needs call `process.exit` with `process.exit(0)`.

I reported this here: https://github.com/vitejs/vite/pull/8348#issuecomment-1140293255.

closes #9328

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
