### PR TITLE
docs: `resolve.alias` for SSR externalized deps

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -110,6 +110,10 @@ When aliasing to file system paths, always use absolute paths. Relative alias va
 
 More advanced custom resolution can be achieved through [plugins](/guide/api-plugin).
 
+::: warning Using with SSR
+If you have configured aliases for [SSR externalized dependencies](/guide/ssr.md#ssr-externals), you may want to alias the actual `node_modules` packages. Both [Yarn](https://classic.yarnpkg.com/en/docs/cli/add/#toc-yarn-add-alias) and [pnpm](https://pnpm.js.org/en/aliases) support aliasing via the `npm:` prefix.
+:::
+
 ## resolve.dedupe
 
 - **Type:** `string[]`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Add a warning about using `resolve.alias` for SSR externalized deps.
This is already written in https://vitejs.dev/guide/ssr.html#ssr-externals but I think it is better to have this in `resolve.alias` docs too.

close #6542

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
