### PR TITLE
fix: externalize explicitly configured linked packages

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -556,7 +556,8 @@ export function tryNodeResolve(
   targetWeb: boolean,
   depsOptimizer?: DepsOptimizer,
   ssr?: boolean,
-  externalize?: boolean
+  externalize?: boolean,
+  allowLinkedExternal: boolean = true
 ): PartialResolvedId | undefined {
   const { root, dedupe, isBuild, preserveSymlinks, packageCache } = options
 
@@ -657,8 +658,8 @@ export function tryNodeResolve(
       return resolved
     }
     // dont external symlink packages
-    if (!resolved.id.includes('node_modules')) {
-      return
+    if (!allowLinkedExternal && !resolved.id.includes('node_modules')) {
+      return resolved
     }
     const resolvedExt = path.extname(resolved.id)
     let resolvedId = id
@@ -666,7 +667,7 @@ export function tryNodeResolve(
       // check ext before externalizing - only externalize
       // extension-less imports and explicit .js imports
       if (resolvedExt && !resolved.id.match(/(.js|.mjs|.cjs)$/)) {
-        return
+        return resolved
       }
       if (!pkg?.data.exports && path.extname(id) !== resolvedExt) {
         resolvedId += resolvedExt

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -120,10 +120,6 @@ export function createIsConfiguredAsSsrExternal(
   return (id: string) => {
     const { ssr } = config
     if (ssr) {
-      const pkgName = getNpmPackageName(id)
-      if (!pkgName) {
-        return undefined
-      }
       if (
         // If this id is defined as external, force it as external
         // Note that individual package entries are allowed in ssr.external
@@ -131,13 +127,15 @@ export function createIsConfiguredAsSsrExternal(
       ) {
         return true
       }
+      const pkgName = getNpmPackageName(id)
+      if (!pkgName) {
+        return undefined
+      }
       if (
-        // A package name in ssr.external externalizes every entry
+        // A package name in ssr.external externalizes every
+        // externalizable package entry
         ssr.external?.includes(pkgName)
       ) {
-        // Return undefined here to avoid short-circuiting the isExternalizable check,
-        // that will filter this id out if it is not externalizable (e.g. a CSS file)
-        // We return here to make ssr.external take precedence over noExternal
         return true
       }
       if (typeof noExternal === 'boolean') {


### PR DESCRIPTION
### Description

Follow up to:
- https://github.com/vitejs/vite/pull/9296

After this PR, vite-plugin-ssr CI [fails in vite-ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci/runs/7488681069?check_suite_focus=true)

When a package is explicitly configured as external, externalize it even if it is linked (it isn't in `node_modules`).

This PR also checks if a package is resolvable before externalizing it. I think this is more consistent between direct package imports and imports of package entries.

The PR also avoids returning undefined when calling `tryNodeResolve` with the `externalize` flag. Instead, it returns the resolved object, and in the ssr logic, we check for its `external` flag.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other