### PR TITLE
fix: normalise css paths in manifest on windows (fixes #9295)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -533,7 +533,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             : chunk.name
 
           const lang = path.extname(cssAssetName).slice(1)
-          const cssFileName = ensureFileExt(cssAssetName, '.css')
+          const cssFileName = normalizePath(ensureFileExt(cssAssetName, '.css'))
 
           if (chunk.isEntry && isPureCssChunk) cssEntryFiles.add(cssAssetName)
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -519,7 +519,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       }
 
       function ensureFileExt(name: string, ext: string) {
-        return path.format({ ...path.parse(name), base: undefined, ext })
+        return normalizePath(
+          path.format({ ...path.parse(name), base: undefined, ext })
+        )
       }
 
       if (config.build.cssCodeSplit) {
@@ -533,7 +535,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             : chunk.name
 
           const lang = path.extname(cssAssetName).slice(1)
-          const cssFileName = normalizePath(ensureFileExt(cssAssetName, '.css'))
+          const cssFileName = ensureFileExt(cssAssetName, '.css')
 
           if (chunk.isEntry && isPureCssChunk) cssEntryFiles.add(cssAssetName)
 

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -103,7 +103,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
       function createAsset(chunk: OutputAsset): ManifestChunk {
         const manifestChunk: ManifestChunk = {
           file: chunk.fileName,
-          src: chunk.name
+          src: normalizePath(chunk.name!)
         }
 
         if (cssEntryFiles.has(chunk.name!)) manifestChunk.isEntry = true
@@ -118,7 +118,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
         if (chunk.type === 'chunk') {
           manifest[getChunkName(chunk)] = createChunk(chunk)
         } else if (chunk.type === 'asset' && typeof chunk.name === 'string') {
-          manifest[chunk.name] = createAsset(chunk)
+          manifest[normalizePath(chunk.name)] = createAsset(chunk)
         }
       }
 

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -103,7 +103,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
       function createAsset(chunk: OutputAsset): ManifestChunk {
         const manifestChunk: ManifestChunk = {
           file: chunk.fileName,
-          src: normalizePath(chunk.name!)
+          src: chunk.name
         }
 
         if (cssEntryFiles.has(chunk.name!)) manifestChunk.isEntry = true
@@ -118,7 +118,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
         if (chunk.type === 'chunk') {
           manifest[getChunkName(chunk)] = createChunk(chunk)
         } else if (chunk.type === 'asset' && typeof chunk.name === 'string') {
-          manifest[normalizePath(chunk.name)] = createAsset(chunk)
+          manifest[chunk.name] = createAsset(chunk)
         }
       }
 

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -35,6 +35,7 @@ describe.runIf(isBuild)('build', () => {
     const cssAssetEntry = manifest['global.css']
     const scssAssetEntry = manifest['nested/blue.scss']
     const imgAssetEntry = manifest['../images/logo.png']
+    const dirFooAssetEntry = manifest['../../dir/foo.css'] // '\\' should not be used even on windows
     expect(htmlEntry.css.length).toEqual(1)
     expect(htmlEntry.assets.length).toEqual(1)
     expect(cssAssetEntry?.file).not.toBeUndefined()
@@ -44,6 +45,7 @@ describe.runIf(isBuild)('build', () => {
     expect(scssAssetEntry?.isEntry).toEqual(true)
     expect(imgAssetEntry?.file).not.toBeUndefined()
     expect(imgAssetEntry?.isEntry).toBeUndefined()
+    expect(dirFooAssetEntry).not.toBeUndefined()
   })
 })
 

--- a/playground/backend-integration/dir/foo.css
+++ b/playground/backend-integration/dir/foo.css
@@ -1,0 +1,3 @@
+.windows-path-foo {
+  color: blue;
+}

--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -19,6 +19,7 @@ function BackendIntegrationExample() {
         .map((filename) => [path.relative(root, filename), filename])
 
       entrypoints.push(['tailwindcss-colors', 'tailwindcss/colors.js'])
+      entrypoints.push(['foo.css', path.resolve(__dirname, './dir/foo.css')])
 
       return {
         build: {


### PR DESCRIPTION
### Description

Fixes: https://github.com/vitejs/vite/issues/9295

We have had several reports in the Laravel official plugin repo that the Vite 3 CSS paths in the manifest are not being normalised as expected on Windows. We do not modify the manifest generation in any way in our plugin.

e.g. https://github.com/laravel/vite-plugin/issues/101

There are also reports on the vite issue tracker for this: https://github.com/vitejs/vite/issues/9295

`npm run build` may result in the following manifest:

```js
{
  "resources/js/app.js": {
    "file": "assets/app.ab93cf8a.js",
    "src": "resources/js/app.js",
    "isEntry": true
  },
  "resources/css\\app.css": {
    "file": "assets/app.1776c6d9.css",
    "src": "resources/css\\app.css"
  }
}
```

Notice the backslashes.

This PR proposes that we run the path through `normalisePath` before writing the manifest. This is what we did to fix this issue in the official Laravel plugin when we were doing this manually in Vite 2.

### Additional context

I do not have direct access to a Windows machine, so I need this to be verified by Windows users!!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
