### PR TITLE
fix(plugin-react): duplicate __self prop and __source prop

### DIFF
--- a/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.spec.ts
+++ b/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.spec.ts
@@ -115,4 +115,28 @@ describe('babel-restore-jsx', () => {
       `"React.createElement(aaa);"`
     )
   })
+
+  it('should not handle contains __self prop', () => {
+    expect(jsx('React.createElement(Provider, { __self: this })'))
+      .toMatchInlineSnapshot(`
+      "React.createElement(Provider, {
+        __self: this
+      });"
+    `)
+  })
+
+  it('should not handle contains __source prop', () => {
+    expect(
+      jsx(
+        'React.createElement(Provider, { __source: { fileName: _jsxFileName, lineNumber: 133 }})'
+      )
+    ).toMatchInlineSnapshot(`
+      "React.createElement(Provider, {
+        __source: {
+          fileName: _jsxFileName,
+          lineNumber: 133
+        }
+      });"
+    `)
+  })
 })

--- a/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.spec.ts
+++ b/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.spec.ts
@@ -117,12 +117,9 @@ describe('babel-restore-jsx', () => {
   })
 
   it('should not handle contains __self prop', () => {
-    expect(jsx('React.createElement(Provider, { __self: this })'))
-      .toMatchInlineSnapshot(`
-      "React.createElement(Provider, {
-        __self: this
-      });"
-    `)
+    expect(
+      jsx('React.createElement(Provider, { __self: this })')
+    ).toMatchInlineSnapshot('"<Provider />;"')
   })
 
   it('should not handle contains __source prop', () => {
@@ -130,13 +127,6 @@ describe('babel-restore-jsx', () => {
       jsx(
         'React.createElement(Provider, { __source: { fileName: _jsxFileName, lineNumber: 133 }})'
       )
-    ).toMatchInlineSnapshot(`
-      "React.createElement(Provider, {
-        __source: {
-          fileName: _jsxFileName,
-          lineNumber: 133
-        }
-      });"
-    `)
+    ).toMatchInlineSnapshot('"<Provider />;"')
   })
 })

--- a/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/babel-restore-jsx.ts
@@ -19,6 +19,16 @@ import type * as babel from '@babel/core'
  */
 export default function ({ types: t }: typeof babel): babel.PluginObj {
   /**
+   * If the props contains '__self' or '__source', it is not transform to JSX.
+   */
+  const isInvalidProps = (props: any[]) =>
+    props.some(
+      (prop) =>
+        t.isJSXIdentifier(prop.name) &&
+        (prop.name.name === '__self' || prop.name.name === '__source')
+    )
+
+  /**
    * Get a `JSXElement` from a `CallExpression`.
    * Returns `null` if this impossible.
    */
@@ -36,7 +46,7 @@ export default function ({ types: t }: typeof babel): babel.PluginObj {
     }
 
     const props = getJSXProps(propsNode)
-    if (props == null) {
+    if (props == null || isInvalidProps(props)) {
       return null //no props → [], invalid → null
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #9363

Both __source and __self are automatically set when using the automatic runtime.

So we should avoid transform a `ReactElement` containing `__source` or `__self` props to jsx.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
