### PR TITLE
test: refactor some regexp, remove `{1}`

### DIFF
--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -272,7 +272,7 @@ describe.runIf(isBuild)('encodeURI', () => {
   test('img src with encodeURI', async () => {
     const img = await page.$('.encodeURI')
     expect(
-      (await img.getAttribute('src')).startsWith('data:image/png;base64')
+      await (await img.getAttribute('src')).startsWith('data:image/png;base64')
     ).toBe(true)
   })
 })

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -197,8 +197,8 @@ describe('image', () => {
     srcset.split(', ').forEach((s) => {
       expect(s).toMatch(
         isBuild
-          ? /\/foo\/assets\/asset\.\w{8}\.png \d{1}x/
-          : /\/foo\/nested\/asset\.png \d{1}x/
+          ? /\/foo\/assets\/asset\.\w{8}\.png \dx/
+          : /\/foo\/nested\/asset\.png \dx/
       )
     })
   })
@@ -272,7 +272,7 @@ describe.runIf(isBuild)('encodeURI', () => {
   test('img src with encodeURI', async () => {
     const img = await page.$('.encodeURI')
     expect(
-      await (await img.getAttribute('src')).startsWith('data:image/png;base64')
+      (await img.getAttribute('src')).startsWith('data:image/png;base64')
     ).toBe(true)
   })
 })

--- a/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
+++ b/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
@@ -158,8 +158,8 @@ describe('image', () => {
     srcset.split(', ').forEach((s) => {
       expect(s).toMatch(
         isBuild
-          ? /other-assets\/asset\.\w{8}\.png \d{1}x/
-          : /\.\/nested\/asset\.png \d{1}x/
+          ? /other-assets\/asset\.\w{8}\.png \dx/
+          : /\.\/nested\/asset\.png \dx/
       )
     })
   })

--- a/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
+++ b/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
@@ -156,8 +156,8 @@ describe('image', () => {
     srcset.split(', ').forEach((s) => {
       expect(s).toMatch(
         isBuild
-          ? /other-assets\/asset\.\w{8}\.png \d{1}x/
-          : /\.\/nested\/asset\.png \d{1}x/
+          ? /other-assets\/asset\.\w{8}\.png \dx/
+          : /\.\/nested\/asset\.png \dx/
       )
     })
   })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed that in the unit test, there are many regexp which includes `{1}`, it is unnecessary, so I remove it.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
