### PR TITLE
fix: url constructor import asset no as url

### DIFF
--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -55,7 +55,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               s.overwrite(
                 index,
                 index + exp.length,
-                `new URL((import.meta.glob(${pattern}, { eager: true, import: 'default' }))[${rawUrl}], self.location)`,
+                `new URL((import.meta.glob(${pattern}, { eager: true, import: 'default', as: 'url' }))[${rawUrl}], self.location)`,
                 { contentOnly: true }
               )
               continue

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -288,6 +288,9 @@ test('new URL(`${dynamic}`, import.meta.url)', async () => {
   expect(await page.textContent('.dynamic-import-meta-url-2')).toMatch(
     assetMatch
   )
+  expect(await page.textContent('.dynamic-import-meta-url-js')).toMatch(
+    isBuild ? 'data:application/javascript;base64' : '/foo/nested/test.js'
+  )
 })
 
 test('new URL(`non-existent`, import.meta.url)', async () => {

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -199,6 +199,9 @@
   <img class="dynamic-import-meta-url-img-2" />
   <code class="dynamic-import-meta-url-2"></code>
 </p>
+<p>
+  <code class="dynamic-import-meta-url-js"></code>
+</p>
 
 <h2>new URL(`./${dynamic}`, import.meta.url,) (with comma)</h2>
 <p>
@@ -389,6 +392,10 @@
 
   testDynamicImportMetaUrlWithComma('icon', 1)
   testDynamicImportMetaUrlWithComma('asset', 2)
+
+  const name = 'test'
+  const js = new URL(`./nested/${name}.js`, import.meta.url).href
+  text('.dynamic-import-meta-url-js', js)
 
   function text(el, text) {
     document.querySelector(el).textContent = text

--- a/playground/assets/nested/test.js
+++ b/playground/assets/nested/test.js
@@ -1,0 +1,3 @@
+export default class a {
+  name = 'a'
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #9309

add `as: url` for `new URL('...', import.meta.url)`
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
