### PR TITLE
fix: inline dynamic imports for ssr-webworker (fixes #9385)

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -444,11 +444,13 @@ async function doBuild(
         )
       }
 
-      const ssrWorkerBuild = ssr && config.ssr?.target !== 'webworker'
-      const cjsSsrBuild = ssr && config.ssr?.format === 'cjs'
+      const ssrNodeBuild = ssr && config.ssr.target === 'node'
+      const ssrWorkerBuild = ssr && config.ssr.target === 'webworker'
+      const cjsSsrBuild = ssr && config.ssr.format === 'cjs'
+
       const format = output.format || (cjsSsrBuild ? 'cjs' : 'es')
       const jsExt =
-        ssrWorkerBuild || libOptions
+        ssrNodeBuild || libOptions
           ? resolveOutputJsExtension(format, getPkgJson(config.root)?.type)
           : 'js'
       return {

--- a/playground/ssr-vue/vite.config.js
+++ b/playground/ssr-vue/vite.config.js
@@ -85,14 +85,14 @@ export default defineConfig(({ command, ssrBuild }) => ({
           }
         },
         transform(code, id) {
+          const cleanId = cleanUrl(id)
           if (
             config.build.ssr &&
-            cleanUrl(id).endsWith('.js') &&
-            !code.includes('__ssr_vue_processAssetPath')
+            (cleanId.endsWith('.js') || cleanId.endsWith('.vue'))
           ) {
             return {
               code:
-                `import { __ssr_vue_processAssetPath } from '${virtualId}';` +
+                `import { __ssr_vue_processAssetPath } from '${virtualId}';__ssr_vue_processAssetPath;` +
                 code,
               sourcemap: null // no sourcemap support to speed up CI
             }

--- a/playground/ssr-vue/vite.config.js
+++ b/playground/ssr-vue/vite.config.js
@@ -88,7 +88,8 @@ export default defineConfig(({ command, ssrBuild }) => ({
           const cleanId = cleanUrl(id)
           if (
             config.build.ssr &&
-            (cleanId.endsWith('.js') || cleanId.endsWith('.vue'))
+            (cleanId.endsWith('.js') || cleanId.endsWith('.vue')) &&
+            !code.includes('__ssr_vue_processAssetPath')
           ) {
             return {
               code:

--- a/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
+++ b/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
@@ -1,5 +1,5 @@
 import { port } from './serve'
-import { page } from '~utils'
+import { findAssetFile, isBuild, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -8,4 +8,9 @@ test('/', async () => {
   expect(await page.textContent('h1')).toMatch('hello from webworker')
   expect(await page.textContent('.linked')).toMatch('dep from upper directory')
   expect(await page.textContent('.external')).toMatch('object')
+})
+
+test.runIf(isBuild)('inlineDynamicImports', () => {
+  const dynamicJsContent = findAssetFile(/dynamic\.\w+\.js/, 'worker')
+  expect(dynamicJsContent).toBe('')
 })

--- a/playground/ssr-webworker/src/dynamic.js
+++ b/playground/ssr-webworker/src/dynamic.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/playground/ssr-webworker/src/entry-worker.jsx
+++ b/playground/ssr-webworker/src/entry-worker.jsx
@@ -1,6 +1,10 @@
 import { msg as linkedMsg } from 'resolve-linked'
 import React from 'react'
 
+import('./dynamic').then(({ foo }) => {
+  console.log(foo)
+})
+
 addEventListener('fetch', function (event) {
   return event.respondWith(
     new Response(

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/triple-slash-reference */
 // test utils used in e2e tests for playgrounds.
 // `import { getColor } from '~utils'`
 
@@ -8,7 +7,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import colors from 'css-color-names'
-import type { ElementHandle, ConsoleMessage } from 'playwright-chromium'
+import type { ConsoleMessage, ElementHandle } from 'playwright-chromium'
 import type { Manifest } from 'vite'
 import { normalizePath } from 'vite'
 import { fromComment } from 'convert-source-map'
@@ -128,7 +127,15 @@ export function findAssetFile(
   assets = 'assets'
 ): string {
   const assetsDir = path.join(testDir, 'dist', base, assets)
-  const files = fs.readdirSync(assetsDir)
+  let files: string[]
+  try {
+    files = fs.readdirSync(assetsDir)
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return ''
+    }
+    throw e
+  }
   const file = files.find((file) => {
     return file.match(match)
   })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#8641 disabled `inlineDynamicImports` **for ssr-webworker**. Instead, it should disable **for ssr-node**.
This PR fixes that.

fixes #9385 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
