### PR TITLE
fix(ssr): allow virtual paths on node modules

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -129,20 +129,25 @@ export function createIsConfiguredAsSsrExternal(
     if (!bareImportRE.test(id) || id.includes('\0')) {
       return false
     }
-    return !!tryNodeResolve(
-      id,
-      undefined,
-      resolveOptions,
-      ssr?.target === 'webworker',
-      undefined,
-      true,
-      // try to externalize, will return undefined or an object without
-      // a external flag if it isn't externalizable
-      true,
-      // Allow linked packages to be externalized if they are explicitly
-      // configured as external
-      !!configuredAsExternal
-    )?.external
+    try {
+      return !!tryNodeResolve(
+        id,
+        undefined,
+        resolveOptions,
+        ssr?.target === 'webworker',
+        undefined,
+        true,
+        // try to externalize, will return undefined or an object without
+        // a external flag if it isn't externalizable
+        true,
+        // Allow linked packages to be externalized if they are explicitly
+        // configured as external
+        !!configuredAsExternal
+      )?.external
+    } catch (e) {
+      // may be an invalid import that's resolved by a plugin
+      return false
+    }
   }
 
   // Returns true if it is configured as external, false if it is filtered

--- a/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -103,3 +103,8 @@ test('msg from linked no external', async () => {
   await page.goto(url)
   expect(await page.textContent('.linked-no-external')).toMatch('Hello World!')
 })
+
+test('msg from linked no external', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.dep-virtual')).toMatch('[success]')
+})

--- a/playground/ssr-deps/package.json
+++ b/playground/ssr-deps/package.json
@@ -27,7 +27,8 @@
     "optimized-cjs-with-nested-external": "file:./optimized-with-nested-external",
     "external-using-external-entry": "file:./external-using-external-entry",
     "external-entry": "file:./external-entry",
-    "linked-no-external": "link:./linked-no-external"
+    "linked-no-external": "link:./linked-no-external",
+    "pkg-exports": "file:./pkg-exports"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/playground/ssr-deps/pkg-exports/index.js
+++ b/playground/ssr-deps/pkg-exports/index.js
@@ -1,0 +1,1 @@
+export default undefined

--- a/playground/ssr-deps/pkg-exports/package.json
+++ b/playground/ssr-deps/pkg-exports/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pkg-exports",
+  "private": true,
+  "version": "0.0.0",
+  "exports": {
+    ".": "./index.js"
+  },
+  "type": "module"
+}

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -45,7 +45,23 @@ export async function createServer(root = process.cwd(), hmrPort) {
       optimizeDeps: {
         disabled: 'build'
       }
-    }
+    },
+    plugins: [
+      {
+        name: 'dep-virtual',
+        enforce: 'pre',
+        resolveId(id) {
+          if (id === 'pkg-exports/virtual') {
+            return 'pkg-exports/virtual'
+          }
+        },
+        load(id) {
+          if (id === 'pkg-exports/virtual') {
+            return 'export default "[success]"'
+          }
+        }
+      }
+    ]
   })
   // use vite's connect instance as middleware
   app.use(vite.middlewares)

--- a/playground/ssr-deps/src/app.js
+++ b/playground/ssr-deps/src/app.js
@@ -12,6 +12,7 @@ import requireAbsolute from 'require-absolute'
 import noExternalCjs from 'no-external-cjs'
 import importBuiltinCjs from 'import-builtin-cjs'
 import { hello as linkedNoExternal } from 'linked-no-external'
+import virtualMessage from 'pkg-exports/virtual'
 
 // This import will set a 'Hello World!" message in the nested-external non-entry dependency
 import 'non-optimized-with-nested-external'
@@ -78,6 +79,8 @@ export async function render(url, rootDir) {
 
   const linkedNoExternalMessage = linkedNoExternal()
   html += `\n<p class="linked-no-external">message from linked-no-external: ${linkedNoExternalMessage}</p>`
+
+  html += `\n<p class="dep-virtual">message from dep-virtual: ${virtualMessage}</p>`
 
   return html + '\n'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,6 +915,7 @@ importers:
       only-object-assigned-exports: file:./only-object-assigned-exports
       optimized-cjs-with-nested-external: file:./optimized-with-nested-external
       optimized-with-nested-external: file:./optimized-with-nested-external
+      pkg-exports: file:./pkg-exports
       primitive-export: file:./primitive-export
       read-file-content: file:./read-file-content
       require-absolute: file:./require-absolute
@@ -935,6 +936,7 @@ importers:
       only-object-assigned-exports: file:playground/ssr-deps/only-object-assigned-exports
       optimized-cjs-with-nested-external: file:playground/ssr-deps/optimized-with-nested-external
       optimized-with-nested-external: file:playground/ssr-deps/optimized-with-nested-external
+      pkg-exports: file:playground/ssr-deps/pkg-exports
       primitive-export: file:playground/ssr-deps/primitive-export
       read-file-content: file:playground/ssr-deps/read-file-content
       require-absolute: file:playground/ssr-deps/require-absolute
@@ -1002,6 +1004,9 @@ importers:
       nested-external: file:../nested-external
     dependencies:
       nested-external: file:playground/ssr-deps/nested-external
+
+  playground/ssr-deps/pkg-exports:
+    specifiers: {}
 
   playground/ssr-deps/primitive-export:
     specifiers: {}
@@ -9188,6 +9193,12 @@ packages:
     version: 0.0.0
     dependencies:
       nested-external: file:playground/ssr-deps/nested-external
+    dev: false
+
+  file:playground/ssr-deps/pkg-exports:
+    resolution: {directory: playground/ssr-deps/pkg-exports, type: directory}
+    name: pkg-exports
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/primitive-export:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #9364

### Additional context

Catch errors from `tryNodeResolve` and no externalize if an error is caught so we process it through Vite.

Maybe also worth discussing whether we want to support #9364

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
