### PR TITLE
feat(create-vite): add support for custom init commands (`create-vue`, Nuxt, and SvelteKit)

### DIFF
--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -4,7 +4,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { spawnSync } from 'node:child_process'
+import spawn from 'cross-spawn'
 import minimist from 'minimist'
 import prompts from 'prompts'
 import {
@@ -284,7 +284,7 @@ async function init() {
       .replace('@latest', () => (pkgManager === 'yarn' ? '' : '@latest'))
 
     const [command, ...args] = fullCustomCommand.split(' ')
-    const { status } = spawnSync(command, args, {
+    const { status } = spawn.sync(command, args, {
       stdio: 'inherit'
     })
     process.exit(status ?? 0)

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -49,12 +49,12 @@ const FRAMEWORKS = [
     variants: [
       {
         name: 'vue',
-        display: 'Basic JavaScript',
+        display: 'JavaScript',
         color: yellow
       },
       {
         name: 'vue-ts',
-        display: 'Basic TypeScript',
+        display: 'TypeScript',
         color: blue
       },
       {
@@ -129,12 +129,12 @@ const FRAMEWORKS = [
     variants: [
       {
         name: 'svelte',
-        display: 'Basic JavaScript',
+        display: 'JavaScript',
         color: yellow
       },
       {
         name: 'svelte-ts',
-        display: 'Basic TypeScript',
+        display: 'TypeScript',
         color: blue
       },
       {

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -25,6 +25,7 @@ const cwd = process.cwd()
 const FRAMEWORKS = [
   {
     name: 'vanilla',
+    display: 'Vanilla',
     color: yellow,
     variants: [
       {
@@ -41,6 +42,7 @@ const FRAMEWORKS = [
   },
   {
     name: 'vue',
+    display: 'Vue',
     color: green,
     variants: [
       {
@@ -57,6 +59,7 @@ const FRAMEWORKS = [
   },
   {
     name: 'react',
+    display: 'React',
     color: cyan,
     variants: [
       {
@@ -73,6 +76,7 @@ const FRAMEWORKS = [
   },
   {
     name: 'preact',
+    display: 'Preact',
     color: magenta,
     variants: [
       {
@@ -89,6 +93,7 @@ const FRAMEWORKS = [
   },
   {
     name: 'lit',
+    display: 'Lit',
     color: lightRed,
     variants: [
       {
@@ -105,6 +110,7 @@ const FRAMEWORKS = [
   },
   {
     name: 'svelte',
+    display: 'Svelte',
     color: red,
     variants: [
       {

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -191,7 +191,7 @@ async function init() {
           choices: FRAMEWORKS.map((framework) => {
             const frameworkColor = framework.color
             return {
-              title: frameworkColor(framework.name),
+              title: frameworkColor(framework.display || framework.name),
               value: framework
             }
           })
@@ -206,7 +206,7 @@ async function init() {
             framework.variants.map((variant) => {
               const variantColor = variant.color
               return {
-                title: variantColor(variant.name),
+                title: variantColor(variant.display || variant.name),
                 value: variant.name
               }
             })

--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -283,7 +283,7 @@ async function init() {
       .replace(/^npm create/, `${pkgManager} create`)
       // Only Yarn 1.x doesn't support `@version` in the `create` command
       .replace('@latest', () => (isYarn1 ? '' : '@latest'))
-      .replace('^npm exec', () => {
+      .replace(/^npm exec/, () => {
         // Prefer `pnpm dlx` or `yarn dlx`
         if (pkgManager === 'pnpm') {
           return 'pnpm dlx'

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/vitejs/vite/tree/main/packages/create-vite#readme",
   "dependencies": {
+    "cross-spawn": "^7.0.3",
     "kolorist": "^1.5.1",
     "minimist": "^1.2.6",
     "prompts": "^2.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,10 +128,12 @@ importers:
 
   packages/create-vite:
     specifiers:
+      cross-spawn: ^7.0.3
       kolorist: ^1.5.1
       minimist: ^1.2.6
       prompts: ^2.4.2
     dependencies:
+      cross-spawn: 7.0.3
       kolorist: 1.5.1
       minimist: 1.2.6
       prompts: 2.4.2
@@ -3955,7 +3957,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
   /crosspath/0.0.8:
     resolution: {integrity: sha512-IKlS3MpP0fhJ50M6ltyLO7Q4NzwfhafpmolMH0EDKyyaY81HutF2mH4hLpCdm3fKZ/TSTW5qPIdTy62YnefEyQ==}
@@ -5814,7 +5815,6 @@ packages:
 
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-    dev: true
 
   /jiti/1.13.0:
     resolution: {integrity: sha512-/n9mNxZj/HDSrincJ6RP+L+yXbpnB8FybySBa+IjIaoH9FIxBbrbRT5XUbe8R7zuVM2AQqNMNDDqz0bzx3znOQ==}
@@ -6796,7 +6796,6 @@ packages:
   /path-key/3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-key/4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
@@ -7724,7 +7723,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex/1.0.0:
     resolution: {integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=}
@@ -7734,7 +7732,6 @@ packages:
   /shebang-regex/3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /shell-exec/1.0.2:
     resolution: {integrity: sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==}
@@ -8735,7 +8732,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/issues/9317

The outcome:

https://user-images.githubusercontent.com/3277634/181470625-8da0b23a-4a80-475b-b30e-855abd1ce18f.mp4

I've also published a package called `create-soda-test` on npm, so that you can test it with package managers (e.g. `pnpm create soda-test`) to see if calling `npm create` inside `npm create` really works.

### Additional context

I also changed the prompts a little bit, but they are in separate commits, so if this PR gets accepted, please don't squash the commits.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
