### PR TITLE
fix(glob): server perf when globbing huge dirs

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -74,10 +74,6 @@ export function importGlobPlugin(config: ResolvedConfig): Plugin {
         if (server) {
           const allGlobs = result.matches.map((i) => i.globsResolved)
           server._importGlobMap.set(id, allGlobs)
-          result.files.forEach((file) => {
-            // update watcher
-            server!.watcher.add(dirname(file))
-          })
         }
         return transformStableResult(result.s, id, config)
       }


### PR DESCRIPTION
The [`vite:import-glob` plugin was unnecessarily watching globbed files](https://github.com/vitejs/vite/blob/875fc116a0c74d5485e61a3b8c4b5bcc5d8bc842/packages/vite/src/node/plugins/importMetaGlob.ts#L63-L66) (and doing so without checking for duplicates). This causes significant overhead when the file list is large (2K or more). It's also redundant to watch the files because [`createServer()` already recursively watches the project's root directory](https://github.com/vitejs/vite/blob/875fc116a0c74d5485e61a3b8c4b5bcc5d8bc842/packages/vite/src/node/server/index.ts#L294-L304).

fixes #9391

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I'd submit a unit test for this, but not yet sure how. The `test-serve` command is flaky on my machine (even without any of my changes).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
