### PR TITLE
feat(ssr): debug failed node resolve

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -145,6 +145,9 @@ export function createIsConfiguredAsSsrExternal(
         !!configuredAsExternal
       )?.external
     } catch (e) {
+      debug(
+        `Failed to node resolve "${id}". Skipping externalizing it by default.`
+      )
       // may be an invalid import that's resolved by a plugin
       return false
     }


### PR DESCRIPTION
followup to #9405


debug if `tryNodeResolve` errors when checking if an id is externalizable