### PR TITLE
fix: respect bare imports in browser field of package.json

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1039,7 +1039,9 @@ function tryResolveBrowserMapping(
     const mapId = isFilePath ? './' + slash(path.relative(pkg.dir, id)) : id
     const browserMappedPath = mapWithBrowserField(mapId, pkg.data.browser)
     if (browserMappedPath) {
-      const fsPath = path.join(pkg.dir, browserMappedPath)
+      const fsPath = bareImportRE.test(browserMappedPath)
+        ? path.join(pkg.dir, '../' + browserMappedPath)
+        : path.join(pkg.dir, browserMappedPath)
       if ((res = tryFsResolve(fsPath, options))) {
         isDebug &&
           debug(`[browser mapped] ${colors.cyan(id)} -> ${colors.dim(res)}`)

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -57,6 +57,10 @@ test('cjs browser field (axios)', async () => {
   expect(await page.textContent('.cjs-browser-field')).toBe('pong')
 })
 
+test('cjs browser field bare', async () => {
+  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
+})
+
 test('dep from linked dep (lodash-es)', async () => {
   expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
 })

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const events = require('events')
+
+module.exports = events

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dep-cjs-browser-field-bare",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "browser": {
+    "events": "test-dep"
+  },
+  "dependencies": {
+    "test-dep": "file:../test-dep"
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -29,6 +29,9 @@
 <h2>CommonJS w/ browser field mapping (axios)</h2>
 <div>This should show pong: <span class="cjs-browser-field"></span></div>
 
+<h2>CommonJS w/ bare id browser field mapping</h2>
+<div>This should show pong: <span class="cjs-browser-field-bare"></span></div>
+
 <h2>Detecting linked src package and optimizing its deps (lodash-es)</h2>
 <div>This should show fooBarBaz: <span class="deps-linked"></span></div>
 
@@ -93,6 +96,9 @@
 <script type="module">
   // test dep detection in globbed files
   const globbed = import.meta.glob('./glob/*.js', { eager: true })
+
+  import cjsBrowerFieldBare from 'dep-cjs-browser-field-bare'
+  text('.cjs-browser-field-bare', cjsBrowerFieldBare)
 
   import { camelCase } from 'dep-linked'
   text('.deps-linked', camelCase('foo-bar-baz'))

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "clipboard": "^2.0.11",
+    "dep-cjs-browser-field-bare": "file:./dep-cjs-browser-field-bare",
     "dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
     "dep-cjs-with-assets": "file:./dep-cjs-with-assets",

--- a/playground/optimize-deps/test-dep/index.js
+++ b/playground/optimize-deps/test-dep/index.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = 'pong'

--- a/playground/optimize-deps/test-dep/package.json
+++ b/playground/optimize-deps/test-dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-dep",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,7 @@ importers:
       added-in-entries: file:./added-in-entries
       axios: ^0.27.2
       clipboard: ^2.0.11
+      dep-cjs-browser-field-bare: file:./dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:./dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:./dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:./dep-cjs-with-assets
@@ -647,6 +648,7 @@ importers:
       added-in-entries: file:playground/optimize-deps/added-in-entries
       axios: 0.27.2
       clipboard: 2.0.11
+      dep-cjs-browser-field-bare: file:playground/optimize-deps/dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:playground/optimize-deps/dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:playground/optimize-deps/dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:playground/optimize-deps/dep-cjs-with-assets
@@ -675,6 +677,12 @@ importers:
 
   playground/optimize-deps/added-in-entries:
     specifiers: {}
+
+  playground/optimize-deps/dep-cjs-browser-field-bare:
+    specifiers:
+      test-dep: file:../test-dep
+    dependencies:
+      test-dep: file:playground/optimize-deps/test-dep
 
   playground/optimize-deps/dep-cjs-compiled-from-cjs:
     specifiers: {}
@@ -728,6 +736,9 @@ importers:
     specifiers: {}
 
   playground/optimize-deps/non-optimizable-include:
+    specifiers: {}
+
+  playground/optimize-deps/test-dep:
     specifiers: {}
 
   playground/optimize-missing-deps:
@@ -8997,6 +9008,14 @@ packages:
     version: 1.0.0
     dev: false
 
+  file:playground/optimize-deps/dep-cjs-browser-field-bare:
+    resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
+    name: dep-cjs-browser-field-bare
+    version: 0.0.0
+    dependencies:
+      test-dep: file:playground/optimize-deps/test-dep
+    dev: false
+
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-cjs, type: directory}
     name: dep-cjs-compiled-from-cjs
@@ -9069,6 +9088,12 @@ packages:
     resolution: {directory: playground/optimize-deps/nested-include, type: directory}
     name: nested-include
     version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/test-dep:
+    resolution: {directory: playground/optimize-deps/test-dep, type: directory}
+    name: test-dep
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-missing-deps/missing-dep:


### PR DESCRIPTION
### Description

This helps vite respect bare package imports in browser fields of package.json. We (@wittjosiah) discovered this when trying to use `sodium-universal` in a vite app, which asks for this substitution of `sodium-native`:
```
  "browser": {
    "sodium-native": "sodium-javascript"
  },
```
Relevant code in vite seemed to be assuming all such browser values are relative paths and not bare imports

### Additional context

We're not sure if we're breaking anything else, and this problem seems related to (but not covered by) the solution in #8709

Let us know how to make this better and we'll get it there, thank you for your time!

Grand merci, Vite team!

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
