### PR TITLE
feat: print server URLs after ever HMR

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -73,6 +73,12 @@ export default defineConfig({
 })
 ```
 
+**Note:** when opening Google Chrome on macOS, Vite will try to re-use an existing tab if your application is already open. This requires that Vite is unpacked on your file system. If you're using yarn PnP, packages are compressed and only made available through a virtual file system. To enable re-using the Chrome tab while using yarn PnP, you can [unplug](https://yarnpkg.com/cli/unplug) Vite so that it is available on disk:
+
+```
+yarn unplug --all --recursive vite
+```
+
 ## server.proxy
 
 - **Type:** `Record<string, string | ProxyOptions>`

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -73,12 +73,6 @@ export default defineConfig({
 })
 ```
 
-**Note:** when opening Google Chrome on macOS, Vite will try to re-use an existing tab if your application is already open. This requires that Vite is unpacked on your file system. If you're using yarn PnP, packages are compressed and only made available through a virtual file system. To enable re-using the Chrome tab while using yarn PnP, you can [unplug](https://yarnpkg.com/cli/unplug) Vite so that it is available on disk:
-
-```
-yarn unplug --all --recursive vite
-```
-
 ## server.proxy
 
 - **Type:** `Record<string, string | ProxyOptions>`

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -166,6 +166,11 @@ export function updateModules(
       clear: true,
       timestamp: true
     })
+    try {
+      server.printUrls()
+    } catch (e) {
+      // Printing URLs can fail if the server isn't started yet
+    }
     server.ws.send({
       type: 'full-reload'
     })
@@ -183,7 +188,11 @@ export function updateModules(
       .join('\n'),
     { clear: true, timestamp: true }
   )
-  server.printUrls()
+  try {
+    server.printUrls()
+  } catch (e) {
+    // Printing URLs can fail if the server isn't started yet
+  }
   server.ws.send({
     type: 'update',
     updates

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -129,7 +129,7 @@ export function updateModules(
   file: string,
   modules: ModuleNode[],
   timestamp: number,
-  { config, ws }: ViteDevServer
+  server: ViteDevServer
 ): void {
   const updates: Update[] = []
   const invalidatedModules = new Set<ModuleNode>()
@@ -162,11 +162,11 @@ export function updateModules(
   }
 
   if (needFullReload) {
-    config.logger.info(colors.green(`page reload `) + colors.dim(file), {
+    server.config.logger.info(colors.green(`page reload `) + colors.dim(file), {
       clear: true,
       timestamp: true
     })
-    ws.send({
+    server.ws.send({
       type: 'full-reload'
     })
     return
@@ -177,13 +177,14 @@ export function updateModules(
     return
   }
 
-  config.logger.info(
+  server.config.logger.info(
     updates
       .map(({ path }) => colors.green(`hmr update `) + colors.dim(path))
       .join('\n'),
     { clear: true, timestamp: true }
   )
-  ws.send({
+  server.printUrls()
+  server.ws.send({
     type: 'update',
     updates
   })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

First off, I just started using Vite after years of create-react-app. Can't overstate how awesome (and fast!) it is!! Attached is some photo evidence of my excitement:

<img width="505" alt="Screen Shot 2022-07-29 at 3 44 15 PM" src="https://user-images.githubusercontent.com/8902272/181854750-5a5dea50-068d-43a5-b97a-7aff2b8362a3.png">

Something I miss from CRA is that it would print the `localhost` server URL after every HMR. Usually `yarn dev` is a long running process, and I might close the `localhost` Chrome tab, and then later when I start devving again, I can't remember the localhost path. Best solutions right now are:
1. Bookmark the `localhost` URL that vite chooses (I assume the port is stable?)
1. Cancel the vite process and re-run `yarn dev`

With this PR, vite reprints the server URLs on every HMR. That means the URLs are always in the terminal and ready to be clicked!

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
- Is my commit message ok?
- This seems to have broken some tests but I can't figure out why. Any ideas?
- Where can I add a test?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
