### PR TITLE
docs: Add note about Mac + Chrome auto-open when using yarn PnP

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -73,6 +73,12 @@ export default defineConfig({
 })
 ```
 
+**Note:** when opening Google Chrome on macOS, Vite will try to re-use an existing tab if your application is already open. This requires that Vite is unpacked on your file system. If you're using yarn PnP, packages are compressed and only made available through a virtual file system. To enable re-using the Chrome tab while using yarn PnP, you can unplug Vite so that it is available on disk:
+
+```
+yarn unplug --all --recursive vite
+```
+
 ## server.proxy
 
 - **Type:** `Record<string, string | ProxyOptions>`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Heyo! I noticed that the cool "re-use Chrome tab on OS X" wasn't working for me

https://github.com/vitejs/vite/blob/364aae13f0826169e8b1c5db41ac6b5bb2756958/packages/vite/src/node/server/openBrowser.ts#L63-L76

This was because Yarn PNP uses virtual directories for packages, and thus `VITE_PACKAGE_DIR` (above on line 76) is `/Users/zachkirsch/Dropbox/Mac/Documents/fern/.yarn/__virtual__/vite-virtual-7bf51d405a/2/vite/packages/vite`.

Of course, passing this (fake) directory as `cwd` to `execSync` doesn't work.

The fix was to use `yarn unplug` to tell yarn that Vite should be installed on disk and not use their fancy virtual filesystem optimization. This PR adds that info to your docs, in case you're interested in spreading the word :)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
