### PR TITLE
feat(plugin-legacy): make terser optional if renderLegacyChunk false

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -27,7 +27,7 @@ export default {
 }
 ```
 
-If `renderLegacyChunks` is not `false`, Terser must be installed because plugin-legacy uses Terser to minify legacy chunks.
+If [renderLegacyChunks](#renderlegacychunks) is `true` (default), Terser must be installed because plugin-legacy uses Terser to minify legacy chunks.
 
 ```sh
 npm add -D terser

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -27,7 +27,7 @@ export default {
 }
 ```
 
-Terser must be installed because plugin-legacy uses Terser for minification.
+If `renderLegacyChunks` is not `false`, Terser must be installed because plugin-legacy uses Terser to minify legacy chunks.
 
 ```sh
 npm add -D terser

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -45,6 +45,11 @@
     "terser": "^5.4.0",
     "vite": "^3.0.0"
   },
+  "peerDependenciesMeta": {
+    "terser": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/core": "^7.18.9",
     "vite": "workspace:*"

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -648,7 +648,9 @@ async function buildPolyfillChunk(
   excludeSystemJS?: boolean
 ) {
   let { minify, assetsDir } = buildOptions
-  minify = minify ? 'terser' : false
+  if (format === 'iife') {
+    minify = minify ? 'terser' : false
+  }
   const res = await build({
     // so that everything is resolved from here
     root: path.dirname(fileURLToPath(import.meta.url)),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`terser` is only needed if we're rendering legacy chunks. If `renderLegacyChunks: false`, we don't need terser as the existing code also actually doesn't need it, per 

https://github.com/vitejs/vite/blob/5f50693d515861eca971174cf9b860059132a58b/packages/plugin-legacy/src/index.ts#L349-L360

where `const genLegacy = options.renderLegacyChunks !== false`.

Ref https://github.com/vitejs/vite/discussions/9435#discussioncomment-3280079

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
So far tested manually with the `legacy` playground only.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
