### PR TITLE
docs: ESM is always strict mode

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -70,8 +70,7 @@ Also if there is a dependency loop, a full reload will happen. To solve this, tr
 
 ### Syntax Error / Type Error happens
 
-Vite cannot handle and does not support code that only runs on non-strict mode (sloppy mode).
-This is because Vite uses ESM and it is always [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) inside ESM.
+Vite cannot handle and does not support code that only runs on non-strict mode (sloppy mode). This is because Vite uses ESM and it is always [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) inside ESM.
 
 For example, you might see these errors.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -65,3 +65,18 @@ If you are running Vite with WSL2, Vite cannot watch file changes in some condit
 If HMR is not handled by Vite or a plugin, a full reload will happen.
 
 Also if there is a dependency loop, a full reload will happen. To solve this, try removing the loop.
+
+## Others
+
+### Syntax Error / Type Error happens
+
+Vite cannot handle and does not support code that only runs on non-strict mode (sloppy mode).
+This is because Vite uses ESM and it is always [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) inside ESM.
+
+For example, you might see these errors.
+
+> [ERROR] With statements cannot be used with the "esm" output format due to strict mode
+
+> TypeError: Cannot create property 'foo' on boolean 'false'
+
+If these code are used inside dependecies, you could use [`patch-package`](https://github.com/ds300/patch-package) (or [`yarn patch`](https://yarnpkg.com/cli/patch) or [`pnpm patch`](https://pnpm.io/cli/patch)) for an escape hatch.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Vite cannot support codes that only runs in non-strict mode. I think this limitation should be documented somewhere.

close #9430
refs #8889

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
