### PR TITLE
fix: svg file as a react component attribute types

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -95,8 +95,8 @@ declare module '*.gif' {
   export default src
 }
 declare module '*.svg' {
-  const src: string
-  export default src
+  const content: any
+  export default content
 }
 declare module '*.ico' {
   const src: string


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
while using svg files as react components, it's impossible to use HTML attributes in the component while using typescript.

I have made this change inspired by what next.js is doing in here:
https://github.com/vercel/next.js/blob/canary/packages/next/image-types/global.d.ts


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
```js
import Icon from "assets/icons/icon.svg";
<Icon style={{ fontSize: "16px" }} />;
```
#### Error:
```
Type '{ style: { fontSize: string; }; }' is not assignable to type 'IntrinsicAttributes'. 
Property 'style' does not exist on type 'IntrinsicAttributes'.
```
  
#### Project Setup:
```
    "@vitejs/plugin-react": "^2.0.0",
    "vite": "^3.0.0",
    "react": "^18.2.0",
    "typescript": "^4.6.4"
```


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
