### PR TITLE
fix: ignore tsconfig target when bundling config

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -932,6 +932,7 @@ async function bundleConfigFile(
     entryPoints: [fileName],
     outfile: 'out.js',
     write: false,
+    target: ['node14.18', 'node16'],
     platform: 'node',
     bundle: true,
     format: isESM ? 'esm' : 'cjs',


### PR DESCRIPTION
### Description
When `target: es5` is set in `tsconfig.json` and `vite.config.ts` exists, Vite fails to start.
This is because esbuild looks for that when bundling config.

Because we always ignore `target` in `tsconfig.json` and users won't expect `target` field to be respected for config loading, I think it is better to ignore `target` field here too. 

reproduction: https://stackblitz.com/edit/vitejs-vite-h1gxde?file=vite.config.ts&terminal=dev

### Additional context

related discussion: #3827

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
