### PR TITLE
fix: use browser field if it is not likely UMD or CJS (fixes #9445)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -868,6 +868,8 @@ export function resolvePackageEntry(
             ) {
               // likely UMD or CJS(!!! e.g. firebase 7.x), prefer module
               entryPoint = data.module
+            } else {
+              entryPoint = browserEntry
             }
           }
         } else {

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -87,6 +87,14 @@ test('browser field', async () => {
   expect(await page.textContent('.browser')).toMatch('[success]')
 })
 
+test('Resolve browser field even if module field exists', async () => {
+  expect(await page.textContent('.browser-module1')).toMatch('[success]')
+})
+
+test('Resolve module field if browser field is likely UMD or CJS', async () => {
+  expect(await page.textContent('.browser-module2')).toMatch('[success]')
+})
+
 test('css entry', async () => {
   expect(await page.textContent('.css')).toMatch('[success]')
 })

--- a/playground/resolve/browser-module-field1/index.js
+++ b/playground/resolve/browser-module-field1/index.js
@@ -1,0 +1,1 @@
+export default '[fail] this should not run in the browser'

--- a/playground/resolve/browser-module-field1/index.web.js
+++ b/playground/resolve/browser-module-field1/index.web.js
@@ -1,0 +1,1 @@
+export default '[success] this should run in browser'

--- a/playground/resolve/browser-module-field1/package.json
+++ b/playground/resolve/browser-module-field1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "resolve-browser-module-field1",
+  "private": true,
+  "version": "1.0.0",
+  "//": "real world example: https://github.com/aws/aws-sdk-js-v3/blob/59cdfd81452bce16bb26d07668e5550ed05d9d06/packages/credential-providers/package.json#L6-L7",
+  "module": "index.js",
+  "browser": "index.web.js"
+}

--- a/playground/resolve/browser-module-field2/index.js
+++ b/playground/resolve/browser-module-field2/index.js
@@ -1,0 +1,1 @@
+export default '[success] this should run in browser'

--- a/playground/resolve/browser-module-field2/index.web.js
+++ b/playground/resolve/browser-module-field2/index.web.js
@@ -1,0 +1,1 @@
+module.exports = '[fail] this should not run in the browser'

--- a/playground/resolve/browser-module-field2/package.json
+++ b/playground/resolve/browser-module-field2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "resolve-browser-module-field2",
+  "private": true,
+  "version": "1.0.0",
+  "module": "index.js",
+  "browser": "index.web.js"
+}

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -76,6 +76,12 @@
 <h2>Browser Field</h2>
 <p class="browser">fail</p>
 
+<h2>Resolve browser field even if module field exists</h2>
+<p class="browser-module1">fail</p>
+
+<h2>Resolve module field if browser field is likely UMD or CJS</h2>
+<p class="browser-module2">fail</p>
+
 <h2>Don't resolve to the `module` field if the importer is a `require` call</h2>
 <p class="require-pkg-with-module-field">fail</p>
 
@@ -212,6 +218,12 @@
   ) {
     text('.browser', main)
   }
+
+  import browserModule1 from 'resolve-browser-module-field1'
+  text('.browser-module1', browserModule1)
+
+  import browserModule2 from 'resolve-browser-module-field2'
+  text('.browser-module2', browserModule2)
 
   import { msg as requireButWithModuleFieldMsg } from 'require-pkg-with-module-field'
   text('.require-pkg-with-module-field', requireButWithModuleFieldMsg)

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -14,6 +14,8 @@
     "normalize.css": "^8.0.1",
     "require-pkg-with-module-field": "link:./require-pkg-with-module-field",
     "resolve-browser-field": "link:./browser-field",
+    "resolve-browser-module-field1": "link:./browser-module-field1",
+    "resolve-browser-module-field2": "link:./browser-module-field2",
     "resolve-custom-condition": "link:./custom-condition",
     "resolve-custom-main-field": "link:./custom-main-field",
     "resolve-exports-env": "link:./exports-env",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,6 +849,8 @@ importers:
       normalize.css: ^8.0.1
       require-pkg-with-module-field: link:./require-pkg-with-module-field
       resolve-browser-field: link:./browser-field
+      resolve-browser-module-field1: link:./browser-module-field1
+      resolve-browser-module-field2: link:./browser-module-field2
       resolve-custom-condition: link:./custom-condition
       resolve-custom-main-field: link:./custom-main-field
       resolve-exports-env: link:./exports-env
@@ -860,6 +862,8 @@ importers:
       normalize.css: 8.0.1
       require-pkg-with-module-field: link:require-pkg-with-module-field
       resolve-browser-field: link:browser-field
+      resolve-browser-module-field1: link:browser-module-field1
+      resolve-browser-module-field2: link:browser-module-field2
       resolve-custom-condition: link:custom-condition
       resolve-custom-main-field: link:custom-main-field
       resolve-exports-env: link:exports-env
@@ -873,6 +877,12 @@ importers:
     specifiers: {}
 
   playground/resolve/browser-field:
+    specifiers: {}
+
+  playground/resolve/browser-module-field1:
+    specifiers: {}
+
+  playground/resolve/browser-module-field2:
     specifiers: {}
 
   playground/resolve/custom-condition:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When the following conditions were met, browser field was not used.

- (the package does not have exports field)
- (Non-SSR build or SSR build for WebWorker)
- the package has both both browser field and module field
- browser field is not likely UMD or CJS (the file does not include `typeof exports` or `typeof module` or `module.exports`)

fixes #9445

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
