### PR TITLE
chore: tidy up eslint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,18 +42,6 @@ module.exports = defineConfig({
         tryExtensions: ['.ts', '.js', '.jsx', '.tsx', '.d.ts']
       }
     ],
-    'node/no-restricted-require': [
-      'error',
-      Object.keys(require('./packages/vite/package.json').devDependencies).map(
-        (d) => ({
-          name: d,
-          message:
-            `devDependencies can only be imported using ESM syntax so ` +
-            `that they are included in the rollup bundle. If you are trying to ` +
-            `lazy load a dependency, use (await import('dependency')).default instead.`
-        })
-      )
-    ],
     'node/no-extraneous-import': [
       'error',
       {
@@ -108,6 +96,30 @@ module.exports = defineConfig({
   },
   overrides: [
     {
+      files: ['packages/**'],
+      excludedFiles: '**/__tests__/**',
+      rules: {
+        'no-restricted-globals': ['error', 'require', '__dirname', '__filename']
+      }
+    },
+    {
+      files: 'packages/vite/**/*.*',
+      rules: {
+        'node/no-restricted-require': [
+          'error',
+          Object.keys(
+            require('./packages/vite/package.json').devDependencies
+          ).map((d) => ({
+            name: d,
+            message:
+              `devDependencies can only be imported using ESM syntax so ` +
+              `that they are included in the rollup bundle. If you are trying to ` +
+              `lazy load a dependency, use (await import('dependency')).default instead.`
+          }))
+        ]
+      }
+    },
+    {
       files: ['packages/vite/src/node/**'],
       rules: {
         'no-console': ['error']
@@ -120,9 +132,11 @@ module.exports = defineConfig({
       }
     },
     {
-      files: ['packages/plugin-*/**/*'],
+      files: ['packages/create-vite/template-*/**', '**/build.config.ts'],
       rules: {
-        'no-restricted-globals': ['error', 'require', '__dirname', '__filename']
+        'no-undef': 'off',
+        'node/no-missing-import': 'off',
+        '@typescript-eslint/explicit-module-boundary-types': 'off'
       }
     },
     {
@@ -132,7 +146,6 @@ module.exports = defineConfig({
         'node/no-extraneous-require': 'off',
         'node/no-missing-import': 'off',
         'node/no-missing-require': 'off',
-        'no-undef': 'off',
         // engine field doesn't exist in playgrounds
         'node/no-unsupported-features/es-builtins': [
           'error',
@@ -145,17 +158,22 @@ module.exports = defineConfig({
           {
             version: '^14.18.0 || >=16.0.0'
           }
-        ]
+        ],
+        '@typescript-eslint/explicit-module-boundary-types': 'off'
       }
     },
     {
-      files: ['packages/create-vite/template-*/**', '**/build.config.ts'],
+      files: ['playground/**'],
+      excludedFiles: '**/__tests__/**',
       rules: {
-        'node/no-missing-import': 'off'
+        'no-undef': 'off',
+        'no-empty': 'off',
+        'no-constant-condition': 'off',
+        '@typescript-eslint/no-empty-function': 'off'
       }
     },
     {
-      files: ['playground/**', '*.js'],
+      files: ['*.js'],
       rules: {
         '@typescript-eslint/explicit-module-boundary-types': 'off'
       }
@@ -164,12 +182,6 @@ module.exports = defineConfig({
       files: ['*.d.ts'],
       rules: {
         '@typescript-eslint/triple-slash-reference': 'off'
-      }
-    },
-    {
-      files: 'packages/vite/**/*.*',
-      rules: {
-        'no-restricted-globals': ['error', 'require', '__dirname', '__filename']
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preinstall": "npx only-allow pnpm",
     "postinstall": "simple-git-hooks",
     "format": "prettier --write --cache .",
-    "lint": "eslint --cache packages/*/{src,types,__tests__}/** playground/**/__tests__/**/*.ts scripts/**/*.ts",
+    "lint": "eslint --cache .",
     "typecheck": "tsc -p scripts --noEmit && tsc -p playground --noEmit",
     "test": "run-s test-unit test-serve test-build",
     "test-serve": "vitest run -c vitest.config.e2e.ts",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "cross-env": "^7.0.3",
     "esbuild": "^0.14.47",
     "eslint": "^8.20.0",
-    "eslint-define-config": "^1.5.1",
+    "eslint-define-config": "^1.6.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "execa": "^6.1.0",

--- a/packages/create-vite/template-lit-ts/src/my-element.ts
+++ b/packages/create-vite/template-lit-ts/src/my-element.ts
@@ -1,4 +1,4 @@
-import { html, css, LitElement } from 'lit'
+import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import litLogo from './assets/lit.svg'
 

--- a/packages/create-vite/template-lit/src/my-element.js
+++ b/packages/create-vite/template-lit/src/my-element.js
@@ -1,4 +1,4 @@
-import { html, css, LitElement } from 'lit'
+import { LitElement, css, html } from 'lit'
 import litLogo from './assets/lit.svg'
 
 /**

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -11,7 +11,7 @@ import MagicString from 'magic-string'
 import colors from 'picocolors'
 import fg from 'fast-glob'
 import { sync as resolve } from 'resolve'
-import type { Plugin } from 'rollup'
+import type { Plugin, RollupOptions } from 'rollup'
 import { defineConfig } from 'rollup'
 import pkg from './package.json'
 
@@ -185,7 +185,7 @@ function createCjsConfig(isProduction: boolean) {
   })
 }
 
-export default (commandLineArgs: any) => {
+export default (commandLineArgs: any): RollupOptions[] => {
   const isDev = commandLineArgs.watch
   const isProduction = !isDev
 

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -47,6 +47,7 @@ text('.charset-css', charset)
 import './dep.css'
 import './glob-dep.css'
 
+// eslint-disable-next-line import/order
 import { barModuleClasses } from 'css-js-dep'
 document
   .querySelector('.css-js-dep-module')

--- a/playground/css/postcss.config.js
+++ b/playground/css/postcss.config.js
@@ -3,8 +3,8 @@ module.exports = {
 }
 
 const fs = require('fs')
-const glob = require('fast-glob')
 const path = require('path')
+const glob = require('fast-glob')
 const { normalizePath } = require('vite')
 
 /**

--- a/playground/json/server.js
+++ b/playground/json/server.js
@@ -15,8 +15,7 @@ async function createServer(
   /**
    * @type {import('vite').ViteDevServer}
    */
-  let vite
-  vite = await require('vite').createServer({
+  const vite = await require('vite').createServer({
     root,
     logLevel: isTest ? 'error' : 'info',
     server: {

--- a/playground/resolve/browser-field/relative.js
+++ b/playground/resolve/browser-field/relative.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-duplicates */
 import ra from './no-ext'
 import rb from './no-ext.js' // no substitution
 import rc from './ext'

--- a/playground/tailwind/__test__/tailwind.spec.ts
+++ b/playground/tailwind/__test__/tailwind.spec.ts
@@ -1,11 +1,11 @@
 import {
-  isBuild,
-  editFile,
-  untilUpdated,
-  getColor,
-  getBgColor,
   browserLogs,
-  page
+  editFile,
+  getBgColor,
+  getColor,
+  isBuild,
+  page,
+  untilUpdated
 } from '~utils'
 
 test('should render', async () => {

--- a/playground/tailwind/src/router.ts
+++ b/playground/tailwind/src/router.ts
@@ -1,4 +1,4 @@
-import { createWebHistory, createRouter } from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
 import Page from './views/Page.vue'
 
 const history = createWebHistory()

--- a/playground/wasm/worker.js
+++ b/playground/wasm/worker.js
@@ -1,5 +1,4 @@
 import init from './add.wasm?init'
 init().then(({ exports }) => {
-  // eslint-disable-next-line no-undef
   self.postMessage({ result: exports.add(1, 2) })
 })

--- a/playground/worker/my-worker.ts
+++ b/playground/worker/my-worker.ts
@@ -1,6 +1,6 @@
+import { msg as msgFromDep } from 'dep-to-optimize'
 import { mode, msg } from './modules/workerImport'
 import { bundleWithPlugin } from './modules/test-plugin'
-import { msg as msgFromDep } from 'dep-to-optimize'
 
 self.onmessage = (e) => {
   if (e.data === 'ping') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
       cross-env: ^7.0.3
       esbuild: ^0.14.47
       eslint: ^8.20.0
-      eslint-define-config: ^1.5.1
+      eslint-define-config: ^1.6.0
       eslint-plugin-import: ^2.26.0
       eslint-plugin-node: ^11.1.0
       execa: ^6.1.0
@@ -97,7 +97,7 @@ importers:
       cross-env: 7.0.3
       esbuild: 0.14.47
       eslint: 8.20.0
-      eslint-define-config: 1.5.1
+      eslint-define-config: 1.6.0
       eslint-plugin-import: 2.26.0_xconv27bia2733zao6ipggqv2i
       eslint-plugin-node: 11.1.0_eslint@8.20.0
       execa: 6.1.0
@@ -4766,8 +4766,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  /eslint-define-config/1.5.1:
-    resolution: {integrity: sha512-6gxrmN7aKGffaO8dCtMMKyo3IxbWymMQ248p4lf8GbaFRcLsqOXHFdUhhM0Hcy1NudvnpwHcfbDf7Nh9pIm1TA==}
+  /eslint-define-config/1.6.0:
+    resolution: {integrity: sha512-3qulYnwDRGYQHXHGdXBSRcfpI7m37ilBoERzTUYI8fBUoK/46yfUVNkGwM9cF/aoBrGgIDcBSz/HyPQJTHI/+w==}
     engines: {node: '>= 14.6.0', npm: '>= 6.0.0', pnpm: '>= 7.0.0'}
     dev: true
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR changes the strategy of configuring what file to run eslint.

**Before**: Use `eslint foo` to run lint on limited files and configure ignore/rules with `.eslintignore`/`overrides`.
**After**: Use `eslint .` to run lint on all files by default and configure ignore/rules with `.eslintignore`/`overrides`.

By using `eslint .`, it will be aligned with other eslint integrations such as eslint VSCode extension.

close #7769 (because after this PR, if `pnpm lint` does not output any errors, it means VSCode extension won't have any errors)

~~requires https://github.com/Shinigami92/eslint-define-config/pull/120 to be released to fix the type error in `.eslintrc.cjs`.~~ updated

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
