### PR TITLE
fix(config): use file url for import path (fixes #9471)

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -975,7 +975,7 @@ async function bundleConfigFile(
               if (path.relative(idPkgDir, fileName).startsWith('..')) {
                 return {
                   // normalize actual import after bundled as a single vite config
-                  path: idFsPath,
+                  path: pathToFileURL(idFsPath).href,
                   external: true
                 }
               }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I tested this PR with #9471.
Actually #9471 needs to change `import { libConfig } from "../vite-config"` into `import { libConfig } from "../vite-config/index.js"` because ESM doesn't support dir imports.

fixes #9471

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
