### PR TITLE
fix: css-post/emitFile uses chunkName

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -543,11 +543,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           chunkCSS = await finalizeCss(chunkCSS, true, config)
 
           // emit corresponding css file
+          const chunkFile = chunk.name + '.css'
           const fileHandle = this.emitFile({
             name: isPreProcessor(lang) ? cssAssetName : cssFileName,
             fileName: assetFileNamesToFileName(
               resolveAssetFileNames(config),
-              cssFileName,
+              chunkFile,
               getHash(chunkCSS),
               chunkCSS
             ),

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -543,12 +543,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           chunkCSS = await finalizeCss(chunkCSS, true, config)
 
           // emit corresponding css file
-          const chunkFile = chunk.name + '.css'
           const fileHandle = this.emitFile({
             name: isPreProcessor(lang) ? cssAssetName : cssFileName,
             fileName: assetFileNamesToFileName(
               resolveAssetFileNames(config),
-              chunkFile,
+              cssFileName,
               getHash(chunkCSS),
               chunkCSS
             ),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

css-post/emitFile/fileName  uses chunkName



<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

I think the file name when emitFIle must be chunkName, it can keep the uniqueness of the output asset name. For specific examples, see [vite-css-post-plugin-demo](https://github.com/yzydeveloper/vite-css-post-plugin-demo)

This example uses assets as input, in order to output a different style theme file

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
