### PR TITLE
fix(ssr): check root import extension for external

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -657,18 +657,22 @@ export function tryNodeResolve(
     if (!externalize) {
       return resolved
     }
-    // dont external symlink packages
+    // don't external symlink packages
     if (!allowLinkedExternal && !resolved.id.includes('node_modules')) {
       return resolved
     }
     const resolvedExt = path.extname(resolved.id)
+    // don't external non-js imports
+    if (
+      resolvedExt &&
+      resolvedExt !== '.js' &&
+      resolvedExt !== '.mjs' &&
+      resolvedExt !== '.cjs'
+    ) {
+      return resolved
+    }
     let resolvedId = id
     if (isDeepImport) {
-      // check ext before externalizing - only externalize
-      // extension-less imports and explicit .js imports
-      if (resolvedExt && !resolved.id.match(/(.js|.mjs|.cjs)$/)) {
-        return resolved
-      }
       if (!pkg?.data.exports && path.extname(id) !== resolvedExt) {
         resolvedId += resolvedExt
       }

--- a/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -1,5 +1,5 @@
 import { port } from './serve'
-import { page } from '~utils'
+import { getColor, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -107,4 +107,9 @@ test('msg from linked no external', async () => {
 test('msg from linked no external', async () => {
   await page.goto(url)
   expect(await page.textContent('.dep-virtual')).toMatch('[success]')
+})
+
+test('import css library', async () => {
+  await page.goto(url)
+  expect(await getColor('.css-lib')).toBe('blue')
 })

--- a/playground/ssr-deps/css-lib/index.css
+++ b/playground/ssr-deps/css-lib/index.css
@@ -1,0 +1,3 @@
+.css-lib {
+  color: blue;
+}

--- a/playground/ssr-deps/css-lib/package.json
+++ b/playground/ssr-deps/css-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/css-lib",
+  "private": true,
+  "version": "0.0.0",
+  "main": "./index.css"
+}

--- a/playground/ssr-deps/index.html
+++ b/playground/ssr-deps/index.html
@@ -8,5 +8,9 @@
   <body>
     <h1>SSR Dependencies</h1>
     <div><!--app-html--></div>
+    <script type="module">
+      // hydration scripts
+      import '@vitejs/css-lib'
+    </script>
   </body>
 </html>

--- a/playground/ssr-deps/package.json
+++ b/playground/ssr-deps/package.json
@@ -9,6 +9,7 @@
     "debug": "node --inspect-brk server"
   },
   "dependencies": {
+    "@vitejs/css-lib": "file:./css-lib",
     "bcrypt": "^5.0.1",
     "define-properties-exports": "file:./define-properties-exports",
     "define-property-exports": "file:./define-property-exports",

--- a/playground/ssr-deps/src/app.js
+++ b/playground/ssr-deps/src/app.js
@@ -13,6 +13,7 @@ import noExternalCjs from 'no-external-cjs'
 import importBuiltinCjs from 'import-builtin-cjs'
 import { hello as linkedNoExternal } from 'linked-no-external'
 import virtualMessage from 'pkg-exports/virtual'
+import '@vitejs/css-lib'
 
 // This import will set a 'Hello World!" message in the nested-external non-entry dependency
 import 'non-optimized-with-nested-external'
@@ -81,6 +82,8 @@ export async function render(url, rootDir) {
   html += `\n<p class="linked-no-external">message from linked-no-external: ${linkedNoExternalMessage}</p>`
 
   html += `\n<p class="dep-virtual">message from dep-virtual: ${virtualMessage}</p>`
+
+  html += `\n<p class="css-lib">I should be blue</p>`
 
   return html + '\n'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,6 +894,7 @@ importers:
 
   playground/ssr-deps:
     specifiers:
+      '@vitejs/css-lib': file:./css-lib
       bcrypt: ^5.0.1
       cross-env: ^7.0.3
       define-properties-exports: file:./define-properties-exports
@@ -917,6 +918,7 @@ importers:
       require-absolute: file:./require-absolute
       ts-transpiled-exports: file:./ts-transpiled-exports
     dependencies:
+      '@vitejs/css-lib': file:playground/ssr-deps/css-lib
       bcrypt: 5.0.1
       define-properties-exports: file:playground/ssr-deps/define-properties-exports
       define-property-exports: file:playground/ssr-deps/define-property-exports
@@ -940,6 +942,9 @@ importers:
     devDependencies:
       cross-env: 7.0.3
       express: 4.18.1
+
+  playground/ssr-deps/css-lib:
+    specifiers: {}
 
   playground/ssr-deps/define-properties-exports:
     specifiers: {}
@@ -9165,6 +9170,12 @@ packages:
   file:playground/react/jsx-entry:
     resolution: {directory: playground/react/jsx-entry, type: directory}
     name: jsx-entry
+    version: 0.0.0
+    dev: false
+
+  file:playground/ssr-deps/css-lib:
+    resolution: {directory: playground/ssr-deps/css-lib, type: directory}
+    name: '@vitejs/css-lib'
     version: 0.0.0
     dev: false
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #9487
I don't think #8454 is the right fix, so I suppose this closes #8454 too.

We're previosly checking deep imports to no-external deps if they match a non-js file, we should also do this for root imports for `normalize.css` for example that exports css at the root.

### Additional context

Slightly out-of-scope and more of a question: I'm not sure why below my PR changes we have special case handling for appending extension to resolved id. And why for deep imports only.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
