### PR TITLE
fix(optimizer): ignore EACCES errors while scanner (fixes #8916)

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -143,7 +143,8 @@ function globEntries(pattern: string | string[], config: ResolvedConfig) {
         ? []
         : [`**/__tests__/**`, `**/coverage/**`])
     ],
-    absolute: true
+    absolute: true,
+    suppressErrors: true // suppress EACCES errors
   })
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#8916 happens with 2.9.x. But it works with 3.x.x (the error message is present though). I think changes around the scanner affected this.

About Vite 3, the error is thrown from `discoverProjectDependencies` and catched here. So I assume the optimizer won't run and the deps will be stuck instead of all js files?
https://github.com/vitejs/vite/blob/1983cf43d4da92d40b1f96dff0a44def044f9130/packages/vite/src/node/optimizer/optimizer.ts#L190-L227

This PR fixes the error.

fixes #8916

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
