### PR TITLE
chore: node prefix lint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 // @ts-check
+const { builtinModules } = require('node:module')
 const { defineConfig } = require('eslint-define-config')
 
 module.exports = defineConfig({
@@ -81,6 +82,10 @@ module.exports = defineConfig({
       { prefer: 'type-imports' }
     ],
 
+    'import/no-nodejs-modules': [
+      'error',
+      { allow: builtinModules.map((mod) => `node:${mod}`) }
+    ],
     'import/no-duplicates': 'error',
     'import/order': 'error',
     'sort-imports': [

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -50,7 +50,7 @@ if (profileIndex > 0) {
   if (next && !next.startsWith('-')) {
     process.argv.splice(profileIndex, 1)
   }
-  const inspector = await import('inspector').then((r) => r.default)
+  const inspector = await import('node:inspector').then((r) => r.default)
   const session = (global.__vite_profile_session = new inspector.Session())
   session.connect()
   session.post('Profiler.enable', () => {

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -95,16 +95,16 @@ export async function resolveHttpServer(
   httpsOptions?: HttpsServerOptions
 ): Promise<HttpServer> {
   if (!httpsOptions) {
-    const { createServer } = await import('http')
+    const { createServer } = await import('node:http')
     return createServer(app)
   }
 
   // #484 fallback to http1 when proxy is needed.
   if (proxy) {
-    const { createServer } = await import('https')
+    const { createServer } = await import('node:https')
     return createServer(httpsOptions, app)
   } else {
-    const { createSecureServer } = await import('http2')
+    const { createSecureServer } = await import('node:http2')
     return createSecureServer(
       {
         // Manually increase the session memory to prevent 502 ENHANCE_YOUR_CALM

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 
-import readline from 'readline'
+import readline from 'node:readline'
 import colors from 'picocolors'
 import type { RollupError } from 'rollup'
 import type { ResolvedServerUrls } from './server'

--- a/packages/vite/src/node/plugins/ssrRequireHook.ts
+++ b/packages/vite/src/node/plugins/ssrRequireHook.ts
@@ -53,7 +53,9 @@ type NodeResolveFilename = (
 /** Respect the `resolve.dedupe` option in production SSR. */
 function dedupeRequire(dedupe: string[]) {
   // eslint-disable-next-line no-restricted-globals
-  const Module = require('module') as { _resolveFilename: NodeResolveFilename }
+  const Module = require('node:module') as {
+    _resolveFilename: NodeResolveFilename
+  }
   const resolveFilename = Module._resolveFilename
   Module._resolveFilename = function (request, parent, isMain, options) {
     if (request[0] !== '.' && request[0] !== '/') {

--- a/packages/vite/types/ws.d.ts
+++ b/packages/vite/types/ws.d.ts
@@ -26,7 +26,7 @@ import type {
 } from 'node:http'
 import type { Server as HTTPSServer } from 'node:https'
 import type { Duplex, DuplexOptions } from 'node:stream'
-import type { SecureContextOptions } from 'tls'
+import type { SecureContextOptions } from 'node:tls'
 import type { URL } from 'node:url'
 import type { ZlibOptions } from 'node:zlib'
 

--- a/playground/alias/vite.config.js
+++ b/playground/alias/vite.config.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 
 /**
  * @type {import('vite').UserConfig}

--- a/playground/assets/vite.config-runtime-base.js
+++ b/playground/assets/vite.config-runtime-base.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 
 const dynamicBaseAssetsCode = `
 globalThis.__toAssetUrl = url => '/' + url

--- a/playground/assets/vite.config.js
+++ b/playground/assets/vite.config.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 
 /**
  * @type {import('vite').UserConfig}

--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 const glob = require('fast-glob')
 const normalizePath = require('vite').normalizePath
 

--- a/playground/css-codesplit-cjs/vite.config.js
+++ b/playground/css-codesplit-cjs/vite.config.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path')
+const { resolve } = require('node:path')
 
 module.exports = {
   build: {

--- a/playground/css-codesplit/vite.config.js
+++ b/playground/css-codesplit/vite.config.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path')
+const { resolve } = require('node:path')
 
 module.exports = {
   build: {

--- a/playground/css/postcss.config.js
+++ b/playground/css/postcss.config.js
@@ -2,8 +2,8 @@ module.exports = {
   plugins: [require('postcss-nested'), testDirDep, testSourceInput]
 }
 
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const glob = require('fast-glob')
 const { normalizePath } = require('vite')
 

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 
 /**
  * @type {import('vite').UserConfig}

--- a/playground/dynamic-import/vite.config.js
+++ b/playground/dynamic-import/vite.config.js
@@ -1,5 +1,5 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const vite = require('vite')
 
 module.exports = vite.defineConfig({

--- a/playground/fs-serve/root/vite.config.js
+++ b/playground/fs-serve/root/vite.config.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 
 /**
  * @type {import('vite').UserConfig}

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path')
+const { resolve } = require('node:path')
 
 /**
  * @type {import('vite').UserConfig}

--- a/playground/json/server.js
+++ b/playground/json/server.js
@@ -1,6 +1,6 @@
 // @ts-check
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const express = require('express')
 
 const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD

--- a/playground/legacy/vite.config.js
+++ b/playground/legacy/vite.config.js
@@ -1,5 +1,5 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const legacy = require('@vitejs/plugin-legacy').default
 
 module.exports = {

--- a/playground/lib/vite.config.js
+++ b/playground/lib/vite.config.js
@@ -1,5 +1,5 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 /**
  * @type {import('vite').UserConfig}

--- a/playground/lib/vite.dyimport.config.js
+++ b/playground/lib/vite.dyimport.config.js
@@ -1,5 +1,5 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 /**
  * @type {import('vite').UserConfig}

--- a/playground/multiple-entrypoints/vite.config.js
+++ b/playground/multiple-entrypoints/vite.config.js
@@ -1,5 +1,5 @@
-const { resolve } = require('path')
-const fs = require('fs')
+const { resolve } = require('node:path')
+const fs = require('node:fs')
 
 module.exports = {
   build: {

--- a/playground/optimize-deps/dep-with-builtin-module-cjs/index.js
+++ b/playground/optimize-deps/dep-with-builtin-module-cjs/index.js
@@ -1,5 +1,7 @@
 // no node: protocol intentionally
+// eslint-disable-next-line import/no-nodejs-modules
 const fs = require('fs')
+// eslint-disable-next-line import/no-nodejs-modules
 const path = require('path')
 
 // NOTE: require destructure would error immediately because of how esbuild

--- a/playground/optimize-deps/dep-with-builtin-module-esm/index.js
+++ b/playground/optimize-deps/dep-with-builtin-module-esm/index.js
@@ -1,5 +1,7 @@
 // no node: protocol intentionally
+// eslint-disable-next-line import/no-nodejs-modules
 import { readFileSync } from 'fs'
+// eslint-disable-next-line import/no-nodejs-modules
 import path from 'path'
 
 // access from named import

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('node:fs')
 const vue = require('@vitejs/plugin-vue')
 
 // Overriding the NODE_ENV set by vitest

--- a/playground/optimize-missing-deps/multi-entry-dep/index.js
+++ b/playground/optimize-missing-deps/multi-entry-dep/index.js
@@ -1,3 +1,3 @@
-const path = require('path')
+const path = require('node:path')
 
 exports.name = path.normalize('./Server')

--- a/playground/optimize-missing-deps/server.js
+++ b/playground/optimize-missing-deps/server.js
@@ -1,6 +1,6 @@
 // @ts-check
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const express = require('express')
 
 const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD

--- a/playground/resolve/browser-field/multiple.dot.path.js
+++ b/playground/resolve/browser-field/multiple.dot.path.js
@@ -1,2 +1,2 @@
-const fs = require('fs')
+const fs = require('node:fs')
 console.log('this should not run in the browser')

--- a/playground/resolve/browser-field/not-browser.js
+++ b/playground/resolve/browser-field/not-browser.js
@@ -1,2 +1,2 @@
-const fs = require('fs')
+const fs = require('node:fs')
 console.log('this should not run in the browser')

--- a/playground/ssr-deps/import-builtin-cjs/index.js
+++ b/playground/ssr-deps/import-builtin-cjs/index.js
@@ -1,4 +1,4 @@
-exports.stream = require('stream')
+exports.stream = require('node:stream')
 
 exports.hello = function () {
   return 'Hello World!'

--- a/playground/ssr-deps/read-file-content/index.js
+++ b/playground/ssr-deps/read-file-content/index.js
@@ -1,9 +1,9 @@
-const path = require('path')
+const path = require('node:path')
 
 module.exports = async function readFileContent(filePath) {
   const fs =
     process.versions.node.split('.')[0] >= '14'
-      ? require('fs/promises')
-      : require('fs').promises
+      ? require('node:fs/promises')
+      : require('node:fs').promises
   return await fs.readFile(path.resolve(filePath), 'utf-8')
 }

--- a/playground/ssr-deps/require-absolute/index.js
+++ b/playground/ssr-deps/require-absolute/index.js
@@ -1,3 +1,3 @@
-const path = require('path')
+const path = require('node:path')
 
 module.exports.hello = () => require(path.resolve(__dirname, './foo.js')).hello

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -1,7 +1,7 @@
 // @ts-check
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import express from 'express'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/playground/ssr-html/server.js
+++ b/playground/ssr-html/server.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import express from 'express'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/playground/ssr-pug/server.js
+++ b/playground/ssr-pug/server.js
@@ -1,6 +1,6 @@
 // @ts-check
 import path from 'node:path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import pug from 'pug'
 import express from 'express'
 

--- a/playground/ssr-react/prerender.js
+++ b/playground/ssr-react/prerender.js
@@ -3,7 +3,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const toAbsolute = (p) => path.resolve(__dirname, p)

--- a/playground/ssr-react/server.js
+++ b/playground/ssr-react/server.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import express from 'express'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/playground/ssr-vue/server.js
+++ b/playground/ssr-vue/server.js
@@ -1,7 +1,7 @@
 // @ts-check
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import express from 'express'
 
 const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD

--- a/playground/ssr-vue/vite.config.js
+++ b/playground/ssr-vue/vite.config.js
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'node:path'
 import { defineConfig } from 'vite'
 import vuePlugin from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'

--- a/playground/ssr-webworker/worker.js
+++ b/playground/ssr-webworker/worker.js
@@ -1,4 +1,4 @@
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { Miniflare } from 'miniflare'
 

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -1,4 +1,4 @@
-const path = require('path')
+const path = require('node:path')
 const vueJsx = require('@vitejs/plugin-vue-jsx')
 const vite = require('vite')
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Used [`import/no-nodejs-modules`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-nodejs-modules.md) and set all node prefixed modules to `allow` option. 

This way we don't need to add an extra dep or maintain a rule.
As a disadvantage, auto-fix does not work. (But I think it's better than having no rules.)

### Additional context
refs #8309

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
