### PR TITLE
fix: use same external rule as rollup for esbuild (fix #9549)

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -9,7 +9,6 @@ import {
   isBuiltin,
   isExternalUrl,
   isRunningWithYarnPnp,
-  moduleListContains,
   normalizePath
 } from '../utils'
 import { browserExternalId } from '../plugins/resolve'
@@ -167,7 +166,7 @@ export function esbuildDepPlugin(
       build.onResolve(
         { filter: /^[\w@][^:]/ },
         async ({ path: id, importer, kind }) => {
-          if (moduleListContains(external, id)) {
+          if (external.includes(id)) {
             return {
               path: id,
               external: true

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -601,7 +601,6 @@ export async function runOptimizeDeps(
           }
         : undefined,
     target: isBuild ? config.build.target || undefined : ESBUILD_MODULES_TARGET,
-    external,
     logLevel: 'error',
     splitting: true,
     sourcemap: true,

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -161,3 +161,7 @@ test.runIf(isServe)('error on builtin modules usage', () => {
     ])
   )
 })
+
+test('import file inside external module', async () => {
+  expect(await page.textContent('.external')).toBe('bar')
+})

--- a/playground/optimize-deps/dep-external-cjs/bar.js
+++ b/playground/optimize-deps/dep-external-cjs/bar.js
@@ -1,0 +1,5 @@
+'use strict'
+function bar() {
+  return 'bar'
+}
+module.exports = bar

--- a/playground/optimize-deps/dep-external-cjs/package.json
+++ b/playground/optimize-deps/dep-external-cjs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep-external-cjs",
+  "private": true,
+  "version": "0.0.0"
+}

--- a/playground/optimize-deps/dep-import-cjs/index.js
+++ b/playground/optimize-deps/dep-import-cjs/index.js
@@ -1,0 +1,2 @@
+import bar from 'dep-external-cjs/bar'
+export default bar

--- a/playground/optimize-deps/dep-import-cjs/package.json
+++ b/playground/optimize-deps/dep-import-cjs/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dep-import-cjs",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js",
+  "dependencies": {
+    "dep-external-cjs": "file:../dep-external-cjs"
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -84,6 +84,9 @@
 <div class="clonedeep-slash"></div>
 <div class="clonedeep-dot"></div>
 
+<h2>Import external cjs</h2>
+<div class="external"></div>
+
 <script>
   function text(el, text) {
     document.querySelector(el).textContent = text
@@ -191,4 +194,9 @@
 
   text('.clonedeep-slash', cloneDeepSlash({ name: 'clonedeep-slash' }).name)
   text('.clonedeep-dot', cloneDeepDot({ name: 'clonedeep-dot' }).name)
+</script>
+
+<script type="module">
+  import importCjs from 'dep-import-cjs'
+  text('.external', importCjs())
 </script>

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -15,6 +15,7 @@
     "dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
     "dep-cjs-with-assets": "file:./dep-cjs-with-assets",
     "dep-esbuild-plugin-transform": "file:./dep-esbuild-plugin-transform",
+    "dep-import-cjs": "file:./dep-import-cjs",
     "dep-linked": "link:./dep-linked",
     "dep-linked-include": "link:./dep-linked-include",
     "dep-node-env": "file:./dep-node-env",

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -48,6 +48,9 @@ module.exports = {
     // Avoid @rollup/plugin-commonjs
     commonjsOptions: {
       include: []
+    },
+    rollupOptions: {
+      external: ['dep-external-cjs']
     }
   },
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,7 @@ importers:
       dep-cjs-compiled-from-esm: file:./dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:./dep-cjs-with-assets
       dep-esbuild-plugin-transform: file:./dep-esbuild-plugin-transform
+      dep-import-cjs: file:./dep-import-cjs
       dep-linked: link:./dep-linked
       dep-linked-include: link:./dep-linked-include
       dep-node-env: file:./dep-node-env
@@ -647,6 +648,7 @@ importers:
       dep-cjs-compiled-from-esm: file:playground/optimize-deps/dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:playground/optimize-deps/dep-cjs-with-assets
       dep-esbuild-plugin-transform: file:playground/optimize-deps/dep-esbuild-plugin-transform
+      dep-import-cjs: file:playground/optimize-deps/dep-import-cjs
       dep-linked: link:dep-linked
       dep-linked-include: link:dep-linked-include
       dep-node-env: file:playground/optimize-deps/dep-node-env
@@ -683,6 +685,15 @@ importers:
 
   playground/optimize-deps/dep-esbuild-plugin-transform:
     specifiers: {}
+
+  playground/optimize-deps/dep-external-cjs:
+    specifiers: {}
+
+  playground/optimize-deps/dep-import-cjs:
+    specifiers:
+      dep-external-cjs: file:../dep-external-cjs
+    dependencies:
+      dep-external-cjs: file:playground/optimize-deps/dep-external-cjs
 
   playground/optimize-deps/dep-linked:
     specifiers:
@@ -9083,6 +9094,20 @@ packages:
     resolution: {directory: playground/optimize-deps/dep-esbuild-plugin-transform, type: directory}
     name: dep-esbuild-plugin-transform
     version: 0.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-external-cjs:
+    resolution: {directory: playground/optimize-deps/dep-external-cjs, type: directory}
+    name: dep-external-cjs
+    version: 0.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-import-cjs:
+    resolution: {directory: playground/optimize-deps/dep-import-cjs, type: directory}
+    name: dep-import-cjs
+    version: 1.0.0
+    dependencies:
+      dep-external-cjs: file:playground/optimize-deps/dep-external-cjs
     dev: false
 
   file:playground/optimize-deps/dep-node-env:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix #9549
If `a-module` is external, do not treat `a-module/file` as external during optimizeDep.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
