### PR TITLE
fix(ssr): use appendRight for import

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -125,6 +125,18 @@ test('export default', async () => {
   ).toMatchInlineSnapshot(`"__vite_ssr_exports__.default = {}"`)
 })
 
+test('export then import minified', async () => {
+  expect(
+    await ssrTransformSimpleCode(
+      `export * from 'vue';import {createApp} from 'vue';`
+    )
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"vue\\");
+    __vite_ssr_exportAll__(__vite_ssr_import_1__);const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
+    "
+  `)
+})
+
 test('import.meta', async () => {
   expect(
     await ssrTransformSimpleCode(`console.log(import.meta.url)`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes SSR transfoming `preact/compat/dist/compat.module.js` noticed in https://github.com/withastro/astro/issues/4093#issuecomment-1206119974

Also looks like this was also reported long ago at https://github.com/vitejs/vite/discussions/2479

### Additional context

The issue is of magic-string's semantics of `appendLeft` and `appendRight`. Since preact's bundled code is minified, the issue is prevalent. Here's a [stackblitz](https://stackblitz.com/edit/node-bhqqs1?file=index.js) of a gist of what's happening.

We're experiencing the first code example in the stackblitz link, so the solution is to use `appendRight()` so that the content isn't removed when we're removing code in front of it (aka left side). And also do an early `remove()` instead, otherwise it would remove the code we added via `appendRight()`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
