### PR TITLE
fix(vite/client): allow ping to http from https website

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -101,7 +101,7 @@ function setupWebSocket(
     }
 
     console.log(`[vite] server connection lost. polling for restart...`)
-    await waitForSuccessfulPing(hostAndPath)
+    await waitForSuccessfulPing(protocol, hostAndPath)
     location.reload()
   })
 
@@ -292,14 +292,22 @@ async function queueUpdate(p: Promise<(() => void) | undefined>) {
   }
 }
 
-async function waitForSuccessfulPing(hostAndPath: string, ms = 1000) {
+async function waitForSuccessfulPing(
+  socketProtocol: string,
+  hostAndPath: string,
+  ms = 1000
+) {
+  const pingHostProtocol = socketProtocol === 'wss' ? 'https' : 'http'
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
       // A fetch on a websocket URL will return a successful promise with status 400,
       // but will reject a networking error.
       // When running on middleware mode, it returns status 426, and an cors error happens if mode is not no-cors
-      await fetch(`${location.protocol}//${hostAndPath}`, { mode: 'no-cors' })
+      await fetch(`${pingHostProtocol}://${hostAndPath}`, {
+        mode: 'no-cors'
+      })
       break
     } catch (e) {
       // wait ms before attempting to ping again


### PR DESCRIPTION
### Description

Allows the ping when running Vite with a HTTP server and the website with the client is running a HTTPS server.

### Additional context

When using Vite and the `server.hmr.protocol` parameter set to `ws`, the Vite client will try to ping the server with current website protocol, which could be incorrect when having the Vite client on a HTTPS website and the Vite server running HTTP.

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

