### PR TITLE
feat: add `throwIfNamespace` option for custom JSX runtime

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -41,6 +41,11 @@ export interface Options {
    */
   jsxPure?: boolean
   /**
+   * Toggles whether or not to throw an error if an XML namespaced tag name is used.
+   * @default true
+   */
+  throwIfNamespace?: boolean;
+  /**
    * Babel configuration applied in both dev and prod.
    */
   babel?:
@@ -248,7 +253,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
                 {
                   runtime: 'automatic',
                   importSource: opts.jsxImportSource,
-                  pure: opts.jsxPure !== false
+                  pure: opts.jsxPure !== false,
+                  throwIfNamespace: opts.throwIfNamespace
                 }
               ])
 

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -44,7 +44,7 @@ export interface Options {
    * Toggles whether or not to throw an error if an XML namespaced tag name is used.
    * @default true
    */
-  throwIfNamespace?: boolean;
+  throwIfNamespace?: boolean
   /**
    * Babel configuration applied in both dev and prod.
    */

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -44,7 +44,7 @@ export interface Options {
    * Toggles whether or not to throw an error if an XML namespaced tag name is used.
    * @default true
    */
-  throwIfNamespace?: boolean
+  jsxThrowIfNamespace?: boolean
   /**
    * Babel configuration applied in both dev and prod.
    */
@@ -254,7 +254,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
                   runtime: 'automatic',
                   importSource: opts.jsxImportSource,
                   pure: opts.jsxPure !== false,
-                  throwIfNamespace: opts.throwIfNamespace
+                  throwIfNamespace: opts.jsxThrowIfNamespace
                 }
               ])
 


### PR DESCRIPTION
### Description

This change allows passing [`throwIfNamespace`](https://babeljs.io/docs/en/babel-plugin-transform-react-jsx#throwifnamespace) to `babel-plugin-transform-react-jsx` through `@vitejs/plugin-react` options.

Fixes https://github.com/vitejs/vite/discussions/6554.

### Additional context

This option is enabled by default, causing the following error when using xml namespace prefixes: `Namespace tags are not supported by default. React's JSX doesn't support namespace tags. You can set throwIfNamespace: false to bypass this warning.`

Currently there is no way to set `throwIfNamespace` to `false` without that change.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
