### PR TITLE
perf: disable rollup `hoistTransitiveImports`

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -479,6 +479,9 @@ async function doBuild(
           output.format === 'umd' ||
           output.format === 'iife' ||
           (ssrWorkerBuild && typeof input === 'string'),
+        // vite hoist by `importAnalysisBuild`
+        // https://rollupjs.org/guide/en/#outputhoisttransitiveimports
+        hoistTransitiveImports: false,
         ...output
       }
     }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -65,6 +65,7 @@ export async function bundleWorkerEntry(
     const {
       output: [outputChunk, ...outputChunks]
     } = await bundle.generate({
+      hoistTransitiveImports: false,
       entryFileNames: path.posix.join(
         config.build.assetsDir,
         '[name].[hash].js'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I think the `importAnalysisBuild` plugin do [the same thing](https://rollupjs.org/guide/en/#why-do-additional-imports-turn-up-in-my-entry-chunks-when-code-splitting) of rollup [hoistTransitiveImports](https://rollupjs.org/guide/en/#outputhoisttransitiveimports) options. But `importAnalysisBuild` will not only hoist js chunk but also css chunk.

Disbale `hoistTransitiveImports` reduce chunk size.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

