### PR TITLE
fix(config): try catch unlink after load

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1039,7 +1039,11 @@ async function loadConfigFromBundledFile(
     try {
       return (await dynamicImport(fileUrl)).default
     } finally {
-      fs.unlinkSync(fileNameTmp)
+      try {
+        fs.unlinkSync(fileNameTmp)
+      } catch {
+        // already removed if this function is called twice simultaneously
+      }
     }
   }
   // for cjs, we can register a custom loader via `_require.extensions`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

While trying to run VitePress build on another project, there is a possibility for the bundled config to be called at the same time (same `Date.now`) based on this [build code](https://github.com/vuejs/vitepress/blob/eab8b872a7e89709450953258bbf4051bbb99527/src/node/build/bundle.ts#L110-L113).

This sometimes cause `Error: ENOENT: no such file or directory, unlink '/Users/bjorn/Work/oss/blas/vite.config.js.timestamp-1659938739266.mjs`. This PR wraps the unlink in a try catch which works reliably for me.

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
