### PR TITLE
chore: remove vitest import for the global options

### DIFF
--- a/playground/alias/__tests__/alias.spec.ts
+++ b/playground/alias/__tests__/alias.spec.ts
@@ -1,4 +1,3 @@
-import { expect, test } from 'vitest'
 import { editFile, getColor, page, untilUpdated } from '~utils'
 
 test('fs', async () => {

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import {
   browserLogs,
   editFile,

--- a/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
+++ b/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import {
   browserLogs,
   findAssetFile,

--- a/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
+++ b/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
@@ -1,4 +1,3 @@
-import { describe, expect, test } from 'vitest'
 import {
   browserLogs,
   findAssetFile,

--- a/playground/build-old/__tests__/build-old.spec.ts
+++ b/playground/build-old/__tests__/build-old.spec.ts
@@ -1,4 +1,3 @@
-import { describe, test } from 'vitest'
 import { page } from '~utils'
 
 describe('syntax preserve', () => {

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -1,4 +1,3 @@
-import { beforeAll, describe, expect, test } from 'vitest'
 import { editFile, getColor, isBuild, isServe, page, viteTestUrl } from '~utils'
 
 function testPage(isNested: boolean) {

--- a/playground/import-assertion/__tests__/import-assertion.spec.ts
+++ b/playground/import-assertion/__tests__/import-assertion.spec.ts
@@ -1,4 +1,3 @@
-import { expect, test } from 'vitest'
 import { page } from '~utils'
 
 test('from source code', async () => {

--- a/playground/minify/__tests__/minify.spec.ts
+++ b/playground/minify/__tests__/minify.spec.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { expect, test } from 'vitest'
 import { isBuild, readFile, testDir } from '~utils'
 
 test.runIf(isBuild)('no minifySyntax', () => {

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -11,7 +11,6 @@ import type { ConsoleMessage, ElementHandle } from 'playwright-chromium'
 import type { Manifest } from 'vite'
 import { normalizePath } from 'vite'
 import { fromComment } from 'convert-source-map'
-import { expect } from 'vitest'
 import type { ExecaChildProcess } from 'execa'
 import { isBuild, isWindows, page, testDir } from './vitestSetup'
 

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -15,7 +15,6 @@ import { build, createServer, mergeConfig } from 'vite'
 import type { Browser, Page } from 'playwright-chromium'
 import type { RollupError, RollupWatcher, RollupWatcherEvent } from 'rollup'
 import type { File } from 'vitest'
-import { beforeAll } from 'vitest'
 
 // #region env
 

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { test } from 'vitest'
 import { isBuild, page, testDir, untilUpdated } from '~utils'
 
 test('normal', async () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Because the config in `vitest.config.e2e.ts` of globals is `true`, so the `import synatx` was unsless.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
