### PR TITLE
fix: add missing query string value

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -47,7 +47,7 @@ export async function handleHotUpdate(
       const scriptModuleRE = new RegExp(
         `type=script.*&lang\.${
           descriptor.scriptSetup?.lang || descriptor.script?.lang
-        }$`
+        }=1$`
       )
       scriptModule = modules.find((m) => scriptModuleRE.test(m.url))
     }
@@ -96,7 +96,7 @@ export async function handleHotUpdate(
       const mod = modules.find(
         (m) =>
           m.url.includes(`type=style&index=${i}`) &&
-          m.url.endsWith(`.${next.lang || 'css'}`) &&
+          m.url.endsWith(`.${next.lang || 'css'}=1`) &&
           !directRequestRE.test(m.url)
       )
       if (mod) {

--- a/packages/plugin-vue/src/main.ts
+++ b/packages/plugin-vue/src/main.ts
@@ -492,9 +492,9 @@ function attrsToQuery(
     query +=
       `lang` in attrs
         ? forceLangFallback
-          ? `&lang.${langFallback}`
-          : `&lang.${attrs.lang}`
-        : `&lang.${langFallback}`
+          ? `&lang.${langFallback}=1`
+          : `&lang.${attrs.lang}=1`
+        : `&lang.${langFallback}=1`
   }
   return query
 }

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -407,7 +407,7 @@ export async function transformGlobImport(
             if (importQuery && importQuery !== '?raw') {
               const fileExtension = basename(file).split('.').slice(-1)[0]
               if (fileExtension && restoreQueryExtension)
-                importQuery = `${importQuery}&lang.${fileExtension}`
+                importQuery = `${importQuery}&lang.${fileExtension}=1`
             }
 
             importPath = `${importPath}${importQuery}`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds a query string value to the dev server so it works correctly when putting a proxy in front of it like `vercel dev`.

#### Before

```
http://127.0.0.1:5173/src/App.vue?vue&type=style&index=0&lang.css
```

#### After

```
http://127.0.0.1:5173/src/App.vue?vue&type=style&index=0&lang.css=1
```

### Additional context

- Related to https://github.com/vercel/vercel/issues/7283

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
