### PR TITLE
fix(ssr): rename objectPattern dynamic key (fixes #9585)

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -400,6 +400,30 @@ const a = () => {
     }
     "
   `)
+
+  // #9585
+  expect(
+    await ssrTransformSimpleCode(
+      `
+import { n, m } from 'foo'
+const foo = {}
+
+{
+  const { [n]: m } = foo
+}
+`
+    )
+  ).toMatchInlineSnapshot(`
+    "
+    const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"foo\\");
+
+    const foo = {}
+
+    {
+      const { [__vite_ssr_import_0__.n]: m } = foo
+    }
+    "
+  `)
 })
 
 test('nested object destructure alias', async () => {
@@ -459,6 +483,45 @@ objRest()
     __vite_ssr_import_0__.set()
     __vite_ssr_import_0__.rest()
     __vite_ssr_import_0__.objRest()
+    "
+  `)
+})
+
+test('object props and methods', async () => {
+  expect(
+    await ssrTransformSimpleCode(
+      `
+import foo from 'foo'
+
+const bar = 'bar'
+
+const obj = {
+  foo() {},
+  [foo]() {},
+  [bar]() {},
+  foo: () => {},
+  [foo]: () => {},
+  [bar]: () => {},
+  bar(foo) {}
+}
+`
+    )
+  ).toMatchInlineSnapshot(`
+    "
+    const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"foo\\");
+
+
+    const bar = 'bar'
+
+    const obj = {
+      foo() {},
+      [__vite_ssr_import_0__.default]() {},
+      [bar]() {},
+      foo: () => {},
+      [__vite_ssr_import_0__.default]: () => {},
+      [bar]: () => {},
+      bar(foo) {}
+    }
     "
   `)
 })

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -230,7 +230,7 @@ async function ssrTransformScript(
         // { foo } -> { foo: __import_x__.foo }
         // skip for destructuring patterns
         if (
-          !isNodeInPatternWeakMap.get(parent) ||
+          !isNodeInPattern(parent) ||
           isInDestructuringAssignment(parent, parentStack)
         ) {
           s.appendLeft(id.end, `: ${binding}`)
@@ -305,7 +305,10 @@ interface Visitors {
   onDynamicImport: (node: Node) => void
 }
 
-const isNodeInPatternWeakMap = new WeakMap<_Node, boolean>()
+const isNodeInPatternWeakSet = new WeakSet<_Node>()
+const setIsNodeInPattern = (node: Property) => isNodeInPatternWeakSet.add(node)
+const isNodeInPattern = (node: _Node): node is Property =>
+  isNodeInPatternWeakSet.has(node)
 
 /**
  * Same logic from \@vue/compiler-core & \@vue/compiler-sfc
@@ -425,7 +428,7 @@ function walk(
         })
       } else if (node.type === 'Property' && parent!.type === 'ObjectPattern') {
         // mark property in destructuring pattern
-        isNodeInPatternWeakMap.set(node, true)
+        setIsNodeInPattern(node)
       } else if (node.type === 'VariableDeclarator') {
         const parentFunction = findParentFunction(parentStack)
         if (parentFunction) {
@@ -474,8 +477,12 @@ function isRefIdentifier(id: Identifier, parent: _Node, parentStack: _Node[]) {
   }
 
   // property key
-  // this also covers object destructuring pattern
-  if (isStaticPropertyKey(id, parent) || isNodeInPatternWeakMap.get(parent)) {
+  if (isStaticPropertyKey(id, parent)) {
+    return false
+  }
+
+  // object destructuring pattern
+  if (isNodeInPattern(parent) && parent.value === id) {
     return false
   }
 


### PR DESCRIPTION
### Description
```js
import { n } from 'foo'
const { [n]: bar } = {} // this "n" was not renamed
```

This PR fixes #9585. 

### Additional context
Changed `isNodeInPatternWeakMap` to a WeakSet as the value was not used.



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
