### PR TITLE
fix: json HMR (fixes #9521)

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -363,7 +363,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             const depModule = await moduleGraph.ensureEntryFromUrl(
               url,
               ssr,
-              canSkipImportAnalysis(url)
+              canSkipImportAnalysis(removeImportQuery(url))
             )
             if (depModule.lastHMRTimestamp > 0) {
               url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -69,7 +69,7 @@ const debug = createDebugger('vite:import-analysis')
 
 const clientDir = normalizePath(CLIENT_DIR)
 
-const skipRE = /\.(map|json)$/
+const skipRE = /\.(map|json)($|\?)/
 export const canSkipImportAnalysis = (id: string): boolean =>
   skipRE.test(id) || isDirectCSSRequest(id)
 
@@ -363,7 +363,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             const depModule = await moduleGraph.ensureEntryFromUrl(
               url,
               ssr,
-              canSkipImportAnalysis(removeImportQuery(url))
+              canSkipImportAnalysis(url)
             )
             if (depModule.lastHMRTimestamp > 0) {
               url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -231,6 +231,11 @@ function propagateUpdate(
   // if the imports of `node` have not been analyzed, then `node` has not
   // been loaded in the browser and we should stop propagation.
   if (node.id && node.isSelfAccepting === undefined) {
+    debugHmr(
+      `[propagate update] stop propagation because not analyzed: ${colors.dim(
+        node.id
+      )}`
+    )
     return false
   }
 

--- a/playground/json/hmr.json
+++ b/playground/json/hmr.json
@@ -1,0 +1,3 @@
+{
+  "hmr": "this is hmr json"
+}

--- a/playground/json/index.html
+++ b/playground/json/index.html
@@ -25,6 +25,9 @@
 <h2>Has BOM Tag</h2>
 <pre class="bom"></pre>
 
+<h2>HMR</h2>
+<pre class="hmr"></pre>
+
 <script type="module">
   import json, { hello } from './test.json'
   import deepJson, { name } from 'vue/package.json'
@@ -57,6 +60,9 @@
 
   import hasBomJson from './json-bom/has-bom.json'
   text('.bom', JSON.stringify(hasBomJson))
+
+  import hmrJSON from './hmr.json'
+  text('.hmr', JSON.stringify(hmrJSON))
 
   function text(sel, text) {
     document.querySelector(sel).textContent = text


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR fixes #9521.

### Additional context
Another way to solve this is to reorder this and move `url = markExplicitImport(url)` after `moduleGraph.ensureEntryFromUrl` instead of using `removeImportQuery`.
https://github.com/vitejs/vite/blob/ee7f78faa1ea06fc4d32acc87757006683f46c93/packages/vite/src/node/plugins/importAnalysis.ts#L339-L376

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
