### PR TITLE
docs: Slight rename of MPA → Multiple pages

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -77,7 +77,7 @@ export default defineConfig({
 
 With the `--watch` flag enabled, changes to the `vite.config.js`, as well as any files to be bundled, will trigger a rebuild.
 
-## Multi-Page App
+## Multiple Pages
 
 Suppose you have the following source code structure:
 


### PR DESCRIPTION
### Description

Slight rename, to for clarity. Since the section is talking about building/bundling multiple pages, not about either the routing or rendering paradigm (associated with MPA), which may in theory be separate. (This page came up as a bit confusing, when discussing various routing and rendering modes in vite-plugin-ssr.)
The doc page moveover doesn't talk about either MPA or CSR/SPA apart from this single usage, so it's better to simply not go into that conceptual model.

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other