### PR TITLE
fix(legacy): skip esbuild transform for systemjs

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -710,6 +710,21 @@ function polyfillsPlugin(
           (excludeSystemJS ? '' : `import "systemjs/dist/s.min.js";`)
         )
       }
+    },
+    renderChunk(_, __, opts) {
+      // systemjs includes code that can't be minified down to es5 by esbuild
+      if (!excludeSystemJS) {
+        // @ts-ignore avoid esbuild transform on legacy chunks since it produces
+        // legacy-unsafe code - e.g. rewriting object properties into shorthands
+        opts.__vite_skip_esbuild__ = true
+
+        // @ts-ignore force terser for legacy chunks. This only takes effect if
+        // minification isn't disabled, because that leaves out the terser plugin
+        // entirely.
+        opts.__vite_force_terser__ = true
+      }
+
+      return null
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #9618

The gist of the issue is that the esbuild plugin is used to built the polyfill chunk which includes the systemjs code. This PR skips esbuild for it.

### Additional context

I think there are many ways to tackle this, so happy to discuss the best option here. e.g. should we always avoid esbuild for polyfill chunks?

I think this may invalidate #9453 too.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
