### PR TITLE
chore: narrow down rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "prettier": "2.7.1",
     "prompts": "^2.4.2",
     "rimraf": "^3.0.2",
-    "rollup": "^2.75.6",
+    "rollup": ">=2.75.6 <2.77.0 || ~2.77.0",
     "semver": "^7.3.7",
     "simple-git-hooks": "^2.8.0",
     "tslib": "^2.4.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -42,7 +42,7 @@
     "@jridgewell/gen-mapping": "^0.3.2",
     "@jridgewell/trace-mapping": "^0.3.14",
     "debug": "^4.3.4",
-    "rollup": "^2.75.6",
+    "rollup": ">=2.75.6 <2.77.0 || ~2.77.0",
     "slash": "^4.0.0",
     "source-map": "^0.6.1",
     "vite": "workspace:*",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -61,7 +61,7 @@
     "esbuild": "^0.14.47",
     "postcss": "^8.4.16",
     "resolve": "^1.22.1",
-    "rollup": "^2.75.6"
+    "rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
       prettier: 2.7.1
       prompts: ^2.4.2
       rimraf: ^3.0.2
-      rollup: ^2.75.6
+      rollup: '>=2.75.6 <2.77.0 || ~2.77.0'
       semver: ^7.3.7
       simple-git-hooks: ^2.8.0
       tslib: ^2.4.0
@@ -65,7 +65,7 @@ importers:
     devDependencies:
       '@babel/types': 7.18.10
       '@microsoft/api-extractor': 7.29.0
-      '@rollup/plugin-typescript': 8.3.4_uct5nfewsakxkk4livyn3qaf3e
+      '@rollup/plugin-typescript': 8.3.4_nzsoit4cp576bo3qoi6msb73em
       '@types/babel__core': 7.1.19
       '@types/babel__standalone': 7.1.4
       '@types/convert-source-map': 1.5.2
@@ -104,7 +104,7 @@ importers:
       prettier: 2.7.1
       prompts: 2.4.2
       rimraf: 3.0.2
-      rollup: 2.75.6
+      rollup: 2.77.0
       semver: 7.3.7
       simple-git-hooks: 2.8.0
       tslib: 2.4.0
@@ -171,7 +171,7 @@ importers:
       '@jridgewell/gen-mapping': ^0.3.2
       '@jridgewell/trace-mapping': ^0.3.14
       debug: ^4.3.4
-      rollup: ^2.75.6
+      rollup: '>=2.75.6 <2.77.0 || ~2.77.0'
       slash: ^4.0.0
       source-map: ^0.6.1
       vite: workspace:*
@@ -180,7 +180,7 @@ importers:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.14
       debug: 4.3.4
-      rollup: 2.75.6
+      rollup: 2.77.0
       slash: 4.0.0
       source-map: 0.6.1
       vite: link:../vite
@@ -2457,6 +2457,24 @@ packages:
       rollup: 2.77.0
     dev: true
 
+  /@rollup/plugin-typescript/8.3.4_nzsoit4cp576bo3qoi6msb73em:
+    resolution: {integrity: sha512-wt7JnYE9antX6BOXtsxGoeVSu4dZfw0dU3xykfOQ4hC3EddxRbVG/K0xiY1Wup7QOHJcjLYXWAn0Kx9Z1SBHHg==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      tslib:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.77.0
+      resolve: 1.22.1
+      rollup: 2.77.0
+      tslib: 2.4.0
+      typescript: 4.6.4
+    dev: true
+
   /@rollup/plugin-typescript/8.3.4_rollup@2.77.0+tslib@2.4.0:
     resolution: {integrity: sha512-wt7JnYE9antX6BOXtsxGoeVSu4dZfw0dU3xykfOQ4hC3EddxRbVG/K0xiY1Wup7QOHJcjLYXWAn0Kx9Z1SBHHg==}
     engines: {node: '>=8.0.0'}
@@ -2472,36 +2490,6 @@ packages:
       resolve: 1.22.1
       rollup: 2.77.0
       tslib: 2.4.0
-    dev: true
-
-  /@rollup/plugin-typescript/8.3.4_uct5nfewsakxkk4livyn3qaf3e:
-    resolution: {integrity: sha512-wt7JnYE9antX6BOXtsxGoeVSu4dZfw0dU3xykfOQ4hC3EddxRbVG/K0xiY1Wup7QOHJcjLYXWAn0Kx9Z1SBHHg==}
-    engines: {node: '>=8.0.0'}
-    peerDependencies:
-      rollup: ^2.14.0
-      tslib: '*'
-      typescript: '>=3.7.0'
-    peerDependenciesMeta:
-      tslib:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.6
-      resolve: 1.22.1
-      rollup: 2.75.6
-      tslib: 2.4.0
-      typescript: 4.6.4
-    dev: true
-
-  /@rollup/pluginutils/3.1.0_rollup@2.75.6:
-    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    dependencies:
-      '@types/estree': 0.0.39
-      estree-walker: 1.0.1
-      picomatch: 2.3.1
-      rollup: 2.75.6
     dev: true
 
   /@rollup/pluginutils/3.1.0_rollup@2.77.0:
@@ -7710,14 +7698,6 @@ packages:
       rollup: 2.77.0
       spdx-expression-validate: 2.0.0
       spdx-satisfies: 5.0.1
-    dev: true
-
-  /rollup/2.75.6:
-    resolution: {integrity: sha512-OEf0TgpC9vU6WGROJIk1JA3LR5vk/yvqlzxqdrE2CzzXnqKXNzbAwlWUXis8RS3ZPe7LAq+YUxsRa0l3r27MLA==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /rollup/2.77.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
       postcss-modules: ^4.3.1
       resolve: ^1.22.1
       resolve.exports: ^1.1.0
-      rollup: ^2.75.6
+      rollup: '>=2.75.6 <2.77.0 || ~2.77.0'
       rollup-plugin-license: ^2.8.1
       sirv: ^2.0.2
       source-map-js: ^1.0.2
@@ -265,7 +265,7 @@ importers:
       esbuild: 0.14.47
       postcss: 8.4.16
       resolve: 1.22.1
-      rollup: 2.75.6
+      rollup: 2.77.0
     optionalDependencies:
       fsevents: 2.3.2
     devDependencies:
@@ -273,12 +273,12 @@ importers:
       '@babel/parser': 7.18.11
       '@babel/types': 7.18.10
       '@jridgewell/trace-mapping': 0.3.14
-      '@rollup/plugin-alias': 3.1.9_rollup@2.75.6
-      '@rollup/plugin-commonjs': 22.0.2_rollup@2.75.6
-      '@rollup/plugin-dynamic-import-vars': 1.4.4_rollup@2.75.6
-      '@rollup/plugin-json': 4.1.0_rollup@2.75.6
-      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.75.6
-      '@rollup/plugin-typescript': 8.3.4_rollup@2.75.6+tslib@2.4.0
+      '@rollup/plugin-alias': 3.1.9_rollup@2.77.0
+      '@rollup/plugin-commonjs': 22.0.2_rollup@2.77.0
+      '@rollup/plugin-dynamic-import-vars': 1.4.4_rollup@2.77.0
+      '@rollup/plugin-json': 4.1.0_rollup@2.77.0
+      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.77.0
+      '@rollup/plugin-typescript': 8.3.4_rollup@2.77.0+tslib@2.4.0
       '@rollup/pluginutils': 4.2.1
       '@vue/compiler-dom': 3.2.37
       acorn: 8.8.0
@@ -311,7 +311,7 @@ importers:
       postcss-load-config: 4.0.1_postcss@8.4.16
       postcss-modules: 4.3.1_postcss@8.4.16
       resolve.exports: 1.1.0
-      rollup-plugin-license: 2.8.1_rollup@2.75.6
+      rollup-plugin-license: 2.8.1_rollup@2.77.0
       sirv: 2.0.2
       source-map-js: 1.0.2
       source-map-support: 0.5.21
@@ -2368,16 +2368,6 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@rollup/plugin-alias/3.1.9_rollup@2.75.6:
-    resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
-    engines: {node: '>=8.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    dependencies:
-      rollup: 2.75.6
-      slash: 3.0.0
-    dev: true
-
   /@rollup/plugin-alias/3.1.9_rollup@2.77.0:
     resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
     engines: {node: '>=8.0.0'}
@@ -2404,23 +2394,23 @@ packages:
       rollup: 2.77.0
     dev: true
 
-  /@rollup/plugin-commonjs/22.0.2_rollup@2.75.6:
+  /@rollup/plugin-commonjs/22.0.2_rollup@2.77.0:
     resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
       rollup: ^2.68.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.6
+      '@rollup/pluginutils': 3.1.0_rollup@2.77.0
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 7.2.0
       is-reference: 1.2.1
       magic-string: 0.25.9
       resolve: 1.22.1
-      rollup: 2.75.6
+      rollup: 2.77.0
     dev: true
 
-  /@rollup/plugin-dynamic-import-vars/1.4.4_rollup@2.75.6:
+  /@rollup/plugin-dynamic-import-vars/1.4.4_rollup@2.77.0:
     resolution: {integrity: sha512-51BcU6ag9EeF09CtEsa5D/IHYo7KI42TR1Jc4doNzV1nHAiH7TvUi5vsLERFMjs9Gzy9K0otbZH/2wb0hpBhRA==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
@@ -2430,16 +2420,7 @@ packages:
       estree-walker: 2.0.2
       fast-glob: 3.2.11
       magic-string: 0.25.9
-      rollup: 2.75.6
-    dev: true
-
-  /@rollup/plugin-json/4.1.0_rollup@2.75.6:
-    resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
-    peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.6
-      rollup: 2.75.6
+      rollup: 2.77.0
     dev: true
 
   /@rollup/plugin-json/4.1.0_rollup@2.77.0:
@@ -2449,21 +2430,6 @@ packages:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.77.0
       rollup: 2.77.0
-    dev: true
-
-  /@rollup/plugin-node-resolve/13.3.0_rollup@2.75.6:
-    resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
-    engines: {node: '>= 10.0.0'}
-    peerDependencies:
-      rollup: ^2.42.0
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.6
-      '@types/resolve': 1.17.1
-      deepmerge: 4.2.2
-      is-builtin-module: 3.1.0
-      is-module: 1.0.0
-      resolve: 1.22.1
-      rollup: 2.75.6
     dev: true
 
   /@rollup/plugin-node-resolve/13.3.0_rollup@2.77.0:
@@ -2491,7 +2457,7 @@ packages:
       rollup: 2.77.0
     dev: true
 
-  /@rollup/plugin-typescript/8.3.4_rollup@2.75.6+tslib@2.4.0:
+  /@rollup/plugin-typescript/8.3.4_rollup@2.77.0+tslib@2.4.0:
     resolution: {integrity: sha512-wt7JnYE9antX6BOXtsxGoeVSu4dZfw0dU3xykfOQ4hC3EddxRbVG/K0xiY1Wup7QOHJcjLYXWAn0Kx9Z1SBHHg==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -2502,9 +2468,9 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.75.6
+      '@rollup/pluginutils': 3.1.0_rollup@2.77.0
       resolve: 1.22.1
-      rollup: 2.75.6
+      rollup: 2.77.0
       tslib: 2.4.0
     dev: true
 
@@ -7728,7 +7694,7 @@ packages:
       - supports-color
     dev: true
 
-  /rollup-plugin-license/2.8.1_rollup@2.75.6:
+  /rollup-plugin-license/2.8.1_rollup@2.77.0:
     resolution: {integrity: sha512-VYd9pzaNL7NN6xQp93XiiCV2UoduXgSmTcz6rl9bHPdiifT6yH3Zw/omEr73Rq8TIyN4nqJACBbKIT/2eE66wg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -7741,7 +7707,7 @@ packages:
       mkdirp: 1.0.4
       moment: 2.29.3
       package-name-regex: 2.0.6
-      rollup: 2.75.6
+      rollup: 2.77.0
       spdx-expression-validate: 2.0.0
       spdx-satisfies: 5.0.1
     dev: true
@@ -7752,6 +7718,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /rollup/2.77.0:
     resolution: {integrity: sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==}
@@ -7759,7 +7726,6 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}


### PR DESCRIPTION
### Description

See @antfu comment for context:
- https://github.com/rollup/rollup/pull/4600#issuecomment-1212040016

Used a more complex range to avoid over-constraining in a patch.

In general, I think we should start to lock rollup version to a minor, and only update it in our minors moving forward.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other