### PR TITLE
refactor(legacy): build polyfill chunk

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -657,8 +657,6 @@ async function buildPolyfillChunk(
     plugins: [polyfillsPlugin(imports, excludeSystemJS)],
     build: {
       write: false,
-      // if a value above 'es5' is set, esbuild injects helper functions which uses es2015 features
-      target: 'es5',
       minify,
       assetsDir,
       rollupOptions: {
@@ -670,6 +668,18 @@ async function buildPolyfillChunk(
           entryFileNames: rollupOutputOptions.entryFileNames,
           manualChunks: undefined
         }
+      }
+    },
+    // Don't run esbuild for transpilation or minification
+    // because we don't want to transpile code.
+    esbuild: false,
+    optimizeDeps: {
+      esbuildOptions: {
+        // If a value above 'es5' is set, esbuild injects helper functions which uses es2015 features.
+        // This limits the input code not to include es2015+ codes.
+        // But core-js is the only dependency which includes commonjs code
+        // and core-js doesn't include es2015+ codes.
+        target: 'es5'
       }
     }
   })
@@ -710,21 +720,6 @@ function polyfillsPlugin(
           (excludeSystemJS ? '' : `import "systemjs/dist/s.min.js";`)
         )
       }
-    },
-    renderChunk(_, __, opts) {
-      // systemjs includes code that can't be minified down to es5 by esbuild
-      if (!excludeSystemJS) {
-        // @ts-ignore avoid esbuild transform on legacy chunks since it produces
-        // legacy-unsafe code - e.g. rewriting object properties into shorthands
-        opts.__vite_skip_esbuild__ = true
-
-        // @ts-ignore force terser for legacy chunks. This only takes effect if
-        // minification isn't disabled, because that leaves out the terser plugin
-        // entirely.
-        opts.__vite_force_terser__ = true
-      }
-
-      return null
     }
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR refactors how to skip esbuild transpilation.

This PR can be regarded as reverting #8660 + #9635 and applying a different fix.

IIUC this PR does not change the behavior.

refs #8660
refs #9635

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
