### PR TITLE
fix: use browser field if likely esm (fixes #9652)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import colors from 'picocolors'
 import type { PartialResolvedId } from 'rollup'
 import { resolve as _resolveExports } from 'resolve.exports'
+import { hasESMSyntax } from 'mlly'
 import type { Plugin } from '../plugin'
 import {
   DEFAULT_EXTENSIONS,
@@ -811,8 +812,6 @@ export async function tryOptimizedResolve(
   }
 }
 
-const importExportRE = /\b(?:import|export)\s/
-
 export function resolvePackageEntry(
   id: string,
   { dir, data, setResolvedCache, getResolvedCache }: PackageData,
@@ -862,7 +861,7 @@ export function resolvePackageEntry(
           )
           if (resolvedBrowserEntry) {
             const content = fs.readFileSync(resolvedBrowserEntry, 'utf-8')
-            if (importExportRE.test(content)) {
+            if (hasESMSyntax(content)) {
               // likely ESM, prefer browser
               entryPoint = browserEntry
             } else {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -867,8 +867,6 @@ export function resolvePackageEntry(
             ) {
               // likely UMD or CJS(!!! e.g. firebase 7.x), prefer module
               entryPoint = data.module
-            } else {
-              entryPoint = browserEntry
             }
           }
         } else {

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -88,8 +88,7 @@ test('browser field', async () => {
   expect(await page.textContent('.browser')).toMatch('[success]')
 })
 
-// TODO: skip because #9459 is reverted
-test.skip('Resolve browser field even if module field exists', async () => {
+test('Resolve browser field even if module field exists', async () => {
   expect(await page.textContent('.browser-module1')).toMatch('[success]')
 })
 

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -97,6 +97,10 @@ test('Resolve module field if browser field is likely UMD or CJS', async () => {
   expect(await page.textContent('.browser-module2')).toMatch('[success]')
 })
 
+test('Resolve module field if browser field is likely IIFE', async () => {
+  expect(await page.textContent('.browser-module3')).toMatch('[success]')
+})
+
 test('css entry', async () => {
   expect(await page.textContent('.css')).toMatch('[success]')
 })

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -88,7 +88,8 @@ test('browser field', async () => {
   expect(await page.textContent('.browser')).toMatch('[success]')
 })
 
-test('Resolve browser field even if module field exists', async () => {
+// TODO: skip because #9459 is reverted
+test.skip('Resolve browser field even if module field exists', async () => {
   expect(await page.textContent('.browser-module1')).toMatch('[success]')
 })
 

--- a/playground/resolve/browser-module-field3/index.js
+++ b/playground/resolve/browser-module-field3/index.js
@@ -1,0 +1,1 @@
+export default '[success] this should run in browser'

--- a/playground/resolve/browser-module-field3/index.web.js
+++ b/playground/resolve/browser-module-field3/index.web.js
@@ -1,0 +1,7 @@
+var browserModuleField3 = (function () {
+  'use strict'
+
+  var main = '[fail] this should not run in the browser'
+
+  return main
+})()

--- a/playground/resolve/browser-module-field3/package.json
+++ b/playground/resolve/browser-module-field3/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "resolve-browser-module-field3",
+  "private": true,
+  "version": "1.0.0",
+  "module": "index.js",
+  "browser": "index.web.js"
+}

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -82,6 +82,9 @@
 <h2>Resolve module field if browser field is likely UMD or CJS</h2>
 <p class="browser-module2">fail</p>
 
+<h2>Resolve module field if browser field is likely IIFE</h2>
+<p class="browser-module3">fail</p>
+
 <h2>Don't resolve to the `module` field if the importer is a `require` call</h2>
 <p class="require-pkg-with-module-field">fail</p>
 
@@ -224,6 +227,9 @@
 
   import browserModule2 from 'resolve-browser-module-field2'
   text('.browser-module2', browserModule2)
+
+  import browserModule3 from 'resolve-browser-module-field3'
+  text('.browser-module3', browserModule3)
 
   import { msg as requireButWithModuleFieldMsg } from 'require-pkg-with-module-field'
   text('.require-pkg-with-module-field', requireButWithModuleFieldMsg)

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -16,6 +16,7 @@
     "resolve-browser-field": "link:./browser-field",
     "resolve-browser-module-field1": "link:./browser-module-field1",
     "resolve-browser-module-field2": "link:./browser-module-field2",
+    "resolve-browser-module-field3": "link:./browser-module-field3",
     "resolve-custom-condition": "link:./custom-condition",
     "resolve-custom-main-field": "link:./custom-main-field",
     "resolve-exports-env": "link:./exports-env",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -847,6 +847,7 @@ importers:
       resolve-browser-field: link:./browser-field
       resolve-browser-module-field1: link:./browser-module-field1
       resolve-browser-module-field2: link:./browser-module-field2
+      resolve-browser-module-field3: link:./browser-module-field3
       resolve-custom-condition: link:./custom-condition
       resolve-custom-main-field: link:./custom-main-field
       resolve-exports-env: link:./exports-env
@@ -860,6 +861,7 @@ importers:
       resolve-browser-field: link:browser-field
       resolve-browser-module-field1: link:browser-module-field1
       resolve-browser-module-field2: link:browser-module-field2
+      resolve-browser-module-field3: link:browser-module-field3
       resolve-custom-condition: link:custom-condition
       resolve-custom-main-field: link:custom-main-field
       resolve-exports-env: link:exports-env
@@ -879,6 +881,9 @@ importers:
     specifiers: {}
 
   playground/resolve/browser-module-field2:
+    specifiers: {}
+
+  playground/resolve/browser-module-field3:
     specifiers: {}
 
   playground/resolve/custom-condition:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR reverts #9459 and uses a different approach to fix #9445.

|browser field<br>content| pre-#9459 | #9459 | this PR |
|--------------|------------|---------|--------|
|UMD            | use module field | use module field | use module field |
|CJS               | use module field | use module field | use module field |
|IIFE (#9652)  | resolve from `mainFields`<br>(default contains module field) | browser field | **module field** |
|ESM (#9445) | resolve from `mainFields`<br>(default contains module field) | browser field | browser field |
|undetermined|resolve from `mainFields`<br>(default contains module field)|browser field | **module field** |

undetermined does not include `module.exports` or `import`/`export`.

fixes #9652

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
