### PR TITLE
chore: publish under previous tag if not latest

### DIFF
--- a/scripts/publishCI.ts
+++ b/scripts/publishCI.ts
@@ -1,4 +1,11 @@
-import { args, getPackageInfo, publishPackage, step } from './releaseUtils'
+import semver from 'semver'
+import {
+  args,
+  getActiveVersion,
+  getPackageInfo,
+  publishPackage,
+  step
+} from './releaseUtils'
 
 async function main() {
   const tag = args._[0]
@@ -21,11 +28,15 @@ async function main() {
       `Package version from tag "${version}" mismatches with current version "${currentVersion}"`
     )
 
+  const activeVersion = await getActiveVersion(pkgName)
+
   step('Publishing package...')
   const releaseTag = version.includes('beta')
     ? 'beta'
     : version.includes('alpha')
     ? 'alpha'
+    : semver.lt(currentVersion, activeVersion)
+    ? 'previous'
     : undefined
   await publishPackage(pkgDir, releaseTag)
 }

--- a/scripts/releaseUtils.ts
+++ b/scripts/releaseUtils.ts
@@ -197,6 +197,11 @@ export async function getLatestTag(pkgName: string): Promise<string> {
     .reverse()[0]
 }
 
+export async function getActiveVersion(pkgName: string): Promise<string> {
+  return (await run('npm', ['info', pkgName, 'version'], { stdio: 'pipe' }))
+    .stdout
+}
+
 export async function logRecentCommits(pkgName: string): Promise<void> {
   const tag = await getLatestTag(pkgName)
   if (!tag) return


### PR DESCRIPTION
### Description

Use `previous` tag when releasing a prev version.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other