### PR TITLE
feat: skip `.git` when emptying dir

### DIFF
--- a/packages/create-vite/index.js
+++ b/packages/create-vite/index.js
@@ -355,6 +355,9 @@ function emptyDir(dir) {
     return
   }
   for (const file of fs.readdirSync(dir)) {
+    if (file === '.git') {
+      continue
+    }
     fs.rmSync(path.resolve(dir, file), { recursive: true, force: true })
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When creating a project with `create-vite`, I think `.git` should be ignored if overwriting what's under the current folder.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
