### PR TITLE
feat: add CLI keyboard shortcuts

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -7,7 +7,6 @@ import type { LogLevel } from './logger'
 import { createLogger } from './logger'
 import { VERSION } from './constants'
 import { resolveConfig } from '.'
-import { bindShortcuts } from './server/shortcuts'
 
 const cli = cac('vite')
 
@@ -118,10 +117,7 @@ cli
       )
 
       server.printUrls()
-
-      if (options.bindShortcuts !== false) {
-        bindShortcuts(server)
-      }
+      server.bindShortcuts()
     } catch (e) {
       createLogger(options.logLevel).error(
         colors.red(`error when starting dev server:\n${e.stack}`),

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -7,6 +7,7 @@ import type { LogLevel } from './logger'
 import { createLogger } from './logger'
 import { VERSION } from './constants'
 import { resolveConfig } from '.'
+import { bindShortcuts } from './server/shortcuts'
 
 const cli = cac('vite')
 
@@ -117,6 +118,10 @@ cli
       )
 
       server.printUrls()
+
+      if (options.bindShortcuts !== false) {
+        bindShortcuts(server)
+      }
     } catch (e) {
       createLogger(options.logLevel).error(
         colors.red(`error when starting dev server:\n${e.stack}`),

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -114,6 +114,13 @@ export interface ServerOptions extends CommonServerOptions {
    * in a future minor version without following semver
    */
   force?: boolean
+  /**
+   * Disable key bindings for the server by setting this to `false`. This can be
+   * useful if you need the `process.stdin` stream for another purpose.
+   *
+   * @default true
+   */
+  bindShortcuts?: boolean
 }
 
 export interface ResolvedServerOptions extends ServerOptions {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -70,6 +70,7 @@ import { openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
 import { searchForWorkspaceRoot } from './searchRoot'
+import { bindShortcuts } from './shortcuts'
 
 export { searchForWorkspaceRoot } from './searchRoot'
 
@@ -263,6 +264,11 @@ export interface ViteDevServer {
    */
   restart(forceOptimize?: boolean): Promise<void>
   /**
+   * Listen to `process.stdin` for pre-defined keyboard shortcuts, which are
+   * printed to the terminal by this method.
+   */
+  bindShortcuts(): void
+  /**
    * @internal
    */
   _importGlobMap: Map<string, string[][]>
@@ -427,6 +433,11 @@ export async function createServer(
         })
       }
       return server._restartPromise
+    },
+    bindShortcuts() {
+      if (serverConfig.bindShortcuts !== false) {
+        bindShortcuts(server)
+      }
     },
 
     _ssrExternals: null,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -119,7 +119,7 @@ export interface ServerOptions extends CommonServerOptions {
    * Disable key bindings for the server by setting this to `false`. This can be
    * useful if you need the `process.stdin` stream for another purpose.
    *
-   * @default true
+   * @default true in CLI, `false` in programmatic usage
    */
   bindShortcuts?: boolean
 }

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -15,8 +15,6 @@ import spawn from 'cross-spawn'
 import colors from 'picocolors'
 import type { Logger } from '../logger'
 import { VITE_PACKAGE_DIR } from '../constants'
-import type { ViteDevServer } from './index'
-import { resolveHostname } from '../utils'
 
 // https://github.com/sindresorhus/open#app
 const OSX_CHROME = 'google chrome'
@@ -39,16 +37,6 @@ export function openBrowser(
     return startBrowserProcess(browser, url)
   }
   return false
-}
-
-export async function resolveBrowserUrl(server: ViteDevServer): Promise<string> {
-  const options = server.config.server
-  const hostname = await resolveHostname(options.host)
-  const port = options.port || 3000
-  const protocol = options.https ? 'https' : 'http'
-  const path =
-    typeof options.open === 'string' ? options.open : server.config.base
-  return `${protocol}://${hostname.name}:${port}${path}`
 }
 
 function executeNodeScript(scriptPath: string, url: string, logger: Logger) {

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -41,9 +41,9 @@ export function openBrowser(
   return false
 }
 
-export function resolveBrowserUrl(server: ViteDevServer): string {
+export async function resolveBrowserUrl(server: ViteDevServer): Promise<string> {
   const options = server.config.server
-  const hostname = resolveHostname(options.host)
+  const hostname = await resolveHostname(options.host)
   const port = options.port || 3000
   const protocol = options.https ? 'https' : 'http'
   const path =

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -15,6 +15,8 @@ import spawn from 'cross-spawn'
 import colors from 'picocolors'
 import type { Logger } from '../logger'
 import { VITE_PACKAGE_DIR } from '../constants'
+import type { ViteDevServer } from './index'
+import { resolveHostname } from '../utils'
 
 // https://github.com/sindresorhus/open#app
 const OSX_CHROME = 'google chrome'
@@ -37,6 +39,16 @@ export function openBrowser(
     return startBrowserProcess(browser, url)
   }
   return false
+}
+
+export function resolveBrowserUrl(server: ViteDevServer): string {
+  const options = server.config.server
+  const hostname = resolveHostname(options.host)
+  const port = options.port || 3000
+  const protocol = options.https ? 'https' : 'http'
+  const path =
+    typeof options.open === 'string' ? options.open : server.config.base
+  return `${protocol}://${hostname.name}:${port}${path}`
 }
 
 function executeNodeScript(scriptPath: string, url: string, logger: Logger) {

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -73,8 +73,9 @@ export const SHORTCUTS: Shortcut[] = [
   {
     key: 'r',
     description: 'restart the server',
-    action(server: ViteDevServer): Promise<void> {
-      return server.restart()
+    async action(server: ViteDevServer): Promise<void> {
+      await server.restart()
+      server.bindShortcuts()
     }
   },
   {

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -12,13 +12,27 @@ export function bindShortcuts(server: ViteDevServer): void {
       }).join(', ')
   )
 
-  const onInput = (input: string) => {
+  let actionRunning = false
+
+  const onInput = async (input: string) => {
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
       return process.kill(process.pid, 'SIGINT')
     }
+
     const shortcut = SHORTCUTS.find((shortcut) => shortcut.key === input)
-    shortcut?.action(server)
+
+    if (!shortcut) {
+      return
+    }
+
+    if (actionRunning) {
+      return
+    }
+
+    actionRunning = true
+    await shortcut.action(server)
+    actionRunning = false
   }
 
   if (process.stdin.isTTY) {
@@ -42,8 +56,8 @@ export const SHORTCUTS: Shortcut[] = [
   {
     key: 'r',
     name: 'restart',
-    action(server: ViteDevServer): void {
-      server.restart()
+    action(server: ViteDevServer): Promise<void> {
+      return server.restart()
     }
   },
   {

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -21,11 +21,11 @@ export function bindShortcuts(server: ViteDevServer): void {
     shortcut?.action(server)
   }
 
-  process.stdin
-    .on('data', onInput)
-    .setEncoding('utf8')
-    .setRawMode(true)
-    .resume()
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+  }
+
+  process.stdin.on('data', onInput).setEncoding('utf8').resume()
 
   server.httpServer.on('close', () => {
     process.stdin.off('data', onInput).pause()

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -55,13 +55,6 @@ export const SHORTCUTS: Shortcut[] = [
     }
   },
   {
-    key: 'f',
-    name: 'force restart',
-    action(server: ViteDevServer): void {
-      server.restart(true)
-    }
-  },
-  {
     key: 'h',
     name: 'toggle hmr',
     action({ config }: ViteDevServer): void {

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -5,12 +5,12 @@ import { openBrowser } from './openBrowser'
 export function bindShortcuts(server: ViteDevServer): void {
   if (!server.httpServer) return
 
-  server.config.logger.info(
-    `  > Shortcuts: ` +
-      SHORTCUTS.map((shortcut) => {
-        return `"${shortcut.key}" ${shortcut.name}`
-      }).join(', ')
-  )
+  const helpInfo =
+    colors.dim('press ') +
+    colors.reset(colors.bold('h')) +
+    colors.dim(' to show help')
+
+  server.config.logger.info(colors.dim(`  ${colors.green('➜')}  ${helpInfo}`))
 
   let actionRunning = false
 
@@ -18,6 +18,17 @@ export function bindShortcuts(server: ViteDevServer): void {
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
       return process.kill(process.pid, 'SIGINT')
+    }
+
+    if (input === 'h') {
+      return server.config.logger.info(
+        SHORTCUTS.map(
+          (shortcut) =>
+            colors.dim('  press ') +
+            colors.reset(colors.bold(shortcut.key)) +
+            colors.dim(` to ${shortcut.description}`)
+        ).join('\n')
+      )
     }
 
     const shortcut = SHORTCUTS.find((shortcut) => shortcut.key === input)
@@ -48,21 +59,21 @@ export function bindShortcuts(server: ViteDevServer): void {
 
 export interface Shortcut {
   key: string
-  name: string
+  description: string
   action(server: ViteDevServer): void | Promise<void>
 }
 
 export const SHORTCUTS: Shortcut[] = [
   {
     key: 'r',
-    name: 'restart',
+    description: 'restart the server',
     action(server: ViteDevServer): Promise<void> {
       return server.restart()
     }
   },
   {
     key: 'o',
-    name: 'open browser',
+    description: 'open in browser',
     action(server: ViteDevServer): void {
       const url = server.resolvedUrls?.local[0]
 
@@ -76,8 +87,8 @@ export const SHORTCUTS: Shortcut[] = [
     }
   },
   {
-    key: 'h',
-    name: 'toggle hmr',
+    key: 'm',
+    description: 'toggle hmr on/off',
     action({ config }: ViteDevServer): void {
       /**
        * Mutating the server config works because Vite reads from
@@ -88,7 +99,7 @@ export const SHORTCUTS: Shortcut[] = [
        */
       config.server.hmr = config.server.hmr !== true
       config.logger.info(
-        colors.cyan(`hmr ${config.server.hmr ? `enabled` : `disabled`}`)
+        colors.cyan(`  hmr ${config.server.hmr ? `enabled` : `disabled`}`)
       )
     }
   }

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import type { ViteDevServer } from '..'
 import { openBrowser, resolveBrowserUrl } from './openBrowser'
 
@@ -57,6 +58,23 @@ export const SHORTCUTS: Shortcut[] = [
     name: 'force restart',
     action(server: ViteDevServer): void {
       server.restart(true)
+    }
+  },
+  {
+    key: 'h',
+    name: 'toggle hmr',
+    action({ config }: ViteDevServer): void {
+      /**
+       * Mutating the server config works because Vite reads from
+       * it on every file change, instead of caching its value.
+       *
+       * Since `undefined` is treated as `true`, we have to
+       * use `!== true` to flip the boolean value.
+       */
+      config.server.hmr = config.server.hmr !== true
+      config.logger.info(
+        chalk.cyanBright(`hmr ${config.server.hmr ? `enabled` : `disabled`}`)
+      )
     }
   }
 ]

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -35,7 +35,7 @@ export function bindShortcuts(server: ViteDevServer): void {
 export interface Shortcut {
   key: string
   name: string
-  action(server: ViteDevServer): void
+  action(server: ViteDevServer): void | Promise<void>
 }
 
 export const SHORTCUTS: Shortcut[] = [
@@ -49,8 +49,9 @@ export const SHORTCUTS: Shortcut[] = [
   {
     key: 'o',
     name: 'open browser',
-    action(server: ViteDevServer): void {
-      openBrowser(resolveBrowserUrl(server), true, server.config.logger)
+    async action(server: ViteDevServer): Promise<void> {
+      const url = await resolveBrowserUrl(server)
+      openBrowser(url, true, server.config.logger)
     }
   },
   {

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -1,6 +1,6 @@
 import colors from 'picocolors'
 import type { ViteDevServer } from '..'
-import { openBrowser, resolveBrowserUrl } from './openBrowser'
+import { openBrowser } from './openBrowser'
 
 export function bindShortcuts(server: ViteDevServer): void {
   if (!server.httpServer) return
@@ -49,8 +49,15 @@ export const SHORTCUTS: Shortcut[] = [
   {
     key: 'o',
     name: 'open browser',
-    async action(server: ViteDevServer): Promise<void> {
-      const url = await resolveBrowserUrl(server)
+    action(server: ViteDevServer): void {
+      const url = server.resolvedUrls?.local[0]
+
+      if (!url) {
+        return server.config.logger.warn(
+          colors.yellow(`cannot open in browser; no server URLs registered.`)
+        )
+      }
+
       openBrowser(url, true, server.config.logger)
     }
   },

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk'
+import colors from 'picocolors'
 import type { ViteDevServer } from '..'
 import { openBrowser, resolveBrowserUrl } from './openBrowser'
 
@@ -74,7 +74,7 @@ export const SHORTCUTS: Shortcut[] = [
        */
       config.server.hmr = config.server.hmr !== true
       config.logger.info(
-        chalk.cyanBright(`hmr ${config.server.hmr ? `enabled` : `disabled`}`)
+        colors.cyan(`hmr ${config.server.hmr ? `enabled` : `disabled`}`)
       )
     }
   }

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -9,8 +9,14 @@ export function bindShortcuts(server: ViteDevServer): void {
     colors.dim('press ') +
     colors.reset(colors.bold('h')) +
     colors.dim(' to show help')
+  const quitInfo =
+    colors.dim('press ') +
+    colors.reset(colors.bold('q')) +
+    colors.dim(' to quit')
 
-  server.config.logger.info(colors.dim(`  ${colors.green('➜')}  ${helpInfo}`))
+  server.config.logger.info(
+    colors.dim(`  ${colors.green('➜')}  ${helpInfo}, ${quitInfo}`)
+  )
 
   let actionRunning = false
 
@@ -101,6 +107,13 @@ export const SHORTCUTS: Shortcut[] = [
       config.logger.info(
         colors.cyan(`  hmr ${config.server.hmr ? `enabled` : `disabled`}`)
       )
+    }
+  },
+  {
+    key: 'q',
+    description: 'quit',
+    action(server: ViteDevServer): void {
+      server.close()
     }
   }
 ]

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -113,8 +113,12 @@ export const SHORTCUTS: Shortcut[] = [
   {
     key: 'q',
     description: 'quit',
-    action(server: ViteDevServer): void {
-      server.close()
+    async action(server: ViteDevServer): Promise<void> {
+      try {
+        await server.close()
+      } finally {
+        process.exit()
+      }
     }
   }
 ]

--- a/packages/vite/src/node/server/shortcuts.ts
+++ b/packages/vite/src/node/server/shortcuts.ts
@@ -1,0 +1,62 @@
+import type { ViteDevServer } from '..'
+import { openBrowser, resolveBrowserUrl } from './openBrowser'
+
+export function bindShortcuts(server: ViteDevServer): void {
+  if (!server.httpServer) return
+
+  server.config.logger.info(
+    `  > Shortcuts: ` +
+      SHORTCUTS.map((shortcut) => {
+        return `"${shortcut.key}" ${shortcut.name}`
+      }).join(', ')
+  )
+
+  const onInput = (input: string) => {
+    // ctrl+c or ctrl+d
+    if (input === '\x03' || input === '\x04') {
+      return process.kill(process.pid, 'SIGINT')
+    }
+    const shortcut = SHORTCUTS.find((shortcut) => shortcut.key === input)
+    shortcut?.action(server)
+  }
+
+  process.stdin
+    .on('data', onInput)
+    .setEncoding('utf8')
+    .setRawMode(true)
+    .resume()
+
+  server.httpServer.on('close', () => {
+    process.stdin.off('data', onInput).pause()
+  })
+}
+
+export interface Shortcut {
+  key: string
+  name: string
+  action(server: ViteDevServer): void
+}
+
+export const SHORTCUTS: Shortcut[] = [
+  {
+    key: 'r',
+    name: 'restart',
+    action(server: ViteDevServer): void {
+      server.restart()
+    }
+  },
+  {
+    key: 'o',
+    name: 'open browser',
+    action(server: ViteDevServer): void {
+      openBrowser(resolveBrowserUrl(server), true, server.config.logger)
+    }
+  },
+  {
+    key: 'f',
+    name: 'force restart',
+    action(server: ViteDevServer): void {
+      server.restart(true)
+    }
+  }
+]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This is a rebase of https://github.com/vitejs/vite/pull/6014 to resolve merge conflicts. It introduces stdin shortcuts for restarting the dev server, opening the server in browser and toggling HMR.  

- `h` - show all shortcuts
- `r` - restart server
- `o` - open in browser
- `m` - toggle HMR on/off
- `q` - quit

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
