### PR TITLE
feat: export helpers to allow 3rd parties to emit assets

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -181,7 +181,7 @@ function createCjsConfig(isProduction: boolean) {
       ...Object.keys(pkg.dependencies),
       ...(isProduction ? [] : Object.keys(pkg.devDependencies))
     ],
-    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(120)]
+    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(930)]
   })
 }
 

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -260,8 +260,8 @@ export function resolveAssetFileNames(
 }
 
 /**
- * converts the source filepath of the asset to the output filename based on the assetFileNames option. \
- * this function imitates the behavior of rollup.js. \
+ * converts the source filepath of the asset to the output filename based on the assetFileNames option.
+ * this function imitates the behavior of rollup.js.
  * https://rollupjs.org/guide/en/#outputassetfilenames
  *
  * @example
@@ -276,10 +276,10 @@ export function resolveAssetFileNames(
  * // fileName: 'assets/file.982d9e3e.txt'
  * ```
  *
- * @param assetFileNames filename pattern. e.g. `'assets/[name].[hash][extname]'`
- * @param file filepath of the asset
- * @param contentHash hash of the asset. used for `'[hash]'` placeholder
- * @param content content of the asset. passed to `assetFileNames` if `assetFileNames` is a function
+ * @param assetFileNames - filename pattern. e.g. `'assets/[name].[hash][extname]'`
+ * @param file - filepath of the asset
+ * @param contentHash - hash of the asset. used for `'[hash]'` placeholder
+ * @param content - content of the asset. passed to `assetFileNames` if `assetFileNames` is a function
  * @returns output filename
  */
 export function assetFileNamesToFileName(

--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -14,7 +14,13 @@ export {
   assetFileNamesToFileName,
   resolveAssetFileNames
 } from './plugins/asset'
-export { normalizePath, mergeConfig, mergeAlias, createFilter } from './utils'
+export {
+  normalizePath,
+  mergeConfig,
+  mergeAlias,
+  createFilter,
+  getHash
+} from './utils'
 export { send } from './server/send'
 export { createLogger } from './logger'
 export { searchForWorkspaceRoot } from './server/searchRoot'

--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -10,6 +10,10 @@ export {
   splitVendorChunkPlugin,
   splitVendorChunk
 } from './plugins/splitVendorChunk'
+export {
+  assetFileNamesToFileName,
+  resolveAssetFileNames
+} from './plugins/asset'
 export { normalizePath, mergeConfig, mergeAlias, createFilter } from './utils'
 export { send } from './server/send'
 export { createLogger } from './logger'


### PR DESCRIPTION
### Description

When using Vite as the build tool for server side language templated views, such as Laravel Blade (or PHP, Ruby, etc), it can be useful to inject assets into the build that are not referenced in JS or CSS "entry points".

Imagine the following contrived Blade template in an application that does not include any built JS or CSS:

```blade
@php
    $logo = Arr:random([
       'resources/images/logo-a.png',
       'resources/images/logo-b.png',
    ]);
@endphp

<img src="{{ $logo }}">
```

Vite does not compile or know about this template, so Vite has no way of knowing about the two logos that the developer wants to bundle.

To allow applications that do not include build entry points to also utilise Vite as a build tool, I would like to propose that Vite export the suggested functions. Exporting these functions allows plugins (namely, the official Laravel plugin) to inject assets that are to be included in the build.

As an example of what this unlocks: in the Laravel plugin we could offer a new key for paths to include in the build:

```js
export default defineConfig({
    plugins: [
        laravel({
            assets: [
                "resources/images/**",
                "resources/fonts/**",
            ],
        }),
        viteImagemin(),
    ],
})
```

The Laravel plugin may then internally use this `emitFile` function to add these to the build. Having access to these internal function allows us to ensure we stay inline with Vite naming conventions and also handle the naming as per the default or overridden config for filename ([hash], [name], etc) patterns.

```js
{
    /* ... */
    async buildStart() {
        resolveAssetsFromConfig().forEach(asset => {
            const content = await fsp.readFile(
                path.resolve(resolveConfig.root, asset)
            )

            this.emitFile({
                type: 'asset',
                source: content,
                name: asset,
                fileName: assetFileNamesToFileName(
                    resolveAssetFileNames(resolvedConfig),
                    asset,
                    getHash(content),
                    content
                ),
            })
        }),
    },
}
```

#### Why not just use the static copy plugin?

As shown in an earlier example, including these in the actual build allows vite plugins such as `viteImagemin` to "just work". Images included in the Laravel plugin then benefit from the same side-effects as if the assets were simply referenced in JS files.

#### Why not just import into your JS

Our current solution is that we recommend people still have an `app.js` and import images with globing:

```js
import.meta.glob(['../images/**', '../fonts/**'])
```

However we feel this is really weird workaround for apps that literally don't have any JS in their app, thus we would love to be able to improve this experience for our plugin users.

### Additional context

- errrmmmm. maybe have a look at the fact that I had to bump the bundle size substantially 🙈
- If you can think of another way to handle this that I haven't seen, please educate me ❤️

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] (n/a) Ideally, include relevant tests that fail without this PR but pass with it.
