### PR TITLE
perf: avoid `ssrTransform` object allocation

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -340,9 +340,7 @@ export async function createServer(
     moduleGraph,
     resolvedUrls: null, // will be set on listen
     ssrTransform(code: string, inMap: SourceMap | null, url: string) {
-      return ssrTransform(code, inMap, url, code, {
-        json: { stringify: server.config.json?.stringify }
-      })
+      return ssrTransform(code, inMap, url, code, server.config)
     },
     transformRequest(url, options) {
       return transformRequest(url, server, options)

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -259,9 +259,13 @@ async function loadAndTransform(
   }
 
   const result = ssr
-    ? await ssrTransform(code, map as SourceMap, url, originalCode, {
-        json: { stringify: !!server.config.json?.stringify }
-      })
+    ? await ssrTransform(
+        code,
+        map as SourceMap,
+        url,
+        originalCode,
+        server.config
+      )
     : ({
         code,
         map,


### PR DESCRIPTION
Probably a bit nitpicky, but as the config share the same interface we could avoid creating a new object on each call.