### PR TITLE
fix(import-analysis): escape quotes

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -527,7 +527,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               rewriteDone = true
             }
             if (!rewriteDone) {
-              str().overwrite(start, end, isDynamicImport ? `'${url}'` : url, {
+              let rewrittenUrl = JSON.stringify(url)
+              if (!isDynamicImport) rewrittenUrl = rewrittenUrl.slice(1, -1)
+              str().overwrite(start, end, rewrittenUrl, {
                 contentOnly: true
               })
             }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -291,14 +291,11 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 rewriteDone = true
               }
               if (!rewriteDone) {
-                str().overwrite(
-                  start,
-                  end,
-                  isDynamicImport ? `'${file}'` : file,
-                  {
-                    contentOnly: true
-                  }
-                )
+                let rewrittenUrl = JSON.stringify(file)
+                if (!isDynamicImport) rewrittenUrl = rewrittenUrl.slice(1, -1)
+                str().overwrite(start, end, rewrittenUrl, {
+                  contentOnly: true
+                })
               }
             }
           }

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -19,9 +19,6 @@ const filteredResult = {
   },
   "./quote'.js": {
     msg: 'single-quote'
-  },
-  './quote".js': {
-    msg: 'double-quote'
   }
 }
 
@@ -71,9 +68,6 @@ const allResult = {
   },
   "/dir/quote'.js": {
     msg: 'single-quote'
-  },
-  '/dir/quote".js': {
-    msg: 'double-quote'
   }
 }
 

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -16,6 +16,12 @@ const filteredResult = {
   },
   './foo.js': {
     msg: 'foo'
+  },
+  "./quote'.js": {
+    msg: 'single-quote'
+  },
+  './quote".js': {
+    msg: 'double-quote'
   }
 }
 
@@ -62,6 +68,12 @@ const allResult = {
       '../baz.json': json
     },
     msg: 'bar'
+  },
+  "/dir/quote'.js": {
+    msg: 'single-quote'
+  },
+  '/dir/quote".js': {
+    msg: 'double-quote'
   }
 }
 

--- a/playground/glob-import/dir/quote".js
+++ b/playground/glob-import/dir/quote".js
@@ -1,1 +1,0 @@
-export const msg = 'double-quote'

--- a/playground/glob-import/dir/quote".js
+++ b/playground/glob-import/dir/quote".js
@@ -1,0 +1,1 @@
+export const msg = 'double-quote'

--- a/playground/glob-import/dir/quote'.js
+++ b/playground/glob-import/dir/quote'.js
@@ -1,0 +1,1 @@
+export const msg = 'single-quote'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

During import analysis which replaces import urls, properly escape quotes. 

Ref https://github.com/withastro/astro/issues/4373

### Additional context

I feel like there are more places within `importAnalysis.ts` where we're not properly escaping quotes, but I think we can also fix them as we go.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
