### PR TITLE
fix(react-plugin): support for external `.ts` files

### DIFF
--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -43,7 +43,7 @@ export async function restoreJSX(
   }
 
   const flowRE = /(\/\/\s*@flow|\/\*\s*@flow\s*\*\/)/
-  const special = flowRE ? 'flow' : 'typescript'
+  const special = flowRE.test(code) ? 'flow' : 'typescript'
 
   const result = await babel.transformAsync(code, {
     babelrc: false,

--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -49,7 +49,7 @@ export async function restoreJSX(
     code: false,
     filename,
     parserOpts: {
-      plugins: ['jsx']
+      plugins: ['typescript', 'jsx']
     },
     plugins: [[await getBabelRestoreJSX(), { reactAlias }]]
   })

--- a/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
+++ b/packages/plugin-react/src/jsx-runtime/restore-jsx.ts
@@ -42,6 +42,9 @@ export async function restoreJSX(
     return jsxNotFound
   }
 
+  const flowRE = /(\/\/\s*@flow|\/\*\s*@flow\s*\*\/)/
+  const special = flowRE ? 'flow' : 'typescript'
+
   const result = await babel.transformAsync(code, {
     babelrc: false,
     configFile: false,
@@ -49,7 +52,7 @@ export async function restoreJSX(
     code: false,
     filename,
     parserOpts: {
-      plugins: ['typescript', 'jsx']
+      plugins: [special, 'jsx']
     },
     plugins: [[await getBabelRestoreJSX(), { reactAlias }]]
   })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If an external file creates a component through `React.createElement`, the compilation will report an error, the ts rule cannot be recognized

Interestingly, version 1.3.2 supports it because of wrong regex match 😂


### Additional context
- fix vitejs/vite-plugin-react#13

[demo](https://github.com/zoy-l/vite-react-plugin-demo)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
