### PR TITLE
fix: sanitize asset filenames

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -324,7 +324,7 @@ export function assetFileNamesToFileName(
           return hash
 
         case '[name]':
-          return name
+          return sanitizeFileName(name)
       }
       throw new Error(
         `invalid placeholder ${placeholder} in assetFileNames "${assetFileNames}"`
@@ -333,6 +333,23 @@ export function assetFileNamesToFileName(
   )
 
   return fileName
+}
+
+// taken from https://github.com/rollup/rollup/blob/a8647dac0fe46c86183be8596ef7de25bc5b4e4b/src/utils/sanitizeFileName.ts
+// https://datatracker.ietf.org/doc/html/rfc2396
+// eslint-disable-next-line no-control-regex
+const INVALID_CHAR_REGEX = /[\x00-\x1F\x7F<>*#"{}|^[\]`;?:&=+$,]/g
+const DRIVE_LETTER_REGEX = /^[a-z]:/i
+function sanitizeFileName(name: string): string {
+  const match = DRIVE_LETTER_REGEX.exec(name)
+  const driveLetter = match ? match[0] : ''
+
+  // A `:` is only allowed as part of a windows drive letter (ex: C:\foo)
+  // Otherwise, avoid them because they can refer to NTFS alternate data streams.
+  return (
+    driveLetter +
+    name.substr(driveLetter.length).replace(INVALID_CHAR_REGEX, '_')
+  )
 }
 
 export const publicAssetUrlCache = new WeakMap<

--- a/playground/assets-sanitize/+circle.svg
+++ b/playground/assets-sanitize/+circle.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#000"></circle>
+</svg>

--- a/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
+++ b/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from 'vitest'
+import { getBg, isBuild, listAssets, page } from '~utils'
+
+if (!isBuild) {
+  test('importing asset with special char in filename works', async () => {
+    expect(await getBg('.circle-bg')).toContain('+circle.svg')
+    expect(await page.textContent('.circle-bg')).toMatch('+circle.svg')
+  })
+} else {
+  const expected_asset_name_RE = /_circle\.[\w]+\.svg/
+  test('importing asset with special char in filename works', async () => {
+    expect(await getBg('.circle-bg')).toMatch(expected_asset_name_RE)
+    expect(await page.textContent('.circle-bg')).toMatch(expected_asset_name_RE)
+  })
+  test('asset with special char in filename gets sanitized', async () => {
+    const svgs = listAssets().filter((a) => a.endsWith('.svg'))
+    expect(svgs[0]).toMatch(expected_asset_name_RE)
+    expect(svgs.length).toBe(1)
+  })
+}

--- a/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
+++ b/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
@@ -21,7 +21,7 @@ if (!isBuild) {
     )
     expect(plusCircleAsset).toMatch('/_circle')
     expect(underscoreCircleAsset).toMatch('/_circle')
-    expect(plusCircleAsset).not.toBe(underscoreCircleAsset)
+    expect(plusCircleAsset).not.toEqual(underscoreCircleAsset)
     expect(Object.keys(manifest).length).toBe(3) // 2 svg, 1 index.js
   })
 }

--- a/playground/assets-sanitize/_circle.svg
+++ b/playground/assets-sanitize/_circle.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="red"></circle>
+</svg>

--- a/playground/assets-sanitize/index.html
+++ b/playground/assets-sanitize/index.html
@@ -1,0 +1,6 @@
+<script type="module" src="./index.js"></script>
+<h1>test element below should show a circle and it's url</h1>
+<div
+  class="circle-bg"
+  style="background-repeat: no-repeat; padding-left: 2rem"
+></div>

--- a/playground/assets-sanitize/index.html
+++ b/playground/assets-sanitize/index.html
@@ -1,6 +1,11 @@
 <script type="module" src="./index.js"></script>
-<h1>test element below should show a circle and it's url</h1>
-<div
-  class="circle-bg"
-  style="background-repeat: no-repeat; padding-left: 2rem"
-></div>
+<style>
+  .test-el {
+    background-repeat: no-repeat;
+    padding-left: 2rem;
+    margin-bottom: 1rem;
+  }
+</style>
+<h1>test elements below should show circles and their url</h1>
+<div class="test-el plus-circle"></div>
+<div class="test-el underscore-circle"></div>

--- a/playground/assets-sanitize/index.js
+++ b/playground/assets-sanitize/index.js
@@ -1,4 +1,9 @@
-import svg from './+circle.svg'
-const el = document.body.querySelector('.circle-bg')
-el.style.backgroundImage = `url(${svg})`
-el.textContent = svg
+import plusCircle from './+circle.svg'
+import underscoreCircle from './_circle.svg'
+function setData(classname, file) {
+  const el = document.body.querySelector(classname)
+  el.style.backgroundImage = `url(${file})`
+  el.textContent = file
+}
+setData('.plus-circle', plusCircle)
+setData('.underscore-circle', underscoreCircle)

--- a/playground/assets-sanitize/index.js
+++ b/playground/assets-sanitize/index.js
@@ -1,0 +1,4 @@
+import svg from './+circle.svg'
+const el = document.body.querySelector('.circle-bg')
+el.style.backgroundImage = `url(${svg})`
+el.textContent = svg

--- a/playground/assets-sanitize/package.json
+++ b/playground/assets-sanitize/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "test-assets-sanitize",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  }
+}

--- a/playground/assets-sanitize/vite.config.js
+++ b/playground/assets-sanitize/vite.config.js
@@ -1,0 +1,11 @@
+const { defineConfig } = require('vite')
+
+module.exports = defineConfig({
+  build: {
+    //speed up build
+    minify: false,
+    target: 'esnext',
+    assetsInlineLimit: 0,
+    manifest: true
+  }
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vite supplies a custom assetFileName to rollup, which means that rollup itself won't sanitize it further.

This PR copies the default sanitize function from rollup and applies it to the name.

fixes https://github.com/sveltejs/kit/issues/5843

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
