### PR TITLE
fix: support process each out dir when there are two or more

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -555,7 +555,7 @@ async function doBuild(
     for (const output of normalizedOutputs) {
       res.push(await generate(output))
     }
-    return res
+    return Array.isArray(outputs) ? res : res[0]
   } catch (e) {
     outputBuildError(e)
     throw e

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -567,7 +567,7 @@ function prepareOutDir(
   emptyOutDir: boolean | null,
   config: ResolvedConfig
 ) {
-  for (const outDir of outDirs) {
+  for (const outDir of new Set(outDirs)) {
     if (fs.existsSync(outDir)) {
       if (
         emptyOutDir == null &&

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -532,7 +532,7 @@ export function isFileReadable(filename: string): boolean {
   }
 }
 
-const splitFirstDirRE = /(.+)?[\\/](.+)/
+const splitFirstDirRE = /(.+?)[\\/](.+)/
 
 /**
  * Delete every file and subdirectory. **The given directory must exist.**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -534,14 +534,27 @@ export function isFileReadable(filename: string): boolean {
 
 /**
  * Delete every file and subdirectory. **The given directory must exist.**
- * Pass an optional `skip` array to preserve files in the root directory.
+ * Pass an optional `skip` array to preserve files under the root directory.
  */
-export function emptyDir(dir: string, skip?: string[]): void {
+export function emptyDir(dir: string, skip: string[] = []): void {
+  const nested: string[] = []
   for (const file of fs.readdirSync(dir)) {
-    if (skip?.includes(file)) {
+    const matched = skip.find((f) => f.startsWith(file))
+    if (matched) {
+      if (matched !== file) {
+        nested.push(`${dir}/${file}`)
+      }
       continue
     }
     fs.rmSync(path.resolve(dir, file), { recursive: true, force: true })
+  }
+  if (nested.length) {
+    skip = skip
+      .filter((f) => path.dirname(f) !== '.')
+      .map((f) => f.replace(/.+?[\\/]/, ''))
+    for (const dir of nested) {
+      emptyDir(dir, skip)
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`prepareOutDir` only process the `build.outDir`, and the actions include empty dir and copy public dir for those defined in `output.dir` will be ignored.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I notice that it will build output options twice if `config.build.watch` defined, so I promote the process to above.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
