### PR TITLE
fix: module graph ensureEntryFromUrl based on id

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -185,7 +185,7 @@ export class ModuleGraph {
     setIsSelfAccepting = true
   ): Promise<ModuleNode> {
     const [url, resolvedId, meta] = await this.resolveUrl(rawUrl, ssr)
-    let mod = this.urlToModuleMap.get(url)
+    let mod = this.idToModuleMap.get(resolvedId)
     if (!mod) {
       mod = new ModuleNode(url, setIsSelfAccepting)
       if (meta) mod.meta = meta
@@ -199,6 +199,11 @@ export class ModuleGraph {
         this.fileToModulesMap.set(file, fileMappedModules)
       }
       fileMappedModules.add(mod)
+    }
+    // multiple urls can map to the same module and id, make sure we register
+    // the url to the existing module in that case
+    else if (!this.urlToModuleMap.has(url)) {
+      this.urlToModuleMap.set(url, mod)
     }
     return mod
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently we check for a module existence via url in `ensureEntryForUrl`, but a url could map to the same resolved id that already exists in `idToModulesMap` (e.g. via a different url that also resolves to the same id).

This can currently happen for two URLs like:
- /Users/foo/bar/project/src/index.js
- /src/index.js

This PR changes to check the resolved id instead, and update the url to use the existing id & module if possible.

### Additional context

Ref https://github.com/withastro/astro/pull/4378
Feels related to #9730 and #7845
Something similar has been happening in SvelteKit too

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
