### PR TITLE
fix: `injectQuery` break relative path

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   getPotentialTsSrcPaths,
   injectQuery,
   isWindows,
+  normalizePath,
   resolveHostname
 } from '../utils'
 
@@ -39,7 +40,9 @@ describe('injectQuery', () => {
             `${process.cwd().slice(1)}/file:/usr/vite/%20a%20\\?direct`
           )
         : // D:/a/vite/vite/file:/usr/vite/%20a%20?direct
-          new RegExp(`${process.cwd()}/file:/usr/vite/%20a%20\\?direct`)
+          new RegExp(
+            `${normalizePath(process.cwd())}/file:/usr/vite/%20a%20\\?direct`
+          )
     )
   })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -28,21 +28,19 @@ describe('injectQuery', () => {
 
   test('relative path "./"', () => {
     expect(injectQuery('./usr/vite/%20a%20', 'direct')).toEqual(
-      'usr/vite/%20a%20?direct'
+      './usr/vite/%20a%20?direct'
+    )
+  })
+
+  test('relative path "../"', () => {
+    expect(injectQuery('../usr/vite/%20a%20', 'direct')).toEqual(
+      '../usr/vite/%20a%20?direct'
     )
   })
 
   test('file path', () => {
     expect(injectQuery('file:///usr/vite/%20a%20', 'direct')).toMatch(
-      !isWindows
-        ? // d/a/vite/vite/file:/usr/vite/%20a%20?direct
-          new RegExp(
-            `${process.cwd().slice(1)}/file:/usr/vite/%20a%20\\?direct`
-          )
-        : // D:/a/vite/vite/file:/usr/vite/%20a%20?direct
-          new RegExp(
-            `${normalizePath(process.cwd())}/file:/usr/vite/%20a%20\\?direct`
-          )
+      new RegExp(`file:///usr/vite/%20a%20\\?direct`)
     )
   })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -6,7 +6,6 @@ import {
   getPotentialTsSrcPaths,
   injectQuery,
   isWindows,
-  normalizePath,
   resolveHostname
 } from '../utils'
 
@@ -15,7 +14,7 @@ describe('injectQuery', () => {
     // this test will work incorrectly on unix systems
     test('normalize windows path', () => {
       expect(injectQuery('C:\\User\\Vite\\Project', 'direct')).toEqual(
-        'C:\\User\\Vite\\Project?direct'
+        'C:/User/Vite/Project?direct'
       )
     })
   }
@@ -29,6 +28,12 @@ describe('injectQuery', () => {
     )
     expect(injectQuery('../usr/vite/%20a%20', 'direct')).toEqual(
       '../usr/vite/%20a%20?direct'
+    )
+  })
+
+  test('path with hash', () => {
+    expect(injectQuery('/usr/vite/path with space/#1?2/', 'direct')).toEqual(
+      '/usr/vite/path with space/?direct#1?2/'
     )
   })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -33,7 +33,7 @@ describe('injectQuery', () => {
 
   test('file path', () => {
     expect(injectQuery('file:///usr/vite/%20a%20', 'direct')).toMatch(
-      isWindows
+      !isWindows
         ? // d/a/vite/vite/file:/usr/vite/%20a%20?direct
           new RegExp(
             `${process.cwd().slice(1)}/file:/usr/vite/%20a%20\\?direct`

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -33,7 +33,13 @@ describe('injectQuery', () => {
 
   test('file path', () => {
     expect(injectQuery('file:///usr/vite/%20a%20', 'direct')).toMatch(
-      new RegExp(`${process.cwd().slice(1)}/file:/usr/vite/%20a%20\\?direct`)
+      isWindows
+        ? // d/a/vite/vite/file:/usr/vite/%20a%20?direct
+          new RegExp(
+            `${process.cwd().slice(1)}/file:/usr/vite/%20a%20\\?direct`
+          )
+        : // D:/a/vite/vite/file:/usr/vite/%20a%20?direct
+          new RegExp(`${process.cwd()}/file:/usr/vite/%20a%20\\?direct`)
     )
   })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -15,32 +15,29 @@ describe('injectQuery', () => {
     // this test will work incorrectly on unix systems
     test('normalize windows path', () => {
       expect(injectQuery('C:\\User\\Vite\\Project', 'direct')).toEqual(
-        'C:/User/Vite/Project?direct'
+        'C:\\User\\Vite\\Project?direct'
       )
     })
   }
 
-  test('relative path ""', () => {
+  test('relative path', () => {
     expect(injectQuery('usr/vite/%20a%20', 'direct')).toEqual(
       'usr/vite/%20a%20?direct'
     )
-  })
-
-  test('relative path "./"', () => {
     expect(injectQuery('./usr/vite/%20a%20', 'direct')).toEqual(
       './usr/vite/%20a%20?direct'
     )
-  })
-
-  test('relative path "../"', () => {
     expect(injectQuery('../usr/vite/%20a%20', 'direct')).toEqual(
       '../usr/vite/%20a%20?direct'
     )
   })
 
-  test('file path', () => {
+  test('path with protocol', () => {
     expect(injectQuery('file:///usr/vite/%20a%20', 'direct')).toMatch(
-      new RegExp(`file:///usr/vite/%20a%20\\?direct`)
+      'file:///usr/vite/%20a%20?direct'
+    )
+    expect(injectQuery('http://usr.vite/%20a%20', 'direct')).toMatch(
+      'http://usr.vite/%20a%20?direct'
     )
   })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -19,6 +19,24 @@ describe('injectQuery', () => {
     })
   }
 
+  test('relative path ""', () => {
+    expect(injectQuery('usr/vite/%20a%20', 'direct')).toEqual(
+      'usr/vite/%20a%20?direct'
+    )
+  })
+
+  test('relative path "./"', () => {
+    expect(injectQuery('./usr/vite/%20a%20', 'direct')).toEqual(
+      'usr/vite/%20a%20?direct'
+    )
+  })
+
+  test('file path', () => {
+    expect(injectQuery('file:///usr/vite/%20a%20', 'direct')).toMatch(
+      new RegExp(`${process.cwd().slice(1)}/file:/usr/vite/%20a%20\\?direct`)
+    )
+  })
+
   test('path with multiple spaces', () => {
     expect(injectQuery('/usr/vite/path with space', 'direct')).toEqual(
       '/usr/vite/path with space?direct'

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -311,16 +311,10 @@ export function injectQuery(url: string, queryToInject: string): string {
   if (resolvedUrl.protocol !== 'relative:') {
     resolvedUrl = pathToFileURL(url)
   }
-  let { protocol, pathname, search, hash } = resolvedUrl
-  // pathname must startWith '/'
-  // if url[0] is not '/' should be relative path
-  if (protocol === 'file:' || url[0] !== '/') {
-    pathname = pathname.slice(1)
-  }
-  pathname = decodeURIComponent(pathname)
-  return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
-    hash ?? ''
-  }`
+  const { search, hash } = resolvedUrl
+  return `${url.split('?')[0]}?${queryToInject}${
+    search ? `&` + search.slice(1) : ''
+  }${hash ?? ''}`
 }
 
 const timestampRE = /\bt=\d{13}&?\b/

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -312,7 +312,7 @@ export function injectQuery(url: string, queryToInject: string): string {
     resolvedUrl = pathToFileURL(url)
   }
   const { search, hash } = resolvedUrl
-  let pathname = normalizePath(url.replace(/#.*$/, '').replace(/\?.*$/, ''))
+  let pathname = normalizePath(cleanUrl(url))
   pathname = isWindows ? slash(pathname) : pathname
   return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
     hash ?? ''

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -312,9 +312,11 @@ export function injectQuery(url: string, queryToInject: string): string {
     resolvedUrl = pathToFileURL(url)
   }
   const { search, hash } = resolvedUrl
-  return `${url.split('?')[0]}?${queryToInject}${
-    search ? `&` + search.slice(1) : ''
-  }${hash ?? ''}`
+  let pathname = normalizePath(url.replace(/#.*$/, '').replace(/\?.*$/, ''))
+  pathname = isWindows ? slash(pathname) : pathname
+  return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
+    hash ?? ''
+  }`
 }
 
 const timestampRE = /\bt=\d{13}&?\b/

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -312,7 +312,7 @@ export function injectQuery(url: string, queryToInject: string): string {
     resolvedUrl = pathToFileURL(url)
   }
   const { search, hash } = resolvedUrl
-  let pathname = normalizePath(cleanUrl(url))
+  let pathname = cleanUrl(url)
   pathname = isWindows ? slash(pathname) : pathname
   return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
     hash ?? ''

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -312,7 +312,9 @@ export function injectQuery(url: string, queryToInject: string): string {
     resolvedUrl = pathToFileURL(url)
   }
   let { protocol, pathname, search, hash } = resolvedUrl
-  if (protocol === 'file:') {
+  // pathname must startWith '/'
+  // if url[0] is not '/' should be relative path
+  if (protocol === 'file:' || url[0] !== '/') {
     pathname = pathname.slice(1)
   }
   pathname = decodeURIComponent(pathname)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #9525

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

injectQuery break the relative path. if url[0] is not '/' should be relative path, should `.slice(1)`

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
