### PR TITLE
perf: legacy avoid insert the entry module css

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -557,6 +557,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           })
           chunk.viteMetadata.importedCss.add(this.getFileName(fileHandle))
         } else if (!config.build.ssr) {
+          // legacy build and inline css
+
+          // simple build will collect all entry module css into chunk.viteMetadata.importedCss
+          // and inject into the `index.html` same with legacy
+          // legacy build should avoid insert the entry module css again
+          if (chunk.isEntry) {
+            return null
+          }
           chunkCSS = await finalizeCss(chunkCSS, true, config)
           let cssString = JSON.stringify(chunkCSS)
           cssString =

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -559,9 +559,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         } else if (!config.build.ssr) {
           // legacy build and inline css
 
-          // simple build will collect all entry module css into chunk.viteMetadata.importedCss
-          // and inject into the `index.html` same with legacy
-          // legacy build should avoid insert the entry module css again
+          // the legacy build should avoid inserting entry CSS modules here, they
+          // will be collected into `chunk.viteMetadata.importedCss` and injected
+          // later by the `'vite:build-html'` plugin into the `index.html`
           if (chunk.isEntry) {
             return null
           }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

simple build will collect all entry module css into chunk.viteMetadata.importedCss and inject into the `index.html` same with legacy.

legacy build should avoid insert the entry module css again

the test would same with #9507. 

Sync chunk no generate the css but also had the style.
Async chunk should generate the css and had the style.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
