### PR TITLE
test: refactor config load

### DIFF
--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -180,12 +180,19 @@ beforeAll(async (s) => {
 })
 
 export async function startDefaultServe(): Promise<void> {
+  let config: UserConfig | null = null
   // config file near the *.spec.ts
-  const { config } = await loadConfigFromFile(
-    null,
+  const res = await loadConfigFromFile(
+    {
+      command: isBuild ? 'build' : 'serve',
+      mode: isBuild ? 'production' : 'development'
+    },
     undefined,
     dirname(testPath)
   )
+  if (res) {
+    config = res.config
+  }
 
   const options: InlineConfig = {
     root: rootDir,
@@ -253,7 +260,7 @@ export async function startDefaultServe(): Promise<void> {
   }
 }
 
-function startStaticServer(config?: UserConfig): Promise<string> {
+function startStaticServer(config: UserConfig): Promise<string> {
   // fallback internal base to ''
   let base = config?.base
   if (!base || base === '/' || base === './') {

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -199,7 +199,7 @@ export async function startDefaultServe(): Promise<void> {
   }
   // config file from test root dir
   if (!config) {
-    const res = await loadConfigFromDir(dirname(rootDir))
+    const res = await loadConfigFromDir(rootDir)
     if (res) {
       config = res.config
     }

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -178,10 +178,21 @@ beforeAll(async (s) => {
   }
 })
 
+function findConfigFile(dir: string): string | null {
+  for (const ext of ['.js', '.ts', '.mjs', '.mts', '.cjs', '.cts']) {
+    const configPath = resolve(dir, 'vite.config' + ext)
+    if (fs.existsSync(configPath)) {
+      return configPath
+    }
+  }
+  return null
+}
+
 export async function startDefaultServe(): Promise<void> {
-  const testCustomConfig = resolve(dirname(testPath), 'vite.config.js')
   let config: InlineConfig | undefined
-  if (fs.existsSync(testCustomConfig)) {
+  // config file near the *.spec.ts
+  const testCustomConfig = findConfigFile(dirname(testPath))
+  if (testCustomConfig) {
     // test has custom server configuration.
     config = await import(testCustomConfig).then((r) => r.default)
   }
@@ -254,10 +265,12 @@ function startStaticServer(
 ): Promise<string> {
   if (!config) {
     // check if the test project has base config
-    const configFile = resolve(rootDir, 'vite.config.js')
-    try {
-      config = require(configFile)
-    } catch (e) {}
+    const configFile = findConfigFile(rootDir)
+    if (configFile) {
+      try {
+        config = require(configFile)
+      } catch (e) {}
+    }
   }
 
   // fallback internal base to ''

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -260,21 +260,11 @@ export async function startDefaultServe(): Promise<void> {
 }
 
 function startStaticServer(
-  resolved: ResolvedConfig,
-  config?: InlineConfig
+  resolved: ResolvedConfig, // resolved config which load by test root dir
+  config?: InlineConfig // user config which near by test file
 ): Promise<string> {
-  if (!config) {
-    // check if the test project has base config
-    const configFile = findConfigFile(rootDir)
-    if (configFile) {
-      try {
-        config = require(configFile)
-      } catch (e) {}
-    }
-  }
-
   // fallback internal base to ''
-  let base = config?.base
+  let base = config?.base || resolved.base
   if (!base || base === '/' || base === './') {
     base = ''
   }
@@ -290,8 +280,12 @@ function startStaticServer(
   }
 
   // start static file server
-  const serve = sirv(resolve(rootDir, 'dist'), { dev: !!config?.build?.watch })
-  const baseDir = config?.testConfig?.baseRoute
+  const serve = sirv(resolve(rootDir, 'dist'), {
+    dev: !!config?.build?.watch || !!resolved.build.watch
+  })
+  // @ts-ignore
+  const baseDir =
+    config?.testConfig?.baseRoute || resolved?.testconfig?.baseRoute
   const httpServer = (server = http.createServer((req, res) => {
     if (req.url === '/ping') {
       res.statusCode = 200

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -283,8 +283,8 @@ function startStaticServer(
   const serve = sirv(resolve(rootDir, 'dist'), {
     dev: !!config?.build?.watch || !!resolved.build.watch
   })
-  // @ts-ignore
   const baseDir =
+    // @ts-ignore
     config?.testConfig?.baseRoute || resolved?.testconfig?.baseRoute
   const httpServer = (server = http.createServer((req, res) => {
     if (req.url === '/ping') {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

support load `vite.config.[[cm]?[jt]s]` near test file 

remove `startStaticServer` load test root config file. because `startStaticServer` using config attr is same with `resolvedConfig` is not need to load the config file again 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
