### PR TITLE
fix(ssr): fix crash when a pnpm/Yarn workspace depends on a CJS package

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -492,7 +492,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                 ) {
                   return
                 }
-              } else if (shouldExternalizeForSSR(specifier, config)) {
+              } else if (shouldExternalizeForSSR(specifier, importer, config)) {
                 return
               }
               if (isBuiltin(specifier)) {

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -69,7 +69,7 @@ export async function resolvePlugins(
       getDepsOptimizer: (ssr: boolean) => getDepsOptimizer(config, ssr),
       shouldExternalize:
         isBuild && config.build.ssr && config.ssr?.format !== 'cjs'
-          ? (id) => shouldExternalizeForSSR(id, config)
+          ? (id, importer) => shouldExternalizeForSSR(id, importer, config)
           : undefined,
     }),
     htmlInlineProxyPlugin(config),

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -69,7 +69,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
               (isInNodeModules(resolvedId) ||
                 optimizeDeps.include?.includes(id)) &&
               isOptimizable(resolvedId, optimizeDeps) &&
-              !(isBuild && ssr && isConfiguredAsExternal(id)) &&
+              !(isBuild && ssr && isConfiguredAsExternal(id, importer)) &&
               (!ssr || optimizeAliasReplacementForSSR(resolvedId, optimizeDeps))
             ) {
               // aliased dep has not yet been optimized

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -114,7 +114,7 @@ export interface InternalResolveOptions extends Required<ResolveOptions> {
   ssrOptimizeCheck?: boolean
   // Resolve using esbuild deps optimization
   getDepsOptimizer?: (ssr: boolean) => DepsOptimizer | undefined
-  shouldExternalize?: (id: string) => boolean | undefined
+  shouldExternalize?: (id: string, importer?: string) => boolean | undefined
 
   /**
    * Set by createResolver, we only care about the resolved id. moduleSideEffects
@@ -329,7 +329,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
       // bare package imports, perform node resolve
       if (bareImportRE.test(id)) {
-        const external = options.shouldExternalize?.(id)
+        const external = options.shouldExternalize?.(id, importer)
         if (
           !external &&
           asSrc &&

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -136,7 +136,7 @@ export function createIsConfiguredAsSsrExternal(
     try {
       return !!tryNodeResolve(
         id,
-        importer,
+        config.command === 'build' ? undefined : importer,
         resolveOptions,
         ssr?.target === 'webworker',
         undefined,

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -136,6 +136,8 @@ export function createIsConfiguredAsSsrExternal(
     try {
       return !!tryNodeResolve(
         id,
+        // Skip passing importer in build to avoid externalizing non-hoisted dependencies
+        // unresolveable from root (which would be unresolvable from output bundles also)
         config.command === 'build' ? undefined : importer,
         resolveOptions,
         ssr?.target === 'webworker',

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -92,11 +92,12 @@ const _require = createRequire(import.meta.url)
 
 const isSsrExternalCache = new WeakMap<
   ResolvedConfig,
-  (id: string) => boolean | undefined
+  (id: string, importer?: string) => boolean | undefined
 >()
 
 export function shouldExternalizeForSSR(
   id: string,
+  importer: string | undefined,
   config: ResolvedConfig,
 ): boolean | undefined {
   let isSsrExternal = isSsrExternalCache.get(config)
@@ -104,12 +105,12 @@ export function shouldExternalizeForSSR(
     isSsrExternal = createIsSsrExternal(config)
     isSsrExternalCache.set(config, isSsrExternal)
   }
-  return isSsrExternal(id)
+  return isSsrExternal(id, importer)
 }
 
 export function createIsConfiguredAsSsrExternal(
   config: ResolvedConfig,
-): (id: string) => boolean {
+): (id: string, importer?: string) => boolean {
   const { ssr, root } = config
   const noExternal = ssr?.noExternal
   const noExternalFilter =
@@ -126,6 +127,7 @@ export function createIsConfiguredAsSsrExternal(
 
   const isExternalizable = (
     id: string,
+    importer?: string,
     configuredAsExternal?: boolean,
   ): boolean => {
     if (!bareImportRE.test(id) || id.includes('\0')) {
@@ -134,7 +136,7 @@ export function createIsConfiguredAsSsrExternal(
     try {
       return !!tryNodeResolve(
         id,
-        undefined,
+        importer,
         resolveOptions,
         ssr?.target === 'webworker',
         undefined,
@@ -157,7 +159,7 @@ export function createIsConfiguredAsSsrExternal(
 
   // Returns true if it is configured as external, false if it is filtered
   // by noExternal and undefined if it isn't affected by the explicit config
-  return (id: string) => {
+  return (id: string, importer?: string) => {
     const { ssr } = config
     if (ssr) {
       if (
@@ -169,14 +171,14 @@ export function createIsConfiguredAsSsrExternal(
       }
       const pkgName = getNpmPackageName(id)
       if (!pkgName) {
-        return isExternalizable(id)
+        return isExternalizable(id, importer)
       }
       if (
         // A package name in ssr.external externalizes every
         // externalizable package entry
         ssr.external?.includes(pkgName)
       ) {
-        return isExternalizable(id, true)
+        return isExternalizable(id, importer, true)
       }
       if (typeof noExternal === 'boolean') {
         return !noExternal
@@ -185,24 +187,24 @@ export function createIsConfiguredAsSsrExternal(
         return false
       }
     }
-    return isExternalizable(id)
+    return isExternalizable(id, importer)
   }
 }
 
 function createIsSsrExternal(
   config: ResolvedConfig,
-): (id: string) => boolean | undefined {
+): (id: string, importer?: string) => boolean | undefined {
   const processedIds = new Map<string, boolean | undefined>()
 
   const isConfiguredAsExternal = createIsConfiguredAsSsrExternal(config)
 
-  return (id: string) => {
+  return (id: string, importer?: string) => {
     if (processedIds.has(id)) {
       return processedIds.get(id)
     }
     let external = false
     if (id[0] !== '.' && !path.isAbsolute(id)) {
-      external = isBuiltin(id) || isConfiguredAsExternal(id)
+      external = isBuiltin(id) || isConfiguredAsExternal(id, importer)
     }
     processedIds.set(id, external)
     return external

--- a/playground/ssr-deps/nested-external-cjs/index.js
+++ b/playground/ssr-deps/nested-external-cjs/index.js
@@ -1,0 +1,12 @@
+// Module with state, to check that it is properly externalized and
+// not bundled in the optimized deps
+let msg
+
+module.exports = {
+  setMessage(externalMsg) {
+    msg = externalMsg
+  },
+  getMessage() {
+    return msg
+  },
+}

--- a/playground/ssr-deps/nested-external-cjs/package.json
+++ b/playground/ssr-deps/nested-external-cjs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "nested-external-cjs",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "type": "commonjs"
+}

--- a/playground/ssr-deps/non-optimized-with-nested-external/index.js
+++ b/playground/ssr-deps/non-optimized-with-nested-external/index.js
@@ -1,3 +1,5 @@
 import { setMessage } from 'nested-external'
+import external from 'nested-external-cjs'
 
 setMessage('Hello World!')
+external.setMessage('Hello World!')

--- a/playground/ssr-deps/non-optimized-with-nested-external/package.json
+++ b/playground/ssr-deps/non-optimized-with-nested-external/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "main": "index.js",
   "dependencies": {
-    "nested-external": "file:../nested-external"
+    "nested-external": "file:../nested-external",
+    "nested-external-cjs": "file:../nested-external-cjs"
   }
 }

--- a/playground/ssr-deps/package.json
+++ b/playground/ssr-deps/package.json
@@ -23,7 +23,7 @@
     "@vitejs/test-no-external-cjs": "file:./no-external-cjs",
     "@vitejs/test-import-builtin-cjs": "file:./import-builtin-cjs",
     "@vitejs/test-no-external-css": "file:./no-external-css",
-    "@vitejs/test-non-optimized-with-nested-external": "file:./non-optimized-with-nested-external",
+    "@vitejs/test-non-optimized-with-nested-external": "workspace:*",
     "@vitejs/test-optimized-with-nested-external": "file:./optimized-with-nested-external",
     "@vitejs/test-optimized-cjs-with-nested-external": "file:./optimized-with-nested-external",
     "@vitejs/test-external-using-external-entry": "file:./external-using-external-entry",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1172,8 +1172,8 @@ importers:
         specifier: file:./no-external-css
         version: file:playground/ssr-deps/no-external-css
       '@vitejs/test-non-optimized-with-nested-external':
-        specifier: file:./non-optimized-with-nested-external
-        version: file:playground/ssr-deps/non-optimized-with-nested-external
+        specifier: workspace:*
+        version: link:non-optimized-with-nested-external
       '@vitejs/test-object-assigned-exports':
         specifier: file:./object-assigned-exports
         version: file:playground/ssr-deps/object-assigned-exports
@@ -1237,6 +1237,8 @@ importers:
 
   playground/ssr-deps/nested-external: {}
 
+  playground/ssr-deps/nested-external-cjs: {}
+
   playground/ssr-deps/no-external-cjs: {}
 
   playground/ssr-deps/no-external-css: {}
@@ -1246,6 +1248,9 @@ importers:
       nested-external:
         specifier: file:../nested-external
         version: file:playground/ssr-deps/nested-external
+      nested-external-cjs:
+        specifier: file:../nested-external-cjs
+        version: file:playground/ssr-deps/nested-external-cjs
 
   playground/ssr-deps/object-assigned-exports: {}
 
@@ -10713,6 +10718,12 @@ packages:
     version: 0.0.0
     dev: false
 
+  file:playground/ssr-deps/nested-external-cjs:
+    resolution: {directory: playground/ssr-deps/nested-external-cjs, type: directory}
+    name: nested-external-cjs
+    version: 0.0.0
+    dev: false
+
   file:playground/ssr-deps/no-external-cjs:
     resolution: {directory: playground/ssr-deps/no-external-cjs, type: directory}
     name: '@vitejs/test-no-external-cjs'
@@ -10723,14 +10734,6 @@ packages:
     resolution: {directory: playground/ssr-deps/no-external-css, type: directory}
     name: '@vitejs/test-no-external-css'
     version: 0.0.0
-    dev: false
-
-  file:playground/ssr-deps/non-optimized-with-nested-external:
-    resolution: {directory: playground/ssr-deps/non-optimized-with-nested-external, type: directory}
-    name: '@vitejs/test-non-optimized-with-nested-external'
-    version: 0.0.0
-    dependencies:
-      nested-external: file:playground/ssr-deps/nested-external
     dev: false
 
   file:playground/ssr-deps/object-assigned-exports:


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/issues/9710

Any pnpm/Yarn workspace that depends on any CommonJS package from npm will crash SSR.

Minimal reproductions:
- https://github.com/rtsao/vite-bug-repro-ssr-pnpm (pnpm)
- https://github.com/rtsao/vite-bug-repro-ssr-pnp (Yarn)

The externalizer logic unconditionally attempts to resolve encountered dependencies from the project root. This works fine with hoisted `node_modules` installations, but does not work with more strict installation schemes where only explicit dependencies are only resolvable (such as pnpm or Yarn PnP). In this case, the externalizer is unable to resolve the sub-dependency from the root, and as a result it is not externalized for SSR.

For example, suppose we have the following dependency graph:
`app` -> `dep-a` -> `dep-b`

With npm, `dep-b` is resolvable from `app` (the root) because it is hoisted:
```
code
├── node_modules
│   ├── dep-a
│   └── dep-b
└── app
```

However, pnpm and PnP ensure strictness where `dep-b` cannot be resolved from `app` (and must be resolved from `dep-a`):
```
code
└── app
    └── node_modules
        └── dep-a
            └── node_modules
                └── dep-b
```

In this case, `dep-b` fails to be externalized for SSR (resulting in errors if `dep-b` is CJS)

This PR fixes the issue by passing along the importer and resolving from the importer, thereby allowing it to be resolved correctly.

### Additional context

The externalization logic is memoized so resolution for a given package name only happens once. However, now resolution depends on two parameters: the package name and the importing path.

But taking into consideration the importing path would largely defeat the point of the cache as misses would be frequent.

I'm not super familiar with the intended logic of externalization, but I suppose a given package is OK to externalize as long as it was resolvable at some point. That being said, I think there probably needs to be more thinking about edge cases here, but I would need some help understanding the original context of this code.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
