### PR TITLE
chore: output tsconfck debug log

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -403,14 +403,17 @@ const tsconfckParseOptions: TSConfckParseOptions = {
 }
 
 async function initTSConfck(config: ResolvedConfig) {
-  tsconfckParseOptions.cache!.clear()
   const workspaceRoot = searchForWorkspaceRoot(config.root)
+  debug(`init TSConfck (root: ${colors.cyan(workspaceRoot)})`)
+
+  tsconfckParseOptions.cache!.clear()
   tsconfckParseOptions.root = workspaceRoot
   tsconfckParseOptions.tsConfigPaths = new Set([
     ...(await findAll(workspaceRoot, {
       skip: (dir) => dir === 'node_modules' || dir === '.git'
     }))
   ])
+  debug(`init TSConfck end`)
 }
 
 async function loadTsconfigJsonForFile(

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -404,7 +404,7 @@ const tsconfckParseOptions: TSConfckParseOptions = {
 
 async function initTSConfck(config: ResolvedConfig) {
   const workspaceRoot = searchForWorkspaceRoot(config.root)
-  debug(`init TSConfck (root: ${colors.cyan(workspaceRoot)})`)
+  debug(`init tsconfck (root: ${colors.cyan(workspaceRoot)})`)
 
   tsconfckParseOptions.cache!.clear()
   tsconfckParseOptions.root = workspaceRoot
@@ -413,7 +413,7 @@ async function initTSConfck(config: ResolvedConfig) {
       skip: (dir) => dir === 'node_modules' || dir === '.git'
     }))
   ])
-  debug(`init TSConfck end`)
+  debug(`init tsconfck end`)
 }
 
 async function loadTsconfigJsonForFile(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR adds a debug log to know which root is used for tsconfck and how long it took.

```
> pnpm dev --debug

> test-wasm@0.0.0 dev D:\documents\GitHub\vite\playground\wasm
> vite "--debug"

  vite:config bundled config file loaded in 75.40ms +0ms
  vite:esbuild init TSConfck (root: D:/documents/GitHub/vite) +0ms
  vite:esbuild init TSConfck end +47ms
```

close #9704

### Additional context
It's ideal to avoid this happening but I didn't come up with a good way to do it.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
