### PR TITLE
refactor: use `server.ssrTransform`

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -220,7 +220,8 @@ export interface ViteDevServer {
   ssrTransform(
     code: string,
     inMap: SourceMap | null,
-    url: string
+    url: string,
+    originalCode?: string
   ): Promise<TransformResult | null>
   /**
    * Load a given URL as an instantiated module for SSR.
@@ -339,8 +340,13 @@ export async function createServer(
     ws,
     moduleGraph,
     resolvedUrls: null, // will be set on listen
-    ssrTransform(code: string, inMap: SourceMap | null, url: string) {
-      return ssrTransform(code, inMap, url, code, server.config)
+    ssrTransform(
+      code: string,
+      inMap: SourceMap | null,
+      url: string,
+      originalCode = code
+    ) {
+      return ssrTransform(code, inMap, url, originalCode, server.config)
     },
     transformRequest(url, options) {
       return transformRequest(url, server, options)

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -16,7 +16,6 @@ import {
   timeFrom
 } from '../utils'
 import { checkPublicFile } from '../plugins/asset'
-import { ssrTransform } from '../ssr/ssrTransform'
 import { getDepsOptimizer } from '../optimizer'
 import { injectSourcesContent } from './sourcemap'
 import { isFileServingAllowed } from './middlewares/static'
@@ -259,13 +258,7 @@ async function loadAndTransform(
   }
 
   const result = ssr
-    ? await ssrTransform(
-        code,
-        map as SourceMap,
-        url,
-        originalCode,
-        server.config
-      )
+    ? await server.ssrTransform(code, map as SourceMap, url, originalCode)
     : ({
         code,
         map,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I am investigating the potential perf improvements of Vitest, and found that `ssrTransform` is taking a lot of time since it runs full AST parsing in JS for all modules. I am experimenting with a native port for this transformation to speed it up. This PR allows to swap the ssrTransform logic by replacing `server.ssrTransform` in a plugin and make the experiment testing outside of Vite core. (/cc @patak-dev)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
