### PR TITLE
feat: watch public files that are imported by JavaScript

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -137,7 +137,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       // will fail to resolve in the main resolver. handle them here.
       const publicFile = checkPublicFile(id, config)
       if (publicFile) {
-        return id
+        return { id: publicFile, meta: { publicUrl: id } }
       }
     },
 
@@ -148,15 +148,18 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
         return
       }
 
+      const moduleInfo = this.getModuleInfo(id)
+      const meta = (moduleInfo?.meta || {}) as { publicUrl?: string }
+
       // raw requests, read from disk
-      if (rawRE.test(id)) {
-        const file = checkPublicFile(id, config) || cleanUrl(id)
-        // raw query, read file and return as string
+      if (rawRE.test(meta.publicUrl || id)) {
+        const file = meta.publicUrl ? id : cleanUrl(id)
         return `export default ${JSON.stringify(
           await fsp.readFile(file, 'utf-8')
         )}`
       }
 
+      id = meta.publicUrl || id
       if (!config.assetsInclude(cleanUrl(id)) && !urlRE.test(id)) {
         return
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Because of how `resolveId` [in the assetPlugin](https://github.com/vitejs/vite/blob/246a087c45133f993aab58166579b68fdde1db13/packages/vite/src/node/plugins/asset.ts#L140) returns the virtual ID as-is, it's hard for me to associate file changes with a `ModuleNode` (the module node is addressed by the virtual ID instead of the absolute file path). This means public files imported in SSR won't trigger a hot reload.

To fix this, I'm returning `{ id: publicFile, meta: { publicUrl: id } }` from the resolveId hook in question. Unfortunately, returning `meta` from resolveId is not supported by Vite until #7477 or similar is merged, so this PR is blocked.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other