### PR TITLE
fix: Skip inlining Git LFS placeholders (fix #9714)

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -53,8 +53,10 @@ Specify the directory to nest generated assets under (relative to `build.outDir`
 
 Imported or referenced assets that are smaller than this threshold will be inlined as base64 URLs to avoid extra http requests. Set to `0` to disable inlining altogether.
 
+Git LFS placeholders are automatically excluded from inlining because they do not contain the content of the file they represent.
+
 ::: tip Note
-If you specify `build.lib`, `build.assetsInlineLimit` will be ignored and assets will always be inlined, regardless of file size.
+If you specify `build.lib`, `build.assetsInlineLimit` will be ignored and assets will always be inlined, regardless of file size or being a Git LFS placeholder.
 :::
 
 ## build.cssCodeSplit

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -26,6 +26,8 @@ The behavior is similar to webpack's `file-loader`. The difference is that the i
 
 - Assets smaller in bytes than the [`assetsInlineLimit` option](/config/build-options.md#build-assetsinlinelimit) will be inlined as base64 data URLs.
 
+- Git LFS placeholders are automatically excluded from inlining because they do not contain the content of the file they represent. To get inlining, make sure to download the file contents via Git LFS before building.
+
 ### Explicit URL Imports
 
 Assets that are not included in the internal list or in `assetsInclude`, can be explicitly imported as a URL using the `?url` suffix. This is useful, for example, to import [Houdini Paint Worklets](https://houdini.how/usage).

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -11,6 +11,7 @@ import type {
   RenderedChunk
 } from 'rollup'
 import MagicString from 'magic-string'
+import colors from 'picocolors'
 import { toOutputFilePathInString } from '../build'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
@@ -437,6 +438,12 @@ async function fileToBuiltUrl(
       content.length < Number(config.build.assetsInlineLimit) &&
       !isGitLfsPlaceholder(content))
   ) {
+    if (config.build.lib && isGitLfsPlaceholder(content)) {
+      config.logger.warn(
+        colors.yellow(`Inlined file ${id} was not downloaded via Git LFS`)
+      )
+    }
+
     const mimeType = mrmime.lookup(file) ?? 'application/octet-stream'
     // base64 inlined as a string
     url = `data:${mimeType};base64,${content.toString('base64')}`

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { parse as parseUrl } from 'node:url'
 import fs, { promises as fsp } from 'node:fs'
+import { Buffer } from 'node:buffer'
 import * as mrmime from 'mrmime'
 import type {
   NormalizedOutputOptions,
@@ -398,6 +399,13 @@ export function publicFileToBuiltUrl(
   return `__VITE_PUBLIC_ASSET__${hash}__`
 }
 
+const GIT_LFS_PREFIX = Buffer.from('version https://git-lfs.github.com')
+function isGitLfsPlaceholder(content: Buffer): boolean {
+  if (content.length < GIT_LFS_PREFIX.length) return false
+  // Check whether the content begins with the characteristic string of Git LFS placeholders
+  return GIT_LFS_PREFIX.compare(content, 0, GIT_LFS_PREFIX.length) === 0
+}
+
 /**
  * Register an asset to be emitted as part of the bundle (if necessary)
  * and returns the resolved public URL
@@ -426,7 +434,8 @@ async function fileToBuiltUrl(
     config.build.lib ||
     (!file.endsWith('.svg') &&
       !file.endsWith('.html') &&
-      content.length < Number(config.build.assetsInlineLimit))
+      content.length < Number(config.build.assetsInlineLimit) &&
+      !isGitLfsPlaceholder(content))
   ) {
     const mimeType = mrmime.lookup(file) ?? 'application/octet-stream'
     // base64 inlined as a string


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Git LFS placeholder files do not contain the actual file content and can therefore not be meaningfully inlined. This PR makes it so that they are automatically excluded from inlining. (Fixes https://github.com/vitejs/vite/issues/9714)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
