### PR TITLE
fix: enforce generating `module` param when needed in relative url resolving (fixes #9807)

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -5,6 +5,7 @@ import type {
   ExternalOption,
   InternalModuleFormat,
   ModuleFormat,
+  NormalizedOutputOptions,
   OutputOptions,
   Plugin,
   RollupBuild,
@@ -956,8 +957,10 @@ export function toOutputFilePathInString(
 
 export function ensureHavingSystemJSModuleParam(
   s: MagicString,
-  code: string
+  code: string,
+  opts: NormalizedOutputOptions
 ): void {
+  if (opts.format !== 'system') return
   const wrapIdx = code.indexOf('System.register')
   if (wrapIdx < 0) return
   const functionStr = 'function ('

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -182,7 +182,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       if (result) {
         const { s, needModuleParam } = result
         if (needModuleParam) {
-          ensureHavingSystemJSModuleParam(s, code)
+          ensureHavingSystemJSModuleParam(s, code, opts)
         }
         return {
           code: s.toString(),

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -589,7 +589,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           const s = new MagicString(code)
           s.appendLeft(insertIdx + insertMark.length, injectCode)
           if (cssRendered?.needModuleParam) {
-            ensureHavingSystemJSModuleParam(s, code)
+            ensureHavingSystemJSModuleParam(s, code, opts)
           }
           if (config.build.sourcemap) {
             // resolve public URL from CSS paths, we need to use absolute paths

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -358,7 +358,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           )
         }
         if (needModuleParam) {
-          ensureHavingSystemJSModuleParam(s, code)
+          ensureHavingSystemJSModuleParam(s, code, outputOptions)
         }
       }
       return result()


### PR DESCRIPTION
More details on the issue it fixes #9807 .

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
