### PR TITLE
fix: close socket when client error handled

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -190,7 +190,9 @@ export function setClientErrorHandler(
   logger: Logger
 ): void {
   server.on('clientError', (err, socket) => {
+    let msg = '400 Bad Request'
     if ((err as any).code === 'HPE_HEADER_OVERFLOW') {
+      msg = '431 Request Header Fields Too Large'
       logger.warn(
         colors.yellow(
           'Server responded with status code 431. ' +
@@ -198,5 +200,9 @@ export function setClientErrorHandler(
         )
       )
     }
+    if ((err as any).code === 'ECONNRESET' || !socket.writable) {
+      return
+    }
+    socket.end(`HTTP/1.1 ${msg}\r\n\r\n`)
   })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

According to the [Node.js docs](https://nodejs.org/api/http.html#event-clienterror), the default behavior of the event `clientError` is try close the socket with a http code 400 or 431.

If the socket is not closed, it will cause the page to hang in some cases.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
