### PR TITLE
fix: `completeSystemWrapPlugin` captures `function ()` (fixes #9807)

### DIFF
--- a/packages/vite/src/node/plugins/completeSystemWrap.ts
+++ b/packages/vite/src/node/plugins/completeSystemWrap.ts
@@ -4,7 +4,7 @@ import type { Plugin } from '../plugin'
  * make sure systemjs register wrap to had complete parameters in system format
  */
 export function completeSystemWrapPlugin(): Plugin {
-  const SystemJSWrapRE = /System.register\(.*\((exports)\)/g
+  const SystemJSWrapRE = /System.register\(.*(\(exports\)|\(\))/g
 
   return {
     name: 'vite:force-systemjs-wrap-complete',
@@ -13,7 +13,7 @@ export function completeSystemWrapPlugin(): Plugin {
       if (opts.format === 'system') {
         return {
           code: code.replace(SystemJSWrapRE, (s, s1) =>
-            s.replace(s1, 'exports, module')
+            s.replace(s1, '(exports, module)')
           ),
           map: null
         }


### PR DESCRIPTION
### Description
An alternative solution to PR #9808 that fixes #9807 , according to [the following suggestion](https://github.com/vitejs/vite/pull/9808#issuecomment-1225584007).

### Example
Before the fix I get the following output while compiling CSS in SystemJS format: (I intentionally told Vite to disable minifying for clarity)
```js
;

(function () {
  System.register([], function () {
    'use strict';

    var __vite_style__ = document.createElement('style');

    __vite_style__.innerHTML = "section.svelte-9si73t{position:relative;margin:0 auto 0 auto;padding:10rem var(--side-nav);max-width:120rem}section.svelte-9si73t h3{color:var(--text)}.blurb.svelte-1x9mfxv{display:grid;grid-row-gap:1em;grid-template-areas:'one'\n\t\t\t'two'\n\t\t\t'three'\n\t\t\t'what'\n\t\t\t'how'}.box.svelte-1x9mfxv{padding:1em;display:flex;flex-direction:column;border-bottom:none;color:var(--back);border-radius:var(--border-r)}.how.svelte-1x9mfxv{padding:1em;border-radius:var(--border-r)}.how.svelte-1x9mfxv pre{margin:0 0 1em 0}.how.svelte-1x9mfxv code{font-size:16px;line-height:1.5}.box.svelte-1x9mfxv>div,.how.svelte-1x9mfxv>div{display:flex;flex-direction:column;height:100%}.box.svelte-1x9mfxv p{flex:1}.box.svelte-1x9mfxv .cta,.how.svelte-1x9mfxv .cta{position:relative;max-width:15em;padding:0.8rem 1.6rem;border-radius:4px;background:var(--back);border:1px solid white;color:var(--second);font-size:var(--h6);text-decoration:none}.how.svelte-1x9mfxv .cta{border:1px solid var(--prime);background-color:var(--prime);color:white}.box.svelte-1x9mfxv .cta:hover{background:transparent;color:var(--back)}.how.svelte-1x9mfxv .cta:hover{background-color:transparent;color:var(--prime)}.box.svelte-1x9mfxv .cta::after,.how.svelte-1x9mfxv .cta::after{content:'';position:absolute;display:block;right:0.5em;top:0em;width:1em;height:100%;background:url(" + new URL('../assets/arrow-right-black-016727be.svg', module.meta.url).href + ");background-size:100% 100%}.how.svelte-1x9mfxv .cta::after{background-image:url(" + new URL('../assets/arrow-right-d58b4dfc.svg', module.meta.url).href + ")}.blurb.svelte-1x9mfxv .cta:hover::after{background-image:url(" + new URL('../assets/arrow-right-d58b4dfc.svg', module.meta.url).href + ")}.how.svelte-1x9mfxv .cta:hover::after{background-image:url(" + new URL('../assets/arrow-right-prime-3502f2ee.svg', module.meta.url).href + ")}.box.svelte-1x9mfxv h2{padding:0;margin:0 0 0.5em 0;font-size:var(--h2);font-weight:300;color:white}.blurb.svelte-1x9mfxv p{font-size:var(--h5)}.one.svelte-1x9mfxv{background:var(--prime);grid-area:one}.two.svelte-1x9mfxv{background:var(--flash);grid-area:two}.three.svelte-1x9mfxv{background:var(--second);grid-area:three}.how.svelte-1x9mfxv{min-width:0;grid-area:how;background:var(--back-light);box-shadow:inset 1px 1px 3px rgba(81, 81, 81, 0.2)}.what.svelte-1x9mfxv{margin:2em 0 0 0;grid-area:what}@media(min-width: 900px){.blurb.svelte-1x9mfxv{grid-column-gap:1em;grid-row-gap:1em;grid-template-columns:repeat(2, 1fr);grid-template-areas:'one two'\n\t\t\t\t'three how'\n\t\t\t\t'what what'}.box.svelte-1x9mfxv,.how.svelte-1x9mfxv{padding:2em}}@media(min-width: 1200px){.blurb.svelte-1x9mfxv{grid-column-gap:1em;grid-row-gap:5em;grid-template-columns:repeat(6, 1fr);grid-template-areas:'one one two two three three'\n\t\t\t\t'what what what how how how'}.what.svelte-1x9mfxv{margin:0}}.hero-banner.svelte-7m1vrc.svelte-7m1vrc{max-width:100vw;background:rgb(211, 214, 217);background:radial-gradient(34.14% 72.25% at 47.58% 31.75%, rgba(232, 244, 255, 0.52) 0%, rgba(255, 255, 255, 0) 100%),\nlinear-gradient(92.4deg, #D1D4D7 14.67%, rgba(238, 247, 255, 0.48) 54.37%, rgba(206, 216, 224, 0.62) 92.49%),\nlinear-gradient(0deg, #DBE7EF, #DBE7EF);position:relative;padding:8rem var(--side-nav) 0;display:flex;justify-content:flex-start;align-items:center;overflow:hidden}.hero-container.svelte-7m1vrc.svelte-7m1vrc{width:100%;max-width:90rem;margin:0 auto;justify-content:center}.hero-text.svelte-7m1vrc.svelte-7m1vrc{display:flex;flex-direction:column;justify-content:center;align-items:center;mix-blend-mode:multiply}.hero-banner.svelte-7m1vrc .tagline.svelte-7m1vrc{margin-top:0;position:relative;font-size:2rem;font-weight:200;line-height:1.2;letter-spacing:0.1em;text-align:center;text-transform:uppercase;color:var(--text);max-width:12em;font-family:var(--font)}.logotype.svelte-7m1vrc.svelte-7m1vrc{position:relative;width:100%;max-width:400px;margin:0 0 2rem 0}.hero-image.svelte-7m1vrc.svelte-7m1vrc{display:flex;flex:1;justify-content:center;align-items:center}.hero-image.svelte-7m1vrc img.svelte-7m1vrc{width:600px;height:450px;object-fit:cover;transform:translate(-2%,-10%)}@media(min-width: 480px){.hero-banner.svelte-7m1vrc .tagline.svelte-7m1vrc{max-width:auto}.hero-image.svelte-7m1vrc img.svelte-7m1vrc{width:800px;height:600px}}@media(min-width: 1024px){.hero-banner.svelte-7m1vrc.svelte-7m1vrc{padding:0 var(--side-nav)}.hero-text.svelte-7m1vrc.svelte-7m1vrc{margin-top:-10rem;align-items:flex-end;flex:1}.hero-image.svelte-7m1vrc.svelte-7m1vrc{flex:1.2}.hero-image.svelte-7m1vrc img.svelte-7m1vrc{width:480px;object-fit:contain;transform:scale(1.8)}.hero-banner.svelte-7m1vrc .tagline.svelte-7m1vrc{text-align:right;max-width:12em}.hero-container.svelte-7m1vrc.svelte-7m1vrc{height:70vh;display:flex;justify-content:flex-start;margin:0 auto;padding:0}}.icon.svelte-5yec89{position:relative;overflow:hidden;vertical-align:middle;-o-object-fit:contain;object-fit:contain;-webkit-transform-origin:center center;transform-origin:center center;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;fill:none}.progress-container.svelte-2v07tr{position:absolute;top:0;left:0;width:100%;height:4px;z-index:999}.progress.svelte-2v07tr{position:absolute;left:0;top:0;height:100%;background-color:var(--prime);transition:width 0.4s}.fade.svelte-2v07tr{position:fixed;width:100%;height:100%;background-color:rgba(255,255,255,0.3);pointer-events:none;z-index:998;animation:svelte-2v07tr-fade 0.4s}@keyframes svelte-2v07tr-fade{from{opacity:0 }to{opacity:1 }}.modal-background.svelte-y6pzn4.svelte-y6pzn4{position:fixed;width:100%;height:100%;top:0;left:0;background:rgba(255, 255, 255, 0.8);z-index:2;backdrop-filter:grayscale(0.5) blur(2px)}nav.svelte-y6pzn4.svelte-y6pzn4{--shadow-height:0.5rem;--shadow-gradient:linear-gradient(\n\t\t\tto bottom,\n\t\t\trgba(0, 0, 0, 0.1) 0%,\n\t\t\trgba(0, 0, 0, 0.05) 30%,\n\t\t\ttransparent 100%\n\t\t);position:fixed;width:100vw;height:var(--nav-h);margin:0 auto;background-color:white;font-family:var(--font);z-index:100;user-select:none;transition:transform 0.2s}nav.svelte-y6pzn4.svelte-y6pzn4::after{content:'';position:absolute;width:100%;height:var(--shadow-height);left:0;bottom:calc(-1 * var(--shadow-height));background:var(--shadow-gradient)}nav.svelte-y6pzn4.svelte-y6pzn4:not(.visible):not(:focus-within){transform:translate(0, calc(-100% - 1rem))}ul.svelte-y6pzn4.svelte-y6pzn4{position:relative;width:100%;padding:0;margin:0;list-style:none}ul.svelte-y6pzn4 a{color:var(--text)}.home.svelte-y6pzn4.svelte-y6pzn4{width:30rem;height:var(--nav-h);display:flex;text-indent:-9999px;background-position:calc(var(--side-nav) - 1rem) 50%;background-repeat:no-repeat;background-size:auto 70%}button.svelte-y6pzn4.svelte-y6pzn4{position:absolute;top:calc(var(--nav-h) / 2 - 1rem);right:var(--side-nav);line-height:1}@media(max-width: 799px){ul.svelte-y6pzn4.svelte-y6pzn4{position:relative;display:none;width:100%;background:white;padding:1rem var(--side-nav)}.open.svelte-y6pzn4 ul.svelte-y6pzn4{display:block}ul.external.svelte-y6pzn4.svelte-y6pzn4{padding:1rem var(--side-nav) 1rem}ul.external.svelte-y6pzn4.svelte-y6pzn4::before{content:'';position:absolute;top:0;left:var(--side-nav);width:calc(100% - 2 * var(--side-nav));height:1px;background:radial-gradient(circle at center, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05))}ul.external.svelte-y6pzn4.svelte-y6pzn4::after{content:'';position:absolute;width:100%;height:var(--shadow-height);left:0;bottom:calc(-1 * var(--shadow-height));background:var(--shadow-gradient)}}@media(min-width: 800px){.modal-background.svelte-y6pzn4.svelte-y6pzn4{display:none}nav.svelte-y6pzn4.svelte-y6pzn4{display:flex;align-items:center;justify-content:space-between}ul.svelte-y6pzn4.svelte-y6pzn4{display:flex;width:auto;height:100%}ul.svelte-y6pzn4 li{margin:0 0.5rem;padding:0}ul.svelte-y6pzn4 a{display:flex;align-items:center;height:100%}ul.external.svelte-y6pzn4.svelte-y6pzn4{width:30rem;padding:0 var(--side-nav) 0 0;justify-content:end}button.svelte-y6pzn4.svelte-y6pzn4{display:none}}a.svelte-pg3cgb{font-size:var(--h5)}a.svelte-pg3cgb:hover{color:var(--flash);opacity:1}[aria-current].svelte-pg3cgb{color:var(--prime)}a.svelte-odr4pc{background:white;color:var(--text);border:2px solid black;padding:8px;position:absolute;inset-block-start:0;inset-inline-start:0;transform:translateY(-100%);z-index:101}a.svelte-odr4pc:focus{transform:translateY(0%)}";
    document.head.appendChild(__vite_style__);
    return {
      execute: function execute() {
        var Section_svelte_svelte_type_style_lang = '';
        var Blurb_svelte_svelte_type_style_lang = '';
        var Hero_svelte_svelte_type_style_lang = '';
        var Icon_svelte_svelte_type_style_lang = '';
        var PreloadingIndicator_svelte_svelte_type_style_lang = '';
        var Nav_svelte_svelte_type_style_lang = '';
        var NavItem_svelte_svelte_type_style_lang = '';
        var SkipLink_svelte_svelte_type_style_lang = '';
      }
    };
  });
})();

```

The previous regex:
https://github.com/vitejs/vite/blob/b2c0ee04d4db4a0ef5a084c50f49782c5f88587c/packages/vite/src/node/plugins/completeSystemWrap.ts#L7
failed to capture this case when we have `System.register([], function () {`, without the `export parameter.

After this PR, this is done properly, and the output now is fixed and get the `module` parameter as well:
```js
;

(function () {
  System.register([], function (exports, module) {
    'use strict';

    var __vite_style__ = document.createElement('style');

    __vite_style__.innerHTML = "section.svelte-9si73t{position:relative;margin:0 auto 0 auto;padding:10rem var(--side-nav);max-width:120rem}section.svelte-9si73t h3{color:var(--text)}.blurb.svelte-1x9mfxv{display:grid;grid-row-gap:1em;grid-template-areas:'one'\n\t\t\t'two'\n\t\t\t'three'\n\t\t\t'what'\n\t\t\t'how'}.box.svelte-1x9mfxv{padding:1em;display:flex;flex-direction:column;border-bottom:none;color:var(--back);border-radius:var(--border-r)}.how.svelte-1x9mfxv{padding:1em;border-radius:var(--border-r)}.how.svelte-1x9mfxv pre{margin:0 0 1em 0}.how.svelte-1x9mfxv code{font-size:16px;line-height:1.5}.box.svelte-1x9mfxv>div,.how.svelte-1x9mfxv>div{display:flex;flex-direction:column;height:100%}.box.svelte-1x9mfxv p{flex:1}.box.svelte-1x9mfxv .cta,.how.svelte-1x9mfxv .cta{position:relative;max-width:15em;padding:0.8rem 1.6rem;border-radius:4px;background:var(--back);border:1px solid white;color:var(--second);font-size:var(--h6);text-decoration:none}.how.svelte-1x9mfxv .cta{border:1px solid var(--prime);background-color:var(--prime);color:white}.box.svelte-1x9mfxv .cta:hover{background:transparent;color:var(--back)}.how.svelte-1x9mfxv .cta:hover{background-color:transparent;color:var(--prime)}.box.svelte-1x9mfxv .cta::after,.how.svelte-1x9mfxv .cta::after{content:'';position:absolute;display:block;right:0.5em;top:0em;width:1em;height:100%;background:url(" + new URL('../assets/arrow-right-black-016727be.svg', module.meta.url).href + ");background-size:100% 100%}.how.svelte-1x9mfxv .cta::after{background-image:url(" + new URL('../assets/arrow-right-d58b4dfc.svg', module.meta.url).href + ")}.blurb.svelte-1x9mfxv .cta:hover::after{background-image:url(" + new URL('../assets/arrow-right-d58b4dfc.svg', module.meta.url).href + ")}.how.svelte-1x9mfxv .cta:hover::after{background-image:url(" + new URL('../assets/arrow-right-prime-3502f2ee.svg', module.meta.url).href + ")}.box.svelte-1x9mfxv h2{padding:0;margin:0 0 0.5em 0;font-size:var(--h2);font-weight:300;color:white}.blurb.svelte-1x9mfxv p{font-size:var(--h5)}.one.svelte-1x9mfxv{background:var(--prime);grid-area:one}.two.svelte-1x9mfxv{background:var(--flash);grid-area:two}.three.svelte-1x9mfxv{background:var(--second);grid-area:three}.how.svelte-1x9mfxv{min-width:0;grid-area:how;background:var(--back-light);box-shadow:inset 1px 1px 3px rgba(81, 81, 81, 0.2)}.what.svelte-1x9mfxv{margin:2em 0 0 0;grid-area:what}@media(min-width: 900px){.blurb.svelte-1x9mfxv{grid-column-gap:1em;grid-row-gap:1em;grid-template-columns:repeat(2, 1fr);grid-template-areas:'one two'\n\t\t\t\t'three how'\n\t\t\t\t'what what'}.box.svelte-1x9mfxv,.how.svelte-1x9mfxv{padding:2em}}@media(min-width: 1200px){.blurb.svelte-1x9mfxv{grid-column-gap:1em;grid-row-gap:5em;grid-template-columns:repeat(6, 1fr);grid-template-areas:'one one two two three three'\n\t\t\t\t'what what what how how how'}.what.svelte-1x9mfxv{margin:0}}.hero-banner.svelte-7m1vrc.svelte-7m1vrc{max-width:100vw;background:rgb(211, 214, 217);background:radial-gradient(34.14% 72.25% at 47.58% 31.75%, rgba(232, 244, 255, 0.52) 0%, rgba(255, 255, 255, 0) 100%),\nlinear-gradient(92.4deg, #D1D4D7 14.67%, rgba(238, 247, 255, 0.48) 54.37%, rgba(206, 216, 224, 0.62) 92.49%),\nlinear-gradient(0deg, #DBE7EF, #DBE7EF);position:relative;padding:8rem var(--side-nav) 0;display:flex;justify-content:flex-start;align-items:center;overflow:hidden}.hero-container.svelte-7m1vrc.svelte-7m1vrc{width:100%;max-width:90rem;margin:0 auto;justify-content:center}.hero-text.svelte-7m1vrc.svelte-7m1vrc{display:flex;flex-direction:column;justify-content:center;align-items:center;mix-blend-mode:multiply}.hero-banner.svelte-7m1vrc .tagline.svelte-7m1vrc{margin-top:0;position:relative;font-size:2rem;font-weight:200;line-height:1.2;letter-spacing:0.1em;text-align:center;text-transform:uppercase;color:var(--text);max-width:12em;font-family:var(--font)}.logotype.svelte-7m1vrc.svelte-7m1vrc{position:relative;width:100%;max-width:400px;margin:0 0 2rem 0}.hero-image.svelte-7m1vrc.svelte-7m1vrc{display:flex;flex:1;justify-content:center;align-items:center}.hero-image.svelte-7m1vrc img.svelte-7m1vrc{width:600px;height:450px;object-fit:cover;transform:translate(-2%,-10%)}@media(min-width: 480px){.hero-banner.svelte-7m1vrc .tagline.svelte-7m1vrc{max-width:auto}.hero-image.svelte-7m1vrc img.svelte-7m1vrc{width:800px;height:600px}}@media(min-width: 1024px){.hero-banner.svelte-7m1vrc.svelte-7m1vrc{padding:0 var(--side-nav)}.hero-text.svelte-7m1vrc.svelte-7m1vrc{margin-top:-10rem;align-items:flex-end;flex:1}.hero-image.svelte-7m1vrc.svelte-7m1vrc{flex:1.2}.hero-image.svelte-7m1vrc img.svelte-7m1vrc{width:480px;object-fit:contain;transform:scale(1.8)}.hero-banner.svelte-7m1vrc .tagline.svelte-7m1vrc{text-align:right;max-width:12em}.hero-container.svelte-7m1vrc.svelte-7m1vrc{height:70vh;display:flex;justify-content:flex-start;margin:0 auto;padding:0}}.icon.svelte-5yec89{position:relative;overflow:hidden;vertical-align:middle;-o-object-fit:contain;object-fit:contain;-webkit-transform-origin:center center;transform-origin:center center;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;fill:none}.progress-container.svelte-2v07tr{position:absolute;top:0;left:0;width:100%;height:4px;z-index:999}.progress.svelte-2v07tr{position:absolute;left:0;top:0;height:100%;background-color:var(--prime);transition:width 0.4s}.fade.svelte-2v07tr{position:fixed;width:100%;height:100%;background-color:rgba(255,255,255,0.3);pointer-events:none;z-index:998;animation:svelte-2v07tr-fade 0.4s}@keyframes svelte-2v07tr-fade{from{opacity:0 }to{opacity:1 }}.modal-background.svelte-y6pzn4.svelte-y6pzn4{position:fixed;width:100%;height:100%;top:0;left:0;background:rgba(255, 255, 255, 0.8);z-index:2;backdrop-filter:grayscale(0.5) blur(2px)}nav.svelte-y6pzn4.svelte-y6pzn4{--shadow-height:0.5rem;--shadow-gradient:linear-gradient(\n\t\t\tto bottom,\n\t\t\trgba(0, 0, 0, 0.1) 0%,\n\t\t\trgba(0, 0, 0, 0.05) 30%,\n\t\t\ttransparent 100%\n\t\t);position:fixed;width:100vw;height:var(--nav-h);margin:0 auto;background-color:white;font-family:var(--font);z-index:100;user-select:none;transition:transform 0.2s}nav.svelte-y6pzn4.svelte-y6pzn4::after{content:'';position:absolute;width:100%;height:var(--shadow-height);left:0;bottom:calc(-1 * var(--shadow-height));background:var(--shadow-gradient)}nav.svelte-y6pzn4.svelte-y6pzn4:not(.visible):not(:focus-within){transform:translate(0, calc(-100% - 1rem))}ul.svelte-y6pzn4.svelte-y6pzn4{position:relative;width:100%;padding:0;margin:0;list-style:none}ul.svelte-y6pzn4 a{color:var(--text)}.home.svelte-y6pzn4.svelte-y6pzn4{width:30rem;height:var(--nav-h);display:flex;text-indent:-9999px;background-position:calc(var(--side-nav) - 1rem) 50%;background-repeat:no-repeat;background-size:auto 70%}button.svelte-y6pzn4.svelte-y6pzn4{position:absolute;top:calc(var(--nav-h) / 2 - 1rem);right:var(--side-nav);line-height:1}@media(max-width: 799px){ul.svelte-y6pzn4.svelte-y6pzn4{position:relative;display:none;width:100%;background:white;padding:1rem var(--side-nav)}.open.svelte-y6pzn4 ul.svelte-y6pzn4{display:block}ul.external.svelte-y6pzn4.svelte-y6pzn4{padding:1rem var(--side-nav) 1rem}ul.external.svelte-y6pzn4.svelte-y6pzn4::before{content:'';position:absolute;top:0;left:var(--side-nav);width:calc(100% - 2 * var(--side-nav));height:1px;background:radial-gradient(circle at center, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.05))}ul.external.svelte-y6pzn4.svelte-y6pzn4::after{content:'';position:absolute;width:100%;height:var(--shadow-height);left:0;bottom:calc(-1 * var(--shadow-height));background:var(--shadow-gradient)}}@media(min-width: 800px){.modal-background.svelte-y6pzn4.svelte-y6pzn4{display:none}nav.svelte-y6pzn4.svelte-y6pzn4{display:flex;align-items:center;justify-content:space-between}ul.svelte-y6pzn4.svelte-y6pzn4{display:flex;width:auto;height:100%}ul.svelte-y6pzn4 li{margin:0 0.5rem;padding:0}ul.svelte-y6pzn4 a{display:flex;align-items:center;height:100%}ul.external.svelte-y6pzn4.svelte-y6pzn4{width:30rem;padding:0 var(--side-nav) 0 0;justify-content:end}button.svelte-y6pzn4.svelte-y6pzn4{display:none}}a.svelte-pg3cgb{font-size:var(--h5)}a.svelte-pg3cgb:hover{color:var(--flash);opacity:1}[aria-current].svelte-pg3cgb{color:var(--prime)}a.svelte-odr4pc{background:white;color:var(--text);border:2px solid black;padding:8px;position:absolute;inset-block-start:0;inset-inline-start:0;transform:translateY(-100%);z-index:101}a.svelte-odr4pc:focus{transform:translateY(0%)}";
    document.head.appendChild(__vite_style__);
    return {
      execute: function execute() {
        var Section_svelte_svelte_type_style_lang = '';
        var Blurb_svelte_svelte_type_style_lang = '';
        var Hero_svelte_svelte_type_style_lang = '';
        var Icon_svelte_svelte_type_style_lang = '';
        var PreloadingIndicator_svelte_svelte_type_style_lang = '';
        var Nav_svelte_svelte_type_style_lang = '';
        var NavItem_svelte_svelte_type_style_lang = '';
        var SkipLink_svelte_svelte_type_style_lang = '';
      }
    };
  });
})();

```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
