### PR TITLE
feat: relax dep browser externals as warning

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -276,7 +276,7 @@ module.exports = Object.create(new Proxy({}, {
       key !== 'constructor' &&
       key !== 'splice'
     ) {
-      throw new Error(\`Module "${path}" has been externalized for browser compatibility. Cannot access "${path}.\${key}" in client code.\`)
+      console.warn(\`Module "${path}" has been externalized for browser compatibility. Cannot access "${path}.\${key}" in client code.\`)
     }
   }
 }))`

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -149,16 +149,23 @@ test('flatten id should generate correctly', async () => {
 test.runIf(isServe)('error on builtin modules usage', () => {
   expect(browserLogs).toEqual(
     expect.arrayContaining([
-      // from dep-with-builtin-module-esm top-level try-catch
+      // from dep-with-builtin-module-esm
+      expect.stringMatching(/dep-with-builtin-module-esm.*is not a function/),
+      // dep-with-builtin-module-esm warnings
       expect.stringContaining(
-        'dep-with-builtin-module-esm Error: Module "fs" has been externalized for browser compatibility. Cannot access "fs.readFileSync" in client code.'
+        'Module "fs" has been externalized for browser compatibility. Cannot access "fs.readFileSync" in client code.'
       ),
       expect.stringContaining(
-        'dep-with-builtin-module-esm Error: Module "path" has been externalized for browser compatibility. Cannot access "path.join" in client code.'
+        'Module "path" has been externalized for browser compatibility. Cannot access "path.join" in client code.'
       ),
-      // from dep-with-builtin-module-cjs top-level try-catch
+      // from dep-with-builtin-module-cjs
+      expect.stringMatching(/dep-with-builtin-module-cjs.*is not a function/),
+      // dep-with-builtin-module-cjs warnings
       expect.stringContaining(
-        'dep-with-builtin-module-cjs Error: Module "path" has been externalized for browser compatibility. Cannot access "path.join" in client code.'
+        'Module "fs" has been externalized for browser compatibility. Cannot access "fs.readFileSync" in client code.'
+      ),
+      expect.stringContaining(
+        'Module "path" has been externalized for browser compatibility. Cannot access "path.join" in client code.'
       )
     ])
   )
@@ -167,11 +174,7 @@ test.runIf(isServe)('error on builtin modules usage', () => {
     expect.arrayContaining([
       // from user source code
       'Module "buffer" has been externalized for browser compatibility. Cannot access "buffer.Buffer" in client code.',
-      'Module "child_process" has been externalized for browser compatibility. Cannot access "child_process.execSync" in client code.',
-      // from dep-with-builtin-module-esm read()
-      'Module "fs" has been externalized for browser compatibility. Cannot access "fs.readFileSync" in client code.',
-      // from dep-with-builtin-module-esm read()
-      'Module "fs" has been externalized for browser compatibility. Cannot access "fs.readFileSync" in client code.'
+      'Module "child_process" has been externalized for browser compatibility. Cannot access "child_process.execSync" in client code.'
     ])
   )
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I believe this fixes #9200. I haven't tested it's repro but this PR likely fixes it.

The issue is that in Vite 3, we're stricter on deps that import nodejs modules by erroring when accessed. In Vite 2, there were simply undefined (even though we have a error proxy, esbuild's cjs-esm conversion bypasses it). This PR relaxes the error as a warning.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Looks like the reason deps access them, even if there are browser friendly is because they are doing a "try import and test if exist" flow, which isn't a great technique for browser compatibility. They should not use the nodejs module at all via `browsers` and `exports` field.

For now this should unblock them, but still with a warning.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
