### PR TITLE
fix: ensure version query for direct node_modules imports

### DIFF
--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -8,7 +8,12 @@ import type {
 } from '..'
 import type { Plugin } from '../plugin'
 import { createIsConfiguredAsSsrExternal } from '../ssr/ssrExternal'
-import { bareImportRE, isOptimizable, moduleListContains } from '../utils'
+import {
+  bareImportRE,
+  cleanUrl,
+  isOptimizable,
+  moduleListContains
+} from '../utils'
 import { getDepsOptimizer } from '../optimizer'
 import { tryOptimizedResolve } from './resolve'
 
@@ -48,7 +53,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
           })
           if (resolved && !depsOptimizer.isOptimizedDepFile(resolved.id)) {
             const optimizeDeps = depsOptimizer.options
-            const resolvedId = resolved.id
+            const resolvedId = cleanUrl(resolved.id)
             const isVirtual = resolvedId === id || resolvedId.includes('\0')
             if (
               !isVirtual &&

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -53,6 +53,8 @@ export const browserExternalId = '__vite-browser-external'
 // special id for packages that are optional peer deps
 export const optionalPeerDepId = '__vite-optional-peer-dep'
 
+const nodeModulesInPathRE = /(^|\/)node_modules\//
+
 const isDebug = process.env.DEBUG
 const debug = createDebugger('vite:resolve-details', {
   onlyWhenFocused: true
@@ -173,7 +175,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
           // as if they would have been imported through a bare import
           // Use the original id to do the check as the resolved id may be the real
           // file path after symlinks resolution
-          const isNodeModule = normalizePath(id).includes('/node_modules/')
+          const isNodeModule = !!normalizePath(id).match(nodeModulesInPathRE)
           if (isNodeModule && !resolved.match(DEP_VERSION_RE)) {
             const versionHash = depsOptimizer.metadata.browserHash
             if (versionHash && OPTIMIZABLE_ENTRY_RE.test(resolved)) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -6,9 +6,11 @@ import { resolve as _resolveExports } from 'resolve.exports'
 import { hasESMSyntax } from 'mlly'
 import type { Plugin } from '../plugin'
 import {
+  CLIENT_ENTRY,
   DEFAULT_EXTENSIONS,
   DEFAULT_MAIN_FIELDS,
   DEP_VERSION_RE,
+  ENV_ENTRY,
   FS_PREFIX,
   OPTIMIZABLE_ENTRY_RE,
   SPECIAL_QUERY_RE
@@ -41,6 +43,9 @@ import type { DepsOptimizer } from '../optimizer'
 import type { SSROptions } from '..'
 import type { PackageCache, PackageData } from '../packages'
 import { loadPackageData, resolvePackageData } from '../packages'
+
+const normalizedClientEntry = normalizePath(CLIENT_ENTRY)
+const normalizedEnvEntry = normalizePath(ENV_ENTRY)
 
 // special id for paths marked with browser: false
 // https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module
@@ -156,7 +161,14 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       }
 
       const ensureVersionQuery = (resolved: string): string => {
-        if (!options.isBuild && depsOptimizer) {
+        if (
+          !options.isBuild &&
+          depsOptimizer &&
+          !(
+            resolved === normalizedClientEntry ||
+            resolved === normalizedEnvEntry
+          )
+        ) {
           // Ensure that direct imports of node_modules have the same version query
           // as if they would have been imported through a bare import
           // Use the original id to do the check as the resolved id may be the real

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -155,6 +155,23 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         return optimizedPath
       }
 
+      const ensureVersionQuery = (resolved: string): string => {
+        if (!options.isBuild && depsOptimizer) {
+          // Ensure that direct imports of node_modules have the same version query
+          // as if they would have been imported through a bare import
+          // Use the original id to do the check as the resolved id may be the real
+          // file path after symlinks resolution
+          const isNodeModule = normalizePath(id).includes('/node_modules/')
+          if (isNodeModule && !resolved.match(DEP_VERSION_RE)) {
+            const versionHash = depsOptimizer.metadata.browserHash
+            if (versionHash && OPTIMIZABLE_ENTRY_RE.test(resolved)) {
+              resolved = injectQuery(resolved, `v=${versionHash}`)
+            }
+          }
+        }
+        return resolved
+      }
+
       // explicit fs paths that starts with /@fs/*
       if (asSrc && id.startsWith(FS_PREFIX)) {
         const fsPath = fsPathFromId(id)
@@ -162,7 +179,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         isDebug && debug(`[@fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         // always return here even if res doesn't exist since /@fs/ is explicit
         // if the file doesn't exist it should be a 404
-        return res || fsPath
+        return ensureVersionQuery(res || fsPath)
       }
 
       // URL
@@ -171,7 +188,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         const fsPath = path.resolve(root, id.slice(1))
         if ((res = tryFsResolve(fsPath, options))) {
           isDebug && debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
-          return res
+          return ensureVersionQuery(res)
         }
       }
 
@@ -201,26 +218,6 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
           return normalizedFsPath
         }
 
-        const pathFromBasedir = normalizedFsPath.slice(basedir.length)
-        if (pathFromBasedir.startsWith('/node_modules/')) {
-          // normalize direct imports from node_modules to bare imports, so the
-          // hashing logic is shared and we avoid duplicated modules #2503
-          const bareImport = pathFromBasedir.slice('/node_modules/'.length)
-          if (
-            (res = tryNodeResolve(
-              bareImport,
-              importer,
-              options,
-              targetWeb,
-              depsOptimizer,
-              ssr
-            )) &&
-            res.id.startsWith(normalizedFsPath)
-          ) {
-            return res
-          }
-        }
-
         if (
           targetWeb &&
           (res = tryResolveBrowserMapping(fsPath, importer, options, true))
@@ -229,6 +226,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         }
 
         if ((res = tryFsResolve(fsPath, options))) {
+          res = ensureVersionQuery(res)
           isDebug &&
             debug(`[relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           const pkg = importer != null && idToPkgMap.get(importer)
@@ -250,7 +248,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         if ((res = tryFsResolve(fsPath, options))) {
           isDebug &&
             debug(`[drive-relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
-          return res
+          return ensureVersionQuery(res)
         }
       }
 
@@ -260,7 +258,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         (res = tryFsResolve(id, options))
       ) {
         isDebug && debug(`[fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
-        return res
+        return ensureVersionQuery(res)
       }
 
       // external
@@ -405,7 +403,7 @@ function tryFsResolve(
 
   let res: string | undefined
 
-  // if we fould postfix exist, we should first try resolving file with postfix. details see #4703.
+  // if there is a postfix, try resolving it as a complete path first (#4703)
   if (
     postfix &&
     (res = tryResolveFile(

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -146,6 +146,12 @@ test('flatten id should generate correctly', async () => {
   expect(await page.textContent('.clonedeep-dot')).toBe('clonedeep-dot')
 })
 
+test('non optimized module is not duplicated', async () => {
+  expect(
+    await page.textContent('.non-optimized-module-is-not-duplicated')
+  ).toBe('from-absolute-path, from-relative-path')
+})
+
 test.runIf(isServe)('error on builtin modules usage', () => {
   expect(browserLogs).toEqual(
     expect.arrayContaining([

--- a/playground/optimize-deps/dep-non-optimized/index.js
+++ b/playground/optimize-deps/dep-non-optimized/index.js
@@ -1,0 +1,6 @@
+// Scheme check that imports from different paths are resolved to the same module
+const messages = []
+export const add = (message) => {
+  messages.push(message)
+}
+export const get = () => messages

--- a/playground/optimize-deps/dep-non-optimized/package.json
+++ b/playground/optimize-deps/dep-non-optimized/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep-non-optimized",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -87,6 +87,9 @@
 <div class="clonedeep-slash"></div>
 <div class="clonedeep-dot"></div>
 
+<h2>Non Optimized Module isn't duplicated</h2>
+<div class="non-optimized-module-is-not-duplicated"></div>
+
 <script>
   function text(el, text) {
     document.querySelector(el).textContent = text
@@ -145,6 +148,18 @@
   text('.url', parse('https://vitejs.dev').hostname)
 
   import './index.astro'
+
+  // All these imports should end up resolved to the same URL (same ?v= injected on them)
+  import { add as addFromDirectAbsolutePath } from '/node_modules/dep-non-optimized/index.js'
+  import { add as addFromDirectRelativePath } from './node_modules/dep-non-optimized/index.js'
+  import { get as getFromBareImport } from 'dep-non-optimized'
+
+  addFromDirectAbsolutePath('from-absolute-path')
+  addFromDirectRelativePath('from-relative-path')
+  text(
+    '.non-optimized-module-is-not-duplicated',
+    getFromBareImport().join(', ')
+  )
 </script>
 
 <script type="module">

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -24,6 +24,7 @@
     "dep-with-builtin-module-esm": "file:./dep-with-builtin-module-esm",
     "dep-with-dynamic-import": "file:./dep-with-dynamic-import",
     "dep-with-optional-peer-dep": "file:./dep-with-optional-peer-dep",
+    "dep-non-optimized": "file:./dep-non-optimized",
     "added-in-entries": "file:./added-in-entries",
     "lodash-es": "^4.17.21",
     "nested-exclude": "file:./nested-exclude",

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -22,7 +22,7 @@ module.exports = {
       // will throw if optimized (should log warning instead)
       'non-optimizable-include'
     ],
-    exclude: ['nested-exclude'],
+    exclude: ['nested-exclude', 'dep-non-optimized'],
     esbuildOptions: {
       plugins: [
         {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,7 @@ importers:
       dep-linked: link:./dep-linked
       dep-linked-include: link:./dep-linked-include
       dep-node-env: file:./dep-node-env
+      dep-non-optimized: file:./dep-non-optimized
       dep-not-js: file:./dep-not-js
       dep-relative-to-main: file:./dep-relative-to-main
       dep-with-builtin-module-cjs: file:./dep-with-builtin-module-cjs
@@ -660,6 +661,7 @@ importers:
       dep-linked: link:dep-linked
       dep-linked-include: link:dep-linked-include
       dep-node-env: file:playground/optimize-deps/dep-node-env
+      dep-non-optimized: file:playground/optimize-deps/dep-non-optimized
       dep-not-js: file:playground/optimize-deps/dep-not-js
       dep-relative-to-main: file:playground/optimize-deps/dep-relative-to-main
       dep-with-builtin-module-cjs: file:playground/optimize-deps/dep-with-builtin-module-cjs
@@ -708,6 +710,9 @@ importers:
       react: 18.2.0
 
   playground/optimize-deps/dep-node-env:
+    specifiers: {}
+
+  playground/optimize-deps/dep-non-optimized:
     specifiers: {}
 
   playground/optimize-deps/dep-not-js:
@@ -9305,6 +9310,12 @@ packages:
   file:playground/optimize-deps/dep-node-env:
     resolution: {directory: playground/optimize-deps/dep-node-env, type: directory}
     name: dep-node-env
+    version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-non-optimized:
+    resolution: {directory: playground/optimize-deps/dep-non-optimized, type: directory}
+    name: dep-non-optimized
     version: 1.0.0
     dev: false
 


### PR DESCRIPTION
Fixes #7621
Fixes #2503 (with a different approach after reverting #2848)
Closes #9730

Potentially unblocks SvelteKit, as it will fix the issue described in #9828 if the direct node_modules import is in a JS source instead of a script tag. We aren't resolving the URL in script tags AFAICS, I'll check if this is something we should start doing. @Rich-Harris @benmccann would you confirm that this is something needed by SvelteKit, or it is just an artifact of how the reproduction was built (I'm assuming it is the later, and this PR may also then fix #9828)

### Description

We mark non-optimized node_modules imports with a `?v={browserHash}` query [here](https://github.com/vitejs/vite/blob/5df788dfe2d89e541461e166f03afb38c2f1dd7e/packages/vite/src/node/plugins/resolve.ts#L769)
```ts
  if (skipOptimization) {
    // excluded from optimization
    // Inject a version query to npm deps so that the browser
    // can cache it without re-validation, but only do so for known js types.
    // otherwise we may introduce duplicated modules for externalized files
    // from pre-bundled deps.
    if (!isBuild) {
      const versionHash = depsOptimizer!.metadata.browserHash
      if (versionHash && isJsType) {
        resolved = injectQuery(resolved, `v=${versionHash}`)
      }
    }
  } 
```
This allows us to cache npm dependencies (even if they aren't optimized). See [here](https://github.com/vitejs/vite/blob/5df788dfe2d89e541461e166f03afb38c2f1dd7e/packages/vite/src/node/server/middlewares/transform.ts#L191)
```ts
  const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
  const type = isDirectCSSRequest(url) ? 'css' : 'js'
  const isDep =
    DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
  return send(req, res, result.code, type, {
    etag: result.etag,
    // allow browser to cache npm deps!
    cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
    headers: server.config.server.headers,
    map: result.map
  })
```
We need the version query because once we re-optimize, we need to resend also the non-optimized node_modules files as they may have imported optimized modules so their imports needs to be rewritten to the new cached files.

Before this PR, we only added the version query to bare imports, and after #2848, also to relative imports of node_modules. After this PR, we are ensuring the version query also for all other ways to direct import a file in node_modules. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other