### PR TITLE
fix: intermittent failures in playground/server-origin test

### DIFF
--- a/playground/vue-server-origin/__tests__/vue-server-origin.spec.ts
+++ b/playground/vue-server-origin/__tests__/vue-server-origin.spec.ts
@@ -4,7 +4,7 @@ import { isBuild, page } from '~utils'
 test('should render', async () => {
   const expected = isBuild
     ? /assets\/asset\.[0-9a-f]+\.png/
-    : /https:\/\/vue-server-origin\.test\/assets\/asset\.png/
+    : 'http://localhost/server-origin/test/assets/asset.png'
 
   expect(await page.getAttribute('img', 'src')).toMatch(expected)
   expect(await page.getAttribute('img:nth-child(2)', 'src')).toMatch(expected)

--- a/playground/vue-server-origin/vite.config.ts
+++ b/playground/vue-server-origin/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   },
   plugins: [vuePlugin()],
   server: {
-    origin: 'https://vue-server-origin.test'
+    origin: 'http://localhost/server-origin/test'
   },
   build: {
     // to make tests faster


### PR DESCRIPTION
fix #9849

<!-- Thank you for contributing! -->

### Description

Updates `playground/vue-server-origin` test to use localhost instead of `https://vue-server-origin.test`, which causes intermittent failures as the test browser tries to resolve it.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
