### PR TITLE
fix: appType mpa

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -543,7 +543,7 @@ export async function createServer(
 
   // spa fallback
   if (config.appType === 'spa' || config.appType === 'mpa') {
-    middlewares.use(spaFallbackMiddleware(root))
+    middlewares.use(spaFallbackMiddleware(root, config.appType === 'spa'))
   }
 
   // run post config hooks

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -542,7 +542,7 @@ export async function createServer(
   middlewares.use(serveStaticMiddleware(root, server))
 
   // spa fallback
-  if (config.appType === 'spa') {
+  if (config.appType === 'spa' || config.appType === 'mpa') {
     middlewares.use(spaFallbackMiddleware(root))
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -50,7 +50,7 @@ import type { WebSocketServer } from './ws'
 import { createWebSocketServer } from './ws'
 import { baseMiddleware } from './middlewares/base'
 import { proxyMiddleware } from './middlewares/proxy'
-import { spaFallbackMiddleware } from './middlewares/spaFallback'
+import { rewriteUrlMiddleware } from './middlewares/rewriteUrl'
 import { transformMiddleware } from './middlewares/transform'
 import {
   createDevHtmlTransformFn,
@@ -543,7 +543,7 @@ export async function createServer(
 
   // spa fallback
   if (config.appType === 'spa' || config.appType === 'mpa') {
-    middlewares.use(spaFallbackMiddleware(root, config.appType === 'spa'))
+    middlewares.use(rewriteUrlMiddleware(root, config.appType === 'spa'))
   }
 
   // run post config hooks

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -287,7 +287,7 @@ export function indexHtmlMiddleware(
     }
 
     const url = req.url && cleanUrl(req.url)
-    // spa-fallback always redirects to /index.html
+    // rewriteUrlMiddleware() appends '.html' to URLs
     if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {
       const filename = getHtmlFilename(url, server)
       if (fs.existsSync(filename)) {

--- a/packages/vite/src/node/server/middlewares/rewriteUrl.ts
+++ b/packages/vite/src/node/server/middlewares/rewriteUrl.ts
@@ -4,7 +4,7 @@ import history from 'connect-history-api-fallback'
 import type { Connect } from 'types/connect'
 import { createDebugger } from '../../utils'
 
-export function spaFallbackMiddleware(
+export function rewriteUrlMiddleware(
   root: string,
   spaFallback: boolean
 ): Connect.NextHandleFunction {

--- a/packages/vite/src/node/server/middlewares/spaFallback.ts
+++ b/packages/vite/src/node/server/middlewares/spaFallback.ts
@@ -5,7 +5,8 @@ import type { Connect } from 'types/connect'
 import { createDebugger } from '../../utils'
 
 export function spaFallbackMiddleware(
-  root: string
+  root: string,
+  spaFallback: boolean
 ): Connect.NextHandleFunction {
   const historySpaFallbackMiddleware = history({
     logger: createDebugger('vite:spa-fallback'),
@@ -20,7 +21,9 @@ export function spaFallbackMiddleware(
           if (fs.existsSync(path.join(root, rewritten))) {
             return rewritten
           } else {
-            return `/index.html`
+            if (spaFallback) {
+              return `/index.html`
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix `appType: 'mpa'` which currently doesn't work: `indexHtmlMiddleware()` doesn't work without `spaFallbackMiddleware()`. In other words MPAs also need `spaFallbackMiddleware()`.

This seems to have been a glitch we missed at #8452.

### Additional context

This is a blocker for Telefunc.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
