### PR TITLE
feat: dangerously allow empty envPrefix

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -342,6 +342,17 @@ Env variables starting with `envPrefix` will be exposed to your client source co
 `envPrefix` should not be set as `''`, which will expose all your env variables and cause unexpected leaking of sensitive information. Vite will throw an error when detecting `''`.
 :::
 
+## dangerouslyAllowEmptyEnvPrefix
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Set to `true` to allow `envPrefix` to be set as `''`. See [envPrefix](/config/shared-options.html#envprefix) for more information.
+
+:::warning SECURITY NOTES
+This option circumvents the error thrown when using `''` as `envPrefix`. This option exposes your application to a serious security risk and should only be used as a last resort.
+:::
+
 ## appType
 
 - **Type:** `'spa' | 'mpa' | 'custom'`

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -203,6 +203,14 @@ describe('resolveEnvPrefix', () => {
     const config: UserConfig = { envPrefix: [' ', 'CUSTOM_'] }
     expect(resolveEnvPrefix(config)).toMatchObject([' ', 'CUSTOM_'])
   })
+
+  test('should not throw an error if empty, but dangerouslyAllowEmptyEnvPrefix is set to true', () => {
+    const config: UserConfig = {
+      envPrefix: '',
+      dangerouslyAllowEmptyEnvPrefix: true
+    }
+    expect(resolveEnvPrefix(config)).toMatchObject([''])
+  })
 })
 
 describe('preview config', () => {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -230,6 +230,12 @@ export interface UserConfig {
    */
   envPrefix?: string | string[]
   /**
+   * Dangerously allow envPrefix to be set to an empty string.
+   * WARNING: This option can potentially expose your secret environment variables to your client source code.
+   * @default false
+   */
+  dangerouslyAllowEmptyEnvPrefix?: boolean
+  /**
    * Worker bundle options
    */
   worker?: {

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -70,9 +70,13 @@ export function loadEnv(
 }
 
 export function resolveEnvPrefix({
-  envPrefix = 'VITE_'
+  envPrefix = 'VITE_',
+  dangerouslyAllowEmptyEnvPrefix = false
 }: UserConfig): string[] {
   envPrefix = arraify(envPrefix)
+  if (dangerouslyAllowEmptyEnvPrefix) {
+    return envPrefix
+  }
   if (envPrefix.some((prefix) => prefix === '')) {
     throw new Error(
       `envPrefix option contains value '', which could lead unexpected exposure of sensitive information.`


### PR DESCRIPTION
Provide an option to disable to warning and subsequent error when configuring Vite with an empty `envPrefix` option.

<!-- Thank you for contributing! -->

### Description

Current behaviour of Vite is to warn and exit with an error when supplying `''` as a value for the `envConfig` configuration option.

In certain cases a project owner should be able to accept the risk and ensure the project isn't exposed to security risks in another way, such as containerised build environment with limited variables.

#### Alternatives Considered

One can technically list the first couple of characters of all of the environment variables that they would like to allow, e.g.:

```ts
defineConfig({
  // ...
  envPrefix: [
    "A",
    "B",
    "C",
    "D",
    "E",
    "F",
    "G",
    "H",
    "I",
    "J",
    "K",
    "L",
    "M",
    "N",
    "O",
    "P",
    "Q",
    "R",
    "S",
    "T",
    "U",
    "V",
    "W",
    "X",
    "Y",
    "Z",
  ],
  // ...
});
```

But a much more pragmatic way to solve this is to allow the user to pass in an option that **explicitly** disables this check. With this pull request I propose the addition of `dangerouslyAllowEmptyEnvPrefix` option, which defaults to `false` and when set to `true` allows the usage of `''` as a value for `envPrefix`. 

### Additional context

In docs, I purposefully did not refer to this option in the description for `envPrefix` option. This new option should be something people stumble upon as a way to solve their problem rather than considered as just something to set to `true` to remove an inconvenience.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
