### PR TITLE
fix(types): explicitly set Vite hooks' `this` to `void`

### DIFF
--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -55,7 +55,10 @@ export interface Plugin extends RollupPlugin {
   /**
    * Apply the plugin only for serve or build, or on certain conditions.
    */
-  apply?: 'serve' | 'build' | ((config: UserConfig, env: ConfigEnv) => boolean)
+  apply?:
+    | 'serve'
+    | 'build'
+    | ((this: void, config: UserConfig, env: ConfigEnv) => boolean)
   /**
    * Modify vite config before it's resolved. The hook can either mutate the
    * passed-in config directly, or return a partial config object that will be
@@ -66,6 +69,7 @@ export interface Plugin extends RollupPlugin {
    */
   config?: ObjectHook<
     (
+      this: void,
       config: UserConfig,
       env: ConfigEnv
     ) => UserConfig | null | void | Promise<UserConfig | null | void>
@@ -73,7 +77,9 @@ export interface Plugin extends RollupPlugin {
   /**
    * Use this hook to read and store the final resolved vite config.
    */
-  configResolved?: ObjectHook<(config: ResolvedConfig) => void | Promise<void>>
+  configResolved?: ObjectHook<
+    (this: void, config: ResolvedConfig) => void | Promise<void>
+  >
   /**
    * Configure the vite server. The hook receives the {@link ViteDevServer}
    * instance. This can also be used to store a reference to the server
@@ -126,6 +132,7 @@ export interface Plugin extends RollupPlugin {
    */
   handleHotUpdate?: ObjectHook<
     (
+      this: void,
       ctx: HmrContext
     ) => Array<ModuleNode> | void | Promise<Array<ModuleNode> | void>
   >

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -846,6 +846,7 @@ export interface IndexHtmlTransformContext {
 }
 
 export type IndexHtmlTransformHook = (
+  this: void,
   html: string,
   ctx: IndexHtmlTransformContext
 ) => IndexHtmlTransformResult | void | Promise<IndexHtmlTransformResult | void>

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -62,10 +62,13 @@ export interface PreviewServer {
   printUrls(): void
 }
 
-export type PreviewServerHook = (server: {
-  middlewares: Connect.Server
-  httpServer: http.Server
-}) => (() => void) | void | Promise<(() => void) | void>
+export type PreviewServerHook = (
+  this: void,
+  server: {
+    middlewares: Connect.Server
+    httpServer: http.Server
+  }
+) => (() => void) | void | Promise<(() => void) | void>
 
 /**
  * Starts the Vite server in preview mode, to simulate a production deployment

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -151,6 +151,7 @@ export interface FileSystemServeOptions {
 }
 
 export type ServerHook = (
+  this: void,
   server: ViteDevServer
 ) => (() => void) | void | Promise<(() => void) | void>
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

With the object hooks introduced, plugins should not rely on the implicit `this` from the plugin object for Vite custom plugins. This PR explicitly set them to `void` to provide early TypeScript hints.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
