### PR TITLE
fix(css): remove css-post plugin sourcemap

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -380,7 +380,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
         const cssContent = await getContentWithSourcemap(css)
         const devBase = config.base
-        return [
+        const code = [
           `import { updateStyle as __vite__updateStyle, removeStyle as __vite__removeStyle } from ${JSON.stringify(
             path.posix.join(devBase, CLIENT_PUBLIC_PATH)
           )}`,
@@ -394,6 +394,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           }`,
           `import.meta.hot.prune(() => __vite__removeStyle(__vite__id))`
         ].join('\n')
+        return { code, map: { mappings: '' } }
       }
 
       // build CSS handling ----------------------------------------------------

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -90,6 +90,15 @@ describe.runIf(isServe)('serve', () => {
     `)
   })
 
+  test.runIf(isServe)('linked css with import', async () => {
+    const res = await page.request.get(
+      new URL('./linked-with-import.css', page.url()).href
+    )
+    const content = await res.text()
+    const lines = content.trim().split('\n')
+    expect(lines[lines.length - 1]).not.toMatch(/^\/\/#/)
+  })
+
   test('imported css', async () => {
     const css = await getStyleTagContentIncluding('.imported ')
     const map = extractSourcemap(css)

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -90,14 +90,17 @@ describe.runIf(isServe)('serve', () => {
     `)
   })
 
-  test.runIf(isServe)('linked css with import', async () => {
-    const res = await page.request.get(
-      new URL('./linked-with-import.css', page.url()).href
-    )
-    const content = await res.text()
-    const lines = content.trim().split('\n')
-    expect(lines[lines.length - 1]).not.toMatch(/^\/\/#/)
-  })
+  test.runIf(isServe)(
+    'js .css request does not include sourcemap',
+    async () => {
+      const res = await page.request.get(
+        new URL('./linked-with-import.css', page.url()).href
+      )
+      const content = await res.text()
+      const lines = content.trim().split('\n')
+      expect(lines[lines.length - 1]).not.toMatch(/^\/\/#/)
+    }
+  )
 
   test('imported css', async () => {
     const css = await getStyleTagContentIncluding('.imported ')


### PR DESCRIPTION
### Description
fixes #9830

`/src/components/HelloWorld.vue` has the sourcemap below.
```json
{
  "version": 3,
  "mappings": "AACA;AAEA;AAAA,EACA;AAAA,IACA;AAAA,EACA;AAAA,EACA;AACA;AACA;AAAA,MACA;AAAA,IACA;AAAA,EACA;AACA",
  "names": [],
  "sources": [
    "/home/projects/mkliybgym.github/src/components/HelloWorld.vue"
  ],
  "file": "/home/projects/mkliybgym.github/src/components/HelloWorld.vue",
  "sourcesContent": [
    "<script lang=\"ts\">\nimport Vue from 'vue';\n\nexport default Vue.extend({\n  props: {\n    msg: { type: String },\n  },\n  data() {\ndebugger;\n    return {\n      count: 0,\n    };\n  },\n});\n</script>\n\n<template>\n  <div>\n    <h1>{{ msg }}</h1>\n\n    <div class=\"card\">\n      <button type=\"button\" @click=\"count++\">count is {{ count }}</button>\n      <p>\n        Edit\n        <code>components/HelloWorld.vue</code> to test HMR\n      </p>\n    </div>\n\n    <p>\n      Check out\n      <a href=\"https://vuejs.org/guide/quick-start.html#local\" target=\"_blank\"\n        >create-vue</a\n      >, the official Vue + Vite starter\n    </p>\n    <p>\n      Install\n      <a href=\"https://github.com/johnsoncodehk/volar\" target=\"_blank\">Volar</a>\n      in your IDE for a better DX\n    </p>\n    <p class=\"read-the-docs\">Click on the Vite and Vue logos to learn more</p>\n  </div>\n</template>\n\n<style lang=\"postcss\" scoped>\n.read-the-docs {\n  color: #888;\n}\n</style>\n"
  ]
}
```
`/src/components/HelloWorld.vue?vue&type=style&index=0&scoped=true&lang.postcss` has the sourcemap below.
```json
{
  "version": 3,
  "sources": [
    "/home/projects/mkliybgym.github/src/components/HelloWorld.vue"
  ],
  "names": [],
  "mappings": ";AA4CA;EACE,WAAW;AACb",
  "file": "HelloWorld.vue",
  "sourcesContent": [
    "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n.read-the-docs {\n  color: #888;\n}\n"
  ]
}
```

`/src/components/HelloWorld.vue`'s `sourcesContent` has correct content but `/src/components/HelloWorld.vue?vue&type=style&index=0&scoped=true&lang.postcss` has a empty lines for non-style part.
Actually, this sourcemap comes from vite-plugin-vue2 and needs a fix on their side.
That said, `vite:css-post` does not need to return sourcemap as the sourcemap is injected inside CSS. So I removed it by setting `map: { 
mappings: '' }`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
