### PR TITLE
feat: include duplicate assets in the manifest

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -21,12 +21,12 @@ import { FS_PREFIX } from '../constants'
 
 export const assetUrlRE = /__VITE_ASSET__([a-z\d]{8})__(?:\$_(.*?)__)?/g
 
+export const duplicateAssets: OutputAsset[] = []
+
 const rawRE = /(\?|&)raw(?:&|$)/
 const urlRE = /(\?|&)url(?:&|$)/
 
 const assetCache = new WeakMap<ResolvedConfig, Map<string, string>>()
-
-const duplicateAssets: OutputAsset[] = []
 
 const assetHashToFilenameMap = new WeakMap<
   ResolvedConfig,
@@ -185,10 +185,6 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     },
 
     generateBundle(_, bundle) {
-      duplicateAssets.forEach((asset) => {
-        bundle[asset.name!] = asset
-      })
-
       // do not emit assets for SSR build
       if (config.command === 'build' && config.build.ssr) {
         for (const file in bundle) {

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -21,7 +21,10 @@ import { FS_PREFIX } from '../constants'
 
 export const assetUrlRE = /__VITE_ASSET__([a-z\d]{8})__(?:\$_(.*?)__)?/g
 
-export const duplicateAssets = new WeakMap<ResolvedConfig, OutputAsset[]>()
+export const duplicateAssets = new WeakMap<
+  ResolvedConfig,
+  Map<string, OutputAsset>
+>()
 
 const rawRE = /(\?|&)raw(?:&|$)/
 const urlRE = /(\?|&)url(?:&|$)/
@@ -132,7 +135,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     buildStart() {
       assetCache.set(config, new Map())
       emittedHashMap.set(config, new Set())
-      duplicateAssets.set(config, [])
+      duplicateAssets.set(config, new Map())
     },
 
     resolveId(id) {
@@ -485,7 +488,7 @@ async function fileToBuiltUrl(
       })
       emittedSet.add(contentHash)
     } else {
-      duplicates.push({
+      duplicates.set(name, {
         name,
         fileName: map.get(contentHash)!,
         type: 'asset',

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -489,7 +489,7 @@ async function fileToBuiltUrl(
     } else {
       duplicateAssets.push({
         name,
-        fileName,
+        fileName: map.get(contentHash)!,
         type: 'asset',
         source: content,
         isAsset: true

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -17,7 +17,6 @@ export interface ManifestChunk {
   isDynamicEntry?: boolean
   imports?: string[]
   dynamicImports?: string[]
-  isDuplicate?: true
 }
 
 export function manifestPlugin(config: ResolvedConfig): Plugin {
@@ -126,7 +125,6 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
 
       duplicateAssets.forEach((asset) => {
         const chunk = createAsset(asset)
-        chunk.isDuplicate = true
         manifest[asset.name!] = chunk
       })
 

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -4,6 +4,7 @@ import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
 import { normalizePath } from '../utils'
 import { cssEntryFilesCache } from './css'
+import { duplicateAssets } from './asset'
 
 export type Manifest = Record<string, ManifestChunk>
 
@@ -16,6 +17,7 @@ export interface ManifestChunk {
   isDynamicEntry?: boolean
   imports?: string[]
   dynamicImports?: string[]
+  isDuplicate?: true
 }
 
 export function manifestPlugin(config: ResolvedConfig): Plugin {
@@ -121,6 +123,12 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
           manifest[chunk.name] = createAsset(chunk)
         }
       }
+
+      duplicateAssets.forEach((asset) => {
+        const chunk = createAsset(asset)
+        chunk.isDuplicate = true
+        manifest[asset.name!] = chunk
+      })
 
       outputCount++
       const output = config.build.rollupOptions?.output

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -123,7 +123,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
         }
       }
 
-      duplicateAssets.forEach((asset) => {
+      duplicateAssets.get(config)!.forEach((asset) => {
         const chunk = createAsset(asset)
         manifest[asset.name!] = chunk
       })


### PR DESCRIPTION
### Description

Laravel has officially made Vite it's out-of-the-box bundler. Although Vite is targeted at full fledged JS applications, we have made some affordances to make it work well with a completely back-end templated language, such as PHP / Blade.

This PR attempts to fix an issue that is present in an entirely back-end templated application.

Here is the scenario:

You have two _duplicate_ files on disk.

```
resources/images/client1/icon.png
resources/images/client2/icon.png
resources/images/client3/icon.png <= duplicate of client1/icon.png
```

In one of your entry points, you do the following in order for Vite to pick up the file and add it to the build:

```js
import.meta.glob('resources/images/**')
```

When you run the build, you will end up with the following manifest:

```json
{
  "resources/images/client1/icon.png": {
    "file": "assets/icon.636a0396.png",
    "src": "resources/images/client1/icon.png"
  },
  "resources/images/client2/icon.png": {
    "file": "assets/icon.71e56d11.png",
    "src": "resources/images/client2/icon.png"
  }
}
```

Notice that the `client3` icon has not been included in the manifest. From an entirely back-end application point of view, this is not great, as when you reference assets, you are going to reference them by their original path. For example in Blade we would do the following:

```blade
<img src="{{ Vite::asset('resources/images/client1/icon.png') }}">
<img src="{{ Vite::asset('resources/images/client2/icon.png') }}">
<img src="{{ Vite::asset('resources/images/client3/icon.png') }}">
``` 

The `Vite::asset()` function will search for the entry in the manifest and output the correct path. i.e. the result of the above would be:

```blade
<img src="https://example.com/assets/icon.636a0396.png">
<img src="https://example.com/assets/icon.71e56d11.png">
<img src="https://example.com/">
``` 

The last one would really throw an error, but I put it there to illustrate the problem, which is that we cannot actually find the asset in the manifest as it was never put there.

This occurs because the **expected** naming collision:

```
client1/icon.png => assets/icon.636a0396.png
client3/icon.png => assets/icon.636a0396.png
```

of course because these files are identical, thus we don't need to emit it and process the file twice - however from a back-end perspective it would be nice if there were two chunks in the manifest that reference this same file.

My proposed solution (which may be highly illegal 🚨 🚓) is to keep track of any duplicate assets as we are processing them and manually add them to the bundle during the `generateBundle` hook. I'm not sure of the possible flow on effects of this, so I will 100% need input on this.

The resulting manifest:


```json
{
  "resources/images/client1/icon.png": {
    "file": "assets/icon.636a0396.png",
    "src": "resources/images/client1/icon.png"
  },
  "resources/images/client2/icon.png": {
    "file": "assets/icon.71e56d11.png",
    "src": "resources/images/client2/icon.png"
  },
  "resources/images/client3/icon.png": {
    "file": "assets/icon.636a0396.png",
    "src": "resources/images/client3/icon.png"
  },
}
```

### Additional context

n/a

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.