### PR TITLE
feat: build.modulePreload options

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -32,7 +32,7 @@ Note: the polyfill does **not** apply to [Library Mode](/guide/build#library-mod
 
 The polyfill can be disabled using `{ polyfill: false }`.
 
-The list of chunks to preload for each dynamic import is computed by Vite. By default, an absolute path including the `base` will be used when loading these dependencies. If the `base` is relative (`''` or `'./'`), `import.meta.url` is used at runtime to avoid absolute paths that depends on final the deployed base.
+The list of chunks to preload for each dynamic import is computed by Vite. By default, an absolute path including the `base` will be used when loading these dependencies. If the `base` is relative (`''` or `'./'`), `import.meta.url` is used at runtime to avoid absolute paths that depend on the final deployed base.
 
 There is experimental support for fine grained control over the dependencies list and their paths using the `resolveDependencies` function. It expects a function of type `ResolveModulePreloadDependenciesFn`
 

--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -46,27 +46,17 @@ type ResolveModulePreloadDependenciesFn = (
 ) => (string | { runtime?: string })[]
 ```
 
-The `resolveDependencies` function will be called for each dynamic import with a list of the chunks it depends on. A new dependencies array can be returned with these filtered or more dependencies injected, and their paths modified. The `deps` paths are relative to the `build.outDir`.
+The `resolveDependencies` function will be called for each dynamic import with a list of the chunks it depends on, and it will also be called for each chunk imported in entry HTML files. A new dependencies array can be returned with these filtered or more dependencies injected, and their paths modified. The `deps` paths are relative to the `build.outDir`. Returning a relative path to the `hostId` for `hostType === 'js'` is allowed, in which case `new URL(dep, import.meta.url)` is used to get an absolute path when injecting this module preload in the HTML head.
 
 ```js
-    modulePreload: {
-        resolveDependencies: (url, deps, { importer }) => {
-            return deps.map((dep) => {
-                if (...) {
-                    // a relative path to the importer makes the dependency independent of the base
-                    // this is the default
-                    return { relative: dep } // ~ `path.relative(path.dirname(importer), dep)`
-                }
-                else if (...) {
-                    // a runtime expression can be returned
-                    return { runtime: `globalThis.__preloadPath(${dep}, import.meta.url)` }
-                }
-                // returning the dep as is defaults to the regular resolution
-                return dep
-            })
-        }
-    }
+modulePreload: {
+  resolveDependencies: (filename, deps, { hostId, hostType }) => {
+    return deps.filter(condition)
+  }
+}
 ```
+
+The resolved dependency paths can be further modified using [`experimental.renderBuiltUrl`](../guide/build.md#advanced-base-options).
 
 ## build.polyfillModulePreload
 

--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -22,7 +22,7 @@ Note the build will fail if the code contains features that cannot be safely tra
 - **Type:** `boolean | { polyfill?: boolean, resolveDependencies?: ResolveModulePreloadDependenciesFn }`
 - **Default:** `true`
 
-By default, a [module preload polyfill](https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill) is automatically injected. The polyfill is auto injected into the proxy module of each `index.html` entry. If the build is configured to use a non-html custom entry via `build.rollupOptions.input`, then it is necessary to manually import the polyfill in your custom entry:
+By default, a [module preload polyfill](https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill) is automatically injected. The polyfill is auto injected into the proxy module of each `index.html` entry. If the build is configured to use a non-HTML custom entry via `build.rollupOptions.input`, then it is necessary to manually import the polyfill in your custom entry:
 
 ```js
 import 'vite/modulepreload-polyfill'

--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -64,7 +64,7 @@ The resolved dependency paths can be further modified using [`experimental.rende
 - **Default:** `true`
 - **Deprecated** use `build.modulePreload.polyfill` instead
 
-Whether to automatically inject [module preload polyfill](https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill).
+Whether to automatically inject a [module preload polyfill](https://guybedford.com/es-module-preloading-integrity#modulepreload-polyfill).
 
 ## build.outDir
 

--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -34,7 +34,7 @@ The polyfill can be disabled using `{ polyfill: false }`.
 
 The list of chunks to preload for each dynamic import is computed by Vite. By default, an absolute path including the `base` will be used when loading these dependencies. If the `base` is relative (`''` or `'./'`), `import.meta.url` is used at runtime to avoid absolute paths that depend on the final deployed base.
 
-There is experimental support for fine grained control over the dependencies list and their paths using the `resolveDependencies` function. It expects a function of type `ResolveModulePreloadDependenciesFn`
+There is experimental support for fine grained control over the dependencies list and their paths using the `resolveDependencies` function. It expects a function of type `ResolveModulePreloadDependenciesFn`:
 
 ```ts
 type ResolveModulePreloadDependenciesFn = (

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -252,12 +252,13 @@ export interface ModulePreloadOptions {
 }
 
 export type ResolveModulePreloadDependenciesFn = (
-  url: string,
+  filename: string,
   deps: string[],
   context: {
-    importer: string
+    hostId: string
+    hostType: 'html' | 'js'
   }
-) => (string | { runtime?: string; relative?: string })[]
+) => string[]
 
 export type ResolvedBuildOptions = Required<
   Omit<BuildOptions, 'polyfillModulePreload'>
@@ -962,19 +963,16 @@ export type RenderBuiltAssetUrl = (
   }
 ) => string | { relative?: boolean; runtime?: string } | undefined
 
-export function toOutputFilePathInString(
+export function toOutputFilePathInJS(
   filename: string,
   type: 'asset' | 'public',
   hostId: string,
   hostType: 'js' | 'css' | 'html',
   config: ResolvedConfig,
-  format: InternalModuleFormat,
   toRelative: (
     filename: string,
     hostType: string
-  ) => string | { runtime: string } = getToImportMetaURLBasedRelativePath(
-    format
-  )
+  ) => string | { runtime: string }
 ): string | { runtime: string } {
   const { renderBuiltUrl } = config.experimental
   let relative = config.base === '' || config.base === './'
@@ -1002,7 +1000,7 @@ export function toOutputFilePathInString(
   return config.base + filename
 }
 
-function getToImportMetaURLBasedRelativePath(
+export function createToImportMetaURLBasedRelativeRuntime(
   format: InternalModuleFormat
 ): (filename: string, importer: string) => { runtime: string } {
   const toRelativePath = relativeUrlMechanisms[format]

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -244,8 +244,7 @@ export interface ModulePreloadOptions {
    */
   polyfill?: boolean
   /**
-   * Resolve the list of dependencies to preload for
-   * a given dynamic import
+   * Resolve the list of dependencies to preload for a given dynamic import
    * @experimental
    */
   resolveDependencies?: ResolveModulePreloadDependenciesFn

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -238,7 +238,7 @@ export type LibraryFormats = 'es' | 'cjs' | 'umd' | 'iife'
 
 export interface ModulePreloadOptions {
   /**
-   * whether to inject module preload polyfill.
+   * Whether to inject a module preload polyfill.
    * Note: does not apply to library mode.
    * @default true
    */

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -249,6 +249,10 @@ export interface ModulePreloadOptions {
    */
   resolveDependencies?: ResolveModulePreloadDependenciesFn
 }
+export interface ResolvedModulePreloadOptions {
+  polyfill: boolean
+  resolveDependencies?: ResolveModulePreloadDependenciesFn
+}
 
 export type ResolveModulePreloadDependenciesFn = (
   filename: string,
@@ -259,9 +263,10 @@ export type ResolveModulePreloadDependenciesFn = (
   }
 ) => string[]
 
-export type ResolvedBuildOptions = Required<
-  Omit<BuildOptions, 'polyfillModulePreload'>
->
+export interface ResolvedBuildOptions
+  extends Required<Omit<BuildOptions, 'polyfillModulePreload'>> {
+  modulePreload: false | ResolvedModulePreloadOptions
+}
 
 export function resolveBuildOptions(
   raw: BuildOptions | undefined,
@@ -286,6 +291,9 @@ export function resolveBuildOptions(
   }
 
   const modulePreload = raw?.modulePreload
+  const defaultModulePreload = {
+    polyfill: true
+  }
 
   const resolved: ResolvedBuildOptions = {
     target: 'modules',
@@ -318,13 +326,16 @@ export function resolveBuildOptions(
       exclude: [/node_modules/],
       ...raw?.dynamicImportVarsOptions
     },
+    // Resolve to false | object
     modulePreload:
-      typeof modulePreload === 'object'
+      modulePreload === false
+        ? false
+        : typeof modulePreload === 'object'
         ? {
-            polyfill: true,
+            ...defaultModulePreload,
             ...modulePreload
           }
-        : modulePreload ?? true
+        : defaultModulePreload
   }
 
   // handle special build targets

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -63,6 +63,7 @@ const debug = createDebugger('vite:config')
 export type {
   RenderBuiltAssetUrl,
   ModulePreloadOptions,
+  ResolvedModulePreloadOptions,
   ResolveModulePreloadDependenciesFn
 } from './build'
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -60,7 +60,11 @@ import { resolveSSROptions } from './ssr'
 
 const debug = createDebugger('vite:config')
 
-export type { RenderBuiltAssetUrl } from './build'
+export type {
+  RenderBuiltAssetUrl,
+  ModulePreloadOptions,
+  ResolveModulePreloadDependenciesFn
+} from './build'
 
 // NOTE: every export in this file is re-exported from ./index.ts so it will
 // be part of the public API.

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -12,7 +12,10 @@ import type {
 } from 'rollup'
 import MagicString from 'magic-string'
 import colors from 'picocolors'
-import { toOutputFilePathInString } from '../build'
+import {
+  createToImportMetaURLBasedRelativeRuntime,
+  toOutputFilePathInJS
+} from '../build'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
 import { cleanUrl, getHash, normalizePath } from '../utils'
@@ -51,6 +54,10 @@ export function renderAssetUrlInJS(
   opts: NormalizedOutputOptions,
   code: string
 ): MagicString | undefined {
+  const toRelativeRuntime = createToImportMetaURLBasedRelativeRuntime(
+    opts.format
+  )
+
   let match: RegExpExecArray | null
   let s: MagicString | undefined
 
@@ -70,13 +77,13 @@ export function renderAssetUrlInJS(
     const file = getAssetFilename(hash, config) || ctx.getFileName(hash)
     chunk.viteMetadata.importedAssets.add(cleanUrl(file))
     const filename = file + postfix
-    const replacement = toOutputFilePathInString(
+    const replacement = toOutputFilePathInJS(
       filename,
       'asset',
       chunk.fileName,
       'js',
       config,
-      opts.format
+      toRelativeRuntime
     )
     const replacementString =
       typeof replacement === 'string'
@@ -94,13 +101,13 @@ export function renderAssetUrlInJS(
     s ||= new MagicString(code)
     const [full, hash] = match
     const publicUrl = publicAssetUrlMap.get(hash)!.slice(1)
-    const replacement = toOutputFilePathInString(
+    const replacement = toOutputFilePathInJS(
       publicUrl,
       'public',
       chunk.fileName,
       'js',
       config,
-      opts.format
+      toRelativeRuntime
     )
     const replacementString =
       typeof replacement === 'string'

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -629,14 +629,14 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       })
 
       const toPreloadTag = (
-        chunk: OutputChunk,
+        filename: string,
         toOutputPath: (filename: string) => string
       ): HtmlTagDescriptor => ({
         tag: 'link',
         attrs: {
           rel: 'modulepreload',
           crossorigin: true,
-          href: toOutputPath(chunk.fileName)
+          href: toOutputPath(filename)
         }
       })
 
@@ -728,15 +728,28 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           // when not inlined, inject <script> for entry and modulepreload its dependencies
           // when inlined, discard entry chunk and inject <script> for everything in post-order
           const imports = getImportedChunks(chunk)
-          const assetTags = canInlineEntry
-            ? imports.map((chunk) =>
-                toScriptTag(chunk, toOutputAssetFilePath, isAsync)
-              )
-            : [
-                toScriptTag(chunk, toOutputAssetFilePath, isAsync),
-                ...imports.map((i) => toPreloadTag(i, toOutputAssetFilePath))
-              ]
-
+          let assetTags: HtmlTagDescriptor[]
+          if (canInlineEntry) {
+            assetTags = imports.map((chunk) =>
+              toScriptTag(chunk, toOutputAssetFilePath, isAsync)
+            )
+          } else {
+            const { modulePreload } = config.build
+            const resolveDependencies =
+              typeof modulePreload === 'object' &&
+              modulePreload.resolveDependencies
+            const importsFileNames = imports.map((chunk) => chunk.fileName)
+            const resolvedDeps = resolveDependencies
+              ? resolveDependencies(chunk.fileName, importsFileNames, {
+                  hostId: relativeUrlPath,
+                  hostType: 'html'
+                })
+              : importsFileNames
+            assetTags = [
+              toScriptTag(chunk, toOutputAssetFilePath, isAsync),
+              ...resolvedDeps.map((i) => toPreloadTag(i, toOutputAssetFilePath))
+            ]
+          }
           assetTags.push(...getCssTagsForChunk(chunk, toOutputAssetFilePath))
 
           result = injectToHead(result, assetTags)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -581,8 +581,10 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         processedHtml.set(id, s.toString())
 
         // inject module preload polyfill only when configured and needed
+        const { modulePreload } = config.build
         if (
-          config.build.polyfillModulePreload &&
+          (modulePreload === true ||
+            (typeof modulePreload === 'object' && modulePreload.polyfill)) &&
           (someScriptsAreAsync || someScriptsAreDefer)
         ) {
           js = `import "${modulePreloadPolyfillId}";\n${js}`

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -122,8 +122,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
   )
 
   const resolveModulePreloadDependencies =
-    typeof config.build.modulePreload === 'object' &&
-    config.build.modulePreload.resolveDependencies
+    config.build.modulePreload && config.build.modulePreload.resolveDependencies
   const renderBuiltUrl = config.experimental.renderBuiltUrl
   const customModulePreloadPaths = !!(
     resolveModulePreloadDependencies || renderBuiltUrl
@@ -134,8 +133,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
   const { modulePreload } = config.build
   const scriptRel =
-    modulePreload === true ||
-    (typeof modulePreload === 'object' && modulePreload.polyfill)
+    modulePreload && modulePreload.polyfill
       ? `'modulepreload'`
       : `(${detectScriptRel.toString()})()`
 
@@ -517,8 +515,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 if (normalizedFile && customModulePreloadPaths) {
                   const { modulePreload } = config.build
                   const resolveDependencies =
-                    typeof modulePreload === 'object' &&
-                    modulePreload.resolveDependencies
+                    modulePreload && modulePreload.resolveDependencies
                   let resolvedDeps: string[]
                   if (resolveDependencies) {
                     // We can't let the user remove css deps as these aren't really preloads, they are just using

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -16,6 +16,7 @@ import {
 import type { Plugin } from '../plugin'
 import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig } from '../config'
+import { toOutputFilePathInJS } from '../build'
 import { genSourceMapUrl } from '../server/sourcemap'
 import { getDepsOptimizer, optimizedDepNeedsInterop } from '../optimizer'
 import { isCSSRequest, removedPureCssFilesCache } from './css'
@@ -39,6 +40,11 @@ const dynamicImportPrefixRE = /import\s*\(/
 // TODO: abstract
 const optimizedDepChunkRE = /\/chunk-[A-Z0-9]{8}\.js/
 const optimizedDepDynamicRE = /-[A-Z0-9]{8}\.js/
+
+function toRelativePath(filename: string, importer: string) {
+  const relPath = path.relative(path.dirname(importer), filename)
+  return relPath.startsWith('.') ? relPath : `./${relPath}`
+}
 
 /**
  * Helper for preloading CSS and direct imports of async chunks in parallel to
@@ -115,12 +121,16 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     config.build.modulePreload === false
   )
 
-  const customResolveModulePreloadDependencies =
+  const resolveModulePreloadDependencies =
     typeof config.build.modulePreload === 'object' &&
     config.build.modulePreload.resolveDependencies
+  const renderBuiltUrl = config.experimental.renderBuiltUrl
+  const customModulePreloadPaths = !!(
+    resolveModulePreloadDependencies || renderBuiltUrl
+  )
   const isRelativeBase = config.base === './' || config.base === ''
-  const relativePreloadUrls =
-    isRelativeBase || customResolveModulePreloadDependencies
+  const optimizeModulePreloadRelativePaths =
+    isRelativeBase && !customModulePreloadPaths
 
   const { modulePreload } = config.build
   const scriptRel =
@@ -128,9 +138,27 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     (typeof modulePreload === 'object' && modulePreload.polyfill)
       ? `'modulepreload'`
       : `(${detectScriptRel.toString()})()`
-  const assetsURL = relativePreloadUrls
-    ? `function(dep,importerUrl) { return new URL(dep, importerUrl).href }`
-    : `function(dep) { return ${JSON.stringify(config.base)}+dep }`
+
+  // There are three different cases for the preload list format in __vitePreload
+  //
+  // __vitePreload(() => import(asyncChunk), [ ...deps... ])
+  //
+  // This is maintained to keep backwards compatibility as some users developed plugins
+  // using regex over this list to workaround the fact that module preload wasn't
+  // configurable.
+  const assetsURL = customModulePreloadPaths
+    ? // If `experimental.renderBuiltUrl` or `build.modulePreload.resolveDependencies` are used
+      // the dependencies are already resolved. To avoid the need for `new URL(dep, import.meta.url)`
+      // a helper `__vitePreloadRelativeDep` is used to resolve from relative paths which can be minimized.
+      `function(dep, importerUrl) { return dep.startsWith('.') ? new URL(dep, importerUrl).href : dep }`
+    : optimizeModulePreloadRelativePaths
+    ? // If there isn't custom resolvers affecting the deps list, deps in the list are relative
+      // to the current chunk and are resolved to absolute URL by the __vitePreload helper itself.
+      // The importerUrl is passed as third parameter to __vitePreload in this case
+      `function(dep, importerUrl) { return new URL(dep, importerUrl).href }`
+    : // If the base isn't relative, then the deps are relative to the projects `outDir` and the base
+      // is appendended inside __vitePreload too.
+      `function(dep) { return ${JSON.stringify(config.base)}+dep }`
   const preloadCode = `const scriptRel = ${scriptRel};const assetsURL = ${assetsURL};const seen = {};export const ${preloadMethod} = ${preload.toString()}`
 
   return {
@@ -255,7 +283,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           str().appendRight(
             expEnd,
             `,${isModernFlag}?"${preloadMarker}":void 0${
-              relativePreloadUrls ? ',import.meta.url' : ''
+              optimizeModulePreloadRelativePaths || customModulePreloadPaths
+                ? ',import.meta.url'
+                : ''
             })`
           )
         }
@@ -425,7 +455,14 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               const deps: Set<string> = new Set()
               let hasRemovedPureCssChunk = false
 
+              let normalizedFile: string | undefined = undefined
+
               if (url) {
+                normalizedFile = path.posix.join(
+                  path.posix.dirname(chunk.fileName),
+                  url
+                )
+
                 const ownerFilename = chunk.fileName
                 // literal import - trace direct imports and add to deps
                 const analyzed: Set<string> = new Set<string>()
@@ -458,10 +495,6 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                     }
                   }
                 }
-                const normalizedFile = path.posix.join(
-                  path.posix.dirname(chunk.fileName),
-                  url
-                )
                 addDeps(normalizedFile)
               }
 
@@ -472,7 +505,6 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               }
 
               if (markerStartPos > 0) {
-                const { modulePreload } = config.build
                 // the dep list includes the main chunk, so only need to reload when there are actual other deps.
                 const depsArray =
                   deps.size > 1 ||
@@ -480,48 +512,65 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   (hasRemovedPureCssChunk && deps.size > 0)
                     ? [...deps]
                     : []
-                const toRelative = (dep: string) =>
-                  path.relative(path.dirname(file), dep)
-                const resolvedDependencies =
-                  url &&
-                  typeof modulePreload === 'object' &&
-                  modulePreload.resolveDependencies
-                    ? modulePreload
-                        .resolveDependencies(url, depsArray, { importer: file })
-                        .map((dep) => {
-                          if (typeof dep === 'object') {
-                            if (dep.runtime) {
-                              return dep.runtime
-                            }
-                            if (dep.relative) {
-                              return JSON.stringify(toRelative(dep.relative))
-                            }
-                            throw new Error(
-                              `Invalid dependency object, no runtime or relative option specified`
-                            )
-                          }
-                          return JSON.stringify(
-                            depsArray.includes(dep)
-                              ? isRelativeBase
-                                ? toRelative(dep)
-                                : config.base + dep
-                              : dep
-                          )
-                        })
-                    : depsArray.map((d) =>
-                        // Don't include the assets dir if the default asset file names
-                        // are used, the path will be reconstructed by the import preload helper
-                        JSON.stringify(
-                          relativePreloadUrls
-                            ? path.relative(path.dirname(file), d)
-                            : d
-                        )
-                      )
+
+                let renderedDeps: string[]
+                if (normalizedFile && customModulePreloadPaths) {
+                  const { modulePreload } = config.build
+                  const resolveDependencies =
+                    typeof modulePreload === 'object' &&
+                    modulePreload.resolveDependencies
+                  let resolvedDeps: string[]
+                  if (resolveDependencies) {
+                    // We can't let the user remove css deps as these aren't really preloads, they are just using
+                    // the same mechanism as module preloads for this chunk
+                    const cssDeps: string[] = []
+                    const otherDeps: string[] = []
+                    for (const dep of depsArray) {
+                      ;(dep.endsWith('.css') ? cssDeps : otherDeps).push(dep)
+                    }
+                    resolvedDeps = [
+                      ...resolveDependencies(normalizedFile, otherDeps, {
+                        hostId: file,
+                        hostType: 'js'
+                      }),
+                      ...cssDeps
+                    ]
+                  } else {
+                    resolvedDeps = depsArray
+                  }
+
+                  renderedDeps = resolvedDeps.map((dep: string) => {
+                    const replacement = toOutputFilePathInJS(
+                      dep,
+                      'asset',
+                      chunk.fileName,
+                      'js',
+                      config,
+                      toRelativePath
+                    )
+                    const replacementString =
+                      typeof replacement === 'string'
+                        ? JSON.stringify(replacement)
+                        : replacement.runtime
+
+                    return replacementString
+                  })
+                } else {
+                  renderedDeps = depsArray.map((d) =>
+                    // Don't include the assets dir if the default asset file names
+                    // are used, the path will be reconstructed by the import preload helper
+                    JSON.stringify(
+                      optimizeModulePreloadRelativePaths
+                        ? toRelativePath(d, file)
+                        : d
+                    )
+                  )
+                }
 
                 s.overwrite(
                   markerStartPos,
                   markerStartPos + preloadMarkerWithQuote.length,
-                  `[${resolvedDependencies.join(',')}]`,
+                  `[${renderedDeps.join(',')}]`,
                   { contentOnly: true }
                 )
                 rewroteMarkerStartPos.add(markerStartPos)

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -36,6 +36,7 @@ export async function resolvePlugins(
   const buildPlugins = isBuild
     ? (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
+  const { modulePreload } = config.build
 
   return [
     isWatch ? ensureWatchPlugin() : null,
@@ -43,7 +44,8 @@ export async function resolvePlugins(
     preAliasPlugin(config),
     aliasPlugin({ entries: config.resolve.alias }),
     ...prePlugins,
-    config.build.polyfillModulePreload
+    modulePreload === true ||
+    (typeof modulePreload === 'object' && modulePreload.polyfill)
       ? modulePreloadPolyfillPlugin(config)
       : null,
     ...(isDepsOptimizerEnabled(config, false) ||

--- a/playground/preload/__tests__/preload-disabled/preload-disabled.spec.ts
+++ b/playground/preload/__tests__/preload-disabled/preload-disabled.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest'
+import { browserLogs, isBuild, page, viteTestUrl } from '~utils'
+
+test('should have no 404s', () => {
+  browserLogs.forEach((msg) => {
+    expect(msg).not.toMatch('404')
+  })
+})
+
+describe.runIf(isBuild)('build', () => {
+  test('dynamic import', async () => {
+    const appHtml = await page.content()
+    expect(appHtml).toMatch('This is <b>home</b> page.')
+  })
+
+  test('dynamic import with comments', async () => {
+    await page.goto(viteTestUrl + '/#/hello')
+    const html = await page.content()
+    expect(html).not.toMatch(/link rel="modulepreload"/)
+    expect(html).not.toMatch(/link rel="stylesheet"/)
+  })
+})

--- a/playground/preload/__tests__/preload-disabled/vite.config.js
+++ b/playground/preload/__tests__/preload-disabled/vite.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../vite.config-preload-disabled')

--- a/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
+++ b/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest'
+import { browserLogs, isBuild, page, viteTestUrl } from '~utils'
+
+test('should have no 404s', () => {
+  browserLogs.forEach((msg) => {
+    expect(msg).not.toMatch('404')
+  })
+})
+
+describe.runIf(isBuild)('build', () => {
+  test('dynamic import', async () => {
+    const appHtml = await page.content()
+    expect(appHtml).toMatch('This is <b>home</b> page.')
+  })
+
+  test('dynamic import with comments', async () => {
+    await page.goto(viteTestUrl + '/#/hello')
+    const html = await page.content()
+    expect(html).toMatch(
+      /link rel="modulepreload".*?href="http.*?\/Hello\.\w{8}\.js"/
+    )
+    expect(html).toMatch(
+      /link rel="stylesheet".*?href="http.*?\/Hello\.\w{8}\.css"/
+    )
+  })
+})

--- a/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
+++ b/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
@@ -19,6 +19,7 @@ describe.runIf(isBuild)('build', () => {
     expect(html).toMatch(
       /link rel="modulepreload".*?href="http.*?\/Hello\.\w{8}\.js"/
     )
+    expect(html).toMatch(/link rel="modulepreload".*?href="\/preloaded.js"/)
     expect(html).toMatch(
       /link rel="stylesheet".*?href="http.*?\/Hello\.\w{8}\.css"/
     )

--- a/playground/preload/__tests__/resolve-deps/vite.config.js
+++ b/playground/preload/__tests__/resolve-deps/vite.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../vite.config-resolve-deps')

--- a/playground/preload/package.json
+++ b/playground/preload/package.json
@@ -6,7 +6,15 @@
     "dev": "vite",
     "build": "vite build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "dev:resolve-deps": "vite --config vite.config-resolve-deps.ts",
+    "build:resolve-deps": "vite build --config vite.config-resolve-deps.ts",
+    "debug:resolve-deps": "node --inspect-brk ../../packages/vite/bin/vite --config vite.config-resolve-deps.ts",
+    "preview:resolve-deps": "vite preview --config vite.config-resolve-deps.ts",
+    "dev:preload-disabled": "vite --config vite.config-preload-disabled.ts",
+    "build:preload-disabled": "vite build --config vite.config-preload-disabled.ts",
+    "debug:preload-disabled": "node --inspect-brk ../../packages/vite/bin/vite --config vite.config-preload-disabled.ts",
+    "preview:preload-disabled": "vite preview --config vite.config-preload-disabled.ts"
   },
   "dependencies": {
     "vue": "^3.2.37",

--- a/playground/preload/public/preloaded.js
+++ b/playground/preload/public/preloaded.js
@@ -1,0 +1,1 @@
+console.log('preloaded')

--- a/playground/preload/vite.config-preload-disabled.ts
+++ b/playground/preload/vite.config-preload-disabled.ts
@@ -1,0 +1,18 @@
+import vuePlugin from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [vuePlugin()],
+  build: {
+    minify: 'terser',
+    terserOptions: {
+      format: {
+        beautify: true
+      },
+      compress: {
+        passes: 3
+      }
+    },
+    modulePreload: false
+  }
+})

--- a/playground/preload/vite.config-resolve-deps.ts
+++ b/playground/preload/vite.config-resolve-deps.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import vuePlugin from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 
@@ -15,17 +14,20 @@ export default defineConfig({
       }
     },
     modulePreload: {
-      resolveDependencies(url, deps, { importer }) {
-        return deps.map((dep) => {
-          return dep.includes('.js')
-            ? { relative: dep }
-            : {
-                runtime: `new URL(${JSON.stringify(
-                  path.relative(path.dirname(importer), dep)
-                )},import.meta.url).href`
-              }
-        })
+      resolveDependencies(filename, deps, { hostId, hostType }) {
+        if (filename.includes('Hello')) {
+          return [...deps, 'preloaded.js']
+        }
+        return deps
       }
+    }
+  },
+  experimental: {
+    renderBuiltUrl(filename, { hostId, hostType }) {
+      if (filename.includes('preloaded')) {
+        return { runtime: `""+${JSON.stringify('/' + filename)}` }
+      }
+      return { relative: true }
     }
   }
 })

--- a/playground/preload/vite.config-resolve-deps.ts
+++ b/playground/preload/vite.config-resolve-deps.ts
@@ -1,0 +1,31 @@
+import path from 'node:path'
+import vuePlugin from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [vuePlugin()],
+  build: {
+    minify: 'terser',
+    terserOptions: {
+      format: {
+        beautify: true
+      },
+      compress: {
+        passes: 3
+      }
+    },
+    modulePreload: {
+      resolveDependencies(url, deps, { importer }) {
+        return deps.map((dep) => {
+          return dep.includes('.js')
+            ? { relative: dep }
+            : {
+                runtime: `new URL(${JSON.stringify(
+                  path.relative(path.dirname(importer), dep)
+                )},import.meta.url).href`
+              }
+        })
+      }
+    }
+  }
+})


### PR DESCRIPTION
Fixes #9680
Fixes #3133
Fixes #5991
Fixes #5120 (it was closed as won't implement)
Closes #7766

### Description

See the issues above for examples of requests to be able to control module preload. We already discussed in a team meeting that we should implement support for completely disabling module preload and also to support filtering.

**DONE:** Pushing a WIP, so we can discuss the API, @danielroe @antfu maybe there is a chance to include this in 3.1 (or we can later add it to a patch). It is WIP, because we should keep the `.css` chunks... even when preload is disabled as the mechanism to preload .js chunks and add the needed styles is shared (in the PR currently I passed both through `modulePreload.resolveDependencies`). 
Question: Should we only allow modifying the .js chunks? Or should we also pass the .css assets to `resolveDependencies` and expect the user to avoid filtering them?

Edit: The new API will only receive an array of modules, CSS assets aren't included and are processed separatedly

## docs

The polyfill can be disabled using `modulePreload: { polyfill: false }`. The previous `polyfillModulePreload` option has been deprecated.

The list of chunks to preload for each dynamic import is computed by Vite. By default, an absolute path including the `base` will be used when loading these dependencies. If the `base` is relative (`''` or `'./'`), `import.meta.url` is used at runtime to avoid absolute paths that depends on final the deployed base.

Edited after [9f1eaa5 (#9938)](https://github.com/vitejs/vite/pull/9938/commits/9f1eaa5f7539eb7588506419465aa8c7251b2efd)

There is experimental support for fine grained control over the dependencies list and their paths using the `resolveDependencies` function. It expects a function of type `ResolveModulePreloadDependenciesFn`

```ts
type ResolveModulePreloadDependenciesFn = (
  filename: string,
  deps: string[],
  context: {
    hostId: string,
    hostType: 'html' | 'js'
  }
) => string[]
```
The `resolveDependencies` function will be called for each dynamic import with a list of the chunks it depends on. A new dependencies array can be returned with these filtered or more dependencies injected, and their paths modified. The `deps` paths are relative to the `build.outDir`.
```js
    modulePreload: {
        resolveDependencies: (url, deps, { importer }) => {
            return deps.filter(condition)
        }
    }
```

The paths can be further modified by `experimental.renderBuiltUrl`. See new config file in `preload` test case and updated docs.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other