### PR TITLE
refactor(create-vite): migrate to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/micromatch": "^4.0.2",
     "@types/minimist": "^1.2.2",
     "@types/node": "^17.0.42",
-    "@types/prompts": "^2.4.0",
+    "@types/prompts": "^2.0.14",
     "@types/resolve": "^1.20.2",
     "@types/sass": "~1.43.1",
     "@types/semver": "^7.3.12",

--- a/packages/create-vite/tsconfig.json
+++ b/packages/create-vite/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": ["src", "__tests__"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "strict": true,
+    "declaration": false,
+    "sourceMap": false,
+    "noUnusedLocals": true,
+    "esModuleInterop": true
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       '@types/micromatch': ^4.0.2
       '@types/minimist': ^1.2.2
       '@types/node': ^17.0.42
-      '@types/prompts': ^2.4.0
+      '@types/prompts': ^2.0.14
       '@types/resolve': ^1.20.2
       '@types/sass': ~1.43.1
       '@types/semver': ^7.3.12
@@ -81,7 +81,7 @@ importers:
       '@types/micromatch': 4.0.2
       '@types/minimist': 1.2.2
       '@types/node': 17.0.42
-      '@types/prompts': 2.4.0
+      '@types/prompts': 2.0.14
       '@types/resolve': 1.20.2
       '@types/sass': 1.43.1
       '@types/semver': 7.3.12
@@ -2807,8 +2807,10 @@ packages:
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
 
-  /@types/prompts/2.4.0:
-    resolution: {integrity: sha512-7th8Opn+0XlN0O6qzO7dXOPwL6rigq/EwRS2DntaTHwSw8cLaYKeAPt5dWEKHSL+ffVSUl1itTPUC06+FlsV4Q==}
+  /@types/prompts/2.0.14:
+    resolution: {integrity: sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==}
+    dependencies:
+      '@types/node': 17.0.42
     dev: true
 
   /@types/resolve/1.17.1:


### PR DESCRIPTION
### Description
Migrated create-vite to TypeScript for better maintainability.

I fixed `@types/prompts` version along this.
2.4.0 is a broken version (https://github.com/DefinitelyTyped/DefinitelyTyped/issues/59890) and it seems [it does not exist any more](https://www.npmjs.com/package/@types/prompts?activeTab=versions).

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
