### PR TITLE
fix: prevent error overlay style being overridden (fixes #9969)

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -1,7 +1,16 @@
 import type { ErrorPayload } from 'types/hmrPayload'
 
+// set :host styles to make playwright detect the element as visible
 const template = /*html*/ `
 <style>
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .backdrop {
   position: fixed;
   z-index: 99999;

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -2,7 +2,7 @@ import type { ErrorPayload } from 'types/hmrPayload'
 
 const template = /*html*/ `
 <style>
-:host {
+.backdrop {
   position: fixed;
   z-index: 99999;
   top: 0;
@@ -99,15 +99,17 @@ code {
   cursor: pointer;
 }
 </style>
-<div class="window">
-  <pre class="message"><span class="plugin"></span><span class="message-body"></span></pre>
-  <pre class="file"></pre>
-  <pre class="frame"></pre>
-  <pre class="stack"></pre>
-  <div class="tip">
-    Click outside or fix the code to dismiss.<br>
-    You can also disable this overlay by setting
-    <code>server.hmr.overlay</code> to <code>false</code> in <code>vite.config.js.</code>
+<div class="backdrop">
+  <div class="window">
+    <pre class="message"><span class="plugin"></span><span class="message-body"></span></pre>
+    <pre class="file"></pre>
+    <pre class="frame"></pre>
+    <pre class="stack"></pre>
+    <div class="tip">
+      Click outside or fix the code to dismiss.<br>
+      You can also disable this overlay by setting
+      <code>server.hmr.overlay</code> to <code>false</code> in <code>vite.config.js.</code>
+    </div>
   </div>
 </div>
 `


### PR DESCRIPTION
### Description
Currently, error overlay uses `:host` to declare styles for the root element.
https://github.com/vitejs/vite/blob/4158b98c8fc30070967de1176f4b1c252d275386/packages/vite/src/client/overlay.ts#L5-L6

But when a style is declared for that element like `*`.
https://github.com/vuejs/create-vue/blob/2f2b040e5a73093926be0f69054a9616918ba5b8/template/base/src/assets/base.css#L53-L58
It gets overridden by that.

> Outside styles always win over styles defined in shadow DOM.
> https://web.dev/shadowdom-v1/#styling-a-component-from-the-outside

For #9969, `position: fixed` was overridden with `position: relative`.

fixes #9969

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
