### PR TITLE
fix(preview): send configured headers

### DIFF
--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -76,7 +76,7 @@ Uses [`http-proxy`](https://github.com/http-party/node-http-proxy). Full options
 
 Configure CORS for the preview server. This is enabled by default and allows any origin. Pass an [options object](https://github.com/expressjs/cors) to fine tune the behavior or `false` to disable.
 
-## server.headers
+## preview.headers
 
 - **Type:** `OutgoingHttpHeaders`
 

--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -75,3 +75,9 @@ Uses [`http-proxy`](https://github.com/http-party/node-http-proxy). Full options
 - **Default:** [`server.cors`](./server-options#server-cors)
 
 Configure CORS for the preview server. This is enabled by default and allows any origin. Pass an [options object](https://github.com/expressjs/cors) to fine tune the behavior or `false` to disable.
+
+## server.headers
+
+- **Type:** `OutgoingHttpHeaders`
+
+Specify server response headers.

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -111,12 +111,20 @@ export async function preview(
 
   // static assets
   const distDir = path.resolve(config.root, config.build.outDir)
+  const headers = config.preview.headers
   app.use(
     previewBase,
     sirv(distDir, {
       etag: true,
       dev: true,
-      single: config.appType === 'spa'
+      single: config.appType === 'spa',
+      setHeaders(res) {
+        if (headers) {
+          for (const name in headers) {
+            res.setHeader(name, headers[name]!)
+          }
+        }
+      }
     })
   )
 

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -1,3 +1,4 @@
+import fetch from 'node-fetch'
 import { beforeAll, describe, expect, test } from 'vitest'
 import testJSON from '../safe.json'
 import { isServe, page, viteTestUrl } from '~utils'
@@ -95,5 +96,12 @@ describe.runIf(isServe)('main', () => {
 
   test('denied', async () => {
     expect(await page.textContent('.unsafe-dotenv')).toBe('404')
+  })
+})
+
+describe('fetch', () => {
+  test('serve with configured headers', async () => {
+    const res = await fetch(viteTestUrl + '/src/')
+    expect(res.headers.get('x-served-by')).toBe('vite')
   })
 })

--- a/playground/fs-serve/__tests__/fs-serve.spec.ts
+++ b/playground/fs-serve/__tests__/fs-serve.spec.ts
@@ -100,7 +100,8 @@ describe.runIf(isServe)('main', () => {
 })
 
 describe('fetch', () => {
-  test('serve with configured headers', async () => {
+  // Note: this should pass in build too, but the test setup doesn't use Vite preview
+  test.runIf(isServe)('serve with configured headers', async () => {
     const res = await fetch(viteTestUrl + '/src/')
     expect(res.headers.get('x-served-by')).toBe('vite')
   })

--- a/playground/fs-serve/package.json
+++ b/playground/fs-serve/package.json
@@ -6,6 +6,6 @@
     "dev": "vite root",
     "build": "vite build root",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
-    "preview": "vite preview"
+    "preview": "vite preview root"
   }
 }

--- a/playground/fs-serve/root/vite.config.js
+++ b/playground/fs-serve/root/vite.config.js
@@ -18,6 +18,14 @@ module.exports = {
     },
     hmr: {
       overlay: false
+    },
+    headers: {
+      'x-served-by': 'vite'
+    }
+  },
+  preview: {
+    headers: {
+      'x-served-by': 'vite'
     }
   },
   define: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #9864 

Update sirv to send headers in preview.

### Additional context

The dev equivalent is set as:

https://github.com/vitejs/vite/blob/f76b1eea0f0dd0096f76a83ff9c9376aa3e5e1f7/packages/vite/src/node/server/middlewares/static.ts#L28-L42

I didn't add the ts handling part as those shouldn't happen in preview.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
