### PR TITLE
fix(build): fix resolution algorithm when `build.ssr` is true

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -717,7 +717,6 @@ export function tryNodeResolve(
     let resolvedId = id
     if (isDeepImport) {
       if (!pkg?.data.exports && path.extname(id) !== resolvedExt) {
-        resolvedId += resolvedExt
         resolvedId = resolved.id.slice(resolved.id.indexOf(id))
         isDebug &&
           debug(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -718,6 +718,11 @@ export function tryNodeResolve(
     if (isDeepImport) {
       if (!pkg?.data.exports && path.extname(id) !== resolvedExt) {
         resolvedId += resolvedExt
+        resolvedId = resolved.id.slice(resolved.id.indexOf(id))
+        isDebug &&
+          debug(
+            `[processResult] ${colors.cyan(id)} -> ${colors.dim(resolvedId)}`
+          )
       }
     }
     return { ...resolved, id: resolvedId, external: true }

--- a/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
+++ b/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+import { isBuild, testDir } from '~utils'
+
+test.runIf(isBuild)('correctly resolve entrypoints', async () => {
+  const { default: output } = await import(`${testDir}/dist/main.mjs`)
+
+  expect(output).toMatchInlineSnapshot(`
+    "
+      Matches: 5,7
+      React: 18.2.0
+      Lodash: true
+    "
+  `)
+})

--- a/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
+++ b/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
@@ -1,14 +1,13 @@
 import { expect, test } from 'vitest'
-import { isBuild, testDir } from '~utils'
+import { isBuild, readFile, testDir } from '~utils'
 
 test.runIf(isBuild)('correctly resolve entrypoints', async () => {
-  const { default: output } = await import(`${testDir}/dist/main.mjs`)
+  const contents = readFile('dist/main.mjs')
 
-  expect(output).toMatchInlineSnapshot(`
-    "
-      Matches: 5,7
-      React: 18.2.0
-      Lodash: true
-    "
-  `)
+  const _ = `['"]`
+  expect(contents).toMatch(new RegExp(`from ${_}entries/dir/index.js${_}`))
+  expect(contents).toMatch(new RegExp(`from ${_}entries/file.js${_}`))
+  expect(contents).toMatch(new RegExp(`from ${_}pkg-exports/entry${_}`))
+
+  await expect(import(`${testDir}/dist/main.mjs`)).resolves.toBeTruthy()
 })

--- a/playground/ssr-resolve/entries/dir/index.js
+++ b/playground/ssr-resolve/entries/dir/index.js
@@ -1,0 +1,1 @@
+module.exports = __filename.slice(__filename.lastIndexOf('entries'))

--- a/playground/ssr-resolve/entries/file.js
+++ b/playground/ssr-resolve/entries/file.js
@@ -1,0 +1,1 @@
+module.exports = __filename.slice(__filename.lastIndexOf('entries'))

--- a/playground/ssr-resolve/entries/package.json
+++ b/playground/ssr-resolve/entries/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "entries",
+  "private": true,
+  "version": "0.0.0"
+}

--- a/playground/ssr-resolve/main.js
+++ b/playground/ssr-resolve/main.js
@@ -1,12 +1,12 @@
-// no `exports` key, should resolve to autosuggest-highlight/match/index.js
-import match from 'autosuggest-highlight/match'
-// no `exports` key, should resolve to lodash/isInteger.js
-import isInteger from 'lodash/isInteger'
-// has `exports` key, should resolve to react-dom/server
-import { version } from 'react-dom/server'
+// no `exports` key, should resolve to entries/dir/index.js
+import dirEntry from 'entries/dir'
+// no `exports` key, should resolve to entries/file.js
+import fileEntry from 'entries/file'
+// has `exports` key, should resolve to pkg-exports/entry
+import pkgExportsEntry from 'pkg-exports/entry'
 
 export default `
-  Matches: ${match('some text', 'te')}
-  React: ${version}
-  Lodash: ${isInteger(42)}
+  entries/dir: ${dirEntry}
+  entries/file: ${fileEntry}
+  pkg-exports/entry: ${pkgExportsEntry}
 `

--- a/playground/ssr-resolve/main.js
+++ b/playground/ssr-resolve/main.js
@@ -1,0 +1,12 @@
+// no `exports` key, should resolve to autosuggest-highlight/match/index.js
+import match from 'autosuggest-highlight/match'
+// no `exports` key, should resolve to lodash/isInteger.js
+import isInteger from 'lodash/isInteger'
+// has `exports` key, should resolve to react-dom/server
+import { version } from 'react-dom/server'
+
+export default `
+  Matches: ${match('some text', 'te')}
+  React: ${version}
+  Lodash: ${isInteger(42)}
+`

--- a/playground/ssr-resolve/package.json
+++ b/playground/ssr-resolve/package.json
@@ -7,9 +7,9 @@
     "debug": "node --inspect-brk ../../packages/vite/bin/vite build"
   },
   "dependencies": {
-    "autosuggest-highlight": "^3.3.4",
-    "lodash": "^4.17.21",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "autosuggest-highlight": "3.3.4",
+    "lodash": "4.17.21",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   }
 }

--- a/playground/ssr-resolve/package.json
+++ b/playground/ssr-resolve/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ssr-resolve",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite build"
+  },
+  "dependencies": {
+    "autosuggest-highlight": "^3.3.4",
+    "lodash": "^4.17.21",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/playground/ssr-resolve/package.json
+++ b/playground/ssr-resolve/package.json
@@ -7,9 +7,7 @@
     "debug": "node --inspect-brk ../../packages/vite/bin/vite build"
   },
   "dependencies": {
-    "autosuggest-highlight": "3.3.4",
-    "lodash": "4.17.21",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "entries": "file:./entries",
+    "pkg-exports": "file:./pkg-exports"
   }
 }

--- a/playground/ssr-resolve/pkg-exports/entry.js
+++ b/playground/ssr-resolve/pkg-exports/entry.js
@@ -1,0 +1,1 @@
+module.exports = 'pkg-exports entry'

--- a/playground/ssr-resolve/pkg-exports/index.js
+++ b/playground/ssr-resolve/pkg-exports/index.js
@@ -1,0 +1,1 @@
+module.exports = undefined

--- a/playground/ssr-resolve/pkg-exports/package.json
+++ b/playground/ssr-resolve/pkg-exports/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pkg-exports",
+  "private": true,
+  "version": "0.0.0",
+  "exports": {
+    ".": "./index.js",
+    "./entry": "./entry.js"
+  }
+}

--- a/playground/ssr-resolve/vite.config.js
+++ b/playground/ssr-resolve/vite.config.js
@@ -1,4 +1,3 @@
-import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({

--- a/playground/ssr-resolve/vite.config.js
+++ b/playground/ssr-resolve/vite.config.js
@@ -3,9 +3,6 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   build: {
-    ssr: true,
-    rollupOptions: {
-      input: resolve(__dirname, 'main.js')
-    }
+    ssr: './main.js'
   }
 })

--- a/playground/ssr-resolve/vite.config.js
+++ b/playground/ssr-resolve/vite.config.js
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    ssr: true,
+    minify: false,
+    rollupOptions: {
+      input: resolve(__dirname, 'main.js')
+    }
+  }
+})

--- a/playground/ssr-resolve/vite.config.js
+++ b/playground/ssr-resolve/vite.config.js
@@ -4,7 +4,6 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   build: {
     ssr: true,
-    minify: false,
     rollupOptions: {
       input: resolve(__dirname, 'main.js')
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,6 +1100,18 @@ importers:
       express: 4.18.1
       serve-static: 1.15.0
 
+  playground/ssr-resolve:
+    specifiers:
+      autosuggest-highlight: ^3.3.4
+      lodash: ^4.17.21
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      autosuggest-highlight: 3.3.4
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+
   playground/ssr-vue:
     specifiers:
       '@vitejs/plugin-vue': workspace:*
@@ -3370,6 +3382,12 @@ packages:
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss-value-parser: 4.2.0
+    dev: false
+
+  /autosuggest-highlight/3.3.4:
+    resolution: {integrity: sha512-j6RETBD2xYnrVcoV1S5R4t3WxOlWZKyDQjkwnggDPSjF5L4jV98ZltBpvPvbkM1HtoSe5o+bNrTHyjPbieGeYA==}
+    dependencies:
+      remove-accents: 0.4.2
     dev: false
 
   /axios/0.27.2:
@@ -8115,6 +8133,9 @@ packages:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
     dev: true
+
+  /remove-accents/0.4.2:
+    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
 
   /require-directory/2.1.1:
     resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1102,10 +1102,10 @@ importers:
 
   playground/ssr-resolve:
     specifiers:
-      autosuggest-highlight: ^3.3.4
-      lodash: ^4.17.21
-      react: ^18.2.0
-      react-dom: ^18.2.0
+      autosuggest-highlight: 3.3.4
+      lodash: 4.17.21
+      react: 18.2.0
+      react-dom: 18.2.0
     dependencies:
       autosuggest-highlight: 3.3.4
       lodash: 4.17.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1102,15 +1102,17 @@ importers:
 
   playground/ssr-resolve:
     specifiers:
-      autosuggest-highlight: 3.3.4
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0
+      entries: file:./entries
+      pkg-exports: file:./pkg-exports
     dependencies:
-      autosuggest-highlight: 3.3.4
-      lodash: 4.17.21
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+      entries: file:playground/ssr-resolve/entries
+      pkg-exports: file:playground/ssr-resolve/pkg-exports
+
+  playground/ssr-resolve/entries:
+    specifiers: {}
+
+  playground/ssr-resolve/pkg-exports:
+    specifiers: {}
 
   playground/ssr-vue:
     specifiers:
@@ -3382,12 +3384,6 @@ packages:
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss-value-parser: 4.2.0
-    dev: false
-
-  /autosuggest-highlight/3.3.4:
-    resolution: {integrity: sha512-j6RETBD2xYnrVcoV1S5R4t3WxOlWZKyDQjkwnggDPSjF5L4jV98ZltBpvPvbkM1HtoSe5o+bNrTHyjPbieGeYA==}
-    dependencies:
-      remove-accents: 0.4.2
     dev: false
 
   /axios/0.27.2:
@@ -8134,9 +8130,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /remove-accents/0.4.2:
-    resolution: {integrity: sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==}
-
   /require-directory/2.1.1:
     resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
     engines: {node: '>=0.10.0'}
@@ -9860,6 +9853,18 @@ packages:
   file:playground/ssr-deps/ts-transpiled-exports:
     resolution: {directory: playground/ssr-deps/ts-transpiled-exports, type: directory}
     name: ts-transpiled-exports
+    version: 0.0.0
+    dev: false
+
+  file:playground/ssr-resolve/entries:
+    resolution: {directory: playground/ssr-resolve/entries, type: directory}
+    name: entries
+    version: 0.0.0
+    dev: false
+
+  file:playground/ssr-resolve/pkg-exports:
+    resolution: {directory: playground/ssr-resolve/pkg-exports, type: directory}
+    name: pkg-exports-cjs
     version: 0.0.0
     dev: false
 


### PR DESCRIPTION
### Description

This PR fixes the resolution algorithm when `build.ssr` is `true` i.e. when `tryNodeResolve` is called with `ssr: true` and `externalize: true`.

I couldn't find any tests covering this edge case, so I added a fixture in `playground/ssr-resolve`.
Related issues/PRs: #8420 #8421.

### Additional context

The current resolution produces an invalid path here https://github.com/vitejs/vite/blob/e7712ffb68b24fc6eafb9359548cf92c15a156c1/packages/vite/src/node/plugins/resolve.ts#L719-L721

In the case of `autosuggest-highlight`, `autosuggest-highlight/match` should resolve to `autosuggest-highlight/match/index.js`, not `autosuggest-highlight/match` + `.js` which doesn't exist.


<details>
<summary>with fix</summary>

```
➜ DEBUG='vite:resolve-details' pnpm build                            

> ssr-resolve@0.0.0 build /__/vite/playground/ssr-resolve
> vite build

vite v3.1.0-beta.2 building SSR bundle for production...
  vite:resolve-details [fs] /__/vite/playground/ssr-resolve/main.js -> /__/vite/playground/ssr-resolve/main.js +0ms
transforming (1) main.js
  vite:resolve-details [node/deep-import] ./match -> /__/vite/node_modules/.pnpm/autosuggest-highlight@3.3.4/node_modules/autosuggest-highlight/match/index.js +24ms
  vite:resolve-details [processResult] autosuggest-highlight/match -> autosuggest-highlight/match/index.js +0ms
  vite:resolve-details [node/deep-import] ./match -> /__/vite/node_modules/.pnpm/autosuggest-highlight@3.3.4/node_modules/autosuggest-highlight/match/index.js +3ms
  vite:resolve-details [processResult] autosuggest-highlight/match -> autosuggest-highlight/match/index.js +0ms
  vite:resolve-details [node/deep-import] ./isInteger -> /__/vite/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/isInteger.js +2ms
  vite:resolve-details [processResult] lodash/isInteger -> lodash/isInteger.js +0ms
  vite:resolve-details [node/deep-import] ./isInteger -> /__/vite/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/isInteger.js +2ms
  vite:resolve-details [processResult] lodash/isInteger -> lodash/isInteger.js +0ms
  vite:resolve-details [node/deep-import] ./server -> /__/vite/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/server.node.js +2ms
  vite:resolve-details [node/deep-import] ./server -> /__/vite/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/server.node.js +1ms
✓ 1 modules transformed.
dist/main.mjs   0.27 KiB
```
</details>

<details>
<summary>without fix (main)</summary>

:warning: Notice the paths in the lines tagged with `[processResult]` (`autosuggest-highlight/match.js` doesn't exist).

```
➜ DEBUG='vite:resolve-details' pnpm build

> ssr-resolve@0.0.0 build /__/vite/playground/ssr-resolve
> vite build

vite v3.1.0-beta.2 building SSR bundle for production...
  vite:resolve-details [fs] /__/vite/playground/ssr-resolve/main.js -> /__/vite/playground/ssr-resolve/main.js +0ms
transforming (1) main.js
  vite:resolve-details [node/deep-import] ./match -> /__/vite/node_modules/.pnpm/autosuggest-highlight@3.3.4/node_modules/autosuggest-highlight/match/index.js +13ms
  vite:resolve-details [processResult] autosuggest-highlight/match -> autosuggest-highlight/match.js +0ms
  vite:resolve-details [node/deep-import] ./match -> /__/vite/node_modules/.pnpm/autosuggest-highlight@3.3.4/node_modules/autosuggest-highlight/match/index.js +2ms
  vite:resolve-details [processResult] autosuggest-highlight/match -> autosuggest-highlight/match.js +0ms
  vite:resolve-details [node/deep-import] ./isInteger -> /__/vite/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/isInteger.js +1ms
  vite:resolve-details [processResult] lodash/isInteger -> lodash/isInteger.js +0ms
  vite:resolve-details [node/deep-import] ./isInteger -> /__/vite/node_modules/.pnpm/lodash@4.17.21/node_modules/lodash/isInteger.js +0ms
  vite:resolve-details [processResult] lodash/isInteger -> lodash/isInteger.js +0ms
  vite:resolve-details [node/deep-import] ./server -> /__/vite/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/server.node.js +1ms
  vite:resolve-details [node/deep-import] ./server -> /__/vite/node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/server.node.js +1ms
✓ 1 modules transformed.
dist/main.mjs   0.27 KiB
```

```
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  playground/ssr-resolve/__tests__/ssr-resolve.spec.ts > correctly resolve entrypoints
Error: [vite-node] Failed to load autosuggest-highlight/match.js
 ❯ async /__/oss/vite/playground-temp/ssr-resolve/dist/main.mjs:1:256
 ❯ async /__/oss/vite/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts:6:31

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```

</details>

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.

