### PR TITLE
fix: ensure version query for relative node_modules imports

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -175,7 +175,10 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
           // as if they would have been imported through a bare import
           // Use the original id to do the check as the resolved id may be the real
           // file path after symlinks resolution
-          const isNodeModule = !!normalizePath(id).match(nodeModulesInPathRE)
+          const isNodeModule =
+            nodeModulesInPathRE.test(normalizePath(id)) ||
+            nodeModulesInPathRE.test(normalizePath(resolved))
+
           if (isNodeModule && !resolved.match(DEP_VERSION_RE)) {
             const versionHash = depsOptimizer.metadata.browserHash
             if (versionHash && OPTIMIZABLE_ENTRY_RE.test(resolved)) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This is a follow-up to:

- https://github.com/vitejs/vite/pull/9848

It ensures that relative imports inside `node_modules` are rewritten to include the version hash.

### Additional context

This problem can cause duplicate modules in development, such as:

- https://github.com/ElMassimo/iles/issues/192#issuecomment-1238060702

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix

### Before submitting the PR, please make sure you do the following

Attempted to create a test case that would trigger this problem, by adding a file inside `dep-non-optimized` with a relative import to `index.js`:

```
  id: './index',
  resolved: '.../node_modules/.pnpm/file+playground+optimize-deps+dep-non-optimized/node_modules/dep-non-optimized/index.js',
  isNodeModule: false,
```

After the fix:

```
  isNodeModule: true,
```

Unfortunately, the bug is not triggered because in this test scenario most imports are later rewritten in the `/@fs/` code path (circumventing the problem), so it's not valuable as a test case.