### PR TITLE
perf: cache compiled glob for `server.fs.deny`

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -297,10 +297,9 @@ export default defineConfig({
 ## server.fs.deny
 
 - **Type:** `string[]`
+- **Default:** `['.env', '.env.*', '*.{pem,crt}']`
 
-Blocklist for sensitive files being restricted to be served by Vite dev server.
-
-Default to `['.env', '.env.*', '*.{pem,crt}']`.
+Blocklist for sensitive files being restricted to be served by Vite dev server. This will have higher priority than [`server.fs.allow`](#server-fs-allow). [picomatch patterns](https://github.com/micromatch/picomatch#globbing-features) are supported.
 
 ## server.origin
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/micromatch": "^4.0.2",
     "@types/minimist": "^1.2.2",
     "@types/node": "^17.0.42",
+    "@types/picomatch": "^2.3.0",
     "@types/prompts": "^2.0.14",
     "@types/resolve": "^1.20.2",
     "@types/sass": "~1.43.1",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -105,6 +105,7 @@
     "parse5": "^7.1.1",
     "periscopic": "^3.0.4",
     "picocolors": "^1.0.0",
+    "picomatch": "^2.3.1",
     "postcss-import": "^15.0.0",
     "postcss-load-config": "^4.0.1",
     "postcss-modules": "^5.0.0",

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -11,6 +11,8 @@ import type { FSWatcher, WatchOptions } from 'types/chokidar'
 import type { Connect } from 'types/connect'
 import launchEditorMiddleware from 'launch-editor-middleware'
 import type { SourceMap } from 'rollup'
+import picomatch from 'picomatch'
+import type { Matcher } from 'picomatch'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,
@@ -143,7 +145,7 @@ export interface FileSystemServeOptions {
    * Restrict accessing files that matches the patterns.
    *
    * This will have higher priority than `allow`.
-   * Glob patterns are supported.
+   * picomatch patterns are supported.
    *
    * @default ['.env', '.env.*', '*.crt', '*.pem']
    */
@@ -283,6 +285,10 @@ export interface ViteDevServer {
       abort: () => void
     }
   >
+  /**
+   * @internal
+   */
+  _fsDenyGlob: Matcher
 }
 
 export interface ResolvedServerUrls {
@@ -429,7 +435,8 @@ export async function createServer(
     _restartPromise: null,
     _importGlobMap: new Map(),
     _forceOptimizeOnRestart: false,
-    _pendingRequests: new Map()
+    _pendingRequests: new Map(),
+    _fsDenyGlob: picomatch(config.server.fs.deny, { matchBase: true })
   }
 
   server.transformIndexHtml = createDevHtmlTransformFn(server)

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -3,7 +3,6 @@ import type { OutgoingHttpHeaders, ServerResponse } from 'node:http'
 import type { Options } from 'sirv'
 import sirv from 'sirv'
 import type { Connect } from 'types/connect'
-import micromatch from 'micromatch'
 import type { ViteDevServer } from '../..'
 import { FS_PREFIX } from '../../constants'
 import {
@@ -17,8 +16,6 @@ import {
   isWindows,
   slash
 } from '../../utils'
-
-const { isMatch } = micromatch
 
 const sirvOptions = (headers?: OutgoingHttpHeaders): Options => {
   return {
@@ -158,8 +155,6 @@ export function serveRawFsMiddleware(
   }
 }
 
-const _matchOptions = { matchBase: true }
-
 export function isFileServingAllowed(
   url: string,
   server: ViteDevServer
@@ -168,8 +163,7 @@ export function isFileServingAllowed(
 
   const file = fsPathFromUrl(url)
 
-  if (server.config.server.fs.deny.some((i) => isMatch(file, i, _matchOptions)))
-    return false
+  if (server._fsDenyGlob(file)) return false
 
   if (server.moduleGraph.safeModulesPath.has(file)) return true
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ importers:
       '@types/micromatch': ^4.0.2
       '@types/minimist': ^1.2.2
       '@types/node': ^17.0.42
+      '@types/picomatch': ^2.3.0
       '@types/prompts': ^2.0.14
       '@types/resolve': ^1.20.2
       '@types/sass': ~1.43.1
@@ -80,6 +81,7 @@ importers:
       '@types/micromatch': 4.0.2
       '@types/minimist': 1.2.2
       '@types/node': 17.0.42
+      '@types/picomatch': 2.3.0
       '@types/prompts': 2.0.14
       '@types/resolve': 1.20.2
       '@types/sass': 1.43.1
@@ -249,6 +251,7 @@ importers:
       parse5: ^7.1.1
       periscopic: ^3.0.4
       picocolors: ^1.0.0
+      picomatch: ^2.3.1
       postcss: ^8.4.16
       postcss-import: ^15.0.0
       postcss-load-config: ^4.0.1
@@ -312,6 +315,7 @@ importers:
       parse5: 7.1.1
       periscopic: 3.0.4
       picocolors: 1.0.0
+      picomatch: 2.3.1
       postcss-import: 15.0.0_postcss@8.4.16
       postcss-load-config: 4.0.1_postcss@8.4.16
       postcss-modules: 5.0.0_postcss@8.4.16
@@ -2765,6 +2769,10 @@ packages:
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+
+  /@types/picomatch/2.3.0:
+    resolution: {integrity: sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==}
+    dev: true
 
   /@types/prompts/2.0.14:
     resolution: {integrity: sha512-HZBd99fKxRWpYCErtm2/yxUZv6/PBI9J7N4TNFffl5JbrYMHBwF25DjQGTW3b3jmXq+9P6/8fCIb2ee57BFfYA==}
@@ -5446,6 +5454,19 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
+
+  /follow-redirects/1.15.0_debug@4.3.4:
+    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -5839,7 +5860,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0
+      follow-redirects: 1.15.0_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
### Description
Splitted `server.fs.deny` part from #10037.

---

This PR makes Vite cache compiled globs. This improved performance for ~4% on my project.

`micromatch.isMatch` always calls `picomatch(patterns, options)(str)` which leads compiling glob every time.
https://github.com/micromatch/micromatch/blob/002d0d184c95e76775528fa1dbe0c446518879b2/index.js#L123
I've changed this to cache `picomatch(patterns, options)` to avoid compiling it.

### Additional context

#### Is it safe to rewrite `micromatch` into `picomatch`?
`picomatch` says [`micromatch` supports more more advanced matching with braces](https://github.com/micromatch/picomatch#braces). But actually it currently does not for some functions (https://github.com/micromatch/micromatch/issues/169#issuecomment-501037462) and as you can see from the implementation I quoted above, `micromatch.isMatch` is just a shorthand.

#### Bundle size
Didn't change.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
