### PR TITLE
feat(client): Add data-id attribute to style elements

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -364,6 +364,7 @@ export function updateStyle(id: string, content: string): void {
     if (!style) {
       style = document.createElement('style')
       style.setAttribute('type', 'text/css')
+      style.setAttribute('data-id', id)
       style.innerHTML = content
       document.head.appendChild(style)
     } else {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -364,7 +364,7 @@ export function updateStyle(id: string, content: string): void {
     if (!style) {
       style = document.createElement('style')
       style.setAttribute('type', 'text/css')
-      style.setAttribute('data-vite-id', id)
+      style.setAttribute('data-vite-dev-id', id)
       style.innerHTML = content
       document.head.appendChild(style)
     } else {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -364,7 +364,7 @@ export function updateStyle(id: string, content: string): void {
     if (!style) {
       style = document.createElement('style')
       style.setAttribute('type', 'text/css')
-      style.setAttribute('data-id', id)
+      style.setAttribute('data-vite-id', id)
       style.innerHTML = content
       document.head.appendChild(style)
     } else {


### PR DESCRIPTION
### Description

The goal is to be able to find quickly the output of some CSS files and to better see in which order files are being bundled

<img width="1139" alt="Screenshot 2022-09-12 at 10 18 33" src="https://user-images.githubusercontent.com/14235743/189606638-0832f5d4-85c0-4cfb-aa5a-c388e4812a78.png">

We could inject the project `ROOT` to display relative id

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
