### PR TITLE
fix: read file error when path has url space encode

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -582,12 +582,17 @@ export async function createPluginContainer(
           'handler' in plugin.resolveId
             ? plugin.resolveId.handler
             : plugin.resolveId
-        const result = await handler.call(ctx as any, rawId, importer, {
-          custom: options?.custom,
-          isEntry: !!options?.isEntry,
-          ssr,
-          scan
-        })
+        const result = await handler.call(
+          ctx as any,
+          rawId.replace(/%20/g, ' '),
+          importer,
+          {
+            custom: options?.custom,
+            isEntry: !!options?.isEntry,
+            ssr,
+            scan
+          }
+        )
         if (!result) continue
 
         if (typeof result === 'string') {


### PR DESCRIPTION
### Description
Possible fix for [#9917](https://github.com/vitejs/vite/issues/9917)

The reason for this problem is node.js fs.readFile error when take the path with the space URL encode.

fix problem by replace %20 by space when resolve file path.

use replace method because of encodeURIComponent is unsafe [(#8498)](https://github.com/vitejs/vite/issues/8498)


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.