### PR TITLE
fix: plugin legacy - module output doesn't support Safari 10

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -110,7 +110,7 @@ const detectModernBrowserVarName = '__vite_is_modern_browser'
 const detectModernBrowserCode = `try{import.meta.url;import("_").catch(()=>1);}catch(e){}window.${detectModernBrowserVarName}=true;`
 const dynamicFallbackInlineCode = `!function(){if(window.${detectModernBrowserVarName})return;console.warn("vite: loading legacy build because dynamic import or import.meta.url is unsupported, syntax error above should be ignored");var e=document.getElementById("${legacyPolyfillId}"),n=document.createElement("script");n.src=e.src,n.onload=function(){${systemJSInlineCode}},document.body.appendChild(n)}();`
 
-const forceDynamicImportUsage = `export function __vite_legacy_guard(){import('data:text/javascript,')};`
+const forceDynamicImportUsageCode = `export function __vite_legacy_guard(){import('data:text/javascript,')};`
 
 const legacyEnvVarMarker = `__VITE_IS_LEGACY__`
 
@@ -121,6 +121,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   const targets = options.targets || 'defaults'
   const genLegacy = options.renderLegacyChunks !== false
   const genDynamicFallback = genLegacy
+  const forceDynamicImportUsage = options.forceDynamicImportUsage !== false
 
   const debugFlags = (process.env.DEBUG || '').split(',')
   const isDebug =
@@ -331,8 +332,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
 
         const ms = new MagicString(raw)
 
-        if (genDynamicFallback && chunk.isEntry) {
-          ms.prepend(forceDynamicImportUsage)
+        if (genDynamicFallback && chunk.isEntry && forceDynamicImportUsage) {
+          ms.prepend(forceDynamicImportUsageCode)
         }
 
         if (raw.includes(legacyEnvVarMarker)) {

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -24,4 +24,8 @@ export interface Options {
    * default: false
    */
   externalSystemJS?: boolean
+  /**
+   * default: true
+   */
+  forceDynamicImportUsage?: boolean
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When using the plugin-legacy the modern bundle of the app includes the dynamic import, and in safari 10 it throws a syntax error that blocks the parsing and the execution of the entire application. 
`safari 10.1 Syntax Error Unexpected Keyword import`
Since this import is a thing used for a specific purpose I just implemented a parameter that let me prevent the plugin from using that forced dynamic import and keep the application running also in safari 10.

closes #10099

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
With this plugin, we just inject the `Safari 10 noModule fix`, but when the 'esm' version of the application is parsed inside the Safari 10 browser and read the 'import' keyword the Syntax Error is thrown.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
