### PR TITLE
fix(sass): reorder sass importers

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1441,8 +1441,8 @@ const scss: SassStylePreprocessor = async (
   const importer = [internalImporter]
   if (options.importer) {
     Array.isArray(options.importer)
-      ? importer.push(...options.importer)
-      : importer.push(options.importer)
+      ? importer.unshift(...options.importer)
+      : importer.unshift(options.importer)
   }
 
   const { content: data, map: additionalMap } = await getSource(

--- a/playground/css/sass.scss
+++ b/playground/css/sass.scss
@@ -3,6 +3,7 @@
 @import 'css-dep'; // package w/ sass entry points
 @import 'virtual-dep'; // virtual file added through importer
 @import '@/pkg-dep'; // package w/out sass field
+@import '@/weapp.wxss'; // wxss file
 
 .sass {
   /* injected via vite.config.js */

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -45,9 +45,14 @@ module.exports = {
     preprocessorOptions: {
       scss: {
         additionalData: `$injectedColor: orange;`,
-        importer(url) {
-          if (url === 'virtual-dep') return { contents: '' }
-        }
+        importer: [
+          function (url) {
+            return url === 'virtual-dep' ? { contents: '' } : null
+          },
+          function (url) {
+            return url.endsWith('.wxss') ? { contents: '' } : null
+          }
+        ]
       },
       styl: {
         additionalData: `$injectedColor ?= orange`,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Currently, the orders of sass's importer options is: `[internalImporter, customImporter]`.

When we import a virtual sass dep like the test case add by #3180, everything is fine.Because **internalImporter** can't resolved it and then customImporter can handle it.

However, if we import a style file with custom extname like `@import './common.wxss';`.The **internalImporter** will resolved it thus there is no chances for customImporter to handle it.

So, we should unshift the customImporters, not push.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Test case is added.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
