### PR TITLE
fix(hmr): dedupe virtual modules in module graph

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -712,10 +712,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // by the deps optimizer
       if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach(({ url, id }) => {
-          url = unwrapId(removeImportQuery(url)).replace(
-            NULL_BYTE_PLACEHOLDER,
-            '\0'
-          )
+          url = unwrapId(removeImportQuery(url))
           transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -359,7 +359,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           try {
             // delay setting `isSelfAccepting` until the file is actually used (#7870)
             const depModule = await moduleGraph.ensureEntryFromUrl(
-              url,
+              unwrapId(url),
               ssr,
               canSkipImportAnalysis(url)
             )
@@ -535,7 +535,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           // record for HMR import chain analysis
           // make sure to unwrap and normalize away base
-          const hmrUrl = unwrapId(url).replace(base, '/')
+          const hmrUrl = unwrapId(url.replace(base, '/'))
           importedUrls.add(hmrUrl)
 
           if (enablePartialAccept && importedBindings) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -15,9 +15,7 @@ import {
   CLIENT_DIR,
   CLIENT_PUBLIC_PATH,
   DEP_VERSION_RE,
-  FS_PREFIX,
-  NULL_BYTE_PLACEHOLDER,
-  VALID_ID_PREFIX
+  FS_PREFIX
 } from '../constants'
 import {
   debugHmr,
@@ -42,7 +40,8 @@ import {
   stripBomTag,
   timeFrom,
   transformStableResult,
-  unwrapId
+  unwrapId,
+  wrapId
 } from '../utils'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
@@ -330,8 +329,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         // prefix it to make it valid. We will strip this before feeding it
         // back into the transform pipeline
         if (!url.startsWith('.') && !url.startsWith('/')) {
-          url =
-            VALID_ID_PREFIX + resolved.id.replace('\0', NULL_BYTE_PLACEHOLDER)
+          url = wrapId(resolved.id)
         }
 
         // make the URL browser-valid if not SSR

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -534,9 +534,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
 
           // record for HMR import chain analysis
-          // make sure to normalize away base
-          const urlWithoutBase = url.replace(base, '/')
-          importedUrls.add(urlWithoutBase)
+          // make sure to unwrap and normalize away base
+          const hmrUrl = unwrapId(url).replace(base, '/')
+          importedUrls.add(hmrUrl)
 
           if (enablePartialAccept && importedBindings) {
             extractImportedBindings(
@@ -549,7 +549,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           if (!isDynamicImport) {
             // for pre-transforming
-            staticImportedUrls.add({ url: urlWithoutBase, id: resolvedId })
+            staticImportedUrls.add({ url: hmrUrl, id: resolvedId })
           }
         } else if (!importer.startsWith(clientDir)) {
           if (!importer.includes('node_modules')) {
@@ -710,7 +710,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // by the deps optimizer
       if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach(({ url, id }) => {
-          url = unwrapId(removeImportQuery(url))
+          url = removeImportQuery(url)
           transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -19,19 +19,15 @@ import {
 } from '../../plugins/html'
 import type { ResolvedConfig, ViteDevServer } from '../..'
 import { send } from '../send'
-import {
-  CLIENT_PUBLIC_PATH,
-  FS_PREFIX,
-  NULL_BYTE_PLACEHOLDER,
-  VALID_ID_PREFIX
-} from '../../constants'
+import { CLIENT_PUBLIC_PATH, FS_PREFIX } from '../../constants'
 import {
   cleanUrl,
   ensureWatchedFile,
   fsPathFromId,
   injectQuery,
   normalizePath,
-  processSrcSetSync
+  processSrcSetSync,
+  wrapId
 } from '../../utils'
 import type { ModuleGraph } from '../moduleGraph'
 
@@ -144,7 +140,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     // and ids are properly handled
     const validPath = `${htmlPath}${trailingSlash ? 'index.html' : ''}`
     proxyModulePath = `\0${validPath}`
-    proxyModuleUrl = `${VALID_ID_PREFIX}${NULL_BYTE_PLACEHOLDER}${validPath}`
+    proxyModuleUrl = wrapId(proxyModulePath)
   }
 
   const s = new MagicString(html)

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -239,14 +239,11 @@ export class ModuleGraph {
   // 2. resolve its extension so that urls with or without extension all map to
   // the same module
   async resolveUrl(url: string, ssr?: boolean): Promise<ResolvedUrl> {
-    url = unwrapId(removeImportQuery(removeTimestampQuery(url)))
-    const resolved = await this.resolveId(url, !!ssr)
-    const resolvedId = resolved?.id || url
-    if (
-      url !== resolvedId &&
-      !url.includes('\0') &&
-      !url.startsWith(`virtual:`)
-    ) {
+    url = removeImportQuery(removeTimestampQuery(url))
+    const id = unwrapId(url)
+    const resolved = await this.resolveId(id, !!ssr)
+    const resolvedId = resolved?.id || id
+    if (id !== resolvedId && !id.includes('\0') && !id.startsWith(`virtual:`)) {
       const ext = extname(cleanUrl(resolvedId))
       const { pathname, search, hash } = new URL(url, 'relative://')
       if (ext && !pathname!.endsWith(ext)) {

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -8,7 +8,7 @@ import {
   removeTimestampQuery,
   unwrapId
 } from '../utils'
-import { FS_PREFIX, NULL_BYTE_PLACEHOLDER } from '../constants'
+import { FS_PREFIX } from '../constants'
 import type { TransformResult } from './transformRequest'
 
 export class ModuleNode {
@@ -239,10 +239,7 @@ export class ModuleGraph {
   // 2. resolve its extension so that urls with or without extension all map to
   // the same module
   async resolveUrl(url: string, ssr?: boolean): Promise<ResolvedUrl> {
-    url = unwrapId(removeImportQuery(removeTimestampQuery(url))).replace(
-      NULL_BYTE_PLACEHOLDER,
-      '\0'
-    )
+    url = unwrapId(removeImportQuery(removeTimestampQuery(url)))
     const resolved = await this.resolveId(url, !!ssr)
     const resolvedId = resolved?.id || url
     if (

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -5,8 +5,7 @@ import {
   cleanUrl,
   normalizePath,
   removeImportQuery,
-  removeTimestampQuery,
-  unwrapId
+  removeTimestampQuery
 } from '../utils'
 import { FS_PREFIX } from '../constants'
 import type { TransformResult } from './transformRequest'
@@ -240,10 +239,13 @@ export class ModuleGraph {
   // the same module
   async resolveUrl(url: string, ssr?: boolean): Promise<ResolvedUrl> {
     url = removeImportQuery(removeTimestampQuery(url))
-    const id = unwrapId(url)
-    const resolved = await this.resolveId(id, !!ssr)
-    const resolvedId = resolved?.id || id
-    if (id !== resolvedId && !id.includes('\0') && !id.startsWith(`virtual:`)) {
+    const resolved = await this.resolveId(url, !!ssr)
+    const resolvedId = resolved?.id || url
+    if (
+      url !== resolvedId &&
+      !url.includes('\0') &&
+      !url.startsWith(`virtual:`)
+    ) {
       const ext = extname(cleanUrl(resolvedId))
       const { pathname, search, hash } = new URL(url, 'relative://')
       if (ext && !pathname!.endsWith(ext)) {

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -5,9 +5,10 @@ import {
   cleanUrl,
   normalizePath,
   removeImportQuery,
-  removeTimestampQuery
+  removeTimestampQuery,
+  unwrapId
 } from '../utils'
-import { FS_PREFIX } from '../constants'
+import { FS_PREFIX, NULL_BYTE_PLACEHOLDER } from '../constants'
 import type { TransformResult } from './transformRequest'
 
 export class ModuleNode {
@@ -238,7 +239,10 @@ export class ModuleGraph {
   // 2. resolve its extension so that urls with or without extension all map to
   // the same module
   async resolveUrl(url: string, ssr?: boolean): Promise<ResolvedUrl> {
-    url = removeImportQuery(removeTimestampQuery(url))
+    url = unwrapId(removeImportQuery(removeTimestampQuery(url))).replace(
+      NULL_BYTE_PLACEHOLDER,
+      '\0'
+    )
     const resolved = await this.resolveId(url, !!ssr)
     const resolvedId = resolved?.id || url
     if (

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -12,7 +12,6 @@ import { transformRequest } from '../server/transformRequest'
 import type { InternalResolveOptions } from '../plugins/resolve'
 import { tryNodeResolve } from '../plugins/resolve'
 import { hookNodeResolve } from '../plugins/ssrRequireHook'
-import { NULL_BYTE_PLACEHOLDER } from '../constants'
 import {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -38,7 +37,7 @@ export async function ssrLoadModule(
   urlStack: string[] = [],
   fixStacktrace?: boolean
 ): Promise<SSRModule> {
-  url = unwrapId(url).replace(NULL_BYTE_PLACEHOLDER, '\0')
+  url = unwrapId(url)
 
   // when we instantiate multiple dependency modules in parallel, they may
   // point to shared modules. We need to avoid duplicate instantiation attempts
@@ -138,7 +137,7 @@ async function instantiateModule(
       return nodeImport(dep, mod.file!, resolveOptions)
     }
     // convert to rollup URL because `pendingImports`, `moduleGraph.urlToModuleMap` requires that
-    dep = unwrapId(dep).replace(NULL_BYTE_PLACEHOLDER, '\0')
+    dep = unwrapId(dep)
     if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
       pendingDeps.push(dep)
       if (pendingDeps.length === 1) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_EXTENSIONS,
   ENV_PUBLIC_PATH,
   FS_PREFIX,
+  NULL_BYTE_PLACEHOLDER,
   OPTIMIZABLE_ENTRY_RE,
   VALID_ID_PREFIX,
   loopbackHosts,
@@ -56,7 +57,9 @@ export function slash(p: string): string {
 // Strip valid id prefix. This is prepended to resolved Ids that are
 // not valid browser import specifiers by the importAnalysis plugin.
 export function unwrapId(id: string): string {
-  return id.startsWith(VALID_ID_PREFIX) ? id.slice(VALID_ID_PREFIX.length) : id
+  return id.startsWith(VALID_ID_PREFIX)
+    ? id.slice(VALID_ID_PREFIX.length).replace(NULL_BYTE_PLACEHOLDER, '\0')
+    : id
 }
 
 export const flattenId = (id: string): string =>

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -54,8 +54,20 @@ export function slash(p: string): string {
   return p.replace(/\\/g, '/')
 }
 
-// Strip valid id prefix. This is prepended to resolved Ids that are
-// not valid browser import specifiers by the importAnalysis plugin.
+/**
+ * Prepend `/@id/` and replace null byte so the id is URL-safe.
+ * This is prepended to resolved ids that are not valid browser
+ * import specifiers by the importAnalysis plugin.
+ */
+export function wrapId(id: string): string {
+  return id.startsWith(VALID_ID_PREFIX)
+    ? id
+    : VALID_ID_PREFIX + id.replace('\0', NULL_BYTE_PLACEHOLDER)
+}
+
+/**
+ * Undo {@link wrapId}'s `/@id/` and null byte replacements.
+ */
 export function unwrapId(id: string): string {
   return id.startsWith(VALID_ID_PREFIX)
     ? id.slice(VALID_ID_PREFIX.length).replace(NULL_BYTE_PLACEHOLDER, '\0')

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -633,6 +633,9 @@ if (!isBuild) {
     const el = await page.$('.virtual')
     expect(await el.textContent()).toBe('[success]')
     editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
-    await untilUpdated(() => el.textContent(), '[wow]')
+    await untilUpdated(async () => {
+      const el = await page.$('.virtual')
+      return await el.textContent()
+    }, '[wow]')
   })
 }

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -627,4 +627,12 @@ if (!isBuild) {
     btn = await page.$('button')
     expect(await btn.textContent()).toBe('Compteur 0')
   })
+
+  test('handle virtual module updates', async () => {
+    await page.goto(viteTestUrl)
+    const el = await page.$('.virtual')
+    expect(await el.textContent()).toBe('[success]')
+    editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
+    await untilUpdated(() => el.textContent(), '[wow]')
+  })
 }

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -1,3 +1,5 @@
+// @ts-ignore
+import { virtual } from 'virtual:file'
 import { foo as depFoo, nestedFoo } from './hmrDep'
 import './importing-updated'
 
@@ -5,9 +7,6 @@ export const foo = 1
 text('.app', foo)
 text('.dep', depFoo)
 text('.nested', nestedFoo)
-
-// @ts-ignore
-import { virtual } from 'virtual:file'
 text('.virtual', virtual)
 
 if (import.meta.hot) {

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -6,6 +6,10 @@ text('.app', foo)
 text('.dep', depFoo)
 text('.nested', nestedFoo)
 
+// @ts-ignore
+import { virtual } from 'virtual:file'
+text('.virtual', virtual)
+
 if (import.meta.hot) {
   import.meta.hot.accept(({ foo }) => {
     console.log('(self-accepting 1) foo is now:', foo)

--- a/playground/hmr/importedVirtual.js
+++ b/playground/hmr/importedVirtual.js
@@ -1,0 +1,1 @@
+export const virtual = '[success]'

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -19,6 +19,7 @@
 <div class="dep"></div>
 <div class="nested"></div>
 <div class="custom"></div>
+<div class="virtual"></div>
 <div class="custom-communication"></div>
 <div class="css-prev"></div>
 <div class="css-post"></div>

--- a/playground/hmr/vite.config.ts
+++ b/playground/hmr/vite.config.ts
@@ -19,6 +19,19 @@ export default defineConfig({
           client.send('custom:remote-add-result', { result: a + b })
         })
       }
+    },
+    {
+      name: 'virtual-file',
+      resolveId(id) {
+        if (id === 'virtual:file') {
+          return '\0virtual:file'
+        }
+      },
+      load(id) {
+        if (id === '\0virtual:file') {
+          return 'import { virtual } from "/importedVirtual.js"; export { virtual };'
+        }
+      }
     }
   ]
 })

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -48,6 +48,7 @@ describe.runIf(isServe)('hmr', () => {
     editFile('src/importedVirtual.js', (code) =>
       code.replace('[success]', '[wow]')
     )
+    await page.waitForNavigation()
     await untilUpdated(async () => {
       const el = await page.$('.virtual')
       return await el.textContent()

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch'
 import { describe, expect, test } from 'vitest'
 import { port } from './serve'
-import { page } from '~utils'
+import { editFile, isServe, page, untilUpdated } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -37,5 +37,20 @@ describe('injected inline scripts', () => {
     for (const code of scriptContents) {
       expect(code).toBeTruthy()
     }
+  })
+})
+
+describe.runIf(isServe)('hmr', () => {
+  test('handle virtual module updates', async () => {
+    await page.goto(url)
+    const el = await page.$('.virtual')
+    expect(await el.textContent()).toBe('[success]')
+    editFile('src/importedVirtual.js', (code) =>
+      code.replace('[success]', '[wow]')
+    )
+    await untilUpdated(async () => {
+      const el = await page.$('.virtual')
+      return await el.textContent()
+    }, '[wow]')
   })
 })

--- a/playground/ssr-html/index.html
+++ b/playground/ssr-html/index.html
@@ -12,5 +12,6 @@
   </head>
   <body>
     <h1>SSR Dynamic HTML</h1>
+    <div class="virtual"></div>
   </body>
 </html>

--- a/playground/ssr-html/server.js
+++ b/playground/ssr-html/server.js
@@ -48,7 +48,22 @@ export async function createServer(root = process.cwd(), hmrPort) {
         port: hmrPort
       }
     },
-    appType: 'custom'
+    appType: 'custom',
+    plugins: [
+      {
+        name: 'virtual-file',
+        resolveId(id) {
+          if (id === 'virtual:file') {
+            return '\0virtual:file'
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:file') {
+            return 'import { virtual } from "/src/importedVirtual.js"; export { virtual };'
+          }
+        }
+      }
+    ]
   })
   // use vite's connect instance as middleware
   app.use(vite.middlewares)

--- a/playground/ssr-html/src/app.js
+++ b/playground/ssr-html/src/app.js
@@ -1,8 +1,9 @@
+import { virtual } from 'virtual:file'
+
 const p = document.createElement('p')
 p.innerHTML = '✅ Dynamically injected script from file'
 document.body.appendChild(p)
 
-import { virtual } from 'virtual:file'
 text('.virtual', virtual)
 
 function text(el, text) {

--- a/playground/ssr-html/src/app.js
+++ b/playground/ssr-html/src/app.js
@@ -1,3 +1,10 @@
 const p = document.createElement('p')
 p.innerHTML = '✅ Dynamically injected script from file'
 document.body.appendChild(p)
+
+import { virtual } from 'virtual:file'
+text('.virtual', virtual)
+
+function text(el, text) {
+  document.querySelector(el).textContent = text
+}

--- a/playground/ssr-html/src/importedVirtual.js
+++ b/playground/ssr-html/src/importedVirtual.js
@@ -1,0 +1,1 @@
+export const virtual = '[success]'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix https://github.com/withastro/astro/issues/4727

In the module graph, `virtual:foo` that resolves to `\0virtual:foo` could be represented as both `/@id/__x00__virtual:foo` and `\0virtual:foo` in the module graph (two separate modules). This is because in some cases we use `unwrapId` and some not.

- ~~This PR calls `unwrapId` in the module graph to ensure they are deduped.~~
- **new**: This PR calls `unwrapId` in the import analysis so that urls passed to the module graph are already unwrapped.
- I also refactored `unwrapId` and added `wrapId` (not related to the bug, but I refactored along)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

**Note**: The below questions has been addressed in the GitHub comments below

- It looks like `\0virtual:foo` is being treated as a "url" in module graph terms, which doesn't sound right. I tried to fix this by passing `/@id/__x00__virtual:foo` as URLs but SSR seems to always fail to load and transform for some reason.
- I tried to avoid using `unwrapId` in the module graph since it feels a bit hacky/catch-all, but there's many place where we're not properly unwrap the id that might further clutter the code.
- Perhaps the above change could be done in the  id <-> url re-definition we discussed before.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
