### PR TITLE
chore: remove duplicated logic in vanilla template

### DIFF
--- a/packages/create-vite/template-vanilla-ts/src/counter.ts
+++ b/packages/create-vite/template-vanilla-ts/src/counter.ts
@@ -4,6 +4,6 @@ export function setupCounter(element: HTMLButtonElement) {
     counter = count
     element.innerHTML = `count is ${counter}`
   }
-  element.addEventListener('click', () => setCounter(++counter))
+  element.addEventListener('click', () => setCounter(counter + 1))
   setCounter(0)
 }

--- a/packages/create-vite/template-vanilla/counter.js
+++ b/packages/create-vite/template-vanilla/counter.js
@@ -4,6 +4,6 @@ export function setupCounter(element) {
     counter = count
     element.innerHTML = `count is ${counter}`
   }
-  element.addEventListener('click', () => setCounter(++counter))
+  element.addEventListener('click', () => setCounter(counter + 1))
   setCounter(0)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When getting started with Vite, I noticed some odd code in the vanilla template:

```js
export function setupCounter(element) {
  let counter = 0              
  const setCounter = (count) => { 
    counter = count            
    element.innerHTML = `count is ${counter}`
  }
  element.addEventListener('click', () => setCounter(++counter))
  setCounter(0)                
} 
```

The `++counter` expression actually mutates `counter`, but then it is also mutated by `counter = count`. I find this confusing, and it's not the sort of thing I would expect to see in a template example.

I would suggest to make a small change so that instead of mutating `counter` twice, it's mutated only once, inside the body of `setCounter`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
