### PR TITLE
fix: esbuildOutputFromId for symlinked root

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -911,12 +911,22 @@ function esbuildOutputFromId(
   id: string,
   cacheDirOutputPath: string
 ): any {
+  const cwd = process.cwd()
   const flatId = flattenId(id) + '.js'
-  return outputs[
-    normalizePath(
-      path.relative(process.cwd(), path.join(cacheDirOutputPath, flatId))
-    )
-  ]
+  const normalizedOutputPath = normalizePath(
+    path.relative(cwd, path.join(cacheDirOutputPath, flatId))
+  )
+  const output = outputs[normalizedOutputPath]
+  if (output) {
+    return output
+  }
+  // If the root dir was symlinked, esbuild could return output keys as `../cwd/`
+  // Normalize keys to support this case too
+  for (const [key, value] of Object.entries(outputs)) {
+    if (normalizePath(path.relative(cwd, key)) === normalizedOutputPath) {
+      return value
+    }
+  }
 }
 
 export async function extractExportsData(


### PR DESCRIPTION
### Description

Fixes #9327

I think this should work around the issue. It looks like esbuild is returning a redundant path when the root was symlinked (maybe it is something to fix at esbuild?). @AlttiRi @vricosti would you help us test this on Windows? I don't know if this is only one of the issues we will experience with this setup though.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other