### PR TITLE
fix(esbuild): transpile with esnext in dev

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -179,6 +179,7 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
   // Remove optimization options for dev as we only need to transpile them,
   // and for build as the final optimization is in `buildEsbuildPlugin`
   const transformOptions: TransformOptions = {
+    target: 'esnext',
     ...options,
     minify: false,
     minifyIdentifiers: false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

ref: https://github.com/vitejs/vite/pull/10207#issuecomment-1255878824

Same change as #10207 except for plugin-vue and backport to 3.1.

I didn't do the same change for `plugin-vue` as it doesn't include beta changes yet.

