### PR TITLE
fix(legacy): don't force set `build.target` when `renderLegacyChunks=false` (fixes #10201)

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -176,17 +176,19 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           config.build.cssTarget = 'chrome61'
         }
 
-        // Vite's default target browsers are **not** the same.
-        // See https://github.com/vitejs/vite/pull/10052#issuecomment-1242076461
-        overriddenBuildTarget = config.build.target !== undefined
-        // browsers supporting ESM + dynamic import + import.meta
-        config.build.target = [
-          'es2020',
-          'edge79',
-          'firefox67',
-          'chrome64',
-          'safari11.1'
-        ]
+        if (genLegacy) {
+          // Vite's default target browsers are **not** the same.
+          // See https://github.com/vitejs/vite/pull/10052#issuecomment-1242076461
+          overriddenBuildTarget = config.build.target !== undefined
+          // browsers supporting ESM + dynamic import + import.meta
+          config.build.target = [
+            'es2020',
+            'edge79',
+            'firefox67',
+            'chrome64',
+            'safari11.1'
+          ]
+        }
       }
 
       return {


### PR DESCRIPTION
### Description

#10072 force set `build.target`, but it's not necessary when `renderLegacyChunks=false`.
For example, when using plugin-legacy for only generating polyfills (https://github.com/vitejs/vite/issues/10201#issuecomment-1255965207).

fixes #10201

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
