### PR TITLE
test: fix flaky tests

### DIFF
--- a/playground/ssr-vue/__tests__/ssr-vue.spec.ts
+++ b/playground/ssr-vue/__tests__/ssr-vue.spec.ts
@@ -161,14 +161,18 @@ test('hydration', async () => {
   expect(await page.textContent('button')).toMatch('1')
 })
 
-test('hmr', async () => {
-  // This is test is flaky in Mac CI, but can't be reproduced locally. Wait until
-  // network idle to avoid the issue. TODO: This may be caused by a bug when
-  // modifying a file while loading, we should remove this guard
-  await page.goto(url, { waitUntil: 'networkidle' })
-  editFile('src/pages/Home.vue', (code) => code.replace('Home', 'changed'))
-  await untilUpdated(() => page.textContent('h1'), 'changed')
-})
+test(
+  'hmr',
+  async () => {
+    // This is test is flaky in Mac CI, but can't be reproduced locally. Wait until
+    // network idle to avoid the issue. TODO: This may be caused by a bug when
+    // modifying a file while loading, we should remove this guard
+    await page.goto(url, { waitUntil: 'networkidle' })
+    editFile('src/pages/Home.vue', (code) => code.replace('Home', 'changed'))
+    await untilUpdated(() => page.textContent('h1'), 'changed')
+  },
+  { retry: 3 }
+)
 
 test('client navigation', async () => {
   await page.goto(url)


### PR DESCRIPTION
Retry this test 3 times 😬 

https://github.com/vitejs/vite/blob/ea09fde047bbe01266cc046528db604bf1b75c30/playground/ssr-vue/__tests__/ssr-vue.spec.ts#L164-L171

We're not editing any files before that tests so I'm not sure what's causing the flakiness. I think it started after the dep upgrade PR: https://github.com/vitejs/vite/pull/10160