### PR TITLE
docs: place `.nojekyll` when deploying to GitHub Pages

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -64,7 +64,7 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 
 2. Inside your project, create `deploy.sh` with the following content (with highlighted lines uncommented appropriately), and run it to deploy:
 
-   ```bash{13,21,24}
+   ```bash{16,24,27}
    #!/usr/bin/env sh
 
    # abort on errors
@@ -75,6 +75,9 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 
    # navigate into the build output directory
    cd dist
+
+   # place .nojekyll to bypass Jekyll processing
+   echo > .nojekyll
 
    # if you are deploying to a custom domain
    # echo 'www.example.com' > CNAME


### PR DESCRIPTION
### Description

`.nojekyll` needs to be placed to bypass Jekyll processing that skips files starting with `_`.
This PR adds some lines to the docs about it.

refs #238, #9119, https://github.com/vuejs/vitepress/issues/1364

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
