### PR TITLE
feat: customize ErrorOverlay

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -9,6 +9,17 @@ const template = /*html*/ `
   left: 0;
   width: 100%;
   height: 100%;
+
+  --monospace: 'SFMono-Regular', Consolas,
+  'Liberation Mono', Menlo, Courier, monospace;
+  --red: #ff5555;
+  --yellow: #e2aa53;
+  --purple: #cfa4ff;
+  --cyan: #2dd9da;
+  --dim: #c9c9c9;
+
+  --window-background: #181818;
+  --window-color: #d8d8d8;
 }
 
 .backdrop {
@@ -21,24 +32,17 @@ const template = /*html*/ `
   overflow-y: scroll;
   margin: 0;
   background: rgba(0, 0, 0, 0.66);
-  --monospace: 'SFMono-Regular', Consolas,
-              'Liberation Mono', Menlo, Courier, monospace;
-  --red: #ff5555;
-  --yellow: #e2aa53;
-  --purple: #cfa4ff;
-  --cyan: #2dd9da;
-  --dim: #c9c9c9;
 }
 
 .window {
   font-family: var(--monospace);
   line-height: 1.5;
   width: 800px;
-  color: #d8d8d8;
+  color: var(--window-color);
   margin: 30px auto;
   padding: 25px 40px;
   position: relative;
-  background: #181818;
+  background: var(--window-background);
   border-radius: 6px 6px 8px 8px;
   box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
   overflow: hidden;
@@ -108,13 +112,13 @@ code {
   cursor: pointer;
 }
 </style>
-<div class="backdrop">
-  <div class="window">
-    <pre class="message"><span class="plugin"></span><span class="message-body"></span></pre>
-    <pre class="file"></pre>
-    <pre class="frame"></pre>
-    <pre class="stack"></pre>
-    <div class="tip">
+<div class="backdrop" part="backdrop">
+  <div class="window" part="window">
+    <pre class="message" part="message"><span class="plugin"></span><span class="message-body"></span></pre>
+    <pre class="file" part="file"></pre>
+    <pre class="frame" part="frame"></pre>
+    <pre class="stack" part="stack"></pre>
+    <div class="tip" part="tip">
       Click outside or fix the code to dismiss.<br>
       You can also disable this overlay by setting
       <code>server.hmr.overlay</code> to <code>false</code> in <code>vite.config.js.</code>
@@ -132,7 +136,7 @@ const { HTMLElement = class {} as typeof globalThis.HTMLElement } = globalThis
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot
 
-  constructor(err: ErrorPayload['err']) {
+  constructor(err: ErrorPayload['err'], links = true) {
     super()
     this.root = this.attachShadow({ mode: 'open' })
     this.root.innerHTML = template
@@ -149,7 +153,7 @@ export class ErrorOverlay extends HTMLElement {
 
     const [file] = (err.loc?.file || err.id || 'unknown file').split(`?`)
     if (err.loc) {
-      this.text('.file', `${file}:${err.loc.line}:${err.loc.column}`, true)
+      this.text('.file', `${file}:${err.loc.line}:${err.loc.column}`, links)
     } else if (err.id) {
       this.text('.file', file)
     }
@@ -157,7 +161,7 @@ export class ErrorOverlay extends HTMLElement {
     if (hasFrame) {
       this.text('.frame', err.frame!.trim())
     }
-    this.text('.stack', err.stack, true)
+    this.text('.stack', err.stack, links)
 
     this.root.querySelector('.window')!.addEventListener('click', (e) => {
       e.stopPropagation()


### PR DESCRIPTION
### Description

As maintainer of Qwik, i would love to customize some aspects of the magnific ErrorOverlay:

- When to display links in the stack: we want to use this component for client-side errors to, and link will be wrong, we prefer to disable it
- Customize some of the color
- Custimizer everything!! by using css parts! https://developer.mozilla.org/en-US/docs/Web/CSS/::part

### Additional context

- Moving the CSS variables to the host element is the right way to declare CSS variables, this way it's possible to override the default values, this is a common practice in WC UI libraries.

- Declaring parts is a risk free API to target WC and style inner parts of a WC!

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
