### PR TITLE
feat: add cssEmitAsset option

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -106,6 +106,15 @@ If disabled, all CSS in the entire project will be extracted into a single CSS f
 If you specify `build.lib`, `build.cssCodeSplit` will be `false` as default.
 :::
 
+## build.cssEmitAsset
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Vite will generate external style files, as part of the build.
+
+If `false` vite will not generate any external asset, all css imports will behave like `.css?inline`;
+
 ## build.cssTarget
 
 - **Type:** `string | string[]`

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -116,6 +116,13 @@ export interface BuildOptions {
    */
   cssTarget?: TransformOptions['target'] | false
   /**
+   * Vite will generate external style files, as part of the build.
+   * If `false` vite will not generate any external asset, all css imports will
+   * behave like `.css?inline`;
+   * @default true
+   */
+  cssEmitAsset?: boolean
+  /**
    * If `true`, a separate sourcemap file will be created. If 'inline', the
    * sourcemap will be appended to the resulting output file as data URI.
    * 'hidden' works like `true` except that the corresponding sourcemap
@@ -301,6 +308,7 @@ export function resolveBuildOptions(
     assetsInlineLimit: 4096,
     cssCodeSplit: !raw?.lib,
     cssTarget: false,
+    cssEmitAsset: true,
     sourcemap: false,
     rollupOptions: {},
     minify: raw?.ssr ? false : 'esbuild',

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -345,8 +345,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       ) {
         return
       }
-
-      const inlined = inlineRE.test(id)
+      const inlined = config.build.cssEmitAsset ? inlineRE.test(id) : true
       const modules = cssModulesCache.get(config)!.get(id)
 
       // #6984, #7552


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

As Qwik maintainer, i would like to disable the default behaviour of Vite that emits .css files, Qwik is a bit special, and this is not a good practice, instead we would like all css imports to behave like inline imports:

ie.
```tsx
import css from './styles.css'
```
same as:
```tsx
import css from './styles.css?inline'
```

Occasionally, we find developers forgetting the `?inline` and causing double load of the styles.


### Additional context

This is an important issue for us, i understand that adding a new option is not ideal, but i think it's a valid use case.

Also, i understand the naming, or location of the config might not be correct, i am open to any different API as long as we can change the default behaviour!


As soon as some vite core team confirms this can get merged, i can work on adding new unit tests!!

Thanks so much for the amazing work!

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
