### PR TITLE
fix(react): conditionally self-accept fast-refresh HMR

### DIFF
--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -104,6 +104,8 @@ import(/* @vite-ignore */ import.meta.url).then(mod => {
   import.meta.hot.accept();
   if (isReactRefreshBoundary(mod)) {
     ${timeout}
+  } else {
+    import.meta.hot.invalidate();
   }
 })
 `

--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -101,8 +101,8 @@ function isReactRefreshBoundary(mod) {
 }
 
 import(/* @vite-ignore */ import.meta.url).then(mod => {
+  import.meta.hot.accept();
   if (isReactRefreshBoundary(mod)) {
-    import.meta.hot.accept();
     ${timeout}
   }
 })

--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -100,14 +100,13 @@ function isReactRefreshBoundary(mod) {
   return hasExports && areAllExportsComponents;
 }
 
-import(/* @vite-ignore */ import.meta.url).then(mod => {
-  import.meta.hot.accept();
+import.meta.hot.accept(mod => {
   if (isReactRefreshBoundary(mod)) {
     ${timeout}
   } else {
     import.meta.hot.invalidate();
   }
-})
+});
 `
 
 export function addRefreshWrapper(

--- a/packages/plugin-react/src/fast-refresh.ts
+++ b/packages/plugin-react/src/fast-refresh.ts
@@ -58,19 +58,55 @@ if (import.meta.hot) {
   window.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
 }`.replace(/[\n]+/gm, '')
 
-const footer = `
-if (import.meta.hot) {
-  window.$RefreshReg$ = prevRefreshReg;
-  window.$RefreshSig$ = prevRefreshSig;
-
-  __ACCEPT__
+const timeout = `
   if (!window.__vite_plugin_react_timeout) {
     window.__vite_plugin_react_timeout = setTimeout(() => {
       window.__vite_plugin_react_timeout = 0;
       RefreshRuntime.performReactRefresh();
     }, 30);
   }
+`
+
+const footer = `
+if (import.meta.hot) {
+  window.$RefreshReg$ = prevRefreshReg;
+  window.$RefreshSig$ = prevRefreshSig;
+
+  __ACCEPT__
 }`
+
+const checkAndAccept = `
+function isReactRefreshBoundary(mod) {
+  if (mod == null || typeof mod !== 'object') {
+    return false;
+  }
+  let hasExports = false;
+  let areAllExportsComponents = true;
+  for (const exportName in mod) {
+    hasExports = true;
+    if (exportName === '__esModule') {
+      continue;
+    }
+    const desc = Object.getOwnPropertyDescriptor(mod, exportName);
+    if (desc && desc.get) {
+      // Don't invoke getters as they may have side effects.
+      return false;
+    }
+    const exportValue = mod[exportName];
+    if (!RefreshRuntime.isLikelyComponentType(exportValue)) {
+      areAllExportsComponents = false;
+    }
+  }
+  return hasExports && areAllExportsComponents;
+}
+
+import(/* @vite-ignore */ import.meta.url).then(mod => {
+  if (isReactRefreshBoundary(mod)) {
+    import.meta.hot.accept();
+    ${timeout}
+  }
+})
+`
 
 export function addRefreshWrapper(
   code: string,
@@ -80,12 +116,13 @@ export function addRefreshWrapper(
   return (
     header.replace('__SOURCE__', JSON.stringify(id)) +
     code +
-    footer.replace('__ACCEPT__', accept ? 'import.meta.hot.accept();' : '')
+    footer.replace('__ACCEPT__', accept ? checkAndAccept : timeout)
   )
 }
 
 export function isRefreshBoundary(ast: t.File): boolean {
-  // Every export must be a React component.
+  // Every export must be a potential React component.
+  // We'll also perform a runtime check that's more robust as well (isLikelyComponentType).
   return ast.program.body.every((node) => {
     if (node.type !== 'ExportNamedDeclaration') {
       return true

--- a/playground/react/App.jsx
+++ b/playground/react/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import Dummy from './components/Dummy?qs-should-not-break-plugin-react'
 import Button from 'jsx-entry'
+import Dummy from './components/Dummy?qs-should-not-break-plugin-react'
+import Parent from './hmr/parent'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -27,6 +28,7 @@ function App() {
       </header>
 
       <Dummy />
+      <Parent />
       <Button>button</Button>
     </div>
   )

--- a/playground/react/App.jsx
+++ b/playground/react/App.jsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import Button from 'jsx-entry'
 import Dummy from './components/Dummy?qs-should-not-break-plugin-react'
 import Parent from './hmr/parent'
+import { CountProvider } from './context/CountProvider'
+import { ContextButton } from './context/ContextButton'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -10,9 +12,15 @@ function App() {
       <header className="App-header">
         <h1>Hello Vite + React</h1>
         <p>
-          <button onClick={() => setCount((count) => count + 1)}>
+          <button
+            id="state-button"
+            onClick={() => setCount((count) => count + 1)}
+          >
             count is: {count}
           </button>
+        </p>
+        <p>
+          <ContextButton />
         </p>
         <p>
           Edit <code>App.jsx</code> and save to test HMR updates.
@@ -34,4 +42,12 @@ function App() {
   )
 }
 
-export default App
+function AppWithProviders() {
+  return (
+    <CountProvider>
+      <App />
+    </CountProvider>
+  )
+}
+
+export default AppWithProviders

--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { editFile, isServe, page, untilUpdated } from '~utils'
+import { browserLogs, editFile, isServe, page, untilUpdated } from '~utils'
 
 test('should render', async () => {
   expect(await page.textContent('h1')).toMatch('Hello Vite + React')
@@ -16,6 +16,19 @@ test('should hmr', async () => {
   await untilUpdated(() => page.textContent('h1'), 'Hello Updated')
   // preserve state
   expect(await page.textContent('button')).toMatch('count is: 1')
+})
+
+// #9869
+test('should only hmr files with exported react components', async () => {
+  browserLogs.length = 0
+  editFile('hmr/no-exported-comp.jsx', (code) =>
+    code.replace('An Object', 'Updated')
+  )
+  await untilUpdated(() => page.textContent('#parent'), 'Updated')
+  expect(browserLogs).toMatchObject([
+    '[vite] hot updated: /hmr/parent.jsx',
+    'Parent rendered'
+  ])
 })
 
 test.runIf(isServe)(

--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -26,9 +26,11 @@ test('should only hmr files with exported react components', async () => {
   )
   await untilUpdated(() => page.textContent('#parent'), 'Updated')
   expect(browserLogs).toMatchObject([
+    '[vite] hot updated: /hmr/no-exported-comp.jsx',
     '[vite] hot updated: /hmr/parent.jsx',
     'Parent rendered'
   ])
+  browserLogs.length = 0
 })
 
 test.runIf(isServe)(

--- a/playground/react/__tests__/react.spec.ts
+++ b/playground/react/__tests__/react.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test } from 'vitest'
-import { browserLogs, editFile, isServe, page, untilUpdated } from '~utils'
+import {
+  browserLogs,
+  editFile,
+  isBuild,
+  isServe,
+  page,
+  untilUpdated
+} from '~utils'
 
 test('should render', async () => {
   expect(await page.textContent('h1')).toMatch('Hello Vite + React')
@@ -16,21 +23,6 @@ test('should hmr', async () => {
   await untilUpdated(() => page.textContent('h1'), 'Hello Updated')
   // preserve state
   expect(await page.textContent('#state-button')).toMatch('count is: 1')
-})
-
-// #9869
-test('should only hmr files with exported react components', async () => {
-  browserLogs.length = 0
-  editFile('hmr/no-exported-comp.jsx', (code) =>
-    code.replace('An Object', 'Updated')
-  )
-  await untilUpdated(() => page.textContent('#parent'), 'Updated')
-  expect(browserLogs).toMatchObject([
-    '[vite] hot updated: /hmr/no-exported-comp.jsx',
-    '[vite] hot updated: /hmr/parent.jsx',
-    'Parent rendered'
-  ])
-  browserLogs.length = 0
 })
 
 test.runIf(isServe)(
@@ -53,27 +45,45 @@ test.runIf(isServe)(
   }
 )
 
-test('should hmr react context', async () => {
-  browserLogs.length = 0
-  expect(await page.textContent('#context-button')).toMatch(
-    'context-based count is: 0'
-  )
-  await page.click('#context-button')
-  expect(await page.textContent('#context-button')).toMatch(
-    'context-based count is: 1'
-  )
-  editFile('context/CountProvider.jsx', (code) =>
-    code.replace('context provider', 'context provider updated')
-  )
-  await untilUpdated(
-    () => page.textContent('#context-provider'),
-    'context provider updated'
-  )
-  expect(browserLogs).toMatchObject([
-    '[vite] hot updated: /context/CountProvider.jsx',
-    '[vite] hot updated: /App.jsx',
-    '[vite] hot updated: /context/ContextButton.jsx',
-    'Parent rendered'
-  ])
-  browserLogs.length = 0
-})
+if (!isBuild) {
+  // #9869
+  test('should only hmr files with exported react components', async () => {
+    browserLogs.length = 0
+    editFile('hmr/no-exported-comp.jsx', (code) =>
+      code.replace('An Object', 'Updated')
+    )
+    await untilUpdated(() => page.textContent('#parent'), 'Updated')
+    expect(browserLogs).toMatchObject([
+      '[vite] hot updated: /hmr/no-exported-comp.jsx',
+      '[vite] hot updated: /hmr/parent.jsx',
+      'Parent rendered'
+    ])
+    browserLogs.length = 0
+  })
+
+  // #3301
+  test('should hmr react context', async () => {
+    browserLogs.length = 0
+    expect(await page.textContent('#context-button')).toMatch(
+      'context-based count is: 0'
+    )
+    await page.click('#context-button')
+    expect(await page.textContent('#context-button')).toMatch(
+      'context-based count is: 1'
+    )
+    editFile('context/CountProvider.jsx', (code) =>
+      code.replace('context provider', 'context provider updated')
+    )
+    await untilUpdated(
+      () => page.textContent('#context-provider'),
+      'context provider updated'
+    )
+    expect(browserLogs).toMatchObject([
+      '[vite] hot updated: /context/CountProvider.jsx',
+      '[vite] hot updated: /App.jsx',
+      '[vite] hot updated: /context/ContextButton.jsx',
+      'Parent rendered'
+    ])
+    browserLogs.length = 0
+  })
+}

--- a/playground/react/context/ContextButton.jsx
+++ b/playground/react/context/ContextButton.jsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+import { CountContext } from './CountProvider'
+
+export function ContextButton() {
+  const { count, setCount } = useContext(CountContext)
+  return (
+    <button id="context-button" onClick={() => setCount((count) => count + 1)}>
+      context-based count is: {count}
+    </button>
+  )
+}

--- a/playground/react/context/CountProvider.jsx
+++ b/playground/react/context/CountProvider.jsx
@@ -1,0 +1,12 @@
+import { createContext, useState } from 'react'
+export const CountContext = createContext()
+
+export const CountProvider = ({ children }) => {
+  const [count, setCount] = useState(0)
+  return (
+    <CountContext.Provider value={{ count, setCount }}>
+      {children}
+      <div id="context-provider">context provider</div>
+    </CountContext.Provider>
+  )
+}

--- a/playground/react/hmr/no-exported-comp.jsx
+++ b/playground/react/hmr/no-exported-comp.jsx
@@ -1,0 +1,7 @@
+// This un-exported react component should not cause this file to be treated
+// as an HMR boundary
+const Unused = () => <span>An unused react component</span>
+
+export const Foo = {
+  is: 'An Object'
+}

--- a/playground/react/hmr/parent.jsx
+++ b/playground/react/hmr/parent.jsx
@@ -1,0 +1,7 @@
+import { Foo } from './no-exported-comp'
+
+export default function Parent() {
+  console.log('Parent rendered')
+
+  return <div id="parent">{Foo.is}</div>
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes https://github.com/vitejs/vite/issues/9869
Fixes https://github.com/vitejs/vite/issues/3301
Fixes vitejs/vite#4298
Fixes vitejs/vite#6885
Fixes vitejs/vite#7396

Based on top of https://github.com/vitejs/vite/pull/10244

This makes a change to the HMR code that's injected by plugin-react to check the exports of a module, and determine whether it is safe to treat as a fast-refresh boundary.  If it is a safe fast-refresh boundary, we will perform fast-refresh.  If not, we now call `hot.invalidate()` (relying on the changes in vitejs/vite#10244) to propagate HMR up to parents.  This is necessary because vite sees `import.meta.hot.accept()` even if it's inside a conditional, and treats the module as self-accepting.  So without calling `hot.invalidate()`, the parent will never know to fast-refresh.  

I've also added a test here for changing a react context file, and verified that it fails without the changes here, but passes with them.  

### Additional context

The other PR, vitejs/vite#10244 should be reviewed first, since this one depends on it.

Thanks for help on this, @aleclarson!  
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
