### PR TITLE
fix: cacheDir should be ignored from watch

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -574,6 +574,7 @@ async function doBuild(
       }
 
       const resolvedChokidarOptions = resolveChokidarOptions(
+        config,
         config.build.watch.chokidar
       )
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -530,11 +530,13 @@ export async function resolveConfig(
 
   // resolve cache directory
   const pkgPath = lookupFile(resolvedRoot, [`package.json`], { pathOnly: true })
-  const cacheDir = config.cacheDir
-    ? path.resolve(resolvedRoot, config.cacheDir)
-    : pkgPath
-    ? path.join(path.dirname(pkgPath), `node_modules/.vite`)
-    : path.join(resolvedRoot, `.vite`)
+  const cacheDir = normalizePath(
+    config.cacheDir
+      ? path.resolve(resolvedRoot, config.cacheDir)
+      : pkgPath
+      ? path.join(path.dirname(pkgPath), `node_modules/.vite`)
+      : path.join(resolvedRoot, `.vite`)
+  )
 
   const assetsFilter = config.assetsInclude
     ? createFilter(config.assetsInclude)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -304,7 +304,7 @@ export async function createServer(
   const httpsOptions = await resolveHttpsConfig(config.server.https)
   const { middlewareMode } = serverConfig
 
-  const resolvedWatchOptions = resolveChokidarOptions({
+  const resolvedWatchOptions = resolveChokidarOptions(config, {
     disableGlobbing: true,
     ...serverConfig.watch
   })

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -1,6 +1,9 @@
+import path from 'node:path'
 import type { WatchOptions } from 'dep-types/chokidar'
+import type { ResolvedConfig } from '.'
 
 export function resolveChokidarOptions(
+  config: ResolvedConfig,
   options: WatchOptions | undefined
 ): WatchOptions {
   const { ignored = [], ...otherOptions } = options ?? {}
@@ -10,6 +13,7 @@ export function resolveChokidarOptions(
       '**/.git/**',
       '**/node_modules/**',
       '**/test-results/**', // Playwright
+      path.relative(config.root, config.cacheDir + '/**'),
       ...(Array.isArray(ignored) ? ignored : [ignored])
     ],
     ignoreInitial: true,

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -13,7 +13,7 @@ export function resolveChokidarOptions(
       '**/.git/**',
       '**/node_modules/**',
       '**/test-results/**', // Playwright
-      escapePath(config.cacheDir + '/**'),
+      escapePath(config.cacheDir) + '/**',
       ...(Array.isArray(ignored) ? ignored : [ignored])
     ],
     ignoreInitial: true,

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -1,4 +1,4 @@
-import path from 'node:path'
+import { escapePath } from 'fast-glob'
 import type { WatchOptions } from 'dep-types/chokidar'
 import type { ResolvedConfig } from '.'
 
@@ -13,7 +13,7 @@ export function resolveChokidarOptions(
       '**/.git/**',
       '**/node_modules/**',
       '**/test-results/**', // Playwright
-      path.relative(config.root, config.cacheDir + '/**'),
+      escapePath(config.cacheDir + '/**'),
       ...(Array.isArray(ignored) ? ignored : [ignored])
     ],
     ignoreInitial: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`cacheDir` should be ignored from watch.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

By default, `cacheDir` is `node_modules/.vite` and is ignored from watch. However user may change this path which leads to unexpected watch on this directory.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
