### PR TITLE
feat: support import.meta.hot.invalidate

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -125,7 +125,18 @@ Calling `import.meta.hot.decline()` indicates this module is not hot-updatable, 
 
 ## `hot.invalidate()`
 
-Calling `import.meta.hot.invalidate()` indicates that changes have occurred and the module's state should be treated as invalid. This will cause importers of the module to HMR, and thus provides a way to force changes to propagate upwards.
+A self-accepting module may realize during runtime that it can't handle a HMR update, and so the update needs to be forcefully propagated to importers. By calling `import.meta.hot.invalidate()`, the HMR server will invalidate the importers of the caller, as if the caller wasn't self-accepting.
+
+Note that you should always call `import.meta.hot.accept` even if you plan to call `invalidate` immediately afterwards, or else the HMR client won't listen for future changes to the self-accepting module. To communicate your intent clearly, we recommend calling `invalidate` within the `accept` callback like so:
+
+    ```ts
+    import.meta.hot.accept(module => {
+      // You may use the new module instance to decide whether to invalidate.
+      if (cannotHandleUpdate(module)) {
+        import.meta.hot.invalidate()
+      }
+    })
+    ```
 
 ## `hot.on(event, cb)`
 

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -125,7 +125,7 @@ Calling `import.meta.hot.decline()` indicates this module is not hot-updatable, 
 
 ## `hot.invalidate()`
 
-For now, calling `import.meta.hot.invalidate()` simply reloads the page.
+Calling `import.meta.hot.invalidate()` indicates that changes have occurred and the module's state should be treated as invalid. This will cause importers of the module to HMR, and thus provides a way to force changes to propagate upwards.
 
 ## `hot.on(event, cb)`
 
@@ -136,6 +136,7 @@ The following HMR events are dispatched by Vite automatically:
 - `'vite:beforeUpdate'` when an update is about to be applied (e.g. a module will be replaced)
 - `'vite:beforeFullReload'` when a full reload is about to occur
 - `'vite:beforePrune'` when modules that are no longer needed are about to be pruned
+- `'vite:invalidate'` when a module is invalidated with `import.meta.hot.invalidate()`
 - `'vite:error'` when an error occurs (e.g. syntax error)
 
 Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plugin#handlehotupdate) for more details.

--- a/packages/vite/src/client-types.d.ts
+++ b/packages/vite/src/client-types.d.ts
@@ -1,6 +1,7 @@
 export type {
   CustomEventMap,
-  InferCustomEventPayload
+  InferCustomEventPayload,
+  InvalidatePayload
 } from './types/customEvent'
 export type {
   HMRPayload,

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -546,10 +546,9 @@ export function createHotContext(ownerPath: string): ViteHotContext {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     decline() {},
 
+    // tell the server to re-perform hmr propagation from this module as root
     invalidate() {
-      // TODO should tell the server to re-perform hmr propagation
-      // from this module as root
-      location.reload()
+      this.send('vite:invalidate', ownerPath)
     },
 
     // custom events

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -548,8 +548,8 @@ export function createHotContext(ownerPath: string): ViteHotContext {
 
     // tell the server to re-perform hmr propagation from this module as root
     invalidate() {
-      notifyListeners('vite:invalidate', ownerPath)
-      this.send('vite:invalidate', ownerPath)
+      notifyListeners('vite:invalidate', { path: ownerPath })
+      this.send('vite:invalidate', { path: ownerPath })
     },
 
     // custom events

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -548,6 +548,7 @@ export function createHotContext(ownerPath: string): ViteHotContext {
 
     // tell the server to re-perform hmr propagation from this module as root
     invalidate() {
+      notifyListeners('vite:invalidate', ownerPath)
       this.send('vite:invalidate', ownerPath)
     },
 

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -102,7 +102,11 @@ export type {
   PrunePayload,
   ErrorPayload
 } from 'types/hmrPayload'
-export type { CustomEventMap, InferCustomEventPayload } from 'types/customEvent'
+export type {
+  CustomEventMap,
+  InferCustomEventPayload,
+  InvalidatePayload
+} from 'types/customEvent'
 // [deprecated: use vite/client/types instead]
 export type {
   ImportGlobFunction,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -498,7 +498,7 @@ export async function createServer(
         importers.add(importer)
       }
       const file = getShortName(mod.file!, config.root)
-      updateModules(file, Array.from(importers), Date.now(), server)
+      updateModules(file, Array.from(importers), mod.lastHMRTimestamp, server)
     }
   })
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -498,12 +498,8 @@ export async function createServer(
   ws.on('vite:invalidate', async (url: string) => {
     const mod = moduleGraph.urlToModuleMap.get(url)
     if (mod && mod.isSelfAccepting && mod.lastHMRTimestamp > 0) {
-      const importers = new Set<ModuleNode>()
-      for (const importer of mod.importers) {
-        importers.add(importer)
-      }
       const file = getShortName(mod.file!, config.root)
-      updateModules(file, Array.from(importers), mod.lastHMRTimestamp, server)
+      updateModules(file, [...mod.importers], mod.lastHMRTimestamp, server)
     }
   })
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -492,7 +492,7 @@ export async function createServer(
 
   ws.on('vite:invalidate', async (url: string) => {
     const mod = moduleGraph.urlToModuleMap.get(url)
-    if (mod) {
+    if (mod && mod.isSelfAccepting) {
       const importers = new Set<ModuleNode>()
       for (const importer of mod.importers) {
         importers.add(importer)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -13,6 +13,7 @@ import launchEditorMiddleware from 'launch-editor-middleware'
 import type { SourceMap } from 'rollup'
 import picomatch from 'picomatch'
 import type { Matcher } from 'picomatch'
+import type { InvalidatePayload } from 'types/customEvent'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,
@@ -494,8 +495,8 @@ export async function createServer(
     handleFileAddUnlink(normalizePath(file), server)
   })
 
-  ws.on('vite:invalidate', async (url: string) => {
-    const mod = moduleGraph.urlToModuleMap.get(url)
+  ws.on('vite:invalidate', async ({ path }: InvalidatePayload) => {
+    const mod = moduleGraph.urlToModuleMap.get(path)
     if (mod && mod.isSelfAccepting && mod.lastHMRTimestamp > 0) {
       const file = getShortName(mod.file!, config.root)
       updateModules(file, [...mod.importers], mod.lastHMRTimestamp, server)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -64,15 +64,15 @@ import {
   serveStaticMiddleware
 } from './middlewares/static'
 import { timeMiddleware } from './middlewares/time'
-import { ModuleGraph, ModuleNode } from './moduleGraph'
+import type { ModuleNode } from './moduleGraph';
+import { ModuleGraph } from './moduleGraph'
 import { errorMiddleware, prepareError } from './middlewares/error'
-import { getShortName, HmrOptions, updateModules } from './hmr'
-import { handleFileAddUnlink, handleHMRUpdate } from './hmr'
+import type { HmrOptions} from './hmr';
+import { getShortName, handleFileAddUnlink , handleHMRUpdate, updateModules } from './hmr'
 import { openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
 import { searchForWorkspaceRoot } from './searchRoot'
-import { HMRPayload } from '../../types/hmrPayload'
 
 export { searchForWorkspaceRoot } from './searchRoot'
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -64,11 +64,16 @@ import {
   serveStaticMiddleware
 } from './middlewares/static'
 import { timeMiddleware } from './middlewares/time'
-import type { ModuleNode } from './moduleGraph';
+import type { ModuleNode } from './moduleGraph'
 import { ModuleGraph } from './moduleGraph'
 import { errorMiddleware, prepareError } from './middlewares/error'
-import type { HmrOptions} from './hmr';
-import { getShortName, handleFileAddUnlink , handleHMRUpdate, updateModules } from './hmr'
+import type { HmrOptions } from './hmr'
+import {
+  getShortName,
+  handleFileAddUnlink,
+  handleHMRUpdate,
+  updateModules
+} from './hmr'
 import { openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -64,14 +64,15 @@ import {
   serveStaticMiddleware
 } from './middlewares/static'
 import { timeMiddleware } from './middlewares/time'
-import { ModuleGraph } from './moduleGraph'
+import { ModuleGraph, ModuleNode } from './moduleGraph'
 import { errorMiddleware, prepareError } from './middlewares/error'
-import type { HmrOptions } from './hmr'
+import { getShortName, HmrOptions, updateModules } from './hmr'
 import { handleFileAddUnlink, handleHMRUpdate } from './hmr'
 import { openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
 import { searchForWorkspaceRoot } from './searchRoot'
+import { HMRPayload } from '../../types/hmrPayload'
 
 export { searchForWorkspaceRoot } from './searchRoot'
 
@@ -487,6 +488,18 @@ export async function createServer(
   })
   watcher.on('unlink', (file) => {
     handleFileAddUnlink(normalizePath(file), server)
+  })
+
+  ws.on('vite:invalidate', async (url: string) => {
+    const mod = moduleGraph.urlToModuleMap.get(url)
+    if (mod) {
+      const importers = new Set<ModuleNode>()
+      for (const importer of mod.importers) {
+        importers.add(importer)
+      }
+      const file = getShortName(mod.file!, config.root)
+      updateModules(file, Array.from(importers), Date.now(), server)
+    }
   })
 
   if (!middlewareMode && httpServer) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -492,7 +492,7 @@ export async function createServer(
 
   ws.on('vite:invalidate', async (url: string) => {
     const mod = moduleGraph.urlToModuleMap.get(url)
-    if (mod && mod.isSelfAccepting) {
+    if (mod && mod.isSelfAccepting && mod.lastHMRTimestamp > 0) {
       const importers = new Set<ModuleNode>()
       for (const importer of mod.importers) {
         importers.add(importer)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -64,7 +64,6 @@ import {
   serveStaticMiddleware
 } from './middlewares/static'
 import { timeMiddleware } from './middlewares/time'
-import type { ModuleNode } from './moduleGraph'
 import { ModuleGraph } from './moduleGraph'
 import { errorMiddleware, prepareError } from './middlewares/error'
 import type { HmrOptions } from './hmr'

--- a/packages/vite/src/types/customEvent.d.ts
+++ b/packages/vite/src/types/customEvent.d.ts
@@ -10,6 +10,11 @@ export interface CustomEventMap {
   'vite:beforePrune': PrunePayload
   'vite:beforeFullReload': FullReloadPayload
   'vite:error': ErrorPayload
+  'vite:invalidate': InvalidatePayload
+}
+
+export interface InvalidatePayload {
+  path: string
 }
 
 export type InferCustomEventPayload<T extends string> =

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -1,1 +1,5 @@
-export type { CustomEventMap, InferCustomEventPayload } from '../client/types'
+export type {
+  CustomEventMap,
+  InferCustomEventPayload,
+  InvalidatePayload
+} from '../client/types'

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -2,6 +2,7 @@
 import { virtual } from 'virtual:file'
 import { foo as depFoo, nestedFoo } from './hmrDep'
 import './importing-updated'
+import './invalidation/parent'
 
 export const foo = 1
 text('.app', foo)
@@ -86,6 +87,10 @@ if (import.meta.hot) {
 
   import.meta.hot.on('vite:error', (event) => {
     console.log(`>>> vite:error -- ${event.type}`)
+  })
+
+  import.meta.hot.on('vite:invalidate', (event) => {
+    console.log(`>>> vite:invalidate -- ${event}`)
   })
 
   import.meta.hot.on('custom:foo', ({ msg }) => {

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -89,8 +89,8 @@ if (import.meta.hot) {
     console.log(`>>> vite:error -- ${event.type}`)
   })
 
-  import.meta.hot.on('vite:invalidate', (event) => {
-    console.log(`>>> vite:invalidate -- ${event}`)
+  import.meta.hot.on('vite:invalidate', ({ path }) => {
+    console.log(`>>> vite:invalidate -- ${path}`)
   })
 
   import.meta.hot.on('custom:foo', ({ msg }) => {

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -20,6 +20,7 @@
 <div class="nested"></div>
 <div class="custom"></div>
 <div class="virtual"></div>
+<div class="invalidation"></div>
 <div class="custom-communication"></div>
 <div class="css-prev"></div>
 <div class="css-post"></div>

--- a/playground/hmr/invalidation/child.js
+++ b/playground/hmr/invalidation/child.js
@@ -1,8 +1,9 @@
 if (import.meta.hot) {
   // Need to accept, to register a callback for HMR
-  import.meta.hot.accept()
-  // Trigger HMR in importers
-  import.meta.hot.invalidate()
+  import.meta.hot.accept(() => {
+    // Trigger HMR in importers
+    import.meta.hot.invalidate()
+  })
 }
 
 export const value = 'child'

--- a/playground/hmr/invalidation/child.js
+++ b/playground/hmr/invalidation/child.js
@@ -1,0 +1,8 @@
+if (import.meta.hot) {
+  // Need to accept, to register a callback for HMR
+  import.meta.hot.accept()
+  // Trigger HMR in importers
+  import.meta.hot.invalidate()
+}
+
+export const value = 'child'

--- a/playground/hmr/invalidation/parent.js
+++ b/playground/hmr/invalidation/parent.js
@@ -1,0 +1,9 @@
+import { value } from './child'
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}
+
+console.log('(invalidation) parent is executing')
+
+document.querySelector('.invalidation').innerHTML = value


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Self-accepting modules can call this to continue propagating the HMR update to importers. Conditional `hot.accept` calls do not work unless `hot.invalidate` is called when the condition fails.

This was pulled out from https://github.com/vitejs/vite/pull/10239, with some docs and tests added.  But the real credit here goes to @aleclarson.


### Additional context

This is needed for propagating HMR updates from files that should not be treated as react fast-refresh boundaries according to the runtime check.  

I think this does not change behavior enough to warrant a breaking change label, but it _does_ change the behavior from simply refreshing the page to propagating HMR upwards.  But it's possible that some users were using `invalidate()` because they _wanted_ a full page refresh.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
