### PR TITLE
test: skip favicon log in debug serve

### DIFF
--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -122,6 +122,14 @@ beforeAll(async (s) => {
 
   try {
     page.on('console', (msg) => {
+      // ignore favicon request in headed browser
+      if (
+        process.env.VITE_DEBUG_SERVE &&
+        msg.text().includes('Failed to load resource:') &&
+        msg.location().url.includes('favicon.ico')
+      ) {
+        return
+      }
       browserLogs.push(msg.text())
     })
     page.on('pageerror', (error) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

@aleclarson brought up that `pnpm debug-serve hmr` is causing it to fail consistently which I can reproduce too.

This is because headed browser would make a request for `favicon.ico` and fails to fetch, inserting an error browser log. This PR skips this specific case to match headless behaviour.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

