### PR TITLE
fix: remove dollar signs ($) in the bash commands

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -161,7 +161,7 @@ export { Foo, Bar }
 Running `vite build` with this config uses a Rollup preset that is oriented towards shipping libraries and produces two bundle formats: `es` and `umd` (configurable via `build.lib`):
 
 ```
-$ vite build
+vite build
 building for production...
 dist/my-lib.js      0.08 KiB / gzip: 0.07 KiB
 dist/my-lib.umd.cjs 0.30 KiB / gzip: 0.16 KiB

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -44,19 +44,19 @@ Vite requires [Node.js](https://nodejs.org/en/) version 14.18+, 16+. However, so
 With NPM:
 
 ```bash
-$ npm create vite@latest
+npm create vite@latest
 ```
 
 With Yarn:
 
 ```bash
-$ yarn create vite
+yarn create vite
 ```
 
 With PNPM:
 
 ```bash
-$ pnpm create vite
+pnpm create vite
 ```
 
 Then follow the prompts!

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -261,7 +261,7 @@ In some cases like `webworker` runtimes, you might want to bundle your SSR build
 
 ## Vite CLI
 
-The CLI commands `$ vite dev` and `$ vite preview` can also be used for SSR apps. You can add your SSR middlewares to the development server with [`configureServer`](/guide/api-plugin#configureserver) and to the preview server with [`configurePreviewServer`](/guide/api-plugin#configurepreviewserver).
+The CLI commands `vite dev` and `vite preview` can also be used for SSR apps. You can add your SSR middlewares to the development server with [`configureServer`](/guide/api-plugin#configureserver) and to the preview server with [`configurePreviewServer`](/guide/api-plugin#configurepreviewserver).
 
 :::tip Note
 Use a post hook so that your SSR middleware runs _after_ Vite's middlewares.

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -26,7 +26,7 @@ These guides provide instructions for performing a static deployment of your Vit
 You may run `npm run build` command to build the app.
 
 ```bash
-$ npm run build
+npm run build
 ```
 
 By default, the build output will be placed at `dist`. You may deploy this `dist` folder to any of your preferred platforms.
@@ -36,8 +36,8 @@ By default, the build output will be placed at `dist`. You may deploy this `dist
 Once you've built the app, you may test it locally by running `npm run preview` command.
 
 ```bash
-$ npm run build
-$ npm run preview
+npm run build
+npm run preview
 ```
 
 The `vite preview` command will boot up a local static web server that serves the files from `dist` at `http://localhost:4173`. It's an easy way to check if the production build looks OK in your local environment.
@@ -142,20 +142,20 @@ You can also run the above script in your CI setup to enable automatic deploymen
 
 ```bash
 # Install the Netlify CLI
-$ npm install -g netlify-cli
+npm install -g netlify-cli
 
 # Create a new site in Netlify
-$ ntl init
+ntl init
 
 # Deploy to a unique preview URL
-$ ntl deploy
+ntl deploy
 ```
 
 The Netlify CLI will share with you a preview URL to inspect. When you are ready to go into production, use the `prod` flag:
 
 ```bash
 # Deploy the site into production
-$ ntl deploy --prod
+ntl deploy --prod
 ```
 
 ### Netlify with Git
@@ -177,8 +177,8 @@ After your project has been imported and deployed, all subsequent pushes to bran
 3. Your application is deployed! (e.g. [vite-vue-template.vercel.app](https://vite-vue-template.vercel.app/))
 
 ```bash
-$ npm i -g vercel
-$ vercel init vite
+npm i -g vercel
+vercel init vite
 Vercel CLI
 > Success! Initialized "vite" example in ~/your-folder.
 - To deploy, `cd vite` and run `vercel`.
@@ -206,16 +206,16 @@ Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/g
 
 ```bash
 # Install Wrangler CLI
-$ npm install -g wrangler
+npm install -g wrangler
 
 # Login to Cloudflare account from CLI
-$ wrangler login
+wrangler login
 
 # Run your build command
-$ npm run build
+npm run build
 
 # Create new deployment
-$ npx wrangler pages publish dist
+npx wrangler pages publish dist
 ```
 
 After your assets are uploaded, Wrangler will give you a preview URL to inspect your site. When you log into the Cloudflare Pages dashboard, you will see your new project.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -27,9 +27,9 @@ To solve this:
 
   ```shell
   # Check current limit
-  $ ulimit -Sn
+  ulimit -Sn
   # Change limit (temporary)
-  $ ulimit -Sn 10000 # You might need to change the hard limit too
+  ulimit -Sn 10000 # You might need to change the hard limit too
   # Restart your browser
   ```
 
@@ -37,11 +37,11 @@ To solve this:
 
   ```shell
   # Check current limits
-  $ sysctl fs.inotify
+  sysctl fs.inotify
   # Change limits (temporary)
-  $ sudo sysctl fs.inotify.max_queued_events=16384
-  $ sudo sysctl fs.inotify.max_user_instances=8192
-  $ sudo sysctl fs.inotify.max_user_watches=524288
+  sudo sysctl fs.inotify.max_queued_events=16384
+  sudo sysctl fs.inotify.max_user_instances=8192
+  sudo sysctl fs.inotify.max_user_watches=524288
   ```
 
 ### 431 Request Header Fields Too Large

--- a/docs/guide/using-plugins.md
+++ b/docs/guide/using-plugins.md
@@ -7,7 +7,7 @@ Vite can be extended using plugins, which are based on Rollup's well-designed pl
 To use a plugin, it needs to be added to the `devDependencies` of the project and included in the `plugins` array in the `vite.config.js` config file. For example, to provide support for legacy browsers, the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy) can be used:
 
 ```
-$ npm add -D @vitejs/plugin-legacy
+npm add -D @vitejs/plugin-legacy
 ```
 
 ```js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removing $ (Dollar Signs) in the bash commands

I started a discussion about it [Discussion-10267](https://github.com/vitejs/vite/discussions/10267)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

When a user clicks on the code block twice, it selects and copies with the `$.` We should remove the sign in the code block. Code blocks are already mentioned as `bash,` so we don't need to use extra `$` to say it like a terminal command.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
