### PR TITLE
feat(legacy): add `terserOptions` to plugin-legacy

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -117,6 +117,13 @@ npm add -D terser
 
   Defaults to `false`. Enabling this option will exclude `systemjs/dist/s.min.js` inside polyfills-legacy chunk.
 
+### `terserOptions`
+
+- **Type:** `BuildOptions['terserOptions']`
+- **Default:** `undefined`
+
+  Defaults to `undefined`. Since `plugin-legacy` enforces the use of `terser` if minify is enabled, `terserOptions` can be passed to [build.terserOptions](https://vitejs.dev/config/build-options.html#build-terseroptions) this option.
+
 ## Dynamic Import
 
 The legacy plugin offers a way to use native `import()` in the modern build while falling back to the legacy build in browsers with native ESM but without dynamic import support (e.g. Legacy Edge). This feature works by injecting a runtime check and loading the legacy bundle with SystemJs runtime if needed. There are the following drawbacks:

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -27,7 +27,7 @@ export default {
 }
 ```
 
-Terser must be installed because plugin-legacy uses Terser for minification.
+Terser must be installed because plugin-legacy uses Terser for minification. To configure terser for main chunks [build.terserOptions](https://vitejs.dev/config/build-options.html#build-terseroptions) can be set. In addition, to configure polyfill chunks [polyfillChunksTerserOptions](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy#polyfillChunksTerserOptions) can be set separately.
 
 ```sh
 npm add -D terser

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -117,12 +117,12 @@ npm add -D terser
 
   Defaults to `false`. Enabling this option will exclude `systemjs/dist/s.min.js` inside polyfills-legacy chunk.
 
-### `terserOptions`
+### `polyfillChunksTerserOptions`
 
 - **Type:** `BuildOptions['terserOptions']`
-- **Default:** `undefined`
+- **Default:** `build.terserOptions`
 
-  Defaults to `undefined`. Since `plugin-legacy` enforces the use of `terser` if minify is enabled, `terserOptions` can be passed to [build.terserOptions](https://vitejs.dev/config/build-options.html#build-terseroptions) this option.
+  Defaults to `build.terserOptions` specified inside config. Since `plugin-legacy` enforces the use of `terser` if minify is enabled, `polyfillChunksTerserOptions` can be set to be passed to [build.terserOptions](https://vitejs.dev/config/build-options.html#build-terseroptions).
 
 ## Dynamic Import
 

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -122,7 +122,7 @@ npm add -D terser
 - **Type:** `BuildOptions['terserOptions']`
 - **Default:** `build.terserOptions`
 
-  Defaults to `build.terserOptions` specified inside config. Since `plugin-legacy` enforces the use of `terser` if minify is enabled, `polyfillChunksTerserOptions` can be set to be passed to [build.terserOptions](https://vitejs.dev/config/build-options.html#build-terseroptions).
+  Defaults to `build.terserOptions` specified inside vite config. Since `plugin-legacy` enforces the use of `terser` if minify is enabled, `polyfillChunksTerserOptions` can be set to be passed to [build.terserOptions](https://vitejs.dev/config/build-options.html#build-terseroptions).
 
 ## Dynamic Import
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -238,7 +238,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           'es',
           opts,
           true,
-          options.terserOptions
+          options.polyfillChunksTerserOptions
         )
         return
       }
@@ -274,7 +274,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           'iife',
           opts,
           options.externalSystemJS,
-          options.terserOptions
+          options.polyfillChunksTerserOptions
         )
       }
     }
@@ -652,10 +652,11 @@ async function buildPolyfillChunk(
   format: 'iife' | 'es',
   rollupOutputOptions: NormalizedOutputOptions,
   excludeSystemJS?: boolean,
-  terserOptions?: BuildOptions['terserOptions']
+  polyfillChunksTerserOptions?: BuildOptions['terserOptions']
 ) {
-  let { minify, assetsDir } = buildOptions
+  let { minify, assetsDir, terserOptions: buildTerserIOptions } = buildOptions
   minify = minify ? 'terser' : false
+  const terserOptions = polyfillChunksTerserOptions || buildTerserIOptions;
   const res = await build({
     mode,
     // so that everything is resolved from here

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -238,7 +238,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           'es',
           opts,
           true,
-          options.terserOptions,
+          options.terserOptions
         )
         return
       }
@@ -274,7 +274,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           'iife',
           opts,
           options.externalSystemJS,
-          options.terserOptions,
+          options.terserOptions
         )
       }
     }
@@ -676,7 +676,7 @@ async function buildPolyfillChunk(
           entryFileNames: rollupOutputOptions.entryFileNames
         }
       },
-      terserOptions,
+      terserOptions
     },
     // Don't run esbuild for transpilation or minification
     // because we don't want to transpile code.

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -656,7 +656,7 @@ async function buildPolyfillChunk(
 ) {
   let { minify, assetsDir, terserOptions: buildTerserIOptions } = buildOptions
   minify = minify ? 'terser' : false
-  const terserOptions = polyfillChunksTerserOptions || buildTerserIOptions;
+  const terserOptions = polyfillChunksTerserOptions || buildTerserIOptions
   const res = await build({
     mode,
     // so that everything is resolved from here

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -237,7 +237,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           config.build,
           'es',
           opts,
-          true
+          true,
+          options.terserOptions,
         )
         return
       }
@@ -272,7 +273,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           config.build,
           'iife',
           opts,
-          options.externalSystemJS
+          options.externalSystemJS,
+          options.terserOptions,
         )
       }
     }
@@ -649,7 +651,8 @@ async function buildPolyfillChunk(
   buildOptions: BuildOptions,
   format: 'iife' | 'es',
   rollupOutputOptions: NormalizedOutputOptions,
-  excludeSystemJS?: boolean
+  excludeSystemJS?: boolean,
+  terserOptions?: BuildOptions['terserOptions']
 ) {
   let { minify, assetsDir } = buildOptions
   minify = minify ? 'terser' : false
@@ -672,7 +675,8 @@ async function buildPolyfillChunk(
           format,
           entryFileNames: rollupOutputOptions.entryFileNames
         }
-      }
+      },
+      terserOptions,
     },
     // Don't run esbuild for transpilation or minification
     // because we don't want to transpile code.

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -26,5 +26,8 @@ export interface Options {
    * default: false
    */
   externalSystemJS?: boolean
-  terserOptions?: BuildOptions['terserOptions']
+  /**
+   * default: config.build.terserOptions
+   */
+  polyfillChunksTerserOptions?: BuildOptions['terserOptions']
 }

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -1,3 +1,5 @@
+import { BuildOptions } from 'vite'
+
 export interface Options {
   /**
    * default: 'defaults'
@@ -24,4 +26,5 @@ export interface Options {
    * default: false
    */
   externalSystemJS?: boolean
+  terserOptions?: BuildOptions['terserOptions'];
 }

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -1,4 +1,4 @@
-import { BuildOptions } from 'vite'
+import type { BuildOptions } from 'vite'
 
 export interface Options {
   /**
@@ -26,5 +26,5 @@ export interface Options {
    * default: false
    */
   externalSystemJS?: boolean
-  terserOptions?: BuildOptions['terserOptions'];
+  terserOptions?: BuildOptions['terserOptions']
 }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -758,7 +758,15 @@ export async function resolveConfig(
     })
   }
 
-  if (config.build?.terserOptions && config.build.minify !== 'terser') {
+  if (
+    config.build?.terserOptions &&
+    config.build.minify !== 'terser' &&
+    /**
+     * To check whether "plugin-legacy" is used as a plugin or not.
+     * Since "plugin-legacy" enforces terser for minification, it uses "build.terserOptions".
+     */
+    !rawUserPlugins.some(({ name }) => name === 'vite:legacy-config')
+  ) {
     logger.warn(
       colors.yellow(
         `build.terserOptions is specified but build.minify is not set to use Terser. ` +


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since usage of `plugin-legacy` enforces `terser` for minification, users can now pass `terserOptions` to configure terser as well.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
