### PR TITLE
fix(optimizer): browser field bare import (fix #7599)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1176,7 +1176,7 @@ function resolvePkg(importer: string, options: InternalResolveOptions) {
 
   const possiblePkgIds: string[] = []
   for (let prevSlashIndex = -1; ; ) {
-    const slashIndex = importer.indexOf('/', prevSlashIndex)
+    const slashIndex = importer.indexOf(isWindows ? '\\' : '/', prevSlashIndex)
     if (slashIndex < 0) {
       break
     }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1169,10 +1169,15 @@ function getRealPath(resolved: string, preserveSymlinks?: boolean): string {
 
 /**
  * if importer was not resolved by vite's resolver previously
+ * (when esbuild resolved it)
  * resolve importer's pkg and add to idToPkgMap
  */
 function resolvePkg(importer: string, options: InternalResolveOptions) {
   const { root, preserveSymlinks, packageCache } = options
+
+  if (importer.includes('\x00')) {
+    return null
+  }
 
   const possiblePkgIds: string[] = []
   for (let prevSlashIndex = -1; ; ) {
@@ -1184,9 +1189,6 @@ function resolvePkg(importer: string, options: InternalResolveOptions) {
     prevSlashIndex = slashIndex + 1
 
     const possiblePkgId = importer.slice(0, slashIndex)
-    if (possiblePkgId.includes('\x00')) {
-      continue
-    }
     possiblePkgIds.push(possiblePkgId)
   }
 

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -58,6 +58,10 @@ test('cjs browser field (axios)', async () => {
   expect(await page.textContent('.cjs-browser-field')).toBe('pong')
 })
 
+test('cjs browser field bare', async () => {
+  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
+})
+
 test('dep from linked dep (lodash-es)', async () => {
   expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
 })

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/events-shim.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: 'foo'
+}

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/index.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const internal = require('./internal')
+
+module.exports = internal

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
@@ -1,5 +1,6 @@
 'use strict'
 
+// eslint-disable-next-line import/no-nodejs-modules
 const events = require('events')
 
 module.exports = 'foo' in events ? 'pong' : ''

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/internal.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const events = require('events')
+
+module.exports = 'foo' in events ? 'pong' : ''

--- a/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
+++ b/playground/optimize-deps/dep-cjs-browser-field-bare/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dep-cjs-browser-field-bare",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "browser": {
+    "events": "./events-shim.js"
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -29,6 +29,9 @@
 <h2>CommonJS w/ browser field mapping (axios)</h2>
 <div>This should show pong: <span class="cjs-browser-field"></span></div>
 
+<h2>CommonJS w/ bare id browser field mapping</h2>
+<div>This should show pong: <span class="cjs-browser-field-bare"></span></div>
+
 <h2>Detecting linked src package and optimizing its deps (lodash-es)</h2>
 <div>This should show fooBarBaz: <span class="deps-linked"></span></div>
 
@@ -99,6 +102,9 @@
 <script type="module">
   // test dep detection in globbed files
   const globbed = import.meta.glob('./glob/*.js', { eager: true })
+
+  import cjsBrowerFieldBare from 'dep-cjs-browser-field-bare'
+  text('.cjs-browser-field-bare', cjsBrowerFieldBare)
 
   import { camelCase } from 'dep-linked'
   text('.deps-linked', camelCase('foo-bar-baz'))

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "clipboard": "^2.0.11",
+    "dep-cjs-browser-field-bare": "file:./dep-cjs-browser-field-bare",
     "dep-cjs-compiled-from-cjs": "file:./dep-cjs-compiled-from-cjs",
     "dep-cjs-compiled-from-esm": "file:./dep-cjs-compiled-from-esm",
     "dep-cjs-with-assets": "file:./dep-cjs-with-assets",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,7 @@ importers:
       added-in-entries: file:./added-in-entries
       axios: ^0.27.2
       clipboard: ^2.0.11
+      dep-cjs-browser-field-bare: file:./dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:./dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:./dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:./dep-cjs-with-assets
@@ -661,6 +662,7 @@ importers:
       added-in-entries: file:playground/optimize-deps/added-in-entries
       axios: 0.27.2
       clipboard: 2.0.11
+      dep-cjs-browser-field-bare: file:playground/optimize-deps/dep-cjs-browser-field-bare
       dep-cjs-compiled-from-cjs: file:playground/optimize-deps/dep-cjs-compiled-from-cjs
       dep-cjs-compiled-from-esm: file:playground/optimize-deps/dep-cjs-compiled-from-esm
       dep-cjs-with-assets: file:playground/optimize-deps/dep-cjs-with-assets
@@ -690,6 +692,9 @@ importers:
       '@vitejs/plugin-vue': link:../../packages/plugin-vue
 
   playground/optimize-deps/added-in-entries:
+    specifiers: {}
+
+  playground/optimize-deps/dep-cjs-browser-field-bare:
     specifiers: {}
 
   playground/optimize-deps/dep-cjs-compiled-from-cjs:
@@ -9102,6 +9107,12 @@ packages:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
     name: added-in-entries
     version: 1.0.0
+    dev: false
+
+  file:playground/optimize-deps/dep-cjs-browser-field-bare:
+    resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
+    name: dep-cjs-browser-field-bare
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Closes #7599
fixes #4798
fixes #7301
fixes #7576

### Additional context
Make vite correctly resolve bare imports with browser field

<!-- e.g. is there anything you'd like reviewers to focus on? -->
In #8706 @sapphi-red mentioned we need to 

> solved by fixing implementation around `idToPkgMap`

instead of the way in #8709

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
