### PR TITLE
feat(lib): cjs instead of umd as default format for multiple entries

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -148,7 +148,7 @@ Options to pass on to [@rollup/plugin-dynamic-import-vars](https://github.com/ro
 - **Type:** `{ entry: string | string[] | { [entryAlias: string]: string }, name?: string, formats?: ('es' | 'cjs' | 'umd' | 'iife')[], fileName?: string | ((format: ModuleFormat, entryName: string) => string) }`
 - **Related:** [Library Mode](/guide/build#library-mode)
 
-Build as a library. `entry` is required since the library cannot use HTML as entry. `name` is the exposed global variable and is required when `formats` includes `'umd'` or `'iife'`. Default `formats` are `['es', 'umd']`. `fileName` is the name of the package file output, default `fileName` is the name option of package.json, it can also be defined as function taking the `format` and `entryAlias` as arguments.
+Build as a library. `entry` is required since the library cannot use HTML as entry. `name` is the exposed global variable and is required when `formats` includes `'umd'` or `'iife'`. Default `formats` are `['es', 'umd']`, or `['es', 'cjs']`, if multiple entries are used. `fileName` is the name of the package file output, default `fileName` is the name option of package.json, it can also be defined as function taking the `format` and `entryAlias` as arguments.
 
 ## build.manifest
 

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,8 +1,9 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import type { Logger } from 'vite'
 import { describe, expect, test } from 'vitest'
 import type { LibraryFormats, LibraryOptions } from '../build'
-import { resolveLibFilename } from '../build'
+import { resolveBuildOutputs, resolveLibFilename } from '../build'
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..')
 
@@ -242,5 +243,28 @@ describe('resolveLibFilename', () => {
 
     expect(fileName1).toBe('custom-filename.mjs')
     expect(fileName2).toBe('custom-filename.mjs')
+  })
+})
+
+describe('resolveBuildOutputs', () => {
+  test('default format: one entry', () => {
+    const libOptions: LibraryOptions = {
+      entry: 'entryA.js',
+      name: 'entryA'
+    }
+
+    const outputs = resolveBuildOutputs(undefined, libOptions, {} as Logger)
+
+    expect(outputs).toEqual([{ format: 'es' }, { format: 'umd' }])
+  })
+
+  test('default format: multiple entries', () => {
+    const libOptions: LibraryOptions = {
+      entry: ['entryA.js', 'entryB.js']
+    }
+
+    const outputs = resolveBuildOutputs(undefined, libOptions, {} as Logger)
+
+    expect(outputs).toEqual([{ format: 'es' }, { format: 'cjs' }])
   })
 })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -752,12 +752,15 @@ function resolveBuildOutputs(
   logger: Logger
 ): OutputOptions | OutputOptions[] | undefined {
   if (libOptions) {
-    const formats = libOptions.formats || ['es', 'umd']
+    const hasMultipleEntries =
+      typeof libOptions.entry !== 'string' &&
+      Object.values(libOptions.entry).length > 1
+
+    const formats =
+      libOptions.formats || (hasMultipleEntries ? ['es', 'cjs'] : ['es', 'umd'])
+
     if (formats.includes('umd') || formats.includes('iife')) {
-      if (
-        typeof libOptions.entry !== 'string' &&
-        Object.values(libOptions.entry).length > 1
-      ) {
+      if (hasMultipleEntries) {
         throw new Error(
           `Multiple entry points are not supported when output formats include "umd" or "iife".`
         )

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -746,7 +746,7 @@ export function resolveLibFilename(
   return `${name}.${format}.${extension}`
 }
 
-function resolveBuildOutputs(
+export function resolveBuildOutputs(
   outputs: OutputOptions | OutputOptions[] | undefined,
   libOptions: LibraryOptions | false,
   logger: Logger


### PR DESCRIPTION
### Description

This is a follow up to #7047. I propose to use different default `format` settings when using multiple entries in lib mode.

At the moment using a config like this:
```ts
lib: {
  entry: {
      primary: 'src/index.ts',
      secondary: 'src/secondary.ts'
  }
}
```
will result in an error
```
Multiple entry points are not supported when output formats include "umd" or "iife".
```
That is because, if not specified otherwise, the output formats in lib mode will be `['es', 'umd']` and Rollup does not support multiple entry points for UMD (https://github.com/rollup/rollup/issues/2072). Since this is not a nice user experience, I think it's better to not use UMD by default - if multiple entries are used. Instead CommonJs could be used, which is at least a part of UMD, minus the AMD part.




### Additional context

Since multiple entries are not released yet, this is not a breaking change. If we can get it in before 3.2 😉

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
