### PR TITLE
fix: do not externalize monorepo modules, revert #9140

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -967,38 +967,10 @@ async function bundleConfigFile(
       {
         name: 'externalize-deps',
         setup(build) {
-          build.onResolve({ filter: /.*/ }, ({ path: id, importer }) => {
-            // externalize bare imports
+          build.onResolve({ filter: /.*/ }, ({ path: id }) => {
             if (id[0] !== '.' && !path.isAbsolute(id)) {
               return {
                 external: true
-              }
-            }
-            // bundle the rest and make sure that the we can also access
-            // it's third-party dependencies. externalize if not.
-            // monorepo/
-            // ├─ package.json
-            // ├─ utils.js -----------> bundle (share same node_modules)
-            // ├─ vite-project/
-            // │  ├─ vite.config.js --> entry
-            // │  ├─ package.json
-            // ├─ foo-project/
-            // │  ├─ utils.js --------> external (has own node_modules)
-            // │  ├─ package.json
-            const idFsPath = path.resolve(path.dirname(importer), id)
-            const idPkgPath = lookupFile(idFsPath, [`package.json`], {
-              pathOnly: true
-            })
-            if (idPkgPath) {
-              const idPkgDir = path.dirname(idPkgPath)
-              // if this file needs to go up one or more directory to reach the vite config,
-              // that means it has it's own node_modules (e.g. foo-project)
-              if (path.relative(idPkgDir, fileName).startsWith('..')) {
-                return {
-                  // normalize actual import after bundled as a single vite config
-                  path: isESM ? pathToFileURL(idFsPath).href : idFsPath,
-                  external: true
-                }
               }
             }
           })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Revert #9140, since it introduced more serious breakage #9202, I think it's better to revert it for now (as SvelteKit no longer needs it either). An alternative solution is under exploring in #10254 for the future.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
