### PR TITLE
feat(server): pass inline config function

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -266,7 +266,7 @@ export interface ViteDevServer {
   /**
    * @internal
    */
-  _inlineConfig: InlineConfig | (() => InlineConfig)
+  _inlineConfig: InlineConfig | ((isRestart: boolean) => InlineConfig)
   /**
    * @internal
    */
@@ -307,10 +307,10 @@ export interface ResolvedServerUrls {
 }
 
 export async function createServer(
-  inlineConfig: InlineConfig | (() => InlineConfig) = {}
+  inlineConfig: InlineConfig | ((isRestart: boolean) => InlineConfig) = {}
 ): Promise<ViteDevServer> {
   const config = await resolveConfig(
-    typeof inlineConfig === 'function' ? inlineConfig() : inlineConfig,
+    typeof inlineConfig === 'function' ? inlineConfig(false) : inlineConfig,
     'serve',
     'development'
   )
@@ -784,7 +784,7 @@ async function restartServer(server: ViteDevServer) {
 
   let inlineConfig =
     typeof server._inlineConfig === 'function'
-      ? server._inlineConfig()
+      ? server._inlineConfig(true)
       : server._inlineConfig
 
   if (server._forceOptimizeOnRestart) {

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -18,7 +18,7 @@ export async function createServer(root = process.cwd(), hmrPort) {
    */
   const vite = await (
     await import('vite')
-  ).createServer({
+  ).createServer(() => ({
     root,
     logLevel: isTest ? 'error' : 'info',
     server: {
@@ -62,7 +62,7 @@ export async function createServer(root = process.cwd(), hmrPort) {
         }
       }
     ]
-  })
+  }))
   // use vite's connect instance as middleware
   app.use(vite.middlewares)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Allow passing an inline config funtion to `createServer` so that restarts get a new set of Vite plugin instance.

This also fixes a bug where if `server.restart(true)` is called once (to force optimize), further restart are always force optimize, even when `server.restart(false)`.

This may also allow metaframeworks to know when a server restarted.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
