### PR TITLE
feat: skip .gitkeep file while emptyOutDir: true

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -685,7 +685,7 @@ function prepareOutDir(
           return ''
         })
         .filter(Boolean)
-      emptyDir(outDir, [...skipDirs, '.git'])
+      emptyDir(outDir, [...skipDirs, '.git', '.gitkeep'])
     }
     if (config.publicDir && fs.existsSync(config.publicDir)) {
       copyDir(config.publicDir, outDir)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Prevent deleting `.gitkeep` file when `build.emptyOutDir: true`.

**Motivation**: developer adds `.gitkeep` to track the empty folder in git. For our case, when we have `build.emptyOutDir: true` it deletes every file including `.gitkeep` and loses git track of the empty build folder which can cause issues while deploying and building in some CI / CD platforms since there is no build/dist folder found.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
