### PR TITLE
fix(server): handle appType mpa html fallback

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -560,7 +560,7 @@ export async function createServer(
   middlewares.use(serveRawFsMiddleware(server))
   middlewares.use(serveStaticMiddleware(root, server))
 
-  // spa fallback
+  // html fallback
   if (config.appType === 'spa' || config.appType === 'mpa') {
     middlewares.use(htmlFallbackMiddleware(root, config.appType === 'spa'))
   }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -53,7 +53,7 @@ import type { WebSocketServer } from './ws'
 import { createWebSocketServer } from './ws'
 import { baseMiddleware } from './middlewares/base'
 import { proxyMiddleware } from './middlewares/proxy'
-import { spaFallbackMiddleware } from './middlewares/spaFallback'
+import { htmlFallbackMiddleware } from './middlewares/htmlFallback'
 import { transformMiddleware } from './middlewares/transform'
 import {
   createDevHtmlTransformFn,
@@ -561,8 +561,8 @@ export async function createServer(
   middlewares.use(serveStaticMiddleware(root, server))
 
   // spa fallback
-  if (config.appType === 'spa') {
-    middlewares.use(spaFallbackMiddleware(root))
+  if (config.appType === 'spa' || config.appType === 'mpa') {
+    middlewares.use(htmlFallbackMiddleware(root, config.appType === 'spa'))
   }
 
   // run post config hooks

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -4,11 +4,12 @@ import history from 'connect-history-api-fallback'
 import type { Connect } from 'dep-types/connect'
 import { createDebugger } from '../../utils'
 
-export function spaFallbackMiddleware(
-  root: string
+export function htmlFallbackMiddleware(
+  root: string,
+  spaFallback: boolean
 ): Connect.NextHandleFunction {
-  const historySpaFallbackMiddleware = history({
-    logger: createDebugger('vite:spa-fallback'),
+  const historyHtmlFallbackMiddleware = history({
+    logger: createDebugger('vite:html-fallback'),
     // support /dir/ without explicit index.html
     rewrites: [
       {
@@ -20,15 +21,16 @@ export function spaFallbackMiddleware(
           if (fs.existsSync(path.join(root, rewritten))) {
             return rewritten
           } else {
-            return `/index.html`
+            if (spaFallback) {
+              return `/index.html`
+            }
           }
         }
       }
     ]
   })
 
-  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return function viteSpaFallbackMiddleware(req, res, next) {
-    return historySpaFallbackMiddleware(req, res, next)
+  return function htmlFallbackMiddleware(req, res, next) {
+    return historyHtmlFallbackMiddleware(req, res, next)
   }
 }

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -30,7 +30,8 @@ export function htmlFallbackMiddleware(
     ]
   })
 
-  return function htmlFallbackMiddleware(req, res, next) {
+  // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
+  return function viteHtmlFallbackMiddleware(req, res, next) {
     return historyHtmlFallbackMiddleware(req, res, next)
   }
 }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -283,7 +283,7 @@ export function indexHtmlMiddleware(
     }
 
     const url = req.url && cleanUrl(req.url)
-    // spa-fallback always redirects to /index.html
+    // rewriteUrlMiddleware() appends '.html' to URLs
     if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {
       const filename = getHtmlFilename(url, server)
       if (fs.existsSync(filename)) {

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -283,7 +283,7 @@ export function indexHtmlMiddleware(
     }
 
     const url = req.url && cleanUrl(req.url)
-    // rewriteUrlMiddleware() appends '.html' to URLs
+    // htmlFallbackMiddleware appends '.html' to URLs
     if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {
       const filename = getHtmlFilename(url, server)
       if (fs.existsSync(filename)) {


### PR DESCRIPTION
### Description

Fix `appType: 'mpa'` which currently doesn't work: `indexHtmlMiddleware()` doesn't work without `spaFallbackMiddleware()`. In other words MPAs also need `spaFallbackMiddleware()`.

This seems to have been a glitch we missed at #8452.

close #9865

### Additional context

This is a blocker for Telefunc.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
