### PR TITLE
fix(config): don't resolve by module field

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -974,7 +974,7 @@ async function bundleConfigFile(
             isRequire: !isESM,
             preferRelative: false,
             tryIndex: true,
-            mainFields: DEFAULT_MAIN_FIELDS,
+            mainFields: [],
             browserField: false,
             conditions: [],
             dedupe: [],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
rollup plugins declares module field.
https://github.com/rollup/plugins/blob/4e85ed78cd2e941107fdf0e8e118e7bee550109d/packages/yaml/package.json#L17

But this field could resolve to `.js` files and this cannot be externalized because it will be treated as CJS by node.

This PR changes `mainFields` to be `[]` so that `module` field won't be used when a module is externalized.

[reproduction](https://stackblitz.com/edit/vitejs-vite-jwhkmh?file=package.json,vite.config.js&terminal=dev)

related: #10254

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
