### PR TITLE
docs: fix code example

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -130,7 +130,7 @@ A self-accepting module may realize during runtime that it can't handle a HMR up
 Note that you should always call `import.meta.hot.accept` even if you plan to call `invalidate` immediately afterwards, or else the HMR client won't listen for future changes to the self-accepting module. To communicate your intent clearly, we recommend calling `invalidate` within the `accept` callback like so:
 
 ```js
-import.meta.hot.accept(module => {
+import.meta.hot.accept((module) => {
   // You may use the new module instance to decide whether to invalidate.
   if (cannotHandleUpdate(module)) {
     import.meta.hot.invalidate()

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -129,14 +129,14 @@ A self-accepting module may realize during runtime that it can't handle a HMR up
 
 Note that you should always call `import.meta.hot.accept` even if you plan to call `invalidate` immediately afterwards, or else the HMR client won't listen for future changes to the self-accepting module. To communicate your intent clearly, we recommend calling `invalidate` within the `accept` callback like so:
 
-    ```ts
-    import.meta.hot.accept(module => {
-      // You may use the new module instance to decide whether to invalidate.
-      if (cannotHandleUpdate(module)) {
-        import.meta.hot.invalidate()
-      }
-    })
-    ```
+```js
+import.meta.hot.accept(module => {
+  // You may use the new module instance to decide whether to invalidate.
+  if (cannotHandleUpdate(module)) {
+    import.meta.hot.invalidate()
+  }
+})
+```
 
 ## `hot.on(event, cb)`
 


### PR DESCRIPTION
### Description

One of the code examples in the docs uses the wrong formatting and looks broken:
<img width="761" alt="CleanShot 2022-10-06 at 13 57 00@2x" src="https://user-images.githubusercontent.com/13352/194217751-3147ddc4-7f01-4c2a-9de6-96bac3b2b952.png">


### Additional context

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Documentation update

### Before submitting the PR, please make sure you do the following
