### PR TITLE
chore: migrate from vuex to pinia

### DIFF
--- a/playground/ssr-vue/package.json
+++ b/playground/ssr-vue/package.json
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "example-external-component": "file:example-external-component",
+    "pinia": "^2.0.22",
     "vue": "^3.2.40",
-    "vue-router": "^4.1.5",
-    "vuex": "^4.0.2"
+    "vue-router": "^4.1.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "workspace:*",

--- a/playground/ssr-vue/src/main.js
+++ b/playground/ssr-vue/src/main.js
@@ -1,3 +1,4 @@
+import { createPinia } from 'pinia'
 import { createSSRApp } from 'vue'
 import App from './App.vue'
 import { createRouter } from './router'
@@ -7,6 +8,8 @@ import { createRouter } from './router'
 // fresh store here.
 export function createApp() {
   const app = createSSRApp(App)
+  const pinia = createPinia()
+  app.use(pinia)
   const router = createRouter()
   app.use(router)
   return { app, router }

--- a/playground/ssr-vue/src/pages/Store.vue
+++ b/playground/ssr-vue/src/pages/Store.vue
@@ -3,16 +3,16 @@
 </template>
 
 <script>
-import { createStore } from 'vuex'
+import { defineStore } from 'pinia'
 
 export default {
   async setup() {
-    const store = createStore({
-      state: {
+    const useFooStore = defineStore('foo-store', {
+      state: () => ({
         foo: 'bar'
-      }
+      })
     })
-    return store.state
+    return useFooStore()
   }
 }
 </script>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,15 +1131,15 @@ importers:
       dep-import-type: link:./dep-import-type
       example-external-component: file:example-external-component
       express: ^4.18.1
+      pinia: ^2.0.22
       serve-static: ^1.15.0
       vue: ^3.2.40
       vue-router: ^4.1.5
-      vuex: ^4.0.2
     dependencies:
       example-external-component: file:playground/ssr-vue/example-external-component
+      pinia: 2.0.22_vue@3.2.40
       vue: 3.2.40
       vue-router: 4.1.5_vue@3.2.40
-      vuex: 4.0.2_vue@3.2.40
     devDependencies:
       '@vitejs/plugin-vue': link:../../packages/plugin-vue
       '@vitejs/plugin-vue-jsx': link:../../packages/plugin-vue-jsx
@@ -2767,7 +2767,6 @@ packages:
 
   /@vue/devtools-api/6.4.2:
     resolution: {integrity: sha512-6hNZ23h1M2Llky+SIAmVhL7s6BjLtZBCzjIz9iRSBUsysjE7kC39ulW0dH4o/eZtycmSt4qEr6RDVGTIuWu+ow==}
-    dev: true
 
   /@vue/reactivity-transform/3.2.40:
     resolution: {integrity: sha512-HQUCVwEaacq6fGEsg2NUuGKIhUveMCjOk8jGHqLXPI2w6zFoPrlQhwWEaINTv5kkZDXKEnCijAp+4gNEHG03yw==}
@@ -6985,6 +6984,23 @@ packages:
     dev: true
     optional: true
 
+  /pinia/2.0.22_vue@3.2.40:
+    resolution: {integrity: sha512-u+b8/BC+tmvo3ACbYO2w5NfxHWFOjvvw9DQnyT0dW8aUMCPRQT5QnfZ5R5W2MzZBMTeZRMQI7V/QFbafmM9QHw==}
+    peerDependencies:
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
+      vue: ^2.6.14 || ^3.2.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/devtools-api': 6.4.2
+      vue: 3.2.40
+      vue-demi: 0.13.1_vue@3.2.40
+    dev: false
+
   /pkg-types/0.3.5:
     resolution: {integrity: sha512-VkxCBFVgQhNHYk9subx+HOhZ4jzynH11ah63LZsprTKwPCWG9pfWBlkElWFbvkP9BVR0dP1jS9xPdhaHQNK74Q==}
     dependencies:
@@ -8775,7 +8791,6 @@ packages:
         optional: true
     dependencies:
       vue: 3.2.40
-    dev: true
 
   /vue-router/4.1.5_vue@3.2.40:
     resolution: {integrity: sha512-IsvoF5D2GQ/EGTs/Th4NQms9gd2NSqV+yylxIyp/OYp8xOwxmU8Kj/74E9DTSYAyH5LX7idVUngN3JSj1X4xcQ==}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Pinia has replaced Vuex

### Additional context

Vuex is packaged in a manner that violates the Node.js spec. That's unlikely to be fixed given that Vuex is end-of-life

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
