### PR TITLE
fix: prefer exports when resolving

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -649,10 +649,25 @@ export function tryNodeResolve(
   }
 
   let pkg: PackageData | undefined
-  const pkgId = possiblePkgIds.reverse().find((pkgId) => {
-    pkg = resolvePackageData(pkgId, basedir, preserveSymlinks, packageCache)!
-    return pkg
-  })!
+  let pkgId: string
+
+  const rootPkg =
+    possiblePkgIds.length &&
+    resolvePackageData(
+      possiblePkgIds[0],
+      basedir,
+      preserveSymlinks,
+      packageCache
+    )!
+  if (rootPkg && rootPkg?.data?.exports) {
+    pkg = rootPkg
+    pkgId = possiblePkgIds[0]
+  } else {
+    pkgId = possiblePkgIds.reverse().find((pkgId) => {
+      pkg = resolvePackageData(pkgId, basedir, preserveSymlinks, packageCache)!
+      return pkg
+    })!
+  }
 
   if (!pkg) {
     // if import can't be found, check if it's an optional peer dep.

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -648,10 +648,12 @@ export function tryNodeResolve(
     basedir = nestedResolveFrom(nestedRoot, basedir, preserveSymlinks)
   }
 
+  // nearest package.json
   let nearestPkg: PackageData | undefined
+  // nearest package.json that may have the `exports` field
   let pkg: PackageData | undefined
 
-  let pkgId: string = possiblePkgIds.reverse().find((pkgId) => {
+  let pkgId = possiblePkgIds.reverse().find((pkgId) => {
     nearestPkg = resolvePackageData(
       pkgId,
       basedir,
@@ -668,7 +670,7 @@ export function tryNodeResolve(
     preserveSymlinks,
     packageCache
   )!
-  if (rootPkg && rootPkg?.data?.exports) {
+  if (rootPkg?.data?.exports) {
     pkg = rootPkg
     pkgId = rootPkgId
   } else {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -126,7 +126,7 @@ async function instantiateModule(
     preserveSymlinks,
     isBuild: true,
     isProduction,
-    isRequire: true,
+    isRequire: false,
     root
   }
 

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -36,6 +36,13 @@ test('deep import with exports field + mapped dir', async () => {
   )
 })
 
+// this is how Svelte 3 is packaged
+test('deep import with exports and legacy fallback', async () => {
+  expect(await page.textContent('.exports-legacy-fallback')).toMatch(
+    '[success]'
+  )
+})
+
 test('Respect exports field env key priority', async () => {
   expect(await page.textContent('.exports-env')).toMatch('[success]')
 })

--- a/playground/resolve/exports-legacy-fallback/dir/index.js
+++ b/playground/resolve/exports-legacy-fallback/dir/index.js
@@ -1,0 +1,1 @@
+export const msg = '[fail] mapped js file'

--- a/playground/resolve/exports-legacy-fallback/dir/index.mjs
+++ b/playground/resolve/exports-legacy-fallback/dir/index.mjs
@@ -1,0 +1,1 @@
+export const msg = '[success] mapped mjs file'

--- a/playground/resolve/exports-legacy-fallback/dir/package.json
+++ b/playground/resolve/exports-legacy-fallback/dir/package.json
@@ -1,4 +1,4 @@
 {
   "main": "index.js",
-  "model": "index.mjs"
+  "module": "index.mjs"
 }

--- a/playground/resolve/exports-legacy-fallback/dir/package.json
+++ b/playground/resolve/exports-legacy-fallback/dir/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index.js",
+  "model": "index.mjs"
+}

--- a/playground/resolve/exports-legacy-fallback/index.js
+++ b/playground/resolve/exports-legacy-fallback/index.js
@@ -1,0 +1,1 @@
+export default 5

--- a/playground/resolve/exports-legacy-fallback/package.json
+++ b/playground/resolve/exports-legacy-fallback/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "resolve-exports-legacy-fallback",
+  "private": true,
+  "version": "1.0.0",
+  "exports": {
+    "./dir": {
+      "import": "./dir/index.mjs",
+      "require": "./dir/index.js"
+    },
+    ".": "index.js"
+  }
+}

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -24,6 +24,9 @@
 <h2>Exports field env priority</h2>
 <p class="exports-env">fail</p>
 
+<h2>Exports with legacy fallback</h2>
+<p class="exports-legacy-fallback">fail</p>
+
 <h2>Resolve /index.*</h2>
 <p class="index">fail</p>
 
@@ -162,6 +165,9 @@
 
   import { msg as exportsEnvMsg } from 'resolve-exports-env'
   text('.exports-env', exportsEnvMsg)
+
+  import { msg as exportsLegacyFallbackMsg } from 'resolve-exports-legacy-fallback/dir'
+  text('.exports-legacy-fallback', exportsLegacyFallbackMsg)
 
   // implicit index resolving
   import { foo } from './util'

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -20,6 +20,7 @@
     "resolve-custom-condition": "link:./custom-condition",
     "resolve-custom-main-field": "link:./custom-main-field",
     "resolve-exports-env": "link:./exports-env",
+    "resolve-exports-legacy-fallback": "link:./exports-legacy-fallback",
     "resolve-exports-path": "link:./exports-path",
     "resolve-linked": "workspace:*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -893,6 +893,7 @@ importers:
       resolve-custom-condition: link:./custom-condition
       resolve-custom-main-field: link:./custom-main-field
       resolve-exports-env: link:./exports-env
+      resolve-exports-legacy-fallback: link:./exports-legacy-fallback
       resolve-exports-path: link:./exports-path
       resolve-linked: workspace:*
     dependencies:
@@ -907,6 +908,7 @@ importers:
       resolve-custom-condition: link:custom-condition
       resolve-custom-main-field: link:custom-main-field
       resolve-exports-env: link:exports-env
+      resolve-exports-legacy-fallback: link:exports-legacy-fallback
       resolve-exports-path: link:exports-path
       resolve-linked: link:../resolve-linked
 
@@ -935,6 +937,12 @@ importers:
     specifiers: {}
 
   playground/resolve/exports-env:
+    specifiers: {}
+
+  playground/resolve/exports-legacy-fallback:
+    specifiers: {}
+
+  playground/resolve/exports-legacy-fallback/dir:
     specifiers: {}
 
   playground/resolve/exports-path:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Closes https://github.com/vitejs/vite/issues/10352

### Additional context

Svelte has a `package.json` in each directory to support older versions of Node since `exports` is only present in Node 12 and newer. Vite is preferring these nested `package.json` files over the `exports` field which is incorrect

The code was also assuming all modules are required, which is wrong since it uses a dynamic import for everything

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
