### PR TITLE
feat(build): support reporting brotli-compressed size

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -211,10 +211,10 @@ By default, Vite will empty the `outDir` on build if it is inside project root. 
 
 ## build.reportCompressedSize
 
-- **Type:** `boolean`
-- **Default:** `true`
+- **Type:** `boolean | 'gzip' | 'brotli'`
+- **Default:** `'gzip'`
 
-Enable/disable gzip-compressed size reporting. Compressing large output files can be slow, so disabling this may increase build performance for large projects.
+Enable/disable gzip or brotli-compressed size reporting. Compressing large output files can be slow, so disabling this may increase build performance for large projects.
 
 ## build.chunkSizeWarningLimit
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -198,7 +198,7 @@ export interface BuildOptions {
    * Set to false to disable reporting compressed chunk sizes.
    * Can slightly improve build speed.
    */
-  reportCompressedSize?: boolean
+  reportCompressedSize?: boolean | 'gzip' | 'brotli'
   /**
    * Adjust chunk size warning limit (in kbs).
    * @default 500
@@ -312,7 +312,7 @@ export function resolveBuildOptions(
     lib: false,
     ssr: false,
     ssrManifest: false,
-    reportCompressedSize: true,
+    reportCompressedSize: 'gzip',
     chunkSizeWarningLimit: 500,
     watch: null,
     ...raw,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds an option to report brotli-compressed size during builds, as opposed to gzip-compressed size.

### Additional context

- I based the option signature on `build.minify`, where a string specifies the mode, and `true` is the same as the default string. Kept the default as `gzip` for backwards-compat.

- I didn't add tests since I didn't find others related to `reportCompressedSize`. I'd be happy to add tests for both `gzip` and `brotli` if necessary, if given a couple of pointers on how to do so :)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.