### PR TITLE
fix(ssr): track var as function scope

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -787,3 +787,27 @@ export class Test {
     Object.defineProperty(__vite_ssr_exports__, \\"Test\\", { enumerable: true, configurable: true, get(){ return Test }});;"
   `)
 })
+
+// #10386
+test('track var scope by function', async () => {
+  expect(
+    await ssrTransformSimpleCode(`
+import { foo } from 'foobar'
+function test() {
+  if (true) {
+    var foo = 'shadow'
+  }
+  return foo
+}`)
+  ).toMatchInlineSnapshot(`
+    "
+    const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"foobar\\");
+
+    function test() {
+      if (true) {
+        var foo = 'shadow'
+      }
+      return foo
+    }"
+  `)
+})

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -792,12 +792,12 @@ export class Test {
 test('track var scope by function', async () => {
   expect(
     await ssrTransformSimpleCode(`
-import { foo } from 'foobar'
+import { foo, bar } from 'foobar'
 function test() {
   if (true) {
-    var foo = 'shadow'
+    var foo = () => { var why = 'would' }, bar = 'someone'
   }
-  return foo
+  return [foo, bar]
 }`)
   ).toMatchInlineSnapshot(`
     "
@@ -805,9 +805,9 @@ function test() {
 
     function test() {
       if (true) {
-        var foo = 'shadow'
+        var foo = () => { var why = 'would' }, bar = 'someone'
       }
-      return foo
+      return [foo, bar]
     }"
   `)
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #10386

`var` should be left as function-scope like before. only let, const (and others) are block scope.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Once this is merged, I can cherry pick into v3.1 branch too.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

