### PR TITLE
docs: add missing binding in asset import example

### DIFF
--- a/packages/plugin-vue/README.md
+++ b/packages/plugin-vue/README.md
@@ -77,7 +77,7 @@ Is the same as:
 import _imports_0 from '../image.png'
 </script>
 
-<img src="_imports_0" />
+<img :src="_imports_0" />
 ```
 
 By default the following tag/attribute combinations are transformed, and can be configured using the `template.transformAssetUrls` option.


### PR DESCRIPTION
### Description

Binds the `_imports_0` value to the `src` attribute by prefixing a `:`. Currently, the `src` attribute is equal to the "_imports_0" string

### Additional context

No

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
