### PR TITLE
refactor: delete dependent pre built proxy modules

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -178,7 +178,7 @@ export function esbuildDepPlugin(
           }
 
           // ensure esbuild uses our resolved entries
-          let entry: { path: string} | undefined
+          let entry: { path: string } | undefined
           // if this is an entry, return entry namespace resolve result
           if (!importer) {
             if ((entry = resolveEntry(id))) return entry

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -178,7 +178,7 @@ export function esbuildDepPlugin(
           }
 
           // ensure esbuild uses our resolved entries
-          let entry: { path: string; namespace: string } | undefined
+          let entry: { path: string} | undefined
           // if this is an entry, return entry namespace resolve result
           if (!importer) {
             if ((entry = resolveEntry(id))) return entry

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -162,7 +162,7 @@ export function esbuildDepPlugin(
         const flatId = flattenId(id)
         if (flatId in qualified) {
           return {
-            path: qualified[flatId],
+            path: qualified[flatId]
           }
         }
       }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -162,8 +162,7 @@ export function esbuildDepPlugin(
         const flatId = flattenId(id)
         if (flatId in qualified) {
           return {
-            path: flatId,
-            namespace: 'dep'
+            path: qualified[flatId],
           }
         }
       }
@@ -197,48 +196,6 @@ export function esbuildDepPlugin(
           }
         }
       )
-
-      // For entry files, we'll read it ourselves and construct a proxy module
-      // to retain the entry's raw id instead of file path so that esbuild
-      // outputs desired output file structure.
-      // It is necessary to do the re-exporting to separate the virtual proxy
-      // module from the actual module since the actual module may get
-      // referenced via relative imports - if we don't separate the proxy and
-      // the actual module, esbuild will create duplicated copies of the same
-      // module!
-      const root = path.resolve(config.root)
-      build.onLoad({ filter: /.*/, namespace: 'dep' }, ({ path: id }) => {
-        const entryFile = qualified[id]
-
-        let relativePath = normalizePath(path.relative(root, entryFile))
-        if (
-          !relativePath.startsWith('./') &&
-          !relativePath.startsWith('../') &&
-          relativePath !== '.'
-        ) {
-          relativePath = `./${relativePath}`
-        }
-
-        let contents = ''
-        const { hasImports, exports, hasReExports } = exportsData[id]
-        if (!hasImports && !exports.length) {
-          // cjs
-          contents += `export default require("${relativePath}");`
-        } else {
-          if (exports.includes('default')) {
-            contents += `import d from "${relativePath}";export default d;`
-          }
-          if (hasReExports || exports.length > 1 || exports[0] !== 'default') {
-            contents += `\nexport * from "${relativePath}"`
-          }
-        }
-
-        return {
-          loader: 'js',
-          contents,
-          resolveDir: root
-        }
-      })
 
       build.onLoad(
         { filter: /.*/, namespace: 'browser-external' },


### PR DESCRIPTION
For the old version of "esbuild", in order to flatten the dependent pre built products, the agent module will be used to process the "require ('react /jsx runtime. js')" The reason why the path was not directly modified to redirect to the entry is that the products will have a nested structure. The subsequent packaging is also added to prevent secondary packaging.
However, for the current version of "esbuild", even if it is directly redirected to the entry module, the product name is still specified by entryPoints and will not result in secondary packaging or nested products. Therefore, we do not need to use the proxy module now.
After the above code is deleted and added, vite still runs well, and the pre built products and product size will not change. Even if module "A" depends on module "B", using modules "A" and "B" in the project can also extract the same part.
Deleting the agent module will optimize more volumes.