### PR TITLE
feat(css): export preprocessCSS API

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -3,7 +3,7 @@ export { createServer } from './server'
 export { preview } from './preview'
 export { build } from './build'
 export { optimizeDeps } from './optimizer'
-export { formatPostcssSourceMap } from './plugins/css'
+export { formatPostcssSourceMap, preprocessCSS } from './plugins/css'
 export { transformWithEsbuild } from './plugins/esbuild'
 export { resolvePackageEntry } from './plugins/resolve'
 export { resolvePackageData } from './packages'
@@ -67,7 +67,11 @@ export type {
   IndexHtmlTransformResult,
   HtmlTagDescriptor
 } from './plugins/html'
-export type { CSSOptions, CSSModulesOptions } from './plugins/css'
+export type {
+  CSSOptions,
+  CSSModulesOptions,
+  PreprocessCSSResult
+} from './plugins/css'
 export type { ChunkMetadata } from './plugins/metadata'
 export type { JsonOptions } from './plugins/json'
 export type { TransformOptions as EsbuildTransformOptions } from 'esbuild'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Export `preprocessCSS()`, which is calling `compileCSS()` without the `urlReplacer` function.

The `urlReplacer` is not ran as it uses the `this` context of Rollup, and it isn't necessary as the preprocessed CSS can run through Vite's pipeline to get it's URL replaced later.

This is helpful for template compilers like Svelte and Astro that can only parse pure CSS, so style tags need to be preprocessed.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I'm currently testing this API in:
- https://github.com/sveltejs/vite-plugin-svelte/tree/vite-preprocess-css-api
- https://github.com/withastro/astro/tree/vite-preprocess-css-api

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
