### PR TITLE
chore(playground): fix `foobar` version

### DIFF
--- a/playground/optimize-deps/dep-with-optional-peer-dep/package.json
+++ b/playground/optimize-deps/dep-with-optional-peer-dep/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "peerDependencies": {
-    "foobar": "0.0.0"
+    "foobar": "1.0.0"
   },
   "peerDependenciesMeta": {
     "foobar": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Can't install. Because of `foobar` haven't `0.0.0` verison. [foobar npm](https://www.npmjs.com/package/foobar).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
