### PR TITLE
fix(config): partial deno support

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -986,6 +986,7 @@ async function bundleConfigFile(
           build.onResolve({ filter: /.*/ }, ({ path: id, importer, kind }) => {
             // externalize bare imports
             if (id[0] !== '.' && !path.isAbsolute(id) && !isBuiltin(id)) {
+              // partial deno support as `npm:` does not work in `tryNodeResolve`
               if (id.startsWith('npm:')) {
                 return { external: true }
               }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -986,6 +986,9 @@ async function bundleConfigFile(
           build.onResolve({ filter: /.*/ }, ({ path: id, importer, kind }) => {
             // externalize bare imports
             if (id[0] !== '.' && !path.isAbsolute(id) && !isBuiltin(id)) {
+              if (id.startsWith('npm:')) {
+                return { external: true }
+              }
               let idFsPath = tryNodeResolve(id, importer, options, false)?.id
               if (idFsPath && (isESM || kind === 'dynamic-import')) {
                 idFsPath = pathToFileURL(idFsPath).href


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

 #10254 uses `tryNodeResolve` trips Deno `npm:*` imports in WIndows.

Fixes https://github.com/bluwy/create-vite-extra/issues/9

"Partial" as we don't support `npm:` in Vite apps, but only in Vite config (we may want to wait out for this to be a convention, or when Deno stabilizes)

### Additional context

Thanks @mathe42 for digging into the bug!


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
