### PR TITLE
fix: when the file path is an absolute path, parsing causes parameter loss

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -18,6 +18,18 @@ describe('injectQuery', () => {
         'C:/User/Vite/Project?direct'
       )
     })
+
+    test('absolute file path', () => {
+      expect(injectQuery('C:\\test-file.vue', 'direct')).toEqual(
+        'C:/test-file.vue?direct'
+      )
+    })
+
+    test('absolute file path with parameters', () => {
+      expect(
+        injectQuery('C:\\test-file.vue?vue&type=template&lang.js', 'direct')
+      ).toEqual('C:/test-file.vue?direct&vue&type=template&lang.js')
+    })
   }
 
   test('relative path', () => {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -323,7 +323,7 @@ export function injectQuery(url: string, queryToInject: string): string {
   // encode percents for consistent behavior with pathToFileURL
   // see #2614 for details
   let resolvedUrl = new URL(url.replace(/%/g, '%25'), 'relative:///')
-  if (resolvedUrl.protocol !== 'relative:') {
+  if (resolvedUrl.protocol === 'file:') {
     resolvedUrl = pathToFileURL(url)
   }
   const { search, hash } = resolvedUrl

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { createHash } from 'node:crypto'
 import { promisify } from 'node:util'
-import { URL, URLSearchParams, pathToFileURL } from 'node:url'
+import { URL, URLSearchParams } from 'node:url'
 import { builtinModules, createRequire } from 'node:module'
 import { promises as dns } from 'node:dns'
 import { performance } from 'node:perf_hooks'
@@ -322,10 +322,7 @@ export function removeImportQuery(url: string): string {
 export function injectQuery(url: string, queryToInject: string): string {
   // encode percents for consistent behavior with pathToFileURL
   // see #2614 for details
-  let resolvedUrl = new URL(url.replace(/%/g, '%25'), 'relative:///')
-  if (resolvedUrl.protocol === 'file:') {
-    resolvedUrl = pathToFileURL(url)
-  }
+  const resolvedUrl = new URL(url.replace(/%/g, '%25'), 'relative:///')
   const { search, hash } = resolvedUrl
   let pathname = cleanUrl(url)
   pathname = isWindows ? slash(pathname) : pathname


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes [#10448](https://github.com/vitejs/vite/issues/10448)

When the file path is an absolute path

For example `E:/_yzydeveloper/vite-resolve-url-encode/node_modules/@ui/components/Test.vue?vue&type=template&lang.js`

`new URL` will resolve to

```js
URL {
  href: 'e:/_yzydeveloper/vite-resolve-url-encode/node_modules/@ui/components/Test.vue?vue&type=template&lang.js',
  origin: 'null',
  protocol: 'e:',
  username: '',
  password: '',
  host: '',
  hostname: '',
  port: '',
  pathname: '/_yzydeveloper/vite-resolve-url-encode/node_modules/@ui/components/Test.vue',
  search: '?vue&type=template&lang.js',
  searchParams: URLSearchParams { 'vue' => '', 'type' => 'template', 'lang.js' => '' },
  hash: ''
}
```

The protocol at this time is `e:`,caused `pathToFileURL` processing error,cause parameter loss.


error handling
```ts
export function injectQuery(url: string, queryToInject: string): string {
  // ...
  if (resolvedUrl.protocol !== 'relative:') {
    resolvedUrl = pathToFileURL(url)
  }
  // ...
}
```
normal handling
```ts
export function injectQuery(url: string, queryToInject: string): string {
  // ...
  if (resolvedUrl.protocol === 'file:') {
    resolvedUrl = pathToFileURL(url)
  }
  // ...
}
```
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
