### PR TITLE
fix(ssr): change CommonJS and resolve plugin order

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -18,7 +18,6 @@ import type {
   WatcherOptions
 } from 'rollup'
 import type { Terser } from 'dep-types/terser'
-import commonjsPlugin from '@rollup/plugin-commonjs'
 import type { RollupCommonJSOptions } from 'dep-types/commonjs'
 import type { RollupDynamicImportVarsOptions } from 'dep-types/dynamicImportVars'
 import type { TransformOptions } from 'esbuild'
@@ -367,16 +366,11 @@ export function resolveBuildPlugins(config: ResolvedConfig): {
   post: Plugin[]
 } {
   const options = config.build
-  const { commonjsOptions } = options
-  const usePluginCommonjs =
-    !Array.isArray(commonjsOptions?.include) ||
-    commonjsOptions?.include.length !== 0
   return {
     pre: [
       completeSystemWrapPlugin(),
       ...(options.watch ? [ensureWatchPlugin()] : []),
       watchPackageDataPlugin(config),
-      ...(usePluginCommonjs ? [commonjsPlugin(options.commonjsOptions)] : []),
       dataURIPlugin(),
       ...(options.rollupOptions.plugins
         ? (options.rollupOptions.plugins.filter(Boolean) as Plugin[])


### PR DESCRIPTION
### Description

When trying to build a node library with the ssr mode, vite was failing with couple of issues

1. CommonJS modules were not always transformed. The specific case for me was dependencies that are CJS build of ES module codebase with  `__esModule` flag set, in this case vite ended up assuming that files in the dependency imported by files in the dependency itself are ES modules instead of CJS. Applying the CommonJS plugin earlier fixed this issue

2. Tree shaking was just not working, I got ~34MB builds and the build did not reference imports properly and was broken. Apply the resolve plugin later fixed this issue, the build came down to ~5MB and generated build was correct.

I figured this out by testing bundling by just using rollup and rollup plugins, there also I was able to reproduce the issue when the CommonJS plugin is not applied early and resolve (the rollup one, not vite one, though I guess similar) is not applied later.


Just as a side note, I did try, enabling the dep optimiser and disabling CommonJS, which did solve the two issues above, but I had the issue that default exports from node builtins were not working. I have a minimal repro of that in this repo https://github.com/jiby-aurum/vite-issue. You will be able to repo it by cloning and running `npm i && npx vite build && node dist/index.mjs`. However I did not report an issue with it, as its experimental and not supported at the moment anyways.

### Additional context

I am very new to the vite codebase and I am not sure if the order change of plugins is going to break something else. If it won't I would really appreciate if we can land this in 3.2 which is the next release in the pipeline

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
