### PR TITLE
fix(cli): when the user enters the same command

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -30,7 +30,12 @@ interface GlobalCLIOptions {
 
 const normalizeOptionsConfig: Record<string, (v: any[]) => any> = {
   port: (v) => {
-    return v.find((p) => typeof p === 'number' || typeof p === 'string') || 5173
+    return (
+      v
+        .slice()
+        .reverse()
+        .find((p) => typeof p === 'number' || typeof p === 'string') || 5173
+    )
   }
 }
 

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -28,8 +28,10 @@ interface GlobalCLIOptions {
   force?: boolean
 }
 
-const normalizeOptionsConfig: Record<string, (v: any) => any> = {
-  port: (v: any[]): any => {
+const normalizeOptionsConfig: {
+  [K in keyof ServerOptions]: (v: any[]) => any
+} = {
+  port: (v) => {
     return v.find((p) => typeof p === 'number' || typeof p === 'string') || 5173
   }
 }

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -28,9 +28,7 @@ interface GlobalCLIOptions {
   force?: boolean
 }
 
-const normalizeOptionsConfig: {
-  [K in keyof ServerOptions]: (v: any[]) => any
-} = {
+const normalizeOptionsConfig: Record<string, (v: any[]) => any> = {
   port: (v) => {
     return v.find((p) => typeof p === 'number' || typeof p === 'string') || 5173
   }

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -28,6 +28,11 @@ interface GlobalCLIOptions {
   force?: boolean
 }
 
+const normalizeOptionsConfig: Record<string, (v: any) => any> = {
+  port: (v: any[]): any => {
+    return v.find((p) => typeof p === 'number' || typeof p === 'string') || 5173
+  }
+}
 /**
  * removing global flags before passing as command specific sub-configs
  */
@@ -48,6 +53,16 @@ function cleanOptions<Options extends GlobalCLIOptions>(
   delete ret.filter
   delete ret.m
   delete ret.mode
+  for (const [key, value] of Object.entries(ret)) {
+    if (Array.isArray(value)) {
+      // may need to define the final return of option by themselves,
+      // so they retain their implementation portal.
+      // If it is not customized, take the last item of InlineConfig as the final result.
+      ret[key as keyof Options] = normalizeOptionsConfig[key]
+        ? normalizeOptionsConfig[key](value)
+        : value[value.length - 1]
+    }
+  }
   return ret
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When the user enters multiple identical options or incorrect option type, it can handle it correctly.  fix: #10424 
```bash
yarn vite --port --port="123" --host --host
```

### Additional context

Fixed to: take the last array, and if you need to customize the output, you can correctly process the returned format.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
