### PR TITLE
fix(html): allow self closing on non-void elements

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -262,6 +262,9 @@ function handleParseError(
       // Accept duplicate attributes #9566
       // The first attribute is used, browsers silently ignore duplicates
       return
+    case 'non-void-html-element-start-tag-with-trailing-solidus':
+      // Allow self closing on non-void elements #10439
+      return
   }
   const parseError = {
     loc: filePath,

--- a/playground/html/valid.html
+++ b/playground/html/valid.html
@@ -13,3 +13,6 @@
   <!-- attr with prefix -->
   <use xlink:href="/sprite.svg#svg"></use>
 </svg>
+
+<!-- allow self closing on non-void elements -->
+<self-close-non-void />


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #10439

Allow `<self-close />` for non-void elements. Technically this is not in par of the HTML spec but it was a regression that used to work before we switch to parse5.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
