### PR TITLE
feat: reuse opening tab in chromium browsers when start dev server

### DIFF
--- a/packages/vite/bin/openChrome.applescript
+++ b/packages/vite/bin/openChrome.applescript
@@ -9,12 +9,19 @@ https://github.com/facebookincubator/create-react-app/blob/master/LICENSE
 property targetTab: null
 property targetTabIndex: -1
 property targetWindow: null
+property theProgram: "Google Chrome"
 
 on run argv
   set theURL to item 1 of argv
 
-  with timeout of 2 seconds
-    tell application "Chrome"
+  -- Allow requested program to be optional,
+  -- default to Google Chrome
+  if (count of argv) > 1 then
+    set theProgram to item 2 of argv
+  end if
+
+  using terms from application "Google Chrome"
+    tell application theProgram
 
       if (count every window) = 0 then
         make new window
@@ -51,7 +58,7 @@ on run argv
         make new tab with properties {URL:theURL}
       end tell
     end tell
-  end timeout
+  end using terms from
 end run
 
 -- Function:
@@ -59,28 +66,30 @@ end run
 -- if found, store tab, index, and window in properties
 -- (properties were declared on top of file)
 on lookupTabWithUrl(lookupUrl)
-  tell application "Chrome"
-    -- Find a tab with the given url
-    set found to false
-    set theTabIndex to -1
-    repeat with theWindow in every window
-      set theTabIndex to 0
-      repeat with theTab in every tab of theWindow
-        set theTabIndex to theTabIndex + 1
-        if (theTab's URL as string) contains lookupUrl then
-          -- assign tab, tab index, and window to properties
-          set targetTab to theTab
-          set targetTabIndex to theTabIndex
-          set targetWindow to theWindow
-          set found to true
+  using terms from application "Google Chrome"
+    tell application theProgram
+      -- Find a tab with the given url
+      set found to false
+      set theTabIndex to -1
+      repeat with theWindow in every window
+        set theTabIndex to 0
+        repeat with theTab in every tab of theWindow
+          set theTabIndex to theTabIndex + 1
+          if (theTab's URL as string) contains lookupUrl then
+            -- assign tab, tab index, and window to properties
+            set targetTab to theTab
+            set targetTabIndex to theTabIndex
+            set targetWindow to theWindow
+            set found to true
+            exit repeat
+          end if
+        end repeat
+
+        if found then
           exit repeat
         end if
       end repeat
-
-      if found then
-        exit repeat
-      end if
-    end repeat
-  end tell
+    end tell
+  end using terms from
   return found
 end lookupTabWithUrl

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -68,17 +68,36 @@ function startBrowserProcess(browser: string | undefined, url: string) {
     process.platform === 'darwin' && (browser === '' || browser === OSX_CHROME)
 
   if (shouldTryOpenChromeWithAppleScript) {
-    try {
-      // Try our best to reuse existing tab
-      // on OS X Google Chrome with AppleScript
-      execSync('ps cax | grep "Google Chrome"')
-      execSync('osascript openChrome.applescript "' + encodeURI(url) + '"', {
-        cwd: join(VITE_PACKAGE_DIR, 'bin'),
-        stdio: 'ignore'
-      })
-      return true
-    } catch (err) {
-      // Ignore errors
+    // Will use the first open browser found from list
+    const supportedChromiumBrowsers = [
+      'Google Chrome Canary',
+      'Google Chrome Dev',
+      'Google Chrome Beta',
+      'Google Chrome',
+      'Microsoft Edge',
+      'Brave Browser',
+      'Vivaldi',
+      'Chromium'
+    ]
+
+    for (const chromiumBrowser of supportedChromiumBrowsers) {
+      try {
+        // Try our best to reuse existing tab
+        // on OS X Google Chrome with AppleScript
+        execSync(`ps cax | grep "${chromiumBrowser}"`)
+        execSync(
+          `osascript openChrome.applescript "${encodeURI(
+            url
+          )}" "${chromiumBrowser}"`,
+          {
+            cwd: join(VITE_PACKAGE_DIR, 'bin'),
+            stdio: 'ignore'
+          }
+        )
+        return true
+      } catch (err) {
+        // Ignore errors
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Currently, if a mac users use Google Chrome, when they start the dev server, vite will try to reuse an opening tab (using AppleScript).

However, many developers they use other Chromium-based browsers such as Chrome Dev, Chrome Beta, Microsoft Edge... This PR is to support reuse an existing tab for some common Chromium browser

Reference:
- https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-dev-utils/openBrowser.js
- https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-dev-utils/openChrome.applescript

### Additional context

This is a "nice to have" feature of vite for mac users. We only need to test it on mac (which I already did)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
