### PR TITLE
feat(resolve): support "fallback array" in package exports field

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -110,7 +110,7 @@
     "postcss-import": "^15.0.0",
     "postcss-load-config": "^4.0.1",
     "postcss-modules": "^5.0.0",
-    "resolve.exports": "^1.1.0",
+    "resolve.exports": "npm:@alloc/resolve.exports@^1.1.0",
     "sirv": "^2.0.2",
     "source-map-js": "^1.0.2",
     "source-map-support": "^0.5.21",

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -48,11 +48,7 @@ import {
   DEFAULT_MAIN_FIELDS,
   ENV_ENTRY
 } from './constants'
-import type {
-  InternalResolveOptions,
-  InternalResolveOptionsWithOverrideConditions,
-  ResolveOptions
-} from './plugins/resolve'
+import type { InternalResolveOptions, ResolveOptions } from './plugins/resolve'
 import { resolvePlugin, tryNodeResolve } from './plugins/resolve'
 import type { LogLevel, Logger } from './logger'
 import { createLogger } from './logger'
@@ -958,7 +954,7 @@ async function bundleConfigFile(
       {
         name: 'externalize-deps',
         setup(build) {
-          const options: InternalResolveOptionsWithOverrideConditions = {
+          const options: InternalResolveOptions = {
             root: path.dirname(fileName),
             isBuild: true,
             isProduction: true,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -968,7 +968,7 @@ async function bundleConfigFile(
             mainFields: [],
             browserField: false,
             conditions: [],
-            overrideConditions: ['node'],
+            overrideConditions: ['node', 'require'],
             dedupe: [],
             extensions: DEFAULT_EXTENSIONS,
             preserveSymlinks: false

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -579,21 +579,19 @@ function tryResolveFile(
   }
 }
 
-export type InternalResolveOptionsWithOverrideConditions =
-  InternalResolveOptions & {
-    /**
-     * @deprecated In future, `conditions` will work like this.
-     * @internal
-     */
-    overrideConditions?: string[]
-  }
+export interface InternalNodeResolveOptions extends InternalResolveOptions {
+  /**
+   * When defined, only conditions defined in this array will be used.
+   */
+  overrideConditions?: string[]
+}
 
 export const idToPkgMap = new Map<string, PackageData>()
 
 export function tryNodeResolve(
   id: string,
   importer: string | null | undefined,
-  options: InternalResolveOptionsWithOverrideConditions,
+  options: InternalNodeResolveOptions,
   targetWeb: boolean,
   depsOptimizer?: DepsOptimizer,
   ssr?: boolean,
@@ -1053,7 +1051,7 @@ function resolveDeepImport(
     data
   }: PackageData,
   targetWeb: boolean,
-  options: InternalResolveOptionsWithOverrideConditions
+  options: InternalNodeResolveOptions
 ): string | undefined {
   const cache = getResolvedCache(id, targetWeb)
   if (cache) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1038,7 +1038,14 @@ function packageEntryFailure(id: string, details?: string) {
 }
 
 function getInlineConditions(conditions: string[], targetWeb: boolean) {
-  return targetWeb && !conditions.includes('node') ? ['browser'] : ['node']
+  const inlineConditions =
+    targetWeb && !conditions.includes('node') ? ['browser'] : ['node']
+
+  // The "module" condition is no longer recommended, but some older
+  // packages may still use it.
+  inlineConditions.push('module')
+
+  return inlineConditions
 }
 
 function resolveDeepImport(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1099,6 +1099,19 @@ function resolveDeepImport(
       getInlineConditions(options, targetWeb),
       options.overrideConditions
     )
+    if (postfix) {
+      if (possibleFiles.length) {
+        possibleFiles = possibleFiles.map((f) => f + postfix)
+      } else {
+        possibleFiles = resolveExports(
+          data,
+          file + postfix,
+          options,
+          getInlineConditions(options, targetWeb),
+          options.overrideConditions
+        )
+      }
+    }
     if (!possibleFiles.length) {
       throw new Error(
         `Package subpath '${file}' is not defined by "exports" in ` +
@@ -1108,7 +1121,7 @@ function resolveDeepImport(
   } else if (targetWeb && options.browserField && isObject(browserField)) {
     const mapped = mapWithBrowserField(file, browserField)
     if (mapped) {
-      possibleFiles = [mapped]
+      possibleFiles = [mapped + postfix]
     } else if (mapped === false) {
       return (webResolvedImports[id] = browserExternalId)
     }
@@ -1127,7 +1140,6 @@ function resolveDeepImport(
         ))
     )
     if (resolved) {
-      resolved += postfix
       isDebug &&
         debug(
           `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
       postcss-load-config: ^4.0.1
       postcss-modules: ^5.0.0
       resolve: ^1.22.1
-      resolve.exports: ^1.1.0
+      resolve.exports: npm:@alloc/resolve.exports@^1.1.0
       rollup: ~3.3.0
       sirv: ^2.0.2
       source-map-js: ^1.0.2
@@ -323,7 +323,7 @@ importers:
       postcss-import: 15.0.0_postcss@8.4.19
       postcss-load-config: 4.0.1_postcss@8.4.19
       postcss-modules: 5.0.0_postcss@8.4.19
-      resolve.exports: 1.1.0
+      resolve.exports: /@alloc/resolve.exports/1.1.0
       sirv: 2.0.2
       source-map-js: 1.0.2
       source-map-support: 0.5.21
@@ -1418,6 +1418,11 @@ packages:
       '@algolia/cache-common': 4.13.1
       '@algolia/logger-common': 4.13.1
       '@algolia/requester-common': 4.13.1
+    dev: true
+
+  /@alloc/resolve.exports/1.1.0:
+    resolution: {integrity: sha512-daZJ4gBXxPUgjWjtxRp+5mU9tV6k7cSG2iKFyiPZOTxRzMRFPEe8dcTuqP+zIVSTfFpN1/SCIOMMYeYA7GwQvQ==}
+    engines: {node: '>=10'}
     dev: true
 
   /@ampproject/remapping/2.2.0:
@@ -7771,11 +7776,6 @@ packages:
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  /resolve.exports/1.1.0:
-    resolution: {integrity: sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==}
-    engines: {node: '>=10'}
-    dev: true
 
   /resolve/1.17.0:
     resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}


### PR DESCRIPTION
### Description

Closes #4439

Adds support for "fallback arrays" (see [these tests](https://github.com/alloc/resolve.exports/blob/6d65f146459537eff718936ba67b2c2c60b61cb9/src/index.spec.ts#L161-L195) for examples).

Replaces the `resolve.exports` package with [`@alloc/resolve.exports`](https://github.com/alloc/resolve.exports) (a higher quality rewrite). I'd be fine with transferring this package to the `@vitejs` organization if you'd like. 

**Why not fix this upstream?** The [related issue](https://github.com/lukeed/resolve.exports/issues/17) has been open without a response from the maintainer for 7 months. I'm confident we (or just me) can support the package better. In addition, the original package values "code golfing" over readability (no TypeScript, no code formatter, confusing variable names), so it's harder for people to contribute. Also, it doesn't use Vitest for its tests.

My rewrite is also tailored for Vite's needs, so any cruft is removed and there's no need to create a new object for every `resolveExports` call. My rewrite also has 100% test coverage and handles more of the "unofficial spec" (as described by [Node.js docs](https://nodejs.org/api/packages.html#package-entry-points) and [Webpack docs](https://webpack.js.org/guides/package-exports/#general-syntax)).

See [here](https://github.com/alloc/resolve.exports#api-differences) for API differences between the original and the rewrite.

### Additional context

I've also merged #8484 into this. @bluwy has said [he'd be willing](https://github.com/vitejs/vite/pull/8484#issuecomment-1175354187) to write tests for that part of the PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
