### PR TITLE
feat(proxy): Include URL of request in proxy errors

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -52,7 +52,9 @@ export function proxyMiddleware(
       const res = originalRes as http.ServerResponse | net.Socket
       if ('req' in res) {
         config.logger.error(
-          `${colors.red(`http proxy error at ${originalRes.req.url}:`)}\n${err.stack}`,
+          `${colors.red(`http proxy error at ${originalRes.req.url}:`)}\n${
+            err.stack
+          }`,
           {
             timestamp: true,
             error: err

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -52,7 +52,7 @@ export function proxyMiddleware(
       const res = originalRes as http.ServerResponse | net.Socket
       if ('req' in res) {
         config.logger.error(
-          `${colors.red(`http proxy error:`)}\n${err.stack}`,
+          `${colors.red(`http proxy error at ${originalRes.req.url}:`)}\n${err.stack}`,
           {
             timestamp: true,
             error: err


### PR DESCRIPTION
### Description

Resolves this issue
https://github.com/vitejs/vite/issues/10507

### Additional context

Improves proxy error message.

Now displays something like this which is helpful for debugging:
```
6:23:26 PM [vite] http proxy error at /some-path:
Error: getaddrinfo ENOTFOUND somedomain.com
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:84:26)
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
