### PR TITLE
chore: disable auto install of peer dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -7,3 +7,4 @@ hoist-pattern[]=source-map-support
 hoist-pattern[]=ts-node
 strict-peer-dependencies=false
 shell-emulator=true
+auto-install-peers=false


### PR DESCRIPTION
### Description

When `auto-install-peers=true` in the global .npmrc file it will lead to the error described in the bug linked below.

Benefits of setting this to false:
* Disabling it in this `.npmrc` will set it for the vite project and override any global npmrc settings.
* Setting to false is consistent with pnpm defaults.

Bug - https://github.com/vitejs/vite/issues/9973

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
