### PR TITLE
feat: include line and column in error format

### DIFF
--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -26,7 +26,11 @@ export function buildErrorMessage(
   includeStack = true
 ): string {
   if (err.plugin) args.push(`  Plugin: ${colors.magenta(err.plugin)}`)
-  if (err.id) args.push(`  File: ${colors.cyan(err.id)}`)
+  let loc = ''
+  if (err.loc) {
+    loc = `:${err.loc.line}:${err.loc.column}`
+  }
+  if (err.id) args.push(`  File: ${colors.cyan(err.id)}${loc}`)
   if (err.frame) args.push(colors.yellow(pad(err.frame)))
   if (includeStack && err.stack) args.push(pad(cleanStack(err.stack)))
   return args.join('\n')

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -26,10 +26,7 @@ export function buildErrorMessage(
   includeStack = true
 ): string {
   if (err.plugin) args.push(`  Plugin: ${colors.magenta(err.plugin)}`)
-  let loc = ''
-  if (err.loc) {
-    loc = `:${err.loc.line}:${err.loc.column}`
-  }
+  const loc = err.loc ? `:${err.loc.line}:${err.loc.column}` : ''
   if (err.id) args.push(`  File: ${colors.cyan(err.id)}${loc}`)
   if (err.frame) args.push(colors.yellow(pad(err.frame)))
   if (includeStack && err.stack) args.push(pad(cleanStack(err.stack)))


### PR DESCRIPTION
### Description

When nice printing a error/warning in vite, the file does not include the line:column, this is unfortunate since vscode can follow that kind of links and the information most of the time is well known!

### Additional context

Here's a small video explaining the PR:

<a href="https://www.loom.com/share/b5f2a5b030c94585b65a8939265bea01">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b5f2a5b030c94585b65a8939265bea01-with-play.gif">
  </a>

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
