### PR TITLE
feat(plugin-react): let `jsxImportSource` be defined with `moduleInfo.meta`

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -95,6 +95,11 @@ declare module 'vite' {
   }
 }
 
+declare module 'rollup' {
+  export interface CustomPluginOptions
+    extends Pick<Options, 'jsxImportSource'> {}
+}
+
 const prependReactImportCode = "import React from 'react'; "
 
 export default function viteReact(opts: Options = {}): PluginOption[] {
@@ -245,6 +250,10 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
                 : [null, false]
 
             if (isJSX || (ast = restoredAst)) {
+              const moduleInfo = this.getModuleInfo(id)!
+              const importSource =
+                moduleInfo.meta.jsxImportSource || opts.jsxImportSource
+
               plugins.push([
                 await loadPlugin(
                   '@babel/plugin-transform-react-jsx' +
@@ -252,7 +261,7 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
                 ),
                 {
                   runtime: 'automatic',
-                  importSource: opts.jsxImportSource,
+                  importSource,
                   pure: opts.jsxPure !== false,
                   throwIfNamespace: opts.jsxThrowIfNamespace
                 }


### PR DESCRIPTION
### Description

This feature is required for [react-dev-ssr](https://github.com/aleclarson/react-dev-ssr)'s upcoming Vite plugin.

Since we need `opts.ssr` (available in `resolveId` hook) before we can change the `jsxImportSource`, the React plugin needs to check `moduleInfo.meta` to see if another plugin wants to override the import source.

**Depends on #7477**

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
