### PR TITLE
test: fix ssr-vue server.js / prerender.js

### DIFF
--- a/playground/ssr-vue/prerender.js
+++ b/playground/ssr-vue/prerender.js
@@ -3,10 +3,15 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import url from 'node:url'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
 const toAbsolute = (p) => path.resolve(__dirname, p)
 
-const manifest = (await import('./dist/static/ssr-manifest.json')).default
+const manifest = JSON.parse(
+  fs.readFileSync(toAbsolute('dist/static/ssr-manifest.json'), 'utf-8')
+)
 const template = fs.readFileSync(toAbsolute('dist/static/index.html'), 'utf-8')
 const { render } = await import('./dist/server/entry-server.js')
 

--- a/playground/ssr-vue/server.js
+++ b/playground/ssr-vue/server.js
@@ -19,8 +19,9 @@ export async function createServer(
     : ''
 
   const manifest = isProd
-    ? // @ts-ignore
-      (await import('./dist/client/ssr-manifest.json')).default
+    ? JSON.parse(
+        fs.readFileSync(resolve('dist/client/ssr-manifest.json'), 'utf-8')
+      )
     : {}
 
   const app = express()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Since we cannot dynamic import json files in node, `pnpm serve` / `pnpm generate` in `ssr-vue` playground was not working.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
