### PR TITLE
fix: call `resolveId` hooks of custom plugins for css imports

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -694,6 +694,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
       return (
         cssResolve ||
         (cssResolve = config.createResolver({
+          plugins: config.plugins,
           extensions: ['.css'],
           mainFields: ['style'],
           tryIndex: false,
@@ -706,6 +707,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
       return (
         sassResolve ||
         (sassResolve = config.createResolver({
+          plugins: config.plugins,
           extensions: ['.scss', '.sass', '.css'],
           mainFields: ['sass', 'style'],
           tryIndex: true,
@@ -719,6 +721,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
       return (
         lessResolve ||
         (lessResolve = config.createResolver({
+          plugins: config.plugins,
           extensions: ['.less', '.css'],
           mainFields: ['less', 'style'],
           tryIndex: false,


### PR DESCRIPTION
Note: All plugins whose `name` matches `vite:*` are excluded from resolution of CSS imports. Any instances of `@rollup/plugin-alias` are also excluded (use `resolve.alias` instead).