### PR TITLE
feat(proxy): added retry option

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -115,6 +115,16 @@ export default defineConfig({
       '/socket.io': {
         target: 'ws://localhost:5173',
         ws: true
+      },
+      // With retry, e.g. when the backend is not ready yet
+      '/api': {
+        target: 'http://jsonplaceholder.typicode.com',
+        retry: {
+          maxTries: 10,
+          delay: 1000,
+          maxDelay: 30000,
+          backoff: true
+        }
       }
     }
   }

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -85,7 +85,10 @@ export type {
 export type { PluginContainer } from './server/pluginContainer'
 export type { ModuleGraph, ModuleNode, ResolvedUrl } from './server/moduleGraph'
 export type { SendOptions } from './server/send'
-export type { ProxyOptions } from './server/middlewares/proxy'
+export type {
+  ProxyOptions,
+  ProxyRetryOptions
+} from './server/middlewares/proxy'
 export type {
   TransformOptions,
   TransformResult

--- a/packages/vite/src/types/http-proxy.d.ts
+++ b/packages/vite/src/types/http-proxy.d.ts
@@ -39,10 +39,10 @@ export namespace HttpProxy {
     secureProtocol?: string | undefined
   }
 
-  export type ErrorCallback = (
+  export type ErrorCallback<Res> = (
     err: Error,
     req: http.IncomingMessage,
-    res: http.ServerResponse,
+    res: Res,
     target?: ProxyTargetUrl
   ) => void
 
@@ -63,7 +63,7 @@ export namespace HttpProxy {
       req: http.IncomingMessage,
       res: http.ServerResponse,
       options?: ServerOptions,
-      callback?: ErrorCallback
+      callback?: ErrorCallback<http.ServerResponse>
     ): void
 
     /**
@@ -78,7 +78,7 @@ export namespace HttpProxy {
       socket: unknown,
       head: unknown,
       options?: ServerOptions,
-      callback?: ErrorCallback
+      callback?: ErrorCallback<net.Socket>
     ): void
 
     /**
@@ -115,7 +115,10 @@ export namespace HttpProxy {
 
     addListener(event: string, listener: () => void): this
     on(event: string, listener: () => void): this
-    on(event: 'error', listener: ErrorCallback): this
+    on(
+      event: 'error',
+      listener: ErrorCallback<http.ServerResponse | net.Socket>
+    ): this
     on(
       event: 'start',
       listener: (


### PR DESCRIPTION
### Description

It is a common scenario that a web project is started in parallel with some backend and using Vite's proxy feature to forward api requests to that backend.
Since Vite is just too fast 😉 it happens, that the frontend is up and starting requests that the backend might not be ready for yet. Handling retries in the frontend is not always possible, e.g. when loading config directly from script tags.

Therefore it would be nice if the proxy could retry requests transparently.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
