### PR TITLE
fix: show error when build outDir does not exist when trying to preview

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -18,8 +18,7 @@ import compression from './server/middlewares/compression'
 import { proxyMiddleware } from './server/middlewares/proxy'
 import { resolveHostname, resolveServerUrls } from './utils'
 import { printServerUrls } from './logger'
-import { resolveConfig } from '.'
-import type { InlineConfig, ResolvedConfig } from '.'
+import type { ResolvedConfig } from '.'
 
 export interface PreviewOptions extends CommonServerOptions {}
 
@@ -74,11 +73,7 @@ export type PreviewServerHook = (
 /**
  * Starts the Vite server in preview mode, to simulate a production deployment
  */
-export async function preview(
-  inlineConfig: InlineConfig = {}
-): Promise<PreviewServer> {
-  const config = await resolveConfig(inlineConfig, 'serve', 'production')
-
+export async function preview(config: ResolvedConfig): Promise<PreviewServer> {
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.preview,

--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -1,5 +1,5 @@
 import type { InlineConfig } from 'vite'
-import { build, createServer, preview } from 'vite'
+import { build, createServer, preview, resolveConfig } from 'vite'
 import { expect, test } from 'vitest'
 import { getColor, isBuild, isServe, page, ports, rootDir } from '~utils'
 
@@ -17,8 +17,9 @@ const getConfig = (base: string): InlineConfig => ({
 })
 
 async function withBuild(base: string, fn: () => Promise<void>) {
-  const config = getConfig(base)
-  await build(config)
+  const inlineConfig = getConfig(base)
+  await build(inlineConfig)
+  const config = await resolveConfig(inlineConfig, 'serve', 'production')
   const server = await preview(config)
 
   try {

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -283,12 +283,8 @@ export async function startDefaultServe(): Promise<void> {
       config.__test__()
     }
     const _nodeEnv = process.env.NODE_ENV
-    const resolvedConfig = await resolveConfig(
-      testConfig,
-      'serve',
-      'production'
-    )
-    const previewServer = await preview(resolvedConfig)
+    const previewConfig = await resolveConfig(testConfig, 'serve', 'production')
+    const previewServer = await preview(previewConfig)
     // prevent preview change NODE_ENV
     process.env.NODE_ENV = _nodeEnv
     viteTestUrl = previewServer.resolvedUrls.local[0]

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -3,11 +3,10 @@ import path, { dirname, join, resolve } from 'node:path'
 import os from 'node:os'
 import fs from 'fs-extra'
 import { chromium } from 'playwright-chromium'
-import {
+import type {
   InlineConfig,
   Logger,
   PluginOption,
-  resolveConfig,
   ResolvedConfig,
   UserConfig,
   ViteDevServer
@@ -17,7 +16,8 @@ import {
   createServer,
   loadConfigFromFile,
   mergeConfig,
-  preview
+  preview,
+  resolveConfig
 } from 'vite'
 import type { Browser, Page } from 'playwright-chromium'
 import type { RollupError, RollupWatcher, RollupWatcherEvent } from 'rollup'

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -283,8 +283,12 @@ export async function startDefaultServe(): Promise<void> {
       config.__test__()
     }
     const _nodeEnv = process.env.NODE_ENV
-    const config = await resolveConfig(testConfig, 'serve', 'production')
-    const previewServer = await preview(config)
+    const resolvedConfig = await resolveConfig(
+      testConfig,
+      'serve',
+      'production'
+    )
+    const previewServer = await preview(resolvedConfig)
     // prevent preview change NODE_ENV
     process.env.NODE_ENV = _nodeEnv
     viteTestUrl = previewServer.resolvedUrls.local[0]

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -3,10 +3,11 @@ import path, { dirname, join, resolve } from 'node:path'
 import os from 'node:os'
 import fs from 'fs-extra'
 import { chromium } from 'playwright-chromium'
-import type {
+import {
   InlineConfig,
   Logger,
   PluginOption,
+  resolveConfig,
   ResolvedConfig,
   UserConfig,
   ViteDevServer
@@ -282,7 +283,8 @@ export async function startDefaultServe(): Promise<void> {
       config.__test__()
     }
     const _nodeEnv = process.env.NODE_ENV
-    const previewServer = await preview(testConfig)
+    const config = await resolveConfig(testConfig, 'serve', 'production')
+    const previewServer = await preview(config)
     // prevent preview change NODE_ENV
     process.env.NODE_ENV = _nodeEnv
     viteTestUrl = previewServer.resolvedUrls.local[0]


### PR DESCRIPTION
### Description

Problem:
When running `vite preview` and no build has been made yet, then it will show 404s on all routes in the browser.

Solution:
Check if out the build dir has been built and fail if it does not

Displays an error like this if it does not exist:
```
error when starting preview server:
Error: "dist" does not exist. Create build then try again.
    at CAC.<anonymous> (file:///Users/fc/tmp/vite-fc/packages/vite/dist/node/cli.js:814:19)
```

### Additional context

* `resolveConfig` logic was lifted up to the CLI code block to keep 
* Will likely conflict with [#10418](https://github.com/vitejs/vite/pull/10418/files)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
