### PR TITLE
chore: revert #10196 until Vite 4

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -72,7 +72,7 @@ interface ViteDevServer {
    * Native Node http server instance.
    * Will be null in middleware mode.
    */
-  httpServer: http.Server | Http2SecureServer | null
+  httpServer: http.Server | null
   /**
    * Chokidar watcher instance.
    * https://github.com/paulmillr/chokidar#api

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -307,7 +307,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
 ### `configurePreviewServer`
 
-- **Type:** `(server: { middlewares: Connect.Server, httpServer: http.Server | Http2SecureServer }) => (() => void) | void | Promise<(() => void) | void>`
+- **Type:** `(server: { middlewares: Connect.Server, httpServer: http.Server }) => (() => void) | void | Promise<(() => void) | void>`
 - **Kind:** `async`, `sequential`
 
   Same as [`configureServer`](/guide/api-plugin.html#configureserver) but for the preview server. It provides the [connect](https://github.com/senchalabs/connect) server and its underlying [http server](https://nodejs.org/api/http.html). Similarly to `configureServer`, the `configurePreviewServer` hook is called before other middlewares are installed. If you want to inject a middleware **after** other middlewares, you can return a function from `configurePreviewServer`, which will be called after internal middlewares are installed:

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -5,7 +5,6 @@ import type {
   OutgoingHttpHeaders as HttpServerHeaders
 } from 'node:http'
 import type { ServerOptions as HttpsServerOptions } from 'node:https'
-import type { Http2SecureServer } from 'node:http2'
 import type { Connect } from 'dep-types/connect'
 import colors from 'picocolors'
 import { isObject } from './utils'
@@ -95,7 +94,7 @@ export async function resolveHttpServer(
   { proxy }: CommonServerOptions,
   app: Connect.Server,
   httpsOptions?: HttpsServerOptions
-): Promise<HttpServer | Http2SecureServer> {
+): Promise<HttpServer> {
   if (!httpsOptions) {
     const { createServer } = await import('node:http')
     return createServer(app)
@@ -117,7 +116,7 @@ export async function resolveHttpServer(
       },
       // @ts-expect-error TODO: is this correct?
       app
-    )
+    ) as unknown as HttpServer
   }
 }
 
@@ -150,7 +149,7 @@ function readFileIfExists(value?: string | Buffer | any[]) {
 }
 
 export async function httpServerStart(
-  httpServer: HttpServer | Http2SecureServer,
+  httpServer: HttpServer,
   serverOptions: {
     port: number
     strictPort: boolean | undefined
@@ -186,7 +185,7 @@ export async function httpServerStart(
 }
 
 export function setClientErrorHandler(
-  server: HttpServer | Http2SecureServer,
+  server: HttpServer,
   logger: Logger
 ): void {
   server.on('clientError', (err, socket) => {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,6 +1,5 @@
 import path from 'node:path'
 import type * as http from 'node:http'
-import type { Http2SecureServer } from 'node:http2'
 import sirv from 'sirv'
 import connect from 'connect'
 import type { Connect } from 'dep-types/connect'
@@ -52,7 +51,7 @@ export interface PreviewServer {
   /**
    * native Node http server instance
    */
-  httpServer: http.Server | Http2SecureServer
+  httpServer: http.Server
   /**
    * The resolved urls Vite prints on the CLI
    */
@@ -67,7 +66,7 @@ export type PreviewServerHook = (
   this: void,
   server: {
     middlewares: Connect.Server
-    httpServer: http.Server | Http2SecureServer
+    httpServer: http.Server
   }
 ) => (() => void) | void | Promise<(() => void) | void>
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import path from 'node:path'
 import type * as net from 'node:net'
 import type * as http from 'node:http'
-import type { Http2SecureServer } from 'node:http2'
 import { performance } from 'node:perf_hooks'
 import connect from 'connect'
 import corsMiddleware from 'cors'
@@ -183,7 +182,7 @@ export interface ViteDevServer {
    * native Node http server instance
    * will be null in middleware mode
    */
-  httpServer: http.Server | Http2SecureServer | null
+  httpServer: http.Server | null
   /**
    * chokidar watcher instance
    * https://github.com/paulmillr/chokidar#api
@@ -693,7 +692,7 @@ async function startServer(
   }
 }
 
-function createServerCloseFn(server: http.Server | Http2SecureServer | null) {
+function createServerCloseFn(server: http.Server | null) {
   if (!server) {
     return () => {}
   }

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -1,5 +1,4 @@
 import type * as http from 'node:http'
-import type { Http2SecureServer } from 'node:http2'
 import type * as net from 'node:net'
 import httpProxy from 'http-proxy'
 import type { Connect } from 'dep-types/connect'
@@ -31,7 +30,7 @@ export interface ProxyOptions extends HttpProxy.ServerOptions {
 }
 
 export function proxyMiddleware(
-  httpServer: http.Server | Http2SecureServer | null,
+  httpServer: http.Server | null,
   options: NonNullable<CommonServerOptions['proxy']>,
   config: ResolvedConfig
 ): Connect.NextHandleFunction {

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -2,7 +2,6 @@ import type { Server } from 'node:http'
 import { STATUS_CODES } from 'node:http'
 import type { ServerOptions as HttpsServerOptions } from 'node:https'
 import { createServer as createHttpsServer } from 'node:https'
-import type { Http2SecureServer } from 'node:http2'
 import type { Socket } from 'node:net'
 import colors from 'picocolors'
 import type { ServerOptions, WebSocket as WebSocketRaw } from 'ws'
@@ -79,7 +78,7 @@ const wsServerEvents = [
 ]
 
 export function createWebSocketServer(
-  server: Server | Http2SecureServer | null,
+  server: Server | null,
   config: ResolvedConfig,
   httpsOptions?: HttpsServerOptions
 ): WebSocketServer {


### PR DESCRIPTION
This reverts commit f328f613cccc6dda261849f4fbf1ce6041a2682b.

### Description

Marko is failing after #10196 

@PengBoUESTC we can do this change in Vite 4 in a month, so we don't introduce a breaking change (even if it is just types) in a minor.

```
Error: src/__tests__/main.test.ts(156,36): error TS2345: Argument of type 'Server | Http2SecureServer' is not assignable to parameter of type 'Server'.
  Type 'Http2SecureServer' is missing the following properties from type 'Server': maxHeadersCount, maxRequestsPerSocket, timeout, headersTimeout, and 2 more.
```

The error is strange, why `Http2SecureServer` is missing properties from `Server`?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other