### PR TITLE
fix(css): strip BOM (fixes #10043)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -43,7 +43,8 @@ import {
   parseRequest,
   processSrcSet,
   removeDirectQuery,
-  requireResolveFromRootWithFallback
+  requireResolveFromRootWithFallback,
+  stripBomTag
 } from '../utils'
 import type { Logger } from '../logger'
 import { addToHTMLProxyTransformResult } from './html'
@@ -352,6 +353,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       ) {
         return
       }
+
+      css = stripBomTag(css)
 
       const inlined = inlineRE.test(id)
       const modules = cssModulesCache.get(config)!.get(id)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fixes #10043 

Note that this isn't needed when postcss is enabled. postcss seems to remove BOM.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
