### PR TITLE
feat: reuse import ids in SSR builds

### DIFF
--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -90,7 +90,7 @@ async function ssrTransformScript(
   const deps = new Set<string>()
   const dynamicDeps = new Set<string>()
   const idToImportMap = new Map<string, string>()
-  const sourceToId = new Map();
+  const sourceToId = new Map()
   const declaredConst = new Set<string>()
 
   function defineImport(node: Node, source: string) {

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -90,15 +90,21 @@ async function ssrTransformScript(
   const deps = new Set<string>()
   const dynamicDeps = new Set<string>()
   const idToImportMap = new Map<string, string>()
+  const sourceToId = new Map();
   const declaredConst = new Set<string>()
 
   function defineImport(node: Node, source: string) {
+    if (sourceToId.has(source)) {
+      return sourceToId.get(source)
+    }
+
     deps.add(source)
     const importId = `__vite_ssr_import_${uid++}__`
     s.appendRight(
       node.start,
       `const ${importId} = await ${ssrImportKey}(${JSON.stringify(source)});\n`
     )
+    sourceToId.set(source, importId)
     return importId
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Right now, it's quite confusing to read the generated source code because imports of the same package have different ids. So, for example, for vue I have one import id per component. This change reuses existing imports if they refer to the same package.

### Additional context

n/a

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
