### PR TITLE
perf: Use only one ps exec to find a Chromium browser opened on Mac OS

### DIFF
--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -72,16 +72,19 @@ function startBrowserProcess(browser: string | undefined, url: string) {
   // requested a different browser, we can try opening
   // a Chromium browser with AppleScript. This lets us reuse an
   // existing tab when possible instead of creating a new one.
+  const preferredOSXBrowser =
+    browser === 'google chrome' ? 'Google Chrome' : browser
   const shouldTryOpenChromeWithAppleScript =
     process.platform === 'darwin' &&
-    (!browser || supportedChromiumBrowsers.includes(browser))
+    (!preferredOSXBrowser ||
+      supportedChromiumBrowsers.includes(preferredOSXBrowser))
 
   if (shouldTryOpenChromeWithAppleScript) {
     try {
       const ps = execSync('ps cax').toString()
       const openedBrowser =
-        browser && ps.includes(browser)
-          ? browser
+        preferredOSXBrowser && ps.includes(preferredOSXBrowser)
+          ? preferredOSXBrowser
           : supportedChromiumBrowsers.find((b) => ps.includes(b))
       // Try our best to reuse existing tab with AppleScript
       execSync(

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -16,9 +16,6 @@ import colors from 'picocolors'
 import type { Logger } from '../logger'
 import { VITE_PACKAGE_DIR } from '../constants'
 
-// https://github.com/sindresorhus/open#app
-const OSX_CHROME = 'google chrome'
-
 /**
  * Reads the BROWSER environment variable and decides what to do with it.
  * Returns true if it opened a browser or ran a node.js script, otherwise false.
@@ -59,45 +56,46 @@ function executeNodeScript(scriptPath: string, url: string, logger: Logger) {
   return true
 }
 
+const supportedChromiumBrowsers = [
+  'Google Chrome Canary',
+  'Google Chrome Dev',
+  'Google Chrome Beta',
+  'Google Chrome',
+  'Microsoft Edge',
+  'Brave Browser',
+  'Vivaldi',
+  'Chromium'
+]
+
 function startBrowserProcess(browser: string | undefined, url: string) {
   // If we're on OS X, the user hasn't specifically
   // requested a different browser, we can try opening
-  // Chrome with AppleScript. This lets us reuse an
+  // a Chromium browser with AppleScript. This lets us reuse an
   // existing tab when possible instead of creating a new one.
   const shouldTryOpenChromeWithAppleScript =
-    process.platform === 'darwin' && (browser === '' || browser === OSX_CHROME)
+    process.platform === 'darwin' &&
+    (!browser || supportedChromiumBrowsers.includes(browser))
 
   if (shouldTryOpenChromeWithAppleScript) {
-    // Will use the first open browser found from list
-    const supportedChromiumBrowsers = [
-      'Google Chrome Canary',
-      'Google Chrome Dev',
-      'Google Chrome Beta',
-      'Google Chrome',
-      'Microsoft Edge',
-      'Brave Browser',
-      'Vivaldi',
-      'Chromium'
-    ]
-
-    for (const chromiumBrowser of supportedChromiumBrowsers) {
-      try {
-        // Try our best to reuse existing tab
-        // on OS X Google Chrome with AppleScript
-        execSync(`ps cax | grep "${chromiumBrowser}"`)
-        execSync(
-          `osascript openChrome.applescript "${encodeURI(
-            url
-          )}" "${chromiumBrowser}"`,
-          {
-            cwd: join(VITE_PACKAGE_DIR, 'bin'),
-            stdio: 'ignore'
-          }
-        )
-        return true
-      } catch (err) {
-        // Ignore errors
-      }
+    try {
+      const ps = execSync('ps cax').toString()
+      const openedBrowser =
+        browser && ps.includes(browser)
+          ? browser
+          : supportedChromiumBrowsers.find((b) => ps.includes(b))
+      // Try our best to reuse existing tab with AppleScript
+      execSync(
+        `osascript openChrome.applescript "${encodeURI(
+          url
+        )}" "${openedBrowser}"`,
+        {
+          cwd: join(VITE_PACKAGE_DIR, 'bin'),
+          stdio: 'ignore'
+        }
+      )
+      return true
+    } catch (err) {
+      // Ignore errors
     }
   }
 


### PR DESCRIPTION
### Description

See https://github.com/vitejs/vite/pull/10485#issuecomment-1285701030

### Additional context

After a quick benchmark I saw that adding a grep was not making things faster

<details>
<summary>Script</summary>

```js
import { execSync } from "node:child_process";

const supportedChromiumBrowsers = [
  "Google Chrome Canary",
  "Google Chrome Dev",
  "Google Chrome Beta",
  "Google Chrome",
  "Microsoft Edge",
  "Brave Browser",
  "Vivaldi",
  "Chromium",
];

const start = performance.now();
for (let i = 0; i < 100; i++) {
  const ps = execSync("ps cax").toString();
  const browser = supportedChromiumBrowsers.find((b) => ps.includes(b));
}
console.log(`no grep: ${(performance.now() - start).toFixed(2)}ms`);

const start2 = performance.now();
for (let i = 0; i < 100; i++) {
  const ps = execSync(
    `ps cax | grep "${supportedChromiumBrowsers.join("\\|")}"`,
  ).toString();
  const browser = supportedChromiumBrowsers.find((b) => ps.includes(b));
}
console.log(`grep: ${(performance.now() - start2).toFixed(2)}ms`);
```
</details>

Also the tab is now reused is the request browser is chromium based