### PR TITLE
feat(server):  support for unprinting update logs

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -46,7 +46,7 @@ export async function handleHMRUpdate(
   const { ws, config, moduleGraph } = server
   const shortFile = getShortName(file, config.root)
   const fileName = path.basename(file)
-
+  const printLog = config.server.printLog
   const isConfig = file === config.configFile
   const isConfigDependency = config.configFileDependencies.some(
     (name) => file === name
@@ -104,10 +104,14 @@ export async function handleHMRUpdate(
   if (!hmrContext.modules.length) {
     // html file cannot be hot updated
     if (file.endsWith('.html')) {
-      config.logger.info(colors.green(`page reload `) + colors.dim(shortFile), {
-        clear: true,
-        timestamp: true
-      })
+      printLog &&
+        config.logger.info(
+          colors.green(`page reload `) + colors.dim(shortFile),
+          {
+            clear: true,
+            timestamp: true
+          }
+        )
       ws.send({
         type: 'full-reload',
         path: config.server.middlewareMode
@@ -133,7 +137,7 @@ export function updateModules(
   const updates: Update[] = []
   const invalidatedModules = new Set<ModuleNode>()
   let needFullReload = false
-
+  const printLog = config.server.printLog
   for (const mod of modules) {
     invalidate(mod, timestamp, invalidatedModules)
     if (needFullReload) {
@@ -165,10 +169,11 @@ export function updateModules(
   }
 
   if (needFullReload) {
-    config.logger.info(colors.green(`page reload `) + colors.dim(file), {
-      clear: true,
-      timestamp: true
-    })
+    printLog &&
+      config.logger.info(colors.green(`page reload `) + colors.dim(file), {
+        clear: true,
+        timestamp: true
+      })
     ws.send({
       type: 'full-reload'
     })
@@ -180,12 +185,13 @@ export function updateModules(
     return
   }
 
-  config.logger.info(
-    updates
-      .map(({ path }) => colors.green(`hmr update `) + colors.dim(path))
-      .join('\n'),
-    { clear: true, timestamp: true }
-  )
+  printLog &&
+    config.logger.info(
+      updates
+        .map(({ path }) => colors.green(`hmr update `) + colors.dim(path))
+        .join('\n'),
+      { clear: true, timestamp: true }
+    )
   ws.send({
     type: 'update',
     updates

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -123,6 +123,10 @@ export interface ServerOptions extends CommonServerOptions {
    * in a future minor version without following semver
    */
   force?: boolean
+  /**
+   * Whether to print the change log
+   */
+  printLog?: boolean
 }
 
 export interface ResolvedServerOptions extends ServerOptions {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Printing file update logs are of little significance to most users. Users may prefer a clean control panel, so they do not print logs by default. Users can open them in ``server.printLog`` by themselves.

### Additional context

#10527 
#10591 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
