### PR TITLE
feat(server): console hold address(fixes  #10527)

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -1,4 +1,3 @@
-import { performance } from 'node:perf_hooks'
 import { cac } from 'cac'
 import colors from 'picocolors'
 import type { BuildOptions } from './build'
@@ -105,25 +104,7 @@ cli
 
       await server.listen()
 
-      const info = server.config.logger.info
-
-      // @ts-ignore
-      const viteStartTime = global.__vite_start_time ?? false
-      const startupDurationString = viteStartTime
-        ? colors.dim(
-            `ready in ${colors.reset(
-              colors.bold(Math.ceil(performance.now() - viteStartTime))
-            )} ms`
-          )
-        : ''
-
-      info(
-        `\n  ${colors.green(
-          `${colors.bold('VITE')} v${VERSION}`
-        )}  ${startupDurationString}\n`,
-        { clear: !server.config.logger.hasWarned }
-      )
-
+      server.printReadyInfo()
       server.printUrls()
     } catch (e) {
       createLogger(options.logLevel).error(

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -54,6 +54,8 @@ export async function handleHMRUpdate(
   const isEnv =
     config.inlineConfig.envFile !== false &&
     (fileName === '.env' || fileName.startsWith('.env.'))
+
+  const keepAddress = config.server.keepAddress
   if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
     debugHmr(`[config change] ${colors.dim(shortFile)}`)
@@ -108,6 +110,11 @@ export async function handleHMRUpdate(
         clear: true,
         timestamp: true
       })
+      if (keepAddress) {
+        server.printReadyInfo()
+        server.printUrls()
+      }
+
       ws.send({
         type: 'full-reload',
         path: config.server.middlewareMode
@@ -128,11 +135,13 @@ export function updateModules(
   file: string,
   modules: ModuleNode[],
   timestamp: number,
-  { config, ws }: ViteDevServer
+  { config, ws, printReadyInfo, printUrls }: ViteDevServer
 ): void {
   const updates: Update[] = []
   const invalidatedModules = new Set<ModuleNode>()
   let needFullReload = false
+
+  const keepAddress = config.server.keepAddress
 
   for (const mod of modules) {
     invalidate(mod, timestamp, invalidatedModules)
@@ -169,6 +178,10 @@ export function updateModules(
       clear: true,
       timestamp: true
     })
+    if (keepAddress) {
+      printReadyInfo()
+      printUrls()
+    }
     ws.send({
       type: 'full-reload'
     })
@@ -186,6 +199,10 @@ export function updateModules(
       .join('\n'),
     { clear: true, timestamp: true }
   )
+  if (keepAddress) {
+    printReadyInfo()
+    printUrls()
+  }
   ws.send({
     type: 'update',
     updates

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -42,7 +42,7 @@ import {
   initDepsOptimizer,
   initDevSsrDepsOptimizer
 } from '../optimizer'
-import { CLIENT_DIR } from '../constants'
+import { CLIENT_DIR, VERSION } from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
 import { invalidatePackageData } from '../packages'
@@ -123,6 +123,12 @@ export interface ServerOptions extends CommonServerOptions {
    * in a future minor version without following semver
    */
   force?: boolean
+
+  /**
+   * Always keep address
+   * @default false
+   */
+  keepAddress?: boolean
 }
 
 export interface ResolvedServerOptions extends ServerOptions {
@@ -263,6 +269,11 @@ export interface ViteDevServer {
    * Print server urls
    */
   printUrls(): void
+
+  /**
+   * Print server start ready info
+   */
+  printReadyInfo(): void
   /**
    * Restart the server.
    *
@@ -435,6 +446,24 @@ export async function createServer(
           'cannot print server URLs before server.listen is called.'
         )
       }
+    },
+    printReadyInfo() {
+      const info = server.config.logger.info
+      // @ts-ignore
+      const viteStartTime = global.__vite_start_time ?? false
+      const startupDurationString = viteStartTime
+        ? colors.dim(
+            `ready in ${colors.reset(
+              colors.bold(Math.ceil(performance.now() - viteStartTime))
+            )} ms`
+          )
+        : ''
+      info(
+        `\n  ${colors.green(
+          `${colors.bold('VITE')} v${VERSION}`
+        )}  ${startupDurationString}\n`,
+        { clear: !server.config.logger.hasWarned }
+      )
     },
     async restart(forceOptimize?: boolean) {
       if (!server._restartPromise) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In one case, when IDE is developed for a period of time, terminal information is flooded by hot update information. After leaving for a period of time, close the browser and forget the access address. You must restart to obtain the access address

Seems to have done repeated work https://github.com/vitejs/vite/pull/10592

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

https://github.com/vitejs/vite/issues/10527
https://github.com/vitejs/vite/issues/10591

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
