### PR TITLE
fix(hmr): cannot reload after missing import on server startup (#9534)

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -294,6 +294,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           if (ssr) {
             return [url, url]
           }
+          // fix#9534, prevent the importerModuleNode being stopped from propagating updates
+          importerModule.isSelfAccepting = false
           return this.error(
             `Failed to resolve import "${url}" from "${path.relative(
               process.cwd(),

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -670,4 +670,28 @@ if (!isBuild) {
       return await el.textContent()
     }, '[wow]1')
   })
+
+  test('keep hmr reload after missing import on server startup', async () => {
+    const file = 'missing-import/a.js'
+    const importCode = "import 'missing-modules'"
+    const unImportCode = `// ${importCode}`
+    const timeout = 2000
+
+    await page.goto(viteTestUrl + '/missing-import/index.html')
+
+    browserLogs.length = 0
+    expect(browserLogs).toMatchObject([])
+
+    editFile(file, (code) => code.replace(importCode, unImportCode))
+
+    await page.waitForNavigation({ timeout })
+    expect(browserLogs.some((msg) => msg.match('missing test'))).toBe(true)
+    browserLogs.length = 0
+
+    editFile(file, (code) => code.replace(unImportCode, importCode))
+
+    await page.waitForNavigation({ timeout })
+    expect(browserLogs.some((msg) => msg.includes('500'))).toBe(true)
+    browserLogs.length = 0
+  })
 }

--- a/playground/hmr/missing-import/a.js
+++ b/playground/hmr/missing-import/a.js
@@ -1,0 +1,3 @@
+import 'missing-modules'
+
+console.log('missing test')

--- a/playground/hmr/missing-import/index.html
+++ b/playground/hmr/missing-import/index.html
@@ -1,0 +1,2 @@
+<div>Page</div>
+<script type="module" src="main.js"></script>

--- a/playground/hmr/missing-import/main.js
+++ b/playground/hmr/missing-import/main.js
@@ -1,0 +1,1 @@
+import './a.js'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When the devserver is started for the first time, this error will occur if a nested missing import relationship is encountered. For details, please see the playground's missing import test in the commit and the releated issue.


### Additional context
<!-- e.g. is there anything you'd like reviewers to focus on? -->
close: #9534

the bug comes from pr #8898 . It seems just to be to adjust the logs display effect? Now it seems that some updates cannot be accurately tracked by the `updates` array, so it follows the previous implementation of versions to send  update and execute `transform` function

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
