### PR TITLE
fix: increase error overlay z-index

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -9,7 +9,7 @@ const template = /*html*/ `
   left: 0;
   width: 100%;
   height: 100%;
-
+  z-index: 99999;
   --monospace: 'SFMono-Regular', Consolas,
   'Liberation Mono', Menlo, Courier, monospace;
   --red: #ff5555;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In some cases, error-overlay is blocked by other higher z-index elements, as follows:

![image](https://user-images.githubusercontent.com/61490799/197385256-2c580ef5-839e-478d-8fd0-edc4ae498a23.png)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Other
- [ ] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
