### PR TITLE
fix: revert es-module-lexer version

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -91,7 +91,7 @@
     "dep-types": "link:./src/types",
     "dotenv": "^14.3.2",
     "dotenv-expand": "^5.1.0",
-    "es-module-lexer": "^1.0.5",
+    "es-module-lexer": "1.0.3",
     "estree-walker": "^3.0.1",
     "etag": "^1.8.1",
     "fast-glob": "^3.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,7 +234,7 @@ importers:
       dep-types: link:./src/types
       dotenv: ^14.3.2
       dotenv-expand: ^5.1.0
-      es-module-lexer: ^1.0.5
+      es-module-lexer: 1.0.3
       esbuild: ^0.15.9
       estree-walker: ^3.0.1
       etag: ^1.8.1
@@ -302,7 +302,7 @@ importers:
       dep-types: link:src/types
       dotenv: 14.3.2
       dotenv-expand: 5.1.0
-      es-module-lexer: 1.0.5
+      es-module-lexer: 1.0.3
       estree-walker: 3.0.1
       etag: 1.8.1
       fast-glob: 3.2.12
@@ -4221,8 +4221,8 @@ packages:
       unbox-primitive: 1.0.2
     dev: true
 
-  /es-module-lexer/1.0.5:
-    resolution: {integrity: sha512-oxJ+R1DzAw6j4g1Lx70bIKgfoRCX67C51kH2Mx7J4bS7ZzWxkcivXskFspzgKHUj6JUwUTghQgUPy8zTp6mMBw==}
+  /es-module-lexer/1.0.3:
+    resolution: {integrity: sha512-iC67eXHToclrlVhQfpRawDiF8D8sQxNxmbqw5oebegOaJkyx/w9C/k57/5e6yJR2zIByRt9OXdqX50DV2t6ZKw==}
     dev: true
 
   /es-shim-unscopables/1.0.0:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
It seems es-module-lexer 1.0.4-1.0.5 has a bug affecting histoire.
Reverting the version worked https://github.com/vitejs/vite-ecosystem-ci/actions/runs/3311221053/jobs/5466393115.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
