### PR TITLE
feat: add `namedExports` option to css modules config

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -104,6 +104,10 @@ export interface CSSModulesOptions {
     | 'dashes'
     | 'dashesOnly'
     | null
+  /**
+   * default: true
+   */
+  namedExports?: boolean
 }
 
 const cssLangs = `\\.(css|less|sass|scss|styl|stylus|pcss|postcss|sss)($|\\?)`
@@ -319,6 +323,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
   let outputToExtractedCSSMap: Map<NormalizedOutputOptions, string>
   let hasEmitted = false
 
+  const modulesOptions = config.css?.modules
   const rollupOptionsOutput = config.build.rollupOptions.output
   const assetFileNames = (
     Array.isArray(rollupOptionsOutput)
@@ -371,7 +376,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       const modulesCode =
         modules &&
         !inlined &&
-        dataToEsm(modules, { namedExports: true, preferConst: true })
+        dataToEsm(modules, {
+          namedExports:
+            modulesOptions && 'namedExports' in modulesOptions
+              ? modulesOptions.namedExports
+              : true,
+          preferConst: true
+        })
 
       if (config.command === 'serve') {
         const getContentWithSourcemap = async (content: string) => {


### PR DESCRIPTION
### Description

Currently `cssPostPlugin` is using hardcoded value (`true`) for `namedExports` to generate classes mapping.
In my project `namedExports`: true, duplicates the classes map file size generated based on css file. 

NOTE: `namedExports`: true, is great to have when css file contains a lot of overrides for same css class. But if the css file has distinct classes it is not optimal to have `namedExports`

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
