### PR TITLE
fix(config): resolve build options with fallback

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -306,7 +306,6 @@ export function resolveBuildOptions(
     assetsDir: 'assets',
     assetsInlineLimit: 4096,
     cssCodeSplit: !raw?.lib,
-    cssTarget: false,
     sourcemap: false,
     rollupOptions: {},
     minify: raw?.ssr ? false : 'esbuild',
@@ -330,6 +329,7 @@ export function resolveBuildOptions(
   // @ts-expect-error Fallback options instead of merging
   const resolved: ResolvedBuildOptions = {
     target: 'modules',
+    cssTarget: false,
     ...userBuildOptions,
     commonjsOptions: {
       include: [/node_modules/],

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -515,11 +515,7 @@ export async function resolveConfig(
       : './'
     : resolveBaseUrl(config.base, isBuild, logger) ?? '/'
 
-  const resolvedBuildOptions = resolveBuildOptions(
-    config.build,
-    isBuild,
-    logger
-  )
+  const resolvedBuildOptions = resolveBuildOptions(config.build, logger)
 
   // resolve cache directory
   const pkgPath = lookupFile(resolvedRoot, [`package.json`], { pathOnly: true })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Use `mergeConfig` when resolving build options, but only for non-array options as we don't want to merge arrays. Array-able options like `target` and `cssTarget` fallback in `resolved` object instead.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Fix failing ecosystem CI for Svelte

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
