### PR TITLE
fix: export missing picomatch type def from optimizer (fixes #10656)

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -33,6 +33,8 @@ export {
   getDepsOptimizer
 } from './optimizer'
 
+export type { default as picomatch } from 'picomatch'
+
 export const debuggerViteDeps = createDebugger('vite:deps')
 const debug = debuggerViteDeps
 const isDebugEnabled = _debug('vite:deps').enabled


### PR DESCRIPTION
### Description

Fixes: #10656 which is also currently failing the Laravel and Svelte Kit builds.

This PR attempts to fix an issue with a missing type definition for Picomatch.

This approach was an attempt to duplicate previous ways of handling this, such as https://github.com/vitejs/vite/pull/8352/

🚨 I have no idea what I'm doing and this could be completely incorrect.

### Additional context

N/A

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).

I think this is covered by the eco-system CI tests...
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
