### PR TITLE
fix: remove picomatch type import (fixes #10656)

### DIFF
--- a/packages/vite/scripts/postPatchTypes.ts
+++ b/packages/vite/scripts/postPatchTypes.ts
@@ -1,7 +1,8 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import fs from 'node:fs'
 import colors from 'picocolors'
-import { rewriteImports } from './util'
+import { rewriteImports, walkDir } from './util'
 
 const dir = dirname(fileURLToPath(import.meta.url))
 const nodeDts = resolve(dir, '../dist/node/index.d.ts')
@@ -14,3 +15,18 @@ rewriteImports(nodeDts, (importPath) => {
 })
 
 console.log(colors.green(colors.bold(`patched types/* imports`)))
+
+// remove picomatch type import because only the internal property uses it
+const picomatchImport = "import type { Matcher as Matcher_2 } from 'picomatch';"
+
+walkDir(nodeDts, (file) => {
+  const content = fs.readFileSync(file, 'utf-8')
+  if (!content.includes(picomatchImport)) {
+    throw new Error(`Should find picomatch type import in ${file}`)
+  }
+
+  const replacedContent = content.replace(picomatchImport, '')
+  fs.writeFileSync(file, replacedContent, 'utf-8')
+})
+
+console.log(colors.green(colors.bold(`removed picomatch type import`)))

--- a/packages/vite/scripts/util.ts
+++ b/packages/vite/scripts/util.ts
@@ -21,7 +21,7 @@ export function slash(p: string): string {
   return p.replace(/\\/g, '/')
 }
 
-function walkDir(dir: string, handleFile: (file: string) => void): void {
+export function walkDir(dir: string, handleFile: (file: string) => void): void {
   if (statSync(dir).isDirectory()) {
     const files = readdirSync(dir)
     for (const file of files) {

--- a/packages/vite/tsconfig.check.json
+++ b/packages/vite/tsconfig.check.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "noEmit": true,
     "moduleResolution": "classic",
+    "noResolve": true,
+    "typeRoots": [],
     // Only add entries to `paths` when you are adding/updating dependencies (not devDependencies)
     // See CONTRIBUTING.md "Ensure type support" for more details
     "paths": {
@@ -14,9 +16,22 @@
       // indirect: postcss depends on it
       "source-map-js": ["./node_modules/source-map-js/source-map.d.ts"]
     },
-    "typeRoots": [],
     "strict": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["dist/**/*.d.ts"]
+  "include": [
+    "../../node_modules/@types/node/**/*",
+    // dependencies
+    "./node_modules/rollup/**/*",
+    "./node_modules/esbuild/**/*",
+    "./node_modules/postcss/**/*",
+    "./node_modules/source-map-js/**/*",
+    // dist
+    "dist/**/*",
+    "types/customEvent.d.ts",
+    "types/hmrPayload.d.ts",
+    "types/importGlob.d.ts",
+    "types/importMeta.d.ts",
+    "types/hot.d.ts"
+  ]
 }


### PR DESCRIPTION
### Description
The type script script was somehow resolving `node_modules/@types` in the root of monorepo and this is the reason why we didn't notice this. I've updated the `tsconfig.json` to detect this case.

Type import of `picomatch` was included in `index.d.ts` but was not used, because the prop that uses this type was marked as internal. (internal properties are removed from the output)
https://github.com/vitejs/vite/blob/675bf07a093c2af5c928bdd1a8458dc235cc442d/packages/vite/src/node/server/index.ts#L300-L304
Since we don't use them, I added some codes in `postPatchTypes.ts` to remove that type import.

fixes #10656
superseds close #10672

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
