### PR TITLE
chore: remove src/client from package

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -28,7 +28,6 @@
     "dist",
     "client.d.ts",
     "index.cjs",
-    "src/client",
     "types"
   ],
   "engines": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
These 12e055007b8055ba1789e7405f0476a0499db53a, 294d8b472ca5d5079d8fe35ecb1b0bf6cf7720db commits added `src/client` to `files` field of `package.json` to include them in the package to avoid sourcemap errors.
But now `dist/client/client.mjs.map` has `sourcesContent` field so the real files in `src/client` is not needed.

I tested #3652's reproduction by upgrading Vite to 2.9.15 and manually removing `src/client` from the vite package.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
