### PR TITLE
fix: remove loaded input sourcemap (fixes #8411)

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -472,6 +472,10 @@ export async function createPluginContainer(
       this.filename = filename
       this.originalCode = code
       if (inMap) {
+        if (isDebugSourcemapCombineFocused) {
+          // @ts-expect-error inject name for debug purpose
+          inMap.name = '$inMap'
+        }
         this.sourcemapChain.push(inMap)
       }
     }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -7,6 +7,7 @@ import type { SourceDescription, SourceMap } from 'rollup'
 import colors from 'picocolors'
 import type { ViteDevServer } from '..'
 import {
+  blankReplacer,
   cleanUrl,
   createDebugger,
   ensureWatchedFile,
@@ -196,6 +197,8 @@ async function loadAndTransform(
           convertSourceMap.fromSource(code) ||
           convertSourceMap.fromMapFileSource(code, path.dirname(file))
         )?.toObject()
+
+        code = code.replace(convertSourceMap.mapFileCommentRegex, blankReplacer)
       } catch (e) {
         logger.warn(`Failed to load source map for ${url}.`, {
           timestamp: true

--- a/playground/css-sourcemap/index.html
+++ b/playground/css-sourcemap/index.html
@@ -26,6 +26,8 @@
   <p class="imported-stylus">&lt;imported stylus&gt;</p>
 
   <p class="imported-sugarss">&lt;imported sugarss&gt;</p>
+
+  <p class="input-map">&lt;input source-map&gt;</p>
 </div>
 
 <script type="module">
@@ -44,6 +46,8 @@
   import './imported.styl'
 
   import './imported.sss'
+
+  import './input-map.css'
 </script>
 
 <iframe src="virtual.html"></iframe>

--- a/playground/css-sourcemap/input-map.css
+++ b/playground/css-sourcemap/input-map.css
@@ -1,0 +1,4 @@
+.input-map {
+  color: #00f;
+}
+/*# sourceMappingURL=input-map.css.map */

--- a/playground/css-sourcemap/input-map.css.map
+++ b/playground/css-sourcemap/input-map.css.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": ["input-map.src.css"],
+  "sourcesContent": [".input-map {\n  color: blue;\n}"],
+  "mappings": "AAAA,WACE",
+  "names": []
+}

--- a/playground/css-sourcemap/input-map.src.css
+++ b/playground/css-sourcemap/input-map.src.css
@@ -1,0 +1,3 @@
+.input-map {
+  color: blue;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fixes #8411

Also fixes the weird behavior with `@vite/client`. `@vite/client` had two `sourceMappingURL`.
```js
export {ErrorOverlay, createHotContext, injectQuery, removeStyle, updateStyle};
//# sourceMappingURL=client.mjs.map

//# sourceMappingURL=data:application/json;base64,foobar
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
