### PR TITLE
fix: tsconfig `jsx` overrides esbuild options, reverts #10374

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -57,7 +57,7 @@ However, some libraries (e.g. [`vue`](https://github.com/vuejs/core/issues/1228)
 
 #### `useDefineForClassFields`
 
-Starting from Vite 2.5.0, the default value will be `true` if the TypeScript target is `ES2022` or higher including `ESNext`. It is consistent with the [behavior of `tsc` 4.3.2 and later](https://github.com/microsoft/TypeScript/pull/42663). It is also the standard ECMAScript runtime behavior.
+Starting from Vite 2.5.0, the default value will be `true` if the TypeScript target is `ESNext`. It is consistent with the [behavior of `tsc` 4.3.2 and later](https://github.com/microsoft/TypeScript/pull/42663). It is also the standard ECMAScript runtime behavior.
 
 But it may be counter-intuitive for those coming from other programming languages or older versions of TypeScript.
 You can read more about the transition in the [TypeScript 3.7 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier).
@@ -71,13 +71,10 @@ But a few libraries haven't transitioned to this new default yet, including [`li
 #### Other Compiler Options Affecting the Build Result
 
 - [`extends`](https://www.typescriptlang.org/tsconfig#extends)
-- [`alwaysStrict`](https://www.typescriptlang.org/tsconfig#alwaysStrict)
 - [`importsNotUsedAsValues`](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues)
-- [`jsx`](https://www.typescriptlang.org/tsconfig#jsx)
+- [`preserveValueImports`](https://www.typescriptlang.org/tsconfig#preserveValueImports)
 - [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
 - [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
-- [`jsxImportSource`](https://www.typescriptlang.org/tsconfig#jsxImportSource)
-- [`preserveValueImports`](https://www.typescriptlang.org/tsconfig#preserveValueImports)
 
 If migrating your codebase to `"isolatedModules": true` is an unsurmountable effort, you may be able to get around it with a third-party plugin such as [rollup-plugin-friendly-type-imports](https://www.npmjs.com/package/rollup-plugin-friendly-type-imports). However, this approach is not officially supported by Vite.
 

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -50,15 +50,12 @@ export type ESBuildTransformResult = Omit<TransformResult, 'map'> & {
 type TSConfigJSON = {
   extends?: string
   compilerOptions?: {
-    alwaysStrict?: boolean
-    importsNotUsedAsValues?: 'remove' | 'preserve' | 'error'
-    jsx?: 'react' | 'react-jsx' | 'react-jsxdev' | 'preserve'
+    target?: string
     jsxFactory?: string
     jsxFragmentFactory?: string
-    jsxImportSource?: string
-    preserveValueImports?: boolean
-    target?: string
     useDefineForClassFields?: boolean
+    importsNotUsedAsValues?: 'remove' | 'preserve' | 'error'
+    preserveValueImports?: boolean
   }
   [key: string]: any
 }
@@ -95,15 +92,12 @@ export async function transformWithEsbuild(
     // these fields would affect the compilation result
     // https://esbuild.github.io/content-types/#tsconfig-json
     const meaningfulFields: Array<keyof TSCompilerOptions> = [
-      'alwaysStrict',
-      'importsNotUsedAsValues',
-      'jsx',
+      'target',
       'jsxFactory',
       'jsxFragmentFactory',
-      'jsxImportSource',
-      'preserveValueImports',
-      'target',
-      'useDefineForClassFields'
+      'useDefineForClassFields',
+      'importsNotUsedAsValues',
+      'preserveValueImports'
     ]
     const compilerOptionsForFile: TSCompilerOptions = {}
     if (loader === 'ts' || loader === 'tsx') {


### PR DESCRIPTION
### Description
This PR reverts #10374.
That PR caused many breakage than I expected.

When `tsconfig.json`'s `jsx` field has `'preserve'` and `esbuild.jsx: 'transform'` in `vite.config.js`, `'preserve'` is applied. (Previously `'transform'` was applied.)
So `tsconfig.json` has precedence over `esbuild` options. This is similar to #10296.

I think we should revert this one and reintroduce this in Vite 4. (Maybe esbuild options should have precedence)

fixes #10670
fixes #10685
fixes #10702

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
