### PR TITLE
feat(cli): build --profile

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+import fs from 'node:fs'
 import { performance } from 'node:perf_hooks'
 import { cac } from 'cac'
 import colors from 'picocolors'
@@ -26,6 +28,27 @@ interface GlobalCLIOptions {
   m?: string
   mode?: string
   force?: boolean
+}
+
+export const stopProfiler = (log: (message: string) => void): void => {
+  // @ts-ignore
+  const profileSession = global.__vite_profile_session
+  if (profileSession) {
+    profileSession.post('Profiler.stop', (err: any, { profile }: any) => {
+      // Write profile to disk, upload, etc.
+      if (!err) {
+        const outPath = path.resolve('./vite-profile.cpuprofile')
+        fs.writeFileSync(outPath, JSON.stringify(profile))
+        log(
+          colors.yellow(
+            `CPU profile written to ${colors.white(colors.dim(outPath))}`
+          )
+        )
+      } else {
+        throw err
+      }
+    })
+  }
 }
 
 const filterDuplicateOptions = <T extends object>(options: T) => {
@@ -125,6 +148,7 @@ cli
       )
 
       server.printUrls()
+      stopProfiler((message) => server.config.logger.info(`  ${message}`))
     } catch (e) {
       createLogger(options.logLevel).error(
         colors.red(`error when starting dev server:\n${e.stack}`),
@@ -194,6 +218,7 @@ cli
       )
       process.exit(1)
     }
+    stopProfiler((message) => createLogger(options.logLevel).info(message))
   })
 
 // optimize

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -150,10 +150,11 @@ cli
       server.printUrls()
       stopProfiler((message) => server.config.logger.info(`  ${message}`))
     } catch (e) {
-      createLogger(options.logLevel).error(
-        colors.red(`error when starting dev server:\n${e.stack}`),
-        { error: e }
-      )
+      const logger = createLogger(options.logLevel)
+      logger.error(colors.red(`error when starting dev server:\n${e.stack}`), {
+        error: e
+      })
+      stopProfiler(logger.info)
       process.exit(1)
     }
   })
@@ -217,8 +218,9 @@ cli
         { error: e }
       )
       process.exit(1)
+    } finally {
+      stopProfiler((message) => createLogger(options.logLevel).info(message))
     }
-    stopProfiler((message) => createLogger(options.logLevel).info(message))
   })
 
 // optimize
@@ -301,6 +303,8 @@ cli
           { error: e }
         )
         process.exit(1)
+      } finally {
+        stopProfiler((message) => createLogger(options.logLevel).info(message))
       }
     }
   )

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs'
 import path from 'node:path'
 import type * as net from 'node:net'
 import type * as http from 'node:http'
@@ -650,7 +649,6 @@ async function startServer(
   const hostname = await resolveHostname(options.host)
 
   const protocol = options.https ? 'https' : 'http'
-  const info = server.config.logger.info
 
   const serverPort = await httpServerStart(httpServer, {
     port,
@@ -658,25 +656,6 @@ async function startServer(
     host: hostname.host,
     logger: server.config.logger
   })
-
-  // @ts-ignore
-  const profileSession = global.__vite_profile_session
-  if (profileSession) {
-    profileSession.post('Profiler.stop', (err: any, { profile }: any) => {
-      // Write profile to disk, upload, etc.
-      if (!err) {
-        const outPath = path.resolve('./vite-profile.cpuprofile')
-        fs.writeFileSync(outPath, JSON.stringify(profile))
-        info(
-          colors.yellow(
-            `  CPU profile written to ${colors.white(colors.dim(outPath))}\n`
-          )
-        )
-      } else {
-        throw err
-      }
-    })
-  }
 
   if (options.open && !isRestart) {
     const path =


### PR DESCRIPTION
This will allow to profile `vite build` to detect performance issues in plugins only applied at build time.

Usage example: 
<img width="726" alt="Screenshot 2022-11-09 at 04 14 30" src="https://user-images.githubusercontent.com/14235743/200729584-1018c142-6653-4e1f-a7c5-19da8ac92048.png">
<img width="721" alt="Screenshot 2022-11-09 at 04 14 56" src="https://user-images.githubusercontent.com/14235743/200729555-44fef818-531c-4b81-bd63-fc3fd0ee2f87.png">

Note: There is a small regression on the initial build message in Vite 4