### PR TITLE
fix: removes short absolute path transitions

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -310,10 +310,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
         // normalize all imports into resolved URLs
         // e.g. `import 'foo'` -> `import '/@fs/.../node_modules/foo/index.js'`
-        if (resolved.id.startsWith(root + '/')) {
-          // in root: infer short absolute path from root
-          url = resolved.id.slice(root.length)
-        } else if (
+        if (
           resolved.id.startsWith(getDepsCacheDirPrefix(config)) ||
           fs.existsSync(cleanUrl(resolved.id))
         ) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

在做一个自动导入指定目录下所有资源的需求，遇到的问题是，在`pnpm start`时，可以拿到该目录下所有资源的文件名，但只要访问页面地址` http://127.0.0.1:5173/`，或者刷新页面，就会报错。输出如图所示：
![](http://entry.chaxus.com/uploads/upload_7b92b48f7888417596a5980e9866bdee.jpeg)

最少关键代码如下：
```js
// index.js

import user from '@/assets/icons?dir'
console.log('user-->',user)

// vite.config.js
 alias: {
        '@/assets': resolve(__dirname, "assets/"),
  },

// plugins/index.js
export default function autoImportFilePlugin(options = {}) {
    const autoImportRegex = /\?(url|dir|raw)/
    return {
        name: 'vite-plugin-auto-import-file',
        enforce: 'pre',
        async resolveId(id) {
            const { defaultImport } = options
            if (!id.match(autoImportRegex)) return
            const [path, query] = id.split('?', 2)
            const importType = query || defaultImport
            if (importType === 'url') return path
            if (importType === 'dir') {
                try {
                    const fileList = fs.readdirSync(path)

                    console.log('fileList--->', fileList)

                    return fileList
                } catch (error) {

                    console.warn('\n', `${id} couldn't be loaded by vite-plugin-auto-import-file`)

                    return
                }
            }
            return path
        },
    }
}
```
最小复现demo地址：https://github.com/chaxus/vite-demo
然后我尝试寻找原因，调试代码发现第一次`fileList`成功输出的
```
fileList---> [
  'check-circle.svg',
  'close-circle.svg',
  'home.svg',
  'user.svg',
  'warning-circle.svg'
]
```
的时候，`import`路径能从`@/assets/icons`转换为`/Users/Documents/code/vite-demo/assets/icons`此时代码正常运行。
但访问页面后，`@/assets/icons`被转换成了`/assets/icons`，导致路径解析失败，项目报错。
然后我发现问题代码是在
```js
// packages/vite/src/node/plugins/importAnalysis.ts

 if (resolved.id.startsWith(root + '/')) {
      // in root: infer short absolute path from root
      url = resolved.id.slice(root.length)
 } 
```
目的是将`/Users/Documents/code/vite-demo/assets/icons`转换成`/assets/icons`。我尝试去掉这段代码，对vite进行dev和link并再次运行项目后，发现没有问题了。

因此，个人愚见是希望移除这段代码，从而使用完整的绝对路径。非常感谢🌹。如有考虑不周，还请多多海涵🙏。


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

最小复现demo地址：https://github.com/chaxus/vite-demo

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
