### PR TITLE
fix: support dynamic path with alias in `new URL()` (fix #10597)

### DIFF
--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -71,7 +71,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               const resolvedUrl = await aliaResolver(
                 rawUrl.slice(1),
                 undefined,
-                true
+                true,
               )
               if (resolvedUrl) {
                 newUrl = normalizePath(path.relative(config.root, resolvedUrl))
@@ -103,9 +103,9 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
                 index + exp.length,
                 `new URL((import.meta.glob(${JSON.stringify(
                   pattern,
-                )}, ${JSON.stringify(
-                  globOptions,
-                )}))[${newUrl ?? pureUrl}], self.location)`,
+                )}, ${JSON.stringify(globOptions)}))[${
+                  newUrl ?? pureUrl
+                }], self.location)`,
               )
               continue
             }

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -337,13 +337,13 @@ test('new URL(`./${dynamic}?abc`, import.meta.url)', async () => {
 
 test('new URL(`@/${dynamic}`, import.meta.url)', async () => {
   expect(await page.textContent('.dynamic-import-meta-url-1-alias')).toMatch(
-    isBuild ? 'data:image/png;base64' : '/foo/nested/icon.png'
+    isBuild ? 'data:image/png;base64' : '/foo/nested/icon.png',
   )
   expect(await page.textContent('.dynamic-import-meta-url-2-alias')).toMatch(
-    assetMatch
+    assetMatch,
   )
   expect(await page.textContent('.dynamic-import-meta-url-js-alias')).toMatch(
-    isBuild ? 'data:application/javascript;base64' : '/foo/nested/test.js'
+    isBuild ? 'data:application/javascript;base64' : '/foo/nested/test.js',
   )
 })
 

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -335,6 +335,18 @@ test('new URL(`./${dynamic}?abc`, import.meta.url)', async () => {
   )
 })
 
+test('new URL(`@/${dynamic}`, import.meta.url)', async () => {
+  expect(await page.textContent('.dynamic-import-meta-url-1-alias')).toMatch(
+    isBuild ? 'data:image/png;base64' : '/foo/nested/icon.png'
+  )
+  expect(await page.textContent('.dynamic-import-meta-url-2-alias')).toMatch(
+    assetMatch
+  )
+  expect(await page.textContent('.dynamic-import-meta-url-js-alias')).toMatch(
+    isBuild ? 'data:application/javascript;base64' : '/foo/nested/test.js'
+  )
+})
+
 test('new URL(`non-existent`, import.meta.url)', async () => {
   expect(await page.textContent('.non-existent-import-meta-url')).toMatch(
     new URL('non-existent', page.url()).pathname,

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -231,6 +231,19 @@
   <code class="dynamic-import-meta-url-2-query"></code>
 </p>
 
+<h2>new URL(`@/${dynamic}`, import.meta.url)</h2>
+<p>
+  <img class="dynamic-import-meta-url-img-1-alias" />
+  <code class="dynamic-import-meta-url-1-alias"></code>
+</p>
+<p>
+  <img class="dynamic-import-meta-url-img-2-alias" />
+  <code class="dynamic-import-meta-url-2-alias"></code>
+</p>
+<p>
+  <code class="dynamic-import-meta-url-js-alias"></code>
+</p>
+
 <h2>new URL(`non-existent`, import.meta.url)</h2>
 <p>
   <code class="non-existent-import-meta-url"></code>
@@ -453,10 +466,25 @@
   testDynamicImportMetaUrlWithQuery('icon', 1)
   testDynamicImportMetaUrlWithQuery('asset', 2)
 
+  
+  function testDynamicImportMetaUrlWithAlias(name, i) {
+    const metaUrl = new URL(`@/${name}.png`, import.meta.url)
+    text(`.dynamic-import-meta-url-${i}-alias`, metaUrl)
+    document.querySelector(`.dynamic-import-meta-url-img-${i}-alias`).src =
+      metaUrl
+  }
+
+  testDynamicImportMetaUrlWithAlias('icon', 1)
+  testDynamicImportMetaUrlWithAlias('asset', 2)
+
   {
     const name = 'test'
+    
     const js = new URL(`./nested/${name}.js`, import.meta.url).href
     text('.dynamic-import-meta-url-js', js)
+
+    const aliasedJs = new URL(`@/${name}.js`, import.meta.url).href
+    text('.dynamic-import-meta-url-js-alias', aliasedJs)
   }
 
   {

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -466,7 +466,6 @@
   testDynamicImportMetaUrlWithQuery('icon', 1)
   testDynamicImportMetaUrlWithQuery('asset', 2)
 
-  
   function testDynamicImportMetaUrlWithAlias(name, i) {
     const metaUrl = new URL(`@/${name}.png`, import.meta.url)
     text(`.dynamic-import-meta-url-${i}-alias`, metaUrl)
@@ -479,7 +478,7 @@
 
   {
     const name = 'test'
-    
+
     const js = new URL(`./nested/${name}.js`, import.meta.url).href
     text('.dynamic-import-meta-url-js', js)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If the path in `new URL()` includes both variables and alias, Vite will not resolve the alias and cause an error during runtime.

This PR resolves the alias appear in `new URL()` in assetImportMetaUrlPlugin.

fixes  #10597

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
