### PR TITLE
feat!: set esbuild default charset to utf8

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -17,6 +17,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'es'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: 'es2020',
       format: 'esm',
       keepNames: true,
@@ -59,6 +60,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'es'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: undefined,
       format: 'esm',
       keepNames: true,
@@ -88,6 +90,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'es'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: 'es2020',
       format: 'esm',
       keepNames: true,
@@ -119,6 +122,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'es'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: undefined,
       format: 'esm',
       keepNames: true,
@@ -150,6 +154,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'cjs'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: undefined,
       format: 'cjs',
       keepNames: true,
@@ -180,6 +185,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'es'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: undefined,
       format: 'esm',
       keepNames: true,
@@ -214,6 +220,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'cjs'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: undefined,
       format: 'cjs',
       keepNames: true,

--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -17,6 +17,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'es'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: 'es2020',
       format: 'esm',
       keepNames: true,
@@ -150,6 +151,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       'cjs'
     )
     expect(options).toEqual({
+      charset: 'utf8',
       target: undefined,
       format: 'cjs',
       keepNames: true,

--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -17,7 +17,6 @@ describe('resolveEsbuildTranspileOptions', () => {
       'es'
     )
     expect(options).toEqual({
-      charset: 'utf8',
       target: 'es2020',
       format: 'esm',
       keepNames: true,
@@ -151,7 +150,6 @@ describe('resolveEsbuildTranspileOptions', () => {
       'cjs'
     )
     expect(options).toEqual({
-      charset: 'utf8',
       target: undefined,
       format: 'cjs',
       keepNames: true,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -116,8 +116,6 @@ export type PluginOption =
   | PluginOption[]
   | Promise<Plugin | false | null | undefined | PluginOption[]>
 
-type Charset = 'ascii' | 'utf8'
-
 export interface UserConfig {
   /**
    * Project root directory. Can be an absolute path, or a path relative from
@@ -154,11 +152,6 @@ export interface UserConfig {
    * each command, and can be overridden by the command line --mode option.
    */
   mode?: string
-  /**
-   * Charset
-   * @default 'utf8'
-   */
-  charset?: Charset
   /**
    * Define global variable replacements.
    * Entries will be defined on `window` during dev and replaced during build.
@@ -637,7 +630,6 @@ export async function resolveConfig(
     resolve: resolveOptions,
     publicDir: resolvedPublicDir,
     cacheDir,
-    charset: config.charset ?? 'utf8',
     command,
     mode,
     ssr,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -116,6 +116,8 @@ export type PluginOption =
   | PluginOption[]
   | Promise<Plugin | false | null | undefined | PluginOption[]>
 
+type Charset = 'ascii' | 'utf8'
+
 export interface UserConfig {
   /**
    * Project root directory. Can be an absolute path, or a path relative from
@@ -152,6 +154,11 @@ export interface UserConfig {
    * each command, and can be overridden by the command line --mode option.
    */
   mode?: string
+  /**
+   * Charset
+   * @default 'utf8'
+   */
+  charset?: Charset
   /**
    * Define global variable replacements.
    * Entries will be defined on `window` during dev and replaced during build.
@@ -630,6 +637,7 @@ export async function resolveConfig(
     resolve: resolveOptions,
     publicDir: resolvedPublicDir,
     cacheDir,
+    charset: config.charset ?? 'utf8',
     command,
     mode,
     ssr,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -612,6 +612,7 @@ export async function runOptimizeDeps(
     ignoreAnnotations: !isBuild,
     metafile: true,
     plugins,
+    charset: 'utf8',
     ...esbuildOptions,
     supported: {
       'dynamic-import': true,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -306,9 +306,10 @@ export function resolveEsbuildTranspileOptions(
   // https://github.com/vuejs/core/issues/2860#issuecomment-926882793
   const isEsLibBuild = config.build.lib && format === 'es'
   const esbuildOptions = config.esbuild || {}
+
   const options: TransformOptions = {
+    charset: 'utf8',
     ...esbuildOptions,
-    charset: config.charset,
     target: target || undefined,
     format: rollupToEsbuildFormatMap[format],
     // the final build should always support dynamic import and import.meta.

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -375,6 +375,7 @@ export function resolveEsbuildTranspileOptions(
     return {
       ...options,
       minify: true,
+      charset: 'utf8',
       treeShaking: true
     }
   }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -308,6 +308,7 @@ export function resolveEsbuildTranspileOptions(
   const esbuildOptions = config.esbuild || {}
   const options: TransformOptions = {
     ...esbuildOptions,
+    charset: config.charset,
     target: target || undefined,
     format: rollupToEsbuildFormatMap[format],
     // the final build should always support dynamic import and import.meta.
@@ -375,7 +376,6 @@ export function resolveEsbuildTranspileOptions(
     return {
       ...options,
       minify: true,
-      charset: 'utf8',
       treeShaking: true
     }
   }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -180,6 +180,7 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
   // and for build as the final optimization is in `buildEsbuildPlugin`
   const transformOptions: TransformOptions = {
     target: 'esnext',
+    charset: 'utf8',
     ...options,
     minify: false,
     minifyIdentifiers: false,


### PR DESCRIPTION
<img width="845" alt="image" src="https://user-images.githubusercontent.com/5698350/199377641-04e1fc7c-7102-4a49-8915-28daf49f9dea.png">

Currently, if I use a language other than English in my javascript code, my bundle gets very large. To avoid this, I have to use a Terser.  For example, Terser preserves "丂", but esbuild seems to convert it to "\u4E02".

In order to solve the problem and start using esbuild without fear, we need to add charset.