### PR TITLE
fix: add `@types/node` as an optional peer dependency

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -123,6 +123,7 @@
     "ws": "^8.10.0"
   },
   "peerDependencies": {
+    "@types/node": ">= 14",
     "less": "*",
     "sass": "*",
     "stylus": "*",
@@ -130,6 +131,9 @@
     "terser": "^5.4.0"
   },
   "peerDependenciesMeta": {
+    "@types/node": {
+      "optional": true
+    },
     "sass": {
       "optional": true
     },


### PR DESCRIPTION
### Description

The built bundle of Vite starts with a reference to `node` types: https://unpkg.com/browse/vite@3.2.2/dist/node/index.d.ts

This means those who depend on Vite type definitions should install `@types/node` in their projects to do type-checking successfully. In that sense, `@types/node` is an optional peer dependency of Vite.

After this is fixed, we should revert https://github.com/vitejs/vite-ecosystem-ci/pull/85 because not explicitly depending on `@types/node` *should* be erroneous. The ecosystem CI shouldn't cover that error for downstream packages.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
