### PR TITLE
feat: deprecated default export of css imports

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -38,35 +38,59 @@ declare module '*.module.sss' {
 
 // CSS
 declare module '*.css' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.css?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 declare module '*.scss' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.scss?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 declare module '*.sass' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.sass?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 declare module '*.less' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.less?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 declare module '*.styl' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.styl?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 declare module '*.stylus' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.stylus?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 declare module '*.pcss' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.pcss?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 declare module '*.sss' {
-  const css: string
+  /**
+   * @deprecated Use `import style from './style.sss?inline'` instead.
+   */
+  const css: unknown
   export default css
 }
 

--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -41,56 +41,56 @@ declare module '*.css' {
   /**
    * @deprecated Use `import style from './style.css?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 declare module '*.scss' {
   /**
    * @deprecated Use `import style from './style.scss?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 declare module '*.sass' {
   /**
    * @deprecated Use `import style from './style.sass?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 declare module '*.less' {
   /**
    * @deprecated Use `import style from './style.less?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 declare module '*.styl' {
   /**
    * @deprecated Use `import style from './style.styl?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 declare module '*.stylus' {
   /**
    * @deprecated Use `import style from './style.stylus?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 declare module '*.pcss' {
   /**
    * @deprecated Use `import style from './style.pcss?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 declare module '*.sss' {
   /**
    * @deprecated Use `import style from './style.sss?inline'` instead.
    */
-  const css: unknown
+  const css: string
   export default css
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Importing a css like:
```ts
import thing from './global.css';
```

Will fundamentally cause a double loading of CSS, since vite will emit a .css file, but it;s likely that the CSS will also be used by the application code, being most likely used by the framework runtime to inject the style.

This is actually hard to detect since, the API does not indicate there is a side effect anywhere. Today's solution is to add `?inline`, but it's a lie, since the original API is also inlined.

`?inline` actually means (ONLY inline, no side effect). Imo, this is wrong.

This PR will not cause any breaking changes, but deprecated the usage of:

```ts
import stuff from './global.css'
```

giving a recomendation to use:

```ts
import stuff from './global.css?inline'
```

### Additional context

https://github.com/vitejs/vite/pull/10235


https://github.com/BuilderIO/qwik/issues/1932
https://github.com/BuilderIO/qwik/issues/749#issuecomment-1184102236
https://github.com/BuilderIO/qwik/pull/1959

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
