### PR TITLE
feat: add vited to start vite in debug mode

### DIFF
--- a/packages/vite/bin/vited.js
+++ b/packages/vite/bin/vited.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node --inspect-brk
+import './vite'

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -6,7 +6,8 @@
   "author": "Evan You",
   "description": "Native-ESM powered web dev build tool",
   "bin": {
-    "vite": "bin/vite.js"
+    "vite": "bin/vite.js",
+    "vited": "bin/vited.js"
   },
   "main": "./dist/node/index.js",
   "module": "./dist/node/index.js",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add a `vited` binary so it's easy to start vite in inspect-brk mode. this is specially important for SSR frameworks, that will run most of the code in node, debugging is not that easy!

`vited`: up to different ideas is the same as `vite` but it's executed with `node --inspect-brk`. This way SSR and oven faulty builds can be easily debugging.

Alternative:
```
    "dev.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js --mode ssr --force",
```
instead of:
```
    "dev.debug": "vited --mode ssr --force",
```

but i always found this very implementation specific, of node, and makes the package.json script look crowded!

Up for alternative ideas!


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
