### PR TITLE
fix: relocated logger to respect config.

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { InlineConfig } from '..'
-import type { UserConfig, UserConfigExport } from '../config'
+import type { PluginOption, UserConfig, UserConfigExport } from '../config'
 import { resolveConfig } from '../config'
 import { resolveEnvPrefix } from '../env'
 import { mergeConfig } from '../publicUtils'
@@ -264,5 +264,53 @@ describe('preview config', () => {
     expect(await resolveConfig(config, 'serve')).toMatchObject({
       preview: previewConfig()
     })
+  })
+})
+
+describe('resolveConfig', () => {
+  const keepScreenMergePlugin = (): PluginOption => {
+    return {
+      name: 'vite-plugin-keep-screen-merge',
+      config() {
+        return { clearScreen: false }
+      }
+    }
+  }
+
+  const keepScreenOverridePlugin = (): PluginOption => {
+    return {
+      name: 'vite-plugin-keep-screen-override',
+      config(config) {
+        config.clearScreen = false
+      }
+    }
+  }
+
+  test('plugin merges `clearScreen` option', async () => {
+    const config1: InlineConfig = { plugins: [keepScreenMergePlugin()] }
+    const config2: InlineConfig = {
+      plugins: [keepScreenMergePlugin()],
+      clearScreen: true
+    }
+
+    const results1 = await resolveConfig(config1, 'build')
+    const results2 = await resolveConfig(config2, 'build')
+
+    expect(results1.clearScreen).toBe(false)
+    expect(results2.clearScreen).toBe(false)
+  })
+
+  test('plugin overrides `clearScreen` option', async () => {
+    const config1: InlineConfig = { plugins: [keepScreenOverridePlugin()] }
+    const config2: InlineConfig = {
+      plugins: [keepScreenOverridePlugin()],
+      clearScreen: true
+    }
+
+    const results1 = await resolveConfig(config1, 'build')
+    const results2 = await resolveConfig(config2, 'build')
+
+    expect(results1.clearScreen).toBe(false)
+    expect(results2.clearScreen).toBe(false)
   })
 })

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -408,12 +408,6 @@ export async function resolveConfig(
     }
   }
 
-  // Define logger
-  const logger = createLogger(config.logLevel, {
-    allowClearScreen: config.clearScreen,
-    customLogger: config.customLogger
-  })
-
   // user config may provide an alternative mode. But --mode has a higher priority
   mode = inlineConfig.mode || config.mode || mode
   configEnv.mode = mode
@@ -456,6 +450,12 @@ export async function resolveConfig(
     config.build ??= {}
     config.build.commonjsOptions = { include: [] }
   }
+
+  // Define logger
+  const logger = createLogger(config.logLevel, {
+    allowClearScreen: config.clearScreen,
+    customLogger: config.customLogger
+  })
 
   // resolve root
   const resolvedRoot = normalizePath(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR simply moves the location of where the logger is created further down in the code. This fixes #10780.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

The logger was being instantiated too early and wasn't respecting potential changes to the `clearScreen` config option that could have been changed via plugins. Now that the logger is instantiated _after_ plugins are processed, it will pick up changes in the config correctly.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
