### PR TITLE
fix: gracefully handle forbidden filesystem access

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { describe, expect, test } from 'vitest'
 import {
   asyncFlatten,
@@ -5,6 +6,7 @@ import {
   getLocalhostAddressIfDiffersFromDNS,
   getPotentialTsSrcPaths,
   injectQuery,
+  isFileReadable,
   isWindows,
   posToNumber,
   resolveHostname
@@ -235,4 +237,29 @@ describe('asyncFlatten', () => {
     ])
     expect(arr).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9])
   })
+})
+
+describe('isFileReadable', () => {
+  test("file doesn't exist", async () => {
+    expect(isFileReadable('/does_not_exist')).toBe(false)
+  })
+
+  const testFile = require.resolve(
+    './utils/isFileReadable/permission-test-file'
+  )
+  test('file with normal permission', async () => {
+    expect(isFileReadable(testFile)).toBe(true)
+  })
+
+  if (process.platform !== 'win32') {
+    test('file with read-only permission', async () => {
+      fs.chmodSync(testFile, '400')
+      expect(isFileReadable(testFile)).toBe(true)
+    })
+    test('file without read permission', async () => {
+      fs.chmodSync(testFile, '044')
+      expect(isFileReadable(testFile)).toBe(false)
+      fs.chmodSync(testFile, '644')
+    })
+  }
 })

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -531,9 +531,6 @@ function tryResolveFile(
   tryPrefix?: string,
   skipPackageJson?: boolean
 ): string | undefined {
-  // #2051 if we don't have read permission on a directory, existsSync() still
-  // works and will result in massively slow subsequent checks (which are
-  // unnecessary in the first place)
   if (isFileReadable(file)) {
     if (!fs.statSync(file).isDirectory()) {
       return getRealPath(file, options.preserveSymlinks) + postfix

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -546,7 +546,7 @@ function tryResolveFile(
           const resolved = resolvePackageEntry(file, pkg, targetWeb, options)
           return resolved
         } catch (e) {
-          if (e.code !== 'ENOENT') {
+          if (e.code !== 'ENOENT' && e.code !== 'EACCES') {
             throw e
           }
         }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -546,7 +546,7 @@ function tryResolveFile(
           const resolved = resolvePackageEntry(file, pkg, targetWeb, options)
           return resolved
         } catch (e) {
-          if (e.code !== 'ENOENT' && e.code !== 'EACCES') {
+          if (e.code !== 'ENOENT') {
             throw e
           }
         }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -537,10 +537,8 @@ export function writeFile(
 
 export function isFileReadable(filename: string): boolean {
   try {
-    const stat = fs.statSync(filename, { throwIfNoEntry: false })
-    // Test user permission. Throws error if no permission.
     fs.accessSync(filename, fs.constants.R_OK)
-    return !!stat
+    return true
   } catch {
     return false
   }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -535,12 +535,6 @@ export function writeFile(
   fs.writeFileSync(filename, content)
 }
 
-/**
- * Use fs.statSync(filename) instead of fs.existsSync(filename)
- * #2051 if we don't have read permission on a directory, existsSync() still
- * works and will result in massively slow subsequent checks (which are
- * unnecessary in the first place)
- */
 export function isFileReadable(filename: string): boolean {
   try {
     const stat = fs.statSync(filename, { throwIfNoEntry: false })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -544,6 +544,8 @@ export function writeFile(
 export function isFileReadable(filename: string): boolean {
   try {
     const stat = fs.statSync(filename, { throwIfNoEntry: false })
+    // Test user permission. Throws error if no permission.
+    fs.accessSync(filename, fs.constants.R_OK)
     return !!stat
   } catch {
     return false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Prior to this PR, URLs like `/root` make Vite throw an error.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
