### PR TITLE
docs: add note to use dotenv-expand (#10440)

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -60,6 +60,17 @@ console.log(import.meta.env.VITE_SOME_KEY) // 123
 console.log(import.meta.env.DB_PASSWORD) // undefined
 ```
 
+Also vite uses [dotenv-expand](https://github.com/motdotla/dotenv-expand#what-rules-does-the-expansion-engine-follow) to expand the functionality of your environments out of the box, you can check the dependency rules to learn how to use it.
+
+Note that if you want to use the `$` inside your environment value, you have to escape it with `\`.
+
+```
+KEY=123
+NEW_KEY1=test$foo   # test
+NEW_KEY2=test\$foo  # test$foo
+NEW_KEY3=test$KEY   # test123
+```
+
 If you want to customize the env variables prefix, see the [envPrefix](/config/shared-options.html#envprefix) option.
 
 :::warning SECURITY NOTES

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -60,7 +60,7 @@ console.log(import.meta.env.VITE_SOME_KEY) // 123
 console.log(import.meta.env.DB_PASSWORD) // undefined
 ```
 
-Also vite uses [dotenv-expand](https://github.com/motdotla/dotenv-expand#what-rules-does-the-expansion-engine-follow) to expand the functionality of your environments out of the box, you can check the dependency rules to learn how to use it.
+Also vite uses [dotenv-expand](https://github.com/motdotla/dotenv-expand) to expand variables out of the box. To learn more about the syntax, check out [their docs](https://github.com/motdotla/dotenv-expand#what-rules-does-the-expansion-engine-follow).
 
 Note that if you want to use the `$` inside your environment value, you have to escape it with `\`.
 

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -60,9 +60,9 @@ console.log(import.meta.env.VITE_SOME_KEY) // 123
 console.log(import.meta.env.DB_PASSWORD) // undefined
 ```
 
-Also vite uses [dotenv-expand](https://github.com/motdotla/dotenv-expand) to expand variables out of the box. To learn more about the syntax, check out [their docs](https://github.com/motdotla/dotenv-expand#what-rules-does-the-expansion-engine-follow).
+Also, Vite uses [dotenv-expand](https://github.com/motdotla/dotenv-expand) to expand variables out of the box. To learn more about the syntax, check out [their docs](https://github.com/motdotla/dotenv-expand#what-rules-does-the-expansion-engine-follow).
 
-Note that if you want to use the `$` inside your environment value, you have to escape it with `\`.
+Note that if you want to use `$` inside your environment value, you have to escape it with `\`.
 
 ```
 KEY=123


### PR DESCRIPTION
Note to how to use `dotevn-exand` #10440

### Description

In this PR, a small explanation of how to use `$` inside the environment value has been added, since vite uses `dotevn-exand` if `\` is not used before it, the dependency will interpret it as variable

This is how it looks

![image](https://user-images.githubusercontent.com/51803643/200143553-ca6d3c42-ce24-41dc-ab6d-f05cf31b0efe.png)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`)
