### PR TITLE
test: add retry guard to css-dynamic-import test

### DIFF
--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -97,7 +97,8 @@ baseOptions.forEach(({ base, label }) => {
           }
         ])
       })
-    }
+    },
+    { retry: 3 }
   )
 
   test.runIf(isServe)(
@@ -116,6 +117,7 @@ baseOptions.forEach(({ base, label }) => {
           }
         ])
       })
-    }
+    },
+    { retry: 3 }
   )
 })


### PR DESCRIPTION
### Description

This test has been flaky during the past two weeks, adding a retry guard while we figure out why. See https://github.com/vitejs/vite/actions/runs/3408695929/attempts/3

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other