### PR TITLE
fix: support polyfill import paths containing an escaping char (e.g. '\')

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -720,7 +720,7 @@ function polyfillsPlugin(
     load(id) {
       if (id === polyfillId) {
         return (
-          [...imports].map((i) => `import "${i}";`).join('') +
+          [...imports].map((i) => `import ${JSON.stringify(i)};`).join('') +
           (excludeSystemJS ? '' : `import "systemjs/dist/s.min.js";`)
         )
       }


### PR DESCRIPTION
### Description

When the `additionalPolyfill` property of `plugin-legacy` containing polyfill paths with escaping characters (e.g. '\\'), the JS fails to compile because `plugin-legacy` doesn't escape them.
This PR add the escaping characters for this, simply by the trick of `JSON.stringify()`.
**This is a breaking change, since old code (e.g. my code) may use a hack to pass an escaped strings to `additionalPolyfill`, so I suggest to merge it now for Vite 4.**

An example of the issue is when you want to include an absolute path of files in Windows (which uses '\\' for directory paths), this was my previous sample with my own escaping workaround:
```ts
import { dirname, resolve } from 'path';
import legacy from '@vitejs/plugin-legacy';
import type { UserConfig } from 'vite';

const __dirname = dirname(fileURLToPath(import.meta.url));
const localPath = (path: string) => JSON.stringify(resolve(__dirname, path)).slice(1, -1);

const config: UserConfig = {
	plugins: [
		legacy({
			additionalLegacyPolyfills: [
				'custom-event-polyfill',
				'core-js/modules/es.promise.js',
				'whatwg-fetch',
				// ...,
				localPath(...),
				// ...,
			],
		}),
	]
};

export default config;
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
