### PR TITLE
fix(plugin-react): jsxDev is not a function when is set NODE_ENV in env files

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,6 +1,7 @@
+import path from 'node:path'
 import type { ParserOptions, TransformOptions, types as t } from '@babel/core'
 import * as babel from '@babel/core'
-import { createFilter } from 'vite'
+import { createFilter, loadEnv, normalizePath, resolveEnvPrefix } from 'vite'
 import type { Plugin, PluginOption, ResolvedConfig } from 'vite'
 import MagicString from 'magic-string'
 import type { SourceMap } from 'magic-string'
@@ -118,8 +119,16 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
   const viteBabel: Plugin = {
     name: 'vite:react-babel',
     enforce: 'pre',
-    config(_, { mode }) {
+    config(userConfig, { mode }) {
       // Copied from https://github.com/vitejs/vite/blob/4e9bdd4fb3654a9d43917e1cb682d3d2bad25115/packages/vite/src/node/config.ts#L488-L490
+      const resolvedRoot = normalizePath(
+        userConfig.root ? path.resolve(userConfig.root) : process.cwd()
+      )
+      const envDir = userConfig.envDir
+        ? normalizePath(path.resolve(resolvedRoot, userConfig.envDir))
+        : resolvedRoot
+      loadEnv(mode, envDir, resolveEnvPrefix(userConfig))
+
       const isProduction =
         (process.env.NODE_ENV || process.env.VITE_USER_NODE_ENV || mode) ===
         'production'

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -120,7 +120,8 @@ export default function viteReact(opts: Options = {}): PluginOption[] {
     name: 'vite:react-babel',
     enforce: 'pre',
     config(userConfig, { mode }) {
-      // Copied from https://github.com/vitejs/vite/blob/4e9bdd4fb3654a9d43917e1cb682d3d2bad25115/packages/vite/src/node/config.ts#L488-L490
+      // Copied from https://github.com/vitejs/vite/blob/4e9bdd4fb3654a9d43917e1cb682d3d2bad25115/packages/vite/src/node/config.ts#L477-L494
+
       const resolvedRoot = normalizePath(
         userConfig.root ? path.resolve(userConfig.root) : process.cwd()
       )

--- a/playground/react-env/.env.staging
+++ b/playground/react-env/.env.staging
@@ -1,0 +1,1 @@
+NODE_ENV=production

--- a/playground/react-env/App.jsx
+++ b/playground/react-env/App.jsx
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+
+function App() {
+  const [count, setCount] = useState(0)
+  return (
+    <div className="App">
+      <header className="App-header">
+        <h1 id="title">Hello Vite + React</h1>
+      </header>
+    </div>
+  )
+}
+
+export default App

--- a/playground/react-env/__tests__/react.spec.ts
+++ b/playground/react-env/__tests__/react.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+import { page } from '~utils'
+
+test('should work', async () => {
+  expect(
+    await page.textContent('h1', {
+      timeout: 100
+    })
+  ).toMatch('Hello Vite + React')
+})

--- a/playground/react-env/index.html
+++ b/playground/react-env/index.html
@@ -1,0 +1,10 @@
+<div id="app"></div>
+<script type="module">
+  import React from 'react'
+  import ReactDOM from 'react-dom/client'
+  import App from './App.jsx'
+
+  ReactDOM.createRoot(document.getElementById('app')).render(
+    React.createElement(App)
+  )
+</script>

--- a/playground/react-env/package.json
+++ b/playground/react-env/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test-react-env",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "workspace:*"
+  }
+}

--- a/playground/react-env/vite.config.ts
+++ b/playground/react-env/vite.config.ts
@@ -1,0 +1,16 @@
+import react from '@vitejs/plugin-react'
+import type { UserConfig } from 'vite'
+
+// Overriding the NODE_ENV set by vitest
+process.env.NODE_ENV = ''
+
+const config: UserConfig = {
+  plugins: [react()],
+  mode: 'staging',
+  build: {
+    // to make tests faster
+    minify: false
+  }
+}
+
+export default config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -875,6 +875,17 @@ importers:
       '@emotion/babel-plugin': 11.10.5
       '@vitejs/plugin-react': link:../../packages/plugin-react
 
+  playground/react-env:
+    specifiers:
+      '@vitejs/plugin-react': workspace:*
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    devDependencies:
+      '@vitejs/plugin-react': link:../../packages/plugin-react
+
   playground/react-sourcemap:
     specifiers:
       '@vitejs/plugin-react': workspace:*
@@ -2000,7 +2011,7 @@ packages:
     dev: true
 
   /@esbuild/android-arm/0.15.11:
-    resolution: {integrity: sha1-vdnD4JgYO9ypcHWqTD4BUu0+EO4=, tarball: '%40esbuild%2Fandroid-arm/-/android-arm-0.15.11.tgz'}
+    resolution: {integrity: sha512-PzMcQLazLBkwDEkrNPi9AbjFt6+3I7HKbiYF2XtWQ7wItrHvEOeO3T8Am434zAozWtVP7lrTue1bEfc2nYWeCA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -2009,7 +2020,7 @@ packages:
     optional: true
 
   /@esbuild/android-arm/0.15.9:
-    resolution: {integrity: sha1-fhIhYEq4jtUCHq10+ozKRAXh5DE=, tarball: '%40esbuild%2Fandroid-arm/-/android-arm-0.15.9.tgz'}
+    resolution: {integrity: sha512-VZPy/ETF3fBG5PiinIkA0W/tlsvlEgJccyN2DzWZEl0DlVKRbu91PvY2D6Lxgluj4w9QtYHjOWjAT44C+oQ+EQ==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -2018,7 +2029,7 @@ packages:
     optional: true
 
   /@esbuild/linux-loong64/0.15.11:
-    resolution: {integrity: sha1-L0+aEIPctPxlIztvWQA8QGq/MuU=, tarball: '%40esbuild%2Flinux-loong64/-/linux-loong64-0.15.11.tgz'}
+    resolution: {integrity: sha512-geWp637tUhNmhL3Xgy4Bj703yXB9dqiLJe05lCUfjSFDrQf9C/8pArusyPUbUbPwlC/EAUjBw32sxuIl/11dZw==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -2027,7 +2038,7 @@ packages:
     optional: true
 
   /@esbuild/linux-loong64/0.15.9:
-    resolution: {integrity: sha1-tlipe6vx9AeDNUr3A5uEw/38P8M=, tarball: '%40esbuild%2Flinux-loong64/-/linux-loong64-0.15.9.tgz'}
+    resolution: {integrity: sha512-O+NfmkfRrb3uSsTa4jE3WApidSe3N5++fyOVGP1SmMZi4A3BZELkhUUvj5hwmMuNdlpzAZ8iAPz2vmcR7DCFQA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -4130,7 +4141,7 @@ packages:
     dev: true
 
   /errno/0.1.8:
-    resolution: {integrity: sha1-i7Ppx9Rjvkl2/4iPdrSAnrwugR8=}
+    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
     hasBin: true
     requiresBuild: true
     dependencies:
@@ -4217,7 +4228,7 @@ packages:
     dev: false
 
   /esbuild-android-64/0.14.50:
-    resolution: {integrity: sha1-pG/ID6IAdpDmR2gNg3SDp1CjCX8=}
+    resolution: {integrity: sha512-H7iUEm7gUJHzidsBlFPGF6FTExazcgXL/46xxLo6i6bMtPim6ZmXyTccS8yOMpy6HAC6dPZ/JCQqrkkin69n6Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -4226,7 +4237,7 @@ packages:
     optional: true
 
   /esbuild-android-64/0.15.11:
-    resolution: {integrity: sha1-UEAhKcPoW7BkNOISN0xfaT5MXwE=}
+    resolution: {integrity: sha512-rrwoXEiuI1kaw4k475NJpexs8GfJqQUKcD08VR8sKHmuW9RUuTR2VxcupVvHdiGh9ihxL9m3lpqB1kju92Ialw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -4235,7 +4246,7 @@ packages:
     optional: true
 
   /esbuild-android-64/0.15.9:
-    resolution: {integrity: sha1-Sn6zIMqNOjBfFHkgYf2WFMzrt8A=}
+    resolution: {integrity: sha512-HQCX7FJn9T4kxZQkhPjNZC7tBWZqJvhlLHPU2SFzrQB/7nDXjmTIFpFTjt7Bd1uFpeXmuwf5h5fZm+x/hLnhbw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -4244,7 +4255,7 @@ packages:
     optional: true
 
   /esbuild-android-arm64/0.14.50:
-    resolution: {integrity: sha1-vdp4Ufp/X3cNb/CtWTqJRdOg/N0=}
+    resolution: {integrity: sha512-NFaoqEwa+OYfoYVpQWDMdKII7wZZkAjtJFo1WdnBeCYlYikvUhTnf2aPwPu5qEAw/ie1NYK0yn3cafwP+kP+OQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -4253,7 +4264,7 @@ packages:
     optional: true
 
   /esbuild-android-arm64/0.15.11:
-    resolution: {integrity: sha1-Sb7jUhjqLM8aDF8Yevd8HApd7nE=}
+    resolution: {integrity: sha512-/hDubOg7BHOhUUsT8KUIU7GfZm5bihqssvqK5PfO4apag7YuObZRZSzViyEKcFn2tPeHx7RKbSBXvAopSHDZJQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -4262,7 +4273,7 @@ packages:
     optional: true
 
   /esbuild-android-arm64/0.15.9:
-    resolution: {integrity: sha1-yUjlaG3yCFetNh7GfgcNQNfKuYU=}
+    resolution: {integrity: sha512-E6zbLfqbFVCNEKircSHnPiSTsm3fCRxeIMPfrkS33tFjIAoXtwegQfVZqMGR0FlsvVxp2NEDOUz+WW48COCjSg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -4271,7 +4282,7 @@ packages:
     optional: true
 
   /esbuild-darwin-64/0.14.50:
-    resolution: {integrity: sha1-8FNUNfl2B2bzDbFKmR7lypTAIqQ=}
+    resolution: {integrity: sha512-gDQsCvGnZiJv9cfdO48QqxkRV8oKAXgR2CGp7TdIpccwFdJMHf8hyIJhMW/05b/HJjET/26Us27Jx91BFfEVSA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -4280,7 +4291,7 @@ packages:
     optional: true
 
   /esbuild-darwin-64/0.15.11:
-    resolution: {integrity: sha1-iakMjPbwAprEFpv+3QEqBBLBV18=}
+    resolution: {integrity: sha512-1DqHD0ms3AhiwkKnjRUzmiW7JnaJJr5FKrPiR7xuyMwnjDqvNWDdMq4rKSD9OC0piFNK6n0LghsglNMe2MwJtA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -4289,7 +4300,7 @@ packages:
     optional: true
 
   /esbuild-darwin-64/0.15.9:
-    resolution: {integrity: sha1-JfVk+ks5wc7ITcRrzlY0/bzh1eQ=}
+    resolution: {integrity: sha512-gI7dClcDN/HHVacZhTmGjl0/TWZcGuKJ0I7/xDGJwRQQn7aafZGtvagOFNmuOq+OBFPhlPv1T6JElOXb0unkSQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -4298,7 +4309,7 @@ packages:
     optional: true
 
   /esbuild-darwin-arm64/0.14.50:
-    resolution: {integrity: sha1-dqQaQOiUehWuYpcOntKFOIPEsWw=}
+    resolution: {integrity: sha512-36nNs5OjKIb/Q50Sgp8+rYW/PqirRiFN0NFc9hEvgPzNJxeJedktXwzfJSln4EcRFRh5Vz4IlqFRScp+aiBBzA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -4307,7 +4318,7 @@ packages:
     optional: true
 
   /esbuild-darwin-arm64/0.15.11:
-    resolution: {integrity: sha1-VW9DhcbegGzIETLde4rwD+nSkt8=}
+    resolution: {integrity: sha512-OMzhxSbS0lwwrW40HHjRCeVIJTURdXFA8c3GU30MlHKuPCcvWNUIKVucVBtNpJySXmbkQMDJdJNrXzNDyvoqvQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -4316,7 +4327,7 @@ packages:
     optional: true
 
   /esbuild-darwin-arm64/0.15.9:
-    resolution: {integrity: sha1-YPrqPtldFSOVNqqI0Gu4KyknioY=}
+    resolution: {integrity: sha512-VZIMlcRN29yg/sv7DsDwN+OeufCcoTNaTl3Vnav7dL/nvsApD7uvhVRbgyMzv0zU/PP0xRhhIpTyc7lxEzHGSw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -4325,7 +4336,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-64/0.14.50:
-    resolution: {integrity: sha1-LtZjPBftQsIKG9aOgsS7x16k+1c=}
+    resolution: {integrity: sha512-/1pHHCUem8e/R86/uR+4v5diI2CtBdiWKiqGuPa9b/0x3Nwdh5AOH7lj+8823C6uX1e0ufwkSLkS+aFZiBCWxA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -4334,7 +4345,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-64/0.15.11:
-    resolution: {integrity: sha1-/Yb9GztlNmBI81uZbZzfNUc4Tu4=}
+    resolution: {integrity: sha512-8dKP26r0/Qyez8nTCwpq60QbuYKOeBygdgOAWGCRalunyeqWRoSZj9TQjPDnTTI9joxd3QYw3UhVZTKxO9QdRg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -4343,7 +4354,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-64/0.15.9:
-    resolution: {integrity: sha1-AznvHJCpGRdeeBZ4giRReJZleg4=}
+    resolution: {integrity: sha512-uM4z5bTvuAXqPxrI204txhlsPIolQPWRMLenvGuCPZTnnGlCMF2QLs0Plcm26gcskhxewYo9LkkmYSS5Czrb5A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -4352,7 +4363,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-arm64/0.14.50:
-    resolution: {integrity: sha1-yxFfTNr+nNvliHW6SC/MxU0yqkM=}
+    resolution: {integrity: sha512-iKwUVMQztnPZe5pUYHdMkRc9aSpvoV1mkuHlCoPtxZA3V+Kg/ptpzkcSY+fKd0kuom+l6Rc93k0UPVkP7xoqrw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -4361,7 +4372,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-arm64/0.15.11:
-    resolution: {integrity: sha1-00a8rP6XeevBoR7awb3t7/bdo7E=}
+    resolution: {integrity: sha512-aSGiODiukLGGnSg/O9+cGO2QxEacrdCtCawehkWYTt5VX1ni2b9KoxpHCT9h9Y6wGqNHmXFnB47RRJ8BIqZgmQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -4370,7 +4381,7 @@ packages:
     optional: true
 
   /esbuild-freebsd-arm64/0.15.9:
-    resolution: {integrity: sha1-Mqv8C+OuPdOOWoapvq27z1kvG1c=}
+    resolution: {integrity: sha512-HHDjT3O5gWzicGdgJ5yokZVN9K9KG05SnERwl9nBYZaCjcCgj/sX8Ps1jvoFSfNCO04JSsHSOWo4qvxFuj8FoA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -4379,7 +4390,7 @@ packages:
     optional: true
 
   /esbuild-linux-32/0.14.50:
-    resolution: {integrity: sha1-/itySZTc8dTkjcSDL/AIrX0AvP0=}
+    resolution: {integrity: sha512-sWUwvf3uz7dFOpLzYuih+WQ7dRycrBWHCdoXJ4I4XdMxEHCECd8b7a9N9u7FzT6XR2gHPk9EzvchQUtiEMRwqw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -4388,7 +4399,7 @@ packages:
     optional: true
 
   /esbuild-linux-32/0.15.11:
-    resolution: {integrity: sha1-ZLUOd0v3Wvfcxqc61Qny6wrESHs=}
+    resolution: {integrity: sha512-lsrAfdyJBGx+6aHIQmgqUonEzKYeBnyfJPkT6N2dOf1RoXYYV1BkWB6G02tjsrz1d5wZzaTc3cF+TKmuTo/ZwA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -4397,7 +4408,7 @@ packages:
     optional: true
 
   /esbuild-linux-32/0.15.9:
-    resolution: {integrity: sha1-k1gTSKTaftKym8VTnyYFrX/O53s=}
+    resolution: {integrity: sha512-AQIdE8FugGt1DkcekKi5ycI46QZpGJ/wqcMr7w6YUmOmp2ohQ8eO4sKUsOxNOvYL7hGEVwkndSyszR6HpVHLFg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -4406,7 +4417,7 @@ packages:
     optional: true
 
   /esbuild-linux-64/0.14.50:
-    resolution: {integrity: sha1-eFGrUVHflQGiGHvUkJxZStIytiM=}
+    resolution: {integrity: sha512-u0PQxPhaeI629t4Y3EEcQ0wmWG+tC/LpP2K7yDFvwuPq0jSQ8SIN+ARNYfRjGW15O2we3XJvklbGV0wRuUCPig==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -4415,7 +4426,7 @@ packages:
     optional: true
 
   /esbuild-linux-64/0.15.11:
-    resolution: {integrity: sha1-+6Oni5V2l3KGP49twxarylXPhBY=}
+    resolution: {integrity: sha512-Y2Rh+PcyVhQqXKBTacPCltINN3uIw2xC+dsvLANJ1SpK5NJUtxv8+rqWpjmBgaNWKQT1/uGpMmA9olALy9PLVA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -4424,7 +4435,7 @@ packages:
     optional: true
 
   /esbuild-linux-64/0.15.9:
-    resolution: {integrity: sha1-DRceeUbJXQ0+1IJgJq8sVjLX3MQ=}
+    resolution: {integrity: sha512-4RXjae7g6Qs7StZyiYyXTZXBlfODhb1aBVAjd+ANuPmMhWthQilWo7rFHwJwL7DQu1Fjej2sODAVwLbcIVsAYQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -4433,7 +4444,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm/0.14.50:
-    resolution: {integrity: sha1-bXqMBxIJGww6Zo3V2LXJJK266xI=}
+    resolution: {integrity: sha512-VALZq13bhmFJYFE/mLEb+9A0w5vo8z+YDVOWeaf9vOTrSC31RohRIwtxXBnVJ7YKLYfEMzcgFYf+OFln3Y0cWg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -4442,7 +4453,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm/0.15.11:
-    resolution: {integrity: sha1-eCTSAJmXeqZxAWx956UDjJhwAQ8=}
+    resolution: {integrity: sha512-TJllTVk5aSyqPFvvcHTvf6Wu1ZKhWpJ/qNmZO8LL/XeB+LXCclm7HQHNEIz6MT7IX8PmlC1BZYrOiw2sXSB95A==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -4451,7 +4462,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm/0.15.9:
-    resolution: {integrity: sha1-3Ols2Be8c3b2rzlnZJxKsfL3lQY=}
+    resolution: {integrity: sha512-3Zf2GVGUOI7XwChH3qrnTOSqfV1V4CAc/7zLVm4lO6JT6wbJrTgEYCCiNSzziSju+J9Jhf9YGWk/26quWPC6yQ==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -4460,7 +4471,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm64/0.14.50:
-    resolution: {integrity: sha1-dqdq/vSEoFEvH7vMdi7dcF3uiJI=}
+    resolution: {integrity: sha512-ZyfoNgsTftD7Rp5S7La5auomKdNeB3Ck+kSKXC4pp96VnHyYGjHHXWIlcbH8i+efRn9brszo1/Thl1qn8RqmhQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -4469,7 +4480,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm64/0.15.11:
-    resolution: {integrity: sha1-wMsxmA7uBmv9OaRZNmCg7OvpJss=}
+    resolution: {integrity: sha512-uhcXiTwTmD4OpxJu3xC5TzAAw6Wzf9O1XGWL448EE9bqGjgV1j+oK3lIHAfsHnuIn8K4nDW8yjX0Sv5S++oRuw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -4478,7 +4489,7 @@ packages:
     optional: true
 
   /esbuild-linux-arm64/0.15.9:
-    resolution: {integrity: sha1-mDh5Wjcgy+c207wgYhvTZurCLyQ=}
+    resolution: {integrity: sha512-a+bTtxJmYmk9d+s2W4/R1SYKDDAldOKmWjWP0BnrWtDbvUBNOm++du0ysPju4mZVoEFgS1yLNW+VXnG/4FNwdQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -4487,7 +4498,7 @@ packages:
     optional: true
 
   /esbuild-linux-mips64le/0.14.50:
-    resolution: {integrity: sha1-Q0JpCcGITF3GtAdlZzoIp+wdIGQ=}
+    resolution: {integrity: sha512-ygo31Vxn/WrmjKCHkBoutOlFG5yM9J2UhzHb0oWD9O61dGg+Hzjz9hjf5cmM7FBhAzdpOdEWHIrVOg2YAi6rTw==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -4496,7 +4507,7 @@ packages:
     optional: true
 
   /esbuild-linux-mips64le/0.15.11:
-    resolution: {integrity: sha1-EGJzMckBZOVTQp7SXgJRhLukhbY=}
+    resolution: {integrity: sha512-WD61y/R1M4BLe4gxXRypoQ0Ci+Vjf714QYzcPNkiYv5I8K8WDz2ZR8Bm6cqKxd6rD+e/rZgPDbhQ9PCf7TMHmA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -4505,7 +4516,7 @@ packages:
     optional: true
 
   /esbuild-linux-mips64le/0.15.9:
-    resolution: {integrity: sha1-AzWgc55hqpfLm0oBjj+s/Mqc3P0=}
+    resolution: {integrity: sha512-Zn9HSylDp89y+TRREMDoGrc3Z4Hs5u56ozZLQCiZAUx2+HdbbXbWdjmw3FdTJ/i7t5Cew6/Q+6kfO3KCcFGlyw==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -4514,7 +4525,7 @@ packages:
     optional: true
 
   /esbuild-linux-ppc64le/0.14.50:
-    resolution: {integrity: sha1-x1TqPaHdGAxum2tQjcGM6YPZKxE=}
+    resolution: {integrity: sha512-xWCKU5UaiTUT6Wz/O7GKP9KWdfbsb7vhfgQzRfX4ahh5NZV4ozZ4+SdzYG8WxetsLy84UzLX3Pi++xpVn1OkFQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -4523,7 +4534,7 @@ packages:
     optional: true
 
   /esbuild-linux-ppc64le/0.15.11:
-    resolution: {integrity: sha1-vkJnmjalJGuJP8i4mBNeustaChQ=}
+    resolution: {integrity: sha512-JVleZS9oPVLTlBhPTWgOwxFWU/wMUdlBwTbGA4GF8c38sLbS13cupj+C8bLq929jU7EMWry4SaL+tKGIaTlqKg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -4532,7 +4543,7 @@ packages:
     optional: true
 
   /esbuild-linux-ppc64le/0.15.9:
-    resolution: {integrity: sha1-GEgq+5W4pwXi2gpZ1xMb/yISgfk=}
+    resolution: {integrity: sha512-OEiOxNAMH9ENFYqRsWUj3CWyN3V8P3ZXyfNAtX5rlCEC/ERXrCEFCJji/1F6POzsXAzxvUJrTSTCy7G6BhA6Fw==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -4541,7 +4552,7 @@ packages:
     optional: true
 
   /esbuild-linux-riscv64/0.14.50:
-    resolution: {integrity: sha1-87LdPEwrkb8ZHTuYqYGciqb1rX8=}
+    resolution: {integrity: sha512-0+dsneSEihZTopoO9B6Z6K4j3uI7EdxBP7YSF5rTwUgCID+wHD3vM1gGT0m+pjCW+NOacU9kH/WE9N686FHAJg==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -4550,7 +4561,7 @@ packages:
     optional: true
 
   /esbuild-linux-riscv64/0.15.11:
-    resolution: {integrity: sha1-OsLzKOPbc8v/gzralDFNjnlQPlQ=}
+    resolution: {integrity: sha512-9aLIalZ2HFHIOZpmVU11sEAS9F8TnHw49daEjcgMpBXHFF57VuT9f9/9LKJhw781Gda0P9jDkuCWJ0tFbErvJw==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -4559,7 +4570,7 @@ packages:
     optional: true
 
   /esbuild-linux-riscv64/0.15.9:
-    resolution: {integrity: sha1-A7b5cIJywRcAa5zhya6Kq5G1pbY=}
+    resolution: {integrity: sha512-ukm4KsC3QRausEFjzTsOZ/qqazw0YvJsKmfoZZm9QW27OHjk2XKSQGGvx8gIEswft/Sadp03/VZvAaqv5AIwNA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -4568,7 +4579,7 @@ packages:
     optional: true
 
   /esbuild-linux-s390x/0.14.50:
-    resolution: {integrity: sha1-PfvEV4sqgZlcqrt53ytijqhqU5A=}
+    resolution: {integrity: sha512-tVjqcu8o0P9H4StwbIhL1sQYm5mWATlodKB6dpEZFkcyTI8kfIGWiWcrGmkNGH2i1kBUOsdlBafPxR3nzp3TDA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -4577,7 +4588,7 @@ packages:
     optional: true
 
   /esbuild-linux-s390x/0.15.11:
-    resolution: {integrity: sha1-53Tg3wYbaEfYZ4O/PIxDAKcuA60=}
+    resolution: {integrity: sha512-sZHtiXXOKsLI3XGBGoYO4qKBzJlb8xNsWmvFiwFMHFzA4AXgDP1KDp7Dawe9C2pavTRBDvl+Ok4n/DHQ59oaTg==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -4586,7 +4597,7 @@ packages:
     optional: true
 
   /esbuild-linux-s390x/0.15.9:
-    resolution: {integrity: sha1-ZftkViPVdXgPFV8O5Sk15i+cyk8=}
+    resolution: {integrity: sha512-uDOQEH55wQ6ahcIKzQr3VyjGc6Po/xblLGLoUk3fVL1qjlZAibtQr6XRfy5wPJLu/M2o0vQKLq4lyJ2r1tWKcw==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -4595,7 +4606,7 @@ packages:
     optional: true
 
   /esbuild-netbsd-64/0.14.50:
-    resolution: {integrity: sha1-F9v1HqpI2YPnlLWI0ZVBVBDvjIU=}
+    resolution: {integrity: sha512-0R/glfqAQ2q6MHDf7YJw/TulibugjizBxyPvZIcorH0Mb7vSimdHy0XF5uCba5CKt+r4wjax1mvO9lZ4jiAhEg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -4604,7 +4615,7 @@ packages:
     optional: true
 
   /esbuild-netbsd-64/0.15.11:
-    resolution: {integrity: sha1-VeJl+kSJ4/OWsWyB9vWhHWyiqaQ=}
+    resolution: {integrity: sha512-hUC9yN06K9sg7ju4Vgu9ChAPdsEgtcrcLfyNT5IKwKyfpLvKUwCMZSdF+gRD3WpyZelgTQfJ+pDx5XFbXTlB0A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -4613,7 +4624,7 @@ packages:
     optional: true
 
   /esbuild-netbsd-64/0.15.9:
-    resolution: {integrity: sha1-eJQpe7nhHz0vbzHv7NG+ThgfDVQ=}
+    resolution: {integrity: sha512-yWgxaYTQz+TqX80wXRq6xAtb7GSBAp6gqLKfOdANg9qEmAI1Bxn04IrQr0Mzm4AhxvGKoHzjHjMgXbCCSSDxcw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -4622,7 +4633,7 @@ packages:
     optional: true
 
   /esbuild-openbsd-64/0.14.50:
-    resolution: {integrity: sha1-z2saUMjPZ7ByWqpLzpdzl2FoxQ4=}
+    resolution: {integrity: sha512-7PAtmrR5mDOFubXIkuxYQ4bdNS6XCK8AIIHUiZxq1kL8cFIH5731jPcXQ4JNy/wbj1C9sZ8rzD8BIM80Tqk29w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -4631,7 +4642,7 @@ packages:
     optional: true
 
   /esbuild-openbsd-64/0.15.11:
-    resolution: {integrity: sha1-vAQQPM/YwvIkHhrdC1GglZVbc8Q=}
+    resolution: {integrity: sha512-0bBo9SQR4t66Wd91LGMAqmWorzO0TTzVjYiifwoFtel8luFeXuPThQnEm5ztN4g0fnvcp7AnUPPzS/Depf17wQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -4640,7 +4651,7 @@ packages:
     optional: true
 
   /esbuild-openbsd-64/0.15.9:
-    resolution: {integrity: sha1-D51Ma2dyrlDUkdaK1MwCgwDdp8A=}
+    resolution: {integrity: sha512-JmS18acQl4iSAjrEha1MfEmUMN4FcnnrtTaJ7Qg0tDCOcgpPPQRLGsZqhes0vmx8VA6IqRyScqXvaL7+Q0Uf3A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -4649,7 +4660,7 @@ packages:
     optional: true
 
   /esbuild-sunos-64/0.14.50:
-    resolution: {integrity: sha1-9wWuDdkUw7RdxDMZxPUyIWw9hB8=}
+    resolution: {integrity: sha512-gBxNY/wyptvD7PkHIYcq7se6SQEXcSC8Y7mE0FJB+CGgssEWf6vBPfTTZ2b6BWKnmaP6P6qb7s/KRIV5T2PxsQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -4658,7 +4669,7 @@ packages:
     optional: true
 
   /esbuild-sunos-64/0.15.11:
-    resolution: {integrity: sha1-zNWAMF0x/eB7XDhtp5yUKq8GkBM=}
+    resolution: {integrity: sha512-EuBdTGlsMTjEl1sQnBX2jfygy7iR6CKfvOzi+gEOfhDqbHXsmY1dcpbVtcwHAg9/2yUZSfMJHMAgf1z8M4yyyw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -4667,7 +4678,7 @@ packages:
     optional: true
 
   /esbuild-sunos-64/0.15.9:
-    resolution: {integrity: sha1-wyt85XSwj4FN6BDOfB40uEN2gSY=}
+    resolution: {integrity: sha512-UKynGSWpzkPmXW3D2UMOD9BZPIuRaSqphxSCwScfEE05Be3KAmvjsBhht1fLzKpiFVJb0BYMd4jEbWMyJ/z1hQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -4676,7 +4687,7 @@ packages:
     optional: true
 
   /esbuild-windows-32/0.14.50:
-    resolution: {integrity: sha1-Y2SQWpnB5sHi/nv8zr2VgTGxzWw=}
+    resolution: {integrity: sha512-MOOe6J9cqe/iW1qbIVYSAqzJFh0p2LBLhVUIWdMVnNUNjvg2/4QNX4oT4IzgDeldU+Bym9/Tn6+DxvUHJXL5Zw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -4685,7 +4696,7 @@ packages:
     optional: true
 
   /esbuild-windows-32/0.15.11:
-    resolution: {integrity: sha1-QP4dSPmyCnb221EJqq8VEa7VjHE=}
+    resolution: {integrity: sha512-O0/Wo1Wk6dc0rZSxkvGpmTNIycEznHmkObTFz2VHBhjPsO4ZpCgfGxNkCpz4AdAIeMczpTXt/8d5vdJNKEGC+Q==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -4694,7 +4705,7 @@ packages:
     optional: true
 
   /esbuild-windows-32/0.15.9:
-    resolution: {integrity: sha1-N6j3z8zbIXfNRmE6Gh4fy0GdNt8=}
+    resolution: {integrity: sha512-aqXvu4/W9XyTVqO/hw3rNxKE1TcZiEYHPsXM9LwYmKSX9/hjvfIJzXwQBlPcJ/QOxedfoMVH0YnhhQ9Ffb0RGA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -4703,7 +4714,7 @@ packages:
     optional: true
 
   /esbuild-windows-64/0.14.50:
-    resolution: {integrity: sha1-VmA8tjZ+MNFAmN63feaqGNdt2Js=}
+    resolution: {integrity: sha512-r/qE5Ex3w1jjGv/JlpPoWB365ldkppUlnizhMxJgojp907ZF1PgLTuW207kgzZcSCXyquL9qJkMsY+MRtaZ5yQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -4712,7 +4723,7 @@ packages:
     optional: true
 
   /esbuild-windows-64/0.15.11:
-    resolution: {integrity: sha1-gMWLHvL/Awx446BuepIndsxMtoc=}
+    resolution: {integrity: sha512-x977Q4HhNjnHx00b4XLAnTtj5vfbdEvkxaQwC1Zh5AN8g5EX+izgZ6e5QgqJgpzyRNJqh4hkgIJF1pyy1be0mQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -4721,7 +4732,7 @@ packages:
     optional: true
 
   /esbuild-windows-64/0.15.9:
-    resolution: {integrity: sha1-X+Hnb8E91/Ug/r7K6hELbxZJx7I=}
+    resolution: {integrity: sha512-zm7h91WUmlS4idMtjvCrEeNhlH7+TNOmqw5dJPJZrgFaxoFyqYG6CKDpdFCQXdyKpD5yvzaQBOMVTCBVKGZDEg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -4730,7 +4741,7 @@ packages:
     optional: true
 
   /esbuild-windows-arm64/0.14.50:
-    resolution: {integrity: sha1-593eapcZQFGlpKwF9PWQDpIqfqU=}
+    resolution: {integrity: sha512-EMS4lQnsIe12ZyAinOINx7eq2mjpDdhGZZWDwPZE/yUTN9cnc2Ze/xUTYIAyaJqrqQda3LnDpADKpvLvol6ENQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -4739,7 +4750,7 @@ packages:
     optional: true
 
   /esbuild-windows-arm64/0.15.11:
-    resolution: {integrity: sha1-AYYkAjtcPwzKM0zJn173E005YzM=}
+    resolution: {integrity: sha512-VwUHFACuBahrvntdcMKZteUZ9HaYrBRODoKe4tIWxguQRvvYoYb7iu5LrcRS/FQx8KPZNaa72zuqwVtHeXsITw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -4748,7 +4759,7 @@ packages:
     optional: true
 
   /esbuild-windows-arm64/0.15.9:
-    resolution: {integrity: sha1-mFBEKPe6fSz8EZQL5o7hE5Fz/c4=}
+    resolution: {integrity: sha512-yQEVIv27oauAtvtuhJVfSNMztJJX47ismRS6Sv2QMVV9RM+6xjbMWuuwM2nxr5A2/gj/mu2z9YlQxiwoFRCfZA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -5367,7 +5378,7 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   /fsevents/2.3.2:
-    resolution: {integrity: sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -5749,7 +5760,7 @@ packages:
     dev: true
 
   /image-size/0.5.5:
-    resolution: {integrity: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=}
+    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     requiresBuild: true
@@ -6364,7 +6375,7 @@ packages:
       sourcemap-codec: 1.4.8
 
   /make-dir/2.1.0:
-    resolution: {integrity: sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=}
+    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
     requiresBuild: true
     dependencies:
@@ -6646,7 +6657,7 @@ packages:
     dev: true
 
   /needle/3.1.0:
-    resolution: {integrity: sha1-O/XNCQwo6xVkQYGrZpngJ71sU8k=}
+    resolution: {integrity: sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==}
     engines: {node: '>= 4.4.x'}
     hasBin: true
     requiresBuild: true
@@ -8677,7 +8688,7 @@ packages:
     dev: true
 
   /uglify-js/3.16.1:
-    resolution: {integrity: sha1-Dn7JKLPQseHZUrzmNMOE/VY3cxc=}
+    resolution: {integrity: sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #10854

We need to execute loadEnv, because `process.env.VITE_USER_NODE_ENV` is only defined in it.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
