### PR TITLE
refactor: use rollup hashing when emitting assets

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -5,7 +5,6 @@ import { Buffer } from 'node:buffer'
 import * as mrmime from 'mrmime'
 import type {
   NormalizedOutputOptions,
-  OutputAsset,
   OutputOptions,
   PluginContext,
   PreRenderedAsset,
@@ -22,24 +21,19 @@ import type { ResolvedConfig } from '../config'
 import { cleanUrl, getHash, joinUrlSegments, normalizePath } from '../utils'
 import { FS_PREFIX } from '../constants'
 
-export const assetUrlRE = /__VITE_ASSET__([a-z\d]{8})__(?:\$_(.*?)__)?/g
-
-export const duplicateAssets = new WeakMap<
-  ResolvedConfig,
-  Map<string, OutputAsset>
->()
+export const assetUrlRE = /__VITE_ASSET__([a-z\d]+)__(?:\$_(.*?)__)?/g
 
 const rawRE = /(\?|&)raw(?:&|$)/
 const urlRE = /(\?|&)url(?:&|$)/
 
 const assetCache = new WeakMap<ResolvedConfig, Map<string, string>>()
 
-const assetHashToFilenameMap = new WeakMap<
+// chunk.name is the basename for the asset ignoring the directory structure
+// For the manifest, we need to preserve the original file path
+export const generatedAssets = new WeakMap<
   ResolvedConfig,
-  Map<string, string>
+  Map<string, { originalName: string }>
 >()
-// save hashes of the files that has been emitted in build watch
-const emittedHashMap = new WeakMap<ResolvedConfig, Set<string>>()
 
 // add own dictionary entry by directly assigning mrmime
 export function registerCustomMime(): void {
@@ -77,10 +71,10 @@ export function renderAssetUrlInJS(
 
   while ((match = assetUrlRE.exec(code))) {
     s ||= new MagicString(code)
-    const [full, hash, postfix = ''] = match
+    const [full, referenceId, postfix = ''] = match
     // some internal plugins may still need to emit chunks (e.g. worker) so
     // fallback to this.getFileName for that. TODO: remove, not needed
-    const file = getAssetFilename(hash, config) || ctx.getFileName(hash)
+    const file = ctx.getFileName(referenceId) // getAssetFilename(hash, config) || ctx.getFileName(hash)
     chunk.viteMetadata.importedAssets.add(cleanUrl(file))
     const filename = file + postfix
     const replacement = toOutputFilePathInJS(
@@ -127,9 +121,6 @@ export function renderAssetUrlInJS(
  * Also supports loading plain strings with import text from './foo.txt?raw'
  */
 export function assetPlugin(config: ResolvedConfig): Plugin {
-  // assetHashToFilenameMap initialization in buildStart causes getAssetFilename to return undefined
-  assetHashToFilenameMap.set(config, new Map())
-
   registerCustomMime()
 
   return {
@@ -137,8 +128,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
 
     buildStart() {
       assetCache.set(config, new Map())
-      emittedHashMap.set(config, new Set())
-      duplicateAssets.set(config, new Map())
+      generatedAssets.set(config, new Map())
     },
 
     resolveId(id) {
@@ -251,13 +241,6 @@ function fileToDevUrl(id: string, config: ResolvedConfig) {
   }
   const base = joinUrlSegments(config.server?.origin ?? '', config.base)
   return joinUrlSegments(base, rtn.replace(/^\//, ''))
-}
-
-export function getAssetFilename(
-  hash: string,
-  config: ResolvedConfig
-): string | undefined {
-  return assetHashToFilenameMap.get(config)?.get(hash)
 }
 
 export function getPublicAssetFilename(
@@ -464,41 +447,20 @@ async function fileToBuiltUrl(
     // into the chunk's hash, so we have to do our own content hashing here.
     // https://bundlers.tooling.report/hashing/asset-cascade/
     // https://github.com/rollup/rollup/issues/3415
-    const map = assetHashToFilenameMap.get(config)!
-    const contentHash = getHash(content)
     const { search, hash } = parseUrl(id)
     const postfix = (search || '') + (hash || '')
 
-    const fileName = assetFileNamesToFileName(
-      resolveAssetFileNames(config),
-      file,
-      contentHash,
-      content
-    )
-    if (!map.has(contentHash)) {
-      map.set(contentHash, fileName)
-    }
-    const emittedSet = emittedHashMap.get(config)!
-    const duplicates = duplicateAssets.get(config)!
-    const name = normalizePath(path.relative(config.root, file))
-    if (!emittedSet.has(contentHash)) {
-      pluginContext.emitFile({
-        name,
-        fileName,
-        type: 'asset',
-        source: content
-      })
-      emittedSet.add(contentHash)
-    } else {
-      duplicates.set(name, {
-        name,
-        fileName: map.get(contentHash)!,
-        type: 'asset',
-        source: content
-      })
-    }
+    const referenceId = pluginContext.emitFile({
+      // Ignore directory structure for asset file names
+      name: path.basename(file),
+      type: 'asset',
+      source: content
+    })
 
-    url = `__VITE_ASSET__${contentHash}__${postfix ? `$_${postfix}__` : ``}` // TODO_BASE
+    const originalName = normalizePath(path.relative(config.root, file))
+    generatedAssets.get(config)!.set(referenceId, { originalName })
+
+    url = `__VITE_ASSET__${referenceId}__${postfix ? `$_${postfix}__` : ``}` // TODO_BASE
   }
 
   cache.set(id, url)

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -74,7 +74,7 @@ export function renderAssetUrlInJS(
     const [full, referenceId, postfix = ''] = match
     // some internal plugins may still need to emit chunks (e.g. worker) so
     // fallback to this.getFileName for that. TODO: remove, not needed
-    const file = ctx.getFileName(referenceId) // getAssetFilename(hash, config) || ctx.getFileName(hash)
+    const file = ctx.getFileName(referenceId)
     chunk.viteMetadata.importedAssets.add(cleanUrl(file))
     const filename = file + postfix
     const replacement = toOutputFilePathInJS(

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -72,8 +72,6 @@ export function renderAssetUrlInJS(
   while ((match = assetUrlRE.exec(code))) {
     s ||= new MagicString(code)
     const [full, referenceId, postfix = ''] = match
-    // some internal plugins may still need to emit chunks (e.g. worker) so
-    // fallback to this.getFileName for that. TODO: remove, not needed
     const file = ctx.getFileName(referenceId)
     chunk.viteMetadata.importedAssets.add(cleanUrl(file))
     const filename = file + postfix

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -441,12 +441,6 @@ async function fileToBuiltUrl(
     url = `data:${mimeType};base64,${content.toString('base64')}`
   } else {
     // emit as asset
-    // rollup supports `import.meta.ROLLUP_FILE_URL_*`, but it generates code
-    // that uses runtime url sniffing and it can be verbose when targeting
-    // non-module format. It also fails to cascade the asset content change
-    // into the chunk's hash, so we have to do our own content hashing here.
-    // https://bundlers.tooling.report/hashing/asset-cascade/
-    // https://github.com/rollup/rollup/issues/3415
     const { search, hash } = parseUrl(id)
     const postfix = (search || '') + (hash || '')
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -55,7 +55,6 @@ import {
   assetUrlRE,
   checkPublicFile,
   fileToUrl,
-  getAssetFilename,
   publicAssetUrlCache,
   publicAssetUrlRE,
   publicFileToBuiltUrl,
@@ -478,7 +477,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       const publicAssetUrlMap = publicAssetUrlCache.get(config)!
 
       // resolve asset URL placeholders to their built file URLs
-      function resolveAssetUrlsInCss(chunkCSS: string, cssAssetName: string) {
+      const resolveAssetUrlsInCss = (
+        chunkCSS: string,
+        cssAssetName: string
+      ) => {
         const encodedPublicUrls = encodePublicUrlsInCSS(config)
 
         const relative = config.base === './' || config.base === ''
@@ -497,7 +499,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
         // replace asset url references with resolved url.
         chunkCSS = chunkCSS.replace(assetUrlRE, (_, fileHash, postfix = '') => {
-          const filename = getAssetFilename(fileHash, config) + postfix
+          const filename = this.getFileName(fileHash) + postfix
           chunk.viteMetadata.importedAssets.add(cleanUrl(filename))
           return toOutputFilePathInCss(
             filename,

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -26,7 +26,6 @@ import { toOutputFilePathInHtml } from '../build'
 import {
   assetUrlRE,
   checkPublicFile,
-  getAssetFilename,
   getPublicAssetFilename,
   publicAssetUrlRE,
   urlToBuiltUrl
@@ -794,9 +793,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         })
         // resolve asset url references
         result = result.replace(assetUrlRE, (_, fileHash, postfix = '') => {
-          return (
-            toOutputAssetFilePath(getAssetFilename(fileHash, config)!) + postfix
-          )
+          return toOutputAssetFilePath(this.getFileName(fileHash)) + postfix
         })
 
         result = result.replace(publicAssetUrlRE, (_, fileHash) => {

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -17,7 +17,7 @@ test('normal', async () => {
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
-    isBuild ? '/es/assets/vite.svg' : '/es/vite.svg',
+    isBuild ? '/es/assets/worker_asset.vite.svg' : '/es/vite.svg',
     true
   )
 })

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -12,7 +12,7 @@ test('normal', async () => {
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
-    isBuild ? '/iife/assets/vite.svg' : '/iife/vite.svg',
+    isBuild ? '/iife/assets/worker_asset.vite.svg' : '/iife/vite.svg',
     true
   )
 })

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -17,7 +17,7 @@ test('normal', async () => {
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
-    isBuild ? '/other-assets/vite' : '/vite.svg',
+    isBuild ? '/worker-assets/worker_asset.vite' : '/vite.svg',
     true
   )
 })


### PR DESCRIPTION
Done: This PR depends on https://github.com/rollup/rollup/pull/4712, Rollup 3.3 includes it and we updated it in a separate PR.

### Description

Rollup 3 has a new hashing algorithm that fixes the issues we had when emitting assets before:
- https://github.com/rollup/rollup/pull/4543

We currently do our own hashing and deduplication, see:
```js
    // emit as asset
    // rollup supports `import.meta.ROLLUP_FILE_URL_*`, but it generates code
    // that uses runtime url sniffing and it can be verbose when targeting
    // non-module format. It also fails to cascade the asset content change
    // into the chunk's hash, so we have to do our own content hashing here.
    // https://bundlers.tooling.report/hashing/asset-cascade/
    // https://github.com/rollup/rollup/issues/3415
```

This is the first PR in a series to try to move back some of the responsibilities to Rollup. This should help to be compatible with external plugins using `emitFile` or config settings like `assetFileNames`. There was actually a faulty test in workers that was not letting us see a bug for workers and `assetFileNames`.

Ideally, we should try to move to also use `import.meta.ROLLUP_FILE_URL_referenceId` instead of our `__VITE_ASSET__hash__`. I still don't know if it is feasible though because we still need our own scheme for references in CSS. This PR already moves from our own hash to using `referenceId` though, and future PRs may move us closer to at least using rollup's scheme in JS files.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other