### PR TITLE
fix(ssr): improve missing file error

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -712,9 +712,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // These requests will also be registered in transformRequest to be awaited
       // by the deps optimizer
       if (config.server.preTransformRequests && staticImportedUrls.size) {
-        staticImportedUrls.forEach(({ url, id }) => {
+        staticImportedUrls.forEach(({ url }) => {
           url = removeImportQuery(url)
-          transformRequest(url, server, { ssr }).catch((e) => {
+          transformRequest(url, server, { ssr, strict: true }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors
               return

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -714,7 +714,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (config.server.preTransformRequests && staticImportedUrls.size) {
         staticImportedUrls.forEach(({ url }) => {
           url = removeImportQuery(url)
-          transformRequest(url, server, { ssr, strict: true }).catch((e) => {
+          transformRequest(url, server, { ssr }).catch((e) => {
             if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
               // This are expected errors
               return

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -9,7 +9,6 @@ import { parse as parseJS } from 'acorn'
 import type { Node } from 'estree'
 import { findStaticImports, parseStaticImport } from 'mlly'
 import { makeLegalIdentifier } from '@rollup/pluginutils'
-import { getDepOptimizationConfig } from '..'
 import type { ViteDevServer } from '..'
 import {
   CLIENT_DIR,
@@ -44,6 +43,7 @@ import {
   unwrapId,
   wrapId
 } from '../utils'
+import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import {

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -18,7 +18,7 @@ import {
   unwrapId
 } from '../../utils'
 import { send } from '../send'
-import { transformRequest } from '../transformRequest'
+import { ERR_LOAD_URL, transformRequest } from '../transformRequest'
 import { isHTMLProxy } from '../../plugins/html'
 import {
   DEP_VERSION_RE,
@@ -223,6 +223,10 @@ export function transformMiddleware(
         // can't be properly fulfilled. This isn't an unexpected
         // error but a normal part of the missing deps discovery flow
         return
+      }
+      if (e?.code === ERR_LOAD_URL) {
+        // Let other middleware handle if we can't load the url via transformRequest
+        return next()
       }
       return next(e)
     }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -37,6 +37,11 @@ export interface TransformResult {
 export interface TransformOptions {
   ssr?: boolean
   html?: boolean
+  /**
+   * For non-fatal errors, set true to throw an error, otherwise set false to
+   * return null instead
+   */
+  strict?: boolean
 }
 
 export function transformRequest(
@@ -161,6 +166,7 @@ async function loadAndTransform(
   const { root, logger } = config
   const prettyUrl = isDebug ? prettifyUrl(url, config.root) : ''
   const ssr = !!options.ssr
+  const strict = !!options.strict
 
   const file = cleanUrl(id)
 
@@ -215,7 +221,11 @@ async function loadAndTransform(
     }
   }
   if (code == null) {
-    const msg = checkPublicFile(url, config)
+    const isPublicFile = checkPublicFile(url, config)
+    if (!isPublicFile && !strict) {
+      return null
+    }
+    const msg = isPublicFile
       ? `This file is in /public and will be copied as-is during build without ` +
         `going through the plugin transforms, and therefore should not be ` +
         `imported from source code. It can only be referenced via HTML tags.`

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -215,18 +215,13 @@ async function loadAndTransform(
     }
   }
   if (code == null) {
-    if (checkPublicFile(url, config)) {
-      throw new Error(
-        `Failed to load url ${url} (resolved id: ${id}). ` +
-          `This file is in /public and will be copied as-is during build without ` +
-          `going through the plugin transforms, and therefore should not be ` +
-          `imported from source code. It can only be referenced via HTML tags.`
-      )
-    } else {
-      return null
-    }
+    const msg = checkPublicFile(url, config)
+      ? `This file is in /public and will be copied as-is during build without ` +
+        `going through the plugin transforms, and therefore should not be ` +
+        `imported from source code. It can only be referenced via HTML tags.`
+      : `Does the file exist?`
+    throw new Error(`Failed to load url ${url} (resolved id: ${id}). ${msg}`)
   }
-
   // ensure module in graph after successful load
   const mod = await moduleGraph.ensureEntryFromUrl(url, ssr)
   ensureWatchedFile(watcher, mod.file, root)

--- a/packages/vite/src/node/ssr/__tests__/fixtures/modules/has-invalid-import.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/modules/has-invalid-import.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line node/no-missing-import
+import { foo } from './non-existent.js'
+
+export const hello = 'world'

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import { createServer } from '../../server'
+
+const root = fileURLToPath(new URL('./', import.meta.url))
+
+async function createDevServer() {
+  const server = await createServer({ configFile: false, root })
+  server.pluginContainer.buildStart({})
+  return server
+}
+
+test('ssrLoad', async () => {
+  expect.assertions(1)
+  const server = await createDevServer()
+  try {
+    await server.ssrLoadModule('/fixtures/modules/has-invalid-import.js')
+  } catch (e) {
+    expect(e.message).toBe(
+      'Failed to load url ./non-existent.js (resolved id: ./non-existent.js). Does the file exist?'
+    )
+  }
+})

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -85,7 +85,7 @@ async function instantiateModule(
   }
   const result =
     mod.ssrTransformResult ||
-    (await transformRequest(url, server, { ssr: true }))
+    (await transformRequest(url, server, { ssr: true, strict: true }))
   if (!result) {
     // TODO more info? is this even necessary?
     throw new Error(`failed to load module for ssr: ${url}`)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -85,7 +85,7 @@ async function instantiateModule(
   }
   const result =
     mod.ssrTransformResult ||
-    (await transformRequest(url, server, { ssr: true, strict: true }))
+    (await transformRequest(url, server, { ssr: true }))
   if (!result) {
     // TODO more info? is this even necessary?
     throw new Error(`failed to load module for ssr: ${url}`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/vitejs/vite/issues/10002

When we can't read a file from the fs, `transformRequest` would `return null`, hiding the error.

This PR throws the error instead, with an error code to handle an edge case explained below. This would print a descriptive error when a file is missing instead.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

Partially reverts https://github.com/vitejs/vite/commit/c30f6d7a2e2ab24b68a8c024644ee1ccb67925af

The server transform middleware uses `transformRequest`, but for invalid urls, it needs to skip and let other middlewares handle instead. Skipping is now done by checking for the error code `ERR_LOAD_URL`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
