### PR TITLE
feat(legacy): add 'assumptions' option

### DIFF
--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -24,4 +24,10 @@ export interface Options {
    * default: false
    */
   externalSystemJS?: boolean
+  /**
+   * default: {}
+   */
+  assumptions?: {
+    [key: string]: boolean
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Babel allows specifying compiler assumptions for generating small output.  This pr adds `assumptions` option to pass to babel transform inside `@vitejs/plugin-legacy`.

Fixes #6965
### Additional context
none

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
