### PR TITLE
feat(hmr): deduplicate paths and join them with commas

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -181,9 +181,8 @@ export function updateModules(
   }
 
   config.logger.info(
-    updates
-      .map(({ path }) => colors.green(`hmr update `) + colors.dim(path))
-      .join('\n'),
+    colors.green(`hmr update `) +
+      colors.dim([...new Set(updates.map((u) => u.path))].join(', ')),
     { clear: true, timestamp: true }
   )
   ws.send({

--- a/playground/tailwind/src/components/HelloWorld.vue
+++ b/playground/tailwind/src/components/HelloWorld.vue
@@ -5,5 +5,6 @@
 </template>
 
 <script setup lang="ts">
-const count = 1
+import { INITIAL_COUNT } from '../utils.ts'
+const count = INITIAL_COUNT
 </script>

--- a/playground/tailwind/src/utils.ts
+++ b/playground/tailwind/src/utils.ts
@@ -1,0 +1,2 @@
+export const NAME = 'Tailwind'
+export const INITIAL_COUNT = 1

--- a/playground/tailwind/src/views/Page.vue
+++ b/playground/tailwind/src/views/Page.vue
@@ -5,7 +5,7 @@
     <div
       class="tailwind-style bg-red-100 inline-block h-24 px-8 mb-8 text-[#888888]"
     >
-      Tailwind style
+      {{ name }} style
     </div>
     <HelloWorld />
     <PugTemplate />
@@ -16,13 +16,16 @@
 import { defineComponent, ref } from 'vue'
 import HelloWorld from '../components/HelloWorld.vue'
 import PugTemplate from '../components/PugTemplate.vue'
+import { NAME } from '../utils.ts'
 
 export default defineComponent({
   components: { HelloWorld, PugTemplate },
   setup() {
+    const name = NAME
     const val = ref(0)
 
     return {
+      name,
       val
     }
   }


### PR DESCRIPTION
When updating a non component file imported in multiple components, the hmr update log become noisy, and very noisy when tailwind is involved.

Before:
<img width="443" alt="Screenshot 2022-11-12 at 13 26 12" src="https://user-images.githubusercontent.com/14235743/201473967-6d7c7db3-9d1c-4219-b042-1b537d2cc996.png">

After:
<img width="842" alt="Screenshot 2022-11-12 at 13 23 55" src="https://user-images.githubusercontent.com/14235743/201473975-301be706-25a1-4c0c-8197-521524a9c613.png">