### PR TITLE
chore(ci): skip workflows on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'vitejs/vite'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'vitejs/vite'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
@@ -97,6 +98,7 @@ jobs:
         run: pnpm run test-docs
 
   lint:
+    if: github.repository == 'vitejs/vite'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     name: "Lint: node-16, ubuntu-latest"

--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/ecosystem-ci run')
+    if: github.repository == 'vitejs/vite' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/ecosystem-ci run')
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   close-issues:
+    if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-latest
     steps:
       - name: need reproduction

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   reply-labeled:
+    if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-latest
     steps:
       - name: contribution welcome

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   action:
+    if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'vitejs/vite'
     runs-on: ubuntu-latest
     name: Semantic Pull Request
     steps:


### PR DESCRIPTION
The cron jobs outside of the main repo are a waste of ressources.

For the main CI, I don't know if people develop their PR directly on main and expect the CI to run, but for me it only runs when I sync the fork, which is annoying and useless.