### PR TITLE
feat(build): cleaner logs output

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -4,71 +4,58 @@ import { promisify } from 'node:util'
 import colors from 'picocolors'
 import type { Plugin } from 'rollup'
 import type { ResolvedConfig } from '../config'
-import { normalizePath } from '../utils'
+import { isDefined, normalizePath } from '../utils'
 import { LogLevels } from '../logger'
 
-const enum WriteType {
-  JS,
-  CSS,
-  ASSET,
-  HTML,
-  SOURCE_MAP
-}
-
-const writeColors = {
-  [WriteType.JS]: colors.cyan,
-  [WriteType.CSS]: colors.magenta,
-  [WriteType.ASSET]: colors.green,
-  [WriteType.HTML]: colors.blue,
-  [WriteType.SOURCE_MAP]: colors.gray
+const groups = [
+  { name: 'Assets', color: colors.green },
+  { name: 'CSS', color: colors.magenta },
+  { name: 'JS', color: colors.cyan }
+]
+type LogEntry = {
+  name: string
+  group: typeof groups[number]['name']
+  size: number
+  compressedSize: number | null
+  mapSize: number | null
 }
 
 export function buildReporterPlugin(config: ResolvedConfig): Plugin {
   const compress = promisify(gzip)
   const chunkLimit = config.build.chunkSizeWarningLimit
 
-  function isLarge(code: string | Uint8Array): boolean {
-    // bail out on particularly large chunks
-    return code.length / 1000 > chunkLimit
-  }
-
-  async function getCompressedSize(code: string | Uint8Array): Promise<string> {
-    if (config.build.ssr || !config.build.reportCompressedSize) {
-      return ''
-    }
-    return ` / gzip: ${displaySize(
-      (await compress(typeof code === 'string' ? code : Buffer.from(code)))
-        .length / 1000
-    )}`
-  }
-
-  function printFileInfo(
-    filePath: string,
-    content: string | Uint8Array,
-    type: WriteType,
-    maxLength: number,
-    outDir = config.build.outDir,
-    compressedSize = ''
-  ) {
-    outDir =
-      normalizePath(
-        path.relative(config.root, path.resolve(config.root, outDir))
-      ) + '/'
-    const kB = content.length / 1000
-    const sizeColor = kB > chunkLimit ? colors.yellow : colors.dim
-    config.logger.info(
-      `${colors.gray(colors.white(colors.dim(outDir)))}${writeColors[type](
-        filePath.padEnd(maxLength + 2)
-      )} ${sizeColor(`${displaySize(kB)}${compressedSize}`)}`
-    )
-  }
-
   const tty = process.stdout.isTTY && !process.env.CI
   const shouldLogInfo = LogLevels[config.logLevel || 'info'] >= LogLevels.info
   let hasTransformed = false
   let hasRenderedChunk = false
+  let hasCompressChunk = false
   let transformedCount = 0
   let chunkCount = 0
+  let compressedCount = 0
+
+  async function getCompressedSize(
+    code: string | Uint8Array
+  ): Promise<number | null> {
+    if (config.build.ssr || !config.build.reportCompressedSize) {
+      return null
+    }
+    if (shouldLogInfo && !hasCompressChunk) {
+      if (!tty) {
+        config.logger.info('computing gzip size...')
+      } else {
+        writeLine('computing gzip size (0)...')
+      }
+      hasCompressChunk = true
+    }
+    const compressed = await compress(
+      typeof code === 'string' ? code : Buffer.from(code)
+    )
+    compressedCount++
+    if (shouldLogInfo && tty) {
+      writeLine(`computing gzip size (${compressedCount})...`)
+    }
+    return compressed.length
+  }
 
   const logTransform = throttle((id: string) => {
     writeLine(
@@ -111,6 +98,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
 
     renderStart() {
       chunkCount = 0
+      compressedCount = 0
     },
 
     renderChunk() {
@@ -129,78 +117,111 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
     },
 
     generateBundle() {
-      if (shouldLogInfo && tty) {
-        process.stdout.clearLine(0)
-        process.stdout.cursorTo(0)
-      }
+      if (shouldLogInfo && tty) clearLine()
     },
 
     async writeBundle({ dir: outDir }, output) {
       let hasLargeChunks = false
 
       if (shouldLogInfo) {
-        let longest = 0
-        for (const file in output) {
-          const l = output[file].fileName.length
-          if (l > longest) longest = l
-        }
-
-        // large chunks are deferred to be logged at the end so they are more
-        // visible.
-        const deferredLogs: (() => void)[] = []
-
-        await Promise.all(
-          Object.keys(output).map(async (file) => {
-            const chunk = output[file]
-            if (chunk.type === 'chunk') {
-              const log = async () => {
-                printFileInfo(
-                  chunk.fileName,
-                  chunk.code,
-                  WriteType.JS,
-                  longest,
-                  outDir,
-                  await getCompressedSize(chunk.code)
-                )
-                if (chunk.map) {
-                  printFileInfo(
-                    chunk.fileName + '.map',
-                    chunk.map.toString(),
-                    WriteType.SOURCE_MAP,
-                    longest,
-                    outDir
-                  )
+        const entries = (
+          await Promise.all(
+            Object.values(output).map(
+              async (chunk): Promise<LogEntry | null> => {
+                if (chunk.type === 'chunk') {
+                  return {
+                    name: chunk.fileName,
+                    group: 'JS',
+                    size: chunk.code.length,
+                    compressedSize: await getCompressedSize(chunk.code),
+                    mapSize: chunk.map ? chunk.map.toString().length : null
+                  }
+                } else {
+                  if (chunk.fileName.endsWith('.map')) return null
+                  const isCSS = chunk.fileName.endsWith('.css')
+                  return {
+                    name: chunk.fileName,
+                    group: isCSS ? 'CSS' : 'Assets',
+                    size: chunk.source.length,
+                    mapSize: null, // Rollup doesn't support CSS maps?
+                    compressedSize: isCSS
+                      ? await getCompressedSize(chunk.source)
+                      : null
+                  }
                 }
               }
-              if (isLarge(chunk.code)) {
-                hasLargeChunks = true
-                deferredLogs.push(log)
-              } else {
-                await log()
-              }
-            } else if (chunk.source) {
-              const isCSS = chunk.fileName.endsWith('.css')
-              const isMap = chunk.fileName.endsWith('.js.map')
-              printFileInfo(
-                chunk.fileName,
-                chunk.source,
-                isCSS
-                  ? WriteType.CSS
-                  : isMap
-                  ? WriteType.SOURCE_MAP
-                  : WriteType.ASSET,
-                longest,
-                outDir,
-                isCSS ? await getCompressedSize(chunk.source) : undefined
+            )
+          )
+        ).filter(isDefined)
+        if (tty) clearLine()
+
+        let longest = 0
+        let biggestSize = 0
+        let biggestMap = 0
+        let biggestCompressSize = 0
+        for (const entry of entries) {
+          if (entry.name.length > longest) longest = entry.name.length
+          if (entry.size > biggestSize) biggestSize = entry.size
+          if (entry.mapSize && entry.mapSize > biggestMap) {
+            biggestMap = entry.mapSize
+          }
+          if (
+            entry.compressedSize &&
+            entry.compressedSize > biggestCompressSize
+          ) {
+            biggestCompressSize = entry.compressedSize
+          }
+        }
+
+        const sizePad = displaySize(biggestSize).length
+        const mapPad = displaySize(biggestMap).length
+        const compressPad = displaySize(biggestCompressSize).length
+
+        const relativeOutDir = normalizePath(
+          path.relative(
+            config.root,
+            path.resolve(config.root, outDir ?? config.build.outDir)
+          )
+        )
+        const assetsDir = `${config.build.assetsDir}/`
+
+        for (const group of groups) {
+          const filtered = entries.filter((e) => e.group === group.name)
+          if (!filtered.length) continue
+          for (const entry of filtered.sort((a, z) => a.size - z.size)) {
+            const isLarge =
+              group.name === 'JS' && entry.size / 1000 > chunkLimit
+            if (isLarge) hasLargeChunks = true
+            const sizeColor = isLarge ? colors.yellow : colors.dim
+            let log = colors.dim(relativeOutDir + '/')
+            log += entry.name.startsWith(assetsDir)
+              ? colors.dim(assetsDir) +
+                group.color(
+                  entry.name
+                    .slice(assetsDir.length)
+                    .padEnd(longest + 2 - assetsDir.length)
+                )
+              : group.color(entry.name.padEnd(longest + 2))
+            log += colors.bold(
+              sizeColor(displaySize(entry.size).padStart(sizePad))
+            )
+            if (entry.compressedSize) {
+              log += colors.dim(
+                ` │ gzip: ${displaySize(entry.compressedSize).padStart(
+                  compressPad
+                )}`
               )
             }
-          })
-        )
-
-        await Promise.all(deferredLogs.map((l) => l()))
+            if (entry.mapSize) {
+              log += colors.dim(
+                ` │ map: ${displaySize(entry.mapSize).padStart(mapPad)}`
+              )
+            }
+            config.logger.info(log)
+          }
+        }
       } else {
-        hasLargeChunks = Object.keys(output).some((file) => {
-          const chunk = output[file]
+        hasLargeChunks = Object.values(output).some((chunk) => {
           return chunk.type === 'chunk' && chunk.code.length / 1000 > chunkLimit
         })
       }
@@ -225,13 +246,17 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
 }
 
 function writeLine(output: string) {
-  process.stdout.clearLine(0)
-  process.stdout.cursorTo(0)
+  clearLine()
   if (output.length < process.stdout.columns) {
     process.stdout.write(output)
   } else {
     process.stdout.write(output.substring(0, process.stdout.columns - 1))
   }
+}
+
+function clearLine() {
+  process.stdout.clearLine(0)
+  process.stdout.cursorTo(0)
 }
 
 function throttle(fn: Function) {
@@ -245,8 +270,8 @@ function throttle(fn: Function) {
   }
 }
 
-function displaySize(kB: number) {
-  return `${kB.toLocaleString('en', {
+function displaySize(bytes: number) {
+  return `${(bytes / 1000).toLocaleString('en', {
     maximumFractionDigits: 2,
     minimumFractionDigits: 2
   })} kB`


### PR DESCRIPTION
There are two improvements that goes together:
- Don't display source map on a separated line. This create a lot of noise for something that is not downloaded by the user.
- Sort chunks based on the size and align numbers to the right (and having lines for map would create a lot more noise here)

Before:
<img width="569" alt="Screenshot 2022-11-12 at 16 00 20" src="https://user-images.githubusercontent.com/14235743/201484701-31ad7196-fc4b-4780-b9e5-6dbc0f239261.png">

Note: IMO map size should not be in yellow.

After:
<img width="712" alt="Screenshot 2022-11-12 at 17 10 05" src="https://user-images.githubusercontent.com/14235743/201484736-c01ad1b3-baa3-4934-b8dd-fd7c98d29612.png">

Note: This is clearly not a carefully optimised webapp, but this new report allow to quickly see images that could be compressed.

Example with chunk size limit & compress size:
<img width="972" alt="Screenshot 2022-11-12 at 17 28 28" src="https://user-images.githubusercontent.com/14235743/201484756-ed1d837f-e2ca-4e17-8c59-d7bb4f84a5be.png">

Note: In Rollup 3 maps have their own assets entries, so they are currently displayed twice in v4
<img width="496" alt="Screenshot 2022-11-12 at 17 33 13" src="https://user-images.githubusercontent.com/14235743/201484830-15c2d8eb-8240-4b00-87f5-dab83b20e9bf.png">

Open question: I would prefer to display size in `kB` instead of `KiB`. Is there any reason for using the later?