### PR TITLE
fix(vue): skip url query request (fixes #10863)

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -207,7 +207,7 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
     transform(code, id, opt) {
       const ssr = opt?.ssr === true
       const { filename, query } = parseVueRequest(id)
-      if (query.raw) {
+      if (query.raw || query.url) {
         return
       }
       if (!filter(filename) && !query.vue) {

--- a/packages/plugin-vue/src/utils/query.ts
+++ b/packages/plugin-vue/src/utils/query.ts
@@ -5,6 +5,7 @@ export interface VueQuery {
   index?: number
   lang?: string
   raw?: boolean
+  url?: boolean
   scoped?: boolean
 }
 
@@ -22,6 +23,9 @@ export function parseVueRequest(id: string): {
   }
   if (query.raw != null) {
     query.raw = true
+  }
+  if (query.url != null) {
+    query.url = true
   }
   if (query.scoped != null) {
     query.scoped = true

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -22,6 +22,7 @@
   <ReactivityTransform :foo="time" />
   <SetupImportTemplate />
   <WorkerTest />
+  <Url />
 </template>
 
 <script setup lang="ts">
@@ -40,6 +41,7 @@ import ReactivityTransform from './ReactivityTransform.vue'
 import SetupImportTemplate from './setup-import-template/SetupImportTemplate.vue'
 import WorkerTest from './worker.vue'
 import { ref } from 'vue'
+import Url from './Url.vue'
 
 const time = ref('loading...')
 

--- a/playground/vue/Null.vue
+++ b/playground/vue/Null.vue
@@ -1,0 +1,1 @@
+<template>null</template>

--- a/playground/vue/Url.vue
+++ b/playground/vue/Url.vue
@@ -1,0 +1,10 @@
+<script setup>
+import url from './Null.vue?url'
+</script>
+
+<template>
+  <h2>import with ?url</h2>
+  <div>
+    URL of Null.vue: <span class="import-with-url-query">{{ url }}</span>
+  </div>
+</template>

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -263,3 +263,11 @@ describe('vue worker', () => {
     expect(await page.textContent('.vue-worker')).toMatch('worker load!')
   })
 })
+
+describe('import with ?url', () => {
+  test('should work', async () => {
+    expect(await page.textContent('.import-with-url-query')).toMatch(
+      isBuild ? /^data:/ : '/Null.vue'
+    )
+  })
+})

--- a/playground/vue/tsconfig.json
+++ b/playground/vue/tsconfig.json
@@ -3,5 +3,5 @@
     // esbuild transpile should ignore this
     "target": "ES5"
   },
-  "include": ["src"]
+  "include": ["."]
 }

--- a/playground/vue/vite-env.d.ts
+++ b/playground/vue/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`new URL(`/src/${url}`, import.meta.url).href;` is transformed to `import vueUrl from './foo.vue?url'`.

`./foo.vue?url` was not returning url and also was transformed by plugin-vue.

Vue now rejects likely invalid components to prevent mistakes (https://github.com/vuejs/core/issues/6676).
So before Vue 3.2.42, `./foo.vue?url` was returning a unintended code and after that the reqeust throws an error.

fixes #10863

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
