### PR TITLE
feat: align default chunk and asset file names with rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "typescript": "^4.6.4",
     "unbuild": "^0.9.4",
     "vite": "workspace:*",
-    "vitepress": "^1.0.0-alpha.28",
+    "vitepress": "^1.0.0-alpha.29",
     "vitest": "^0.25.1",
     "vue": "^3.2.45"
   },

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -298,7 +298,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           | string
           | ((chunkInfo: PreRenderedChunk) => string)
           | undefined,
-        defaultFileName = '[name]-legacy.[hash].js'
+        defaultFileName = '[name]-legacy-[hash].js'
       ): string | ((chunkInfo: PreRenderedChunk) => string) => {
         if (!fileNames) {
           return path.posix.join(config.build.assetsDir, defaultFileName)

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -576,13 +576,13 @@ async function doBuild(
           : libOptions
           ? ({ name }) =>
               resolveLibFilename(libOptions, format, name, config.root, jsExt)
-          : path.posix.join(options.assetsDir, `[name].[hash].${jsExt}`),
+          : path.posix.join(options.assetsDir, `[name]-[hash].${jsExt}`),
         chunkFileNames: libOptions
-          ? `[name].[hash].${jsExt}`
-          : path.posix.join(options.assetsDir, `[name].[hash].${jsExt}`),
+          ? `[name]-[hash].${jsExt}`
+          : path.posix.join(options.assetsDir, `[name]-[hash].${jsExt}`),
         assetFileNames: libOptions
           ? `[name].[ext]`
-          : path.posix.join(options.assetsDir, `[name].[hash].[ext]`),
+          : path.posix.join(options.assetsDir, `[name]-[hash].[ext]`),
         inlineDynamicImports:
           output.format === 'umd' ||
           output.format === 'iife' ||

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -79,15 +79,15 @@ export async function bundleWorkerEntry(
     } = await bundle.generate({
       entryFileNames: path.posix.join(
         config.build.assetsDir,
-        '[name].[hash].js'
+        '[name]-[hash].js'
       ),
       chunkFileNames: path.posix.join(
         config.build.assetsDir,
-        '[name].[hash].js'
+        '[name]-[hash].js'
       ),
       assetFileNames: path.posix.join(
         config.build.assetsDir,
-        '[name].[hash].[ext]'
+        '[name]-[hash].[ext]'
       ),
       ...workerConfig,
       format,

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -210,7 +210,7 @@ describe('image', () => {
       expect(s).toMatch(
         isBuild
           ? /\/foo\/assets\/asset-\w{8}\.png \dx/
-          : /\/foo\/nested\/asset-png \dx/
+          : /\/foo\/nested\/asset.png \dx/
       )
     })
   })

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -19,7 +19,7 @@ import {
 } from '~utils'
 
 const assetMatch = isBuild
-  ? /\/foo\/assets\/asset\.\w{8}\.png/
+  ? /\/foo\/assets\/asset-\w{8}\.png/
   : '/foo/nested/asset.png'
 
 const iconMatch = `/foo/icon.png`
@@ -209,8 +209,8 @@ describe('image', () => {
     srcset.split(', ').forEach((s) => {
       expect(s).toMatch(
         isBuild
-          ? /\/foo\/assets\/asset\.\w{8}\.png \dx/
-          : /\/foo\/nested\/asset\.png \dx/
+          ? /\/foo\/assets\/asset-\w{8}\.png \dx/
+          : /\/foo\/nested\/asset-png \dx/
       )
     })
   })
@@ -338,7 +338,7 @@ describe.runIf(isBuild)('css and assets in css in build watch', () => {
   test('css will not be lost and css does not contain undefined', async () => {
     editFile('index.html', (code) => code.replace('Assets', 'assets'), true)
     await notifyRebuildComplete(watcher)
-    const cssFile = findAssetFile(/index\.\w+\.css$/, 'foo')
+    const cssFile = findAssetFile(/index-\w+\.css$/, 'foo')
     expect(cssFile).not.toBe('')
     expect(cssFile).not.toMatch(/undefined/)
   })

--- a/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
+++ b/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '~utils'
 
 const absoluteAssetMatch = isBuild
-  ? /http.*\/other-assets\/asset\.\w{8}\.png/
+  ? /http.*\/other-assets\/asset-\w{8}\.png/
   : '/nested/asset.png'
 
 // Asset URLs in CSS are relative to the same dir, the computed
@@ -20,7 +20,7 @@ const cssBgAssetMatch = absoluteAssetMatch
 const iconMatch = `/icon.png`
 
 const absoluteIconMatch = isBuild
-  ? /http.*\/icon\.\w{8}\.png/
+  ? /http.*\/icon-\w{8}\.png/
   : '/nested/icon.png'
 
 const absolutePublicIconMatch = isBuild ? /http.*\/icon\.png/ : '/icon.png'
@@ -143,7 +143,7 @@ describe.runIf(isBuild)('index.css URLs', () => {
   })
 
   test('relative asset URL', () => {
-    expect(css).toMatch(`./asset.`)
+    expect(css).toMatch(`./asset-`)
   })
 
   test('preserve postfix query/hash', () => {
@@ -158,7 +158,7 @@ describe('image', () => {
     srcset.split(', ').forEach((s) => {
       expect(s).toMatch(
         isBuild
-          ? /other-assets\/asset\.\w{8}\.png \dx/
+          ? /other-assets\/asset-\w{8}\.png \dx/
           : /\.\/nested\/asset\.png \dx/
       )
     })
@@ -191,14 +191,14 @@ test('?raw import', async () => {
 
 test('?url import', async () => {
   expect(await page.textContent('.url')).toMatch(
-    isBuild ? /http.*\/other-assets\/foo\.\w{8}\.js/ : `/foo.js`
+    isBuild ? /http.*\/other-assets\/foo-\w{8}\.js/ : `/foo.js`
   )
 })
 
 test('?url import on css', async () => {
   const txt = await page.textContent('.url-css')
   expect(txt).toMatch(
-    isBuild ? /http.*\/other-assets\/icons\.\w{8}\.css/ : '/css/icons.css'
+    isBuild ? /http.*\/other-assets\/icons-\w{8}\.css/ : '/css/icons.css'
   )
 })
 

--- a/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
+++ b/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '~utils'
 
 const absoluteAssetMatch = isBuild
-  ? /\/other-assets\/asset\.\w{8}\.png/
+  ? /\/other-assets\/asset-\w{8}\.png/
   : '/nested/asset.png'
 
 // Asset URLs in CSS are relative to the same dir, the computed
@@ -19,7 +19,7 @@ const cssBgAssetMatch = absoluteAssetMatch
 const iconMatch = `/icon.png`
 
 const absoluteIconMatch = isBuild
-  ? /\/other-assets\/icon\.\w{8}\.png/
+  ? /\/other-assets\/icon-\w{8}\.png/
   : '/nested/icon.png'
 
 const absolutePublicIconMatch = isBuild ? /\/icon\.png/ : '/icon.png'
@@ -137,11 +137,11 @@ describe('css url() references', () => {
 describe.runIf(isBuild)('index.css URLs', () => {
   let css: string
   beforeAll(() => {
-    css = findAssetFile(/index.*\.css$/, '', 'other-assets')
+    css = findAssetFile(/index-\w{8}\.css$/, '', 'other-assets')
   })
 
   test('relative asset URL', () => {
-    expect(css).toMatch(`./asset.`)
+    expect(css).toMatch(`./asset-`)
   })
 
   test('preserve postfix query/hash', () => {
@@ -156,7 +156,7 @@ describe('image', () => {
     srcset.split(', ').forEach((s) => {
       expect(s).toMatch(
         isBuild
-          ? /other-assets\/asset\.\w{8}\.png \dx/
+          ? /other-assets\/asset-\w{8}\.png \dx/
           : /\.\/nested\/asset\.png \dx/
       )
     })
@@ -189,14 +189,14 @@ test('?raw import', async () => {
 
 test('?url import', async () => {
   expect(await page.textContent('.url')).toMatch(
-    isBuild ? /\/other-assets\/foo\.\w{8}\.js/ : `/foo.js`
+    isBuild ? /\/other-assets\/foo-\w{8}\.js/ : `/foo.js`
   )
 })
 
 test('?url import on css', async () => {
   const txt = await page.textContent('.url-css')
   expect(txt).toMatch(
-    isBuild ? /\/other-assets\/icons\.\w{8}\.css/ : '/css/icons.css'
+    isBuild ? /\/other-assets\/icons-\w{8}\.css/ : '/css/icons.css'
   )
 })
 

--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -15,8 +15,8 @@ module.exports = {
     rollupOptions: {
       output: {
         entryFileNames: 'entries/[name].js',
-        chunkFileNames: 'chunks/[name].[hash].js',
-        assetFileNames: 'other-assets/[name].[hash][extname]'
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: 'other-assets/[name]-[hash][extname]'
       }
     }
   },

--- a/playground/assets/vite.config-runtime-base.js
+++ b/playground/assets/vite.config-runtime-base.js
@@ -22,8 +22,8 @@ module.exports = {
     rollupOptions: {
       output: {
         entryFileNames: 'entries/[name].js',
-        chunkFileNames: 'chunks/[name].[hash].js',
-        assetFileNames: 'other-assets/[name].[hash][extname]'
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: 'other-assets/[name]-[hash][extname]'
       }
     }
   },

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '~utils'
 
 const outerAssetMatch = isBuild
-  ? /\/dev\/assets\/logo\.\w{8}\.png/
+  ? /\/dev\/assets\/logo-\w{8}\.png/
   : /\/dev\/@fs\/.+?\/images\/logo\.png/
 
 test('should have no 404s', () => {

--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -66,32 +66,32 @@ baseOptions.forEach(({ base, label }) => {
         expect(await getColor('.css-dynamic-import')).toBe('green')
         expect(await getLinks()).toEqual([
           {
-            pathname: expect.stringMatching(/^\/assets\/index\..+\.css$/),
+            pathname: expect.stringMatching(/^\/assets\/index-.+\.css$/),
             rel: 'stylesheet',
             as: ''
           },
           {
-            pathname: expect.stringMatching(/^\/assets\/dynamic\..+\.css$/),
+            pathname: expect.stringMatching(/^\/assets\/dynamic-.+\.css$/),
             rel: 'preload',
             as: 'style'
           },
           {
-            pathname: expect.stringMatching(/^\/assets\/dynamic\..+\.js$/),
+            pathname: expect.stringMatching(/^\/assets\/dynamic-.+\.js$/),
             rel: 'modulepreload',
             as: 'script'
           },
           {
-            pathname: expect.stringMatching(/^\/assets\/dynamic\..+\.css$/),
+            pathname: expect.stringMatching(/^\/assets\/dynamic-.+\.css$/),
             rel: 'stylesheet',
             as: ''
           },
           {
-            pathname: expect.stringMatching(/^\/assets\/static\..+\.js$/),
+            pathname: expect.stringMatching(/^\/assets\/static-.+\.js$/),
             rel: 'modulepreload',
             as: 'script'
           },
           {
-            pathname: expect.stringMatching(/^\/assets\/index\..+\.js$/),
+            pathname: expect.stringMatching(/^\/assets\/index-.+\.js$/),
             rel: 'modulepreload',
             as: 'script'
           }

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -64,7 +64,7 @@ test('css import from js', async () => {
 test('css import asset with space', async () => {
   const importedWithSpace = await page.$('.import-with-space')
 
-  expect(await getBg(importedWithSpace)).toMatch(/.*ok\..*png/)
+  expect(await getBg(importedWithSpace)).toMatch(/.*ok-.*png/)
 })
 
 test('postcss config', async () => {
@@ -90,7 +90,7 @@ test('sass', async () => {
     isBuild ? /base64/ : '/nested/icon.png'
   )
   expect(await getBg(urlStartsWithVariable)).toMatch(
-    isBuild ? /ok\.\w+\.png/ : `${viteTestUrl}/ok.png`
+    isBuild ? /ok-\w+\.png/ : `${viteTestUrl}/ok.png`
   )
   expect(await getColor(partialImport)).toBe('orchid')
 
@@ -124,7 +124,7 @@ test('less', async () => {
     isBuild ? /base64/ : '/nested/icon.png'
   )
   expect(await getBg(urlStartsWithVariable)).toMatch(
-    isBuild ? /ok\.\w+\.png/ : `${viteTestUrl}/ok.png`
+    isBuild ? /ok-\w+\.png/ : `${viteTestUrl}/ok.png`
   )
 
   editFile('less.less', (code) => code.replace('@color: blue', '@color: red'))
@@ -297,8 +297,8 @@ test('async chunk', async () => {
   if (isBuild) {
     // assert that the css is extracted into its own file instead of in the
     // main css file
-    expect(findAssetFile(/index\.\w+\.css$/)).not.toMatch('teal')
-    expect(findAssetFile(/async\.\w+\.css$/)).toMatch('.async{color:teal}')
+    expect(findAssetFile(/index-\w+\.css$/)).not.toMatch('teal')
+    expect(findAssetFile(/async-\w+\.css$/)).toMatch('.async{color:teal}')
   } else {
     // test hmr
     editFile('async.css', (code) => code.replace('color: teal', 'color: blue'))
@@ -316,8 +316,8 @@ test('treeshaken async chunk', async () => {
     ).toBeNull()
     // assert that the css is not present anywhere
     expect(findAssetFile(/\.css$/)).not.toMatch('plum')
-    expect(findAssetFile(/index\.\w+\.js$/)).not.toMatch('.async{color:plum}')
-    expect(findAssetFile(/async\.\w+\.js$/)).not.toMatch('.async{color:plum}')
+    expect(findAssetFile(/index-\w+\.js$/)).not.toMatch('.async{color:plum}')
+    expect(findAssetFile(/async-\w+\.js$/)).not.toMatch('.async{color:plum}')
     // should have no chunk!
     expect(findAssetFile(/async-treeshaken/)).toBe('')
   } else {
@@ -416,7 +416,7 @@ test('minify css', async () => {
   }
 
   // should keep the rgba() syntax
-  const cssFile = findAssetFile(/index\.\w+\.css$/)
+  const cssFile = findAssetFile(/index-\w+\.css$/)
   expect(cssFile).toMatch('rgba(')
   expect(cssFile).not.toMatch('#ffff00b3')
 })

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -64,7 +64,7 @@ test('css import from js', async () => {
 test('css import asset with space', async () => {
   const importedWithSpace = await page.$('.import-with-space')
 
-  expect(await getBg(importedWithSpace)).toMatch(/.*ok-.*png/)
+  expect(await getBg(importedWithSpace)).toMatch(/.*\/ok.*\.png/)
 })
 
 test('postcss config', async () => {

--- a/playground/css/vite.config-relative-base.js
+++ b/playground/css/vite.config-relative-base.js
@@ -15,8 +15,8 @@ module.exports = {
     rollupOptions: {
       output: {
         entryFileNames: 'entries/[name].js',
-        chunkFileNames: 'chunks/[name].[hash].js',
-        assetFileNames: 'other-assets/[name].[hash][extname]'
+        chunkFileNames: 'chunks/[name]-[hash].js',
+        assetFileNames: 'other-assets/[name]-[hash][extname]'
       }
     }
   },

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -185,7 +185,7 @@ test('tree-shake eager css', async () => {
   )
 
   if (isBuild) {
-    const content = findAssetFile(/index\.\w+\.js/)
+    const content = findAssetFile(/index-\w+\.js/)
     expect(content).not.toMatch('.tree-shake-eager-css')
   }
 })

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -116,6 +116,6 @@ describe.runIf(isBuild)('build', () => {
 
   test('includes structuredClone polyfill which is supported after core-js v3', () => {
     expect(findAssetFile(/polyfills-legacy/)).toMatch('"structuredClone"')
-    expect(findAssetFile(/polyfills\./)).toMatch('"structuredClone"')
+    expect(findAssetFile(/polyfills-\w{8}\./)).toMatch('"structuredClone"')
   })
 })

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -76,7 +76,7 @@ test('should load dynamic import with css', async () => {
 
 test('asset url', async () => {
   expect(await page.textContent('#asset-path')).toMatch(
-    isBuild ? /\/assets\/vite\.\w+\.svg/ : '/vite.svg'
+    isBuild ? /\/assets\/vite-\w+\.svg/ : '/vite.svg'
   )
 })
 

--- a/playground/legacy/vite.config-multiple-output.js
+++ b/playground/legacy/vite.config-multiple-output.js
@@ -10,14 +10,14 @@ export default defineConfig({
       output: [
         {
           assetFileNames() {
-            return 'assets/subdir/[name].[hash][extname]'
+            return 'assets/subdir/[name]-[hash][extname]'
           },
           entryFileNames: `assets/subdir/[name].js`,
           chunkFileNames: `assets/subdir/[name].js`
         },
         {
           assetFileNames() {
-            return 'assets/subdir/[name].[hash][extname]'
+            return 'assets/subdir/[name]-[hash][extname]'
           },
           entryFileNames: `assets/anotherSubdir/[name].js`,
           chunkFileNames: `assets/anotherSubdir/[name].js`

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -36,7 +36,7 @@ describe.runIf(isBuild)('build', () => {
     expect(code).not.toMatch('__vitePreload')
 
     // Test that library chunks are hashed
-    expect(code).toMatch(/await import\("\.\/message.[a-z\d]{8}.mjs"\)/)
+    expect(code).toMatch(/await import\("\.\/message-[a-z\d]{8}.mjs"\)/)
   })
 
   test('@import hoist', async () => {

--- a/playground/preload/__tests__/preload.spec.ts
+++ b/playground/preload/__tests__/preload.spec.ts
@@ -17,10 +17,10 @@ describe.runIf(isBuild)('build', () => {
     await page.goto(viteTestUrl + '/#/hello')
     const html = await page.content()
     expect(html).toMatch(
-      /link rel="modulepreload".*?href=".*?\/assets\/Hello\.\w{8}\.js"/
+      /link rel="modulepreload".*?href=".*?\/assets\/Hello-\w{8}\.js"/
     )
     expect(html).toMatch(
-      /link rel="stylesheet".*?href=".*?\/assets\/Hello\.\w{8}\.css"/
+      /link rel="stylesheet".*?href=".*?\/assets\/Hello-\w{8}\.css"/
     )
   })
 })

--- a/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
+++ b/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
@@ -17,11 +17,11 @@ describe.runIf(isBuild)('build', () => {
     await page.goto(viteTestUrl + '/#/hello')
     const html = await page.content()
     expect(html).toMatch(
-      /link rel="modulepreload".*?href="http.*?\/Hello\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="http.*?\/Hello-\w{8}\.js"/
     )
     expect(html).toMatch(/link rel="modulepreload".*?href="\/preloaded.js"/)
     expect(html).toMatch(
-      /link rel="stylesheet".*?href="http.*?\/Hello\.\w{8}\.css"/
+      /link rel="stylesheet".*?href="http.*?\/Hello-\w{8}\.css"/
     )
   })
 })

--- a/playground/ssr-vue/__tests__/ssr-vue.spec.ts
+++ b/playground/ssr-vue/__tests__/ssr-vue.spec.ts
@@ -39,16 +39,16 @@ test('/about', async () => {
   if (isBuild) {
     // assert correct preload directive generation for async chunks and CSS
     expect(aboutHtml).not.toMatch(
-      /link rel="modulepreload".*?href="\/test\/assets\/Home\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="\/test\/assets\/Home-\w{8}\.js"/
     )
     expect(aboutHtml).not.toMatch(
-      /link rel="stylesheet".*?href="\/test\/assets\/Home\.\w{8}\.css"/
+      /link rel="stylesheet".*?href="\/test\/assets\/Home-\w{8}\.css"/
     )
     expect(aboutHtml).toMatch(
-      /link rel="modulepreload".*?href="\/test\/assets\/About\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="\/test\/assets\/About-\w{8}\.js"/
     )
     expect(aboutHtml).toMatch(
-      /link rel="stylesheet".*?href="\/test\/assets\/About\.\w{8}\.css"/
+      /link rel="stylesheet".*?href="\/test\/assets\/About-\w{8}\.css"/
     )
   }
 })
@@ -69,13 +69,13 @@ test('/external', async () => {
   if (isBuild) {
     // assert correct preload directive generation for async chunks and CSS
     expect(externalHtml).not.toMatch(
-      /link rel="modulepreload".*?href="\/test\/assets\/Home\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="\/test\/assets\/Home-\w{8}\.js"/
     )
     expect(externalHtml).not.toMatch(
-      /link rel="stylesheet".*?href="\/test\/assets\/Home\.\w{8}\.css"/
+      /link rel="stylesheet".*?href="\/test\/assets\/Home-\w{8}\.css"/
     )
     expect(externalHtml).toMatch(
-      /link rel="modulepreload".*?href="\/test\/assets\/External\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="\/test\/assets\/External-\w{8}\.js"/
     )
   }
 })
@@ -93,23 +93,23 @@ test('/', async () => {
   if (isBuild) {
     // assert correct preload directive generation for async chunks and CSS
     expect(html).toMatch(
-      /link rel="modulepreload".*?href="\/test\/assets\/Home\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="\/test\/assets\/Home-\w{8}\.js"/
     )
     expect(html).toMatch(
-      /link rel="stylesheet".*?href="\/test\/assets\/Home\.\w{8}\.css"/
+      /link rel="stylesheet".*?href="\/test\/assets\/Home-\w{8}\.css"/
     )
     // JSX component preload registration
     expect(html).toMatch(
-      /link rel="modulepreload".*?href="\/test\/assets\/Foo\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="\/test\/assets\/Foo-\w{8}\.js"/
     )
     expect(html).toMatch(
-      /link rel="stylesheet".*?href="\/test\/assets\/Foo\.\w{8}\.css"/
+      /link rel="stylesheet".*?href="\/test\/assets\/Foo-\w{8}\.css"/
     )
     expect(html).not.toMatch(
-      /link rel="modulepreload".*?href="\/test\/assets\/About\.\w{8}\.js"/
+      /link rel="modulepreload".*?href="\/test\/assets\/About-\w{8}\.js"/
     )
     expect(html).not.toMatch(
-      /link rel="stylesheet".*?href="\/test\/assets\/About\.\w{8}\.css"/
+      /link rel="stylesheet".*?href="\/test\/assets\/About-\w{8}\.css"/
     )
   }
 })
@@ -135,7 +135,7 @@ test('asset', async () => {
   })
   const img = await page.$('img')
   expect(await img.getAttribute('src')).toMatch(
-    isBuild ? /\/test\/assets\/logo\.\w{8}\.png/ : '/src/assets/logo.png'
+    isBuild ? /\/test\/assets\/logo-\w{8}\.png/ : '/src/assets/logo.png'
   )
 })
 
@@ -194,7 +194,7 @@ test.runIf(isBuild)('dynamic css file should be preloaded', async () => {
   await page.goto(url)
   const homeHtml = await (await fetch(url)).text()
   const re =
-    /link rel="modulepreload".*?href="\/test\/assets\/(Home\.\w{8}\.js)"/
+    /link rel="modulepreload".*?href="\/test\/assets\/(Home-\w{8}\.js)"/
   const filename = re.exec(homeHtml)[1]
   const manifest = (
     await import(

--- a/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
+++ b/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
@@ -12,6 +12,6 @@ test('/', async () => {
 })
 
 test.runIf(isBuild)('inlineDynamicImports', () => {
-  const dynamicJsContent = findAssetFile(/dynamic\.\w+\.js/, 'worker')
+  const dynamicJsContent = findAssetFile(/dynamic-\w+\.js/, 'worker')
   expect(dynamicJsContent).toBe('')
 })

--- a/playground/vue-server-origin/__tests__/vue-server-origin.spec.ts
+++ b/playground/vue-server-origin/__tests__/vue-server-origin.spec.ts
@@ -3,7 +3,7 @@ import { isBuild, page } from '~utils'
 
 test('should render', async () => {
   const expected = isBuild
-    ? /assets\/asset\.[0-9a-f]+\.png/
+    ? /assets\/asset-[0-9a-f]+\.png/
     : 'http://localhost/server-origin/test/assets/asset.png'
 
   expect(await page.getAttribute('img', 'src')).toMatch(expected)

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -116,7 +116,7 @@ describe('css modules', () => {
 
 describe('asset reference', () => {
   const assetMatch = isBuild
-    ? /\/assets\/asset\.\w{8}\.png/
+    ? /\/assets\/asset-\w{8}\.png/
     : '/assets/asset.png'
 
   test('should not 404', () => {
@@ -153,7 +153,7 @@ describe('asset reference', () => {
 
   test('relative url from <style>', async () => {
     const assetMatch = isBuild
-      ? /\/assets\/asset\.\w{8}\.png/
+      ? /\/assets\/asset-\w{8}\.png/
       : '/assets/asset.png'
     expect(await getBg('.relative-style-url')).toMatch(assetMatch)
   })

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -17,7 +17,7 @@ test('normal', async () => {
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
-    isBuild ? '/es/assets/worker_asset.vite.svg' : '/es/vite.svg',
+    isBuild ? '/es/assets/worker_asset-vite.svg' : '/es/vite.svg',
     true
   )
 })

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -12,7 +12,7 @@ test('normal', async () => {
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
-    isBuild ? '/iife/assets/worker_asset.vite.svg' : '/iife/vite.svg',
+    isBuild ? '/iife/assets/worker_asset-vite.svg' : '/iife/vite.svg',
     true
   )
 })

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -17,7 +17,7 @@ test('normal', async () => {
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
-    isBuild ? '/worker-assets/worker_asset.vite' : '/vite.svg',
+    isBuild ? '/worker-assets/worker_asset-vite' : '/vite.svg',
     true
   )
 })
@@ -65,7 +65,7 @@ describe.runIf(isBuild)('build', () => {
       'dist/relative-base/worker-entries'
     )
     const workerFiles = fs.readdirSync(workerEntriesDir)
-    const worker = workerFiles.find((f) => f.includes('worker_entry.my-worker'))
+    const worker = workerFiles.find((f) => f.includes('worker_entry-my-worker'))
     const workerContent = fs.readFileSync(
       path.resolve(workerEntriesDir, worker),
       'utf-8'

--- a/playground/worker/__tests__/sourcemap-hidden/sourcemap-hidden-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/sourcemap-hidden-worker.spec.ts
@@ -14,22 +14,20 @@ describe.runIf(isBuild)('build', () => {
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)
-    const worker = files.find((f) => /^my-worker\.\w+\.js$/.test(f))
+    const worker = files.find((f) => /^my-worker-\w+\.js$/.test(f))
     const workerContent = fs.readFileSync(
       path.resolve(assetsDir, worker),
       'utf-8'
     )
     const workerSourcemap = getSourceMapUrl(workerContent)
-    const sharedWorker = files.find((f) =>
-      /^my-shared-worker\.\w+\.js$/.test(f)
-    )
+    const sharedWorker = files.find((f) => /^my-shared-worker-\w+\.js$/.test(f))
     const sharedWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, sharedWorker),
       'utf-8'
     )
     const sharedWorkerSourcemap = getSourceMapUrl(sharedWorkerContent)
     const possibleTsOutputWorker = files.find((f) =>
-      /^possible-ts-output-worker\.\w+\.js$/.test(f)
+      /^possible-ts-output-worker-\w+\.js$/.test(f)
     )
     const possibleTsOutputWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, possibleTsOutputWorker),
@@ -39,7 +37,7 @@ describe.runIf(isBuild)('build', () => {
       possibleTsOutputWorkerContent
     )
     const workerNestedWorker = files.find((f) =>
-      /^worker-nested-worker\.\w+\.js$/.test(f)
+      /^worker-nested-worker-\w+\.js$/.test(f)
     )
     const workerNestedWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, workerNestedWorker),
@@ -48,28 +46,28 @@ describe.runIf(isBuild)('build', () => {
     const workerNestedWorkerSourcemap = getSourceMapUrl(
       workerNestedWorkerContent
     )
-    const subWorker = files.find((f) => /^sub-worker\.\w+\.js$/.test(f))
+    const subWorker = files.find((f) => /^sub-worker-\w+\.js$/.test(f))
     const subWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, subWorker),
       'utf-8'
     )
     const subWorkerSourcemap = getSourceMapUrl(subWorkerContent)
 
-    expect(files).toContainEqual(expect.stringMatching(/^index\.\w+\.js\.map$/))
+    expect(files).toContainEqual(expect.stringMatching(/^index-\w+\.js\.map$/))
     expect(files).toContainEqual(
-      expect.stringMatching(/^my-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^my-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^my-shared-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^my-shared-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^possible-ts-output-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^possible-ts-output-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^worker-nested-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^worker-nested-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^sub-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^sub-worker-\w+\.js\.map$/)
     )
 
     // sourcemap should exist and have a data URL

--- a/playground/worker/__tests__/sourcemap-inline/sourcemap-inline-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/sourcemap-inline-worker.spec.ts
@@ -14,22 +14,20 @@ describe.runIf(isBuild)('build', () => {
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)
-    const worker = files.find((f) => /^my-worker\.\w+\.js$/.test(f))
+    const worker = files.find((f) => /^my-worker-\w+\.js$/.test(f))
     const workerContent = fs.readFileSync(
       path.resolve(assetsDir, worker),
       'utf-8'
     )
     const workerSourcemap = getSourceMapUrl(workerContent)
-    const sharedWorker = files.find((f) =>
-      /^my-shared-worker\.\w+\.js$/.test(f)
-    )
+    const sharedWorker = files.find((f) => /^my-shared-worker-\w+\.js$/.test(f))
     const sharedWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, sharedWorker),
       'utf-8'
     )
     const sharedWorkerSourcemap = getSourceMapUrl(sharedWorkerContent)
     const possibleTsOutputWorker = files.find((f) =>
-      /^possible-ts-output-worker\.\w+\.js$/.test(f)
+      /^possible-ts-output-worker-\w+\.js$/.test(f)
     )
     const possibleTsOutputWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, possibleTsOutputWorker),
@@ -39,7 +37,7 @@ describe.runIf(isBuild)('build', () => {
       possibleTsOutputWorkerContent
     )
     const workerNestedWorker = files.find((f) =>
-      /^worker-nested-worker\.\w+\.js$/.test(f)
+      /^worker-nested-worker-\w+\.js$/.test(f)
     )
     const workerNestedWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, workerNestedWorker),
@@ -48,7 +46,7 @@ describe.runIf(isBuild)('build', () => {
     const workerNestedWorkerSourcemap = getSourceMapUrl(
       workerNestedWorkerContent
     )
-    const subWorker = files.find((f) => /^sub-worker\.\w+\.js$/.test(f))
+    const subWorker = files.find((f) => /^sub-worker-\w+\.js$/.test(f))
     const subWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, subWorker),
       'utf-8'

--- a/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
@@ -13,22 +13,20 @@ describe.runIf(isBuild)('build', () => {
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)
-    const worker = files.find((f) => /^my-worker\.\w+\.js$/.test(f))
+    const worker = files.find((f) => /^my-worker-\w+\.js$/.test(f))
     const workerContent = fs.readFileSync(
       path.resolve(assetsDir, worker),
       'utf-8'
     )
     const workerSourcemap = getSourceMapUrl(workerContent)
-    const sharedWorker = files.find((f) =>
-      /^my-shared-worker\.\w+\.js$/.test(f)
-    )
+    const sharedWorker = files.find((f) => /^my-shared-worker-\w+\.js$/.test(f))
     const sharedWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, sharedWorker),
       'utf-8'
     )
     const sharedWorkerSourcemap = getSourceMapUrl(sharedWorkerContent)
     const possibleTsOutputWorker = files.find((f) =>
-      /^possible-ts-output-worker\.\w+\.js$/.test(f)
+      /^possible-ts-output-worker-\w+\.js$/.test(f)
     )
     const possibleTsOutputWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, possibleTsOutputWorker),
@@ -38,7 +36,7 @@ describe.runIf(isBuild)('build', () => {
       possibleTsOutputWorkerContent
     )
     const workerNestedWorker = files.find((f) =>
-      /^worker-nested-worker\.\w+\.js$/.test(f)
+      /^worker-nested-worker-\w+\.js$/.test(f)
     )
     const workerNestedWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, workerNestedWorker),
@@ -47,41 +45,41 @@ describe.runIf(isBuild)('build', () => {
     const workerNestedWorkerSourcemap = getSourceMapUrl(
       workerNestedWorkerContent
     )
-    const subWorker = files.find((f) => /^sub-worker\.\w+\.js$/.test(f))
+    const subWorker = files.find((f) => /^sub-worker-\w+\.js$/.test(f))
     const subWorkerContent = fs.readFileSync(
       path.resolve(assetsDir, subWorker),
       'utf-8'
     )
     const subWorkerSourcemap = getSourceMapUrl(subWorkerContent)
 
-    expect(files).toContainEqual(expect.stringMatching(/^index\.\w+\.js\.map$/))
+    expect(files).toContainEqual(expect.stringMatching(/^index-\w+\.js\.map$/))
     expect(files).toContainEqual(
-      expect.stringMatching(/^my-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^my-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^my-shared-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^my-shared-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^possible-ts-output-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^possible-ts-output-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^worker-nested-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^worker-nested-worker-\w+\.js\.map$/)
     )
     expect(files).toContainEqual(
-      expect.stringMatching(/^sub-worker\.\w+\.js\.map$/)
+      expect.stringMatching(/^sub-worker-\w+\.js\.map$/)
     )
 
     // sourcemap should exist and have a data URL
-    expect(indexSourcemap).toMatch(/^main-module\.\w+\.js\.map$/)
-    expect(workerSourcemap).toMatch(/^my-worker\.\w+\.js\.map$/)
-    expect(sharedWorkerSourcemap).toMatch(/^my-shared-worker\.\w+\.js\.map$/)
+    expect(indexSourcemap).toMatch(/^main-module-\w+\.js\.map$/)
+    expect(workerSourcemap).toMatch(/^my-worker-\w+\.js\.map$/)
+    expect(sharedWorkerSourcemap).toMatch(/^my-shared-worker-\w+\.js\.map$/)
     expect(possibleTsOutputWorkerSourcemap).toMatch(
-      /^possible-ts-output-worker\.\w+\.js\.map$/
+      /^possible-ts-output-worker-\w+\.js\.map$/
     )
     expect(workerNestedWorkerSourcemap).toMatch(
-      /^worker-nested-worker\.\w+\.js\.map$/
+      /^worker-nested-worker-\w+\.js\.map$/
     )
-    expect(subWorkerSourcemap).toMatch(/^sub-worker\.\w+\.js\.map$/)
+    expect(subWorkerSourcemap).toMatch(/^sub-worker-\w+\.js\.map$/)
 
     // worker should have all imports resolved and no exports
     expect(workerContent).not.toMatch(`import`)

--- a/playground/worker/vite.config-es.js
+++ b/playground/worker/vite.config-es.js
@@ -14,9 +14,9 @@ module.exports = vite.defineConfig({
     plugins: [vueJsx()],
     rollupOptions: {
       output: {
-        assetFileNames: 'assets/worker_asset.[name].[ext]',
-        chunkFileNames: 'assets/worker_chunk.[name].js',
-        entryFileNames: 'assets/worker_entry.[name].js'
+        assetFileNames: 'assets/worker_asset-[name].[ext]',
+        chunkFileNames: 'assets/worker_chunk-[name].js',
+        entryFileNames: 'assets/worker_entry-[name].js'
       }
     }
   },

--- a/playground/worker/vite.config-iife.js
+++ b/playground/worker/vite.config-iife.js
@@ -19,7 +19,7 @@ module.exports = vite.defineConfig({
             worker: {
               rollupOptions: {
                 output: {
-                  entryFileNames: 'assets/worker_entry.[name].js'
+                  entryFileNames: 'assets/worker_entry-[name].js'
                 }
               }
             }
@@ -29,10 +29,10 @@ module.exports = vite.defineConfig({
     ],
     rollupOptions: {
       output: {
-        assetFileNames: 'assets/worker_asset.[name].[ext]',
-        chunkFileNames: 'assets/worker_chunk.[name].js',
+        assetFileNames: 'assets/worker_asset-[name].[ext]',
+        chunkFileNames: 'assets/worker_chunk-[name].js',
         // should fix by config-test plugin
-        entryFileNames: 'assets/worker_.[name].js'
+        entryFileNames: 'assets/worker_-[name].js'
       }
     }
   },

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -14,9 +14,9 @@ module.exports = vite.defineConfig({
     plugins: [vueJsx()],
     rollupOptions: {
       output: {
-        assetFileNames: 'worker-assets/worker_asset.[name]-[hash].[ext]',
-        chunkFileNames: 'worker-chunks/worker_chunk.[name]-[hash].js',
-        entryFileNames: 'worker-entries/worker_entry.[name]-[hash].js'
+        assetFileNames: 'worker-assets/worker_asset-[name]-[hash].[ext]',
+        chunkFileNames: 'worker-chunks/worker_chunk-[name]-[hash].js',
+        entryFileNames: 'worker-entries/worker_entry-[name]-[hash].js'
       }
     }
   },

--- a/playground/worker/vite.config-sourcemap.js
+++ b/playground/worker/vite.config-sourcemap.js
@@ -20,9 +20,9 @@ module.exports = vite.defineConfig((sourcemap) => {
       plugins: [vueJsx()],
       rollupOptions: {
         output: {
-          assetFileNames: 'assets/[name].worker_asset[hash].[ext]',
-          chunkFileNames: 'assets/[name].worker_chunk[hash].js',
-          entryFileNames: 'assets/[name].worker_entry[hash].js'
+          assetFileNames: 'assets/[name]-worker_asset[hash].[ext]',
+          chunkFileNames: 'assets/[name]-worker_chunk[hash].js',
+          entryFileNames: 'assets/[name]-worker_entry[hash].js'
         }
       }
     },
@@ -33,9 +33,9 @@ module.exports = vite.defineConfig((sourcemap) => {
       sourcemap: sourcemap,
       rollupOptions: {
         output: {
-          assetFileNames: 'assets/[name].[hash].[ext]',
-          chunkFileNames: 'assets/[name].[hash].js',
-          entryFileNames: 'assets/[name].[hash].js'
+          assetFileNames: 'assets/[name]-[hash].[ext]',
+          chunkFileNames: 'assets/[name]-[hash].js',
+          entryFileNames: 'assets/[name]-[hash].js'
         }
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
       typescript: ^4.6.4
       unbuild: ^0.9.4
       vite: workspace:*
-      vitepress: ^1.0.0-alpha.28
+      vitepress: ^1.0.0-alpha.29
       vitest: ^0.25.1
       vue: ^3.2.45
     devDependencies:
@@ -120,7 +120,7 @@ importers:
       typescript: 4.6.4
       unbuild: 0.9.4
       vite: link:packages/vite
-      vitepress: 1.0.0-alpha.28
+      vitepress: 1.0.0-alpha.29
       vitest: 0.25.1
       vue: 3.2.45
 
@@ -8858,8 +8858,8 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vitepress/1.0.0-alpha.28:
-    resolution: {integrity: sha512-pvbLssDMgLUN1terajmPlFBxHSDGO4DqwexKbjFyr7LeELerVuwGrG6F2J1hxmwOlbpLd1kHXEDqGm9JX/kTDQ==}
+  /vitepress/1.0.0-alpha.29:
+    resolution: {integrity: sha512-oaRaeMLcN9M3Bxz97fFVF6Gzm3Aqtb0CijTt5TOW0XPzNPuKA0YpFnsmS97gdKmA+VztM6itRJ8K7JJuU0VS3g==}
     hasBin: true
     dependencies:
       '@docsearch/css': 3.3.0


### PR DESCRIPTION
### Description

Both rollup and esbuild use `[name]-[hash].[extname]` for their default chunk and asset file names. In Vite the default is `[name].[hash].[extname]` (for historical reasons according to Evan)

I think we should use the opportunity of Vite 4 to align with the closest tools in the ecosystem. @benmccann and @danielroe already said this would be fine with them. @matthewp @bluwy interested to know Astro's position. Given that `assetFileNames` and `chunkFileNames` are configurable, the ecosystem shouldn't be relying on our defaults, but there may be CI tests failures if there are regexes against the default like we had in Vite (cc @dominikg)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other