### PR TITLE
feat(resolve): support subpath imports

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -110,7 +110,7 @@
     "postcss-import": "^15.0.0",
     "postcss-load-config": "^4.0.1",
     "postcss-modules": "^5.0.0",
-    "resolve.exports": "^1.1.0",
+    "resolve.exports": "npm:@alloc/resolve.exports@^1.1.0",
     "sirv": "^2.0.2",
     "source-map-js": "^1.0.2",
     "source-map-support": "^0.5.21",

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -48,11 +48,7 @@ import {
   DEFAULT_MAIN_FIELDS,
   ENV_ENTRY
 } from './constants'
-import type {
-  InternalResolveOptions,
-  InternalResolveOptionsWithOverrideConditions,
-  ResolveOptions
-} from './plugins/resolve'
+import type { InternalResolveOptions, ResolveOptions } from './plugins/resolve'
 import { resolvePlugin, tryNodeResolve } from './plugins/resolve'
 import type { LogLevel, Logger } from './logger'
 import { createLogger } from './logger'
@@ -958,7 +954,7 @@ async function bundleConfigFile(
       {
         name: 'externalize-deps',
         setup(build) {
-          const options: InternalResolveOptionsWithOverrideConditions = {
+          const options: InternalResolveOptions = {
             root: path.dirname(fileName),
             isBuild: true,
             isProduction: true,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -968,7 +968,7 @@ async function bundleConfigFile(
             mainFields: [],
             browserField: false,
             conditions: [],
-            overrideConditions: ['node'],
+            overrideConditions: ['node', 'require'],
             dedupe: [],
             extensions: DEFAULT_EXTENSIONS,
             preserveSymlinks: false

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -141,7 +141,7 @@ export function loadNearestPackageData(
   lookupFile(startDir, ['package.json'], {
     pathOnly: true,
     predicate(pkgPath) {
-      importerPkg = loadPackageData(pkgPath, options)
+      importerPkg = loadPackageData(pkgPath, options?.preserveSymlinks)
       return !predicate || predicate(importerPkg)
     }
   })

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -163,3 +163,40 @@ export function watchPackageDataPlugin(config: ResolvedConfig): Plugin {
     }
   }
 }
+
+export function findPackageJson(dir: string): string | null {
+  // Stop looking at node_modules directory.
+  if (path.basename(dir) === 'node_modules') {
+    return null
+  }
+  const pkgPath = path.join(dir, 'package.json')
+  if (fs.existsSync(pkgPath)) {
+    return pkgPath
+  }
+  const parentDir = path.dirname(dir)
+  return parentDir !== dir ? findPackageJson(parentDir) : null
+}
+
+const workspaceRootFiles = ['lerna.json', 'pnpm-workspace.yaml', '.git']
+
+export function isWorkspaceRoot(
+  dir: string,
+  preserveSymlinks?: boolean,
+  packageCache?: PackageCache
+): boolean {
+  const files = fs.readdirSync(dir)
+  if (files.some((file) => workspaceRootFiles.includes(file))) {
+    return true // Found a lerna/pnpm workspace or git repository.
+  }
+  if (files.includes('package.json')) {
+    const workspacePkg = loadPackageData(
+      path.join(dir, 'package.json'),
+      preserveSymlinks,
+      packageCache
+    )
+    if (workspacePkg?.data.workspaces) {
+      return true // Found a npm/yarn workspace.
+    }
+  }
+  return false
+}

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -579,21 +579,19 @@ function tryResolveFile(
   }
 }
 
-export type InternalResolveOptionsWithOverrideConditions =
-  InternalResolveOptions & {
-    /**
-     * @deprecated In future, `conditions` will work like this.
-     * @internal
-     */
-    overrideConditions?: string[]
-  }
+export interface InternalNodeResolveOptions extends InternalResolveOptions {
+  /**
+   * When defined, only conditions defined in this array will be used.
+   */
+  overrideConditions?: string[]
+}
 
 export const idToPkgMap = new Map<string, PackageData>()
 
 export function tryNodeResolve(
   id: string,
   importer: string | null | undefined,
-  options: InternalResolveOptionsWithOverrideConditions,
+  options: InternalNodeResolveOptions,
   targetWeb: boolean,
   depsOptimizer?: DepsOptimizer,
   ssr?: boolean,
@@ -1053,7 +1051,7 @@ function resolveDeepImport(
     data
   }: PackageData,
   targetWeb: boolean,
-  options: InternalResolveOptionsWithOverrideConditions
+  options: InternalNodeResolveOptions
 ): string | undefined {
   const cache = getResolvedCache(id, targetWeb)
   if (cache) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1038,7 +1038,14 @@ function packageEntryFailure(id: string, details?: string) {
 }
 
 function getInlineConditions(conditions: string[], targetWeb: boolean) {
-  return targetWeb && !conditions.includes('node') ? ['browser'] : ['node']
+  const inlineConditions =
+    targetWeb && !conditions.includes('node') ? ['browser'] : ['node']
+
+  // The "module" condition is no longer recommended, but some older
+  // packages may still use it.
+  inlineConditions.push('module')
+
+  return inlineConditions
 }
 
 function resolveDeepImport(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1099,6 +1099,19 @@ function resolveDeepImport(
       getInlineConditions(options, targetWeb),
       options.overrideConditions
     )
+    if (postfix) {
+      if (possibleFiles.length) {
+        possibleFiles = possibleFiles.map((f) => f + postfix)
+      } else {
+        possibleFiles = resolveExports(
+          data,
+          file + postfix,
+          options,
+          getInlineConditions(options, targetWeb),
+          options.overrideConditions
+        )
+      }
+    }
     if (!possibleFiles.length) {
       throw new Error(
         `Package subpath '${file}' is not defined by "exports" in ` +
@@ -1108,7 +1121,7 @@ function resolveDeepImport(
   } else if (targetWeb && options.browserField && isObject(browserField)) {
     const mapped = mapWithBrowserField(file, browserField)
     if (mapped) {
-      possibleFiles = [mapped]
+      possibleFiles = [mapped + postfix]
     } else if (mapped === false) {
       return (webResolvedImports[id] = browserExternalId)
     }
@@ -1127,7 +1140,6 @@ function resolveDeepImport(
         ))
     )
     if (resolved) {
-      resolved += postfix
       isDebug &&
         debug(
           `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -144,3 +144,12 @@ test('resolve package that contains # in path', async () => {
     '[success]'
   )
 })
+
+// Support this so we can add symlinks to local directories without
+// creating a package.json file (and because Node.js also supports
+// this).
+test('unpackaged modules in node_modules', async () => {
+  expect(await page.textContent('.unpackaged-file')).toMatch('[success]')
+  expect(await page.textContent('.unpackaged-index-file')).toMatch('[success]')
+  expect(await page.textContent('.unpackaged-deep-import')).toMatch('[success]')
+})

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -121,6 +121,15 @@
 <h2>resolve package that contains # in path</h2>
 <p class="path-contains-sharp-symbol"></p>
 
+<h2>unpackaged file in node_modules</h2>
+<p class="unpackaged-file"></p>
+
+<h2>index file from unpackaged directory in node_modules</h2>
+<p class="unpackaged-index-file"></p>
+
+<h2>deep import of unpackaged directory in node_modules</h2>
+<p class="unpackaged-deep-import"></p>
+
 <script type="module">
   import '@generated-content-virtual-file'
   function text(selector, text) {
@@ -277,6 +286,15 @@
 
   import es5Ext from 'es5-ext'
   text('.path-contains-sharp-symbol', '[success]')
+
+  import unpackagedFile from 'pr-9170/unpackaged-file'
+  text('.unpackaged-file', unpackagedFile)
+
+  import unpackagedIndexFile from 'pr-9170/unpackaged-index-file'
+  text('.unpackaged-index-file', unpackagedIndexFile)
+
+  import unpackagedDeepImport from 'pr-9170/unpackaged-deep-import'
+  text('.unpackaged-deep-import', unpackagedDeepImport)
 </script>
 
 <style>

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -12,6 +12,7 @@
     "@babel/runtime": "^7.20.1",
     "es5-ext": "0.10.62",
     "normalize.css": "^8.0.1",
+    "pr-9170": "link:./pr-9170/node_modules/pr-9170",
     "require-pkg-with-module-field": "link:./require-pkg-with-module-field",
     "resolve-browser-field": "link:./browser-field",
     "resolve-browser-module-field1": "link:./browser-module-field1",

--- a/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-deep-import.js
+++ b/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-deep-import.js
@@ -1,0 +1,1 @@
+export default '[success]'

--- a/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-file.js
+++ b/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-file.js
@@ -1,0 +1,1 @@
+export { default } from 'unpackaged-file'

--- a/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-index-file/index.js
+++ b/playground/resolve/pr-9170/node_modules/pr-9170/unpackaged-index-file/index.js
@@ -1,0 +1,1 @@
+export default '[success]'

--- a/playground/resolve/pr-9170/node_modules/unpackaged-file.js
+++ b/playground/resolve/pr-9170/node_modules/unpackaged-file.js
@@ -1,0 +1,1 @@
+export default '[success]'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -896,6 +896,7 @@ importers:
       '@babel/runtime': ^7.20.1
       es5-ext: 0.10.62
       normalize.css: ^8.0.1
+      pr-9170: link:./pr-9170/node_modules/pr-9170
       require-pkg-with-module-field: link:./require-pkg-with-module-field
       resolve-browser-field: link:./browser-field
       resolve-browser-module-field1: link:./browser-module-field1
@@ -911,6 +912,7 @@ importers:
       '@babel/runtime': 7.20.1
       es5-ext: 0.10.62
       normalize.css: 8.0.1
+      pr-9170: link:pr-9170/node_modules/pr-9170
       require-pkg-with-module-field: link:require-pkg-with-module-field
       resolve-browser-field: link:browser-field
       resolve-browser-module-field1: link:browser-module-field1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,7 +260,7 @@ importers:
       postcss-load-config: ^4.0.1
       postcss-modules: ^5.0.0
       resolve: ^1.22.1
-      resolve.exports: ^1.1.0
+      resolve.exports: npm:@alloc/resolve.exports@^1.1.0
       rollup: ~3.3.0
       sirv: ^2.0.2
       source-map-js: ^1.0.2
@@ -323,7 +323,7 @@ importers:
       postcss-import: 15.0.0_postcss@8.4.19
       postcss-load-config: 4.0.1_postcss@8.4.19
       postcss-modules: 5.0.0_postcss@8.4.19
-      resolve.exports: 1.1.0
+      resolve.exports: /@alloc/resolve.exports/1.1.0
       sirv: 2.0.2
       source-map-js: 1.0.2
       source-map-support: 0.5.21
@@ -1418,6 +1418,11 @@ packages:
       '@algolia/cache-common': 4.13.1
       '@algolia/logger-common': 4.13.1
       '@algolia/requester-common': 4.13.1
+    dev: true
+
+  /@alloc/resolve.exports/1.1.0:
+    resolution: {integrity: sha512-daZJ4gBXxPUgjWjtxRp+5mU9tV6k7cSG2iKFyiPZOTxRzMRFPEe8dcTuqP+zIVSTfFpN1/SCIOMMYeYA7GwQvQ==}
+    engines: {node: '>=10'}
     dev: true
 
   /@ampproject/remapping/2.2.0:
@@ -7771,11 +7776,6 @@ packages:
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
-
-  /resolve.exports/1.1.0:
-    resolution: {integrity: sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==}
-    engines: {node: '>=10'}
-    dev: true
 
   /resolve/1.17.0:
     resolution: {integrity: sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==}


### PR DESCRIPTION
# ⚠️ Merge #9170 before this

### Description

This uses `resolveExports` to resolve [subpath imports](https://nodejs.org/api/packages.html#subpath-imports). To do so, it has to replace the leading `#` with `./` to mimic an `exports` mapping field. With each path returned by `resolveExports`, we call `this.resolve` to support mapping to external packages (the Node.js docs say this is valid).

⚠️  Since this PR currently contains commits from other PRs, I suggest looking at https://github.com/vitejs/vite/pull/10929/commits/b3ef8f33c8c52cbe6e845b2e18ace7ace0ffd3ca specifically if you want to review this.

### Additional context

Closes #7385

**TODO:** Write tests or copy them over from #7770

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
