### PR TITLE
chore: emit .d.cts files

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -13,7 +13,10 @@
   "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/node/index.d.ts",
+      "types": {
+        "import": "./dist/node/index.d.ts",
+        "require": "./dist/node-cjs/index.d.cts"
+      },
       "import": "./dist/node/index.js",
       "require": "./index.cjs"
     },
@@ -46,12 +49,13 @@
     "dev": "rimraf dist && pnpm run build-bundle -w",
     "build": "rimraf dist && run-s build-bundle build-types",
     "build-bundle": "rollup --config rollup.config.ts --configPlugin typescript",
-    "build-types": "run-s build-types-temp build-types-pre-patch build-types-roll build-types-post-patch build-types-check",
+    "build-types": "run-s build-types-temp build-types-pre-patch build-types-roll build-types-post-patch build-types-check build-emit-cjs-types",
     "build-types-temp": "tsc --emitDeclarationOnly --outDir temp/node -p src/node",
     "build-types-pre-patch": "tsx scripts/prePatchTypes.ts",
     "build-types-roll": "api-extractor run && rimraf temp",
     "build-types-post-patch": "tsx scripts/postPatchTypes.ts",
     "build-types-check": "tsc --project tsconfig.check.json",
+    "build-emit-cjs-types": "tsx scripts/emitCjsTypes.ts",
     "lint": "eslint --cache --ext .ts src/**",
     "format": "prettier --write --cache --parser typescript \"src/**/*.ts\"",
     "prepublishOnly": "npm run build"

--- a/packages/vite/scripts/emitCjsTypes.ts
+++ b/packages/vite/scripts/emitCjsTypes.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import glob from 'fast-glob'
+import * as lexer from 'es-module-lexer'
+import colors from 'picocolors'
+
+async function main() {
+  const typeFiles = await glob('**/*.d.ts', {
+    cwd: 'dist',
+    absolute: true
+  })
+
+  for (const file of typeFiles) {
+    let text = fs.readFileSync(file, 'utf8')
+
+    const [imports] = lexer.parse(text)
+    for (const i of [...imports].reverse()) {
+      let id = i.n
+      if (!id || !/^\.\.?(?:\/|$)/.test(id)) {
+        continue
+      }
+
+      const importedFile = path.resolve(path.dirname(file), id)
+      if (isDirectory(importedFile)) {
+        id += '/index'
+      }
+
+      const cjsModuleSpec = id + '.cjs'
+      text = text.slice(0, i.s) + cjsModuleSpec + text.slice(i.e)
+    }
+
+    const outFile = file
+      .replace('/node/', '/node-cjs/')
+      .replace(/\.ts$/, '.cts')
+
+    fs.mkdirSync(path.dirname(outFile), { recursive: true })
+    fs.writeFileSync(outFile, text)
+  }
+
+  console.log(colors.green(colors.bold(`emitted CJS types`)))
+}
+
+function isDirectory(file: string) {
+  try {
+    return fs.statSync(file).isDirectory()
+  } catch (e) {
+    return false
+  }
+}
+
+main()

--- a/packages/vite/scripts/emitCjsTypes.ts
+++ b/packages/vite/scripts/emitCjsTypes.ts
@@ -14,9 +14,14 @@ async function main() {
     let text = fs.readFileSync(file, 'utf8')
 
     const [imports] = lexer.parse(text)
-    for (const i of [...imports].reverse()) {
+    const typeImports = parseTypeImports(text, true)
+    const allImports = [...imports, ...typeImports]
+      // In reverse order
+      .sort((a, b) => b.s - a.s)
+
+    for (const i of allImports) {
       let id = i.n
-      if (!id || !/^\.\.?(?:\/|$)/.test(id)) {
+      if (!id || !/^\.\.?(?:\/|$)/.test(id) || id.endsWith('.cjs')) {
         continue
       }
 
@@ -46,6 +51,46 @@ function isDirectory(file: string) {
   } catch (e) {
     return false
   }
+}
+
+// This assumes no each import/export statement is on its own line.
+function parseTypeImports(code: string, exportsOnly?: boolean) {
+  const imports = []
+
+  const openKeywords = exportsOnly ? ['export'] : ['import', 'export']
+  const openPattern = [['', '\n'], openKeywords, ['type']]
+  const fromPattern = [['from'], ['"', "'"]]
+
+  let cursor = 0
+  let pattern = openPattern
+  let patternIndex = 0
+
+  const words = code.split(/([\w/\-@.]+|\n)/g)
+  for (let i = 0; i < words.length; i++) {
+    const word = words[i].replace(/ /g, '')
+    if (pattern[patternIndex].includes(word)) {
+      if (++patternIndex === pattern.length) {
+        patternIndex = 0
+        if (pattern === openPattern) {
+          pattern = fromPattern
+        } else if (pattern === fromPattern) {
+          pattern = openPattern
+          const moduleSpecifier = words[i + 1]
+          const start = cursor + words[i].length
+          imports.push({
+            s: start,
+            e: start + moduleSpecifier.length,
+            n: moduleSpecifier
+          })
+        }
+      }
+    } else if (patternIndex > 0 && word) {
+      patternIndex = 0
+    }
+    cursor += words[i].length
+  }
+
+  return imports
 }
 
 main()


### PR DESCRIPTION
### Description

This will allow CJS projects using `moduleResolution: node16` to import Vite.

It copies the types from `dist/node` into `dist/node-cjs`, changing file extension from `.d.ts` to `.d.cts` and rewriting relative imports to include `.cjs` suffix.

<s>It only does this on `pnpm build`.</s>

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
