### PR TITLE
chore: use isArray to check array

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -533,7 +533,7 @@ export async function resolveConfig(
 
   const assetsFilter =
     config.assetsInclude &&
-    (!(config.assetsInclude instanceof Array) || config.assetsInclude.length)
+    (!Array.isArray(config.assetsInclude) || config.assetsInclude.length)
       ? createFilter(config.assetsInclude)
       : () => false
 


### PR DESCRIPTION
Use `Array.isArray` instead of `instanceof Array` from #10941