### PR TITLE
fix: adjust vue plugin peer dependencies so it is usable with v4

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/vitejs/vite/tree/main/packages/plugin-vue#readme",
   "peerDependencies": {
-    "vite": "^3.0.0",
+    "vite": "^3.0.0 || ^4.0.0",
     "vue": "^3.2.25"
   },
   "devDependencies": {


### PR DESCRIPTION
Using

```
"@vitejs/plugin-vue": "4.0.0-alpha.0",
"vite": "4.0.0-alpha.3",
```
you get:
```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer vite@"^3.0.0" from @vitejs/plugin-vue@4.0.0-alpha.0
npm ERR! node_modules/@vitejs/plugin-vue
npm ERR!   dev @vitejs/plugin-vue@"4.0.0-alpha.0" from the root project
```