### PR TITLE
chore: filter the empty value in envPrefix and don't throw error when envPrefix includes ''

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -192,16 +192,16 @@ describe('resolveEnvPrefix', () => {
     expect(resolveEnvPrefix(config)).toMatchObject(['VITE_'])
   })
 
-  test(`throw error if envPrefix contains ''`, () => {
+  test(`filter '' if envPrefix contains ''`, () => {
     let config: UserConfig = { envPrefix: '' }
-    expect(() => resolveEnvPrefix(config)).toThrow()
+    expect(resolveEnvPrefix(config)).toMatchObject([])
     config = { envPrefix: ['', 'CUSTOM_'] }
-    expect(() => resolveEnvPrefix(config)).toThrow()
+    expect(resolveEnvPrefix(config)).toMatchObject(['CUSTOM_'])
   })
 
   test('should work correctly for valid envPrefix value', () => {
     const config: UserConfig = { envPrefix: [' ', 'CUSTOM_'] }
-    expect(resolveEnvPrefix(config)).toMatchObject([' ', 'CUSTOM_'])
+    expect(resolveEnvPrefix(config)).toMatchObject(['CUSTOM_'])
   })
 })
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -495,7 +495,7 @@ export async function resolveConfig(
     : resolvedRoot
   const userEnv =
     inlineConfig.envFile !== false &&
-    loadEnv(mode, envDir, resolveEnvPrefix(config))
+    loadEnv(mode, envDir, resolveEnvPrefix(config, logger))
 
   // Note it is possible for user to have a custom mode, e.g. `staging` where
   // production-like behavior is expected. This is indicated by NODE_ENV=production

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -495,7 +495,7 @@ export async function resolveConfig(
     : resolvedRoot
   const userEnv =
     inlineConfig.envFile !== false &&
-    loadEnv(mode, envDir, resolveEnvPrefix(config, logger))
+    loadEnv(mode, envDir, resolveEnvPrefix(config, logger), logger)
 
   // Note it is possible for user to have a custom mode, e.g. `staging` where
   // production-like behavior is expected. This is indicated by NODE_ENV=production

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -3,6 +3,7 @@ import dotenv from 'dotenv'
 import dotenvExpand from 'dotenv-expand'
 import { arraify, lookupFile } from './utils'
 import type { UserConfig } from './config'
+import type { Logger } from './logger'
 
 export function loadEnv(
   mode: string,
@@ -77,14 +78,15 @@ export function loadEnv(
   return env
 }
 
-export function resolveEnvPrefix({
-  envPrefix = 'VITE_'
-}: UserConfig): string[] {
-  envPrefix = arraify(envPrefix)
-  if (envPrefix.some((prefix) => prefix === '')) {
-    throw new Error(
+export function resolveEnvPrefix(
+  { envPrefix = 'VITE_' }: UserConfig,
+  logger?: Logger
+): string[] {
+  envPrefix = arraify(envPrefix).map((prefix) => prefix.trim())
+  if (logger && envPrefix.some((prefix) => prefix === '')) {
+    logger.warn(
       `envPrefix option contains value '', which could lead unexpected exposure of sensitive information.`
     )
   }
-  return envPrefix
+  return envPrefix.filter((prefix) => !!prefix)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

filter the empty value of `envPrefix` in `resolveEnvPrefix` function
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
