### PR TITLE
refactor: import version from rollup

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -30,9 +30,9 @@ SOFTWARE.
 */
 
 import fs from 'node:fs'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
-import { createRequire } from 'node:module'
+import { VERSION as rollupVersion } from 'rollup'
 import type {
   AsyncPluginHooks,
   CustomPluginOptions,
@@ -173,18 +173,9 @@ export async function createPluginContainer(
 
   const watchFiles = new Set<string>()
 
-  // TODO: use import()
-  const _require = createRequire(import.meta.url)
-
-  // get rollup version
-  const rollupPkgPath = resolve(
-    _require.resolve('rollup'),
-    '../../package.json'
-  )
   const minimalContext: MinimalPluginContext = {
     meta: {
-      rollupVersion: JSON.parse(fs.readFileSync(rollupPkgPath, 'utf-8'))
-        .version,
+      rollupVersion,
       watchMode: true
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
rollup exports `VERSION` variable. So changed to use that instead of reading `package.json` manually.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
