### PR TITLE
fix: relocated logger to respect config. (#10787)

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { InlineConfig } from '..'
-import type { UserConfig, UserConfigExport } from '../config'
+import type { PluginOption, UserConfig, UserConfigExport } from '../config'
 import { resolveConfig } from '../config'
 import { resolveEnvPrefix } from '../env'
 import { mergeConfig } from '../publicUtils'
@@ -264,5 +264,53 @@ describe('preview config', () => {
     expect(await resolveConfig(config, 'serve')).toMatchObject({
       preview: previewConfig()
     })
+  })
+})
+
+describe('resolveConfig', () => {
+  const keepScreenMergePlugin = (): PluginOption => {
+    return {
+      name: 'vite-plugin-keep-screen-merge',
+      config() {
+        return { clearScreen: false }
+      }
+    }
+  }
+
+  const keepScreenOverridePlugin = (): PluginOption => {
+    return {
+      name: 'vite-plugin-keep-screen-override',
+      config(config) {
+        config.clearScreen = false
+      }
+    }
+  }
+
+  test('plugin merges `clearScreen` option', async () => {
+    const config1: InlineConfig = { plugins: [keepScreenMergePlugin()] }
+    const config2: InlineConfig = {
+      plugins: [keepScreenMergePlugin()],
+      clearScreen: true
+    }
+
+    const results1 = await resolveConfig(config1, 'build')
+    const results2 = await resolveConfig(config2, 'build')
+
+    expect(results1.clearScreen).toBe(false)
+    expect(results2.clearScreen).toBe(false)
+  })
+
+  test('plugin overrides `clearScreen` option', async () => {
+    const config1: InlineConfig = { plugins: [keepScreenOverridePlugin()] }
+    const config2: InlineConfig = {
+      plugins: [keepScreenOverridePlugin()],
+      clearScreen: true
+    }
+
+    const results1 = await resolveConfig(config1, 'build')
+    const results2 = await resolveConfig(config2, 'build')
+
+    expect(results1.clearScreen).toBe(false)
+    expect(results2.clearScreen).toBe(false)
   })
 })

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -408,12 +408,6 @@ export async function resolveConfig(
     }
   }
 
-  // Define logger
-  const logger = createLogger(config.logLevel, {
-    allowClearScreen: config.clearScreen,
-    customLogger: config.customLogger
-  })
-
   // user config may provide an alternative mode. But --mode has a higher priority
   mode = inlineConfig.mode || config.mode || mode
   configEnv.mode = mode
@@ -456,6 +450,12 @@ export async function resolveConfig(
     config.build ??= {}
     config.build.commonjsOptions = { include: [] }
   }
+
+  // Define logger
+  const logger = createLogger(config.logLevel, {
+    allowClearScreen: config.clearScreen,
+    customLogger: config.customLogger
+  })
 
   // resolve root
   const resolvedRoot = normalizePath(


### PR DESCRIPTION
back-porting fix https://github.com/vitejs/vite/pull/10787 as not being able to configure the logger via plugins is a major blocker for us in v3