### PR TITLE
feat: let user plugins add plugins in `config` hook

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1129,10 +1129,10 @@ async function runConfigHook(
     (p.config && ('handler' in p.config ? p.config.order : p.enforce)) || null
 
   const isEligible = (p: Plugin, order: typeof orders[number]) => {
-    if (calledPlugins.has(p)) {
+    if (!p.config) {
       return false
     }
-    if (!p.config) {
+    if (calledPlugins.has(p)) {
       return false
     }
     return orders.indexOf(enforce(p)) <= orders.indexOf(order)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1115,8 +1115,8 @@ async function runConfigHook(
   const callConfigHandler = async (plugin: Plugin) => {
     calledPlugins.add(plugin)
     const handler =
-      plugin.config && 'handler' in plugin.config
-        ? plugin.config.handler!
+      typeof plugin.config !== 'function'
+        ? plugin.config!.handler!
         : plugin.config!
 
     const result = await handler(config, configEnv)
@@ -1130,6 +1130,10 @@ async function runConfigHook(
 
   const isEligible = (p: Plugin, order: typeof orders[number]) => {
     if (!p.config) {
+      return false
+    }
+    const handler = typeof p.config !== 'function' ? p.config.handler : p.config
+    if (!handler) {
       return false
     }
     if (calledPlugins.has(p)) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1166,11 +1166,19 @@ export function transformStableResult(
   }
 }
 
-export async function asyncFlatten<T>(arr: T[]): Promise<T[]> {
+type FlatAwaited<T> = Exclude<
+  Awaited<T extends readonly (infer U)[] ? U : T>,
+  readonly any[]
+>
+
+export async function asyncFlatten<T>(
+  arr: readonly T[]
+): Promise<FlatAwaited<T>[]> {
+  let flatArr: any[]
   do {
-    arr = (await Promise.all(arr)).flat(Infinity) as any
+    flatArr = (await Promise.all(arr)).flat(Infinity)
   } while (arr.some((v: any) => v?.then))
-  return arr
+  return flatArr
 }
 
 // strip UTF-8 BOM

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1174,10 +1174,10 @@ type FlatAwaited<T> = Exclude<
 export async function asyncFlatten<T>(
   arr: readonly T[]
 ): Promise<FlatAwaited<T>[]> {
-  let flatArr: any[]
+  let flatArr = arr as any[]
   do {
-    flatArr = (await Promise.all(arr)).flat(Infinity)
-  } while (arr.some((v: any) => v?.then))
+    flatArr = (await Promise.all(flatArr)).flat(Infinity)
+  } while (flatArr.some((v: any) => v?.then))
   return flatArr
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Todo: Explain stuff

Todo: Support `worker.plugins`

---

**New public utils**

This PR also adds a few helper functions for Vite plugin arrays:
- `flattenVitePlugins`
  Encapsulates the `asyncFlatten` call with plugin filtering based on `apply` and truthiness
- `sortVitePlugins`
  Sort a plugin array in-place using the `enforce` property of each plugin
- `splitVitePlugins`
  Split a plugin array into 3 arrays: pre, normal, post

Back when I originally implemented this, these helper functions were something I needed in Saus, but not anymore, so we can make them private if you think that's best.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

