### PR TITLE
feat(css): upgrade postcss-modules

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -1576,13 +1576,6 @@ Repository: https://github.com/http-party/node-http-proxy.git
 
 ---------------------------------------
 
-## icss-replace-symbols
-License: ISC
-By: Glen Maddern
-Repository: git+https://github.com/css-modules/icss-replace-symbols.git
-
----------------------------------------
-
 ## icss-utils
 License: ISC
 By: Glen Maddern

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -109,7 +109,7 @@
     "picomatch": "^2.3.1",
     "postcss-import": "^15.0.0",
     "postcss-load-config": "^4.0.1",
-    "postcss-modules": "^5.0.0",
+    "postcss-modules": "^6.0.0",
     "resolve.exports": "^1.1.0",
     "sirv": "^2.0.2",
     "source-map-js": "^1.0.2",

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -916,9 +916,9 @@ async function compileCSS(
             modulesOptions.getJSON(cssFileName, _modules, outputFileName)
           }
         },
-        async resolve(id: string) {
+        async resolve(id: string, importer: string) {
           for (const key of getCssResolversKeys(atImportResolvers)) {
-            const resolved = await atImportResolvers[key](id)
+            const resolved = await atImportResolvers[key](id, importer)
             if (resolved) {
               return path.resolve(resolved)
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,7 +258,7 @@ importers:
       postcss: ^8.4.19
       postcss-import: ^15.0.0
       postcss-load-config: ^4.0.1
-      postcss-modules: ^5.0.0
+      postcss-modules: ^6.0.0
       resolve: ^1.22.1
       resolve.exports: ^1.1.0
       rollup: ~3.3.0
@@ -322,7 +322,7 @@ importers:
       picomatch: 2.3.1
       postcss-import: 15.0.0_postcss@8.4.19
       postcss-load-config: 4.0.1_postcss@8.4.19
-      postcss-modules: 5.0.0_postcss@8.4.19
+      postcss-modules: 6.0.0_postcss@8.4.19
       resolve.exports: 1.1.0
       sirv: 2.0.2
       source-map-js: 1.0.2
@@ -1217,6 +1217,9 @@ importers:
       tailwindcss: ^3.2.4
     dependencies:
       tailwindcss: 3.2.4
+
+  playground/transform-plugin:
+    specifiers: {}
 
   playground/tsconfig-json:
     specifiers: {}
@@ -5751,10 +5754,6 @@ packages:
     dev: true
     optional: true
 
-  /icss-replace-symbols/1.1.0:
-    resolution: {integrity: sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg==}
-    dev: true
-
   /icss-utils/5.1.0_postcss@8.4.19:
     resolution: {integrity: sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==}
     engines: {node: ^10 || ^12 || >= 14}
@@ -7313,13 +7312,13 @@ packages:
       postcss: 8.4.19
     dev: true
 
-  /postcss-modules/5.0.0_postcss@8.4.19:
-    resolution: {integrity: sha512-rGvpTDOM3//3Ysn3Xtvhzaj8ab984wKCpP02TEF559tLbUjNay3RQDpPxb7BREmfBtJm3/1WbQOZ7fSXwYLZ/w==}
+  /postcss-modules/6.0.0_postcss@8.4.19:
+    resolution: {integrity: sha512-7DGfnlyi/ju82BRzTIjWS5C4Tafmzl3R79YP/PASiocj+aa6yYphHhhKUOEoXQToId5rgyFgJ88+ccOUydjBXQ==}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
       generic-names: 4.0.0
-      icss-replace-symbols: 1.1.0
+      icss-utils: 5.1.0_postcss@8.4.19
       lodash.camelcase: 4.3.0
       postcss: 8.4.19
       postcss-modules-extract-imports: 3.0.0_postcss@8.4.19


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Upgrades the css-modules postcss plugin to the latest version. The upgrade is a major version but the change is not breaking in behavior (as far as I can tell) but an API change where this second argument is passed in to the `resolve` options. I passed the new `importer` argument to the vite resolvers, since that seems to be more correct HOWEVER, if we are very afraid of potential behavior changes i can ignore the option and fully ensure the change doesn't change anything

Beyond this option there are upgrades to the CSS module helpers that bring it's behavior up to date with other CSS module implementations (e.g. webpack's css-loader). Specifically Vite does not replace `@value` references in selectors when it should.

### Additional context

I am trying to build a proper [astroturf](https://github.com/astroturfcss/astroturf) plugin which depends on the selector replacement of CSS modules

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
