### PR TITLE
fix(html): transform relative path with long base in /index.html

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import {
   asyncFlatten,
@@ -9,6 +10,7 @@ import {
   isFileReadable,
   isWindows,
   posToNumber,
+  processSrcSetSync,
   resolveHostname,
   shouldServe
 } from '../utils'
@@ -269,4 +271,16 @@ describe('isFileReadable', () => {
       fs.chmodSync(testFile, '644')
     })
   }
+})
+
+describe('processSrcSetSync', () => {
+  test('replace srcset with base url /base/', async () => {
+    const devBase = '/base/'
+    expect(
+      processSrcSetSync(
+        './nested/asset.png 1x, ./nested/asset.png 2x',
+        ({ url }) => path.posix.join(devBase, url)
+      )
+    ).toBe('/base/nested/asset.png 1x, /base/nested/asset.png 2x')
+  })
 })

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -274,7 +274,7 @@ describe('isFileReadable', () => {
 })
 
 describe('processSrcSetSync', () => {
-  test('replace srcset with base url /base/', async () => {
+  test('prepend base URL to srcset', async () => {
     const devBase = '/base/'
     expect(
       processSrcSetSync(

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -105,7 +105,7 @@ const processNodeUrl = (
     // #10990 config.base './' or '' will be changed to `/` in dev mode
     // this function is only run in dev mode and config.base is always to be an absolute path.
     // we needn't handle config.base './' or ''
-    const replacer = (url: string) => path.posix.join(devBase, url.slice(1))
+    const replacer = (url: string) => path.posix.join(devBase, url)
 
     // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets
     // path will add `/a/` prefix, it will caused 404.

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -102,12 +102,7 @@ const processNodeUrl = (
     originalUrl !== '/' &&
     htmlPath === '/index.html'
   ) {
-    const replacer = (url: string) =>
-      path.posix.join(
-        devBase,
-        path.posix.relative(originalUrl, devBase),
-        url.slice(1)
-      )
+    const replacer = (url: string) => path.posix.join(devBase, url.slice(1))
 
     // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets
     // path will add `/a/` prefix, it will caused 404.

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -102,6 +102,9 @@ const processNodeUrl = (
     originalUrl !== '/' &&
     htmlPath === '/index.html'
   ) {
+    // #10990 config.base './' or '' will be changed to `/` in dev mode
+    // this function is only run in dev mode and config.base is always to be an absolute path.
+    // we needn't handle config.base './' or ''
     const replacer = (url: string) => path.posix.join(devBase, url.slice(1))
 
     // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -94,7 +94,7 @@ const processNodeUrl = (
   const devBase = config.base
   if (startsWithSingleSlashRE.test(url)) {
     // prefix with base (dev only, base is never relative)
-    const fullUrl = joinUrlSegments(devBase, url)
+    const fullUrl = path.posix.join(devBase, url)
     overwriteAttrValue(s, sourceCodeLocation, fullUrl)
   } else if (
     url.startsWith('.') &&
@@ -102,9 +102,7 @@ const processNodeUrl = (
     originalUrl !== '/' &&
     htmlPath === '/index.html'
   ) {
-    // #10990 config.base './' or '' will be changed to `/` in dev mode
-    // this function is only run in dev mode and config.base is always to be an absolute path.
-    // we needn't handle config.base './' or ''
+    // prefix with base (dev only, base is never relative)
     const replacer = (url: string) => path.posix.join(devBase, url)
 
     // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix: #10989

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I found that the url replacer function is not correctly replace the url.
```ts
  const replacer = (url: string) =>
    path.posix.join(
      devBase,
      path.posix.relative(originalUrl, devBase),
      url.slice(1)
    )
```
when the devBase is `/a/b/c`
originalUrl ` /a/b/c/d/e`
path.posix.relative(originalUrl, devBase) will be ` '../..'`
so `./src/mian.ts` will be change to `/a/src/main.ts`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
