### PR TITLE
fix!: make `NODE_ENV` more predictable

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -452,7 +452,12 @@ export async function build(
 async function doBuild(
   inlineConfig: InlineConfig = {}
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
-  const config = await resolveConfig(inlineConfig, 'build', 'production')
+  const config = await resolveConfig(
+    inlineConfig,
+    'build',
+    'production',
+    'production'
+  )
   const options = config.build
   const ssr = !!options.ssr
   const libOptions = options.lib

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -242,8 +242,7 @@ cli
             configFile: options.config,
             logLevel: options.logLevel
           },
-          'build',
-          'development'
+          'build'
         )
         await optimizeDeps(config, options.force, true)
       } catch (e) {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -372,21 +372,17 @@ export type ResolveFn = (
 export async function resolveConfig(
   inlineConfig: InlineConfig,
   command: 'build' | 'serve',
-  defaultMode = 'development'
+  defaultMode = 'development',
+  defaultNodeEnv = 'development'
 ): Promise<ResolvedConfig> {
   let config = inlineConfig
   let configFileDependencies: string[] = []
   let mode = inlineConfig.mode || defaultMode
 
   // some dependencies e.g. @vue/compiler-* relies on NODE_ENV for getting
-  // production-specific behavior, so set it here even though we haven't
-  // resolve the final mode yet
-  if (mode === 'production') {
-    process.env.NODE_ENV = 'production'
-  }
-  // production env would not work in serve, fallback to development
-  if (command === 'serve' && process.env.NODE_ENV === 'production') {
-    process.env.NODE_ENV = 'development'
+  // production-specific behavior, so set it early on
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = defaultNodeEnv
   }
 
   const configEnv = {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -76,7 +76,12 @@ export type PreviewServerHook = (
 export async function preview(
   inlineConfig: InlineConfig = {}
 ): Promise<PreviewServer> {
-  const config = await resolveConfig(inlineConfig, 'serve', 'production')
+  const config = await resolveConfig(
+    inlineConfig,
+    'serve',
+    'production',
+    'production'
+  )
 
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -310,7 +310,7 @@ export interface ResolvedServerUrls {
 export async function createServer(
   inlineConfig: InlineConfig = {}
 ): Promise<ViteDevServer> {
-  const config = await resolveConfig(inlineConfig, 'serve', 'development')
+  const config = await resolveConfig(inlineConfig, 'serve')
   const { root, server: serverConfig } = config
   const httpsOptions = await resolveHttpsConfig(config.server.https)
   const { middlewareMode } = serverConfig

--- a/playground/json/server.js
+++ b/playground/json/server.js
@@ -3,7 +3,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 const express = require('express')
 
-const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+const isTest = process.env.VITEST
 
 async function createServer(
   root = process.cwd(),

--- a/playground/legacy/__tests__/client-and-ssr/serve.ts
+++ b/playground/legacy/__tests__/client-and-ssr/serve.ts
@@ -8,17 +8,8 @@ export const port = ports['legacy/client-and-ssr']
 export async function serve(): Promise<{ close(): Promise<void> }> {
   const { build } = await import('vite')
 
-  // In a CLI app it is possible that you may run `build` several times one after another
-  // For example, you may want to override an option specifically for the SSR build
-  // And you may have a CLI app built for that purpose to make a more concise API
-  // An unexpected behaviour is for the plugin-legacy to override the process.env.NODE_ENV value
-  // And any build after the first client build that called plugin-legacy will misbehave and
-  // build with process.env.NODE_ENV=production, rather than your CLI's env: NODE_ENV=myWhateverEnv my-cli-app build
-  // The issue is with plugin-legacy's index.ts file not explicitly passing mode: process.env.NODE_ENV to vite's build function
-  // This causes vite to call resolveConfig with defaultMode = 'production' and mutate process.env.NODE_ENV to 'production'
-
   await build({
-    mode: process.env.NODE_ENV,
+    mode: 'test',
     root: rootDir,
     logLevel: 'silent',
     build: {
@@ -28,7 +19,7 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
   })
 
   await build({
-    mode: process.env.NODE_ENV,
+    mode: 'test',
     root: rootDir,
     logLevel: 'silent',
     build: {

--- a/playground/optimize-missing-deps/server.js
+++ b/playground/optimize-missing-deps/server.js
@@ -3,7 +3,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 const express = require('express')
 
-const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+const isTest = process.env.VITEST
 
 async function createServer(root = process.cwd(), hmrPort) {
   const resolve = (p) => path.resolve(__dirname, p)

--- a/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -102,7 +102,9 @@ test('msg from external using external entry', async () => {
 
 test('msg from linked no external', async () => {
   await page.goto(url)
-  expect(await page.textContent('.linked-no-external')).toMatch('Hello World!')
+  expect(await page.textContent('.linked-no-external')).toMatch(
+    `Hello World from ${process.env.NODE_ENV}!`
+  )
 })
 
 test('msg from linked no external', async () => {

--- a/playground/ssr-deps/linked-no-external/index.js
+++ b/playground/ssr-deps/linked-no-external/index.js
@@ -1,5 +1,7 @@
 export const hello = function () {
   // make sure linked package is not externalized so Vite features like
   // import.meta.env works (or handling TS files)
-  return import.meta.env.DEV && 'Hello World!'
+  return `Hello World from ${
+    import.meta.env.DEV ? 'development' : 'production'
+  }!`
 }

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -6,7 +6,7 @@ import express from 'express'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+const isTest = process.env.VITEST
 
 export async function createServer(root = process.cwd(), hmrPort) {
   const resolve = (p) => path.resolve(__dirname, p)

--- a/playground/ssr-deps/src/app.js
+++ b/playground/ssr-deps/src/app.js
@@ -79,7 +79,7 @@ export async function render(url, rootDir) {
   html += `\n<p class="external-using-external-entry">message from external-using-external-entry: ${externalUsingExternalEntryMessage}</p>`
 
   const linkedNoExternalMessage = linkedNoExternal()
-  html += `\n<p class="linked-no-external">message from linked-no-external: ${linkedNoExternalMessage}</p>`
+  html += `\n<p class="linked-no-external">linked-no-external msg: ${linkedNoExternalMessage}</p>`
 
   html += `\n<p class="dep-virtual">message from dep-virtual: ${virtualMessage}</p>`
 

--- a/playground/ssr-html/server.js
+++ b/playground/ssr-html/server.js
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import express from 'express'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+const isTest = process.env.VITEST
 
 const DYNAMIC_SCRIPTS = `
   <script type="module">

--- a/playground/ssr-pug/server.js
+++ b/playground/ssr-pug/server.js
@@ -6,7 +6,7 @@ import express from 'express'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+const isTest = process.env.VITEST
 
 const DYNAMIC_SCRIPTS = `
   <script type="module">

--- a/playground/ssr-react/server.js
+++ b/playground/ssr-react/server.js
@@ -5,7 +5,7 @@ import express from 'express'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+const isTest = process.env.VITEST
 
 process.env.MY_CUSTOM_SECRET = 'API_KEY_qwertyuiop'
 

--- a/playground/ssr-vue/server.js
+++ b/playground/ssr-vue/server.js
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import express from 'express'
 
-const isTest = process.env.NODE_ENV === 'test' || !!process.env.VITE_TEST_BUILD
+const isTest = process.env.VITEST
 
 export async function createServer(
   root = process.cwd(),

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -9,6 +9,10 @@ const DIR = path.join(os.tmpdir(), 'vitest_playwright_global_setup')
 let browserServer: BrowserServer | undefined
 
 export async function setup(): Promise<void> {
+  process.env.NODE_ENV = process.env.VITE_TEST_BUILD
+    ? 'production'
+    : 'development'
+
   browserServer = await chromium.launchServer({
     headless: !process.env.VITE_DEBUG_SERVE,
     args: process.env.CI


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Make the value of `NODE_ENV` more predictable

### Additional context

This was discussed in https://github.com/vitejs/vite/discussions/9274

The one intricacy in implementing was related to running tests. When the first test runs Vite will set a value for NODE_ENV and then Vite will no longer reset the value on subsequent tests, so I had to handle that in the tests themselves. That's unlikely to affect our users though, so I think this is still a good trade-off. E.g. when Playwright runs the Vite server in the tests, it will do so in a sub-process, which I think would isolate each server process from one another.

There was a comment in one of the tests about `plugin-legacy` that I deleted as it appears to be outdated. Had it not been outdated, I think fixing `plugin-legacy` would have been the better approach than making Vite adhere to the behavior of a single plugin, but that appears no longer relevant.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
