### PR TITLE
fix: handle .htm as same as .html (fix #10997)

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -210,7 +210,10 @@ async function handleMessage(payload: HMRPayload) {
     }
     case 'full-reload':
       notifyListeners('vite:beforeFullReload', payload)
-      if (payload.path && payload.path.endsWith('.html')) {
+      if (
+        payload.path &&
+        (payload.path.endsWith('.html') || payload.path.endsWith('.htm'))
+      ) {
         // if html file is edited, only reload the page if the browser is
         // currently on that page.
         const pagePath = decodeURI(location.pathname)

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -482,7 +482,11 @@ async function doBuild(
     ? resolve(options.ssr)
     : options.rollupOptions?.input || resolve('index.html')
 
-  if (ssr && typeof input === 'string' && input.endsWith('.html')) {
+  if (
+    ssr &&
+    typeof input === 'string' &&
+    (input.endsWith('.html') || input.endsWith('.htm'))
+  ) {
     throw new Error(
       `rollupOptions.input should not be an html file when building for SSR. ` +
         `Please specify a dedicated SSR entry.`

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -29,7 +29,7 @@ type ResolveIdOptions = Parameters<PluginContainer['resolveId']>[2]
 
 const debug = createDebugger('vite:deps')
 
-const htmlTypesRE = /\.(html|vue|svelte|astro|imba)$/
+const htmlTypesRE = /\.(html|htm|vue|svelte|astro|imba)$/
 
 // A simple regex to detect import sources. This is only used on
 // <script lang="ts"> blocks in vue (setup only) or svelte files, since
@@ -278,7 +278,7 @@ function esbuildScanPlugin(
           let raw = fs.readFileSync(path, 'utf-8')
           // Avoid matching the content of the comment
           raw = raw.replace(commentRE, '<!---->')
-          const isHtml = path.endsWith('.html')
+          const isHtml = path.endsWith('.html') || path.endsWith('.htm')
           const regex = isHtml ? scriptModuleRE : scriptRE
           regex.lastIndex = 0
           let js = ''

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -314,6 +314,7 @@ async function fileToBuiltUrl(
     config.build.lib ||
     (!file.endsWith('.svg') &&
       !file.endsWith('.html') &&
+      !file.endsWith('.htm') &&
       content.length < Number(config.build.assetsInlineLimit) &&
       !isGitLfsPlaceholder(content))
   ) {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -298,7 +298,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:build-html',
 
     async transform(html, id) {
-      if (id.endsWith('.html')) {
+      if (isHTMLRequest(id)) {
         const relativeUrlPath = path.posix.relative(
           config.root,
           normalizePath(id)

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -223,7 +223,10 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       // relative
       if (
         id.startsWith('.') ||
-        ((preferRelative || importer?.endsWith('.html')) && /^\w/.test(id))
+        ((preferRelative ||
+          importer?.endsWith('.html') ||
+          importer?.endsWith('.htm')) &&
+          /^\w/.test(id))
       ) {
         const basedir = importer ? path.dirname(importer) : process.cwd()
         const fsPath = path.resolve(basedir, id)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -103,7 +103,7 @@ export async function handleHMRUpdate(
 
   if (!hmrContext.modules.length) {
     // html file cannot be hot updated
-    if (file.endsWith('.html')) {
+    if (file.endsWith('.html') || file.endsWith('.htm')) {
       config.logger.info(colors.green(`page reload `) + colors.dim(shortFile), {
         clear: true,
         timestamp: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #10997.
This will add support parsing .htm file as same as .html.
When there are both index.html and index.html, only index.html is loaded.

### Additional context

I changed the .html file extension conditions in various files, so I might have changed some extreme conditions. Can you confirm that these changes are correct?
Also, according to #10997, it has unexported `htmlLangRE` and found [`isHTMLRequest(request: string): boolean`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/html.ts#L56-L57) to test with the regex, but `isHTMLRequest` is only used in [`/packages/vite/src/node/plugins/define.ts:110-118`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/define.ts#L110-L118) and has the normalized name like other functions. Should we use it to check the extension of HTML files?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
