### PR TITLE
refactor(client): simplify fetchUpdate code

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -94,7 +94,8 @@ if (import.meta.hot) {
   import.meta.hot.accept(
     ['./foo.js', './bar.js'],
     ([newFooModule, newBarModule]) => {
-      // the callback receives the updated modules in an Array
+      // The callback receives an array where only the updated module is non null
+      // If the update was not succeful (syntax error for ex.), the array is empty
     }
   )
 }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -525,10 +525,10 @@ export function createHotContext(ownerPath: string): ViteHotContext {
     accept(deps?: any, callback?: any) {
       if (typeof deps === 'function' || !deps) {
         // self-accept: hot.accept(() => {})
-        acceptDeps([ownerPath], ([mod]) => deps && deps(mod))
+        acceptDeps([ownerPath], ([mod]) => deps?.(mod))
       } else if (typeof deps === 'string') {
         // explicit deps
-        acceptDeps([deps], ([mod]) => callback && callback(mod))
+        acceptDeps([deps], ([mod]) => callback?.(mod))
       } else if (Array.isArray(deps)) {
         acceptDeps(deps, callback)
       } else {
@@ -538,8 +538,8 @@ export function createHotContext(ownerPath: string): ViteHotContext {
 
     // export names (first arg) are irrelevant on the client side, they're
     // extracted in the server for propagation
-    acceptExports(_: string | readonly string[], callback?: any) {
-      acceptDeps([ownerPath], callback && (([mod]) => callback(mod)))
+    acceptExports(_, callback) {
+      acceptDeps([ownerPath], ([mod]) => callback?.(mod))
     },
 
     dispose(cb) {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -425,12 +425,12 @@ async function fetchUpdate({
   if (isSelfUpdate || qualifiedCallbacks.length > 0) {
     const disposer = disposeMap.get(acceptedPath)
     if (disposer) await disposer(dataMap.get(acceptedPath))
-    const [path, query] = acceptedPath.split(`?`)
+    const [acceptedPathWithoutQuery, query] = acceptedPath.split(`?`)
     try {
       const newMod: ModuleNamespace = await import(
         /* @vite-ignore */
         base +
-          path.slice(1) +
+          acceptedPathWithoutQuery.slice(1) +
           `?${explicitImportRequired ? 'import&' : ''}t=${timestamp}${
             query ? `&${query}` : ''
           }`

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -423,10 +423,9 @@ async function fetchUpdate({
   )
 
   if (isSelfUpdate || qualifiedCallbacks.length > 0) {
-    const dep = acceptedPath
-    const disposer = disposeMap.get(dep)
-    if (disposer) await disposer(dataMap.get(dep))
-    const [path, query] = dep.split(`?`)
+    const disposer = disposeMap.get(acceptedPath)
+    if (disposer) await disposer(dataMap.get(acceptedPath))
+    const [path, query] = acceptedPath.split(`?`)
     try {
       const newMod: ModuleNamespace = await import(
         /* @vite-ignore */
@@ -436,9 +435,9 @@ async function fetchUpdate({
             query ? `&${query}` : ''
           }`
       )
-      moduleMap.set(dep, newMod)
+      moduleMap.set(acceptedPath, newMod)
     } catch (e) {
-      warnFailedFetch(e, dep)
+      warnFailedFetch(e, acceptedPath)
     }
   }
 

--- a/packages/vite/types/hot.d.ts
+++ b/packages/vite/types/hot.d.ts
@@ -15,10 +15,9 @@ export interface ViteHotContext {
     cb: (mods: Array<ModuleNamespace | undefined>) => void
   ): void
 
-  acceptExports(exportNames: string | readonly string[]): void
   acceptExports(
     exportNames: string | readonly string[],
-    cb: (mod: ModuleNamespace | undefined) => void
+    cb?: (mod: ModuleNamespace | undefined) => void
   ): void
 
   dispose(cb: (data: any) => void): void


### PR DESCRIPTION
I spend few hours understanding the logic of the client and wanted to cleanup some inconsistency before sending a PR to update the hot.accept API.

Each commit is independant.

The main fix to me is the drop of the `moduleMap` that introduced me in error at the beginning. Thanks @patak-dev for [this comment](https://github.com/vitejs/vite/pull/9881#pullrequestreview-1088668923)!

Re: https://github.com/vitejs/vite/pull/7475#discussion_r835782237

This is technically breaking is people when doing calling noop decline method, but that's a good thing we're in alpha!