### PR TITLE
docs: adds CLI section in guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -186,6 +186,10 @@ export default defineConfig({
               link: '/guide/features'
             },
             {
+              text: 'CLI',
+              link: '/guide/cli'
+            },
+            {
               text: 'Using Plugins',
               link: '/guide/using-plugins'
             },

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -115,9 +115,9 @@ vite preview [root]
 | `--strictPort`           | Exit if specified port is already in use (`boolean`) |
 | `--https`                | Use TLS + HTTP/2 (`boolean`)                         |
 | `--open [path]`          | Open browser on startup (`boolean \| string`)        |
-| `--outDir <dir>`         | Output directory (default: `dist`)(`string`)           |
+| `--outDir <dir>`         | Output directory (default: `dist`)(`string`)         |
 | `-c, --config <file>`    | Use specified config file (`string`)                 |
-| `--base <path>`          | Public base path (default: `/`) (`string`)             |
+| `--base <path>`          | Public base path (default: `/`) (`string`)           |
 | `-l, --logLevel <level>` | Info \| warn \| error \| silent (`string`)           |
 | `--clearScreen`          | Allow/disable clear screen when logging (`boolean`)  |
 | `-d, --debug [feat]`     | Show debug logs (`string \| boolean`)                |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,7 +1,3 @@
----
-title: Command Line Interface | Guide
----
-
 # Command Line Interface
 
 ## Dev server
@@ -19,19 +15,19 @@ vite [root]
 #### Options
 
 | Options                  |                                                                 |
-| ------------------------ | --------------------------------------------------------------- | ------------------------------- | ----- | ------ |
+| ------------------------ | --------------------------------------------------------------- |
 | `--host [host]`          | [string] specify hostname                                       |
 | `--port <port>`          | [number] specify port                                           |
 | `--https`                | [boolean] use TLS + HTTP/2                                      |
-| `--open [path]`          | [boolean \\                                                     | string] open browser on startup |
+| `--open [path]`          | [boolean \| string] open browser on startup                     |
 | `--cors`                 | [boolean] enable CORS                                           |
 | `--strictPort`           | [boolean] exit if specified port is already in use              |
 | `--force`                | [boolean] force the optimizer to ignore the cache and re-bundle |
 | `-c, --config <file>`    | [string] use specified config file                              |
 | `--base <path>`          | [string] public base path (default: `/`)                        |
-| `-l, --logLevel <level>` | [string] info                                                   | warn                            | error | silent |
+| `-l, --logLevel <level>` | [string] info \| warn \| error \| silent                        |
 | `--clearScreen`          | [boolean] allow/disable clear screen when logging               |
-| `-d, --debug [feat]`     | [string \\                                                      | boolean] show debug logs        |
+| `-d, --debug [feat]`     | [string \| boolean] show debug logs                             |
 | `-f, --filter <filter>`  | [string] filter debug logs                                      |
 | `-m, --mode <mode>`      | [string] set env mode                                           |
 | `-h, --help`             | Display available CLI options                                   |
@@ -51,28 +47,28 @@ vite build [root]
 
 #### Options
 
-| Options                        |                                                                                |
-| ------------------------------ | ------------------------------------------------------------------------------ | -------------------------------- | --------------------------------------------------------------------------------------- | ------ |
-| `--target <target>`            | [string] transpile target (default: `'modules'`)                               |
-| `--outDir <dir>`               | [string] output directory (default: `dist`)                                    |
-| `--assetsDir <dir>`            | [string] directory under outDir to place assets in (default: `assets`)         |
-| `--assetsInlineLimit <number>` | [number] static asset base64 inline threshold in bytes (default: `4096`)       |
-| `--ssr [entry]`                | [string] build specified entry for server-side rendering                       |
-| `--sourcemap`                  | [boolean] output source maps for build (default: `false`)                      |
-| `--minify [minifier]`          | [boolean \\                                                                    | "terser"                         | "esbuild"] enable/disable minification, or specify minifier to use (default: `esbuild`) |
-| `--manifest [name]`            | [boolean \\                                                                    | string] emit build manifest json |
-| `--ssrManifest [name]`         | [boolean \\                                                                    | string] emit ssr manifest json   |
-| `--force`                      | [boolean] force the optimizer to ignore the cache and re-bundle (experimental) |
-| `--emptyOutDir`                | [boolean] force empty outDir when it's outside of root                         |
-| `-w, --watch`                  | [boolean] rebuilds when modules have changed on disk                           |
-| `-c, --config <file>`          | [string] use specified config file                                             |
-| `--base <path>`                | [string] public base path (default: `/`)                                       |
-| `-l, --logLevel <level>`       | [string] info                                                                  | warn                             | error                                                                                   | silent |
-| `--clearScreen`                | [boolean] allow/disable clear screen when logging                              |
-| `-d, --debug [feat]`           | [string \\                                                                     | boolean] show debug logs         |
-| `-f, --filter <filter>`        | [string] filter debug logs                                                     |
-| `-m, --mode <mode>`            | [string] set env mode                                                          |
-| `-h, --help`                   | Display available CLI options                                                  |
+| Options                        |                                                                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `--target <target>`            | [string] transpile target (default: `'modules'`)                                                                |
+| `--outDir <dir>`               | [string] output directory (default: `dist`)                                                                     |
+| `--assetsDir <dir>`            | [string] directory under outDir to place assets in (default: `assets`)                                          |
+| `--assetsInlineLimit <number>` | [number] static asset base64 inline threshold in bytes (default: `4096`)                                        |
+| `--ssr [entry]`                | [string] build specified entry for server-side rendering                                                        |
+| `--sourcemap`                  | [boolean] output source maps for build (default: `false`)                                                       |
+| `--minify [minifier]`          | [boolean \| "terser" \| "esbuild"] enable/disable minification, or specify minifier to use (default: `esbuild`) |
+| `--manifest [name]`            | [boolean \| string] emit build manifest json                                                                    |
+| `--ssrManifest [name]`         | [boolean \| string] emit ssr manifest json                                                                      |
+| `--force`                      | [boolean] force the optimizer to ignore the cache and re-bundle (experimental)                                  |
+| `--emptyOutDir`                | [boolean] force empty outDir when it's outside of root                                                          |
+| `-w, --watch`                  | [boolean] rebuilds when modules have changed on disk                                                            |
+| `-c, --config <file>`          | [string] use specified config file                                                                              |
+| `--base <path>`                | [string] public base path (default: `/`)                                                                        |
+| `-l, --logLevel <level>`       | [string] info \| warn \| error \| silent                                                                        |
+| `--clearScreen`                | [boolean] allow/disable clear screen when logging                                                               |
+| `-d, --debug [feat]`           | [string \| boolean] show debug logs                                                                             |
+| `-f, --filter <filter>`        | [string] filter debug logs                                                                                      |
+| `-m, --mode <mode>`            | [string] set env mode                                                                                           |
+| `-h, --help`                   | Display available CLI options                                                                                   |
 
 ## Others
 
@@ -89,13 +85,13 @@ vite optimize [root]
 #### Options
 
 | Options                  |                                                                 |
-| ------------------------ | --------------------------------------------------------------- | ------------------------ | ----- | ------ |
+| ------------------------ | --------------------------------------------------------------- |
 | `--force`                | [boolean] force the optimizer to ignore the cache and re-bundle |
 | `-c, --config <file>`    | [string] use specified config file                              |
 | `--base <path>`          | [string] public base path (default: `/`)                        |
-| `-l, --logLevel <level>` | [string] info                                                   | warn                     | error | silent |
+| `-l, --logLevel <level>` | [string] info \| warn \| error \| silent                        |
 | `--clearScreen`          | [boolean] allow/disable clear screen when logging               |
-| `-d, --debug [feat]`     | [string \\                                                      | boolean] show debug logs |
+| `-d, --debug [feat]`     | [string \| boolean] show debug logs                             |
 | `-f, --filter <filter>`  | [string] filter debug logs                                      |
 | `-m, --mode <mode>`      | [string] set env mode                                           |
 | `-h, --help`             | Display available CLI options                                   |
@@ -113,18 +109,18 @@ vite preview [root]
 #### Options
 
 | Options                  |                                                    |
-| ------------------------ | -------------------------------------------------- | ------------------------------- | ----- | ------ |
+| ------------------------ | -------------------------------------------------- |
 | `--host [host]`          | [string] specify hostname                          |
 | `--port <port>`          | [number] specify port                              |
 | `--strictPort`           | [boolean] exit if specified port is already in use |
 | `--https`                | [boolean] use TLS + HTTP/2                         |
-| `--open [path]`          | [boolean                                           | string] open browser on startup |
+| `--open [path]`          | [boolean \| string] open browser on startup        |
 | `--outDir <dir>`         | [string] output directory (default: dist)          |
 | `-c, --config <file>`    | [string] use specified config file                 |
 | `--base <path>`          | [string] public base path (default: /)             |
-| `-l, --logLevel <level>` | [string] info                                      | warn                            | error | silent |
+| `-l, --logLevel <level>` | [string] info \| warn \| error \| silent           |
 | `--clearScreen`          | [boolean] allow/disable clear screen when logging  |
-| `-d, --debug [feat]`     | [string                                            | boolean] show debug logs        |
+| `-d, --debug [feat]`     | [string \| boolean] show debug logs                |
 | `-f, --filter <filter>`  | [string] filter debug logs                         |
 | `-m, --mode <mode>`      | [string] set env mode                              |
 | `-h, --help`             | Display available CLI options                      |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -14,24 +14,24 @@ vite [root]
 
 #### Options
 
-| Options                  |                                                                 |
-| ------------------------ | --------------------------------------------------------------- |
-| `--host [host]`          | [string] specify hostname                                       |
-| `--port <port>`          | [number] specify port                                           |
-| `--https`                | [boolean] use TLS + HTTP/2                                      |
-| `--open [path]`          | [boolean \| string] open browser on startup                     |
-| `--cors`                 | [boolean] enable CORS                                           |
-| `--strictPort`           | [boolean] exit if specified port is already in use              |
-| `--force`                | [boolean] force the optimizer to ignore the cache and re-bundle |
-| `-c, --config <file>`    | [string] use specified config file                              |
-| `--base <path>`          | [string] public base path (default: `/`)                        |
-| `-l, --logLevel <level>` | [string] info \| warn \| error \| silent                        |
-| `--clearScreen`          | [boolean] allow/disable clear screen when logging               |
-| `-d, --debug [feat]`     | [string \| boolean] show debug logs                             |
-| `-f, --filter <filter>`  | [string] filter debug logs                                      |
-| `-m, --mode <mode>`      | [string] set env mode                                           |
-| `-h, --help`             | Display available CLI options                                   |
-| `-v, --version`          | Display version number                                          |
+| Options                  |                                                                   |
+| ------------------------ | ----------------------------------------------------------------- |
+| `--host [host]`          | Specify hostname (`string`)                                       |
+| `--port <port>`          | Specify port (`number`)                                           |
+| `--https`                | Use TLS + HTTP/2 (`boolean`)                                      |
+| `--open [path]`          | Open browser on startup (`boolean \| string`)                     |
+| `--cors`                 | Enable CORS (`boolean`)                                           |
+| `--strictPort`           | Exit if specified port is already in use (`boolean`)              |
+| `--force`                | Force the optimizer to ignore the cache and re-bundle (`boolean`) |
+| `-c, --config <file>`    | Use specified config file (`string`)                              |
+| `--base <path>`          | Public base path (default: `/`) (`string`)                        |
+| `-l, --logLevel <level>` | Info \| warn \| error \| silent (`string`)                        |
+| `--clearScreen`          | Allow/disable clear screen when logging (`boolean`)               |
+| `-d, --debug [feat]`     | Show debug logs (`string \| boolean`)                             |
+| `-f, --filter <filter>`  | Filter debug logs (`string`)                                      |
+| `-m, --mode <mode>`      | Set env mode (`string`)                                           |
+| `-h, --help`             | Display available CLI options                                     |
+| `-v, --version`          | Display version number                                            |
 
 ## Build
 
@@ -47,28 +47,28 @@ vite build [root]
 
 #### Options
 
-| Options                        |                                                                                                                 |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `--target <target>`            | [string] transpile target (default: `'modules'`)                                                                |
-| `--outDir <dir>`               | [string] output directory (default: `dist`)                                                                     |
-| `--assetsDir <dir>`            | [string] directory under outDir to place assets in (default: `assets`)                                          |
-| `--assetsInlineLimit <number>` | [number] static asset base64 inline threshold in bytes (default: `4096`)                                        |
-| `--ssr [entry]`                | [string] build specified entry for server-side rendering                                                        |
-| `--sourcemap`                  | [boolean] output source maps for build (default: `false`)                                                       |
-| `--minify [minifier]`          | [boolean \| "terser" \| "esbuild"] enable/disable minification, or specify minifier to use (default: `esbuild`) |
-| `--manifest [name]`            | [boolean \| string] emit build manifest json                                                                    |
-| `--ssrManifest [name]`         | [boolean \| string] emit ssr manifest json                                                                      |
-| `--force`                      | [boolean] force the optimizer to ignore the cache and re-bundle (experimental)                                  |
-| `--emptyOutDir`                | [boolean] force empty outDir when it's outside of root                                                          |
-| `-w, --watch`                  | [boolean] rebuilds when modules have changed on disk                                                            |
-| `-c, --config <file>`          | [string] use specified config file                                                                              |
-| `--base <path>`                | [string] public base path (default: `/`)                                                                        |
-| `-l, --logLevel <level>`       | [string] info \| warn \| error \| silent                                                                        |
-| `--clearScreen`                | [boolean] allow/disable clear screen when logging                                                               |
-| `-d, --debug [feat]`           | [string \| boolean] show debug logs                                                                             |
-| `-f, --filter <filter>`        | [string] filter debug logs                                                                                      |
-| `-m, --mode <mode>`            | [string] set env mode                                                                                           |
-| `-h, --help`                   | Display available CLI options                                                                                   |
+| Options                        |                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `--target <target>`            | Transpile target (default: `'modules'`) (`string`)                                                                  |
+| `--outDir <dir>`               | Output directory (default: `dist`) (`string`)                                                                       |
+| `--assetsDir <dir>`            | Directory under outDir to place assets in (default: `"assets"`) (`string`)                                          |
+| `--assetsInlineLimit <number>` | Static asset base64 inline threshold in bytes (default: `4096`) (`number`)                                          |
+| `--ssr [entry]`                | Build specified entry for server-side rendering (`string`)                                                          |
+| `--sourcemap`                  | Output source maps for build (default: `false`) (`boolean`)                                                         |
+| `--minify [minifier]`          | Enable/disable minification, or specify minifier to use (default: `"esbuild"`) (`boolean \| "terser" \| "esbuild"`) |
+| `--manifest [name]`            | Emit build manifest json (`boolean \| string`)                                                                      |
+| `--ssrManifest [name]`         | Emit ssr manifest json (`boolean \| string`)                                                                        |
+| `--force`                      | Force the optimizer to ignore the cache and re-bundle (experimental)(`boolean`)                                     |
+| `--emptyOutDir`                | Force empty outDir when it's outside of root (`boolean`)                                                            |
+| `-w, --watch`                  | Rebuilds when modules have changed on disk (`boolean`)                                                              |
+| `-c, --config <file>`          | Use specified config file (`string`)                                                                                |
+| `--base <path>`                | Public base path (default: `/`) (`string`)                                                                          |
+| `-l, --logLevel <level>`       | Info \| warn \| error \| silent (`string`)                                                                          |
+| `--clearScreen`                | Allow/disable clear screen when logging (`boolean`)                                                                 |
+| `-d, --debug [feat]`           | Show debug logs (`string \| boolean`)                                                                               |
+| `-f, --filter <filter>`        | Filter debug logs (`string`)                                                                                        |
+| `-m, --mode <mode>`            | Set env mode (`string`)                                                                                             |
+| `-h, --help`                   | Display available CLI options                                                                                       |
 
 ## Others
 
@@ -84,17 +84,17 @@ vite optimize [root]
 
 #### Options
 
-| Options                  |                                                                 |
-| ------------------------ | --------------------------------------------------------------- |
-| `--force`                | [boolean] force the optimizer to ignore the cache and re-bundle |
-| `-c, --config <file>`    | [string] use specified config file                              |
-| `--base <path>`          | [string] public base path (default: `/`)                        |
-| `-l, --logLevel <level>` | [string] info \| warn \| error \| silent                        |
-| `--clearScreen`          | [boolean] allow/disable clear screen when logging               |
-| `-d, --debug [feat]`     | [string \| boolean] show debug logs                             |
-| `-f, --filter <filter>`  | [string] filter debug logs                                      |
-| `-m, --mode <mode>`      | [string] set env mode                                           |
-| `-h, --help`             | Display available CLI options                                   |
+| Options                  |                                                                   |
+| ------------------------ | ----------------------------------------------------------------- |
+| `--force`                | Force the optimizer to ignore the cache and re-bundle (`boolean`) |
+| `-c, --config <file>`    | Use specified config file (`string`)                              |
+| `--base <path>`          | Public base path (default: `/`) (`string`)                        |
+| `-l, --logLevel <level>` | Info \| warn \| error \| silent (`string`)                        |
+| `--clearScreen`          | Allow/disable clear screen when logging (`boolean`)               |
+| `-d, --debug [feat]`     | Show debug logs (`string \| boolean`)                             |
+| `-f, --filter <filter>`  | Filter debug logs (`string`)                                      |
+| `-m, --mode <mode>`      | Set env mode (`string`)                                           |
+| `-h, --help`             | Display available CLI options                                     |
 
 ### `vite preview`
 
@@ -108,19 +108,19 @@ vite preview [root]
 
 #### Options
 
-| Options                  |                                                    |
-| ------------------------ | -------------------------------------------------- |
-| `--host [host]`          | [string] specify hostname                          |
-| `--port <port>`          | [number] specify port                              |
-| `--strictPort`           | [boolean] exit if specified port is already in use |
-| `--https`                | [boolean] use TLS + HTTP/2                         |
-| `--open [path]`          | [boolean \| string] open browser on startup        |
-| `--outDir <dir>`         | [string] output directory (default: dist)          |
-| `-c, --config <file>`    | [string] use specified config file                 |
-| `--base <path>`          | [string] public base path (default: /)             |
-| `-l, --logLevel <level>` | [string] info \| warn \| error \| silent           |
-| `--clearScreen`          | [boolean] allow/disable clear screen when logging  |
-| `-d, --debug [feat]`     | [string \| boolean] show debug logs                |
-| `-f, --filter <filter>`  | [string] filter debug logs                         |
-| `-m, --mode <mode>`      | [string] set env mode                              |
-| `-h, --help`             | Display available CLI options                      |
+| Options                  |                                                      |
+| ------------------------ | ---------------------------------------------------- |
+| `--host [host]`          | Specify hostname (`string`)                          |
+| `--port <port>`          | Specify port (`number`)                              |
+| `--strictPort`           | Exit if specified port is already in use (`boolean`) |
+| `--https`                | Use TLS + HTTP/2 (`boolean`)                         |
+| `--open [path]`          | Open browser on startup (`boolean \| string`)        |
+| `--outDir <dir>`         | Output directory (default: dist)(`string`)           |
+| `-c, --config <file>`    | Use specified config file (`string`)                 |
+| `--base <path>`          | Public base path (default: /) (`string`)             |
+| `-l, --logLevel <level>` | Info \| warn \| error \| silent (`string`)           |
+| `--clearScreen`          | Allow/disable clear screen when logging (`boolean`)  |
+| `-d, --debug [feat]`     | Show debug logs (`string \| boolean`)                |
+| `-f, --filter <filter>`  | Filter debug logs (`string`)                         |
+| `-m, --mode <mode>`      | Set env mode (`string`)                              |
+| `-h, --help`             | Display available CLI options                        |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -49,7 +49,7 @@ vite build [root]
 
 | Options                        |                                                                                                                     |
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `--target <target>`            | Transpile target (default: `'modules'`) (`string`)                                                                  |
+| `--target <target>`            | Transpile target (default: `"modules"`) (`string`)                                                                  |
 | `--outDir <dir>`               | Output directory (default: `dist`) (`string`)                                                                       |
 | `--assetsDir <dir>`            | Directory under outDir to place assets in (default: `"assets"`) (`string`)                                          |
 | `--assetsInlineLimit <number>` | Static asset base64 inline threshold in bytes (default: `4096`) (`number`)                                          |
@@ -115,9 +115,9 @@ vite preview [root]
 | `--strictPort`           | Exit if specified port is already in use (`boolean`) |
 | `--https`                | Use TLS + HTTP/2 (`boolean`)                         |
 | `--open [path]`          | Open browser on startup (`boolean \| string`)        |
-| `--outDir <dir>`         | Output directory (default: dist)(`string`)           |
+| `--outDir <dir>`         | Output directory (default: `dist`)(`string`)           |
 | `-c, --config <file>`    | Use specified config file (`string`)                 |
-| `--base <path>`          | Public base path (default: /) (`string`)             |
+| `--base <path>`          | Public base path (default: `/`) (`string`)             |
 | `-l, --logLevel <level>` | Info \| warn \| error \| silent (`string`)           |
 | `--clearScreen`          | Allow/disable clear screen when logging (`boolean`)  |
 | `-d, --debug [feat]`     | Show debug logs (`string \| boolean`)                |

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,0 +1,130 @@
+---
+title: Command Line Interface | Guide
+---
+
+# Command Line Interface
+
+## Dev server
+
+### `vite`
+
+Start Vite dev server in the current directory. Will enter the watch mode in development environment and run mode in CI automatically.
+
+#### Usage
+
+```bash
+vite [root]
+```
+
+#### Options
+
+| Options                  |                                                                 |
+| ------------------------ | --------------------------------------------------------------- | ------------------------------- | ----- | ------ |
+| `--host [host]`          | [string] specify hostname                                       |
+| `--port <port>`          | [number] specify port                                           |
+| `--https`                | [boolean] use TLS + HTTP/2                                      |
+| `--open [path]`          | [boolean \\                                                     | string] open browser on startup |
+| `--cors`                 | [boolean] enable CORS                                           |
+| `--strictPort`           | [boolean] exit if specified port is already in use              |
+| `--force`                | [boolean] force the optimizer to ignore the cache and re-bundle |
+| `-c, --config <file>`    | [string] use specified config file                              |
+| `--base <path>`          | [string] public base path (default: `/`)                        |
+| `-l, --logLevel <level>` | [string] info                                                   | warn                            | error | silent |
+| `--clearScreen`          | [boolean] allow/disable clear screen when logging               |
+| `-d, --debug [feat]`     | [string \\                                                      | boolean] show debug logs        |
+| `-f, --filter <filter>`  | [string] filter debug logs                                      |
+| `-m, --mode <mode>`      | [string] set env mode                                           |
+| `-h, --help`             | Display available CLI options                                   |
+| `-v, --version`          | Display version number                                          |
+
+## Build
+
+### `vite build`
+
+Build for production.
+
+#### Usage
+
+```bash
+vite build [root]
+```
+
+#### Options
+
+| Options                        |                                                                                |
+| ------------------------------ | ------------------------------------------------------------------------------ | -------------------------------- | --------------------------------------------------------------------------------------- | ------ |
+| `--target <target>`            | [string] transpile target (default: `'modules'`)                               |
+| `--outDir <dir>`               | [string] output directory (default: `dist`)                                    |
+| `--assetsDir <dir>`            | [string] directory under outDir to place assets in (default: `assets`)         |
+| `--assetsInlineLimit <number>` | [number] static asset base64 inline threshold in bytes (default: `4096`)       |
+| `--ssr [entry]`                | [string] build specified entry for server-side rendering                       |
+| `--sourcemap`                  | [boolean] output source maps for build (default: `false`)                      |
+| `--minify [minifier]`          | [boolean \\                                                                    | "terser"                         | "esbuild"] enable/disable minification, or specify minifier to use (default: `esbuild`) |
+| `--manifest [name]`            | [boolean \\                                                                    | string] emit build manifest json |
+| `--ssrManifest [name]`         | [boolean \\                                                                    | string] emit ssr manifest json   |
+| `--force`                      | [boolean] force the optimizer to ignore the cache and re-bundle (experimental) |
+| `--emptyOutDir`                | [boolean] force empty outDir when it's outside of root                         |
+| `-w, --watch`                  | [boolean] rebuilds when modules have changed on disk                           |
+| `-c, --config <file>`          | [string] use specified config file                                             |
+| `--base <path>`                | [string] public base path (default: `/`)                                       |
+| `-l, --logLevel <level>`       | [string] info                                                                  | warn                             | error                                                                                   | silent |
+| `--clearScreen`                | [boolean] allow/disable clear screen when logging                              |
+| `-d, --debug [feat]`           | [string \\                                                                     | boolean] show debug logs         |
+| `-f, --filter <filter>`        | [string] filter debug logs                                                     |
+| `-m, --mode <mode>`            | [string] set env mode                                                          |
+| `-h, --help`                   | Display available CLI options                                                  |
+
+## Others
+
+### `vite optimize`
+
+Pre-bundle dependencies.
+
+#### Usage
+
+```bash
+vite optimize [root]
+```
+
+#### Options
+
+| Options                  |                                                                 |
+| ------------------------ | --------------------------------------------------------------- | ------------------------ | ----- | ------ |
+| `--force`                | [boolean] force the optimizer to ignore the cache and re-bundle |
+| `-c, --config <file>`    | [string] use specified config file                              |
+| `--base <path>`          | [string] public base path (default: `/`)                        |
+| `-l, --logLevel <level>` | [string] info                                                   | warn                     | error | silent |
+| `--clearScreen`          | [boolean] allow/disable clear screen when logging               |
+| `-d, --debug [feat]`     | [string \\                                                      | boolean] show debug logs |
+| `-f, --filter <filter>`  | [string] filter debug logs                                      |
+| `-m, --mode <mode>`      | [string] set env mode                                           |
+| `-h, --help`             | Display available CLI options                                   |
+
+### `vite preview`
+
+Locally preview production build.
+
+#### Usage
+
+```bash
+vite preview [root]
+```
+
+#### Options
+
+| Options                  |                                                    |
+| ------------------------ | -------------------------------------------------- | ------------------------------- | ----- | ------ |
+| `--host [host]`          | [string] specify hostname                          |
+| `--port <port>`          | [number] specify port                              |
+| `--strictPort`           | [boolean] exit if specified port is already in use |
+| `--https`                | [boolean] use TLS + HTTP/2                         |
+| `--open [path]`          | [boolean                                           | string] open browser on startup |
+| `--outDir <dir>`         | [string] output directory (default: dist)          |
+| `-c, --config <file>`    | [string] use specified config file                 |
+| `--base <path>`          | [string] public base path (default: /)             |
+| `-l, --logLevel <level>` | [string] info                                      | warn                            | error | silent |
+| `--clearScreen`          | [boolean] allow/disable clear screen when logging  |
+| `-d, --debug [feat]`     | [string                                            | boolean] show debug logs        |
+| `-f, --filter <filter>`  | [string] filter debug logs                         |
+| `-m, --mode <mode>`      | [string] set env mode                              |
+| `-h, --help`             | Display available CLI options                      |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -128,6 +128,8 @@ In a project where Vite is installed, you can use the `vite` binary in your npm 
 
 You can specify additional CLI options like `--port` or `--https`. For a full list of CLI options, run `npx vite --help` in your project.
 
+Learn more about the [Command Line Interface](./cli.md)
+
 ## Using Unreleased Commits
 
 If you can't wait for a new release to test the latest features, you will need to clone the [vite repo](https://github.com/vitejs/vite) to your local machine and then build and link it yourself ([pnpm](https://pnpm.io/) is required):


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Adds CLI section to docs guide in same manner as [vitest does have](https://vitest.dev/guide/cli.html).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
It was difficult to follow exact structure of the vitest document as it shares options between all commands. Here we have different options for each command, so I somehow tried to solve this.

Also I have notice type notations in options, vitest does not have such, but I consider them useful and kept them in shape `[type]`, not sure if it is OK
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
