### PR TITLE
feat: dedupe the `vue` in client bundle by default

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -128,6 +128,9 @@ export default function vuePlugin(rawOptions: Options = {}): Plugin {
 
     config(config) {
       return {
+        resolve: {
+          dedupe: config.build?.ssr ? [] : ['vue']
+        },
         define: {
           __VUE_OPTIONS_API__: config.define?.__VUE_OPTIONS_API__ ?? true,
           __VUE_PROD_DEVTOOLS__: config.define?.__VUE_PROD_DEVTOOLS__ ?? false


### PR DESCRIPTION
Fixes vitejs/vite#2443
Fixes vitejs/vite#7454

It's already been set by default in Nuxt 3 for a while now https://github.com/nuxt/framework/pull/6735 So I think this change should be harmless.
And technically it could be considered a fix than a feat.

Nevertheless, it's better to ship it in v4 to minimize disruptions on the user side.

Things that are not covered in this PR:
1. SSR, because `resolve.dedupe` doesn't work for ESM build outputs, and the CommonJS version is kinda hacky, I think it's better to skip the config for SSR completely. Besides, most related issues are from the client side.
2. vitejs/vite-plugin-vue#12 isn't fixed by this PR.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes vitejs/vite#123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
