### PR TITLE
docs: clarify that `optimizeDeps.exclude` take precedence over `include`

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -14,7 +14,7 @@ If neither of these fit your needs, you can specify custom entries using this op
 
 - **Type:** `string[]`
 
-Dependencies to exclude from pre-bundling.
+Dependencies to exclude from pre-bundling. This option will take precedence over `optimizeDeps.include`.
 
 :::warning CommonJS
 CommonJS dependencies should not be excluded from optimization. If an ESM dependency is excluded from optimization, but has a nested CommonJS dependency, the CommonJS dependency should be added to `optimizeDeps.include`. Example:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Clarify `exclude` overtakes `include`

### Additional context

I wanted to know if `vite-plugin-svelte` automatically add stuff to `include` if users could still exclude it

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
