### PR TITLE
fix: fix escape character for import.meta.env

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -46,7 +46,8 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       SSR: !!config.build.ssr
     }
     for (const key in env) {
-      importMetaKeys[`import.meta.env.${key}`] = JSON.stringify(env[key])
+      const envVal = env[key]
+      importMetaKeys[`import.meta.env.${key}`] = typeof envVal === 'string' ? `\`${envVal}\`` : JSON.stringify(envVal)
     }
     Object.assign(importMetaFallbackKeys, {
       'import.meta.env.': `({}).`,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I find a bug when using import.meta.env:
*.vue?raw will be transformed into `export default "xxxx"`, if I use `import.meta.env.xxx` in a vue component, it will be replaced with "xxx" directly. 
For example, The source code is `export default "...  import.meta.env.xxx === 'dev' ... "`, but the final code will be `export default "...  "xxx" === 'dev' ... "`. The `"xxx"` should be `\"xxx\"`, or the rollup AST parser will go wrong.
I don't know if this is the best solution for this bug, just a suggestion. Maybe the import.meta.env replacement run before *.vue?raw transform will be better?

Forgive me for bad English hhhh.
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
