### PR TITLE
fix: glob import parsing (#10949)

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
         "peerDependencies": {
           "postcss": "*"
         }
+      },
+      "acorn-walk": {
+        "peerDependencies": {
+          "acorn": "*"
+        }
       }
     }
   }

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -566,6 +566,35 @@ Repository: https://github.com/acornjs/acorn.git
 
 ---------------------------------------
 
+## acorn-walk
+License: MIT
+By: Marijn Haverbeke, Ingvar Stepanyan, Adrian Heine
+Repository: https://github.com/acornjs/acorn.git
+
+> MIT License
+> 
+> Copyright (C) 2012-2020 by various contributors (see AUTHORS)
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
+---------------------------------------
+
 ## ansi-regex
 License: MIT
 By: Sindre Sorhus

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -79,6 +79,7 @@
     "@rollup/plugin-typescript": "^9.0.2",
     "@rollup/pluginutils": "^5.0.2",
     "acorn": "^8.8.1",
+    "acorn-walk": "^8.2.0",
     "cac": "^6.7.14",
     "chokidar": "^3.5.3",
     "connect": "^3.7.0",

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -155,10 +155,9 @@ export async function parseImportGlob(
       }
     }
 
-    const callExpr = findNodeAt(ast, start, undefined, 'CallExpression')
-    if (!callExpr) throw err(`Expect CallExpression, got ${ast.type}`)
-
-    ast = callExpr.node as CallExpression
+    const found = findNodeAt(ast as any, start, undefined, 'CallExpression')
+    if (!found) throw err(`Expect CallExpression, got ${ast.type}`)
+    ast = found.node as unknown as CallExpression
 
     if (ast.arguments.length < 1 || ast.arguments.length > 2)
       throw err(`Expected 1-2 arguments, but got ${ast.arguments.length}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ overrides:
   vite: workspace:*
   '@vitejs/plugin-vue': workspace:*
 
-packageExtensionsChecksum: 696422bac84dd936748019990f84746e
+packageExtensionsChecksum: 2a87e01b470616d3b7def19cc0830231
 
 importers:
 
@@ -293,7 +293,7 @@ importers:
       '@rollup/plugin-typescript': 9.0.2_rollup@3.3.0+tslib@2.4.1
       '@rollup/pluginutils': 5.0.2_rollup@3.3.0
       acorn: 8.8.1
-      acorn-walk: 8.2.0
+      acorn-walk: 8.2.0_acorn@8.8.1
       cac: 6.7.14
       chokidar: 3.5.3
       connect: 3.7.0
@@ -2962,16 +2962,24 @@ packages:
     resolution: {integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==}
     dependencies:
       acorn: 7.4.1
-      acorn-walk: 7.2.0
+      acorn-walk: 7.2.0_acorn@7.4.1
       xtend: 4.0.2
 
-  /acorn-walk/7.2.0:
+  /acorn-walk/7.2.0_acorn@7.4.1:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
     engines: {node: '>=0.4.0'}
+    peerDependencies:
+      acorn: '*'
+    dependencies:
+      acorn: 7.4.1
 
-  /acorn-walk/8.2.0:
+  /acorn-walk/8.2.0_acorn@8.8.1:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
+    peerDependencies:
+      acorn: '*'
+    dependencies:
+      acorn: 8.8.1
 
   /acorn/7.4.1:
     resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
@@ -5322,19 +5330,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: false
-
-  /follow-redirects/1.15.0_debug@4.3.4:
-    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dependencies:
-      debug: 4.3.4
-    dev: true
 
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -5729,7 +5724,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0_debug@4.3.4
+      follow-redirects: 1.15.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -8612,7 +8607,7 @@ packages:
       '@tsconfig/node14': 1.0.1
       '@tsconfig/node16': 1.0.2
       acorn: 8.8.1
-      acorn-walk: 8.2.0
+      acorn-walk: 8.2.0_acorn@8.8.1
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -8945,7 +8940,7 @@ packages:
       '@types/chai-subset': 1.3.3
       '@types/node': 17.0.42
       acorn: 8.8.1
-      acorn-walk: 8.2.0
+      acorn-walk: 8.2.0_acorn@8.8.1
       chai: 4.3.6
       debug: 4.3.4
       local-pkg: 0.4.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,7 @@ importers:
       '@rollup/plugin-typescript': ^9.0.2
       '@rollup/pluginutils': ^5.0.2
       acorn: ^8.8.1
+      acorn-walk: ^8.2.0
       cac: ^6.7.14
       chokidar: ^3.5.3
       connect: ^3.7.0
@@ -292,6 +293,7 @@ importers:
       '@rollup/plugin-typescript': 9.0.2_rollup@3.3.0+tslib@2.4.1
       '@rollup/pluginutils': 5.0.2_rollup@3.3.0
       acorn: 8.8.1
+      acorn-walk: 8.2.0
       cac: 6.7.14
       chokidar: 3.5.3
       connect: 3.7.0
@@ -5320,6 +5322,19 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
+
+  /follow-redirects/1.15.0_debug@4.3.4:
+    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -5714,7 +5729,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0
+      follow-redirects: 1.15.0_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
closes #10949 
supersedes/closes #11051

I was originally planning on just using `findNodeAt` but then noticed that it's using `strip-literal` which IIUC also tries to parse the file. Figured why not do it with a single AST pass.

### Additional context
Keeping as draft for now because `acorn-walk` is giving a type error for the build script

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
