### PR TITLE
fix(worker): disable build reporter plugin when bundling worker

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -415,7 +415,7 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
       ...(options.minify ? [terserPlugin(config)] : []),
       ...(options.manifest ? [manifestPlugin(config)] : []),
       ...(options.ssrManifest ? [ssrManifestPlugin(config)] : []),
-      buildReporterPlugin(config),
+      ...(!config.isWorker ? [buildReporterPlugin(config)] : []),
       loadFallbackPlugin()
     ]
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When running `pnpm build` in `playground/worker`, the log was like:
```
vite v4.0.0-alpha.5 building for production...
✓ 1 modules transformed.
✓ 2 modules transformed.
✓ 3 modules transformed.
✓ 4 modules transformed.
✓ 5 modules transformed.
✓ 7 modules transformed.
✓ 11 modules transformed.
✓ 12 modules transformed.
✓ 17 modules transformed.
✓ 18 modules transformed.
✓ 25 modules transformed.
✓ 32 modules transformed.
✓ 33 modules transformed.
✓ 34 modules transformed.
✓ 16 modules transformed.
```

This PR fixes this output to be:
```
vite v4.0.0-alpha.5 building for production...
✓ 16 modules transformed.
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
