### PR TITLE
fix(plugin-vue): invalidate script module cache when it changed in hot update

### DIFF
--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -44,6 +44,7 @@ export async function handleHotUpdate(
       return m1.url.length - m2.url.length
     })[0]
   const templateModule = modules.find((m) => /type=template/.test(m.url))
+
   const scriptChanged = hasScriptChanged(prevDescriptor, descriptor)
   if (scriptChanged) {
     let scriptModule: ModuleNode | undefined
@@ -66,7 +67,7 @@ export async function handleHotUpdate(
     // binding metadata. However, when reloading the template alone the binding
     // metadata will not be available since the script part isn't loaded.
     // in this case, reuse the compiled script from previous descriptor.
-    if (mainModule && !scriptChanged) {
+    if (!scriptChanged) {
       setResolvedScript(
         descriptor,
         getResolvedScript(prevDescriptor, false)!,

--- a/packages/plugin-vue/src/handleHotUpdate.ts
+++ b/packages/plugin-vue/src/handleHotUpdate.ts
@@ -44,8 +44,8 @@ export async function handleHotUpdate(
       return m1.url.length - m2.url.length
     })[0]
   const templateModule = modules.find((m) => /type=template/.test(m.url))
-
-  if (hasScriptChanged(prevDescriptor, descriptor)) {
+  const scriptChanged = hasScriptChanged(prevDescriptor, descriptor)
+  if (scriptChanged) {
     let scriptModule: ModuleNode | undefined
     if (
       (descriptor.scriptSetup?.lang && !descriptor.scriptSetup.src) ||
@@ -66,7 +66,7 @@ export async function handleHotUpdate(
     // binding metadata. However, when reloading the template alone the binding
     // metadata will not be available since the script part isn't loaded.
     // in this case, reuse the compiled script from previous descriptor.
-    if (mainModule && !affectedModules.has(mainModule)) {
+    if (mainModule && !scriptChanged) {
       setResolvedScript(
         descriptor,
         getResolvedScript(prevDescriptor, false)!,

--- a/playground/vue/HmrTsx.vue
+++ b/playground/vue/HmrTsx.vue
@@ -1,0 +1,17 @@
+<template>
+  <h2 class="hmr-tsx">HMR</h2>
+  <p>Click the button then edit this message. The count should be preserved.</p>
+  <button class="hmr-tsx-inc" @click="count++">count is {{ count }}</button>
+</template>
+
+<script setup lang="tsx">
+import { ref } from 'vue'
+
+const count = ref(0)
+</script>
+
+<style>
+.hmr-tsx-inc {
+  color: red;
+}
+</style>

--- a/playground/vue/Main.vue
+++ b/playground/vue/Main.vue
@@ -5,6 +5,9 @@
   <div class="hmr-block">
     <Hmr />
   </div>
+  <div class="hmr-tsx-block">
+    <HmrTsx />
+  </div>
   <Syntax />
   <PreProcessors />
   <CssModules />
@@ -27,6 +30,7 @@
 
 <script setup lang="ts">
 import Hmr from './Hmr.vue'
+import HmrTsx from './HmrTsx.vue'
 import Syntax from './Syntax.vue'
 import PreProcessors from './PreProcessors.vue'
 import CssModules from './CssModules.vue'

--- a/playground/vue/__tests__/vue.spec.ts
+++ b/playground/vue/__tests__/vue.spec.ts
@@ -191,6 +191,14 @@ describe('hmr', () => {
     editFile('Hmr.vue', (code) => code.replace(/<template>.+<\/template>/s, ''))
     await untilUpdated(() => page.innerHTML('.hmr-block'), '<!---->')
   })
+
+  test('should re-render when template and tsx script both changed', async () => {
+    editFile('HmrTsx.vue', (code) => code.replace(/count/g, 'updatedCount'))
+    await untilUpdated(
+      () => page.innerHTML('.hmr-tsx-block .hmr-tsx-inc'),
+      'updatedCount is 0'
+    )
+  })
 })
 
 describe('src imports', () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fixes #11008

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
