### PR TITLE
fix: export preprocessCSS in CJS

### DIFF
--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -15,7 +15,8 @@ const asyncFunctions = [
   'resolveConfig',
   'optimizeDeps',
   'formatPostcssSourceMap',
-  'loadConfigFromFile'
+  'loadConfigFromFile',
+  'preprocessCSS'
 ]
 asyncFunctions.forEach((name) => {
   module.exports[name] = (...args) =>


### PR DESCRIPTION
I forgot to export this for CJS 😬 

I should probably backport this to v3 too.