### PR TITLE
test: reduce hmr test flakiness

### DIFF
--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -8,6 +8,7 @@ import {
   isServe,
   page,
   readManifest,
+  untilBrowserLogAfter,
   untilUpdated
 } from '~utils'
 
@@ -71,12 +72,13 @@ describe.runIf(isServe)('serve', () => {
 
   test('CSS dependencies are tracked for HMR', async () => {
     const el = await page.$('h1')
-    browserLogs.length = 0
-
-    editFile('frontend/entrypoints/main.ts', (code) =>
-      code.replace('text-black', 'text-[rgb(204,0,0)]')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('frontend/entrypoints/main.ts', (code) =>
+          code.replace('text-black', 'text-[rgb(204,0,0)]')
+        ),
+      '[vite] css hot updated: /global.css'
     )
     await untilUpdated(() => getColor(el), 'rgb(204, 0, 0)')
-    expect(browserLogs).toContain('[vite] css hot updated: /global.css')
   })
 })

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -25,135 +25,148 @@ if (!isBuild) {
 
   test('self accept', async () => {
     const el = await page.$('.app')
-    browserLogs.length = 0
-    editFile('hmr.ts', (code) => code.replace('const foo = 1', 'const foo = 2'))
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hmr.ts', (code) =>
+          code.replace('const foo = 1', 'const foo = 2')
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        'foo was: 1',
+        '(self-accepting 1) foo is now: 2',
+        '(self-accepting 2) foo is now: 2',
+        '[vite] hot updated: /hmr.ts',
+        '>>> vite:afterUpdate -- update'
+      ],
+      true
+    )
     await untilUpdated(() => el.textContent(), '2')
 
-    expect(browserLogs).toMatchObject([
-      '>>> vite:beforeUpdate -- update',
-      'foo was: 1',
-      '(self-accepting 1) foo is now: 2',
-      '(self-accepting 2) foo is now: 2',
-      '[vite] hot updated: /hmr.ts',
-      '>>> vite:afterUpdate -- update'
-    ])
-    browserLogs.length = 0
-
-    editFile('hmr.ts', (code) => code.replace('const foo = 2', 'const foo = 3'))
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hmr.ts', (code) =>
+          code.replace('const foo = 2', 'const foo = 3')
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        'foo was: 2',
+        '(self-accepting 1) foo is now: 3',
+        '(self-accepting 2) foo is now: 3',
+        '[vite] hot updated: /hmr.ts',
+        '>>> vite:afterUpdate -- update'
+      ],
+      true
+    )
     await untilUpdated(() => el.textContent(), '3')
-
-    expect(browserLogs).toMatchObject([
-      '>>> vite:beforeUpdate -- update',
-      'foo was: 2',
-      '(self-accepting 1) foo is now: 3',
-      '(self-accepting 2) foo is now: 3',
-      '[vite] hot updated: /hmr.ts',
-      '>>> vite:afterUpdate -- update'
-    ])
-    browserLogs.length = 0
   })
 
   test('accept dep', async () => {
     const el = await page.$('.dep')
-
-    editFile('hmrDep.js', (code) =>
-      code.replace('const foo = 1', 'const foo = 2')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hmrDep.js', (code) =>
+          code.replace('const foo = 1', 'const foo = 2')
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(dep) foo was: 1',
+        '(dep) foo from dispose: 1',
+        '(single dep) foo is now: 2',
+        '(single dep) nested foo is now: 1',
+        '(multi deps) foo is now: 2',
+        '(multi deps) nested foo is now: 1',
+        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        '>>> vite:afterUpdate -- update'
+      ],
+      true
     )
     await untilUpdated(() => el.textContent(), '2')
 
-    expect(browserLogs).toMatchObject([
-      '>>> vite:beforeUpdate -- update',
-      '(dep) foo was: 1',
-      '(dep) foo from dispose: 1',
-      '(single dep) foo is now: 2',
-      '(single dep) nested foo is now: 1',
-      '(multi deps) foo is now: 2',
-      '(multi deps) nested foo is now: 1',
-      '[vite] hot updated: /hmrDep.js via /hmr.ts',
-      '>>> vite:afterUpdate -- update'
-    ])
-    browserLogs.length = 0
-
-    editFile('hmrDep.js', (code) =>
-      code.replace('const foo = 2', 'const foo = 3')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hmrDep.js', (code) =>
+          code.replace('const foo = 2', 'const foo = 3')
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(dep) foo was: 2',
+        '(dep) foo from dispose: 2',
+        '(single dep) foo is now: 3',
+        '(single dep) nested foo is now: 1',
+        '(multi deps) foo is now: 3',
+        '(multi deps) nested foo is now: 1',
+        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        '>>> vite:afterUpdate -- update'
+      ],
+      true
     )
     await untilUpdated(() => el.textContent(), '3')
-
-    expect(browserLogs).toMatchObject([
-      '>>> vite:beforeUpdate -- update',
-      '(dep) foo was: 2',
-      '(dep) foo from dispose: 2',
-      '(single dep) foo is now: 3',
-      '(single dep) nested foo is now: 1',
-      '(multi deps) foo is now: 3',
-      '(multi deps) nested foo is now: 1',
-      '[vite] hot updated: /hmrDep.js via /hmr.ts',
-      '>>> vite:afterUpdate -- update'
-    ])
-    browserLogs.length = 0
   })
 
   test('nested dep propagation', async () => {
     const el = await page.$('.nested')
-    browserLogs.length = 0
-
-    editFile('hmrNestedDep.js', (code) =>
-      code.replace('const foo = 1', 'const foo = 2')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hmrNestedDep.js', (code) =>
+          code.replace('const foo = 1', 'const foo = 2')
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(dep) foo was: 3',
+        '(dep) foo from dispose: 3',
+        '(single dep) foo is now: 3',
+        '(single dep) nested foo is now: 2',
+        '(multi deps) foo is now: 3',
+        '(multi deps) nested foo is now: 2',
+        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        '>>> vite:afterUpdate -- update'
+      ],
+      true
     )
     await untilUpdated(() => el.textContent(), '2')
 
-    expect(browserLogs).toMatchObject([
-      '>>> vite:beforeUpdate -- update',
-      '(dep) foo was: 3',
-      '(dep) foo from dispose: 3',
-      '(single dep) foo is now: 3',
-      '(single dep) nested foo is now: 2',
-      '(multi deps) foo is now: 3',
-      '(multi deps) nested foo is now: 2',
-      '[vite] hot updated: /hmrDep.js via /hmr.ts',
-      '>>> vite:afterUpdate -- update'
-    ])
-    browserLogs.length = 0
-
-    editFile('hmrNestedDep.js', (code) =>
-      code.replace('const foo = 2', 'const foo = 3')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('hmrNestedDep.js', (code) =>
+          code.replace('const foo = 2', 'const foo = 3')
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '(dep) foo was: 3',
+        '(dep) foo from dispose: 3',
+        '(single dep) foo is now: 3',
+        '(single dep) nested foo is now: 3',
+        '(multi deps) foo is now: 3',
+        '(multi deps) nested foo is now: 3',
+        '[vite] hot updated: /hmrDep.js via /hmr.ts',
+        '>>> vite:afterUpdate -- update'
+      ],
+      true
     )
     await untilUpdated(() => el.textContent(), '3')
-
-    expect(browserLogs).toMatchObject([
-      '>>> vite:beforeUpdate -- update',
-      '(dep) foo was: 3',
-      '(dep) foo from dispose: 3',
-      '(single dep) foo is now: 3',
-      '(single dep) nested foo is now: 3',
-      '(multi deps) foo is now: 3',
-      '(multi deps) nested foo is now: 3',
-      '[vite] hot updated: /hmrDep.js via /hmr.ts',
-      '>>> vite:afterUpdate -- update'
-    ])
-    browserLogs.length = 0
   })
 
   test('invalidate', async () => {
-    browserLogs.length = 0
     const el = await page.$('.invalidation')
-
-    editFile('invalidation/child.js', (code) =>
-      code.replace('child', 'child updated')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('invalidation/child.js', (code) =>
+          code.replace('child', 'child updated')
+        ),
+      [
+        '>>> vite:beforeUpdate -- update',
+        '>>> vite:invalidate -- /invalidation/child.js',
+        '[vite] invalidate /invalidation/child.js',
+        '[vite] hot updated: /invalidation/child.js',
+        '>>> vite:afterUpdate -- update',
+        '>>> vite:beforeUpdate -- update',
+        '(invalidation) parent is executing',
+        '[vite] hot updated: /invalidation/parent.js',
+        '>>> vite:afterUpdate -- update'
+      ],
+      true
     )
     await untilUpdated(() => el.textContent(), 'child updated')
-    expect(browserLogs).toMatchObject([
-      '>>> vite:beforeUpdate -- update',
-      '>>> vite:invalidate -- /invalidation/child.js',
-      '[vite] invalidate /invalidation/child.js',
-      '[vite] hot updated: /invalidation/child.js',
-      '>>> vite:afterUpdate -- update',
-      '>>> vite:beforeUpdate -- update',
-      '(invalidation) parent is executing',
-      '[vite] hot updated: /invalidation/parent.js',
-      '>>> vite:afterUpdate -- update'
-    ])
-    browserLogs.length = 0
   })
 
   test('plugin hmr handler + custom event', async () => {
@@ -688,19 +701,16 @@ if (!isBuild) {
 
     await page.goto(viteTestUrl + '/missing-import/index.html')
 
-    browserLogs.length = 0
-    expect(browserLogs).toMatchObject([])
+    await untilBrowserLogAfter(async () => {
+      const navigationPromise = page.waitForNavigation({ timeout })
+      editFile(file, (code) => code.replace(importCode, unImportCode))
+      await navigationPromise
+    }, 'missing test')
 
-    editFile(file, (code) => code.replace(importCode, unImportCode))
-
-    await page.waitForNavigation({ timeout })
-    expect(browserLogs.some((msg) => msg.match('missing test'))).toBe(true)
-    browserLogs.length = 0
-
-    editFile(file, (code) => code.replace(unImportCode, importCode))
-
-    await page.waitForNavigation({ timeout })
-    expect(browserLogs.some((msg) => msg.includes('500'))).toBe(true)
-    browserLogs.length = 0
+    await untilBrowserLogAfter(async () => {
+      const navigationPromise = page.waitForNavigation({ timeout })
+      editFile(file, (code) => code.replace(unImportCode, importCode))
+      await navigationPromise
+    }, /500/)
   })
 }

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -96,7 +96,7 @@ if (import.meta.hot) {
   })
 
   import.meta.hot.on('vite:error', (event) => {
-    console.log(`>>> vite:error -- ${event.type}`)
+    console.log(`>>> vite:error -- ${event.err.message}`)
   })
 
   import.meta.hot.on('vite:invalidate', ({ path }) => {

--- a/playground/tailwind/__test__/tailwind.spec.ts
+++ b/playground/tailwind/__test__/tailwind.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from 'vitest'
 import {
-  browserLogs,
   editFile,
   getBgColor,
   getColor,
   isBuild,
   page,
+  untilBrowserLogAfter,
   untilUpdated
 } from '~utils'
 
@@ -15,75 +15,69 @@ test('should render', async () => {
 
 if (!isBuild) {
   test('regenerate CSS and HMR (glob pattern)', async () => {
-    browserLogs.length = 0
     const el = await page.$('#pagetitle')
     const el2 = await page.$('#helloroot')
-
     expect(await getColor(el)).toBe('rgb(11, 22, 33)')
 
-    editFile('src/views/Page.vue', (code) =>
-      code.replace('|Page title|', '|Page title updated|')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('src/views/Page.vue', (code) =>
+          code.replace('|Page title|', '|Page title updated|')
+        ),
+      [
+        '[vite] css hot updated: /index.css',
+        '[vite] hot updated: /src/views/Page.vue'
+      ],
+      true
     )
     await untilUpdated(() => el.textContent(), '|Page title updated|')
 
-    expect(browserLogs).toMatchObject([
-      '[vite] css hot updated: /index.css',
-      '[vite] hot updated: /src/views/Page.vue'
-    ])
-
-    browserLogs.length = 0
-
-    editFile('src/components/HelloWorld.vue', (code) =>
-      code.replace('text-gray-800', 'text-[rgb(10,20,30)]')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('src/components/HelloWorld.vue', (code) =>
+          code.replace('text-gray-800', 'text-[rgb(10,20,30)]')
+        ),
+      [
+        '[vite] css hot updated: /index.css',
+        '[vite] hot updated: /src/components/HelloWorld.vue'
+      ],
+      true
     )
-
     await untilUpdated(() => getColor(el2), 'rgb(10, 20, 30)')
-
-    expect(browserLogs).toMatchObject([
-      '[vite] css hot updated: /index.css',
-      '[vite] hot updated: /src/components/HelloWorld.vue'
-    ])
-
-    browserLogs.length = 0
   })
 
   test('regenerate CSS and HMR (relative path)', async () => {
-    browserLogs.length = 0
     const el = await page.$('h1')
-
     expect(await getColor(el)).toBe('black')
 
-    editFile('src/App.vue', (code) =>
-      code.replace('text-black', 'text-[rgb(11,22,33)]')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('src/App.vue', (code) =>
+          code.replace('text-black', 'text-[rgb(11,22,33)]')
+        ),
+      [
+        '[vite] css hot updated: /index.css',
+        '[vite] hot updated: /src/App.vue'
+      ],
+      true
     )
-
     await untilUpdated(() => getColor(el), 'rgb(11, 22, 33)')
-
-    expect(browserLogs).toMatchObject([
-      '[vite] css hot updated: /index.css',
-      '[vite] hot updated: /src/App.vue'
-    ])
-
-    browserLogs.length = 0
   })
 
   test('regenerate CSS and HMR (pug template)', async () => {
-    browserLogs.length = 0
     const el = await page.$('.pug')
-
     expect(await getBgColor(el)).toBe('rgb(248, 113, 113)')
 
-    editFile('src/components/PugTemplate.vue', (code) =>
-      code.replace('bg-red-400', 'bg-red-600')
+    await untilBrowserLogAfter(
+      () =>
+        editFile('src/components/PugTemplate.vue', (code) =>
+          code.replace('bg-red-400', 'bg-red-600')
+        ),
+      [
+        '[vite] css hot updated: /index.css',
+        '[vite] hot updated: /src/components/PugTemplate.vue?vue&type=template&lang.js'
+      ]
     )
-
     await untilUpdated(() => getBgColor(el), 'rgb(220, 38, 38)')
-
-    expect(browserLogs).toContain('[vite] css hot updated: /index.css')
-    expect(browserLogs).toContain(
-      '[vite] hot updated: /src/components/PugTemplate.vue?vue&type=template&lang.js'
-    )
-
-    browserLogs.length = 0
   })
 }

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -187,12 +187,29 @@ export async function withRetry(
   await func()
 }
 
+type UntilBrowserLogAfterCallback = (logs: string[]) => PromiseLike<void> | void
+
 export async function untilBrowserLogAfter(
   operation: () => any,
   target: string | RegExp | Array<string | RegExp>,
-  callback?: (logs: string[]) => PromiseLike<void> | void
+  expectOrder?: boolean,
+  callback?: UntilBrowserLogAfterCallback
+): Promise<string[]>
+export async function untilBrowserLogAfter(
+  operation: () => any,
+  target: string | RegExp | Array<string | RegExp>,
+  callback?: UntilBrowserLogAfterCallback
+): Promise<string[]>
+export async function untilBrowserLogAfter(
+  operation: () => any,
+  target: string | RegExp | Array<string | RegExp>,
+  arg3?: boolean | UntilBrowserLogAfterCallback,
+  arg4?: UntilBrowserLogAfterCallback
 ): Promise<string[]> {
-  const promise = untilBrowserLog(target, false)
+  const expectOrder = typeof arg3 === 'boolean' ? arg3 : false
+  const callback = typeof arg3 === 'boolean' ? arg4 : arg3
+
+  const promise = untilBrowserLog(target, expectOrder)
   await operation()
   const logs = await promise
   if (callback) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I think this will fix HMR test's flaky fails.
Example:

> AssertionError: expected [ Array(2) ] to include '[vite] css hot updated: /global.css'

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
