### PR TITLE
feat: add `meta` object property to IndexHtmlTransformContext

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -64,6 +64,7 @@ export type {
   IndexHtmlTransform,
   IndexHtmlTransformHook,
   IndexHtmlTransformContext,
+  IndexHtmlTransformMetadata,
   IndexHtmlTransformResult,
   HtmlTagDescriptor
 } from './plugins/html'

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -321,7 +321,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         // pre-transform
         html = await applyHtmlTransforms(html, preHooks, {
           path: publicPath,
-          filename: id
+          filename: id,
+          meta: {}
         })
 
         let js = ''
@@ -790,7 +791,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           path: '/' + relativeUrlPath,
           filename: id,
           bundle,
-          chunk
+          chunk,
+          meta: {}
         })
         // resolve asset url references
         result = result.replace(assetUrlRE, (_, fileHash, postfix = '') => {
@@ -831,12 +833,15 @@ export interface HtmlTagDescriptor {
   injectTo?: 'head' | 'body' | 'head-prepend' | 'body-prepend'
 }
 
+export interface IndexHtmlTransformMetadata {}
+
 export type IndexHtmlTransformResult =
   | string
   | HtmlTagDescriptor[]
   | {
       html: string
       tags: HtmlTagDescriptor[]
+      meta?: Partial<IndexHtmlTransformMetadata>
     }
 
 export interface IndexHtmlTransformContext {
@@ -848,6 +853,7 @@ export interface IndexHtmlTransformContext {
    * filename on disk
    */
   filename: string
+  meta: Readonly<IndexHtmlTransformMetadata>
   server?: ViteDevServer
   bundle?: OutputBundle
   chunk?: OutputChunk
@@ -953,6 +959,9 @@ export async function applyHtmlTransforms(
       } else {
         html = res.html || html
         tags = res.tags
+        if (res.meta) {
+          Object.assign(ctx.meta, res.meta)
+        }
       }
 
       const headTags: HtmlTagDescriptor[] = []

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -54,6 +54,7 @@ import { baseMiddleware } from './middlewares/base'
 import { proxyMiddleware } from './middlewares/proxy'
 import { htmlFallbackMiddleware } from './middlewares/htmlFallback'
 import { transformMiddleware } from './middlewares/transform'
+import type { DevHtmlTransformFn } from './middlewares/indexHtml'
 import {
   createDevHtmlTransformFn,
   indexHtmlMiddleware
@@ -216,11 +217,7 @@ export interface ViteDevServer {
   /**
    * Apply vite built-in HTML transforms and any plugin HTML transforms.
    */
-  transformIndexHtml(
-    url: string,
-    html: string,
-    originalUrl?: string
-  ): Promise<string>
+  transformIndexHtml: DevHtmlTransformFn
   /**
    * Transform module code into SSR format.
    */

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -4,7 +4,10 @@ import MagicString from 'magic-string'
 import type { SourceMapInput } from 'rollup'
 import type { Connect } from 'dep-types/connect'
 import type { DefaultTreeAdapterMap, Token } from 'parse5'
-import type { IndexHtmlTransformHook } from '../../plugins/html'
+import type {
+  IndexHtmlTransformHook,
+  IndexHtmlTransformMetadata
+} from '../../plugins/html'
 import {
   addToHTMLProxyCache,
   applyHtmlTransforms,
@@ -39,11 +42,18 @@ interface AssetNode {
   code: string
 }
 
+export type DevHtmlTransformFn = (
+  url: string,
+  html: string,
+  originalUrl?: string,
+  meta?: IndexHtmlTransformMetadata
+) => Promise<string>
+
 export function createDevHtmlTransformFn(
   server: ViteDevServer
-): (url: string, html: string, originalUrl: string) => Promise<string> {
+): DevHtmlTransformFn {
   const [preHooks, postHooks] = resolveHtmlTransforms(server.config.plugins)
-  return (url: string, html: string, originalUrl: string): Promise<string> => {
+  return (url, html, originalUrl, meta = {}) => {
     return applyHtmlTransforms(
       html,
       [
@@ -57,7 +67,8 @@ export function createDevHtmlTransformFn(
         path: url,
         filename: getHtmlFilename(url, server),
         server,
-        originalUrl
+        originalUrl,
+        meta
       }
     )
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This allows `indexHtmlTransform` hooks to receive arbitrary metadata from preceding hooks and from the caller of `server.transformIndexHtml`.

For an `indexHtmlTransform` hook to mutate the properties of the `ctx.meta` object, it must return an object with a `meta` object property, which is merged in with `Object.assign`. This design is meant to mimic Rollup's module metadata API.

The `IndexHtmlTransformMetadata` interface can be extended by plugins via declaration merging.

```ts
declare module 'vite' {
  export interface IndexHtmlTransformMetadata {
    'my-plugin'?: { a: number }
  }
}
```

The `IndexHtmlTransformMetadata` type is an empty object by default (not a `Record<string, any>` type, for type safety reasons).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other