### PR TITLE
feat: support css?url to return asset path

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -50,6 +50,8 @@ export const OPTIMIZABLE_ENTRY_RE = /\.[cm]?[jt]s$/
 
 export const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/
 
+export const URL_RE = /(\?|&)url(?:&|$)/
+
 /**
  * Prefix for resolved fs paths, since windows paths may not be valid as URLs.
  */

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -18,6 +18,7 @@ import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
 import { cleanUrl, getHash, joinUrlSegments, normalizePath } from '../utils'
 import { FS_PREFIX } from '../constants'
+import { isCSSRequest } from './css'
 
 export const assetUrlRE = /__VITE_ASSET__([a-z\d]+)__(?:\$_(.*?)__)?/g
 
@@ -148,6 +149,11 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       if (id.startsWith('\0')) {
         // Rollup convention, this id should be handled by the
         // plugin that marked it with \0
+        return
+      }
+
+      if (isCSSRequest(id) && urlRE.test(id)) {
+        // leave css?url to css plugin
         return
       }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -168,7 +168,7 @@ export function getDynamicCssAssetUrl(importUrl: string): string | undefined {
  * remove ?url from module id
  */
 export function getPureCssId(id: string, root: string): string {
-  return path.relative(root, id.replace(URL_RE, ''))
+  return path.relative(root, id.replace(/\?.+$/, ''))
 }
 
 const postcssConfigCache: Record<

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -205,7 +205,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
         const pureCssId = getPureCssId(id, config.root)
 
         if (config.command === 'serve') {
-          return `export default "${pureCssId}"`
+          return `export default "${config.base}${pureCssId}"`
         }
 
         this.emitFile({
@@ -607,7 +607,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             // connect css id with css file name
             pureCssIdMapAssetUrl.set(
               getPureCssId(chunk.facadeModuleId, config.root),
-              fileName
+              config.base + fileName
             )
           }
           chunk.viteMetadata.importedCss.add(fileName)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`vite` support [Importing Asset as URL](https://vitejs.dev/guide/assets.html#importing-asset-as-url)
while using CSS or Less file, works fine in `dev` mode, but in `build`, it returns a useless dataurl which means nothing for production

```js
import cssPath from './index.css'

/**
 * in dev mode  "/src/index.css"
 * in build mode "data:text/css...."
 */
console.log(cssPath);
```

in this PR, I changed the original process, replace `vite:asset`  with `vite:css`. using `emitFile` to create a new chunk for target CSS file.

```js
import cssPath from './index.css?url'

// "/asset/index.xxx.css"
console.log(cssPath);
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
should fix #2522

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
