### PR TITLE
chore: allow breaking commit message

### DIFF
--- a/scripts/verifyCommit.ts
+++ b/scripts/verifyCommit.ts
@@ -9,7 +9,7 @@ const msg = readFileSync(msgPath, 'utf-8').trim()
 
 const releaseRE = /^v\d/
 const commitRE =
-  /^(?:revert: )?(?:feat|fix|docs|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(?:\(.+\))?: .{1,50}/
+  /^(?:revert: )?(?:feat|fix|docs|dx|refactor|perf|test|workflow|build|ci|chore|types|wip|release|deps)(?:\(.+\))?!?: .{1,50}/
 
 if (!releaseRE.test(msg) && !commitRE.test(msg)) {
   console.log()


### PR DESCRIPTION
Allow using `!` in commit messages like `feat!: something` and `feat(ssr)!: something` locally.

As GitHub generates the PR title from the first commit, it would be nice to allow this locally.