### PR TITLE
fix(esbuild): handle inline sourcemap option

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import type { ResolvedConfig, UserConfig } from '../../config'
-import { resolveEsbuildTranspileOptions } from '../../plugins/esbuild'
+import {
+  ESBuildTransformResult,
+  resolveEsbuildTranspileOptions,
+  transformWithEsbuild
+} from '../../plugins/esbuild'
 
 describe('resolveEsbuildTranspileOptions', () => {
   test('resolve default', () => {
@@ -234,6 +238,16 @@ describe('resolveEsbuildTranspileOptions', () => {
         'import-meta': true
       }
     })
+  })
+})
+
+describe('transformWithEsbuild', () => {
+  test('not throw on inline sourcemap', async () => {
+    const result = await transformWithEsbuild(`const foo = 'bar'`, '', {
+      sourcemap: 'inline'
+    })
+    expect(result?.code).toBeTruthy()
+    expect(result?.map).toBeTruthy()
   })
 })
 

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -145,9 +145,10 @@ export async function transformWithEsbuild(
         inMap as RawSourceMap
       ]) as SourceMap
     } else {
-      map = resolvedOptions.sourcemap
-        ? JSON.parse(result.map)
-        : { mappings: '' }
+      map =
+        resolvedOptions.sourcemap && resolvedOptions.sourcemap !== 'inline'
+          ? JSON.parse(result.map)
+          : { mappings: '' }
     }
     if (Array.isArray(map.sources)) {
       map.sources = map.sources.map((it) => toUpperCaseDriveLetter(it))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When passing `sourcemap: 'inline'` to `transformWithEsbuild` options, `esbuild` returns `result.map = ''` but we're trying to `JSON.parse` it which fails.

This PR skips `JSON.parse` for inline sourcemap

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
