### PR TITLE
fix: reset global regex before match

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -178,6 +178,7 @@ export class ErrorOverlay extends HTMLElement {
     } else {
       let curIndex = 0
       let match: RegExpExecArray | null
+      fileRE.lastIndex = 0
       while ((match = fileRE.exec(text))) {
         const { 0: file, index } = match
         if (index != null) {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -534,11 +534,8 @@ function extractImportPaths(code: string) {
 
   let js = ''
   let m
+  importsRE.lastIndex = 0
   while ((m = importsRE.exec(code)) != null) {
-    // This is necessary to avoid infinite loops with zero-width matches
-    if (m.index === importsRE.lastIndex) {
-      importsRE.lastIndex++
-    }
     js += `\nimport ${m[1]}`
   }
   return js

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -72,6 +72,7 @@ export function renderAssetUrlInJS(
 
   // In both cases, the wrapping should already be fine
 
+  assetUrlRE.lastIndex = 0
   while ((match = assetUrlRE.exec(code))) {
     s ||= new MagicString(code)
     const [full, referenceId, postfix = ''] = match
@@ -96,6 +97,7 @@ export function renderAssetUrlInJS(
   // Replace __VITE_PUBLIC_ASSET__5aa0ddc0__ with absolute paths
 
   const publicAssetUrlMap = publicAssetUrlCache.get(config)!
+  publicAssetUrlRE.lastIndex = 0
   while ((match = publicAssetUrlRE.exec(code))) {
     s ||= new MagicString(code)
     const [full, hash] = match

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -398,6 +398,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               const cleanCode = stripLiteral(scriptNode.value)
 
               let match: RegExpExecArray | null
+              inlineImportRE.lastIndex = 0
               while ((match = inlineImportRE.exec(cleanCode))) {
                 const { 1: url, index } = match
                 const startUrl = cleanCode.indexOf(url, index)
@@ -779,6 +780,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         // no use assets plugin because it will emit file
         let match: RegExpExecArray | null
         let s: MagicString | undefined
+        inlineCSSRE.lastIndex = 0
         while ((match = inlineCSSRE.exec(result))) {
           s ||= new MagicString(result)
           const { 0: full, 1: scopedName } = match

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -336,6 +336,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
 
         let match: RegExpExecArray | null
         s = new MagicString(code)
+        workerAssetUrlRE.lastIndex = 0
 
         // Replace "__VITE_WORKER_ASSET__5aa0ddc0__" using relative paths
         const workerMap = workerCache.get(config.mainConfig || config)!


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
I noticed we're not properly resetting the global regex when running while-loop regex match, which means the result we could be missing regex captures every other run. ([StackOverflow explanation](https://stackoverflow.com/questions/1520800/why-does-a-regexp-with-global-flag-give-wrong-results))

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I'm not sure how we haven't got a bug report for this before 😬 

[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex#description) has notes about how `lastIndex` is set. I also find that using global regex for `str.replace` or `str.match` are not affected by `.lastIndex`, and it would also always reset `.lastIndex`. (Maybe that's how the bug appear less often for some regex)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
