### PR TITLE
fix: Revert "fix: missing js sourcemaps with rewritten imports broke debugging (#7767) (#9476)"

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -5,7 +5,6 @@ import getEtag from 'etag'
 import convertSourceMap from 'convert-source-map'
 import type { SourceDescription, SourceMap } from 'rollup'
 import colors from 'picocolors'
-import MagicString from 'magic-string'
 import type { ViteDevServer } from '..'
 import {
   blankReplacer,
@@ -19,8 +18,6 @@ import {
 } from '../utils'
 import { checkPublicFile } from '../plugins/asset'
 import { getDepsOptimizer } from '../optimizer'
-import { isCSSRequest } from '../plugins/css'
-import { SPECIAL_QUERY_RE } from '../constants'
 import { injectSourcesContent } from './sourcemap'
 import { isFileServingAllowed } from './middlewares/static'
 
@@ -257,26 +254,11 @@ async function loadAndTransform(
     isDebug && debugTransform(`${timeFrom(transformStart)} ${prettyUrl}`)
     code = transformResult.code!
     map = transformResult.map
-
-    // To enable IDE debugging, add a minimal sourcemap for modified JS files without one
-    if (
-      !map &&
-      mod.file &&
-      mod.type === 'js' &&
-      code !== originalCode &&
-      !(isCSSRequest(id) && !SPECIAL_QUERY_RE.test(id)) // skip CSS : #9914
-    ) {
-      map = new MagicString(code).generateMap({ source: mod.file })
-    }
   }
 
   if (map && mod.file) {
     map = (typeof map === 'string' ? JSON.parse(map) : map) as SourceMap
-    if (
-      map.mappings &&
-      (!map.sourcesContent ||
-        (map.sourcesContent as Array<string | null>).includes(null))
-    ) {
+    if (map.mappings && !map.sourcesContent) {
       await injectSourcesContent(map, mod.file, logger)
     }
   }

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -9,32 +9,11 @@ import {
 } from '~utils'
 
 if (!isBuild) {
-  test('js without import', async () => {
+  test('js', async () => {
     const res = await page.request.get(new URL('./foo.js', page.url()).href)
     const js = await res.text()
     const lines = js.split('\n')
     expect(lines[lines.length - 1].includes('//')).toBe(false) // expect no sourcemap
-  })
-
-  test('js', async () => {
-    const res = await page.request.get(new URL('./qux.js', page.url()).href)
-    const js = await res.text()
-    const map = extractSourcemap(js)
-    expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
-      {
-        "mappings": "AAAA;AACA;AACA;",
-        "sources": [
-          "/root/qux.js",
-        ],
-        "sourcesContent": [
-          "import { foo } from './foo'
-
-export const qux = 'qux'
-",
-        ],
-        "version": 3,
-      }
-    `)
   })
 
   test('ts', async () => {

--- a/playground/js-sourcemap/qux.js
+++ b/playground/js-sourcemap/qux.js
@@ -1,3 +1,0 @@
-import { foo } from './foo'
-
-export const qux = 'qux'


### PR DESCRIPTION
### Description

This reverts commit 3fa96f6a7dac361773c6050cc63db5644207b6ef. FYI @BenceSzalai

This is causing SvelteKit's source map test to fail with an incorrect location. See the failing tests on this branch: https://github.com/sveltejs/kit/pull/7543

To move forward, we can do something along the lines of:

1. commit this PR to revert back to the old behavior
2. update the issue with the additional information we've learned
3. start a new PR, add  2 testcases that a) check stacktrace positions with line and column and b) sourcemap accuracy in general (may initially fail due to importanalysis updates not being recorded)
4. implement proper sourcemap support for importanalysis in dev (test should pass now)
5. test perf impact by comparing main with that PR
6. if 5 shows low to no impact, just change the behavior, if it shows slowdowns, add an option
7. merge PR for 4.1

### Additional context

Discussion on Discord in #ecosystem-ci thread 20221130-sveltekit:
https://discord.com/channels/804011606160703521/1047380773990314004/1047447169168310328

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
