### PR TITLE
fix: add type for function localsConvention value

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -103,7 +103,16 @@ export interface CSSModulesOptions {
   /**
    * default: undefined
    */
-  localsConvention?: 'camelCase' | 'camelCaseOnly' | 'dashes' | 'dashesOnly'
+  localsConvention?:
+    | 'camelCase'
+    | 'camelCaseOnly'
+    | 'dashes'
+    | 'dashesOnly'
+    | ((
+        originalClassName: string,
+        generatedClassName: string,
+        inputFile: string
+      ) => string)
 }
 
 const cssModuleRE = new RegExp(`\\.module${CSS_LANGS_RE.source}`)


### PR DESCRIPTION
### Description

PostCSS Modules supports a function as a value to `localsConvention`. This PR adds typing for that function. See the postcss modules documentation here: https://github.com/madyankin/postcss-modules#localsconvention

### Additional context

Nope

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
