### PR TITLE
fix: formatError() outside rollup context

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -445,6 +445,21 @@ export async function createPluginContainer(
           }
         }
       }
+    } else if (err.loc) {
+      if (!err.frame) {
+        let code = err.pluginCode
+        if (err.loc.file) {
+          err.id = normalizePath(err.loc.file)
+          if (!code) {
+            try {
+              code = fs.readFileSync(err.loc.file, 'utf-8')
+            } catch {}
+          }
+        }
+        if (code) {
+          err.frame = generateCodeFrame(code, err.loc)
+        }
+      }
     }
     return err
   }


### PR DESCRIPTION

### Description

Fix `formatError()` to be able to compute the error frame outside the activeCtx (useful for SSR rendering if app crashes during execution).

Right now `formatError()` is not generating the frame automatically, even though throwing a error with all the necessary information.

When using Vite with dev SSR, custom user's code might run right after `ssrLoadModule()` and this code could crash, right now it's is missing nice printing, even though the source of the error is known!

### Additional context

Discussion with @patak-dev 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
