### PR TITLE
fix: don't check .yarn/patches for computing dependencies hash

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1043,10 +1043,10 @@ function isSingleDefaultExport(exports: readonly string[]) {
 }
 
 const lockfileFormats = [
-  { name: 'package-lock.json', patchesDirs: ['patches'] }, // Default of https://github.com/ds300/patch-package
-  { name: 'yarn.lock', patchesDirs: ['patches', '.yarn/patches'] }, // .yarn/patches for v2+
-  { name: 'pnpm-lock.yaml', patchesDirs: [] }, // Included in lockfile
-  { name: 'bun.lockb', patchesDirs: ['patches'] },
+  { name: 'package-lock.json', checkPatches: true },
+  { name: 'yarn.lock', checkPatches: true }, // Included in lockfile for v2+
+  { name: 'pnpm-lock.yaml', checkPatches: false }, // Included in lockfile
+  { name: 'bun.lockb', checkPatches: true },
 ]
 
 export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
@@ -1058,17 +1058,16 @@ export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
   let content = lockfilePath ? fs.readFileSync(lockfilePath, 'utf-8') : ''
   if (lockfilePath) {
     const lockfileName = path.basename(lockfilePath)
-    const { patchesDirs } = lockfileFormats.find(
+    const { checkPatches } = lockfileFormats.find(
       (f) => f.name === lockfileName,
     )!
-    const dependenciesRoot = path.dirname(lockfilePath)
-    for (const patchesDir of patchesDirs) {
-      const fullPath = path.join(dependenciesRoot, patchesDir)
+    if (checkPatches) {
+      // Default of https://github.com/ds300/patch-package
+      const fullPath = path.join(path.dirname(lockfilePath), 'patches')
       if (fs.existsSync(fullPath)) {
         const stats = fs.statSync(fullPath)
         if (stats.isDirectory()) {
           content += stats.mtimeMs.toString()
-          break
         }
       }
     }


### PR DESCRIPTION
As noticed by @merceyz (https://github.com/vitejs/vite/pull/10286#discussion_r1032954300) in yarn 2+, patches modify the lockfile (the DX is a bit poor, because you need to manually re-run `yarn install` after running the patch command without any notice) so there is no need to check it.