### PR TITLE
test: improve `css-dynamic-import` playground test code

### DIFF
--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -33,12 +33,12 @@ async function withServe(base: string, fn: () => Promise<void>) {
   const config = getConfig(base)
   const server = await createServer(config)
   await server.listen()
-  await new Promise((r) => setTimeout(r, 500))
 
   try {
     await page.goto(server.resolvedUrls.local[0])
     await fn()
   } finally {
+    await page.goto('about:blank') // move to a different page to avoid auto-refresh after server start
     await server.close()
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This `setTimeout` was needed because

1. a server for relative base starts
2. browser navigates to the page by `page.goto`
3. the server closes
4. a server for absolute base starts
2. browser navigates to the page by `page.goto`
5. the HMR client tries to reload (since it detects the server is started) and aborts the previous navigation triggered by `page.goto`
6. because `page.goto` is aborted, it throws `net::ERR_ABORTED` error

This PR changes `setTimeout` to `page.goto('about:blank')` to make the reason more understandable and the test more faster.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
