### PR TITLE
chore: update @types/node to v18

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Vite aims to be fully usable as a dependency in a TypeScript project (e.g. it sh
 
 To get around this, we inline some of these dependencies' types in `packages/vite/src/types`. This way, we can still expose the typing but bundle the dependency's source code.
 
-Use `pnpm run check-dist-types` to check that the bundled types do not rely on types in `devDependencies`. If you are adding `dependencies`, make sure to configure `tsconfig.check.json`.
+Use `pnpm run build-types-check` to check that the bundled types do not rely on types in `devDependencies`.
 
 For types shared between client and node, they should be added into `packages/vite/types`. These types are not bundled and are published as is (though they are still considered internal). Dependency types within this directory (e.g. `packages/vite/types/chokidar.d.ts`) are deprecated and should be added to `packages/vite/src/types` instead.
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/less": "^3.0.3",
     "@types/micromatch": "^4.0.2",
     "@types/minimist": "^1.2.2",
-    "@types/node": "^17.0.42",
+    "@types/node": "^18.11.10",
     "@types/picomatch": "^2.3.0",
     "@types/prompts": "^2.4.1",
     "@types/resolve": "^1.20.2",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -51,7 +51,7 @@
     "build-types-pre-patch": "tsx scripts/prePatchTypes.ts",
     "build-types-roll": "api-extractor run && rimraf temp",
     "build-types-post-patch": "tsx scripts/postPatchTypes.ts",
-    "build-types-check": "tsc --project tsconfig.check.json",
+    "build-types-check": "tsx scripts/checkBuiltTypes.ts && tsc --project tsconfig.check.json",
     "lint": "eslint --cache --ext .ts src/**",
     "format": "prettier --write --cache --parser typescript \"src/**/*.ts\"",
     "prepublishOnly": "npm run build"

--- a/packages/vite/scripts/checkBuiltTypes.ts
+++ b/packages/vite/scripts/checkBuiltTypes.ts
@@ -1,0 +1,100 @@
+/**
+ * Checks whether the built files depend on devDependencies types.
+ * We shouldn't depend on them.
+ */
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import colors from 'picocolors'
+import type { ParseResult } from '@babel/parser'
+import type { File, SourceLocation } from '@babel/types'
+import { parse } from '@babel/parser'
+import { walkDir } from './util'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+const distDir = resolve(dir, '../dist')
+
+const pkgJson = JSON.parse(
+  readFileSync(resolve(dir, '../package.json'), 'utf-8'),
+)
+const deps = new Set(Object.keys(pkgJson.dependencies))
+
+type SpecifierError = {
+  loc: SourceLocation | null | undefined
+  value: string
+  file: string
+}
+
+const errors: SpecifierError[] = []
+walkDir(distDir, (file) => {
+  if (!file.endsWith('.d.ts')) return
+
+  const specifiers = collectImportSpecifiers(file)
+  const notAllowedSpecifiers = specifiers.filter(
+    ({ value }) =>
+      !(
+        value.startsWith('./') ||
+        value.startsWith('../') ||
+        value.startsWith('node:') ||
+        deps.has(value)
+      ),
+  )
+
+  errors.push(...notAllowedSpecifiers)
+})
+
+if (errors.length <= 0) {
+  console.log(colors.green(colors.bold(`passed built types check`)))
+} else {
+  console.log(colors.red(colors.bold(`failed built types check`)))
+  console.log()
+  errors.forEach((error) => {
+    const pos = error.loc
+      ? `${colors.yellow(error.loc.start.line)}:${colors.yellow(
+          error.loc.start.column,
+        )}`
+      : ''
+    console.log(
+      `${colors.cyan(error.file)}:${pos} - importing ${colors.bold(
+        JSON.stringify(error.value),
+      )} is not allowed in built files`,
+    )
+  })
+  console.log()
+}
+
+function collectImportSpecifiers(file: string) {
+  const content = readFileSync(file, 'utf-8')
+
+  let ast: ParseResult<File>
+  try {
+    ast = parse(content, {
+      sourceType: 'module',
+      plugins: ['typescript', 'classProperties'],
+    })
+  } catch (e) {
+    console.log(colors.red(`failed to parse ${file}`))
+    throw e
+  }
+
+  const result: SpecifierError[] = []
+
+  for (const statement of ast.program.body) {
+    if (
+      statement.type === 'ImportDeclaration' ||
+      statement.type === 'ExportNamedDeclaration' ||
+      statement.type === 'ExportAllDeclaration'
+    ) {
+      const source = statement.source
+      if (source?.value) {
+        result.push({
+          loc: source.loc,
+          value: source.value,
+          file,
+        })
+      }
+    }
+  }
+
+  return result
+}

--- a/packages/vite/tsconfig.check.json
+++ b/packages/vite/tsconfig.check.json
@@ -1,37 +1,12 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "moduleResolution": "classic",
-    "noResolve": true,
-    "typeRoots": [],
-    // Only add entries to `paths` when you are adding/updating dependencies (not devDependencies)
-    // See CONTRIBUTING.md "Ensure type support" for more details
-    "paths": {
-      // direct
-      "rollup": ["./node_modules/rollup/dist/rollup.d.ts"],
-      // direct
-      "esbuild": ["./node_modules/esbuild/lib/main.d.ts"],
-      // direct
-      "postcss": ["./node_modules/postcss/lib/postcss.d.ts"],
-      // indirect: postcss depends on it
-      "source-map-js": ["./node_modules/source-map-js/source-map.d.ts"]
-    },
     "strict": true,
     "exactOptionalPropertyTypes": true
   },
   "include": [
-    "../../node_modules/@types/node/**/*",
-    // dependencies
-    "./node_modules/rollup/**/*",
-    "./node_modules/esbuild/**/*",
-    "./node_modules/postcss/**/*",
-    "./node_modules/source-map-js/**/*",
     // dist
     "dist/**/*",
-    "types/customEvent.d.ts",
-    "types/hmrPayload.d.ts",
-    "types/importGlob.d.ts",
-    "types/importMeta.d.ts",
-    "types/hot.d.ts"
+    "types/**/*"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
       '@types/less': ^3.0.3
       '@types/micromatch': ^4.0.2
       '@types/minimist': ^1.2.2
-      '@types/node': ^17.0.42
+      '@types/node': ^18.11.10
       '@types/picomatch': ^2.3.0
       '@types/prompts': ^2.4.1
       '@types/resolve': ^1.20.2
@@ -80,7 +80,7 @@ importers:
       '@types/less': 3.0.3
       '@types/micromatch': 4.0.2
       '@types/minimist': 1.2.2
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
       '@types/picomatch': 2.3.0
       '@types/prompts': 2.4.1
       '@types/resolve': 1.20.2
@@ -2092,7 +2092,7 @@ packages:
   /@types/cross-spawn/6.0.2:
     resolution: {integrity: sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
     dev: true
 
   /@types/debug/4.1.7:
@@ -2108,13 +2108,13 @@ packages:
   /@types/etag/1.8.1:
     resolution: {integrity: sha512-bsKkeSqN7HYyYntFRAmzcwx/dKW4Wa+KVMTInANlI72PWLQmOpZu96j0OqHZGArW4VQwCmJPteQlXaUDeOB0WQ==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
     dev: true
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
     dev: true
 
   /@types/json-schema/7.0.11:
@@ -2155,8 +2155,8 @@ packages:
     resolution: {integrity: sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==}
     dev: true
 
-  /@types/node/17.0.42:
-    resolution: {integrity: sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ==}
+  /@types/node/18.11.10:
+    resolution: {integrity: sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -2170,7 +2170,7 @@ packages:
   /@types/prompts/2.4.1:
     resolution: {integrity: sha512-1Mqzhzi9W5KlooNE4o0JwSXGUDeQXKldbGn9NO4tpxwZbHXYd+WcKpCksG2lbhH7U9I9LigfsdVsP2QAY0lNPA==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
     dev: true
 
   /@types/resolve/1.20.2:
@@ -2180,7 +2180,7 @@ packages:
   /@types/sass/1.43.1:
     resolution: {integrity: sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
     dev: true
 
   /@types/semver/7.3.13:
@@ -2194,7 +2194,7 @@ packages:
   /@types/stylus/0.48.38:
     resolution: {integrity: sha512-B5otJekvD6XM8iTrnO6e2twoTY2tKL9VkL/57/2Lo4tv3EatbCaufdi68VVtn/h4yjO+HVvYEyrNQd0Lzj6riw==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
     dev: true
 
   /@types/web-bluetooth/0.0.16:
@@ -2204,7 +2204,7 @@ packages:
   /@types/ws/8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
     dependencies:
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
     dev: true
 
   /@typescript-eslint/eslint-plugin/5.44.0_tu3ppasffl73sg2len737zqm4q:
@@ -8347,7 +8347,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.3
       '@types/chai-subset': 1.3.3
-      '@types/node': 17.0.42
+      '@types/node': 18.11.10
       acorn: 8.8.1
       acorn-walk: 8.2.0_acorn@8.8.1
       chai: 4.3.6


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR updates @types/node to v18 and fixes the built file type check script.

I'm not sure if this script covers #8701, but I checked that this covers #8352 and #10678.

Superseds close #11183


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
