### PR TITLE
fix: Dynamic import result is not the same between dev and prod

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -68,7 +68,11 @@ function preload(
 ) {
   // @ts-ignore
   if (!__VITE_IS_MODERN__ || !deps || deps.length === 0) {
-    return baseModule()
+    return baseModule().then((m: any) =>
+      m.default && m.default.__esModule
+        ? m.default
+        : { ...m.default, default: m.default },
+    )
   }
 
   const links = document.getElementsByTagName('link')


### PR DESCRIPTION

fix #11198

<!-- Thank you for contributing! -->

### Description

make production `() => import()` result same as development


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
