### PR TITLE
fix(env): prevent env expand on process.env

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,9 @@
           "acorn": "*"
         }
       }
+    },
+    "patchedDependencies": {
+      "dotenv-expand@9.0.0": "patches/dotenv-expand@9.0.0.patch"
     }
   }
 }

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -35,19 +35,9 @@ export function loadEnv(
     }),
   )
 
-  const expandOptions = {
-    parsed: {
-      ...(process.env as any),
-      ...parsed,
-    },
-    // prevent process.env mutation
-    ignoreProcessEnv: true,
-  }
-
-  let expandParsed: NonNullable<ReturnType<typeof expand>['parsed']>
   try {
     // let environment variables use each other
-    expandParsed = expand(expandOptions).parsed!
+    expand({ parsed })
   } catch (e) {
     // custom error handling until https://github.com/motdotla/dotenv-expand/issues/65 is fixed upstream
     // check for message "TypeError: Cannot read properties of undefined (reading 'split')"
@@ -58,10 +48,6 @@ export function loadEnv(
     }
     throw e
   }
-
-  Object.keys(parsed).forEach((key) => {
-    parsed[key] = expandParsed[key]
-  })
 
   // only keys that start with prefix are exposed to client
   for (const [key, value] of Object.entries(parsed)) {

--- a/patches/dotenv-expand@9.0.0.patch
+++ b/patches/dotenv-expand@9.0.0.patch
@@ -1,0 +1,18 @@
+diff --git a/lib/main.js b/lib/main.js
+index c873cc77229d4cd0cf9de98ae0970b25d89f312f..ddf570558e985760efde52af37a41b56282d30a6 100644
+--- a/lib/main.js
++++ b/lib/main.js
+@@ -50,9 +50,10 @@ function expand (config) {
+     config.parsed[configKey] = _interpolate(value, environment, config)
+   }
+ 
+-  for (const processKey in config.parsed) {
+-    environment[processKey] = config.parsed[processKey]
+-  }
++  // PATCH: don't write to process.env
++  // for (const processKey in config.parsed) {
++  //   environment[processKey] = config.parsed[processKey]
++  // }
+ 
+   return config
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,11 @@ overrides:
 
 packageExtensionsChecksum: 2a87e01b470616d3b7def19cc0830231
 
+patchedDependencies:
+  dotenv-expand@9.0.0:
+    hash: 6vdpvodnfhahap67xag6diqqtu
+    path: patches/dotenv-expand@9.0.0.patch
+
 importers:
 
   .:
@@ -248,7 +253,7 @@ importers:
       debug: 4.3.4
       dep-types: link:src/types
       dotenv: 16.0.3
-      dotenv-expand: 9.0.0
+      dotenv-expand: 9.0.0_6vdpvodnfhahap67xag6diqqtu
       es-module-lexer: 1.1.0
       estree-walker: 3.0.1
       etag: 1.8.1
@@ -3479,10 +3484,11 @@ packages:
       is-obj: 2.0.0
     dev: true
 
-  /dotenv-expand/9.0.0:
+  /dotenv-expand/9.0.0_6vdpvodnfhahap67xag6diqqtu:
     resolution: {integrity: sha512-uW8Hrhp5ammm9x7kBLR6jDfujgaDarNA02tprvZdyrJ7MpdzD1KyrIHG4l+YoC2fJ2UcdFdNWNWIjt+sexBHJw==}
     engines: {node: '>=12'}
     dev: true
+    patched: true
 
   /dotenv/16.0.3:
     resolution: {integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==}
@@ -4705,6 +4711,19 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
+
+  /follow-redirects/1.15.0_debug@4.3.4:
+    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -5086,7 +5105,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0
+      follow-redirects: 1.15.0_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/vitejs/vite/issues/11197

Patches `dotenv-expand` to not write to `process.env` by default. Use simpler expand implementation.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
