### PR TITLE
chore: fix test run in dev

### DIFF
--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -1,4 +1,4 @@
-import { escapePath } from 'fast-glob'
+import glob from 'fast-glob'
 import type { WatchOptions } from 'dep-types/chokidar'
 import type { ResolvedConfig } from '.'
 
@@ -13,7 +13,7 @@ export function resolveChokidarOptions(
       '**/.git/**',
       '**/node_modules/**',
       '**/test-results/**', // Playwright
-      escapePath(config.cacheDir) + '/**',
+      glob.escapePath(config.cacheDir) + '/**',
       ...(Array.isArray(ignored) ? ignored : [ignored]),
     ],
     ignoreInitial: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When running `pnpm dev` to build Vite, `pnpm test` fails because `fast-glob` is a CJS package, but the dev output tries to named import it.

This PR uses default import instead.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
