### PR TITLE
fix: serialize bundleWorkerEntry

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -50,7 +50,7 @@ function saveEmitWorkerAsset(
 }
 
 // Ensure that only one rollup build is called at the same time to avoid
-// leaking state in plugins between worker builds. 
+// leaking state in plugins between worker builds.
 // TODO: Review if we can parallelize the bundling of workers.
 const workerConfigSemaphore = new WeakMap<
   ResolvedConfig,

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -49,7 +49,29 @@ function saveEmitWorkerAsset(
   workerMap.assets.set(fileName, asset)
 }
 
+// Ensure that only one rollup build is called at the same time to avoid
+// leaking state in plugins between worker builds.
+const workerConfigSemaphore = new WeakMap<
+  ResolvedConfig,
+  Promise<OutputChunk>
+>()
 export async function bundleWorkerEntry(
+  config: ResolvedConfig,
+  id: string,
+  query: Record<string, string> | null,
+): Promise<OutputChunk> {
+  const processing = workerConfigSemaphore.get(config)
+  if (processing) {
+    await processing
+    return bundleWorkerEntry(config, id, query)
+  }
+  const promise = serialBundleWorkerEntry(config, id, query)
+  workerConfigSemaphore.set(config, promise)
+  promise.then(() => workerConfigSemaphore.delete(config))
+  return promise
+}
+
+async function serialBundleWorkerEntry(
   config: ResolvedConfig,
   id: string,
   query: Record<string, string> | null,

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -50,7 +50,8 @@ function saveEmitWorkerAsset(
 }
 
 // Ensure that only one rollup build is called at the same time to avoid
-// leaking state in plugins between worker builds.
+// leaking state in plugins between worker builds. 
+// TODO: Review if we can parallelize the bundling of workers.
 const workerConfigSemaphore = new WeakMap<
   ResolvedConfig,
   Promise<OutputChunk>


### PR DESCRIPTION
### Description

@sapphi-red discovered that multiple rollup runs to bundle workers could share state, this PR serializes `bundleWorkerEntry` until we have a better way to handle these runs in parallel. cc @poyoho @bluwy 

Hopefully fixes the CI on Windows.

https://discord.com/channels/804011606160703521/804439875226173480/1049584735267074069

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other