### PR TITLE
fix(config): resolve dynamic import as esm

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -973,7 +973,6 @@ async function bundleConfigFile(
             root: path.dirname(fileName),
             isBuild: true,
             isProduction: true,
-            isRequire: !isESM,
             preferRelative: false,
             tryIndex: true,
             mainFields: [],
@@ -1001,8 +1000,15 @@ async function bundleConfigFile(
               if (id.startsWith('npm:')) {
                 return { external: true }
               }
-              let idFsPath = tryNodeResolve(id, importer, options, false)?.id
-              if (idFsPath && (isESM || kind === 'dynamic-import')) {
+
+              const isIdESM = isESM || kind === 'dynamic-import'
+              let idFsPath = tryNodeResolve(
+                id,
+                importer,
+                { ...options, isRequire: !isIdESM },
+                false,
+              )?.id
+              if (idFsPath && isIdESM) {
                 idFsPath = pathToFileURL(idFsPath).href
               }
               return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When calling `tryNodeResolve` when bundling the config, make sure the `isRequire` option depends on whether the import is a dynamic import or not.

Dynamic imports uses the `import` exports condition when resolving in Node. So `isRequire` should be false for that even in `vite.config.cjs`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
