### PR TITLE
feat: add CLI keyboard shortcuts

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -152,7 +152,7 @@ cli
       server.printUrls()
       server.bindShortcuts({
         print: true,
-        additionalShortCuts: [
+        customShortcuts: [
           profileSession && {
             key: 's',
             description: 'stop the profiler',

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -61,6 +61,7 @@ export type {
   LogType,
   LoggerOptions,
 } from './logger'
+export type { BindShortcutsOptions, CLIShortcut } from './shortcuts'
 export type {
   IndexHtmlTransform,
   IndexHtmlTransformHook,

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -61,7 +61,6 @@ export type {
   LogType,
   LoggerOptions,
 } from './logger'
-export type { BindShortcutsOptions, CLIShortcut } from './shortcuts'
 export type {
   IndexHtmlTransform,
   IndexHtmlTransformHook,

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -22,6 +22,7 @@ export function bindShortcuts(
   opts: BindShortcutsOptions,
 ): void {
   if (!server.httpServer) return
+  server._shortcutsOptions = opts
 
   if (opts.print) {
     server.config.logger.info(

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -9,7 +9,7 @@ export type BindShortcutsOptions = {
    * Print a one line hint to the terminal.
    */
   print?: boolean
-  additionalShortCuts?: (CLIShortcut | undefined | null)[]
+  customShortcuts?: (CLIShortcut | undefined | null)[]
 }
 
 export type CLIShortcut = {
@@ -33,7 +33,7 @@ export function bindShortcuts(
     )
   }
 
-  const shortcuts = (opts.additionalShortCuts ?? [])
+  const shortcuts = (opts.customShortcuts ?? [])
     .filter(isDefined)
     .concat(BASE_SHORTCUTS)
 

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -1,7 +1,6 @@
 import colors from 'picocolors'
 import type { ViteDevServer } from './server'
 import { openBrowser } from './server/openBrowser'
-import type { HmrOptions } from './server/hmr'
 import { isDefined } from './utils'
 
 export type BindShortcutsOptions = {
@@ -80,8 +79,6 @@ export function bindShortcuts(
   })
 }
 
-let initialHmrOptions: HmrOptions | boolean
-
 const BASE_SHORTCUTS: CLIShortcut[] = [
   {
     key: 'r',
@@ -102,26 +99,6 @@ const BASE_SHORTCUTS: CLIShortcut[] = [
       }
 
       openBrowser(url, true, server.config.logger)
-    },
-  },
-  {
-    key: 'm',
-    description: 'toggle hmr on/off',
-    action({ config }: ViteDevServer): void {
-      initialHmrOptions ??= config.server.hmr ?? true
-      /**
-       * Mutating the server config works because Vite reads from
-       * it on every file change, instead of caching its value.
-       */
-      config.server.hmr =
-        config.server.hmr === false
-          ? initialHmrOptions === false
-            ? true
-            : initialHmrOptions
-          : false
-      config.logger.info(
-        colors.cyan(`hmr ${config.server.hmr ? `enabled` : `disabled`}`),
-      )
     },
   },
   {

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -108,9 +108,7 @@ const BASE_SHORTCUTS: CLIShortcut[] = [
     key: 'm',
     description: 'toggle hmr on/off',
     action({ config }: ViteDevServer): void {
-      if (initialHmrOptions === undefined) {
-        initialHmrOptions = config.server.hmr ?? true
-      }
+      initialHmrOptions ??= config.server.hmr ?? true
       /**
        * Mutating the server config works because Vite reads from
        * it on every file change, instead of caching its value.

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -1,0 +1,136 @@
+import colors from 'picocolors'
+import type { ViteDevServer } from './server'
+import { openBrowser } from './server/openBrowser'
+import type { HmrOptions } from './server/hmr'
+import { isDefined } from './utils'
+
+export type BindShortcutsOptions = {
+  /**
+   * Print a one line hint to the terminal.
+   */
+  print?: boolean
+  additionalShortCuts?: (CLIShortcut | undefined | null)[]
+}
+
+export type CLIShortcut = {
+  key: string
+  description: string
+  action(server: ViteDevServer): void | Promise<void>
+}
+
+export function bindShortcuts(
+  server: ViteDevServer,
+  opts: BindShortcutsOptions,
+): void {
+  if (!server.httpServer) return
+
+  if (opts.print) {
+    server.config.logger.info(
+      colors.dim(colors.green('  ➜')) +
+        colors.dim('  press ') +
+        colors.bold('h') +
+        colors.dim(' to show help'),
+    )
+  }
+
+  const shortcuts = (opts.additionalShortCuts ?? [])
+    .filter(isDefined)
+    .concat(BASE_SHORTCUTS)
+
+  let actionRunning = false
+
+  const onInput = async (input: string) => {
+    // ctrl+c or ctrl+d
+    if (input === '\x03' || input === '\x04') {
+      process.emit('SIGTERM')
+      return
+    }
+
+    if (actionRunning) return
+
+    if (input === 'h') {
+      server.config.logger.info(
+        shortcuts
+          .map(
+            (shortcut) =>
+              colors.dim('  press ') +
+              colors.bold(shortcut.key) +
+              colors.dim(` to ${shortcut.description}`),
+          )
+          .join('\n'),
+      )
+    }
+
+    const shortcut = shortcuts.find((shortcut) => shortcut.key === input)
+    if (!shortcut) return
+
+    actionRunning = true
+    await shortcut.action(server)
+    actionRunning = false
+  }
+
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+  }
+
+  process.stdin.on('data', onInput).setEncoding('utf8').resume()
+
+  server.httpServer.on('close', () => {
+    process.stdin.off('data', onInput).pause()
+  })
+}
+
+let initialHmrOptions: HmrOptions | boolean
+
+const BASE_SHORTCUTS: CLIShortcut[] = [
+  {
+    key: 'r',
+    description: 'restart the server',
+    async action(server) {
+      await server.restart()
+    },
+  },
+  {
+    key: 'o',
+    description: 'open in browser',
+    action(server) {
+      const url = server.resolvedUrls?.local[0]
+
+      if (!url) {
+        server.config.logger.warn('No URL available to open in browser')
+        return
+      }
+
+      openBrowser(url, true, server.config.logger)
+    },
+  },
+  {
+    key: 'm',
+    description: 'toggle hmr on/off',
+    action({ config }: ViteDevServer): void {
+      if (initialHmrOptions === undefined) {
+        initialHmrOptions = config.server.hmr ?? true
+      }
+      /**
+       * Mutating the server config works because Vite reads from
+       * it on every file change, instead of caching its value.
+       */
+      config.server.hmr =
+        config.server.hmr === false
+          ? initialHmrOptions === false
+            ? true
+            : initialHmrOptions
+          : false
+      config.logger.info(
+        colors.cyan(`hmr ${config.server.hmr ? `enabled` : `disabled`}`),
+      )
+    },
+  },
+  {
+    key: 'q',
+    description: 'quit',
+    async action(server) {
+      await server.close().finally(() => process.exit())
+    },
+  },
+]


### PR DESCRIPTION
This is based on the work from #9673 by @HomyeeKing , @aleclarson and @joelmukuthu

Closes #9673

Few changes have been made:
- Don't display hint by default, I think it's nice for people building on top of Vite
- Don't display quit in default hint, I think people know how to quit a process by default
- Fix rebind of shortcuts for external restart
- Send `SIGTERM` for ctrl+c, enable nicer exit and probably better in middleware mode (not tested)
- Restore initial hmrConfig on HMR toggle
- Enable custom shortcuts and use it in cli for stopping dev profiler

<img width="345" alt="image" src="https://user-images.githubusercontent.com/14235743/206048371-9be6f2b3-e558-43b1-bd6f-18270447be65.png">