### PR TITLE
fix: don't print urls on restart with default port

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -811,7 +811,7 @@ async function restartServer(server: ViteDevServer) {
   if (!middlewareMode) {
     await server.listen(port, true)
     logger.info('server restarted.', { timestamp: true })
-    if (port !== prevPort || host !== prevHost) {
+    if ((port ?? 5173) !== (prevPort ?? 5173) || host !== prevHost) {
       logger.info('')
       server.printUrls()
     }


### PR DESCRIPTION
When using the default port, config.server.port is `undefined` after createServer, but 5173 once [listening triggers](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/index.ts#L531)

Which causes `undefined` !== `5173` on the fixed line