### PR TITLE
fix: await scanner

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -168,7 +168,9 @@ async function createDepsOptimizer(
   let optimizingNewDeps: Promise<DepOptimizationResult> | undefined
   async function close() {
     closed = true
-    await discoverProjectDependenciesPromise
+    await discoverProjectDependenciesPromise?.catch(() => {
+      /* ignore error for scanner because it's not important */
+    })
     await postScanOptimizationResult
     await optimizingNewDeps
   }

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -161,10 +161,14 @@ async function createDepsOptimizer(
   let firstRunCalled = !!cachedMetadata
 
   let postScanOptimizationResult: Promise<DepOptimizationResult> | undefined
+  let discoverProjectDependenciesPromise:
+    | Promise<Record<string, string>>
+    | undefined
 
   let optimizingNewDeps: Promise<DepOptimizationResult> | undefined
   async function close() {
     closed = true
+    await discoverProjectDependenciesPromise
     await postScanOptimizationResult
     await optimizingNewDeps
   }
@@ -202,7 +206,9 @@ async function createDepsOptimizer(
         try {
           debug(colors.green(`scanning for dependencies...`))
 
-          const deps = await discoverProjectDependencies(config)
+          discoverProjectDependenciesPromise =
+            discoverProjectDependencies(config)
+          const deps = await discoverProjectDependenciesPromise
 
           debug(
             colors.green(

--- a/playground/multiple-entrypoints/__tests__/multiple-entrypoints.spec.ts
+++ b/playground/multiple-entrypoints/__tests__/multiple-entrypoints.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
 import { getColor, page, untilUpdated } from '~utils'
 
-test.skip('should have css applied on second dynamic import', async () => {
+test('should have css applied on second dynamic import', async () => {
   await untilUpdated(() => page.textContent('.content'), 'Initial', true)
   await page.click('.b')
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When scanner didn't finish before server is closed, esbuild hanged up, I guess.

1. scanner starts
2. server close
3. scanner ends

refs #11239

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
