### PR TITLE
feat: single cancellable scan

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -239,7 +239,7 @@ export async function optimizeDeps(
     return cachedMetadata
   }
 
-  const deps = await discoverProjectDependencies(config)
+  const deps = await (await discoverProjectDependencies(config)).depsPromise
 
   const depsString = depsLogString(Object.keys(deps))
   log(colors.green(`Optimizing dependencies:\n  ${depsString}`))
@@ -382,24 +382,31 @@ export function loadCachedDepOptimizationMetadata(
  */
 export async function discoverProjectDependencies(
   config: ResolvedConfig,
-): Promise<Record<string, string>> {
-  const { deps, missing } = await scanImports(config)
-
-  const missingIds = Object.keys(missing)
-  if (missingIds.length) {
-    throw new Error(
-      `The following dependencies are imported but could not be resolved:\n\n  ${missingIds
-        .map(
-          (id) =>
-            `${colors.cyan(id)} ${colors.white(
-              colors.dim(`(imported by ${missing[id]})`),
-            )}`,
+): Promise<{
+  cancel: () => void
+  depsPromise: Promise<Record<string, string>>
+}> {
+  const { cancel, resultsPromise } = await scanImports(config)
+  return {
+    cancel,
+    depsPromise: resultsPromise.then(({ deps, missing }) => {
+      const missingIds = Object.keys(missing)
+      if (missingIds.length) {
+        throw new Error(
+          `The following dependencies are imported but could not be resolved:\n\n  ${missingIds
+            .map(
+              (id) =>
+                `${colors.cyan(id)} ${colors.white(
+                  colors.dim(`(imported by ${missing[id]})`),
+                )}`,
+            )
+            .join(`\n  `)}\n\nAre they installed?`,
         )
-        .join(`\n  `)}\n\nAre they installed?`,
-    )
-  }
+      }
 
-  return deps
+      return deps
+    }),
+  }
 }
 
 export function toDiscoveredDependencies(
@@ -679,7 +686,7 @@ export async function findKnownImports(
   config: ResolvedConfig,
   ssr: boolean,
 ): Promise<string[]> {
-  const deps = (await scanImports(config)).deps
+  const { deps } = await (await scanImports(config)).resultsPromise
   await addManuallyIncludedOptimizeDeps(deps, config, ssr)
   return Object.keys(deps)
 }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -106,20 +106,19 @@ export async function scanImports(config: ResolvedConfig): Promise<{
   const { plugins = [], ...esbuildOptions } =
     config.optimizeDeps?.esbuildOptions ?? {}
 
-  await Promise.all(
-    entries.map((entry) =>
-      build({
-        absWorkingDir: process.cwd(),
-        write: false,
-        entryPoints: [entry],
-        bundle: true,
-        format: 'esm',
-        logLevel: 'error',
-        plugins: [...plugins, plugin],
-        ...esbuildOptions,
-      }),
-    ),
-  )
+  await build({
+    absWorkingDir: process.cwd(),
+    write: false,
+    stdin: {
+      contents: entries.map((e) => `import '${e}'`).join('\n'),
+      loader: 'js',
+    },
+    bundle: true,
+    format: 'esm',
+    logLevel: 'error',
+    plugins: [...plugins, plugin],
+    ...esbuildOptions,
+  })
 
   debug(`Scan completed in ${(performance.now() - start).toFixed(2)}ms:`, deps)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

scanning currently starts multiple esbuild promises and there is no way to cancel them.

use a single pass promise and add a plugin that cancels the running build when calling `cancel()`

### Additional context

this may be useful to prevent parallel runs of the optimizer too, ideally there was a simpler way to cancel the esbuild promise but i didn't see it :/

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
