### PR TITLE
fix: less promises for scanning and await with allSettled

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -168,11 +168,13 @@ async function createDepsOptimizer(
   let optimizingNewDeps: Promise<DepOptimizationResult> | undefined
   async function close() {
     closed = true
-    await discoverProjectDependenciesPromise?.catch(() => {
-      /* ignore error for scanner because it's not important */
-    })
-    await postScanOptimizationResult
-    await optimizingNewDeps
+    await Promise.allSettled([
+      discoverProjectDependenciesPromise?.catch(() => {
+        /* ignore error for scanner because it's not important */
+      }),
+      postScanOptimizationResult,
+      optimizingNewDeps,
+    ])
   }
 
   if (!cachedMetadata) {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -106,20 +106,19 @@ export async function scanImports(config: ResolvedConfig): Promise<{
   const { plugins = [], ...esbuildOptions } =
     config.optimizeDeps?.esbuildOptions ?? {}
 
-  await Promise.all(
-    entries.map((entry) =>
-      build({
-        absWorkingDir: process.cwd(),
-        write: false,
-        entryPoints: [entry],
-        bundle: true,
-        format: 'esm',
-        logLevel: 'error',
-        plugins: [...plugins, plugin],
-        ...esbuildOptions,
-      }),
-    ),
-  )
+  await build({
+    absWorkingDir: process.cwd(),
+    write: false,
+    stdin: {
+      contents: entries.map((e) => `import '${e}'`).join('\n'),
+      loader: 'js',
+    },
+    bundle: true,
+    format: 'esm',
+    logLevel: 'error',
+    plugins: [...plugins, plugin],
+    ...esbuildOptions,
+  })
 
   debug(`Scan completed in ${(performance.now() - start).toFixed(2)}ms:`, deps)
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -410,7 +410,7 @@ export async function createServer(
           process.stdin.off('end', exitProcess)
         }
       }
-      await Promise.all([
+      await Promise.allSettled([
         watcher.close(),
         ws.close(),
         container.close(),


### PR DESCRIPTION
alternative to https://github.com/vitejs/vite/pull/11243  

doesn't add `cancel()` function to as that may have performance implications and the way the function has to be passed around isn't nice. 

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
