### PR TITLE
fix(optimizer): escape entrypoints when running scanner

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -110,7 +110,7 @@ export async function scanImports(config: ResolvedConfig): Promise<{
     absWorkingDir: process.cwd(),
     write: false,
     stdin: {
-      contents: entries.map((e) => `import '${e}'`).join('\n'),
+      contents: entries.map((e) => `import ${JSON.stringify(e)}`).join('\n'),
       loader: 'js',
     },
     bundle: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
scanner was not working on windows.

refs #11245

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
