### PR TITLE
test: fix postcss-caching test flakiness

### DIFF
--- a/playground/css/postcss-caching/css.spec.ts
+++ b/playground/css/postcss-caching/css.spec.ts
@@ -21,11 +21,16 @@ test('postcss config', async () => {
     await server.listen()
     return server
   }
+
   const blueAppDir = path.join(__dirname, 'blue-app')
   const greenAppDir = path.join(__dirname, 'green-app')
   let blueApp
   let greenApp
   try {
+    const hmrConnectionPromise = page.waitForEvent('console', (msg) =>
+      msg.text().includes('connected'),
+    )
+
     blueApp = await startServer(blueAppDir)
 
     await page.goto(`http://localhost:${port}`)
@@ -33,11 +38,16 @@ test('postcss config', async () => {
     expect(await getColor(blueA)).toBe('blue')
     const blueB = await page.$('.postcss-b')
     expect(await getColor(blueB)).toBe('black')
+
+    // wait for hmr connection because: if server stops before connection, auto reload does not happen
+    await hmrConnectionPromise
     await blueApp.close()
     blueApp = null
 
+    const navigationPromise = page.waitForNavigation() // wait for server restart auto reload
     greenApp = await startServer(greenAppDir)
-    await page.reload() // hmr reloads it automatically but reload here for consistency
+    await navigationPromise
+
     const greenA = await page.$('.postcss-a')
     expect(await getColor(greenA)).toBe('black')
     const greenB = await page.$('.postcss-b')

--- a/playground/css/postcss-caching/css.spec.ts
+++ b/playground/css/postcss-caching/css.spec.ts
@@ -1,9 +1,9 @@
 import path from 'node:path'
 import { createServer } from 'vite'
 import { expect, test } from 'vitest'
-import { getColor, page, ports } from '~utils'
+import { getColor, isServe, page, ports } from '~utils'
 
-test('postcss config', async () => {
+test.runIf(isServe)('postcss config', async () => {
   const port = ports['css/postcss-caching']
   const startServer = async (root) => {
     const server = await createServer({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When the server stops before HMR connection, auto reload does not happen. This is because auto reload does not happen if HMR wasn't connected at least once to prevent unwanted reloads.

Also this test was running on both serve and build. But it does the same thing. I made this test to only run on serve test.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
