### PR TITLE
docs: specify that 'worker' means 'web worker'

### DIFF
--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -1,6 +1,6 @@
-# Web Worker Options
+# Worker Options
 
-Options for web workers (these are not service workers).
+Options related to Web Workers.
 
 ## worker.format
 

--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -1,4 +1,6 @@
-# Worker Options
+# Web Worker Options
+
+Options for web workers (these are not service workers).
 
 ## worker.format
 


### PR DESCRIPTION
### Description

https://vitejs.dev/config/worker-options.html just says worker options - it's unclear whether these are web workers or service workers. https://vitejs.dev/guide/features.html#web-workers seems to indicate 'workers' means web workers.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
