### PR TITLE
fix(hmr): Fix circular dep root starts hmr, and has invalidate in it,…

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -67,12 +67,7 @@ import type { ModuleNode } from './moduleGraph'
 import { ModuleGraph } from './moduleGraph'
 import { errorMiddleware, prepareError } from './middlewares/error'
 import type { HmrOptions } from './hmr'
-import {
-  getShortName,
-  handleFileAddUnlink,
-  handleHMRUpdate,
-  updateModules,
-} from './hmr'
+import { handleFileAddUnlink, handleHMRUpdate, updateModules } from './hmr'
 import { openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
@@ -518,9 +513,9 @@ export async function createServer(
           (message ? ` ${message}` : ''),
         { timestamp: true },
       )
-      const file = getShortName(mod.file!, config.root)
+
       updateModules(
-        file,
+        mod.file!,
         [...mod.importers],
         mod.lastHMRTimestamp,
         server,

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -20,7 +20,7 @@ test('should render', async () => {
 
 if (!isBuild) {
   test('should connect', async () => {
-    expect(browserLogs.length).toBe(3)
+    expect(browserLogs.length).toBe(4)
     expect(browserLogs.some((msg) => msg.match('connected'))).toBe(true)
     browserLogs.length = 0
   })
@@ -167,6 +167,14 @@ if (!isBuild) {
         '>>> vite:afterUpdate -- update',
       ],
       true,
+    )
+    await untilUpdated(() => el.textContent(), 'child updated')
+  })
+
+  test('invalidate in circular dep should not trigger infinite HMR', async () => {
+    const el = await page.$('.invalidation-circular-deps')
+    await editFile('invalidation-circular-deps/child.js', (code) =>
+      code.replace('child', 'child updated'),
     )
     await untilUpdated(() => el.textContent(), 'child updated')
   })

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -3,6 +3,7 @@ import { virtual } from 'virtual:file'
 import { foo as depFoo, nestedFoo } from './hmrDep'
 import './importing-updated'
 import './invalidation/parent'
+import './invalidation-circular-deps/parent'
 import './file-delete-restore'
 
 export const foo = 1

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -23,6 +23,7 @@
 <div class="custom"></div>
 <div class="virtual"></div>
 <div class="invalidation"></div>
+<div class="invalidation-circular-deps"></div>
 <div class="custom-communication"></div>
 <div class="css-prev"></div>
 <div class="css-post"></div>

--- a/playground/hmr/invalidation-circular-deps/child.js
+++ b/playground/hmr/invalidation-circular-deps/child.js
@@ -1,0 +1,11 @@
+import './parent'
+
+if (import.meta.hot) {
+  // Need to accept, to register a callback for HMR
+  import.meta.hot.accept(() => {
+    // Trigger HMR in importers
+    import.meta.hot.invalidate()
+  })
+}
+
+export const value = 'child'

--- a/playground/hmr/invalidation-circular-deps/parent.js
+++ b/playground/hmr/invalidation-circular-deps/parent.js
@@ -1,0 +1,10 @@
+import { value } from './child'
+
+if (import.meta.hot) {
+  import.meta.hot.accept()
+}
+
+console.log('(invalidation circular deps) parent is executing')
+setTimeout(() => {
+  document.querySelector('.invalidation-circular-deps').innerHTML = value
+})


### PR DESCRIPTION
Infinite HMR caused by circular dep and `hot.invalidate()`

<!-- Thank you for contributing! -->

### Description

Image a module A has dep B, and B also has dep A, if B has `hot.invalidate()` in it, and B triggers `hmr`, then it obviously will send `vite:invalidate` to the server, then B's importers all starts to propagate this update, and B's importer is A, which has B as its dependency again. So it will cause infinite loop.

**How to reprod**

- Create a new vite project.
- Add 2 modules, `main` and `dep`, `main` import some stuff from `dep`, and `dep` also import some stuff from `main`, add `import.meta.hot.accept(() => { import.meta.hot.invalidate() })` to the `dep`.
- Go to browser and open that page.
- Save `main.ts` file


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
