### PR TITLE
docs: add plugin-react-swc to official plugins list

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -18,11 +18,11 @@ Check out [Using Plugins](../guide/using-plugins) for information on how to use 
 
 ### [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/tree/main/packages/plugin-react)
 
-- Provides all-in-one React Support.
+- Uses esbuild and Babel, achieving fast HMR with a small package footprint and the flexibility of being able to use the Babel transform pipeline.
 
 ### [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc)
 
-- Provides fast React development via [SWC](https://swc.rs/)
+- Uses esbuild during build, but replaces Babel with SWC during development. For big projects that don't require non-standard React extensions, cold start and Hot Module Replacement (HMR) can be significantly faster.
 
 ### [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy)
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -20,6 +20,10 @@ Check out [Using Plugins](../guide/using-plugins) for information on how to use 
 
 - Provides all-in-one React Support.
 
+### [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc)
+
+- Provides fast React development via [SWC](https://swc.rs/)
+
 ### [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy)
 
 - Provides legacy browsers support for the production build.


### PR DESCRIPTION
Opening for discussion. Maybe we should add a bit more context to both React plugins? Or link to the blog post announcement?

Also should we add vue-2, basic-ssl and other org plugins?