### PR TITLE
chore: split ci jobs for faster docs & template updates

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -1,0 +1,57 @@
+name: CI Lint
+
+env:
+  # 7 GiB by default on GitHub, setting to 6 GiB
+  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+  NODE_OPTIONS: --max-old-space-size=6144
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+      - feat/*
+      - fix/*
+      - perf/*
+      - v1
+      - v2
+      - v2.*
+      - v3.*
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    name: "Lint, Format, Typecheck, Docs"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2.2.4
+
+      - name: Set node version to 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "pnpm"
+
+      - name: Install deps
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Check formatting
+        run: pnpm prettier --check .
+
+      - name: Typecheck
+        run: pnpm run typecheck
+
+      - name: Test docs
+        run: pnpm run test-docs

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2.2.4
 
-      - name: Set node version to 16
+      - name: Set node version to 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: "pnpm"
 
       - name: Install deps
@@ -56,5 +56,15 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      # Run unit test for create-vite only PRs
+      - name: Test unit
+        run: pnpm run test-unit
+
       - name: Test docs
         run: pnpm run test-docs
+
+      # From https://github.com/rhysd/actionlint/blob/main/docs/usage.md#use-actionlint-on-github-actions
+      - name: Check workflow files
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color -shellcheck=""

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Install deps
         run: pnpm install
 
+      - name: Build
+        run: pnpm run build
+
       - name: Lint
         run: pnpm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ on:
       - v2.*
       - v3.*
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "packages/create-vite/**"
   workflow_dispatch:
 
 concurrency:
@@ -98,40 +101,3 @@ jobs:
 
       - name: Test build
         run: pnpm run test-build
-
-      - name: Test docs
-        run: pnpm run test-docs
-
-  lint:
-    if: github.repository == 'vitejs/vite'
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    name: "Lint: node-16, ubuntu-latest"
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.4
-
-      - name: Set node version to 16
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: "pnpm"
-
-      - name: Install deps
-        run: pnpm install
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Check formatting
-        run: pnpm prettier --check .
-
-      - name: Typecheck
-        run: pnpm run typecheck

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,7 +28,7 @@ jobs:
             pkgName=${GITHUB_REF_NAME%@*}
           fi
 
-          echo "::set-output name=pkgName::$pkgName"
+          echo "pkgName=$pkgName" >> $GITHUB_OUTPUT
 
       - name: Create Release for Tag
         id: release_tag


### PR DESCRIPTION
Uses `paths-ignore` feature for GH action to avoid running the whole test suite for simple updates.

This is only available for top level workflow, so we need to split in 2.

This also avoid to build the docs 5 times.

I removed fetch-depth 0 because I don't see anything that need git history in that job