### PR TITLE
docs: fix path to main.js

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -34,7 +34,7 @@ If you need a custom integration, you can follow the steps in this guide to conf
    ```html
    <!-- if development -->
    <script type="module" src="http://localhost:5173/@vite/client"></script>
-   <script type="module" src="http://localhost:5173/main.js"></script>
+   <script type="module" src="http://localhost:5173/js/main.js"></script>
    ```
 
    In order to properly serve assets, you have two options:


### PR DESCRIPTION
The path to main.js was missing the js-folder

<!-- Thank you for contributing! -->

### Description

The documentation for backend integration with Vite is incorrect. The path to the `main.js` is missing the `js`-Folder. This PR fixes this.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
