### PR TITLE
chore: fix format

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -87,7 +87,7 @@ export async function preview(
   const distDir = path.resolve(config.root, config.build.outDir)
   if (!fs.existsSync(distDir)) {
     throw new Error(
-      `"${config.build.outDir}" does not exist. Did you build your project?`
+      `"${config.build.outDir}" does not exist. Did you build your project?`,
     )
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#10564 was using a prettierrc before #11167. So the lint ci passed before merge and failed after merge.
The recent lint fails are caused by this line.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
