### PR TITLE
test: fix custom serve teardown

### DIFF
--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -165,7 +165,6 @@ beforeAll(async (s) => {
         if (serve) {
           server = await serve()
           viteServer = mod.viteServer
-          return
         }
       } else {
         await startDefaultServe()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When running `pnpm test-serve`, the error below was happening on my PC.
```
error during global teardown of ./playground/vitestGlobalSetup.ts Error: EBUSY: resource busy or locked, rmdir '\\?\C:\foo\vite\playground-temp\cli-module
```

This was happening because of this `return` on line 168.
This causes `server?.close()` and other things on line 185-191 not to be called.
https://github.com/vitejs/vite/blob/9f65af19c441d4e6d9d7784dd94a1870123482e3/playground/vitestSetup.ts#L165-L193

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
