### PR TITLE
fix: replace import.meta.hot with undefined in the production

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -41,17 +41,17 @@ describe('definePlugin', () => {
   })
 
   test('preserve import.meta.hot with override', async () => {
-    // assert that the default behavior is to replace import.meta.hot with false
+    // assert that the default behavior is to replace import.meta.hot with undefined
     const transform = await createDefinePluginTransform()
-    expect(await transform('const isHot = import.meta.hot;')).toBe(
-      'const isHot = false;',
+    expect(await transform('const hot = import.meta.hot;')).toBe(
+      'const hot = undefined;',
     )
     // assert that we can specify a user define to preserve import.meta.hot
     const overrideTransform = await createDefinePluginTransform({
       'import.meta.hot': 'import.meta.hot',
     })
-    expect(await overrideTransform('const isHot = import.meta.hot;')).toBe(
-      'const isHot = import.meta.hot;',
+    expect(await overrideTransform('const hot = import.meta.hot;')).toBe(
+      'const hot = import.meta.hot;',
     )
   })
 })

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -46,7 +46,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       SSR: !!config.build.ssr,
     }
     // set here to allow override with config.define
-    importMetaKeys['import.meta.hot'] = `false`
+    importMetaKeys['import.meta.hot'] = `undefined`
     for (const key in env) {
       importMetaKeys[`import.meta.env.${key}`] = JSON.stringify(env[key])
     }

--- a/playground/hmr/counter/dep.ts
+++ b/playground/hmr/counter/dep.ts
@@ -1,2 +1,4 @@
 // This file is never loaded
-import.meta.hot.accept(() => {})
+if (import.meta.hot) {
+  import.meta.hot.accept(() => {})
+}


### PR DESCRIPTION
### Description

`import.meta.hot` is replaced with `false` when building the production, not `undefined`.
https://github.com/vitejs/vite/blob/29abeeab9cc147c6d3383c672ded68311304bbaf/packages/vite/src/node/plugins/define.ts#L54



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
