### PR TITLE
feat: show server url by pressing `u`

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -91,6 +91,13 @@ const BASE_SHORTCUTS: CLIShortcut[] = [
     },
   },
   {
+    key: 'u',
+    description: 'show server url',
+    action(server) {
+      server.printUrls()
+    },
+  },
+  {
     key: 'o',
     description: 'open in browser',
     action(server) {

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -94,6 +94,7 @@ const BASE_SHORTCUTS: CLIShortcut[] = [
     key: 'u',
     description: 'show server url',
     action(server) {
+      server.config.logger.info('')
       server.printUrls()
     },
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#11228 implemented keyboard shortcuts. A shortcut to open the local server URL by the browser was implemented in that PR and could be considered as a solution of #10527. But I think there's cases when I want to open other URLs or in a non-default browser.

This PR implements a shortcut to show the server URLs. This way we can avoid the terminal to be narrow. The disadvantage of this approach is that additional two steps ("focusing the terminal" and "pressing u key") are required compared to #10527's suggested solution. 

closes #10527
alternative to close #10592
alternative to close #10594

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
