### PR TITLE
feat(html): clickable error position for html parse error

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -228,21 +228,17 @@ export function overwriteAttrValue(
 /**
  * Format parse5 @type {ParserError} to @type {RollupError}
  */
-function formatParseError(
-  parserError: ParserError,
-  id: string,
-  html: string,
-): RollupError {
-  const formattedError: RollupError = {
+function formatParseError(parserError: ParserError, id: string, html: string) {
+  const formattedError = {
     code: parserError.code,
     message: `parse5 error code ${parserError.code}`,
-  }
-  formattedError.frame = generateCodeFrame(html, parserError.startOffset)
-  formattedError.loc = {
-    file: id,
-    line: parserError.startLine,
-    column: parserError.startCol,
-  }
+    frame: generateCodeFrame(html, parserError.startOffset),
+    loc: {
+      file: id,
+      line: parserError.startLine,
+      column: parserError.startCol,
+    },
+  } satisfies RollupError
   return formattedError
 }
 
@@ -266,15 +262,11 @@ function handleParseError(
       // Allow self closing on non-void elements #10439
       return
   }
-  const parseError = {
-    loc: filePath,
-    frame: '',
-    ...formatParseError(parserError, filePath, html),
-  }
+  const parseError = formatParseError(parserError, filePath, html)
   throw new Error(
-    `Unable to parse HTML; ${parseError.message}\n at ${JSON.stringify(
-      parseError.loc,
-    )}\n${parseError.frame}`,
+    `Unable to parse HTML; ${parseError.message}\n` +
+      ` at ${parseError.loc.file}:${parseError.loc.line}:${parseError.loc.column}\n` +
+      `${parseError.frame}`,
   )
 }
 

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -193,7 +193,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     )
   }
 
-  await traverseHtml(html, htmlPath, (node) => {
+  await traverseHtml(html, filename, (node) => {
     if (!nodeIsElement(node)) {
       return
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
![image](https://user-images.githubusercontent.com/49056869/207040400-890b79e1-bfb8-4c33-9030-f882c9ec1124.png)
```
Unable to parse HTML; parse5 error code unexpected-character-in-attribute-name
 at {"file":"/index.html","line":16,"column":1}
```

Currently when Vite fails to parse a HTML, the error above is shown. But this `at {"file": ... }` part is not clickable.
This PR changes that part to be like below and make it clickable.
```
Unable to parse HTML; parse5 error code unexpected-character-in-attribute-name
 at C:/foo/bar/vite/playground/assets/index.html:16:1
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
