### PR TITLE
fix(preview): Revert #10564 - throw Error on missing outDir

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs'
 import path from 'node:path'
 import type * as http from 'node:http'
 import sirv from 'sirv'
@@ -84,13 +83,6 @@ export async function preview(
     'production',
   )
 
-  const distDir = path.resolve(config.root, config.build.outDir)
-  if (!fs.existsSync(distDir)) {
-    throw new Error(
-      `"${config.build.outDir}" does not exist. Did you build your project?`,
-    )
-  }
-
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.preview,
@@ -123,6 +115,7 @@ export async function preview(
     config.base === './' || config.base === '' ? '/' : config.base
 
   // static assets
+  const distDir = path.resolve(config.root, config.build.outDir)
   const headers = config.preview.headers
   const assetServer = sirv(distDir, {
     etag: true,


### PR DESCRIPTION
This reverts commit 0a1db8c1

`configurePreviewServer` can be used to make it work regardless of that directory existing, throwing the Error that wasn't there before is a breaking change.

see for details https://github.com/vitejs/vite/pull/10564#issuecomment-1346341736   

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
