### PR TITLE
fix(ssr): emit js sourcemaps for ssr builds

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -23,6 +23,7 @@ export const assetUrlRE = /__VITE_ASSET__([a-z\d]+)__(?:\$_(.*?)__)?/g
 
 const rawRE = /(?:\?|&)raw(?:&|$)/
 const urlRE = /(\?|&)url(?:&|$)/
+const jsSourceMapRE = /\.[cm]?js\.map$/
 
 const assetCache = new WeakMap<ResolvedConfig, Map<string, string>>()
 
@@ -187,10 +188,13 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     generateBundle(_, bundle) {
       // do not emit assets for SSR build
       if (config.command === 'build' && config.build.ssr) {
-        for (const file in bundle) {
+        const assetFiles = Object.keys(bundle).filter(
+          (file) => bundle[file].type === 'asset',
+        )
+        for (const file of assetFiles) {
           if (
-            bundle[file].type === 'asset' &&
-            !file.includes('ssr-manifest.json')
+            !file.endsWith('ssr-manifest.json') &&
+            !jsSourceMapRE.test(file)
           ) {
             delete bundle[file]
           }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -188,11 +188,9 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     generateBundle(_, bundle) {
       // do not emit assets for SSR build
       if (config.command === 'build' && config.build.ssr) {
-        const assetFiles = Object.keys(bundle).filter(
-          (file) => bundle[file].type === 'asset',
-        )
-        for (const file of assetFiles) {
+        for (const file in bundle) {
           if (
+            bundle[file].type === 'asset' &&
             !file.endsWith('ssr-manifest.json') &&
             !jsSourceMapRE.test(file)
           ) {


### PR DESCRIPTION
Fix: #11344

### Description

Rollup 3 switched the way sourcemaps were handled to be more consistent between the in-memory representation and what ultimately gets emitted to disk. Part of this change was moving the sourcemaps themselves to be assets within the bundle.

At the same time, vite's `generateBundle` hook for the `assetPlugin` is configured to delete assets within the bundle (with the exception of "ssr-manifest.json"). Since `.js.map` files are now considered assets within the bundle at this stage, vite is removing the sourcemaps from the bundle when `build.ssr = true` and they never wind up on disk.

This change adds an additional check to see if the file ends with `.js.map`, `.cjs.map`, or `.mjs.map` and it will leave these files in the bundle so that they are emitted to the outDir when the bundle is written.

### Additional context

Relevant rollup change that introduced this regression: https://github.com/rollup/rollup/pull/4605

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
