### PR TITLE
feat(css): allow specifying `stopDir` for postcss config resolution

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -219,6 +219,22 @@ The search is done using [postcss-load-config](https://github.com/postcss/postcs
 
 Note if an inline config is provided, Vite will not search for other PostCSS config sources.
 
+## css.resolveOptions
+
+- **Type:** `PostCSSConfigResolutionOptions`
+
+Specify options for postcss config resolution. Currently only the [stopDir](https://github.com/davidtheclark/cosmiconfig#stopdir) option for cosmicconfig is supported.
+
+```js
+export default defineConfig({
+  css: {
+    resolveOptions: {
+      stopDir: process.cwd(),
+    },
+  },
+})
+```
+
 ## css.preprocessorOptions
 
 - **Type:** `Record<string, object>`

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -96,6 +96,7 @@ export type {
 export type {
   CSSOptions,
   CSSModulesOptions,
+  PostCSSConfigResolutionOptions,
   PreprocessCSSResult,
   ResolvedCSSOptions,
 } from './plugins/css'


### PR DESCRIPTION
### Description

[postcss-load-config](https://github.com/postcss/postcss-load-config) has a behavior where it will find any `postcss.config.js` (or other supported postcss configuration formats) recursively from the current directory to the home directory of the user.

As of Sanity Studio v3, we're using Vite to power the development experience, and we are seeing quite a large number of reports from people who get an error such as this one upon starting the studio:
```
[plugin:vite:css] [postcss] Cannot read properties of undefined (reading 'config')
    at getTailwindConfig (/Users/adamsmith/Desktop/codingprojects/portfolio/node_modules/tailwindcss/lib/lib/setupTrackingContext.js:84:63)
    at /Users/adamsmith/Desktop/codingprojects/portfolio/node_modules/tailwindcss/lib/lib/setupTrackingContext.js:96:92
    at /Users/adamsmith/Desktop/codingprojects/portfolio/node_modules/tailwindcss/lib/processTailwindFeatures.js:46:11
    at plugins (/Users/adamsmith/Desktop/codingprojects/portfolio/node_modules/tailwindcss/lib/index.js:38:63)
    ...
```

This is caused by the user having a postcss configuration file in a parent folder, which while technically speaking is a documented behavior, is not easy to understand or discover for the user.

We are wanting to disable this behavior for our users, instead requiring a postcss configuration to reside inside of the project folder. This can be done by passing a `stopDir` option to cosmicconfig (technically speaking, [lilconfig](https://www.npmjs.com/package/lilconfig)), which is used by [postcss-load-config](https://github.com/postcss/postcss-load-config) in order to find the configuration file in vite.

This PR introduces a new option to the CSS options of vite, `resolveOptions`, which currently only accepts the `stopDir` option (the other options did not quite make sense to me in the context of vite on first look, so I decided to limit it for now).

Open to other suggestions for how to solve this.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
