### PR TITLE
style: Added a transition to the logo color drop shadow, making it look smooth

### DIFF
--- a/packages/create-vite/template-lit-ts/src/my-element.ts
+++ b/packages/create-vite/template-lit-ts/src/my-element.ts
@@ -58,6 +58,7 @@ export class MyElement extends LitElement {
       height: 6em;
       padding: 1.5em;
       will-change: filter;
+      transition: filter 300ms;
     }
     .logo:hover {
       filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-lit/src/my-element.js
+++ b/packages/create-vite/template-lit/src/my-element.js
@@ -65,6 +65,7 @@ export class MyElement extends LitElement {
         height: 6em;
         padding: 1.5em;
         will-change: filter;
+        transition: filter 300ms;
       }
       .logo:hover {
         filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-react-ts/src/App.css
+++ b/packages/create-vite/template-react-ts/src/App.css
@@ -9,6 +9,7 @@
   height: 6em;
   padding: 1.5em;
   will-change: filter;
+  transition: filter 300ms;
 }
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-react/src/App.css
+++ b/packages/create-vite/template-react/src/App.css
@@ -9,6 +9,7 @@
   height: 6em;
   padding: 1.5em;
   will-change: filter;
+  transition: filter 300ms;
 }
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-svelte-ts/src/App.svelte
+++ b/packages/create-vite/template-svelte-ts/src/App.svelte
@@ -32,6 +32,7 @@
     height: 6em;
     padding: 1.5em;
     will-change: filter;
+    transition: filter 300ms;
   }
   .logo:hover {
     filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-svelte/src/App.svelte
+++ b/packages/create-vite/template-svelte/src/App.svelte
@@ -32,6 +32,7 @@
     height: 6em;
     padding: 1.5em;
     will-change: filter;
+    transition: filter 300ms;
   }
   .logo:hover {
     filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-vanilla-ts/src/style.css
+++ b/packages/create-vite/template-vanilla-ts/src/style.css
@@ -48,6 +48,7 @@ h1 {
   height: 6em;
   padding: 1.5em;
   will-change: filter;
+  transition: filter 300ms;
 }
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-vanilla/style.css
+++ b/packages/create-vite/template-vanilla/style.css
@@ -48,6 +48,7 @@ h1 {
   height: 6em;
   padding: 1.5em;
   will-change: filter;
+  transition: filter 300ms;
 }
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-vue-ts/src/App.vue
+++ b/packages/create-vite/template-vue-ts/src/App.vue
@@ -19,6 +19,7 @@ import HelloWorld from './components/HelloWorld.vue'
   height: 6em;
   padding: 1.5em;
   will-change: filter;
+  transition: filter 300ms;
 }
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);

--- a/packages/create-vite/template-vue/src/App.vue
+++ b/packages/create-vite/template-vue/src/App.vue
@@ -19,6 +19,7 @@ import HelloWorld from './components/HelloWorld.vue'
   height: 6em;
   padding: 1.5em;
   will-change: filter;
+  transition: filter 300ms;
 }
 .logo:hover {
   filter: drop-shadow(0 0 2em #646cffaa);


### PR DESCRIPTION
This adds a little snippet of code that makes the drop shadow that makes the logo colors glow on hover have a nice smooth transition, it looks 10 times better, and it's just one line of CSS!

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
