### PR TITLE
docs: add docs for build.disabled

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -244,3 +244,14 @@ There are cases that file system watching does not work with WSL2.
 See [`server.watch`](./server-options.md#server-watch) for more details.
 
 :::
+
+
+## build.disabled
+
+- **Type:** `boolean | string`
+- **Default:** `disabled`
+
+Use esbuild to optimize dependencies during build time. If enabled, it removes one of the most significant differences between dev and prod present in v2. [`@rollup/plugin-commonjs`](https://github.com/rollup/plugins/tree/master/packages/commonjs) is no longer needed in this case since esbuild converts CJS-only dependencies to ESM.
+
+If you want to try this build strategy, you can use `optimizeDeps.disabled: false` (the default in v3 is `disabled: 'build'`). `@rollup/plugin-commonjs`
+can be removed by passing `build.commonjsOptions: { include: [] }`.

--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -248,6 +248,7 @@ See [`server.watch`](./server-options.md#server-watch) for more details.
 
 ## build.disabled
 
+- **Experimental**
 - **Type:** `boolean | string`
 - **Default:** `disabled`
 


### PR DESCRIPTION
### Description

This experimental feature is only documented in the migration docs of v2 to v3.  It seems like this should be included in the main docs.  I added the experimental bullet but not sure if it is this is still considered experimental or not.

https://v3.vitejs.dev/guide/migration.html#using-esbuild-deps-optimization-at-build-time

Question:
Would we want to add a link to it from here too? https://vitejs.dev/guide/dep-pre-bundling.html

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
