### PR TITLE
fix: skip applescript when no Chromium browser found (fixes #11205)

### DIFF
--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -86,17 +86,19 @@ function startBrowserProcess(browser: string | undefined, url: string) {
         preferredOSXBrowser && ps.includes(preferredOSXBrowser)
           ? preferredOSXBrowser
           : supportedChromiumBrowsers.find((b) => ps.includes(b))
-      // Try our best to reuse existing tab with AppleScript
-      execSync(
-        `osascript openChrome.applescript "${encodeURI(
-          url,
-        )}" "${openedBrowser}"`,
-        {
-          cwd: join(VITE_PACKAGE_DIR, 'bin'),
-          stdio: 'ignore',
-        },
-      )
-      return true
+      if (openedBrowser) {
+        // Try our best to reuse existing tab with AppleScript
+        execSync(
+          `osascript openChrome.applescript "${encodeURI(
+            url,
+          )}" "${openedBrowser}"`,
+          {
+            cwd: join(VITE_PACKAGE_DIR, 'bin'),
+            stdio: 'ignore',
+          },
+        )
+        return true
+      }
     } catch (err) {
       // Ignore errors
     }


### PR DESCRIPTION
Fixes #11205

Bad bug from #10588

I've started a branch to update lint rules and enable rules like this https://typescript-eslint.io/rules/restrict-template-expressions/

