### PR TITLE
fix(ssr): ignore module exports condition

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -8,7 +8,7 @@ import {
   usingDynamicImport,
 } from '../utils'
 import { transformRequest } from '../server/transformRequest'
-import type { InternalResolveOptions } from '../plugins/resolve'
+import type { InternalResolveOptionsWithOverrideConditions } from '../plugins/resolve'
 import { tryNodeResolve } from '../plugins/resolve'
 import {
   ssrDynamicImportKey,
@@ -112,10 +112,11 @@ async function instantiateModule(
     root,
   } = server.config
 
-  const resolveOptions: InternalResolveOptions = {
+  const resolveOptions: InternalResolveOptionsWithOverrideConditions = {
     mainFields: ['main'],
     browserField: true,
     conditions: [],
+    overrideConditions: ['production', 'development'],
     extensions: ['.js', '.cjs', '.json'],
     dedupe,
     preserveSymlinks,
@@ -223,7 +224,7 @@ async function instantiateModule(
 async function nodeImport(
   id: string,
   importer: string,
-  resolveOptions: InternalResolveOptions,
+  resolveOptions: InternalResolveOptionsWithOverrideConditions,
 ) {
   let url: string
   if (id.startsWith('node:') || isBuiltin(id)) {

--- a/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -116,3 +116,8 @@ test('import css library', async () => {
   await page.goto(url)
   expect(await getColor('.css-lib')).toBe('blue')
 })
+
+test('import css library', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.module-condition')).toMatch('[success]')
+})

--- a/playground/ssr-deps/module-condition/import.mjs
+++ b/playground/ssr-deps/module-condition/import.mjs
@@ -1,0 +1,1 @@
+export default '[success]'

--- a/playground/ssr-deps/module-condition/module.js
+++ b/playground/ssr-deps/module-condition/module.js
@@ -1,0 +1,4 @@
+// this is written in ESM but the file extension implies this is evaluated as CJS.
+// BUT this doesn't matter in practice as the `module` condition is not used in node.
+// hence SSR should not load this file.
+export default '[fail] should not load me'

--- a/playground/ssr-deps/module-condition/package.json
+++ b/playground/ssr-deps/module-condition/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitejs/test-module-condition",
+  "private": true,
+  "version": "0.0.0",
+  "exports": {
+    ".": {
+      "module": "./module.js",
+      "import": "./import.mjs"
+    }
+  }
+}

--- a/playground/ssr-deps/package.json
+++ b/playground/ssr-deps/package.json
@@ -29,7 +29,8 @@
     "@vitejs/test-external-using-external-entry": "file:./external-using-external-entry",
     "@vitejs/test-external-entry": "file:./external-entry",
     "@vitejs/test-linked-no-external": "link:./linked-no-external",
-    "@vitejs/test-pkg-exports": "file:./pkg-exports"
+    "@vitejs/test-pkg-exports": "file:./pkg-exports",
+    "@vitejs/test-module-condition": "file:./module-condition"
   },
   "devDependencies": {
     "express": "^4.18.2"

--- a/playground/ssr-deps/src/app.js
+++ b/playground/ssr-deps/src/app.js
@@ -15,6 +15,7 @@ import noExternalCjs from '@vitejs/test-no-external-cjs'
 import importBuiltinCjs from '@vitejs/test-import-builtin-cjs'
 import { hello as linkedNoExternal } from '@vitejs/test-linked-no-external'
 import virtualMessage from '@vitejs/test-pkg-exports/virtual'
+import moduleConditionMessage from '@vitejs/test-module-condition'
 import '@vitejs/test-css-lib'
 
 // This import will set a 'Hello World!" message in the nested-external non-entry dependency
@@ -86,6 +87,8 @@ export async function render(url, rootDir) {
   html += `\n<p class="dep-virtual">message from dep-virtual: ${virtualMessage}</p>`
 
   html += `\n<p class="css-lib">I should be blue</p>`
+
+  html += `\n<p class="module-condition">${moduleConditionMessage}</p>`
 
   return html + '\n'
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -898,6 +898,7 @@ importers:
       '@vitejs/test-forwarded-export': file:./forwarded-export
       '@vitejs/test-import-builtin-cjs': file:./import-builtin-cjs
       '@vitejs/test-linked-no-external': link:./linked-no-external
+      '@vitejs/test-module-condition': file:./module-condition
       '@vitejs/test-no-external-cjs': file:./no-external-cjs
       '@vitejs/test-no-external-css': file:./no-external-css
       '@vitejs/test-non-optimized-with-nested-external': file:./non-optimized-with-nested-external
@@ -921,6 +922,7 @@ importers:
       '@vitejs/test-forwarded-export': file:playground/ssr-deps/forwarded-export
       '@vitejs/test-import-builtin-cjs': file:playground/ssr-deps/import-builtin-cjs
       '@vitejs/test-linked-no-external': link:linked-no-external
+      '@vitejs/test-module-condition': file:playground/ssr-deps/module-condition
       '@vitejs/test-no-external-cjs': file:playground/ssr-deps/no-external-cjs
       '@vitejs/test-no-external-css': file:playground/ssr-deps/no-external-css
       '@vitejs/test-non-optimized-with-nested-external': file:playground/ssr-deps/non-optimized-with-nested-external
@@ -965,6 +967,9 @@ importers:
     specifiers: {}
 
   playground/ssr-deps/linked-no-external:
+    specifiers: {}
+
+  playground/ssr-deps/module-condition:
     specifiers: {}
 
   playground/ssr-deps/nested-external:
@@ -8789,6 +8794,12 @@ packages:
   file:playground/ssr-deps/import-builtin-cjs:
     resolution: {directory: playground/ssr-deps/import-builtin-cjs, type: directory}
     name: '@vitejs/test-import-builtin'
+    version: 0.0.0
+    dev: false
+
+  file:playground/ssr-deps/module-condition:
+    resolution: {directory: playground/ssr-deps/module-condition, type: directory}
+    name: '@vitejs/test-module-condition'
     version: 0.0.0
     dev: false
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/11385

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Ignore the `"module"` exports condition during SSR. The condition should be used by bundlers only.

This may technically be a breaking change, but I don't think it should have worked in the first place, and isn't something we explicitly support.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Bug introduced in #11101

I also noticed that SSR also supports the `production` and `development` condition since Vite 2 (?), but I don't think we can change this for now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
