### PR TITLE
fix: unoptimized package can resolve to optimized deps

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -53,7 +53,7 @@ import type {
   InternalResolveOptionsWithOverrideConditions,
   ResolveOptions,
 } from './plugins/resolve'
-import { resolvePlugin, tryNodeResolve } from './plugins/resolve'
+import { resolvePlugin, tryNodeResolveCore } from './plugins/resolve'
 import type { LogLevel, Logger } from './logger'
 import { createLogger } from './logger'
 import type { DepOptimizationConfig, DepOptimizationOptions } from './optimizer'
@@ -997,12 +997,18 @@ async function bundleConfigFile(
               }
 
               const isIdESM = isESM || kind === 'dynamic-import'
-              let idFsPath = tryNodeResolve(
+              let idFsPath: undefined | string
+              const resolveResult = tryNodeResolveCore(
                 id,
                 importer,
                 { ...options, isRequire: !isIdESM },
                 false,
-              )?.id
+              )
+              if (
+                resolveResult.resultType === 'success' ||
+                resolveResult.resultType === 'fail-as-optional-peer-dep'
+              )
+                idFsPath = resolveResult.resolved
               if (idFsPath && isIdESM) {
                 idFsPath = pathToFileURL(idFsPath).href
               }

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -16,11 +16,15 @@ import {
 } from '../utils'
 import { getDepsOptimizer } from '../optimizer'
 import { tryOptimizedResolve } from './resolve'
+import type { InternalResolveOptions } from './resolve'
 
 /**
  * A plugin to avoid an aliased AND optimized dep from being aliased in src
  */
-export function preAliasPlugin(config: ResolvedConfig): Plugin {
+export function preAliasPlugin(
+  config: ResolvedConfig,
+  resolveOptions: InternalResolveOptions,
+): Plugin {
   const findPatterns = getAliasPatterns(config.resolve.alias)
   const isConfiguredAsExternal = createIsConfiguredAsSsrExternal(config)
   const isBuild = config.command === 'build'
@@ -39,9 +43,11 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
       ) {
         if (findPatterns.find((pattern) => matches(pattern, id))) {
           const optimizedId = await tryOptimizedResolve(
-            depsOptimizer,
             id,
             importer,
+            resolveOptions,
+            depsOptimizer,
+            ssr,
           )
           if (optimizedId) {
             return optimizedId // aliased dep already optimized

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -28,8 +28,7 @@ export function preAliasPlugin(
   const findPatterns = getAliasPatterns(config.resolve.alias)
   const isConfiguredAsExternal = createIsConfiguredAsSsrExternal(config)
   const isBuild = config.command === 'build'
-  const { ssrConfig } = resolveOptions
-  const { target: ssrTarget } = ssrConfig ?? {}
+  const ssrTarget = resolveOptions.ssrConfig?.target
 
   return {
     name: 'vite:pre-alias',

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -28,6 +28,9 @@ export function preAliasPlugin(
   const findPatterns = getAliasPatterns(config.resolve.alias)
   const isConfiguredAsExternal = createIsConfiguredAsSsrExternal(config)
   const isBuild = config.command === 'build'
+  const { ssrConfig } = resolveOptions
+  const { target: ssrTarget } = ssrConfig ?? {}
+
   return {
     name: 'vite:pre-alias',
     async resolveId(id, importer, options) {
@@ -42,12 +45,13 @@ export function preAliasPlugin(
         id !== '@vite/env'
       ) {
         if (findPatterns.find((pattern) => matches(pattern, id))) {
+          const targetWeb = !ssr || ssrTarget === 'webworker'
           const optimizedId = await tryOptimizedResolve(
             id,
             importer,
             resolveOptions,
+            targetWeb,
             depsOptimizer,
-            ssr,
           )
           if (optimizedId) {
             return optimizedId // aliased dep already optimized

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -790,9 +790,7 @@ export function tryNodeResolve(
     return {
       id: coreResult.resolved,
     }
-  if (coreResult.resultType !== 'success') {
-    return assertUnreachable(coreResult)
-  }
+  if (coreResult.resultType !== 'success') return assertUnreachable(coreResult)
 
   const { pkg, pkgId, nearestPkg, isDeepImport } = coreResult
   let { resolved } = coreResult

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -888,12 +888,14 @@ export async function tryOptimizedResolve(
 
   const metadata = depsOptimizer.metadata
 
-  const depInfo = optimizedDepInfoFromId(metadata, id)
-  if (depInfo) {
-    return depsOptimizer.getOptimizedDepId(depInfo)
+  if (!importer) {
+    // no importer. try our best to find an optimized dep
+    const depInfo = optimizedDepInfoFromId(metadata, id)
+    if (depInfo) {
+      return depsOptimizer.getOptimizedDepId(depInfo)
+    }
+    return
   }
-
-  if (!importer) return
 
   // further check if id is imported by nested dependency
   let resolvedSrc: string | undefined

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1263,3 +1263,11 @@ export function evalValue<T = any>(rawValue: string): T {
   `)
   return fn()
 }
+
+/**
+ * let typescript do exhaustive check to ensure we have handled all cases
+ * https://stackoverflow.com/a/39419171
+ */
+export function assertUnreachable(x: never): never {
+  throw new Error("Didn't expect to get here")
+}

--- a/playground/resolve-optimized-dup-deps/__tests__/resolve-optimized-dup-deps.spec.ts
+++ b/playground/resolve-optimized-dup-deps/__tests__/resolve-optimized-dup-deps.spec.ts
@@ -1,0 +1,7 @@
+import { expect, test } from 'vitest'
+import { page } from '~utils'
+
+test('resolve-optimized-dup-deps', async () => {
+  expect(await page.textContent('.a')).toBe('test-package-a:test-package-b-v2')
+  expect(await page.textContent('.b')).toBe('test-package-b-v1')
+})

--- a/playground/resolve-optimized-dup-deps/index.html
+++ b/playground/resolve-optimized-dup-deps/index.html
@@ -1,0 +1,17 @@
+<h2>direct dependency A</h2>
+<pre class="a"></pre>
+
+<h2>direct dependency B</h2>
+<pre class="b"></pre>
+
+<script type="module">
+  import A from '@vitejs/test-resolve-optimized-dup-deps-package-a'
+  import B from '@vitejs/test-resolve-optimized-dup-deps-package-b'
+
+  text('.a', A)
+  text('.b', B)
+
+  function text(sel, text) {
+    document.querySelector(sel).textContent = text
+  }
+</script>

--- a/playground/resolve-optimized-dup-deps/package-a/index.js
+++ b/playground/resolve-optimized-dup-deps/package-a/index.js
@@ -1,0 +1,6 @@
+import b from '@vitejs/test-resolve-optimized-dup-deps-package-b'
+
+// should get test-package-a:test-package-b-v2
+const result = 'test-package-a:' + b
+
+export default result

--- a/playground/resolve-optimized-dup-deps/package-a/package.json
+++ b/playground/resolve-optimized-dup-deps/package-a/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-resolve-optimized-dup-deps-package-a",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "@vitejs/test-resolve-optimized-dup-deps-package-b": "file:../package-b-v2"
+  }
+}

--- a/playground/resolve-optimized-dup-deps/package-b-v1/index.js
+++ b/playground/resolve-optimized-dup-deps/package-b-v1/index.js
@@ -1,0 +1,3 @@
+// test-package-b-v1 is install and imported by user
+// it is written in cjs and should be optimized
+module.exports = 'test-package-b-v1'

--- a/playground/resolve-optimized-dup-deps/package-b-v1/package.json
+++ b/playground/resolve-optimized-dup-deps/package-b-v1/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-resolve-optimized-dup-deps-package-b",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/playground/resolve-optimized-dup-deps/package-b-v2/index.js
+++ b/playground/resolve-optimized-dup-deps/package-b-v2/index.js
@@ -1,0 +1,3 @@
+// test-package-b-v2 is install and imported by test-package-a
+// it is written in esm. it is not optimized
+export default 'test-package-b-v2'

--- a/playground/resolve-optimized-dup-deps/package-b-v2/package.json
+++ b/playground/resolve-optimized-dup-deps/package-b-v2/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-resolve-optimized-dup-deps-package-b",
+  "private": true,
+  "version": "2.0.0",
+  "main": "index.js"
+}

--- a/playground/resolve-optimized-dup-deps/package.json
+++ b/playground/resolve-optimized-dup-deps/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vitejs/test-resolve-optimized-dup-deps",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@vitejs/test-resolve-optimized-dup-deps-package-a": "file:./package-a",
+    "@vitejs/test-resolve-optimized-dup-deps-package-b": "file:./package-b-v1"
+  }
+}

--- a/playground/resolve-optimized-dup-deps/vite.config.js
+++ b/playground/resolve-optimized-dup-deps/vite.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = {
+  optimizeDeps: {
+    exclude: ['@vitejs/test-resolve-optimized-dup-deps-package-a'],
+  },
+}

--- a/playground/resolve-optimized/__tests__/resolve-optimized.spec.ts
+++ b/playground/resolve-optimized/__tests__/resolve-optimized.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+import { page } from '~utils'
+
+test('resolve-optimized', async () => {
+  expect(await page.textContent('.a')).toBe('package-a-module')
+  expect(await page.textContent('.b')).toBe(
+    'package-b-module:package-a-module:package-custom-main-field:package-custom-condition',
+  )
+  expect(await page.textContent('.custom-main-field')).toBe(
+    'package-custom-main-field',
+  )
+  expect(await page.textContent('.custom-condition')).toBe(
+    'package-custom-condition',
+  )
+
+  expect(await page.textContent('.a-count')).toBe('success')
+  expect(await page.textContent('.custom-main-field-count')).toBe('success')
+  expect(await page.textContent('.custom-condition-count')).toBe('success')
+})

--- a/playground/resolve-optimized/index.html
+++ b/playground/resolve-optimized/index.html
@@ -1,0 +1,46 @@
+<h2>direct dependency A</h2>
+<pre class="a"></pre>
+<pre class="a-count"></pre>
+
+<h2>direct dependency B</h2>
+<pre class="b"></pre>
+
+<h2>direct dependency custom-main-field</h2>
+<pre class="custom-main-field"></pre>
+<pre class="custom-main-field-count"></pre>
+
+<h2>direct dependency custom-condition</h2>
+<pre class="custom-condition"></pre>
+<pre class="custom-condition-count"></pre>
+
+<script type="module">
+  import A from '@vitejs/test-resolve-optimized-package-a'
+  import B from '@vitejs/test-resolve-optimized-package-b'
+
+  import customMain from '@vitejs/test-resolve-optimized-package-custom-main-field'
+  import customCondition from '@vitejs/test-resolve-optimized-package-custom-condition'
+
+  text('.a', A)
+  text('.b', B)
+  text('.custom-main-field', customMain)
+  text('.custom-condition', customCondition)
+
+  const packageACount = globalThis['package-a-module']
+  text('.a-count', packageACount === 1 ? 'success' : 'fail')
+
+  const packageCustomMainFieldCount = globalThis['package-custom-main-field']
+  text(
+    '.custom-main-field-count',
+    packageCustomMainFieldCount === 1 ? 'success' : 'fail',
+  )
+
+  const packageCustomConditionCount = globalThis['package-custom-condition']
+  text(
+    '.custom-condition-count',
+    packageCustomConditionCount === 1 ? 'success' : 'fail',
+  )
+
+  function text(sel, text) {
+    document.querySelector(sel).textContent = text
+  }
+</script>

--- a/playground/resolve-optimized/package-a/index.main.js
+++ b/playground/resolve-optimized/package-a/index.main.js
@@ -1,0 +1,3 @@
+export default 'package-a-main'
+
+throw new Error('should resolve to package-a/index.module.js instead of this')

--- a/playground/resolve-optimized/package-a/index.module.js
+++ b/playground/resolve-optimized/package-a/index.module.js
@@ -1,0 +1,6 @@
+const key = 'package-a-module'
+
+export default key
+
+globalThis[key] ||= 0
+globalThis[key]++

--- a/playground/resolve-optimized/package-a/package.json
+++ b/playground/resolve-optimized/package-a/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@vitejs/test-resolve-optimized-package-a",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.main.js",
+  "module": "index.module.js",
+  "dependencies": {}
+}

--- a/playground/resolve-optimized/package-b/index.module.js
+++ b/playground/resolve-optimized/package-b/index.module.js
@@ -1,0 +1,5 @@
+import a from '@vitejs/test-resolve-optimized-package-a'
+import customMain from '@vitejs/test-resolve-optimized-package-custom-main-field'
+import customCondition from '@vitejs/test-resolve-optimized-package-custom-condition'
+
+export default `package-b-module:${a}:${customMain}:${customCondition}`

--- a/playground/resolve-optimized/package-b/package.json
+++ b/playground/resolve-optimized/package-b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitejs/test-resolve-optimized-package-b",
+  "private": true,
+  "version": "1.0.0",
+  "module": "index.module.js",
+  "dependencies": {},
+  "peerDependencies": {
+    "@vitejs/test-resolve-optimized-package-a": "*",
+    "@vitejs/test-resolve-optimized-package-custom-condition": "*",
+    "@vitejs/test-resolve-optimized-package-custom-main-field": "*"
+  }
+}

--- a/playground/resolve-optimized/package-custom-condition/index.custom.js
+++ b/playground/resolve-optimized/package-custom-condition/index.custom.js
@@ -1,0 +1,6 @@
+const key = 'package-custom-condition'
+
+export default key
+
+globalThis[key] ||= 0
+globalThis[key]++

--- a/playground/resolve-optimized/package-custom-condition/index.js
+++ b/playground/resolve-optimized/package-custom-condition/index.js
@@ -1,0 +1,3 @@
+export default '[fail]'
+
+throw new Error('should resolve to custom condition instead of this')

--- a/playground/resolve-optimized/package-custom-condition/package.json
+++ b/playground/resolve-optimized/package-custom-condition/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vitejs/test-resolve-optimized-package-custom-condition",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "custom": "./index.custom.js",
+      "import": "./index.js",
+      "require": "./index.js"
+    }
+  }
+}

--- a/playground/resolve-optimized/package-custom-main-field/index.custom.js
+++ b/playground/resolve-optimized/package-custom-main-field/index.custom.js
@@ -1,0 +1,6 @@
+const key = 'package-custom-main-field'
+
+export default key
+
+globalThis[key] ||= 0
+globalThis[key]++

--- a/playground/resolve-optimized/package-custom-main-field/index.js
+++ b/playground/resolve-optimized/package-custom-main-field/index.js
@@ -1,0 +1,3 @@
+export default '[fail]'
+
+throw new Error('should resolve to custom main field instead of this')

--- a/playground/resolve-optimized/package-custom-main-field/package.json
+++ b/playground/resolve-optimized/package-custom-main-field/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/test-resolve-optimized-package-custom-main-field",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js",
+  "custom": "index.custom.js"
+}

--- a/playground/resolve-optimized/package.json
+++ b/playground/resolve-optimized/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@vitejs/test-resolve-optimized-dup-deps",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@vitejs/test-resolve-optimized-package-a": "file:./package-a",
+    "@vitejs/test-resolve-optimized-package-b": "file:./package-b",
+    "@vitejs/test-resolve-optimized-package-custom-condition": "file:./package-custom-condition",
+    "@vitejs/test-resolve-optimized-package-custom-main-field": "file:./package-custom-main-field"
+  }
+}

--- a/playground/resolve-optimized/vite.config.js
+++ b/playground/resolve-optimized/vite.config.js
@@ -1,0 +1,13 @@
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = {
+  optimizeDeps: {
+    exclude: ['@vitejs/test-resolve-optimized-package-b'],
+  },
+  resolve: {
+    // test if tryOptimizedResolve respect resolve options
+    mainFields: ['custom', 'module'],
+    conditions: ['custom'],
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,18 @@ importers:
   playground/resolve-linked:
     specifiers: {}
 
+  playground/resolve-optimized:
+    specifiers:
+      '@vitejs/test-resolve-optimized-package-a': file:./package-a
+      '@vitejs/test-resolve-optimized-package-b': file:./package-b
+      '@vitejs/test-resolve-optimized-package-custom-condition': file:./package-custom-condition
+      '@vitejs/test-resolve-optimized-package-custom-main-field': file:./package-custom-main-field
+    dependencies:
+      '@vitejs/test-resolve-optimized-package-a': file:playground/resolve-optimized/package-a
+      '@vitejs/test-resolve-optimized-package-b': file:playground/resolve-optimized/package-b_j3czbr56p6y2ktoozljpzmhxu4
+      '@vitejs/test-resolve-optimized-package-custom-condition': file:playground/resolve-optimized/package-custom-condition
+      '@vitejs/test-resolve-optimized-package-custom-main-field': file:playground/resolve-optimized/package-custom-main-field
+
   playground/resolve-optimized-dup-deps:
     specifiers:
       '@vitejs/test-resolve-optimized-dup-deps-package-a': file:./package-a
@@ -847,6 +859,18 @@ importers:
     specifiers: {}
 
   playground/resolve-optimized-dup-deps/package-b-v2:
+    specifiers: {}
+
+  playground/resolve-optimized/package-a:
+    specifiers: {}
+
+  playground/resolve-optimized/package-b:
+    specifiers: {}
+
+  playground/resolve-optimized/package-custom-condition:
+    specifiers: {}
+
+  playground/resolve-optimized/package-custom-main-field:
     specifiers: {}
 
   playground/resolve/browser-field:
@@ -8818,6 +8842,39 @@ packages:
     resolution: {directory: playground/resolve-optimized-dup-deps/package-b-v2, type: directory}
     name: '@vitejs/test-resolve-optimized-dup-deps-package-b'
     version: 2.0.0
+    dev: false
+
+  file:playground/resolve-optimized/package-a:
+    resolution: {directory: playground/resolve-optimized/package-a, type: directory}
+    name: '@vitejs/test-resolve-optimized-package-a'
+    version: 1.0.0
+    dev: false
+
+  file:playground/resolve-optimized/package-b_j3czbr56p6y2ktoozljpzmhxu4:
+    resolution: {directory: playground/resolve-optimized/package-b, type: directory}
+    id: file:playground/resolve-optimized/package-b
+    name: '@vitejs/test-resolve-optimized-package-b'
+    version: 1.0.0
+    peerDependencies:
+      '@vitejs/test-resolve-optimized-package-a': '*'
+      '@vitejs/test-resolve-optimized-package-custom-condition': '*'
+      '@vitejs/test-resolve-optimized-package-custom-main-field': '*'
+    dependencies:
+      '@vitejs/test-resolve-optimized-package-a': file:playground/resolve-optimized/package-a
+      '@vitejs/test-resolve-optimized-package-custom-condition': file:playground/resolve-optimized/package-custom-condition
+      '@vitejs/test-resolve-optimized-package-custom-main-field': file:playground/resolve-optimized/package-custom-main-field
+    dev: false
+
+  file:playground/resolve-optimized/package-custom-condition:
+    resolution: {directory: playground/resolve-optimized/package-custom-condition, type: directory}
+    name: '@vitejs/test-resolve-optimized-package-custom-condition'
+    version: 1.0.0
+    dev: false
+
+  file:playground/resolve-optimized/package-custom-main-field:
+    resolution: {directory: playground/resolve-optimized/package-custom-main-field, type: directory}
+    name: '@vitejs/test-resolve-optimized-package-custom-main-field'
+    version: 1.0.0
     dev: false
 
   file:playground/ssr-deps/css-lib:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,6 +829,26 @@ importers:
   playground/resolve-linked:
     specifiers: {}
 
+  playground/resolve-optimized-dup-deps:
+    specifiers:
+      '@vitejs/test-resolve-optimized-dup-deps-package-a': file:./package-a
+      '@vitejs/test-resolve-optimized-dup-deps-package-b': file:./package-b-v1
+    dependencies:
+      '@vitejs/test-resolve-optimized-dup-deps-package-a': file:playground/resolve-optimized-dup-deps/package-a
+      '@vitejs/test-resolve-optimized-dup-deps-package-b': file:playground/resolve-optimized-dup-deps/package-b-v1
+
+  playground/resolve-optimized-dup-deps/package-a:
+    specifiers:
+      '@vitejs/test-resolve-optimized-dup-deps-package-b': file:../package-b-v2
+    dependencies:
+      '@vitejs/test-resolve-optimized-dup-deps-package-b': file:playground/resolve-optimized-dup-deps/package-b-v2
+
+  playground/resolve-optimized-dup-deps/package-b-v1:
+    specifiers: {}
+
+  playground/resolve-optimized-dup-deps/package-b-v2:
+    specifiers: {}
+
   playground/resolve/browser-field:
     specifiers: {}
 
@@ -8779,6 +8799,26 @@ packages:
       '@vitejs/test-dep-a': file:playground/preload/dep-a
       dep-a: file:playground/preload/dep-a
     dev: true
+
+  file:playground/resolve-optimized-dup-deps/package-a:
+    resolution: {directory: playground/resolve-optimized-dup-deps/package-a, type: directory}
+    name: '@vitejs/test-resolve-optimized-dup-deps-package-a'
+    version: 1.0.0
+    dependencies:
+      '@vitejs/test-resolve-optimized-dup-deps-package-b': file:playground/resolve-optimized-dup-deps/package-b-v2
+    dev: false
+
+  file:playground/resolve-optimized-dup-deps/package-b-v1:
+    resolution: {directory: playground/resolve-optimized-dup-deps/package-b-v1, type: directory}
+    name: '@vitejs/test-resolve-optimized-dup-deps-package-b'
+    version: 1.0.0
+    dev: false
+
+  file:playground/resolve-optimized-dup-deps/package-b-v2:
+    resolution: {directory: playground/resolve-optimized-dup-deps/package-b-v2, type: directory}
+    name: '@vitejs/test-resolve-optimized-dup-deps-package-b'
+    version: 2.0.0
+    dev: false
 
   file:playground/ssr-deps/css-lib:
     resolution: {directory: playground/ssr-deps/css-lib, type: directory}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/vitejs/vite/pull/11290 make `tryOptimizedResolve` stricter, removing some **wrong code path** that would resolve to optimized deps without considering the importer.

But the wrong code path hid another bug in `tryOptimizedResolve`. There are some cases that relied on the wrong code path to behave normally. Removing the code path in `4.0.1` make these cases fail, which reveal the new bug.

The new bug is: `resolveFrom` always use `package.json#main` as the main field, which is not aligned with the vite's built in resolve algorithm (which is used to compute `optimizedData.src`). So `tryOptimizedResolve` doesn't match any package with `package.json#module` field:
https://github.com/vitejs/vite/blob/0a07686f651b8583e8091ada146b96576e8501e9/packages/vite/src/node/plugins/resolve.ts#L911

Here is an example(the test case in this PR):
```
project
  - package-a (optimized. `package.json#module` as main field)
  - package-b (not optimized. peer-depend on package-a.)
```
Without this fix, the project import `package-a` and gets the optimized bundle. But `package-b` get the unoptimized module. So it ends up with two instance of `package-a`.

Fix: https://github.com/solidjs/solid/issues/1426

> https://github.com/vitejs/vite/pull/11290 was reverted to fix(hide) the bug in https://github.com/solidjs/solid/issues/1426 . This PR cherry-pick https://github.com/vitejs/vite/pull/11290 and add more fix around it (fix https://github.com/solidjs/solid/issues/1426).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
