### PR TITLE
feat: add experimental option to skip SSR transform

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -292,6 +292,14 @@ export interface ExperimentalOptions {
    * @default false
    */
   hmrPartialAccept?: boolean
+  /**
+   * Skips SSR transform to make it easier to use Vite with Node ESM loaders.
+   * @warning Enabling this will break normal operation of Vite's SSR in development mode.
+   *
+   * @experimental
+   * @default false
+   */
+  skipSsrTransform?: boolean
 }
 
 export interface LegacyOptions {

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -266,13 +266,14 @@ async function loadAndTransform(
     }
   }
 
-  const result = ssr
-    ? await server.ssrTransform(code, map as SourceMap, url, originalCode)
-    : ({
-        code,
-        map,
-        etag: getEtag(code, { weak: true }),
-      } as TransformResult)
+  const result =
+    ssr && !server.config.experimental.skipSsrTransform
+      ? await server.ssrTransform(code, map as SourceMap, url, originalCode)
+      : ({
+          code,
+          map,
+          etag: getEtag(code, { weak: true }),
+        } as TransformResult)
 
   // Only cache the result if the module wasn't invalidated while it was
   // being processed, so it is re-processed next time if it is stale


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds an experimental option to skip SSR transform so that we can use Vite directly in [Node's (currently experimental) ESM loaders](https://nodejs.org/api/esm.html#loaders). You can think of it as a minimal alternative to #9740. This tiny change enables the ecosystem to experiment with this approach without modifying Vite's core.

Building a Node ESM loader on top of Vite using this approach would render #3288 and #3928 less urgent.

~~The PR also exposes `shouldExternalizeForSSR` which does most of the work in deciding whether a dep should be externalized. Exposing it makes it possible to use the same logic in loaders.~~ (not necessary, import analysis plugin takes care of it, a simple "is first char dot or slash" check is enough)

### Additional context

In SSR dev mode, Vite transforms ESM imports and exports into special forms like `__vite_ssr_import__` and `__vite_ssr_exports__`. This PR adds an option to skip that transform so that transform output is valid native ESM. Of course it breaks normal operation but it allows using Vite in Node's ESM loaders.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
