### PR TITLE
feat(cli): suspend process on ctrl-z on non-windows platforms

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -48,7 +48,7 @@ export function bindShortcuts(
       return
     }
 
-    // suspens when we hit ctrl-z on non-windows platforms
+    // suspend when we hit ctrl-z on non-windows platforms
     if (!isWindows && input === '\x1A') {
       process.kill(process.ppid, 'SIGTSTP')
       process.kill(process.pid, 'SIGTSTP')

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -1,7 +1,7 @@
 import colors from 'picocolors'
 import type { ViteDevServer } from './server'
 import { openBrowser } from './server/openBrowser'
-import { isDefined } from './utils'
+import { isDefined, isWindows } from './utils'
 
 export type BindShortcutsOptions = {
   /**
@@ -45,6 +45,13 @@ export function bindShortcuts(
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
       process.emit('SIGTERM')
+      return
+    }
+
+    // suspens when we hit ctrl-z on non-windows platforms
+    if (!isWindows && input === '\x1A') {
+      process.kill(process.ppid, 'SIGTSTP')
+      process.kill(process.pid, 'SIGTSTP')
       return
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!--  suspend process on ctrl-z on non-windows platforms closes #11300  -->
this PR to suspend the process when we hit ctrl-z on non-windows platforms closes #11300  
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
