### PR TITLE
test: remove vue plugin from optimize-deps playground

### DIFF
--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -113,8 +113,10 @@ test('CJS dep with css import', async () => {
   expect(await getColor('.cjs-with-assets')).toBe('blue')
 })
 
-test('dep w/ non-js files handled via plugin', async () => {
-  expect(await page.textContent('.plugin')).toMatch(`[success]`)
+test('externalize known non-js files in optimize included dep', async () => {
+  expect(await page.textContent('.externalize-known-non-js')).toMatch(
+    `[success]`,
+  )
 })
 
 test('vue + vuex', async () => {

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -65,8 +65,8 @@
 <h2>Import from dependency with optional peer dep</h2>
 <div class="dep-with-optional-peer-dep"></div>
 
-<h2>Dep w/ special file format supported via plugins</h2>
-<div class="plugin"></div>
+<h2>Externalize known non-js files in optimize included dep</h2>
+<div class="externalize-known-non-js"></div>
 
 <h2>Vue & Vuex</h2>
 <div class="vue"></div>
@@ -111,7 +111,7 @@
 
   import { msg, VueSFC } from '@vitejs/test-dep-linked-include'
   text('.force-include', msg)
-  text('.plugin', VueSFC.render())
+  text('.externalize-known-non-js', VueSFC.render())
 
   import * as linked from '@vitejs/test-dep-linked-include'
   const keys = Object.keys(linked)

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -38,8 +38,5 @@
     "vuex": "^4.1.0",
     "lodash": "^4.17.21",
     "lodash.clonedeep": "^4.5.0"
-  },
-  "devDependencies": {
-    "@vitejs/plugin-vue": "^4.0.0"
   }
 }

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -1,5 +1,4 @@
 const fs = require('node:fs')
-const vue = require('@vitejs/plugin-vue')
 
 // Overriding the NODE_ENV set by vitest
 process.env.NODE_ENV = ''
@@ -52,7 +51,7 @@ module.exports = {
   },
 
   plugins: [
-    vue(),
+    testVue(),
     notjs(),
     // for axios request test
     {
@@ -93,6 +92,29 @@ module.exports = {
       },
     },
   ],
+}
+
+// Handles Test.vue in dep-linked-include package
+function testVue() {
+  return {
+    name: 'testvue',
+    transform(code, id) {
+      if (id.includes('dep-linked-include/Test.vue')) {
+        return {
+          code: `
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'Test',
+  render() {
+    return '[success] rendered from Vue'
+  }
+})
+`.trim(),
+        }
+      }
+    },
+  }
 }
 
 // Handles .notjs file, basically remove wrapping <notjs> and </notjs> tags

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,7 +609,6 @@ importers:
 
   playground/optimize-deps:
     specifiers:
-      '@vitejs/plugin-vue': ^4.0.0
       '@vitejs/test-added-in-entries': file:./added-in-entries
       '@vitejs/test-dep-cjs-browser-field-bare': file:./dep-cjs-browser-field-bare
       '@vitejs/test-dep-cjs-compiled-from-cjs': file:./dep-cjs-compiled-from-cjs
@@ -669,8 +668,6 @@ importers:
       url: 0.11.0
       vue: 3.2.45
       vuex: 4.1.0_vue@3.2.45
-    devDependencies:
-      '@vitejs/plugin-vue': 4.0.0_vue@3.2.45
 
   playground/optimize-deps/added-in-entries:
     specifiers: {}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#11175

This test seems to be added by https://github.com/vitejs/vite/commit/1ea016823975f3d0e37bf7b65614eded213e0869 and was intended to test whether the plugins will run on dep-optimization.
But since dep-optimization now uses esbuild instead of rollup, this test was outdated.
I changed this test's name to describe the actual thing we are now testing.
IIUC this test is now testing this part.
https://github.com/vitejs/vite/blob/d3c9c0b7c186c4415e8b347aebb5dd6942b0625a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts#L119-L126

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
