### PR TITLE
refactor(build): close rollup bundle directly

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -8,7 +8,6 @@ import type {
   ModuleFormat,
   OutputOptions,
   Plugin,
-  RollupBuild,
   RollupError,
   RollupOptions,
   RollupOutput,
@@ -422,34 +421,10 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
 }
 
 /**
- * Track parallel build calls and only stop the esbuild service when all
- * builds are done. (#1098)
- */
-let parallelCallCounts = 0
-// we use a separate counter to track since the call may error before the
-// bundle is even pushed.
-const parallelBuilds: RollupBuild[] = []
-
-/**
  * Bundles the app for production.
  * Returns a Promise containing the build result.
  */
 export async function build(
-  inlineConfig: InlineConfig = {},
-): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
-  parallelCallCounts++
-  try {
-    return await doBuild(inlineConfig)
-  } finally {
-    parallelCallCounts--
-    if (parallelCallCounts <= 0) {
-      await Promise.all(parallelBuilds.map((bundle) => bundle.close()))
-      parallelBuilds.length = 0
-    }
-  }
-}
-
-async function doBuild(
   inlineConfig: InlineConfig = {},
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
   const config = await resolveConfig(
@@ -653,7 +628,6 @@ async function doBuild(
     // write or generate files with rollup
     const { rollup } = await import('rollup')
     const bundle = await rollup(rollupOptions)
-    parallelBuilds.push(bundle)
 
     const generate = (output: OutputOptions = {}) => {
       return bundle[options.write ? 'write' : 'generate'](output)
@@ -667,6 +641,7 @@ async function doBuild(
     for (const output of normalizedOutputs) {
       res.push(await generate(output))
     }
+    await bundle.close()
     return Array.isArray(outputs) ? res : res[0]
   } catch (e) {
     outputBuildError(e)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Remove paralled build handling as https://github.com/vitejs/vite/issues/1098 doesn't apply to esbuild anymore. This should allow GC when multiple builds run in parallel.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
