### PR TITLE
feat: support rollup plugin this.load in plugin container context

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -322,7 +322,7 @@ export async function createPluginContainer(
       // but we can at least update the module info properties we support
       updateModuleInfo(options.id, options)
 
-      await container.load(options.id)
+      await container.load(options.id, { ssr: this.ssr })
       const moduleInfo = this.getModuleInfo(options.id)
       // This shouldn't happen due to calling ensureEntryFromUrl, but 1) our types can't ensure that
       // and 2) moduleGraph may not have been provided (though in the situations where that happens,

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -42,9 +42,11 @@ import type {
   LoadResult,
   MinimalPluginContext,
   ModuleInfo,
+  ModuleOptions,
   NormalizedInputOptions,
   OutputOptions,
   ParallelPluginHooks,
+  PartialNull,
   PartialResolvedId,
   ResolvedId,
   RollupError,
@@ -126,8 +128,6 @@ export interface PluginContainer {
 
 type PluginContext = Omit<
   RollupPluginContext,
-  // not supported
-  | 'load'
   // not documented
   | 'cache'
   // deprecated
@@ -221,6 +221,10 @@ export async function createPluginContainer(
       if (key in info) {
         return info[key]
       }
+      // Don't throw an error when returning from an async function
+      if (key === 'then') {
+        return undefined
+      }
       throw Error(
         `[vite] The "${key}" property of ModuleInfo is not supported.`,
       )
@@ -304,6 +308,28 @@ export async function createPluginContainer(
       })
       if (typeof out === 'string') out = { id: out }
       return out as ResolvedId | null
+    }
+
+    async load(
+      options: {
+        id: string
+        resolveDependencies?: boolean
+      } & Partial<PartialNull<ModuleOptions>>,
+    ): Promise<ModuleInfo> {
+      // We may not have added this to our module graph yet, so ensure it exists
+      await moduleGraph?.ensureEntryFromUrl(options.id)
+      // Not all options passed to this function make sense in the context of loading individual files,
+      // but we can at least update the module info properties we support
+      updateModuleInfo(options.id, options)
+
+      await container.load(options.id)
+      const moduleInfo = this.getModuleInfo(options.id)
+      // This shouldn't happen due to calling ensureEntryFromUrl, but 1) our types can't ensure that
+      // and 2) moduleGraph may not have been provided (though in the situations where that happens,
+      // we should never have plugins calling this.load)
+      if (!moduleInfo)
+        throw Error(`Failed to load module with id ${options.id}`)
+      return moduleInfo
     }
 
     getModuleInfo(id: string) {


### PR DESCRIPTION
### Description

This adds support for calling [this.load](https://rollupjs.org/guide/en/#thisload) (added in Rollup 2.60) in a rollup plugin when using a plugin context via Vite's plugin container (namely, when using the dev server).

Resolves #6810

### Additional context

This fixes the issue I have in my specific use case (rollup-plugin-typescript2 needing to call this.load, though not using any of its output - I tested this PR locally with that test case), and is strictly more functional than the previous lack of support. However, there are some limitations which I don't know if it's appropriate to address or otherwise present issues:
* The return of `this.load` from Vite will be a ModuleInfoProxy, which doesn't include most of the properties from ModuleInfo. I imagine some plugins are likely to be calling `this.load` expecting some of these parameters to work. That said, this is already an existing limitation of getModuleInfo, so I assume that is out of scope.
* Further, `this.load` is supposed to trigger `transform` and `moduleParsed` - this does not (in accordance with vite's on-demand nature)
* The resolveDependencies parameter is left unused, as since the modules are not actually transformed/parsed, from my understanding dependency information is unavailable/irrelevant
* ModuleOptions properties other than meta are unused (though as far as I know, that's the responsibility of updateModuleInfo, and so out of scope, and presumably unnecessary in the on-demand situation)

I don't have much experience working at this level, so feedback is definitely appreciated, and I'm happy to make any adjustments

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
