### PR TITLE
fix: import(/* @vite-ignore */) is not worked in *.ts for v4 (#11377)

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -254,6 +254,14 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
     },
     async transform(code, id) {
       if (filter(id) || filter(cleanUrl(id))) {
+        let hasViteIgnore = false
+        if (/\/\* @vite-ignore \*\//.test(code)) {
+          hasViteIgnore = true
+          code = code.replace(
+            /\s*\/\* @vite-ignore \*\/\s*/g,
+            '__vite__ignore__',
+          )
+        }
         const result = await transformWithEsbuild(code, id, transformOptions)
         if (result.warnings.length) {
           result.warnings.forEach((m) => {
@@ -262,6 +270,12 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
         }
         if (options.jsxInject && /\.(?:j|t)sx\b/.test(id)) {
           result.code = options.jsxInject + ';' + result.code
+        }
+        if (hasViteIgnore) {
+          result.code = result.code.replace(
+            /__vite__ignore__/,
+            '/* @vite-ignore */',
+          )
         }
         return {
           code: result.code,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -273,7 +273,7 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
         }
         if (hasViteIgnore) {
           result.code = result.code.replace(
-            /__vite__ignore__/,
+            /__vite__ignore__/g,
             '/* @vite-ignore */',
           )
         }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -255,12 +255,10 @@ export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
     async transform(code, id) {
       if (filter(id) || filter(cleanUrl(id))) {
         let hasViteIgnore = false
-        if (/\/\* @vite-ignore \*\//.test(code)) {
+        const ignoreRegExp = /\/\*\s*@vite-ignore\s*\*\/\s*/g
+        if (ignoreRegExp.test(code)) {
           hasViteIgnore = true
-          code = code.replace(
-            /\s*\/\* @vite-ignore \*\/\s*/g,
-            '__vite__ignore__',
-          )
+          code = code.replace(ignoreRegExp, '__vite__ignore__')
         }
         const result = await transformWithEsbuild(code, id, transformOptions)
         if (result.warnings.length) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->
fix #11377 
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Beacuse of a breaking change in esbuild 0.15.17 (https://github.com/evanw/esbuild/issues/2439) , esbuild will remove comment /* @vite-ignore */ in import(/* @vite-ignore */).

so i replace '/* @vite-ignore */' to '__vite__ignore__' before transform and change back after transform to avoid this bug.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
