### PR TITLE
fix: importmap should insert before module preload link

### DIFF
--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -251,12 +251,6 @@ describe.runIf(isServe)('invalid', () => {
   })
 })
 
-test('importmap', () => {
-  expect(browserLogs).not.toContain(
-    'An import map is added after module script load was triggered.',
-  )
-})
-
 describe('Valid HTML', () => {
   test('valid HTML is parsed', async () => {
     await page.goto(viteTestUrl + '/valid.html')
@@ -265,5 +259,18 @@ describe('Valid HTML', () => {
     )
 
     expect(await getColor('#duplicated-attrs')).toBe('green')
+  })
+})
+
+describe('importmap', () => {
+  beforeAll(async () => {
+    await page.goto(viteTestUrl + '/importmapOrder.html')
+  })
+
+  // Should put this test at the end to get all browser logs above
+  test('importmap should be prepended', async () => {
+    expect(browserLogs).not.toContain(
+      'An import map is added after module script load was triggered.',
+    )
   })
 })

--- a/playground/html/importmapOrder.html
+++ b/playground/html/importmapOrder.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script type="importmap">
+      {
+        "imports": {
+          "some-pkg": "url-of-pkg"
+        }
+      }
+    </script>
+    <link rel="modulepreload" href="url-of-pkg" />
+    <script type="module" src="/main.js"></script>
+  </head>
+</html>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -28,6 +28,7 @@ module.exports = {
         ),
         linkProps: resolve(__dirname, 'link-props/index.html'),
         valid: resolve(__dirname, 'valid.html'),
+        importmapOrder: resolve(__dirname, 'importmapOrder.html'),
       },
     },
   },
@@ -168,7 +169,9 @@ ${
     },
     {
       name: 'head-prepend-importmap',
-      transformIndexHtml() {
+      transformIndexHtml(_, ctx) {
+        if (ctx.path.includes('importmapOrder')) return
+
         return [
           {
             tag: 'script',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/11304.
Vite now moves the existing importmap before the first script. But in #11304, there's a modulepreload link declared after the importmap. After Vite's `postImportMapHook`, the order became `modulepreload importmap script` but the correct order should be`importmap modulepreload script`, modulepreload should come after import otherwise it will throw an error.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
The modulepreload link may not indicate the module declared in the importmap. But moving the importmap before all modulepreload link seems like an acceptable and no side effect practice.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
