### PR TITLE
fix: remove moment from force interop packages

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -997,11 +997,6 @@ export async function extractExportsData(
   return exportsData
 }
 
-// https://github.com/vitejs/vite/issues/1724#issuecomment-767619642
-// a list of modules that pretends to be ESM but still uses `require`.
-// this causes esbuild to wrap them as CJS even when its entry appears to be ESM.
-const KNOWN_INTEROP_IDS = new Set(['moment'])
-
 function needsInterop(
   config: ResolvedConfig,
   ssr: boolean,
@@ -1009,10 +1004,7 @@ function needsInterop(
   exportsData: ExportsData,
   output?: { exports: string[] },
 ): boolean {
-  if (
-    getDepOptimizationConfig(config, ssr)?.needsInterop?.includes(id) ||
-    KNOWN_INTEROP_IDS.has(id)
-  ) {
+  if (getDepOptimizationConfig(config, ssr)?.needsInterop?.includes(id)) {
     return true
   }
   const { hasImports, exports } = exportsData


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/10039.
The context could be found here https://github.com/vitejs/vite/issues/1724#issuecomment-767619642.
esbuild seems smarter now and won't wrap moment as a CommonJS module anymore. So the workaround could be dropped now.
I tested `moment@2.29.1` which is released on 2020-10-06 and the latest version, and both works fine.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
