### PR TITLE
feat(cli): allow to specify sourcemap mode via --sourcemap build's option

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -54,7 +54,7 @@ vite build [root]
 | `--assetsDir <dir>`            | Directory under outDir to place assets in (default: `"assets"`) (`string`)                                          |
 | `--assetsInlineLimit <number>` | Static asset base64 inline threshold in bytes (default: `4096`) (`number`)                                          |
 | `--ssr [entry]`                | Build specified entry for server-side rendering (`string`)                                                          |
-| `--sourcemap`                  | Output source maps for build (default: `false`) (`boolean`)                                                         |
+| `--sourcemap [output]`         | Output source maps for build (default: `false`) (`boolean \| "inline" \| "hidden"`)                                 |
 | `--minify [minifier]`          | Enable/disable minification, or specify minifier to use (default: `"esbuild"`) (`boolean \| "terser" \| "esbuild"`) |
 | `--manifest [name]`            | Emit build manifest json (`boolean \| string`)                                                                      |
 | `--ssrManifest [name]`         | Emit ssr manifest json (`boolean \| string`)                                                                        |

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -212,7 +212,7 @@ cli
     `[string] build specified entry for server-side rendering`,
   )
   .option(
-    '--sourcemap [mode]',
+    '--sourcemap [output]',
     `[boolean | "inline" | "hidden"] output source maps for build (default: false)`,
   )
   .option(

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -212,8 +212,8 @@ cli
     `[string] build specified entry for server-side rendering`,
   )
   .option(
-    '--sourcemap',
-    `[boolean] output source maps for build (default: false)`,
+    '--sourcemap [mode]',
+    `[boolean | "inline" | "hidden"] output source maps for build (default: false)`,
   )
   .option(
     '--minify [minifier]',


### PR DESCRIPTION
### Description

Currently there are no ways to set `build.sourcemap` to `hidden` via CLI. But it may be useful to set it on different environments without customization of Vite config, for example in CI:
```shell
# On staging:
npm run build -- --sourcemap
# On production:
npm run build -- --sourcemap hidden
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
