### PR TITLE
fix(css): fix stale css when reloading with hmr disabled (#10270)

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -128,7 +128,7 @@ export function updateModules(
   file: string,
   modules: ModuleNode[],
   timestamp: number,
-  { config, ws }: ViteDevServer,
+  { config, ws, moduleGraph }: ViteDevServer,
   afterInvalidation?: boolean,
 ): void {
   const updates: Update[] = []
@@ -136,7 +136,7 @@ export function updateModules(
   let needFullReload = false
 
   for (const mod of modules) {
-    invalidate(mod, timestamp, invalidatedModules)
+    moduleGraph.invalidateModule(mod, invalidatedModules, timestamp, true)
     if (needFullReload) {
       continue
     }
@@ -315,23 +315,6 @@ function propagateUpdate(
     }
   }
   return false
-}
-
-function invalidate(mod: ModuleNode, timestamp: number, seen: Set<ModuleNode>) {
-  if (seen.has(mod)) {
-    return
-  }
-  seen.add(mod)
-  mod.lastHMRTimestamp = timestamp
-  mod.transformResult = null
-  mod.ssrModule = null
-  mod.ssrError = null
-  mod.ssrTransformResult = null
-  mod.importers.forEach((importer) => {
-    if (!importer.acceptedHmrDeps.has(mod)) {
-      invalidate(importer, timestamp, seen)
-    }
-  })
 }
 
 export function handlePrunedModules(


### PR DESCRIPTION
### Description
Fixes #10270.

In the non-hmr code path, when invalidating a module, it wasn't invalidating the importers. This meant that CSS dynamically generated based on a module's contents (e.g., what tailwind does) would not regenerate when refreshing a page.

The HMR code path already invalidated importers, which is why the bug didn't exist with HMR enabled. This change makes the invalidation consistent between HMR and non-HMR.

The changes are quite minimal -- it's just merging some of the logic from the `invalidate` function (in hmr.ts) into the `invalidateModule` function (in moduleGraph.ts) and updating the call site.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following
- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
