### PR TITLE
fix(css): resolve style field skipping package exports

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -732,6 +732,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
           mainFields: ['style'],
           tryIndex: false,
           preferRelative: true,
+          skipExports: true,
         }))
       )
     },
@@ -745,6 +746,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
           tryIndex: true,
           tryPrefix: '_',
           preferRelative: true,
+          skipExports: true,
         }))
       )
     },
@@ -757,6 +759,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
           mainFields: ['less', 'style'],
           tryIndex: false,
           preferRelative: true,
+          skipExports: true,
         }))
       )
     },

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -91,6 +91,7 @@ export interface InternalResolveOptions extends Required<ResolveOptions> {
   tryPrefix?: string
   skipPackageJson?: boolean
   preferRelative?: boolean
+  skipExports?: boolean
   isRequire?: boolean
   // #3040
   // when the importer is a ts module,
@@ -927,7 +928,7 @@ export function resolvePackageEntry(
 
     // resolve exports field with highest priority
     // using https://github.com/lukeed/resolve.exports
-    if (data.exports) {
+    if (data.exports && !options.skipExports) {
       entryPoint = resolveExports(data, '.', options, targetWeb)
     }
 

--- a/playground/css/css-dep/package.json
+++ b/playground/css/css-dep/package.json
@@ -4,5 +4,10 @@
   "version": "1.0.0",
   "main": "index.js",
   "style": "index.css",
-  "sass": "index.scss"
+  "sass": "index.scss",
+  "exports": {
+    ".": {
+      "default": "./index.js"
+    }
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR is alternative to #7817 but it aims to solve the same problem. At the moment, vite fails to import css modules from package.json `style` field if the module has also a package exports map.
Please note that, differently from #7817, this PR does not introduce new features but it "just" fix the wrong resolution.

I have also updated the playground in order to test the case with and without `skipExports` option.

### Additional context

`skipExports` may not be the best option name for the case, I am open to suggestions.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
