### PR TITLE
fix(metadata): expose viteMetadata type

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -73,14 +73,12 @@ export type {
   CSSModulesOptions,
   PreprocessCSSResult,
 } from './plugins/css'
-export type { ChunkMetadata } from './plugins/metadata'
 export type { JsonOptions } from './plugins/json'
 export type { TransformOptions as EsbuildTransformOptions } from 'esbuild'
 export type { ESBuildOptions, ESBuildTransformResult } from './plugins/esbuild'
 export type { Manifest, ManifestChunk } from './plugins/manifest'
 export type { ResolveOptions, InternalResolveOptions } from './plugins/resolve'
 export type { SplitVendorChunkCache } from './plugins/splitVendorChunk'
-import type { ChunkMetadata } from './plugins/metadata'
 
 export type {
   WebSocketServer,
@@ -119,6 +117,7 @@ export type {
   GeneralImportGlobOptions,
   KnownAsTypeMap,
 } from 'types/importGlob'
+export type { ChunkMetadata } from 'types/metadata'
 
 // dep types
 export type {
@@ -140,9 +139,3 @@ export type { Terser } from 'dep-types/terser'
 export type { RollupCommonJSOptions } from 'dep-types/commonjs'
 export type { RollupDynamicImportVarsOptions } from 'dep-types/dynamicImportVars'
 export type { Matcher, AnymatchPattern, AnymatchFn } from 'dep-types/anymatch'
-
-declare module 'rollup' {
-  export interface RenderedChunk {
-    viteMetadata: ChunkMetadata
-  }
-}

--- a/packages/vite/src/node/plugins/metadata.ts
+++ b/packages/vite/src/node/plugins/metadata.ts
@@ -1,10 +1,5 @@
 import type { Plugin } from '../plugin'
 
-export interface ChunkMetadata {
-  importedAssets: Set<string>
-  importedCss: Set<string>
-}
-
 /**
  * Prepares the rendered chunks to contain additional metadata during build.
  */

--- a/packages/vite/types/metadata.d.ts
+++ b/packages/vite/types/metadata.d.ts
@@ -1,0 +1,10 @@
+export interface ChunkMetadata {
+  importedAssets: Set<string>
+  importedCss: Set<string>
+}
+
+declare module 'rollup' {
+  export interface RenderedChunk {
+    viteMetadata: ChunkMetadata
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/11324

I believe `viteMetadata` is public API (we also export the `ChunkMetadata` types), but when a user creates a Vite plugin with `renderChunk()`, the `chunk` autocomplete doesn't show `viteMetadata` as a possible property.

This is because the `declare module` augmented types isn't bundled by api-extractor. This PR re-shuffles the types so that the augmented types are in `types/metadata.d.ts`, and `node/index.d.ts` would re-export the `ChunkMetadata` types from it. Indirectly doing so, the augmented types are detected by TypeScript too.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
