### PR TITLE
feat: support BROWSER and BROWSER_ARGS in env file

### DIFF
--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -58,7 +58,9 @@ The value can also be an [options object](https://nodejs.org/api/https.html#http
 - **Type:** `boolean | string`
 - **Default:** [`server.open`](./server-options#server-open)
 
-Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can set the env `process.env.BROWSER` (e.g. `firefox`). See [the `open` package](https://github.com/sindresorhus/open#app) for more details.
+Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can set the env `process.env.BROWSER` (e.g. `firefox`). You can also set `process.env.BROWSER_ARGS` to pass additional arguments (e.g. `--incognito`).
+
+`BROWSER` and `BROWSER_ARGS` are also special environment variables you can set in the `.env` file to configure it. See [the `open` package](https://github.com/sindresorhus/open#app) for more details.
 
 ## preview.proxy
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -61,7 +61,9 @@ A valid certificate is needed. For a basic setup, you can add [@vitejs/plugin-ba
 
 - **Type:** `boolean | string`
 
-Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can set the env `process.env.BROWSER` (e.g. `firefox`). See [the `open` package](https://github.com/sindresorhus/open#app) for more details.
+Automatically open the app in the browser on server start. When the value is a string, it will be used as the URL's pathname. If you want to open the server in a specific browser you like, you can set the env `process.env.BROWSER` (e.g. `firefox`). You can also set `process.env.BROWSER_ARGS` to pass additional arguments (e.g. `--incognito`).
+
+`BROWSER` and `BROWSER_ARGS` are also special environment variables you can set in the `.env` file to configure it. See [the `open` package](https://github.com/sindresorhus/open#app) for more details.
 
 **Example:**
 

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -39,6 +39,13 @@ export function loadEnv(
   if (parsed.NODE_ENV && process.env.VITE_USER_NODE_ENV === undefined) {
     process.env.VITE_USER_NODE_ENV = parsed.NODE_ENV
   }
+  // support BROWSER and BROWSER_ARGS env variables
+  if (parsed.BROWSER && process.env.BROWSER === undefined) {
+    process.env.BROWSER = parsed.BROWSER
+  }
+  if (parsed.BROWSER_ARGS && process.env.BROWSER_ARGS === undefined) {
+    process.env.BROWSER_ARGS = parsed.BROWSER_ARGS
+  }
 
   try {
     // let environment variables use each other

--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -31,7 +31,10 @@ export function openBrowser(
   if (browser.toLowerCase().endsWith('.js')) {
     return executeNodeScript(browser, url, logger)
   } else if (browser.toLowerCase() !== 'none') {
-    return startBrowserProcess(browser, url)
+    const browserArgs = process.env.BROWSER_ARGS
+      ? process.env.BROWSER_ARGS.split(' ')
+      : []
+    return startBrowserProcess(browser, browserArgs, url)
   }
   return false
 }
@@ -67,7 +70,11 @@ const supportedChromiumBrowsers = [
   'Chromium',
 ]
 
-function startBrowserProcess(browser: string | undefined, url: string) {
+function startBrowserProcess(
+  browser: string | undefined,
+  browserArgs: string[],
+  url: string,
+) {
   // If we're on OS X, the user hasn't specifically
   // requested a different browser, we can try opening
   // a Chromium browser with AppleScript. This lets us reuse an
@@ -115,7 +122,9 @@ function startBrowserProcess(browser: string | undefined, url: string) {
   // Fallback to open
   // (It will always open new tab)
   try {
-    const options: open.Options = browser ? { app: { name: browser } } : {}
+    const options: open.Options = browser
+      ? { app: { name: browser, arguments: browserArgs } }
+      : {}
     open(url, options).catch(() => {}) // Prevent `unhandledRejection` error.
     return true
   } catch (err) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

close https://github.com/vitejs/vite/issues/7329
close https://github.com/vitejs/vite/issues/9557?notification_referrer_id=NT_kwDOAgiTKLM0MTQzMzExMjEyOjM0MTE2Mzky#issuecomment-1363189938

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Support passing browser args through `process.env.BROWSER_ARGS`, [similar to CRA](https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-dev-utils/openBrowser.js#L29).

Support `BROWSER` and `BROWSER_ARGS` configuration in `.env` files as convenience. This _could_ be a breaking change for users who set this for some specific configuration, but I don't think there's a significant impact in practice.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
