### PR TITLE
test(html): do not wrap duplicated html

### DIFF
--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -41,6 +41,10 @@ module.exports = {
           if (html.includes('/@vite/client')) {
             throw new Error('pre transform applied at wrong time!')
           }
+
+          const doctypeRE = /<!doctype html>/i
+          if (doctypeRE.test(html)) return
+
           const head = `
   <head lang="en">
     <meta charset="UTF-8">


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When trying to add test for importmap in `playground/html` for https://github.com/vitejs/vite/pull/11492. I found that all the html will be wrapped into another html tag by `pre-transform` hook. Even there's already an existing `<html>` tag in the html file itself. 

Files already have a html tag in `playround/html`

<img width="352" alt="image" src="https://user-images.githubusercontent.com/12322740/209857922-51bd0844-6c28-482d-9c41-23c6f7d384ef.png">

So, the transformed html of above looks like below (`/emptyattr` in dev mode)

```html

<!DOCTYPE html>
<html lang="en">
  <head lang="en">
    <meta name="description" content="a vite app">

    <script type="importmap">
              {
                "imports": {
                  "vue": "https://unpkg.com/vue@3.2.0/dist/vue.runtime.esm-browser.js"
                }
              }
            </script>
    <script type="module" src="/@vite/client"></script>

    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Test HTML transforms</title>
    <meta name="keywords" content="es modules">

  </head>
<body>
  <noscript><!-- this is prepended to body --></noscript>

  <!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Empty Attr</title>
  </head>
  <body>
    <img src="" alt="" />
    <p class="inject">This is injected</p>
    <p class="server">This is injected only during dev</p>
    <noscript><!-- this is appended to body --></noscript>
  </body>
</html>

</body>
</html>
```

after fixing, will be

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta name="description" content="a vite app">

    <script type="importmap">
              {
                "imports": {
                  "vue": "https://unpkg.com/vue@3.2.0/dist/vue.runtime.esm-browser.js"
                }
              }
            </script>
    <script type="module" src="/@vite/client"></script>

    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Empty Attr</title>
    <meta name="keywords" content="es modules">

  </head>
  <body>
    <noscript><!-- this is prepended to body --></noscript>

    <img src="" alt="" />
    <p class="inject">This is injected</p>
    <p class="server">This is injected only during dev</p>
    <noscript><!-- this is appended to body --></noscript>
  </body>
</html>
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

https://github.com/vitejs/vite/pull/11492 relies on this to add a test case with importmap, multiple heads in html will mess the test up.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
