### PR TITLE
fix(cli): ctrl+C no longer kills processes (#11434)

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -44,11 +44,9 @@ export function bindShortcuts(
   const onInput = async (input: string) => {
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
-      try {
-        await server.close()
-      } finally {
-        process.exit(1)
-      }
+      process.stdin.setRawMode(false)
+      process.stdin.write(input)
+      return
     }
 
     if (actionRunning) return

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -44,8 +44,11 @@ export function bindShortcuts(
   const onInput = async (input: string) => {
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
-      // process.emit('SIGTERM')
-      process.exit(1)
+      try {
+        await server.close()
+      } finally {
+        process.exit(1)
+      }
     }
 
     if (actionRunning) return

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -44,8 +44,8 @@ export function bindShortcuts(
   const onInput = async (input: string) => {
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
-      process.emit('SIGTERM')
-      return
+      // process.emit('SIGTERM')
+      process.exit(1)
     }
 
     if (actionRunning) return


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The binding of shortcut keys makes `Ctrl+C` unable to exit the program directly. Although the SIGTERM signal is sent upward, it cannot end when the console has an asynchronous output task. I think `Ctrl+C` should exit `process.exit(1)`

### Additional context

close #11434 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
