### PR TITLE
feat: reproducible manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/estree": "^1.0.0",
     "@types/etag": "^1.8.1",
     "@types/fs-extra": "^9.0.13",
+    "@types/json-stable-stringify": "^1.0.34",
     "@types/less": "^3.0.3",
     "@types/micromatch": "^4.0.2",
     "@types/minimist": "^1.2.2",

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -1833,6 +1833,32 @@ Repository: git+https://github.com/isaacs/isexe.git
 
 ---------------------------------------
 
+## json-stable-stringify
+License: MIT
+By: James Halliday
+Repository: git://github.com/ljharb/json-stable-stringify.git
+
+> This software is released under the MIT license:
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy of
+> this software and associated documentation files (the "Software"), to deal in
+> the Software without restriction, including without limitation the rights to
+> use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+> the Software, and to permit persons to whom the Software is furnished to do so,
+> subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+> FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+> COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+> IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+> CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------
+
 ## launch-editor
 License: MIT
 By: Evan You

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -97,6 +97,7 @@
     "etag": "^1.8.1",
     "fast-glob": "^3.2.12",
     "http-proxy": "^1.18.1",
+    "json-stable-stringify": "^1.0.2",
     "launch-editor-middleware": "^2.6.0",
     "magic-string": "^0.27.0",
     "micromatch": "^4.0.5",

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -112,6 +112,10 @@ function createNodePlugins(
           pattern: /require(?=\((configFile|'ts-node')\))/g,
           replacement: `eval('require')`,
         },
+        'json-stable-stringify/index.js': {
+          pattern: /^var json = typeof JSON.+require\('jsonify'\);$/gm,
+          replacement: 'var json = JSON',
+        },
       }),
 
     commonjs({

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import type { OutputAsset, OutputChunk } from 'rollup'
+import jsonStableStringify from 'json-stable-stringify'
 import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
 import { normalizePath } from '../utils'
@@ -158,7 +159,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
               ? config.build.manifest
               : 'manifest.json',
           type: 'asset',
-          source: JSON.stringify(manifest, null, 2),
+          source: jsonStableStringify(manifest, { space: 2 }),
         })
       }
     },

--- a/packages/vite/src/node/ssr/ssrManifestPlugin.ts
+++ b/packages/vite/src/node/ssr/ssrManifestPlugin.ts
@@ -2,6 +2,7 @@ import { basename, dirname, join, relative } from 'node:path'
 import { parse as parseImports } from 'es-module-lexer'
 import type { ImportSpecifier } from 'es-module-lexer'
 import type { OutputChunk } from 'rollup'
+import jsonStableStringify from 'json-stable-stringify'
 import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
 import { preloadMethod } from '../plugins/importAnalysisBuild'
@@ -81,7 +82,7 @@ export function ssrManifestPlugin(config: ResolvedConfig): Plugin {
             ? config.build.ssrManifest
             : 'ssr-manifest.json',
         type: 'asset',
-        source: JSON.stringify(ssrManifest, null, 2),
+        source: jsonStableStringify(ssrManifest, { space: 2 }),
       })
     },
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ importers:
       '@types/estree': ^1.0.0
       '@types/etag': ^1.8.1
       '@types/fs-extra': ^9.0.13
+      '@types/json-stable-stringify': ^1.0.34
       '@types/less': ^3.0.3
       '@types/micromatch': ^4.0.2
       '@types/minimist': ^1.2.2
@@ -84,6 +85,7 @@ importers:
       '@types/estree': 1.0.0
       '@types/etag': 1.8.1
       '@types/fs-extra': 9.0.13
+      '@types/json-stable-stringify': 1.0.34
       '@types/less': 3.0.3
       '@types/micromatch': 4.0.2
       '@types/minimist': 1.2.2
@@ -195,6 +197,7 @@ importers:
       fast-glob: ^3.2.12
       fsevents: ~2.3.2
       http-proxy: ^1.18.1
+      json-stable-stringify: ^1.0.2
       launch-editor-middleware: ^2.6.0
       magic-string: ^0.27.0
       micromatch: ^4.0.5
@@ -261,6 +264,7 @@ importers:
       etag: 1.8.1
       fast-glob: 3.2.12
       http-proxy: 1.18.1_debug@4.3.4
+      json-stable-stringify: 1.0.2
       launch-editor-middleware: 2.6.0
       magic-string: 0.27.0
       micromatch: 4.0.5
@@ -2200,6 +2204,10 @@ packages:
 
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: true
+
+  /@types/json-stable-stringify/1.0.34:
+    resolution: {integrity: sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==}
     dev: true
 
   /@types/json5/0.0.29:
@@ -4709,6 +4717,19 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
+
+  /follow-redirects/1.15.0_debug@4.3.4:
+    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: true
 
   /form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -5099,7 +5120,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0
+      follow-redirects: 1.15.0_debug@4.3.4
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -5479,6 +5500,12 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
+  /json-stable-stringify/1.0.2:
+    resolution: {integrity: sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==}
+    dependencies:
+      jsonify: 0.0.1
+    dev: true
+
   /json-stringify-safe/5.0.1:
     resolution: {integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=}
     dev: true
@@ -5512,6 +5539,10 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.10
+    dev: true
+
+  /jsonify/0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
     dev: true
 
   /jsonparse/1.3.1:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
AFAIK the order of the properties doesn't have any meanings in manifest/ssrManifest unlike `exports` field of `package.json`.
This PR uses `json-stable-stringify` to stringify the object deterministically.

I confirmed that `json-stable-stringify` [does not reorder values in arrays](https://github.com/ljharb/json-stable-stringify/blob/8243ea1a4c780c126b8800334b398e1c5e2ed9f9/index.js#L53-L60).

The package size doesn't change significantly: (used `npm pack` to get this value)
```
- before
npm notice package size:  732.8 kB
npm notice unpacked size: 3.2 MB
- after
npm notice package size:  733.3 kB
npm notice unpacked size: 3.2 MB
```


close #11540

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
