### PR TITLE
test: use default import for fs-extra

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import type { ExecaSyncReturnValue, SyncOptions } from 'execa'
 import { execaCommandSync } from 'execa'
-import { mkdirpSync, readdirSync, remove, writeFileSync } from 'fs-extra'
+import fs from 'fs-extra'
 import { afterEach, beforeAll, expect, test } from 'vitest'
 
 const CLI_PATH = join(__dirname, '..')
@@ -19,21 +19,22 @@ const run = (
 // Helper to create a non-empty directory
 const createNonEmptyDir = () => {
   // Create the temporary directory
-  mkdirpSync(genPath)
+  fs.mkdirpSync(genPath)
 
   // Create a package.json file
   const pkgJson = join(genPath, 'package.json')
-  writeFileSync(pkgJson, '{ "foo": "bar" }')
+  fs.writeFileSync(pkgJson, '{ "foo": "bar" }')
 }
 
 // Vue 3 starter template
-const templateFiles = readdirSync(join(CLI_PATH, 'template-vue'))
+const templateFiles = fs
+  .readdirSync(join(CLI_PATH, 'template-vue'))
   // _gitignore is renamed to .gitignore
   .map((filePath) => (filePath === '_gitignore' ? '.gitignore' : filePath))
   .sort()
 
-beforeAll(() => remove(genPath))
-afterEach(() => remove(genPath))
+beforeAll(() => fs.remove(genPath))
+afterEach(() => fs.remove(genPath))
 
 test('prompts for the project name if none supplied', () => {
   const { stdout } = run([])
@@ -41,7 +42,7 @@ test('prompts for the project name if none supplied', () => {
 })
 
 test('prompts for the framework if none supplied when target dir is current directory', () => {
-  mkdirpSync(genPath)
+  fs.mkdirpSync(genPath)
   const { stdout } = run(['.'], { cwd: genPath })
   expect(stdout).toContain('Select a framework:')
 })
@@ -79,7 +80,7 @@ test('successfully scaffolds a project based on vue starter template', () => {
   const { stdout } = run([projectName, '--template', 'vue'], {
     cwd: __dirname,
   })
-  const generatedFiles = readdirSync(genPath).sort()
+  const generatedFiles = fs.readdirSync(genPath).sort()
 
   // Assertions
   expect(stdout).toContain(`Scaffolding project in ${genPath}`)
@@ -90,7 +91,7 @@ test('works with the -t alias', () => {
   const { stdout } = run([projectName, '-t', 'vue'], {
     cwd: __dirname,
   })
-  const generatedFiles = readdirSync(genPath).sort()
+  const generatedFiles = fs.readdirSync(genPath).sort()
 
   // Assertions
   expect(stdout).toContain(`Scaffolding project in ${genPath}`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR fixes this CI fail.
https://github.com/vitejs/vite/actions/runs/3811060325/jobs/6483511814
This fail is caused by https://github.com/vitest-dev/vitest/pull/2512, a breaking change in vitest 0.26.0. (Because we now use vitest 0.25.x the test is passing.)
This test was relying on an invalid named exports. This PR changes that part to use the default export.

#11419 seems not to work even with this PR. I guess it's https://github.com/microsoft/playwright/issues/19661.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
