### PR TITLE
fix(cli): exit 1 on crtl+c (fix #11434)

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -42,13 +42,13 @@ export function bindShortcuts(
   let actionRunning = false
 
   const onInput = async (input: string) => {
+    if (actionRunning) return
+
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
-      process.emit('SIGTERM')
-      return
+      actionRunning = true
+      server.close().finally(() => process.exit(1))
     }
-
-    if (actionRunning) return
 
     if (input === 'h') {
       server.config.logger.info(


### PR DESCRIPTION
Fix: #11434
Closes: #11518

Thanks @kinfuy for the initial PR. I tested and updated the code to avoid issues with hitting twice ctrl+c
