### PR TITLE
fix: skip warning for `import(import.meta.url)`

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -588,12 +588,13 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
         } else if (!importer.startsWith(clientDir)) {
           if (!importer.includes('node_modules')) {
-            // check @vite-ignore which suppresses dynamic import warning
-            const hasViteIgnore = /\/\*\s*@vite-ignore\s*\*\//.test(
-              // complete expression inside parens
-              source.slice(dynamicIndex + 1, end),
-            )
-            if (!hasViteIgnore) {
+            const content = source.slice(dynamicIndex + 1, end)
+            const skipDynamicImportWarning =
+              // Workaround https://github.com/evanw/esbuild/issues/2721 for
+              // the React plugin: https://github.com/vitejs/vite-plugin-react/pull/79
+              content === 'import.meta.url' ||
+              /\/\*\s*@vite-ignore\s*\*\//.test(content)
+            if (!skipDynamicImportWarning) {
               this.warn(
                 `\n` +
                   colors.cyan(importerModule.file) +

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -129,3 +129,15 @@ test('should work with load ../ and contain itself directory', async () => {
     true,
   )
 })
+
+test('should load dynamic import.meta.url without warning', async () => {
+  await page.click('.dynamic-import-meta-url')
+  await untilUpdated(
+    () => page.textContent('.dynamic-import-meta-url'),
+    'Success',
+    true,
+  )
+  expect(
+    serverLogs.some((log) => log.includes('cannot be analyzed by vite')),
+  ).toBe(false)
+})

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -130,14 +130,17 @@ test('should work with load ../ and contain itself directory', async () => {
   )
 })
 
-test('should load dynamic import.meta.url without warning', async () => {
-  await page.click('.dynamic-import-meta-url')
-  await untilUpdated(
-    () => page.textContent('.dynamic-import-meta-url'),
-    'Success',
-    true,
-  )
-  expect(
-    serverLogs.some((log) => log.includes('cannot be analyzed by vite')),
-  ).toBe(false)
-})
+test.runIf(!isBuild)(
+  'should load dynamic import.meta.url without warning',
+  async () => {
+    await page.click('.dynamic-import-meta-url')
+    await untilUpdated(
+      () => page.textContent('.dynamic-import-meta-url'),
+      'Success',
+      true,
+    )
+    expect(
+      serverLogs.some((log) => log.includes('cannot be analyzed by vite')),
+    ).toBe(false)
+  },
+)

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -9,6 +9,7 @@
 <button class="issue-2658-2">Issue 2658 - 2</button>
 <button class="css">css</button>
 <button class="pkg-css">pkg-css</button>
+<button class="dynamic-import-meta-url">import.meta.url</button>
 
 <p>dynamic-import-with-vars</p>
 <div class="dynamic-import-with-vars">todo</div>
@@ -32,6 +33,7 @@
 <div class="dynamic-import-nested-self"></div>
 
 <script type="module" src="./nested/index.js"></script>
+<script type="module" src="./nested/importMeta.ts"></script>
 <style>
   p {
     color: #0088ff;

--- a/playground/dynamic-import/nested/importMeta.ts
+++ b/playground/dynamic-import/nested/importMeta.ts
@@ -1,0 +1,8 @@
+document
+  .querySelector('.dynamic-import-meta-url')
+  .addEventListener('click', async () => {
+    const { message } = await import(import.meta.url)
+    document.querySelector('.dynamic-import-meta-url').textContent = message
+  })
+
+export const message = 'Success'


### PR DESCRIPTION
For: https://github.com/vitejs/vite-plugin-react/pull/79