### PR TITLE
fix(cli): revert ctrl+C no longer kills processes (#11434) (#11518)

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -44,8 +44,7 @@ export function bindShortcuts(
   const onInput = async (input: string) => {
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
-      process.stdin.setRawMode(false)
-      process.stdin.write(input)
+      process.emit('SIGTERM')
       return
     }
 


### PR DESCRIPTION
Revert #11518: I messed up in while testing the last suggestion I proposed. This doesn't work at all and forces a double `ctrl+c` with and without `npm-run-all`

I will open another PR to discuss the best solution for this issue.