### PR TITLE
fix(cli): exit 1 on ctrl+c

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -44,7 +44,7 @@ export function bindShortcuts(
   const onInput = async (input: string) => {
     // ctrl+c or ctrl+d
     if (input === '\x03' || input === '\x04') {
-      process.emit('SIGTERM')
+      await server.close().finally(() => process.exit(1))
       return
     }
 


### PR DESCRIPTION
This seems to be the only option to enable both shortcuts and exiting vite running via `npm-run-all` with default options in one `ctrl+c`.

The bad part is that when running vite via `yarn` or `pnpm`, you get an extra error on exit:

<img width="688" alt="Screenshot 2023-01-03 at 02 05 33" src="https://user-images.githubusercontent.com/14235743/210288705-c640e7ae-7dab-4865-bee4-b462a31b1efe.png">

When using `npm-run-all`, it logs: `ERROR: "dev" exited with 1.`

The other option is to not fix the issue. I suggested multiple way to "workaround" the issue: https://github.com/vitejs/vite/issues/11434#issuecomment-1367438576

For information, [vitest is exiting is code 0](https://github.com/vitest-dev/vitest/blob/ce9319563a3456319623f9fcb86ad316db59d0ff/packages/vitest/src/node/core.ts#L547) which is subject to the same issue (but probably people don't use vitest watch mode along other watch process)

Re: #11518 #11562