### PR TITLE
feat: check whether to build before preview

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import fs from 'node:fs'
 import type * as http from 'node:http'
 import sirv from 'sirv'
 import connect from 'connect'
@@ -83,6 +84,14 @@ export async function preview(
     'production',
   )
 
+  const distDir = path.resolve(config.root, config.build.outDir)
+  const isAlreadyBuild = fs.existsSync(distDir)
+  if (!isAlreadyBuild) {
+    throw Error(
+      'The outputDir cannot be found, please try again after building',
+    )
+  }
+
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.preview,
@@ -115,7 +124,6 @@ export async function preview(
     config.base === './' || config.base === '' ? '/' : config.base
 
   // static assets
-  const distDir = path.resolve(config.root, config.build.outDir)
   const headers = config.preview.headers
   const assetServer = sirv(distDir, {
     etag: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I think when we open the preview mode, if the build operation has not been performed, an error should be thrown to remind the developer instead of continuing to open the preview service. like below

<img width="576" alt="image" src="https://user-images.githubusercontent.com/83797583/210371300-f7797329-90a1-48a5-9126-6821d36d5cc4.png">

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
