### PR TITLE
fix(ssr): load sourcemaps alongside modules (fix: #3288)

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -181,6 +181,17 @@ async function instantiateModule(
     }
   }
 
+  let sourceMapSuffix = ''
+  if (result.map) {
+    const moduleSourceMap = Object.assign({}, result.map, {
+      // offset the first three lines of the module (function declaration and 'use strict')
+      mappings: ';;;' + result.map.mappings,
+    })
+    sourceMapSuffix = `\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
+      JSON.stringify(moduleSourceMap),
+    ).toString('base64')}`
+  }
+
   try {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const AsyncFunction = async function () {}.constructor as typeof Function
@@ -191,7 +202,9 @@ async function instantiateModule(
       ssrImportKey,
       ssrDynamicImportKey,
       ssrExportAllKey,
-      '"use strict";' + result.code + `\n//# sourceURL=${mod.url}`,
+      '"use strict";\n' +
+        result.code +
+        `\n//# sourceURL=${mod.url}${sourceMapSuffix}`,
     )
     await initModule(
       context.global,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -187,7 +187,8 @@ async function instantiateModule(
       // offset the first three lines of the module (function declaration and 'use strict')
       mappings: ';;;' + result.map.mappings,
     })
-    sourceMapSuffix = `\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
+    // The ${'//'} is to avoid being replaced by node/server/transformRequest
+    sourceMapSuffix = `\n${'//'}# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
       JSON.stringify(moduleSourceMap),
     ).toString('base64')}`
   }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -188,9 +188,7 @@ async function instantiateModule(
       mappings: ';;;' + result.map.mappings,
     })
     // The ${'//'} is to avoid being replaced by node/server/transformRequest
-    sourceMapSuffix = `\n${'//'}# sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
-      JSON.stringify(moduleSourceMap),
-    ).toString('base64')}`
+    sourceMapSuffix = `\n${'//'}# sourceMappingURL=${genSourceMapUrl(moduleSourceMap)}`
   }
 
   try {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -198,10 +198,7 @@ async function instantiateModule(
       // offset the first three lines of the module (function declaration and 'use strict')
       mappings: ';'.repeat(fnDeclarationLineCount + 1) + result.map.mappings,
     })
-    // The ${'//'} is to avoid being replaced by node/server/transformRequest
-    sourceMapSuffix = `\n${'//'}# sourceMappingURL=${genSourceMapUrl(
-      moduleSourceMap,
-    )}`
+    sourceMapSuffix = `\n//# sourceMappingURL=${genSourceMapUrl(moduleSourceMap)}`
   }
 
   try {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -198,7 +198,8 @@ async function instantiateModule(
       // offset the first three lines of the module (function declaration and 'use strict')
       mappings: ';'.repeat(fnDeclarationLineCount + 1) + result.map.mappings,
     })
-    sourceMapSuffix = `\n//# sourceMappingURL=${genSourceMapUrl(moduleSourceMap)}`
+    sourceMapSuffix =
+      '\n//# sourceMappingURL=' + genSourceMapUrl(moduleSourceMap)
   }
 
   try {


### PR DESCRIPTION
### Description

Fixes #3288

This PR adds runtime sourcemaps to SSR modules inline.
This isn't a very large change as vite's request transformer provides source maps. The only modification that needed to be made to the source maps was prepending `';;;'` to the mappings, as the first three lines of every module will look like this:
```js
async function(a, b, c
) {
'use strict';
```

#### Before Changes
![image](https://user-images.githubusercontent.com/20448879/210450516-a23dab40-26a7-4ddd-b67d-0c135fd163dd.png)

#### After Changes
![image](https://user-images.githubusercontent.com/20448879/210450655-13b22e46-13b6-4c6b-a19b-89b2e28ad749.png)

---

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
