### PR TITLE
feat(css): build assets with the entry name when it is an entry point

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -569,16 +569,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           pureCssChunks.add(chunk)
         }
         if (opts.format === 'es' || opts.format === 'cjs') {
-          const cssAssetName = chunk.facadeModuleId
-            ? normalizePath(path.relative(config.root, chunk.facadeModuleId))
-            : chunk.name
-
           const isEntry = chunk.isEntry && isPureCssChunk
+          const cssAssetName =
+            !isEntry && chunk.facadeModuleId
+              ? normalizePath(path.relative(config.root, chunk.facadeModuleId))
+              : chunk.name
+
           const lang = path.extname(cssAssetName).slice(1)
-          const cssFileName = ensureFileExt(
-            isEntry ? chunk.name : cssAssetName,
-            '.css',
-          )
+          const cssFileName = ensureFileExt(cssAssetName, '.css')
 
           chunkCSS = resolveAssetUrlsInCss(chunkCSS, cssAssetName)
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -573,8 +573,12 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             ? normalizePath(path.relative(config.root, chunk.facadeModuleId))
             : chunk.name
 
+          const isEntry = chunk.isEntry && isPureCssChunk
           const lang = path.extname(cssAssetName).slice(1)
-          const cssFileName = ensureFileExt(cssAssetName, '.css')
+          const cssFileName = ensureFileExt(
+            isEntry ? chunk.name : cssAssetName,
+            '.css',
+          )
 
           chunkCSS = resolveAssetUrlsInCss(chunkCSS, cssAssetName)
 
@@ -601,7 +605,6 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             source: chunkCSS,
           })
           const originalName = isPreProcessor(lang) ? cssAssetName : cssFileName
-          const isEntry = chunk.isEntry && isPureCssChunk
           generatedAssets
             .get(config)!
             .set(referenceId, { originalName, isEntry })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -570,10 +570,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
         if (opts.format === 'es' || opts.format === 'cjs') {
           const isEntry = chunk.isEntry && isPureCssChunk
-          const cssAssetName =
+          const cssAssetName = normalizePath(
             !isEntry && chunk.facadeModuleId
-              ? normalizePath(path.relative(config.root, chunk.facadeModuleId))
-              : chunk.name
+              ? path.relative(config.root, chunk.facadeModuleId)
+              : chunk.name,
+          )
 
           const lang = path.extname(cssAssetName).slice(1)
           const cssFileName = ensureFileExt(cssAssetName, '.css')

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -37,7 +37,6 @@ describe.runIf(isBuild)('build', () => {
     const cssAssetEntry = manifest['global.css']
     const scssAssetEntry = manifest['nested/blue.scss']
     const imgAssetEntry = manifest['../images/logo.png']
-    const dirFooAssetEntry = manifest['../../dir/foo.css'] // '\\' should not be used even on windows
     expect(htmlEntry.css.length).toEqual(1)
     expect(htmlEntry.assets.length).toEqual(1)
     expect(cssAssetEntry?.file).not.toBeUndefined()
@@ -47,7 +46,9 @@ describe.runIf(isBuild)('build', () => {
     expect(scssAssetEntry?.isEntry).toEqual(true)
     expect(imgAssetEntry?.file).not.toBeUndefined()
     expect(imgAssetEntry?.isEntry).toBeUndefined()
-    expect(dirFooAssetEntry).not.toBeUndefined()
+    // use the entry name
+    expect(manifest['bar.css']).not.toBeUndefined()
+    expect(manifest['foo.css']).toBeUndefined()
   })
 })
 

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -37,6 +37,7 @@ describe.runIf(isBuild)('build', () => {
     const cssAssetEntry = manifest['global.css']
     const scssAssetEntry = manifest['nested/blue.scss']
     const imgAssetEntry = manifest['../images/logo.png']
+    const dirFooAssetEntry = manifest['../dynamic/foo.css'] // '\\' should not be used even on windows
     expect(htmlEntry.css.length).toEqual(1)
     expect(htmlEntry.assets.length).toEqual(1)
     expect(cssAssetEntry?.file).not.toBeUndefined()
@@ -46,6 +47,7 @@ describe.runIf(isBuild)('build', () => {
     expect(scssAssetEntry?.isEntry).toEqual(true)
     expect(imgAssetEntry?.file).not.toBeUndefined()
     expect(imgAssetEntry?.isEntry).toBeUndefined()
+    expect(dirFooAssetEntry).not.toBeUndefined()
     // use the entry name
     expect(manifest['bar.css']).not.toBeUndefined()
     expect(manifest['foo.css']).toBeUndefined()

--- a/playground/backend-integration/dir/foo.css
+++ b/playground/backend-integration/dir/foo.css
@@ -1,3 +1,3 @@
-.windows-path-foo {
+.entry-name-foo {
   color: blue;
 }

--- a/playground/backend-integration/frontend/dynamic/foo.css
+++ b/playground/backend-integration/frontend/dynamic/foo.css
@@ -1,0 +1,3 @@
+.windows-path-foo {
+  color: blue;
+}

--- a/playground/backend-integration/frontend/dynamic/foo.ts
+++ b/playground/backend-integration/frontend/dynamic/foo.ts
@@ -1,0 +1,1 @@
+import './foo.css'

--- a/playground/backend-integration/frontend/entrypoints/main.ts
+++ b/playground/backend-integration/frontend/entrypoints/main.ts
@@ -1,4 +1,5 @@
 import 'vite/modulepreload-polyfill'
+import('../dynamic/foo') // should be dynamic import to split chunks
 
 export const colorClass = 'text-black'
 

--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -19,7 +19,7 @@ function BackendIntegrationExample() {
         .map((filename) => [path.relative(root, filename), filename])
 
       entrypoints.push(['tailwindcss-colors', 'tailwindcss/colors.js'])
-      entrypoints.push(['foo.css', path.resolve(__dirname, './dir/foo.css')])
+      entrypoints.push(['bar.css', path.resolve(__dirname, './dir/foo.css')])
 
       return {
         build: {


### PR DESCRIPTION
REF: https://github.com/vitejs/vite/issues/4863#issuecomment-1367775712

How can we use the entry name to construct two files with the name `L.css` and `X.css` when specifying an entry like this:

```js
export default {
    build : {
        rollupOptions : {
            input : {
                L : 'login/index.less',
                X : 'X/index.less'
            }
        }
    }
};
```

Inside the `assetFileNames` hook, we cannot distinguish two assets with the same name `index.css`. 

In comparison with Webpack, it will use the entry name as the asset name when using the plugin, [`mini-css-extract-plugin`](https://github.com/webpack-contrib/mini-css-extract-plugin).

<!-- Thank you for contributing! -->

### Description

To resolve the problem mentioned above, I hope that Vite can use the entry name as the asset name.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix https://github.com/vitejs/vite/issues/9877
close https://github.com/vitejs/vite/pull/9485

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
