### PR TITLE
fix(resolve): ensure exports has precedence over mainFields (cherry pick #11234)

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -945,6 +945,8 @@ export function resolvePackageEntry(
       entryPoint = resolveExports(data, '.', options, targetWeb)
     }
 
+    const resolvedFromExports = !!entryPoint
+
     // if exports resolved to .mjs, still resolve other fields.
     // This is because .mjs files can technically import .cjs files which would
     // make them invalid for pure ESM environments - so if other module/browser
@@ -994,7 +996,9 @@ export function resolvePackageEntry(
       }
     }
 
-    if (!entryPoint || entryPoint.endsWith('.mjs')) {
+    // fallback to mainFields if still not resolved
+    // TODO: review if `.mjs` check is still needed
+    if (!resolvedFromExports && (!entryPoint || entryPoint.endsWith('.mjs'))) {
       for (const field of options.mainFields) {
         if (field === 'browser') continue // already checked above
         if (typeof data[field] === 'string') {

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -63,6 +63,10 @@ test('Respect production/development conditionals', async () => {
   )
 })
 
+test('Respect exports to take precedence over mainFields', async () => {
+  expect(await page.textContent('.exports-with-module')).toMatch('[success]')
+})
+
 test('implicit dir/index.js', async () => {
   expect(await page.textContent('.index')).toMatch('[success]')
 })

--- a/playground/resolve/exports-with-module/import.mjs
+++ b/playground/resolve/exports-with-module/import.mjs
@@ -1,0 +1,2 @@
+// import.mjs should take precedence
+export const msg = '[success] exports with module (import.mjs)'

--- a/playground/resolve/exports-with-module/module.mjs
+++ b/playground/resolve/exports-with-module/module.mjs
@@ -1,0 +1,2 @@
+// import.mjs should take precedence
+export const msg = '[fail] exports with module (module.mjs)'

--- a/playground/resolve/exports-with-module/package.json
+++ b/playground/resolve/exports-with-module/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@vitejs/test-resolve-exports-with-module",
+  "private": true,
+  "version": "1.0.0",
+  "type": "commonjs",
+  "module": "./module.mjs",
+  "exports": {
+    "import": "./import.mjs"
+  }
+}

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -33,6 +33,9 @@
 <h2>Exports with legacy fallback</h2>
 <p class="exports-legacy-fallback">fail</p>
 
+<h2>Exports with module</h2>
+<p class="exports-with-module">fail</p>
+
 <h2>Resolve /index.*</h2>
 <p class="index">fail</p>
 
@@ -180,6 +183,9 @@
 
   import { msg as exportsLegacyFallbackMsg } from '@vitejs/test-resolve-exports-legacy-fallback/dir'
   text('.exports-legacy-fallback', exportsLegacyFallbackMsg)
+
+  import { msg as exportsWithModule } from '@vitejs/test-resolve-exports-with-module'
+  text('.exports-with-module', exportsWithModule)
 
   // implicit index resolving
   import { foo } from './util'

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -24,6 +24,7 @@
     "@vitejs/test-resolve-exports-from-root": "link:./exports-from-root",
     "@vitejs/test-resolve-exports-legacy-fallback": "link:./exports-legacy-fallback",
     "@vitejs/test-resolve-exports-path": "link:./exports-path",
+    "@vitejs/test-resolve-exports-with-module": "link:./exports-with-module",
     "@vitejs/test-resolve-linked": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,6 +800,7 @@ importers:
       '@vitejs/test-resolve-exports-from-root': link:./exports-from-root
       '@vitejs/test-resolve-exports-legacy-fallback': link:./exports-legacy-fallback
       '@vitejs/test-resolve-exports-path': link:./exports-path
+      '@vitejs/test-resolve-exports-with-module': link:./exports-with-module
       '@vitejs/test-resolve-linked': workspace:*
       es5-ext: 0.10.62
       normalize.css: ^8.0.1
@@ -817,6 +818,7 @@ importers:
       '@vitejs/test-resolve-exports-from-root': link:exports-from-root
       '@vitejs/test-resolve-exports-legacy-fallback': link:exports-legacy-fallback
       '@vitejs/test-resolve-exports-path': link:exports-path
+      '@vitejs/test-resolve-exports-with-module': link:exports-with-module
       '@vitejs/test-resolve-linked': link:../resolve-linked
       es5-ext: 0.10.62
       normalize.css: 8.0.1
@@ -867,6 +869,9 @@ importers:
     specifiers: {}
 
   playground/resolve/exports-path:
+    specifiers: {}
+
+  playground/resolve/exports-with-module:
     specifiers: {}
 
   playground/resolve/inline-package:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/vitejs/vite/issues/11114

This is a cherry-pick of #11234 which was previously reverted in #11270.

This removes an incorrect behaviour that's blocking correct exports of certain packages. This will fix the preact errors in ecosystem-ci and will bring an error in Histoire's CI, which we will investigate later on.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
More context in https://github.com/vitejs/vite/pull/11259#issuecomment-1368860610

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
