### PR TITLE
fix: duplicated sourceMappingURL for worker bundles (fix #11601)

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -142,13 +142,7 @@ function emitSourcemapForWorkerEntry(
   const { map: sourcemap } = chunk
 
   if (sourcemap) {
-    if (config.build.sourcemap === 'inline') {
-      // Manually add the sourcemap to the code if configured for inline sourcemaps.
-      // TODO: Remove when https://github.com/rollup/rollup/issues/3913 is resolved
-      // Currently seems that it won't be resolved until Rollup 3
-      const dataUrl = sourcemap.toUrl()
-      chunk.code += `//# sourceMappingURL=${dataUrl}`
-    } else if (
+    if (
       config.build.sourcemap === 'hidden' ||
       config.build.sourcemap === true
     ) {
@@ -159,20 +153,6 @@ function emitSourcemapForWorkerEntry(
         type: 'asset',
         source: data,
       })
-
-      // Emit the comment that tells the JS debugger where it can find the
-      // sourcemap file.
-      // 'hidden' causes the sourcemap file to be created but
-      // the comment in the file to be omitted.
-      if (config.build.sourcemap === true) {
-        // inline web workers need to use the full sourcemap path
-        // non-inline web workers can use a relative path
-        const sourceMapUrl =
-          query?.inline != null
-            ? mapFileName
-            : path.relative(config.build.assetsDir, mapFileName)
-        chunk.code += `//# sourceMappingURL=${sourceMapUrl}`
-      }
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR solved this [TODO](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/worker.ts#L147), now rollup can add sourceMappingURL comment automatically , so there is no need to add it manually. Otherwise, there will be duplicated sourceMappingURL in worker bundles.

### Additional context

Any comment is need?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
