### PR TITLE
fix: rebuilds don't happen in watch mode after the first rebuild throws an error during the load function

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -170,8 +170,14 @@ async function loadAndTransform(
   let code: string | null = null
   let map: SourceDescription['map'] = null
 
+  // Ensure that the module is in the graph before it is loaded and the file is checked.
+  // This prevents errors from occurring during the load process and interrupting the watching process at its inception.
+  const mod = await moduleGraph.ensureEntryFromUrl(url, ssr)
+  ensureWatchedFile(watcher, mod.file, root)
+
   // load
   const loadStart = isDebug ? performance.now() : 0
+
   const loadResult = await pluginContainer.load(id, { ssr })
   if (loadResult == null) {
     // if this is an html request and there is no load result, skip ahead to
@@ -233,9 +239,6 @@ async function loadAndTransform(
     err.code = isPublicFile ? ERR_LOAD_PUBLIC_URL : ERR_LOAD_URL
     throw err
   }
-  // ensure module in graph after successful load
-  const mod = await moduleGraph.ensureEntryFromUrl(url, ssr)
-  ensureWatchedFile(watcher, mod.file, root)
 
   // transform
   const transformStart = isDebug ? performance.now() : 0


### PR DESCRIPTION
Rebuilds don't happen in watch mode after the first rebuild throws an error during the load function.

The position of the watcher changed so that the file review would start before the load function is executed, and in the event of an error, the primary renderer will not crash and the file will be able to be watched.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
