### PR TITLE
feat(ssr): add importer path to error msg when invalid url import occur

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -5,7 +5,7 @@ import getEtag from 'etag'
 import convertSourceMap from 'convert-source-map'
 import type { SourceDescription, SourceMap } from 'rollup'
 import colors from 'picocolors'
-import type { ViteDevServer } from '..'
+import type { ModuleNode, ViteDevServer } from '..'
 import {
   blankReplacer,
   cleanUrl,
@@ -227,12 +227,15 @@ async function loadAndTransform(
         `going through the plugin transforms, and therefore should not be ` +
         `imported from source code. It can only be referenced via HTML tags.`
       : `Does the file exist?`
-    const modulePath = server.moduleGraph.idToModuleMap
+    const importerMod: ModuleNode | undefined = server.moduleGraph.idToModuleMap
       .get(id)
       ?.importers.values()
-      .next().value.file
+      .next().value
+    const importer = importerMod?.file || importerMod?.url
     const err: any = new Error(
-      `Failed to load url ${url} (resolved id: ${id}) in ${modulePath} ${msg}`,
+      `Failed to load url ${url} (resolved id: ${id})${
+        importer ? ` in ${importer}` : ''
+      }. ${msg}`,
     )
     err.code = isPublicFile ? ERR_LOAD_PUBLIC_URL : ERR_LOAD_URL
     throw err

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -227,8 +227,12 @@ async function loadAndTransform(
         `going through the plugin transforms, and therefore should not be ` +
         `imported from source code. It can only be referenced via HTML tags.`
       : `Does the file exist?`
+    const modulePath = server.moduleGraph.idToModuleMap
+      .get(id)
+      ?.importers.values()
+      .next().value.file
     const err: any = new Error(
-      `Failed to load url ${url} (resolved id: ${id}). ${msg}`,
+      `Failed to load url ${url} (resolved id: ${id}) in ${modulePath} ${msg}`,
     )
     err.code = isPublicFile ? ERR_LOAD_PUBLIC_URL : ERR_LOAD_URL
     throw err

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -1,4 +1,5 @@
 import { fileURLToPath } from 'node:url'
+import path from 'node:path'
 import { expect, test } from 'vitest'
 import { createServer } from '../../server'
 
@@ -13,11 +14,13 @@ async function createDevServer() {
 test('ssrLoad', async () => {
   expect.assertions(1)
   const server = await createDevServer()
+  const moduleRelativePath = '/fixtures/modules/has-invalid-import.js'
+  const moduleAbsolutePath = path.join(root, moduleRelativePath)
   try {
-    await server.ssrLoadModule('/fixtures/modules/has-invalid-import.js')
+    await server.ssrLoadModule(moduleRelativePath)
   } catch (e) {
     expect(e.message).toBe(
-      'Failed to load url ./non-existent.js (resolved id: ./non-existent.js) in /fixtures/modules/has-invalid-import.js Does the file exist?',
+      `Failed to load url ./non-existent.js (resolved id: ./non-existent.js) in ${moduleAbsolutePath} Does the file exist?`,
     )
   }
 })

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -20,7 +20,7 @@ test('ssrLoad', async () => {
     await server.ssrLoadModule(moduleRelativePath)
   } catch (e) {
     expect(e.message).toBe(
-      `Failed to load url ./non-existent.js (resolved id: ./non-existent.js) in ${moduleAbsolutePath} Does the file exist?`,
+      `Failed to load url ./non-existent.js (resolved id: ./non-existent.js) in ${moduleAbsolutePath}. Does the file exist?`,
     )
   }
 })

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -17,7 +17,7 @@ test('ssrLoad', async () => {
     await server.ssrLoadModule('/fixtures/modules/has-invalid-import.js')
   } catch (e) {
     expect(e.message).toBe(
-      'Failed to load url ./non-existent.js (resolved id: ./non-existent.js). Does the file exist?',
+      'Failed to load url ./non-existent.js (resolved id: ./non-existent.js) in /fixtures/modules/has-invalid-import.js Does the file exist?',
     )
   }
 })

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { expect, test } from 'vitest'
 import { createServer } from '../../server'
+import { normalizePath } from '../../utils'
 
 const root = fileURLToPath(new URL('./', import.meta.url))
 
@@ -15,7 +16,7 @@ test('ssrLoad', async () => {
   expect.assertions(1)
   const server = await createDevServer()
   const moduleRelativePath = '/fixtures/modules/has-invalid-import.js'
-  const moduleAbsolutePath = path.join(root, moduleRelativePath)
+  const moduleAbsolutePath = normalizePath(path.join(root, moduleRelativePath))
   try {
     await server.ssrLoadModule(moduleRelativePath)
   } catch (e) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When a url fail to load there is no info in the error message about where the failed import occur which make it hard to debug especially during tests with vitest. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
