### PR TITLE
fix: two folders are created when the project name contains spaces

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -318,7 +318,6 @@ async function init() {
 
   if (customCommand) {
     const fullCustomCommand = customCommand
-      .replace('TARGET_DIR', targetDir)
       .replace(/^npm create/, `${pkgManager} create`)
       // Only Yarn 1.x doesn't support `@version` in the `create` command
       .replace('@latest', () => (isYarn1 ? '' : '@latest'))
@@ -336,10 +335,9 @@ async function init() {
       })
 
     const [command, ...args] = fullCustomCommand.split(' ')
-    if (targetDir.includes(' ')) {
-      args.splice(2, args.length - 2, targetDir)
-    }
-    const { status } = spawn.sync(command, args, {
+    // we replace TARGET_DIR here because targetDir may include a space
+    const replacedArgs = args.map((arg) => arg.replace('TARGET_DIR', targetDir))
+    const { status } = spawn.sync(command, replacedArgs, {
       stdio: 'inherit',
     })
     process.exit(status ?? 0)

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -336,6 +336,9 @@ async function init() {
       })
 
     const [command, ...args] = fullCustomCommand.split(' ')
+    if (targetDir.includes(' ')) {
+      args.splice(2, args.length - 2, targetDir)
+    }
     const { status } = spawn.sync(command, args, {
       stdio: 'inherit',
     })

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -377,9 +377,14 @@ async function init() {
     setupReactSwc(root, template.endsWith('-ts'))
   }
 
+  const cdProjectName = path.relative(cwd, root)
   console.log(`\nDone. Now run:\n`)
   if (root !== cwd) {
-    console.log(`  cd ${path.relative(cwd, root)}`)
+    console.log(
+      `  cd ${
+        cdProjectName.includes(' ') ? `"${cdProjectName}"` : cdProjectName
+      }`,
+    )
   }
   switch (pkgManager) {
     case 'yarn':


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When select `customize with create-vue`, If the project name contains a space, two folders will be created, and then the template content will be filled into the folder named with the character before the first space.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
