### PR TITLE
docs(deploy): add stoat preview for github pull requests

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -315,3 +315,41 @@ You can deploy your Vite app as a Static Site on [Render](https://render.com/).
 By default, any new commit pushed to the specified branch will automatically trigger a new deployment. [Auto-Deploy](https://render.com/docs/deploys#toggling-auto-deploy-for-a-service) can be configured in the project settings.
 
 You can also add a [custom domain](https://render.com/docs/custom-domains) to your project.
+
+## Stoat
+
+You can preview your Vite app built by the GitHub workflows on pull requests with [Stoat](https://stoat.dev/).
+
+1. Install the [Stoat App](https://github.com/apps/stoat-app).
+
+2. Append the [Stoat Action](https://github.com/marketplace/actions/stoat-action) at the of the GitHub workflow that generates the Vite preview.
+
+   ```yaml{5-8}
+   # existing step that generates the preview
+   - name: Build Vite preview
+     run: npm run build
+
+   # new step to append
+   - name: Run Stoat Action
+     uses: stoat-dev/stoat-action@v0
+     if: always()
+   ```
+
+3. Add a Stoat config file in `.stoat/config.yaml`.
+
+   ```yaml
+   version: 1
+   enabled: true
+   plugins:
+   static_hosting:
+     vite-preview:
+       # This is the path to the generated preview.
+       # Please update it if you have customized the build.outDir.
+       path: dist
+   ```
+
+Now whenever a pull request is created on GitHub, the Stoat App will create and maintain a pinned comment with a link to the hosted preview.
+
+<img width="500" src="https://stoat-dev--static.stoat.page/screenshot-vite-preview.png" alt="screenshot of preview vite via stoat">
+
+Learn more about Stoat's [static site preview](https://docs.stoat.dev/docs/tutorials/preview-static-site).


### PR DESCRIPTION
### Description

This PR adds a new way to easily host and preview Vite apps in GitHub pull requests with [Stoat](https://stoat.dev).

### Additional context

None.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
