### PR TITLE
chore: ci: fix if check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,10 @@ jobs:
           echo "Diff result: ${{ needs.diff.result }}"
           echo "Lint result: ${{ needs.lint.result }}"
           echo "Test result: ${{ needs.test.result }}"
-          $diff_success = ${{ needs.diff.result == 'success' }}
-          $lint_success = ${{ needs.lint.result == 'success' }}
-          $test_success = ${{ needs.test.result == 'success' || needs.test.result == 'skipped' }}
-          if [[ !$diff_success || !$lint_success || !$test_success ]]; then
+          diff_success=${{ needs.diff.result == 'success' }}
+          lint_success=${{ needs.lint.result == 'success' }}
+          test_success=${{ needs.test.result == 'success' || needs.test.result == 'skipped' }}
+          if [[ $diff_success == false || $lint_success == false || $test_success == false ]]; then
             echo "Some jobs failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   test:
     needs: diff
-    if: needs.diff.outputs.runTest
+    if: needs.diff.outputs.runTest != 'false'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:
-      - name: Checkout
+      - name: Checkout ${{ needs.diff.outputs.runTest }}
         uses: actions/checkout@v3
 
       - name: Install pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
     steps:
-      - name: Checkout ${{ needs.diff.outputs.runTest }}
+      - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install pnpm
@@ -129,25 +129,6 @@ jobs:
       - name: Test build
         run: pnpm run test-build
 
-  test-skip:
-    needs: diff
-    if: needs.diff.outputs.runTest == 'false'
-    timeout-minutes: 1
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node_version: [14, 16, 18]
-        include:
-          # Active LTS + other OS
-          - os: macos-latest
-            node_version: 18
-          - os: windows-latest
-            node_version: 18
-    name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
-    steps:
-      - run: echo "No test required"
-
   lint:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -187,3 +168,17 @@ jobs:
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color -shellcheck=""
+
+  required:
+    needs: [test, lint]
+    if: always()
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    name: "Required job"
+    steps:
+      - run: |
+          if [[ "${{ needs.test.result }}" == "true" && "${{ needs.lint.result }}" == "true" ]]; then
+            exit 0
+          else
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           files: |
             docs/**
             .github/**
+            !.github/workflows/ci.yml
             packages/create-vite/template**
             **.md
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,13 +53,12 @@ jobs:
           files: |
             docs/**
             .github/**
-            !.github/workflows/ci.yml
             packages/create-vite/template**
             **.md
 
   test:
     needs: diff
-    if: ${{ needs.diff.outputs.runTest }}
+    if: needs.diff.outputs.runTest
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,18 +168,30 @@ jobs:
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color -shellcheck=""
 
+  # At the time of writing GH only support job level require checks using labels.
+  # Which means to that all the name of the test matrix should be marked as required.
+  # And that skipping the matrix gives pending required jobs because the skip happen before the labels are evaluated
+  # A first solution is to create dummy jobs that runs with an opposite conditions like what the documentation suggest
+  # when skipping with path filtering: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  # But this requires to sync the two matrix and the list of required jobs in settings
+  # This step emulate a "workflow successful" output and simplify the GH requirement
+  # Note: we need to check that the diff job is successful to be sure test is not skipped because previous job failed
+  # For the same reason we need always() condition because a skipped job passes the requirement check
   required:
-    needs: [test, lint]
+    needs: [diff, test, lint]
     if: always()
     timeout-minutes: 1
     runs-on: ubuntu-latest
     name: "Required job"
     steps:
       - run: |
+          echo "Diff result: ${{ needs.diff.result }}"
           echo "Lint result: ${{ needs.lint.result }}"
           echo "Test result: ${{ needs.test.result }}"
-          if [[ "${{ needs.lint.result }}" == "success" && ("${{ needs.text.result }}" == "success" || "${{ needs.text.result }}" == "skipped") ]]; then
-            exit 0
-          else
+          $diff_success = ${{ needs.diff.result == 'success' }}
+          $lint_success = ${{ needs.lint.result == 'success' }}
+          $test_success = ${{ needs.test.result == 'success' || needs.test.result == 'skipped' }}
+          if [[ !$diff_success || !$lint_success || !$test_success ]]; then
+            echo "Some jobs failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # Should be in sync with test-skip & GH required jobs
         os: [ubuntu-latest]
         node_version: [14, 16, 18]
         include:
@@ -127,6 +128,25 @@ jobs:
 
       - name: Test build
         run: pnpm run test-build
+
+  test-skip:
+    needs: diff
+    if: needs.diff.outputs.runTest == 'false'
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node_version: [14, 16, 18]
+        include:
+          # Active LTS + other OS
+          - os: macos-latest
+            node_version: 18
+          - os: windows-latest
+            node_version: 18
+    name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
+    steps:
+      - run: echo "No test required"
 
   lint:
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,11 @@ jobs:
 
   test:
     needs: diff
-    if: needs.diff.outputs.runTest != 'false'
+    if: needs.diff.outputs.runTest == 'true'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Should be in sync with test-skip & GH required jobs
         os: [ubuntu-latest]
         node_version: [14, 16, 18]
         include:
@@ -177,7 +176,9 @@ jobs:
     name: "Required job"
     steps:
       - run: |
-          if [[ "${{ needs.test.result }}" == "true" && "${{ needs.lint.result }}" == "true" ]]; then
+          echo "Lint result: ${{ needs.lint.result }}"
+          echo "Test result: ${{ needs.test.result }}"
+          if [[ "${{ needs.lint.result }}" == "success" && ("${{ needs.text.result }}" == "success" || "${{ needs.text.result }}" == "skipped") ]]; then
             exit 0
           else
             exit 1


### PR DESCRIPTION
Re #11548 
The condition did not work for #11638

This was way more complicated than I though. Really hard to make PR required checks behaves as expected when suing conditions.

Proposed solution:
See comment in the yml file. The issue with that is that is requires a transition period where require jobs will be off for old PRs. The advantage is that it will not happen later when we update node versions. This is the reason I opted for this solution.

Other solution:
```yml
  test-skip:
    needs: diff
    if: needs.diff.outputs.runTest == 'false'
    timeout-minutes: 1
    runs-on: ubuntu-latest
    strategy:
      matrix:
        os: [ubuntu-latest]
        node_version: [14, 16, 18]
        include:
          # Active LTS + other OS
          - os: macos-latest
            node_version: 18
          - os: windows-latest
            node_version: 18
    name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"
    steps:
      - run: echo "No test required"
```

Other possibilities:
- Remove required check on `test`
- Split jobs, skip tests via path filtering and use dummy test job for requirement as suggested by the doc: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
- Remove conditional run of test and make few PRs slower 
- Remove conditional run of test and use nx