### PR TITLE
chore: shrink genSourceMapUrl type

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -59,7 +59,7 @@ export async function injectSourcesContent(
   }
 }
 
-export function genSourceMapUrl(map: SourceMap | string | undefined): string {
+export function genSourceMapUrl(map: SourceMap | string): string {
   if (typeof map !== 'string') {
     map = JSON.stringify(map)
   }
@@ -69,16 +69,16 @@ export function genSourceMapUrl(map: SourceMap | string | undefined): string {
 export function getCodeWithSourcemap(
   type: 'js' | 'css',
   code: string,
-  map: SourceMap | null,
+  map: SourceMap,
 ): string {
   if (isDebug) {
     code += `\n/*${JSON.stringify(map, null, 2).replace(/\*\//g, '*\\/')}*/\n`
   }
 
   if (type === 'js') {
-    code += `\n//# sourceMappingURL=${genSourceMapUrl(map ?? undefined)}`
+    code += `\n//# sourceMappingURL=${genSourceMapUrl(map)}`
   } else if (type === 'css') {
-    code += `\n/*# sourceMappingURL=${genSourceMapUrl(map ?? undefined)} */`
+    code += `\n/*# sourceMappingURL=${genSourceMapUrl(map)} */`
   }
 
   return code


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The genSourceMapUrl function will not receive parameters of undefined type, and it is meaningless to receive parameters of undefined type to generate sourcemap.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
