### PR TITLE
chore: fix type warning during building vite

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -1,11 +1,11 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import colors from 'picocolors'
-import type { Logger } from 'vite'
 import { describe, expect, test, vi } from 'vitest'
 import type { OutputChunk, OutputOptions, RollupOutput } from 'rollup'
 import type { LibraryFormats, LibraryOptions } from '../build'
 import { build, resolveBuildOutputs, resolveLibFilename } from '../build'
+import type { Logger } from '../logger'
 import { createLogger } from '../logger'
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..')

--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.test.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.test.ts
@@ -1,8 +1,8 @@
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { normalizePath } from 'vite'
 import { describe, expect, it } from 'vitest'
 import { transformDynamicImport } from '../../../plugins/dynamicImportVars'
+import { normalizePath } from '../../../utils'
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..')
 


### PR DESCRIPTION
### Description
When running `pnpm build` in `packages/vite`, rollup output the following warning.
```
loaded rollup.config.ts with warnings
(!) Plugin typescript: @rollup/plugin-typescript TS2307: Cannot find module 'vite' or its corresponding type declarations.
src/node/__tests__/build.spec.ts: (4:29)

4 import type { Logger } from 'vite'
                              ~~~~~~

src/node/__tests__/plugins/dynamicImportVar/parse.test.ts: (3:31)

3 import { normalizePath } from 'vite'
```
This PR fixes this.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
