### PR TITLE
fix: set conditions when bundling config file

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -940,6 +940,12 @@ async function bundleConfigFile(
   fileName: string,
   isESM: boolean,
 ): Promise<{ code: string; dependencies: string[] }> {
+  if (!process.env.NODE_ENV) {
+    throw new Error(
+      'process.env.NODE_ENV must be set before loading config file',
+    )
+  }
+  const envCondition = process.env.NODE_ENV
   const dirnameVarName = '__vite_injected_original_dirname'
   const filenameVarName = '__vite_injected_original_filename'
   const importMetaUrlVarName = '__vite_injected_original_import_meta_url'
@@ -950,6 +956,7 @@ async function bundleConfigFile(
     write: false,
     target: ['node14.18', 'node16'],
     platform: 'node',
+    conditions: [envCondition],
     bundle: true,
     format: isESM ? 'esm' : 'cjs',
     mainFields: ['main'],
@@ -973,7 +980,7 @@ async function bundleConfigFile(
             mainFields: [],
             browserField: false,
             conditions: [],
-            overrideConditions: ['node'],
+            overrideConditions: ['node', envCondition],
             dedupe: [],
             extensions: DEFAULT_EXTENSIONS,
             preserveSymlinks: false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Pass either `production` or `development` to `conditions`

### Additional context

The `production` or `development` condition is set everywhere else in the code, so it would be nice to do it here as well for consistency

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
