### PR TITLE
chore: after successfully creating a new service, close the previous …

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -776,8 +776,6 @@ async function restartServer(server: ViteDevServer) {
   const { port: prevPort, host: prevHost } = server.config.server
   const shortcutsOptions: BindShortcutsOptions = server._shortcutsOptions
 
-  await server.close()
-
   let inlineConfig = server.config.inlineConfig
   if (server._forceOptimizeOnRestart) {
     inlineConfig = mergeConfig(inlineConfig, {
@@ -790,7 +788,8 @@ async function restartServer(server: ViteDevServer) {
   let newServer = null
   try {
     newServer = await createServer(inlineConfig)
-  } catch (err: any) {
+    await server.close()
+  } catch (err) {
     server.config.logger.error(err.message, {
       timestamp: true,
     })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When modifying the vite configuration file, the following situations are likely to occur during the writing process, causing us to have to re-pnpm dev after writing the configuration, which is unfriendly.
<img width="694" alt="image" src="https://user-images.githubusercontent.com/83797583/212239823-f5fcafcf-22ac-4e36-b67d-cb3fbcf02371.png">
If we wait until the new serve is successfully created before closing the old serve, then the above situation can be avoided. The following is the effect after modifying the code:
<img width="734" alt="image" src="https://user-images.githubusercontent.com/83797583/212240441-a246b954-e365-470c-a78e-3ac21510cef1.png">



### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
