### PR TITLE
chore: StackBlitz startCommand

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,5 +131,8 @@
       "dotenv-expand@9.0.0": "patches/dotenv-expand@9.0.0.patch",
       "sirv@2.0.2": "patches/sirv@2.0.2.patch"
     }
+  },
+  "stackblitz": {
+    "startCommand": "pnpm --filter='./packages/vite' run dev"
   }
 }


### PR DESCRIPTION
### Description

This PR adds a config option to only run the dev command for the vite package instead of the default dev that also includes create-vite and plugin-legacy. There are some possible performance issues we are checking with @d3lm with unbuild dev command in codeflow.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other