### PR TITLE
chore: remove unused `module` field in `package.json`

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -17,7 +17,6 @@
     "vite"
   ],
   "main": "./dist/node/index.js",
-  "module": "./dist/node/index.js",
   "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Only `exports` will be used when present so `module` does nothing

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
