### PR TITLE
chore: use jsdoc's default tag

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -219,7 +219,7 @@ export interface UserConfig {
   legacy?: LegacyOptions
   /**
    * Log level.
-   * @default: 'info'
+   * @default 'info'
    */
   logLevel?: LogLevel
   /**
@@ -227,7 +227,7 @@ export interface UserConfig {
    */
   customLogger?: Logger
   /**
-   * @default: true
+   * @default true
    */
   clearScreen?: boolean
   /**

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -219,7 +219,7 @@ export interface UserConfig {
   legacy?: LegacyOptions
   /**
    * Log level.
-   * Default: 'info'
+   * @default: 'info'
    */
   logLevel?: LogLevel
   /**
@@ -227,7 +227,7 @@ export interface UserConfig {
    */
   customLogger?: Logger
   /**
-   * Default: true
+   * @default: true
    */
   clearScreen?: boolean
   /**


### PR DESCRIPTION
### Description

Only update typo to keep name convention for `@default` comment.
File: packages/vite/src/node/config.ts
Change: without code logic changes, only update the comments, should be safe.

### Additional context

-

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
