### PR TITLE
feat: export rollup types

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -118,7 +118,7 @@ export type {
   KnownAsTypeMap,
 } from 'types/importGlob'
 export type { ChunkMetadata } from 'types/metadata'
-
+export type { RollupWatcher, RollupWatcherEvent, RollupOutput } from 'rollup'
 // dep types
 export type {
   AliasOptions,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I have been working on the [vite plugin](https://github.com/nrwl/nx/tree/master/packages/vite) in Nx.

We use the vite API to call build

https://github.com/nrwl/nx/blob/9cc2be61066c9281db229fb2b0ee72a2d153b2ee/packages/vite/src/executors/build/build.impl.ts#L75-L79

When watch mode is enabled `buid()` returns a `RollupWatcher` emitting `RollupWatcherEvent`

I can not [add types](https://github.com/nrwl/nx/blob/9cc2be61066c9281db229fb2b0ee72a2d153b2ee/packages/vite/src/executors/build/build.impl.ts#L53-L54) in the code because `import { RollupWatcher, RollupWatcherEvent } from 'rollup';` import from the rollup package installed by Nx which is not compatible with the rollup version used by vite.

With this change I could  `import { RollupWatcher, RollupWatcherEvent } from 'vite';` and add those types to the code.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
