### PR TITLE
fix(esbuild): check server before reload tsconfig

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -485,6 +485,8 @@ async function loadTsconfigJsonForFile(
 }
 
 function reloadOnTsconfigChange(changedFile: string) {
+  // server could be closed externally after a file change is detected
+  if (!server) return
   // any tsconfig.json that's added in the workspace could be closer to a code file than a previously cached one
   // any json file in the tsconfig cache could have been used to compile ts
   if (


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Astro currently watches and reload tsconfig changes itself. When a `tsconfig.json` is updated, it closes the Vite dev server immediately, which synchronously invokes:

https://github.com/vitejs/vite/blob/7112d7a99c2e9405ea2257584df5f08f0df416d2/packages/vite/src/node/plugins/esbuild.ts#L253

But since Vite's watcher is still tearing down at:

https://github.com/vitejs/vite/blob/7112d7a99c2e9405ea2257584df5f08f0df416d2/packages/vite/src/node/server/index.ts#L417

It could trigger Vite's tsconfig reload watch handler that now relies on `server` that is `null`:

https://github.com/vitejs/vite/blob/a65d31bbdfca43f76cf0e6212fef7841af8f148d/packages/vite/src/node/plugins/esbuild.ts#L487-L498

This PR adds a `null` check to the handler to cover this case.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
