### PR TITLE
docs: update build-options.md

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -3,7 +3,7 @@
 ## build.target
 
 - **Type:** `string | string[]`
-- **Default:** `'modules'`
+- **Default:** `['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14']`
 - **Related:** [Browser Compatibility](/guide/build#browser-compatibility)
 
 Browser compatibility target for the final bundle. The default value is a Vite special value, `'modules'`, which targets browsers with [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta) support.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
 the `build.target` default is `'modules'`, but when `build.target === 'module'` vite will replace `modules` to `['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14']`. So i think the real default is `['es2020', 'edge88', 'firefox78', 'chrome87', 'safari14']`

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
