### PR TITLE
chore: remove pnpm devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "npm-run-all": "^4.1.5",
     "picocolors": "^1.0.0",
     "playwright-chromium": "^1.29.2",
-    "pnpm": "^7.25.0",
     "prettier": "2.8.3",
     "prompts": "^2.4.2",
     "resolve": "^1.22.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,7 +57,6 @@ importers:
       npm-run-all: ^4.1.5
       picocolors: ^1.0.0
       playwright-chromium: ^1.29.2
-      pnpm: ^7.25.0
       prettier: 2.8.3
       prompts: ^2.4.2
       resolve: ^1.22.1
@@ -114,7 +113,6 @@ importers:
       npm-run-all: 4.1.5
       picocolors: 1.0.0
       playwright-chromium: 1.29.2
-      pnpm: 7.25.0
       prettier: 2.8.3
       prompts: 2.4.2
       resolve: 1.22.1
@@ -6706,12 +6704,6 @@ packages:
   /playwright-core/1.29.2:
     resolution: {integrity: sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==}
     engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
-  /pnpm/7.25.0:
-    resolution: {integrity: sha512-FGFQUON8kJ6ma39elJ8lyD8wPIfgp3opGJD9sX0TgIJk4zSr556qCgC8AN+3BFHe4yuRkEauf4JVLW2RKyyEcA==}
-    engines: {node: '>=14.6'}
     hasBin: true
     dev: true
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

found that during debugging an issue in vite-ecosystem-ci and havn't seen any usage of it.
Having it as a local devDependency causes it to be used over global pnpm *after* the global was used for the initial install.
This can cause mismatches.

If we want to enforce a certain pnpm version, using engines.pnpm alongside the already set packageManager field would be a better option imho.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
