### PR TITLE
fix(css): insert styles in the same position

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -347,6 +347,9 @@ const sheetsMap = new Map<
   string,
   HTMLStyleElement | CSSStyleSheet | undefined
 >()
+// all css imports should be inserted at the same position
+// because after build it will be a single css file
+let lastInsertedStyle: HTMLStyleElement | undefined
 
 export function updateStyle(id: string, content: string): void {
   let style = sheetsMap.get(id)
@@ -374,7 +377,19 @@ export function updateStyle(id: string, content: string): void {
       style.setAttribute('type', 'text/css')
       style.setAttribute('data-vite-dev-id', id)
       style.textContent = content
-      document.head.appendChild(style)
+
+      if (!lastInsertedStyle) {
+        document.head.appendChild(style)
+
+        // reset lastInsertedStyle after async
+        // because dynamically imported css will be splitted into a different file
+        setTimeout(() => {
+          lastInsertedStyle = undefined
+        }, 0)
+      } else {
+        lastInsertedStyle.insertAdjacentElement('afterend', style)
+      }
+      lastInsertedStyle = style
     } else {
       style.textContent = content
     }

--- a/playground/css-codesplit/__tests__/css-codesplit.spec.ts
+++ b/playground/css-codesplit/__tests__/css-codesplit.spec.ts
@@ -21,6 +21,12 @@ test('should load dynamic import with module', async () => {
   expect(await getColor('.mod')).toBe('yellow')
 })
 
+test('style order should be consistent when style tag is inserted by JS', async () => {
+  expect(await getColor('.order-bulk')).toBe('orange')
+  await page.click('.order-bulk-update')
+  expect(await getColor('.order-bulk')).toBe('green')
+})
+
 describe.runIf(isBuild)('build', () => {
   test('should remove empty chunk', async () => {
     expect(findAssetFile(/style.*\.js$/)).toBe('')

--- a/playground/css-codesplit/index.html
+++ b/playground/css-codesplit/index.html
@@ -7,5 +7,10 @@
 <p class="mod">This should be yellow</p>
 <p class="dynamic-module"></p>
 
+<p class="order-bulk">
+  This should be orange
+  <button class="order-bulk-update">change to green</button>
+</p>
+
 <script type="module" src="/main.js"></script>
 <div id="app"></div>

--- a/playground/css-codesplit/main.js
+++ b/playground/css-codesplit/main.js
@@ -1,5 +1,6 @@
 import './style.css'
 import './main.css'
+import './order'
 
 import('./async.css')
 

--- a/playground/css-codesplit/order/base.css
+++ b/playground/css-codesplit/order/base.css
@@ -1,0 +1,3 @@
+.order-bulk {
+  color: blue;
+}

--- a/playground/css-codesplit/order/dynamic.css
+++ b/playground/css-codesplit/order/dynamic.css
@@ -1,0 +1,3 @@
+.order-bulk {
+  color: green;
+}

--- a/playground/css-codesplit/order/index.js
+++ b/playground/css-codesplit/order/index.js
@@ -1,0 +1,6 @@
+import './insert' // inserts "color: orange"
+import './base.css' // includes "color: blue"
+
+document.querySelector('.order-bulk-update').addEventListener('click', () => {
+  import('./dynamic.css') // includes "color: green"
+})

--- a/playground/css-codesplit/order/insert.js
+++ b/playground/css-codesplit/order/insert.js
@@ -1,0 +1,3 @@
+const style = document.createElement('style')
+style.textContent = '.order-bulk { color: orange; }'
+document.head.appendChild(style)


### PR DESCRIPTION
### Description
When a style was injected by JS, the order was inconsistent between dev and build.

While this works for the current style-injection approach, this is not feasible by the `adoptedStyleSheets` approach (currently disabled due to low perf) because `adoptedStyleSheets` are [ordered after all the other style sheets](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets#:~:text=Stylesheets%20in%20the%20property%20are%20evaluated%20along%20with%20the%20document%27s%20other%20stylesheets%20using%20the%20CSS%20cascade%20algorithm.%20Where%20the%20resolution%20of%20rules%20considers%20stylesheet%20order%2C%20adoptedStyleSheets%20are%20assumed%20to%20be%20ordered%20after%20those%20in%20Document.styleSheets.).
I didn't touch the `adoptedStyleSheets` approach but maybe we can simply remove this.

fixes #11760

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
