### PR TITLE
fix(ssr): load sourcemaps alongside modules

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -10,6 +10,7 @@ import {
 import { transformRequest } from '../server/transformRequest'
 import type { InternalResolveOptionsWithOverrideConditions } from '../plugins/resolve'
 import { tryNodeResolve } from '../plugins/resolve'
+import { genSourceMapUrl } from '../server/sourcemap'
 import {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -24,6 +25,16 @@ interface SSRContext {
 }
 
 type SSRModule = Record<string, any>
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const AsyncFunction = async function () {}.constructor as typeof Function
+let fnDeclarationLineCount = 0
+{
+  const body = '/*code*/'
+  const source = new AsyncFunction('a', 'b', body).toString()
+  fnDeclarationLineCount =
+    source.slice(0, source.indexOf(body)).split('\n').length - 1
+}
 
 const pendingModules = new Map<string, Promise<SSRModule>>()
 const pendingImports = new Map<string, string[]>()
@@ -181,9 +192,17 @@ async function instantiateModule(
     }
   }
 
+  let sourceMapSuffix = ''
+  if (result.map) {
+    const moduleSourceMap = Object.assign({}, result.map, {
+      // offset the first three lines of the module (function declaration and 'use strict')
+      mappings: ';'.repeat(fnDeclarationLineCount + 1) + result.map.mappings,
+    })
+    sourceMapSuffix =
+      '\n//# sourceMappingURL=' + genSourceMapUrl(moduleSourceMap)
+  }
+
   try {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const AsyncFunction = async function () {}.constructor as typeof Function
     const initModule = new AsyncFunction(
       `global`,
       ssrModuleExportsKey,
@@ -191,7 +210,9 @@ async function instantiateModule(
       ssrImportKey,
       ssrDynamicImportKey,
       ssrExportAllKey,
-      '"use strict";' + result.code + `\n//# sourceURL=${mod.url}`,
+      '"use strict";\n' +
+        result.code +
+        `\n//# sourceURL=${mod.url}${sourceMapSuffix}`,
     )
     await initModule(
       context.global,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -195,7 +195,8 @@ async function instantiateModule(
   let sourceMapSuffix = ''
   if (result.map) {
     const moduleSourceMap = Object.assign({}, result.map, {
-      // offset the first three lines of the module (function declaration)
+      // currently we need to offset the line
+      // https://github.com/nodejs/node/issues/43047#issuecomment-1180632750
       mappings: ';'.repeat(fnDeclarationLineCount) + result.map.mappings,
     })
     sourceMapSuffix =

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -195,8 +195,8 @@ async function instantiateModule(
   let sourceMapSuffix = ''
   if (result.map) {
     const moduleSourceMap = Object.assign({}, result.map, {
-      // offset the first three lines of the module (function declaration and 'use strict')
-      mappings: ';'.repeat(fnDeclarationLineCount + 1) + result.map.mappings,
+      // offset the first three lines of the module (function declaration)
+      mappings: ';'.repeat(fnDeclarationLineCount) + result.map.mappings,
     })
     sourceMapSuffix =
       '\n//# sourceMappingURL=' + genSourceMapUrl(moduleSourceMap)
@@ -210,7 +210,7 @@ async function instantiateModule(
       ssrImportKey,
       ssrDynamicImportKey,
       ssrExportAllKey,
-      '"use strict";\n' +
+      '"use strict";' +
         result.code +
         `\n//# sourceURL=${mod.url}${sourceMapSuffix}`,
     )

--- a/playground/ssr-html/package.json
+++ b/playground/ssr-html/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "node server",
     "serve": "NODE_ENV=production node server",
-    "debug": "node --inspect-brk server"
+    "debug": "node --inspect-brk server",
+    "test-stacktrace:off": "node test-stacktrace false",
+    "test-stacktrace:on": "node test-stacktrace true"
   },
   "dependencies": {},
   "devDependencies": {

--- a/playground/ssr-html/src/error.js
+++ b/playground/ssr-html/src/error.js
@@ -1,0 +1,3 @@
+export function error() {
+  throw new Error('e')
+}

--- a/playground/ssr-html/test-stacktrace.js
+++ b/playground/ssr-html/test-stacktrace.js
@@ -6,6 +6,19 @@ const isSourceMapEnabled = process.argv[2] === 'true'
 process.setSourceMapsEnabled(isSourceMapEnabled)
 console.log('# sourcemaps enabled:', isSourceMapEnabled)
 
+const version = (() => {
+  const m = process.version.match(/^v(\d+)\.(\d+)\.\d+$/)
+  if (!m) throw new Error(`Failed to parse version: ${process.version}`)
+
+  return { major: m[1], minor: m[2] }
+})()
+
+// https://github.com/nodejs/node/pull/43428
+const isFunctionSourceMapSupported =
+  (version.major === 16 && version.minor >= 17) ||
+  (version.major === 18 && version.minor >= 6) ||
+  version.major >= 19
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const isTest = process.env.VITEST
 
@@ -23,9 +36,9 @@ try {
   mod.error()
 } catch (e) {
   // this should not be called
-  // when running on Node.js "^16.17.0 || >=18.6.0" and sourcemap is enabled
-  // because the stacktrace is already rewritten
-  if (!isSourceMapEnabled) {
+  // when sourcemap support for `new Function` is supported and sourcemap is enabled
+  // because the stacktrace is already rewritten by Node.js
+  if (!(isSourceMapEnabled && isFunctionSourceMapSupported)) {
     vite.ssrFixStacktrace(e)
   }
   console.log(e)

--- a/playground/ssr-html/test-stacktrace.js
+++ b/playground/ssr-html/test-stacktrace.js
@@ -22,6 +22,8 @@ const mod = await vite.ssrLoadModule('/src/error.js')
 try {
   mod.error()
 } catch (e) {
+  // this is not required
+  // when running on Node.js "^16.17.0 || >=18.6.0" and sourcemap is enabled
   vite.ssrFixStacktrace(e)
   console.log(e)
 }

--- a/playground/ssr-html/test-stacktrace.js
+++ b/playground/ssr-html/test-stacktrace.js
@@ -25,7 +25,7 @@ try {
   // this should not be called
   // when running on Node.js "^16.17.0 || >=18.6.0" and sourcemap is enabled
   // because the stacktrace is already rewritten
-  if (isSourceMapEnabled) {
+  if (!isSourceMapEnabled) {
     vite.ssrFixStacktrace(e)
   }
   console.log(e)

--- a/playground/ssr-html/test-stacktrace.js
+++ b/playground/ssr-html/test-stacktrace.js
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createServer } from 'vite'
+
+const isSourceMapEnabled = process.argv[2] === 'true'
+process.setSourceMapsEnabled(isSourceMapEnabled)
+console.log('# sourcemaps enabled:', isSourceMapEnabled)
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const isTest = process.env.VITEST
+
+const vite = await createServer({
+  root: __dirname,
+  logLevel: isTest ? 'error' : 'info',
+  server: {
+    middlewareMode: true,
+  },
+  appType: 'custom',
+})
+
+const mod = await vite.ssrLoadModule('/src/error.js')
+try {
+  mod.error()
+} catch (e) {
+  vite.ssrFixStacktrace(e)
+  console.log(e)
+}
+
+await vite.close()

--- a/playground/ssr-html/test-stacktrace.js
+++ b/playground/ssr-html/test-stacktrace.js
@@ -22,9 +22,12 @@ const mod = await vite.ssrLoadModule('/src/error.js')
 try {
   mod.error()
 } catch (e) {
-  // this is not required
+  // this should not be called
   // when running on Node.js "^16.17.0 || >=18.6.0" and sourcemap is enabled
-  vite.ssrFixStacktrace(e)
+  // because the stacktrace is already rewritten
+  if (isSourceMapEnabled) {
+    vite.ssrFixStacktrace(e)
+  }
   console.log(e)
 }
 

--- a/playground/ssr-html/test-stacktrace.js
+++ b/playground/ssr-html/test-stacktrace.js
@@ -10,7 +10,7 @@ const version = (() => {
   const m = process.version.match(/^v(\d+)\.(\d+)\.\d+$/)
   if (!m) throw new Error(`Failed to parse version: ${process.version}`)
 
-  return { major: m[1], minor: m[2] }
+  return { major: +m[1], minor: +m[2] }
 })()
 
 // https://github.com/nodejs/node/pull/43428


### PR DESCRIPTION
### Description
This PR reapplies #11576 with a fix and tests.
Also this PR adds some comments why this works.

fixes #3288 

cc @patak-dev @Vap0r1ze @benmccann 

### Additional context
#11576 requires [source map support for `new Function`](https://github.com/nodejs/node/pull/43428) which landed in Node.js "^16.17.0 || >=18.6.0".
Adding the offset seems to be required due to V8's bug (https://github.com/nodejs/node/issues/43047#issuecomment-1180632750). When the bug is fixed, that part of the code needs to be removed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
