### PR TITLE
doc: use -- in the correct place

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -67,8 +67,8 @@ You can also directly specify the project name and the template you want to use 
 # npm 6.x
 npm create vite@latest my-vue-app --template vue
 
-# npm 7+, extra double-dash is needed:
-npm create vite@latest -- my-vue-app --template vue
+# npm 7+, an escaping double-dash is needed:
+npm create -- vite@latest my-vue-app --template vue
 
 # yarn
 yarn create vite my-vue-app --template vue

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -68,7 +68,7 @@ You can also directly specify the project name and the template you want to use 
 npm create vite@latest my-vue-app --template vue
 
 # npm 7+, extra double-dash is needed:
-npm create vite@latest my-vue-app -- --template vue
+npm create vite@latest -- my-vue-app --template vue
 
 # yarn
 yarn create vite my-vue-app --template vue


### PR DESCRIPTION
```diff
  # npm 7+, extra double-dash is needed:
- npm create vite@latest my-vue-app -- --template vue
  # npm 7+, an escaping double-dash is needed:
+ npm create -- vite@latest my-vue-app --template vue
      ^ cmd  ^ escape  ^ arg1   ^ arg1'      ^ opt1
```

### Description

The standard for the escpaing `--` is that it goes after all flags and options (but not arguments) of the program that consumes it, not before the first flag of the program that needs to be escaped.

Since `npm create` is a "subcommand" (before flags and options) and there are no flags or options being passed to `npm create` (or npm), it should go _before_ `npm create`s first argument.

Although the current behavior works, it is confusing and will likely lead to people doing copy pasta, making the incorrect modification based on the semantics that are currently being shown (which are misleading), and then meeting doom when everything goes wrong for "no reason".

So it's kind of a silent bug at the moment because it "works"... by mistake.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] **N/A** Ideally, include relevant tests that fail without this PR but pass with it.
