### PR TITLE
fix: deep resolve side effects when glob does not contain /

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -100,7 +100,20 @@ export function loadPackageData(
   if (typeof sideEffects === 'boolean') {
     hasSideEffects = () => sideEffects
   } else if (Array.isArray(sideEffects)) {
-    hasSideEffects = createFilter(sideEffects, null, { resolve: pkgDir })
+    const finalPackageSideEffects = sideEffects.map((sideEffect) => {
+      /*
+       * The array accepts simple glob patterns to the relevant files... Patterns like *.css, which do not include a /, will be treated like **\/*.css.
+       * https://webpack.js.org/guides/tree-shaking/
+       */
+      if (sideEffect.includes('/')) {
+        return sideEffect
+      }
+      return `**/${sideEffect}`
+    })
+
+    hasSideEffects = createFilter(finalPackageSideEffects, null, {
+      resolve: pkgDir,
+    })
   } else {
     hasSideEffects = () => true
   }

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -104,6 +104,7 @@ export function loadPackageData(
       /*
        * The array accepts simple glob patterns to the relevant files... Patterns like *.css, which do not include a /, will be treated like **\/*.css.
        * https://webpack.js.org/guides/tree-shaking/
+       * https://github.com/vitejs/vite/pull/11807
        */
       if (sideEffect.includes('/')) {
         return sideEffect


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This will automatically prefix "simple globs" like `*.css` in sideEffects in package.json to `**/*.css`, so such files deep in the module would also be considered as side effects.

This is how other bundlers (e.g. webpack, rollup) behave as well, so this is sort of important for cross-bundler compatibility. We ran into this issue, as we updated vite to v4, but had not encountered such issue with any other bundler setup. As an example, here is the very similar [code in rollup](https://github.com/rollup/plugins/blob/master/packages/node-resolve/src/util.js#L146-L159), the [relevant PR](https://github.com/rollup/plugins/pull/1148) and [issue](https://github.com/rollup/rollup/issues/4084).

### Additional context

I'd add tests, but did not immediately find any that relate to the loadPackageData function. Can you point me to the appropriate place?

Also, sorry for not filing an issue beforehand, but this change is so small, essentially copy-paste from rollup, so perhaps we can discuss directly in here.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
