### PR TITLE
feat: allow package subpaths in ssr.noExternal

### DIFF
--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -165,6 +165,10 @@ export function createIsConfiguredAsSsrExternal(
       ) {
         return true
       }
+      // Allow individual package entries to be specified in noExternal
+      if (noExternalFilter && !noExternalFilter(id)) {
+        return false
+      }
       const pkgName = getNpmPackageName(id)
       if (!pkgName) {
         return isExternalizable(id)

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -111,7 +111,7 @@ export function createIsConfiguredAsSsrExternal(
   const { ssr, root } = config
   const noExternal = ssr?.noExternal
   const noExternalFilter =
-    noExternal !== 'undefined' &&
+    typeof noExternal !== 'undefined' &&
     typeof noExternal !== 'boolean' &&
     createFilter(undefined, noExternal, { resolve: false })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I often need to package a Vite plugin along with some runtime library and some piece of code that requires processing by Vite. I want the runtime entry to be externalized for SSR but the entry that requires processing (maybe a virtual module) *not* to be externalized. Without this PR, it is not easily possible because `ssr.external` accepts subpaths but `ssr.noExternal` doesn't. Furthermore, a package name in `ssr.external` is interpreted as applying to all subpaths of that package. This PR modifies the algorithm to check if the ID is in `ssr.noExternal` before applying the previous rule.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
