### PR TITLE
docs: restore locale links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -86,6 +86,13 @@ export default defineConfig({
     ],
   ],
 
+  locales: {
+    root: { label: 'English' },
+    zh: { label: '简体中文', link: 'https://cn.vitejs.dev' },
+    ja: { label: '日本語', link: 'https://ja.vitejs.dev' },
+    es: { label: 'Español', link: 'https://es.vitejs.dev' },
+  },
+
   vue: {
     reactivityTransform: true,
   },
@@ -116,15 +123,6 @@ export default defineConfig({
     carbonAds: {
       code: 'CEBIEK3N',
       placement: 'vitejsdev',
-    },
-
-    localeLinks: {
-      text: 'English',
-      items: [
-        { text: '简体中文', link: 'https://cn.vitejs.dev' },
-        { text: '日本語', link: 'https://ja.vitejs.dev' },
-        { text: 'Español', link: 'https://es.vitejs.dev' },
-      ],
     },
 
     footer: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Follow up to #11720.

I noticed the locale links now disappeared: https://main.vitejs.dev/
![image](https://user-images.githubusercontent.com/49056869/214816719-371b78ab-4b96-449c-b4f7-1718c980e021.png)

This PR fixes that.

refs https://github.com/vuejs/vitepress/pull/1339

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
