### PR TITLE
docs: distinguish plugins config used for workers in build and serve

### DIFF
--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -13,7 +13,7 @@ Output format for worker bundle.
 
 - **Type:** [`(Plugin | Plugin[])[]`](./shared-options#plugins)
 
-Vite plugins that apply to worker bundle. Note that [config.plugins](./shared-options#plugins) does not apply to workers, it should be configured here instead.
+Vite plugins that apply to worker bundle. Note that [config.plugins](./shared-options#plugins) only applies to workers in serve, it should be configured here instead for build.
 
 ## worker.rollupOptions
 

--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -13,7 +13,7 @@ Output format for worker bundle.
 
 - **Type:** [`(Plugin | Plugin[])[]`](./shared-options#plugins)
 
-Vite plugins that apply to worker bundle. Note that [config.plugins](./shared-options#plugins) only applies to workers in serve, it should be configured here instead for build.
+Vite plugins that apply to worker bundle. Note that [config.plugins](./shared-options#plugins) only applies to workers in dev, it should be configured here instead for build.
 
 ## worker.rollupOptions
 


### PR DESCRIPTION
### Description

I believe currently workers use the main `config.plugins` configuration in serve - `config.workers.plugins` is only used in build. It sounds like https://github.com/vitejs/vite/pull/8586 might improve the consistency here (which would be great!), but in the meantime I thought there could be some additional clarity in the docs for this option.

Thank you!

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
