### PR TITLE
fix(plugin-legacy): legacy sourcemap not generate (fix #11693)

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -578,7 +578,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       if (isLegacyBundle(bundle, opts)) {
         // avoid emitting duplicate assets
         for (const name in bundle) {
-          if (bundle[name].type === 'asset') {
+          if (bundle[name].type === 'asset' && !/.+\.map$/.test(name)) {
             delete bundle[name]
           }
         }

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -118,4 +118,15 @@ describe.runIf(isBuild)('build', () => {
     expect(findAssetFile(/polyfills-legacy/)).toMatch('"structuredClone"')
     expect(findAssetFile(/polyfills-\w{8}\./)).toMatch('"structuredClone"')
   })
+
+  test('should generate legacy sourcemap file', async () => {
+    expect(
+      listAssets().some((filename) => /index-legacy.+\.map$/.test(filename)),
+    ).toBeTruthy()
+    expect(
+      listAssets().some((filename) =>
+        /polyfills-legacy.+\.map$/.test(filename),
+      ),
+    ).toBeFalsy()
+  })
 })

--- a/playground/legacy/vite.config.js
+++ b/playground/legacy/vite.config.js
@@ -14,6 +14,7 @@ module.exports = {
   build: {
     cssCodeSplit: false,
     manifest: true,
+    sourcemap: true,
     rollupOptions: {
       input: {
         index: path.resolve(__dirname, 'index.html'),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #11693

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

`plugin-legacy` should compatible with rollup3.x: don't  `delete` sourcemap in bundle

See [rollup3.x  break changes](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#300)

> When using the API and sourcemaps, sourcemap comments are contained in the emitted files and sourcemaps are emitted as regular assets (#4605)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
