### PR TITLE
fix: update CJS interop error message

### DIFF
--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -28,7 +28,7 @@ const unsupportedCJS = ['resolvePackageEntry', 'resolvePackageData']
 unsupportedCJS.forEach((name) => {
   module.exports[name] = () => {
     throw new Error(
-      `"${name}" is not supported in CJS build of Vite 3.\nPlease use ESM or dynamic imports \`const { ${name} } = await import('vite')\`.`,
+      `"${name}" is not supported in CJS build of Vite 4.\nPlease use ESM or dynamic imports \`const { ${name} } = await import('vite')\`.`,
     )
   }
 })


### PR DESCRIPTION
Update error message to match build version.

### Description

A warning message references the previous version of vite.

### Additional context

It's a very small change. Changed number from 3 to 4. Ran into this today and I thought my build environment had reverted to 3.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
