### PR TITLE
test(legacy): make emit css file test case available

### DIFF
--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -111,7 +111,9 @@ describe.runIf(isBuild)('build', () => {
   })
 
   test('should emit css file', async () => {
-    expect(listAssets().some((filename) => filename.endsWith('.css')))
+    expect(
+      listAssets().some((filename) => filename.endsWith('.css')),
+    ).toBeTruthy()
   })
 
   test('includes structuredClone polyfill which is supported after core-js v3', () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Just a small change to make `emit css file` test case work in legacy.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
