### PR TITLE
fix: add style nonce to comply with content security policy (fix #11862)

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -408,7 +408,7 @@ export function updateStyle(id: string, content: string): void {
     if (cspNonce === undefined) {
       cspNonce =
         document.querySelector<HTMLMetaElement>('meta[property=csp-nonce]')
-          ?.content ?? null
+          ?.nonce ?? null
     }
     if (cspNonce) {
       style.setAttribute('nonce', cspNonce)

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -404,6 +404,13 @@ export function updateStyle(id: string, content: string): void {
     style.setAttribute('data-vite-dev-id', id)
     style.textContent = content
 
+    const cspNonce = document.querySelector<HTMLMetaElement>(
+      'meta[property=csp-nonce]',
+    )?.content
+    if (cspNonce) {
+      style.setAttribute('nonce', cspNonce)
+    }
+
     if (!lastInsertedStyle) {
       document.head.appendChild(style)
 

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -395,6 +395,7 @@ if ('document' in globalThis) {
 // all css imports should be inserted at the same position
 // because after build it will be a single css file
 let lastInsertedStyle: HTMLStyleElement | undefined
+let cspNonce: string | undefined | null = undefined
 
 export function updateStyle(id: string, content: string): void {
   let style = sheetsMap.get(id)
@@ -404,9 +405,11 @@ export function updateStyle(id: string, content: string): void {
     style.setAttribute('data-vite-dev-id', id)
     style.textContent = content
 
-    const cspNonce = document.querySelector<HTMLMetaElement>(
-      'meta[property=csp-nonce]',
-    )?.content
+    if (cspNonce === undefined) {
+      cspNonce =
+        document.querySelector<HTMLMetaElement>('meta[property=csp-nonce]')
+          ?.content ?? null
+    }
     if (cspNonce) {
       style.setAttribute('nonce', cspNonce)
     }

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -6,6 +6,7 @@ import {
   getBg,
   getColor,
   isBuild,
+  isServe,
   page,
   removeFile,
   serverLogs,

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -508,3 +508,8 @@ test('async css order with css modules', async () => {
 test('@import scss', async () => {
   expect(await getColor('.at-import-scss')).toBe('red')
 })
+
+test.runIf(isServe)('style csp nonce', async () => {
+  const cspNonce = await page.getAttribute('style', 'nonce')
+  expect(cspNonce).toBe('random')
+})

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -1,4 +1,4 @@
-<meta property="csp-nonce" content="random" />
+<meta property="csp-nonce" nonce="random" />
 
 <link rel="stylesheet" href="./linked.css" />
 

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -1,3 +1,5 @@
+<meta property="csp-nonce" content="random" />
+
 <link rel="stylesheet" href="./linked.css" />
 
 <div class="wrapper">


### PR DESCRIPTION
### Description

Fixes #11862 

### Additional context

Unlike webpack there's no standard convention for where to get the nonce value from. For instance webpack style-loader will get it from `window.__webpack_nonce__`. Setting the nonce in a meta tag seems to be a cssinjs convention. See https://cssinjs.org/csp/?v=v10.9.2 but I also seen it used in https://github.com/marco-prontera/vite-plugin-css-injected-by-js. 

The actual server that is serving the html file and generating the CSP headers is responsible to generate or rewrite the nonce placeholder value in the meta tag with a random nonce.

The project at https://github.com/justin-tay/vite-csp-issue can be used to see the issue and the fix.

I'm not sure how to add a test case for this. I have added a test to the css playground.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
