### PR TITLE
fix(client): serve client sources next to deployed scripts

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -26,6 +26,9 @@ const envConfig = defineConfig({
   output: {
     file: path.resolve(__dirname, 'dist/client', 'env.mjs'),
     sourcemap: true,
+    sourcemapPathTransform(relativeSourcePath) {
+      return path.basename(relativeSourcePath)
+    },
   },
 })
 
@@ -40,6 +43,9 @@ const clientConfig = defineConfig({
   output: {
     file: path.resolve(__dirname, 'dist/client', 'client.mjs'),
     sourcemap: true,
+    sourcemapPathTransform(relativeSourcePath) {
+      return path.basename(relativeSourcePath)
+    },
   },
 })
 


### PR DESCRIPTION
### Description

As detailed in https://crbug.com/1411596, Vite currently serves its own client sources under `<origin>/src/client/*.ts`, which is confusing for developers that expect to find only their own code within `/src/`.

Ideally the `client.ts`, `overlay.ts`, and `env.ts` would just appear next to their deployed counterparts, which can be accomplished by making sure that the sourcemaps generated by rollup contain only the file name without any additional relative path (which the DevTools will not be able to resolve meaningfully for at least `/@vite/client`).

### Additional context

Ref: https://crbug.com/1411596
Demo: https://github.com/jecfish/coffee-cart (@jecfish)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
