### PR TITLE
docs: fix generated output code for custom queries

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -443,10 +443,8 @@ const modules = import.meta.glob('./dir/*.js', {
 ```ts
 // code produced by vite:
 const modules = {
-  './dir/foo.js': () =>
-    import('./dir/foo.js?foo=bar&bar=true'),
-  './dir/bar.js': () =>
-    import('./dir/bar.js?foo=bar&bar=true'),
+  './dir/foo.js': () => import('./dir/foo.js?foo=bar&bar=true'),
+  './dir/bar.js': () => import('./dir/bar.js?foo=bar&bar=true'),
 }
 ```
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -444,9 +444,9 @@ const modules = import.meta.glob('./dir/*.js', {
 // code produced by vite:
 const modules = {
   './dir/foo.js': () =>
-    import('./dir/foo.js?foo=bar&bar=true').then((m) => m.setup),
+    import('./dir/foo.js?foo=bar&bar=true'),
   './dir/bar.js': () =>
-    import('./dir/bar.js?foo=bar&bar=true').then((m) => m.setup),
+    import('./dir/bar.js?foo=bar&bar=true'),
 }
 ```
 


### PR DESCRIPTION
### Description

Docs bug: the docs had the wrong generated output code for custom queries with `import.meta.glob`. See https://github.com/vitejs/vite/issues/11868.

The generated output included `.then((m) => m.setup)` even though the source code had no reference to `setup`. This was a copy-and-paste error from the named import section of the docs.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
