### PR TITLE
process.env seems to be import.meta.env now

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -84,7 +84,7 @@ export default defineConfig(async ({ command, mode }) => {
 
 ## Environment Variables
 
-Environmental Variables can be obtained from `process.env` as usual.
+Environmental Variables can be obtained from `import.meta.env`.
 
 Note that Vite doesn't load `.env` files by default as the files to load can only be determined after evaluating the Vite config, for example, the `root` and `envDir` options affect the loading behaviour. However, you can use the exported `loadEnv` helper to load the specific `.env` file if needed.
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

[Documentation](https://vitejs.dev/config/) says that 
"_Environmental Variables can be obtained from `process.env` as usual._"
however [it looks like](https://github.com/vitejs/vite/issues/1973) process has been removed and `import.meta.en` is the way to access env variables.

