### PR TITLE
fix: await bundle closing

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -652,7 +652,7 @@ export async function build(
     outputBuildError(e)
     throw e
   } finally {
-    if (bundle) bundle.close()
+    if (bundle) await bundle.close()
   }
 }
 


### PR DESCRIPTION
### Description

Vite does not `await` when calling `bundle.close` which causes code expected to run after the `closeBundle` plugin hook to run before it instead

Closes https://github.com/vite-pwa/sveltekit/issues/21

### Additional context

A recent refactoring in SvelteKit caused this issue to be hit extremely frequently

Vite does do an `await` in the other location where it calls `bundle.close`:

https://github.com/vitejs/vite/blob/544478172c66eca657efeeb33c1b536e5390d1e6/packages/vite/src/node/plugins/worker.ts#L132

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
