### PR TITLE
fix(esbuild): avoid polluting global namespace while minify is false 

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -27,9 +27,9 @@ import { searchForWorkspaceRoot } from '..'
 const debug = createDebugger('vite:esbuild')
 
 const INJECT_HELPERS_IIFE_RE =
-  /^(.*?)((?:const|var) \S+=function\([^)]*\)\{"use strict";)/s
+  /^(.*?)((?:const|var)\s+\S+\s*=\s*function\s*\([^)]*\)\s*\{.*?"use strict";)/s
 const INJECT_HELPERS_UMD_RE =
-  /^(.*?)(\(function\([^)]*\)\{.+amd.+function\([^)]*\)\{"use strict";)/s
+  /^(.*?)(\(function\([^)]*\)\s*\{.+amd.+function\([^)]*\)\s*\{.*?"use strict";)/s
 
 let server: ViteDevServer
 

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -16,15 +16,23 @@ describe.runIf(isBuild)('build', () => {
   test('umd', async () => {
     expect(await page.textContent('.umd')).toBe('It works')
     const code = readFile('dist/my-lib-custom-filename.umd.js')
+    const noMinifyCode = readFile('dist/nominify/my-lib-custom-filename.umd.js')
     // esbuild helpers are injected inside of the UMD wrapper
     expect(code).toMatch(/^\(function\(/)
+    expect(noMinifyCode).toMatch(/^\(function\(global/)
   })
 
   test('iife', async () => {
     expect(await page.textContent('.iife')).toBe('It works')
     const code = readFile('dist/my-lib-custom-filename.iife.js')
+    const noMinifyCode = readFile(
+      'dist/nominify/my-lib-custom-filename.iife.js',
+    )
     // esbuild helpers are injected inside of the IIFE wrapper
     expect(code).toMatch(/^var MyLib=function\(\)\{"use strict";/)
+    expect(noMinifyCode).toMatch(
+      /^var MyLib\s*=\s*function\(\)\s*\{.*?"use strict";/s,
+    )
   })
 
   test('Library mode does not include `preload`', async () => {

--- a/playground/lib/__tests__/serve.ts
+++ b/playground/lib/__tests__/serve.ts
@@ -61,6 +61,12 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
       configFile: path.resolve(__dirname, '../vite.dyimport.config.js'),
     })
 
+    await build({
+      root: rootDir,
+      logLevel: 'warn', // output esbuild warns
+      configFile: path.resolve(__dirname, '../vite.nominify.config.js'),
+    })
+
     // start static file server
     const serve = sirv(path.resolve(rootDir, 'dist'))
     const httpServer = http.createServer((req, res) => {

--- a/playground/lib/vite.nominify.config.js
+++ b/playground/lib/vite.nominify.config.js
@@ -1,0 +1,11 @@
+const baseConfig = require('./vite.config')
+
+module.exports = {
+  ...baseConfig,
+  build: {
+    ...baseConfig.build,
+    minify: false,
+    outDir: 'dist/nominify',
+  },
+  plugins: [],
+}


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

fix #11641

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
