### PR TITLE
fix(legacy): fix browserslist import, close https://github.com/vitejs/vite/issues/11898

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -23,7 +23,7 @@ import type {
   types as BabelTypes,
 } from '@babel/core'
 import colors from 'picocolors'
-import { loadConfig as browserslistLoadConfig } from 'browserslist'
+import browserslist from 'browserslist'
 import type { Options } from './types'
 import {
   detectModernBrowserCode,
@@ -44,6 +44,10 @@ async function loadBabel() {
   }
   return babel
 }
+
+// The requested module 'browserslist' is a CommonJS module
+// which may not support all module.exports as named exports
+const { loadConfig: browserslistLoadConfig } = browserslist
 
 // Duplicated from build.ts in Vite Core, at least while the feature is experimental
 // We should later expose this helper for other plugins to use


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`browserslist` is a CommonJS module. We can't use named import.

This bug is introduced by <https://github.com/vitejs/vite/commit/d5b8f8615e880e854a3e1105e3193c24cc964f30#diff-ab75c34fa418085884af97e74c9166830b9f0a3456f9d3336e0c075d6ae9b05aR26>.

This PR fixes the import.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
