### PR TITLE
test: reduce flaky fails

### DIFF
--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -13,6 +13,7 @@ const getConfig = (base: string): InlineConfig => ({
   root: rootDir,
   logLevel: 'silent',
   server: { port: ports['css/dynamic-import'] },
+  preview: { port: ports['css/dynamic-import'] },
   build: { assetsInlineLimit: 0 },
 })
 

--- a/playground/css/__tests__/postcss-plugins-different-dir/postcss-plugins-different-dir.spec.ts
+++ b/playground/css/__tests__/postcss-plugins-different-dir/postcss-plugins-different-dir.spec.ts
@@ -1,10 +1,10 @@
 import path from 'node:path'
 import { createServer } from 'vite'
 import { expect, test } from 'vitest'
-import { getBgColor, getColor, page, ports } from '~utils'
+import { getBgColor, getColor, isServe, page, ports } from '~utils'
 
 // Regression test for https://github.com/vitejs/vite/issues/4000
-test('postcss plugins in different dir', async () => {
+test.runIf(isServe)('postcss plugins in different dir', async () => {
   const port = ports['css/postcss-plugins-different-dir']
   const server = await createServer({
     root: path.join(__dirname, '..', '..', '..', 'tailwind'),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`css-dynamic-import/__tests__/css-dynamic-import.spec.ts` was not using a dedicated port for build tests.

Also the postcss config test only need to run for dev, so I added `.runIf(isServe)`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
