### PR TITLE
fix(CSP): nonce support

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -244,6 +244,11 @@ export interface BuildOptions {
    * @default null
    */
   watch?: WatcherOptions | null
+
+  /**
+   * If specified, adds a `nonce` attribute to HTML script and link tags with the placeholder value.
+   */
+  noncePlaceholder?: string
 }
 
 export interface LibraryOptions {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -625,6 +625,9 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         return chunks
       }
 
+      const hasNonce = config.build.noncePlaceholder?.length > 0
+      const nonce = config.build.noncePlaceholder
+
       const toScriptTag = (
         chunk: OutputChunk,
         toOutputPath: (filename: string) => string,
@@ -636,6 +639,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           type: 'module',
           crossorigin: true,
           src: toOutputPath(chunk.fileName),
+          ...(hasNonce ? { nonce } : {}),
         },
       })
 
@@ -648,6 +652,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           rel: 'modulepreload',
           crossorigin: true,
           href: toOutputPath(filename),
+          ...(hasNonce ? { nonce } : {}),
         },
       })
 
@@ -675,6 +680,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               attrs: {
                 rel: 'stylesheet',
                 href: toOutputPath(file),
+                ...(hasNonce ? { nonce } : {}),
               },
             })
           }
@@ -782,6 +788,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                 attrs: {
                   rel: 'stylesheet',
                   href: toOutputAssetFilePath(cssChunk.fileName),
+                  ...(hasNonce ? { nonce } : {}),
                 },
               },
             ])

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -179,6 +179,28 @@ describe.runIf(isBuild)('build', () => {
       )
     })
   })
+
+  describe('nonce', () => {
+    beforeAll(async () => {
+      await page.goto(viteTestUrl + '/nonce.html')
+    })
+
+    test('nonce should be included in html tags', async () => {
+      const scripts = await page.locator('script').all()
+      const links = await page.locator('link[rel=stylesheet]').all()
+
+      await Promise.all(
+        scripts.map(async (script) =>
+          expect(await script.getAttribute('nonce')).toBe('TEST_NONCE'),
+        ),
+      )
+      await Promise.all(
+        links.map(async (link) =>
+          expect(await link.getAttribute('nonce')).toBe('TEST_NONCE'),
+        ),
+      )
+    })
+  })
 })
 
 describe('noHead', () => {

--- a/playground/html/nonce.html
+++ b/playground/html/nonce.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/main.css" />
+    <title>Nonce</title>
+  </head>
+  <body>
+    <h1>Nonce.html</h1>
+    <script nonce="TEST_NONCE">
+      console.log('hello world')
+    </script>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -30,8 +30,10 @@ export default defineConfig({
         env: resolve(__dirname, 'env.html'),
         sideEffects: resolve(__dirname, 'side-effects/index.html'),
         'a á': resolve(__dirname, 'a á.html'),
+        nonce: resolve(__dirname, 'nonce.html'),
       },
     },
+    noncePlaceholder: 'TEST_NONCE',
   },
 
   define: {
@@ -175,7 +177,9 @@ ${
     {
       name: 'head-prepend-importmap',
       transformIndexHtml(_, ctx) {
-        if (ctx.path.includes('importmapOrder')) return
+        if (ctx.path.includes('importmapOrder') || ctx.path.includes('nonce')) {
+          return
+        }
 
         return [
           {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently, if you include a `nonce` attribute on `script` or `style` tags in your html file, Vite will strip it out. See discussion #5218 

This PR adds a new build option for specifying a nonce placeholder. If specified, `script` and `link` tags will include the nonce placeholder in the generated HTML. This allows applications to support nonces in their Content Security Policy.

Fixes #9719

The downside of this PR is it includes yet another option to the build config which goes against the [Think Before Adding Yet Another Option
](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#think-before-adding-yet-another-option) section of the PR guide. 

Ideally, this could be achieved by just not stripping out the nonce tag building your app.

### Related PRs

- #11864 (this appears to only fix `style` tags in Dev mode)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
