### PR TITLE
docs(troubleshooting): add network stalled solution for ubuntu linux (fixes #11468)

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -49,7 +49,7 @@ If the above steps don't work, you can try adding `DefaultLimitNOFILE=65536` as 
 - /etc/systemd/system.conf
 - /etc/systemd/user.conf
 
-For Ubuntu Linux the working solution is to add the line `* - nofile 65536` to the file `/etc/security/limits.conf` instead of updating systemd config files.
+For Ubuntu Linux, you may need to add the line `* - nofile 65536` to the file `/etc/security/limits.conf` instead of updating systemd config files.
 
 Note that these settings persist but a **restart is required**.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -49,6 +49,8 @@ If the above steps don't work, you can try adding `DefaultLimitNOFILE=65536` as 
 - /etc/systemd/system.conf
 - /etc/systemd/user.conf
 
+For Ubuntu Linux the working solution is to add the line `* - nofile 65536` to the file `/etc/security/limits.conf` instead of updating systemd config files.
+
 Note that these settings persist but a **restart is required**.
 
 ### Network requests stop loading


### PR DESCRIPTION
This documentation update solves the problem with Linux version of the Chrome browser on projects with huge amount of files (like this one for example - fixes https://github.com/vitejs/vite/issues/11468)

Seems like Ubuntu Linux requires different approach as the proposed solution (that is claimed to be working for Arch Linux) does nothing in Ubuntu, probably, due to different treating of systemd config files.