### PR TITLE
fix: re-run build when config files are changed in watch mode

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -235,6 +235,8 @@ cli
     filterDuplicateOptions(options)
     const { build } = await import('./build')
     const buildOptions: BuildOptions = cleanOptions(options)
+    // TODO: make this default by true in Vite 5
+    buildOptions.watchConfig = true
 
     try {
       await build({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix #11916 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I left a `TODO` in the returned watcher variable, when the build function is re-runed, the `watcher` will be not be valid anymore. We need to add something like `getWatcher: ()=> RollupWatcher`(will be a breaking change) or use a global watcher ref to hold the reference. I'm not sure which is the better solution so I left a TODO there for code review. Anyway, with this PR, we could make the build re-run in cli.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
