### PR TITLE
fix: keep track of ssr version of imported modules separately

### DIFF
--- a/playground/ssr-deps/index.html
+++ b/playground/ssr-deps/index.html
@@ -12,5 +12,15 @@
       // hydration scripts
       import '@vitejs/test-css-lib'
     </script>
+    <script type="module">
+      // Using dynamic import, so the module is transformed when browser actually
+      // requests it. This essentially disables pre-transform optimization that's
+      // crucial to trigger a race condition, covered by the test case introduced
+      // in https://github.com/vitejs/vite/pull/11973
+      import('virtual:isomorphic-module').then(({ default: message }) => {
+        document.querySelector('.isomorphic-module-browser').textContent =
+          message
+      })
+    </script>
   </body>
 </html>

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -64,6 +64,23 @@ export async function createServer(root = process.cwd(), hmrPort) {
           }
         },
       },
+      {
+        name: 'virtual-isomorphic-module',
+        resolveId(id) {
+          if (id === 'virtual:isomorphic-module') {
+            return '\0virtual:isomorphic-module'
+          }
+        },
+        load(id, { ssr }) {
+          if (id === '\0virtual:isomorphic-module') {
+            if (ssr) {
+              return 'export { default } from "/src/isomorphic-module-server.js";'
+            } else {
+              return 'export { default } from "/src/isomorphic-module-browser.js";'
+            }
+          }
+        },
+      },
     ],
   })
   // use vite's connect instance as middleware

--- a/playground/ssr-deps/src/app.js
+++ b/playground/ssr-deps/src/app.js
@@ -29,6 +29,7 @@ import optimizedCjsWithNestedExternal from '@vitejs/test-optimized-cjs-with-nest
 import { setMessage } from '@vitejs/test-external-entry/entry'
 setMessage('Hello World!')
 import externalUsingExternalEntry from '@vitejs/test-external-using-external-entry'
+import isomorphicModuleMessage from 'virtual:isomorphic-module'
 
 export async function render(url, rootDir) {
   let html = ''
@@ -89,6 +90,10 @@ export async function render(url, rootDir) {
   html += `\n<p class="css-lib">I should be blue</p>`
 
   html += `\n<p class="module-condition">${moduleConditionMessage}</p>`
+
+  html += `\n<p class="isomorphic-module-server">${isomorphicModuleMessage}</p>`
+
+  html += `\n<p class="isomorphic-module-browser"></p>`
 
   return html + '\n'
 }

--- a/playground/ssr-deps/src/isomorphic-module-browser.js
+++ b/playground/ssr-deps/src/isomorphic-module-browser.js
@@ -1,0 +1,3 @@
+const message = 'message from isomorphic-module (browser): [browser]'
+
+export default message

--- a/playground/ssr-deps/src/isomorphic-module-server.js
+++ b/playground/ssr-deps/src/isomorphic-module-server.js
@@ -1,0 +1,3 @@
+const message = 'message from isomorphic-module (server): [server]'
+
+export default message


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Patch `moduleGraph` so it keeps separate lists of imported modules for browser (client) vs. server (SSR) version of a module. This fixes a scenario, where modules may use different sets of imports on browser vs. server (e.g., isomorphic modules, where Node.js (server) dependencies get stripped out from the browser version by running it trough some build-time transform). In which case Vite would fail to recognize and properly propagate the updates in server-only modules that always results in stale code running on the server (or, vice verse), because the module graph may get corrupted as a result of removing importers that are "no longer there", but in fact may still be imported in the counterpart version. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
