### PR TITLE
fix(cli): after setting server.open, the default open is inconsistent…

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -73,7 +73,7 @@ import {
   handleHMRUpdate,
   updateModules,
 } from './hmr'
-import { openBrowser } from './openBrowser'
+import { openBrowser as _openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
 import { searchForWorkspaceRoot } from './searchRoot'
@@ -271,7 +271,7 @@ export interface ViteDevServer {
   /**
    * Open browser
    */
-  openDevBrowser(): void
+  openBrowser(): void
   /**
    * @internal
    */
@@ -408,12 +408,11 @@ export async function createServer(
           config.server,
           config,
         )
+        if (!isRestart && config.server.open) server.openBrowser()
       }
-
-      if (!isRestart && config.server.open) server.openDevBrowser()
       return server
     },
-    openDevBrowser() {
+    openBrowser() {
       const options = server.config.server
       const url = server.resolvedUrls?.local[0]
       if (url) {
@@ -422,7 +421,7 @@ export async function createServer(
             ? new URL(options.open, url).href
             : url
 
-        openBrowser(path, true, server.config.logger)
+        _openBrowser(path, true, server.config.logger)
       } else {
         server.config.logger.warn('No URL available to open in browser')
       }

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -1,6 +1,5 @@
 import colors from 'picocolors'
 import type { ViteDevServer } from './server'
-import { openBrowser } from './server/openBrowser'
 import { isDefined } from './utils'
 
 export type BindShortcutsOptions = {
@@ -102,18 +101,7 @@ const BASE_SHORTCUTS: CLIShortcut[] = [
     key: 'o',
     description: 'open in browser',
     action(server) {
-      const url = server.resolvedUrls?.local[0]
-
-      if (!url) {
-        server.config.logger.warn('No URL available to open in browser')
-        return
-      }
-
-      const path =
-        typeof server.config.server.open === 'string'
-          ? new URL(server.config.server.open, url).href
-          : ''
-      openBrowser(path ? path : url, true, server.config.logger)
+      server.openDevBrowser()
     },
   },
   {

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -101,7 +101,7 @@ const BASE_SHORTCUTS: CLIShortcut[] = [
     key: 'o',
     description: 'open in browser',
     action(server) {
-      server.openDevBrowser()
+      server.openBrowser()
     },
   },
   {

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -109,7 +109,11 @@ const BASE_SHORTCUTS: CLIShortcut[] = [
         return
       }
 
-      openBrowser(url, true, server.config.logger)
+      const path =
+        typeof server.config.server.open === 'string'
+          ? new URL(server.config.server.open, url).href
+          : ''
+      openBrowser(path ? path : url, true, server.config.logger)
     },
   },
   {


### PR DESCRIPTION
… with the shortcut key (#11971)

<!-- Thank you for contributing! -->

### Description

fix #11971

After setting server.open, the default open is inconsistent with the shortcut key，Now only the shortcut key processing has been modified

PS: Another point is that the displayed urls are also inconsistent. I don't know whether to handle them



### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
