### PR TITLE
fix(optimizer): log esbuild error when scanning deps

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -233,7 +233,7 @@ async function createDepsOptimizer(
             // do another optimize step
             postScanOptimizationResult = runOptimizeDeps(config, knownDeps)
           } catch (e) {
-            logger.error(e.message)
+            logger.error(e.stack || e.message)
           } finally {
             resolve()
             depsOptimizer.scanProcessing = undefined

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -121,18 +121,20 @@ export async function scanImports(config: ResolvedConfig): Promise<{
       ...esbuildOptions,
     })
   } catch (e) {
-    e.message = '[Failed to scan dependencies from entries]' + e.message
-    e.stack = new Error().stack + '\n' + e.stack
-    const esbuildMsg = e.errors
-      ? await formatMessages(e.errors, { kind: 'error' })
-      : ''
+    const prependMessage = colors.red(`\
+Failed to scan for dependencies from entries:
+${entries.join('\n')}
 
-    config.logger.error(
-      colors.red(
-        `${e.message}:\n${entries.join('\n')}\n\n${esbuildMsg}${e.stack}`,
-      ),
-    )
-
+`)
+    if (e.errors) {
+      const msgs = await formatMessages(e.errors, {
+        kind: 'error',
+        color: true,
+      })
+      e.message = prependMessage + msgs.join('\n')
+    } else {
+      e.message = prependMessage + e.message
+    }
     throw e
   }
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -121,17 +121,19 @@ export async function scanImports(config: ResolvedConfig): Promise<{
       ...esbuildOptions,
     })
   } catch (e) {
-    const err = new Error('Failed to scan dependencies from entries')
-    err.stack = e.stack + '\n' + err.stack
+    e.message = '[Failed to scan dependencies from entries]' + e.message
+    e.stack = new Error().stack + '\n' + e.stack
     const esbuildMsg = e.errors
       ? await formatMessages(e.errors, { kind: 'error' })
       : ''
 
     config.logger.error(
       colors.red(
-        `${err.message}:\n${entries.join('\n')}\n\n${esbuildMsg}${err.stack}`,
+        `${e.message}:\n${entries.join('\n')}\n\n${esbuildMsg}${e.stack}`,
       ),
     )
+
+    throw e
   }
 
   debug(`Scan completed in ${(performance.now() - start).toFixed(2)}ms:`, deps)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

from https://github.com/vitejs/vite/issues/11966
The error message thrown from esbuild in the scanning stage now is quite opaque. This PR added essential error messages and stack traces.

log before:

<img width="683" alt="image" src="https://user-images.githubusercontent.com/12322740/217498372-b0e657fe-7b8a-4b69-81ff-10e4b3b16e4b.png">

log now:

<img width="933" alt="image" src="https://user-images.githubusercontent.com/12322740/217498063-11b2aa54-4bc8-4b7e-a212-1c0a4bf0c9bb.png">


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
