### PR TITLE
fix: catch and handle websocket error (#11991)

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -159,7 +159,7 @@ export function createWebSocketServer(
     }
     socket.on('error', (e) => {
       config.logger.info(`WebSocket error:\n${e.stack || e.message}`)
-    });
+    })
   })
 
   wss.on('error', (e: Error & { code: string }) => {

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -152,14 +152,17 @@ export function createWebSocketServer(
       const client = getSocketClient(socket)
       listeners.forEach((listener) => listener(parsed.data, client))
     })
+    socket.on('error', (err) => {
+      config.logger.error(`${colors.red(`ws proxy error:`)}\n${err.stack}`, {
+        timestamp: true,
+        error: err,
+      })
+    })
     socket.send(JSON.stringify({ type: 'connected' }))
     if (bufferedError) {
       socket.send(JSON.stringify(bufferedError))
       bufferedError = null
     }
-    socket.on('error', (e) => {
-      config.logger.info(`WebSocket error:\n${e.stack || e.message}`)
-    })
   })
 
   wss.on('error', (e: Error & { code: string }) => {

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -157,6 +157,9 @@ export function createWebSocketServer(
       socket.send(JSON.stringify(bufferedError))
       bufferedError = null
     }
+    socket.on('error', (e) => {
+      config.logger.info(`WebSocket error:\n${e.stack || e.message}`)
+    });
   })
 
   wss.on('error', (e: Error & { code: string }) => {

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -153,7 +153,7 @@ export function createWebSocketServer(
       listeners.forEach((listener) => listener(parsed.data, client))
     })
     socket.on('error', (err) => {
-      config.logger.error(`${colors.red(`ws proxy error:`)}\n${err.stack}`, {
+      config.logger.error(`${colors.red(`ws error:`)}\n${err.stack}`, {
         timestamp: true,
         error: err,
       })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

By attaching a listener to the `error` event on the socket instance rather than the server, we're catching and not letting it crash the node process.

This happens when the computer goes to sleep and wakes up.

More here https://github.com/vitejs/vite/issues/11991

Tested on a React app, running on `/login`

> Below is the error unhandled, see the node crash.

```

VITE v4.1.1 ready in 648 ms

➜ Local: https://localhost:3001/login
 ➜ Network: use --host to expose
 ➜ press h to show help
node:events:491
throw er; // Unhandled 'error' event
^

RangeError: Invalid WebSocket frame: invalid status code 1006
at Receiver.controlMessage (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:55108:18)
at Receiver.getData (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:54984:42)
at Receiver.startLoop (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:54700:22)
at Receiver._write (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:54626:10)
 at writeOrBuffer (node:internal/streams/writable:392:12)
 at _write (node:internal/streams/writable:333:10)
 at Writable.write (node:internal/streams/writable:337:10)
at TLSSocket.socketOnData (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:57408:37)
 at TLSSocket.emit (node:events:513:28)
 at addChunk (node:internal/streams/readable:324:12)
 at readableAddChunk (node:internal/streams/readable:297:9)
 at Readable.push (node:internal/streams/readable:234:10)
 at TLSWrap.onStreamRead (node:internal/stream_base_commons:190:23)
Emitted 'error' event on WebSocket instance at:
at Receiver.receiverOnError (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:57294:13)
 at Receiver.emit (node:events:513:28)
 at emitErrorNT (node:internal/streams/destroy:151:8)
 at emitErrorCloseNT (node:internal/streams/destroy:116:3)
 at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
code: 'WS_ERR_INVALID_CLOSE_CODE',
[Symbol(status-code)]: 1002
}

Node.js v19.0.0

```
> And here is the error handled. HMR continues to function 🎉 

```
VITE v4.1.1 ready in 878 ms

➜ Local: https://localhost:3001/login
 ➜ Network: use --host to expose
 ➜ press h to show help
WebSocket error:
RangeError: Invalid WebSocket frame: invalid status code 1006
at Receiver.controlMessage (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:55108:18)
at Receiver.getData (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:54984:42)
at Receiver.startLoop (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:54700:22)
at Receiver._write (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:54626:10)
at writeOrBuffer (node:internal/streams/writable:392:12)
at _write (node:internal/streams/writable:333:10)
at Writable.write (node:internal/streams/writable:337:10)
at TLSSocket.socketOnData (file:///Users/XXX/node_modules/vite/dist/node/chunks/dep-3007b26d.js:57408:37)
at TLSSocket.emit (node:events:513:28)
at addChunk (node:internal/streams/readable:324:12)
at readableAddChunk (node:internal/streams/readable:297:9)
at Readable.push (node:internal/streams/readable:234:10)
at TLSWrap.onStreamRead (node:internal/stream_base_commons:190:23)

```
Thank you for the amazing work creators and maintainers, we ❤️  Vite
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
