### PR TITLE
fix: correct access to `crossOrigin` attribute

### DIFF
--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -78,13 +78,13 @@ function polyfill() {
     }
   }).observe(document, { childList: true, subtree: true })
 
-  function getFetchOpts(script: any) {
+  function getFetchOpts(link: any) {
     const fetchOpts = {} as any
-    if (script.integrity) fetchOpts.integrity = script.integrity
-    if (script.referrerpolicy) fetchOpts.referrerPolicy = script.referrerpolicy
-    if (script.crossorigin === 'use-credentials')
+    if (link.integrity) fetchOpts.integrity = link.integrity
+    if (link.referrerpolicy) fetchOpts.referrerPolicy = link.referrerpolicy
+    if (link.crossOrigin === 'use-credentials')
       fetchOpts.credentials = 'include'
-    else if (script.crossorigin === 'anonymous') fetchOpts.credentials = 'omit'
+    else if (link.crossOrigin === 'anonymous') fetchOpts.credentials = 'omit'
     else fetchOpts.credentials = 'same-origin'
     return fetchOpts
   }

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -81,7 +81,7 @@ function polyfill() {
   function getFetchOpts(link: any) {
     const fetchOpts = {} as any
     if (link.integrity) fetchOpts.integrity = link.integrity
-    if (link.referrerpolicy) fetchOpts.referrerPolicy = link.referrerpolicy
+    if (link.referrerPolicy) fetchOpts.referrerPolicy = link.referrerPolicy
     if (link.crossOrigin === 'use-credentials')
       fetchOpts.credentials = 'include'
     else if (link.crossOrigin === 'anonymous') fetchOpts.credentials = 'omit'


### PR DESCRIPTION
### Description

Credit to @Rich-Harris for this. He noticed that the casing was wrong here:
```
'crossorigin' in document.createElement('link'); // false
'crossOrigin' in document.createElement('link'); // true
```

Also renaming the variable here since the function is only called with a `link` and not a `script`

### Additional context

Even with the fix, the feature still seems pretty broken: https://github.com/vitejs/vite/issues/5532

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.