### PR TITLE
feat(create-vite): move TypeScript ones up

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -45,14 +45,14 @@ const FRAMEWORKS: Framework[] = [
     color: yellow,
     variants: [
       {
-        name: 'vanilla',
-        display: 'JavaScript',
-        color: yellow,
-      },
-      {
         name: 'vanilla-ts',
         display: 'TypeScript',
         color: blue,
+      },
+      {
+        name: 'vanilla',
+        display: 'JavaScript',
+        color: yellow,
       },
     ],
   },
@@ -62,14 +62,14 @@ const FRAMEWORKS: Framework[] = [
     color: green,
     variants: [
       {
-        name: 'vue',
-        display: 'JavaScript',
-        color: yellow,
-      },
-      {
         name: 'vue-ts',
         display: 'TypeScript',
         color: blue,
+      },
+      {
+        name: 'vue',
+        display: 'JavaScript',
+        color: yellow,
       },
       {
         name: 'custom-create-vue',
@@ -91,24 +91,24 @@ const FRAMEWORKS: Framework[] = [
     color: cyan,
     variants: [
       {
-        name: 'react',
-        display: 'JavaScript',
-        color: yellow,
-      },
-      {
         name: 'react-ts',
         display: 'TypeScript',
         color: blue,
       },
       {
-        name: 'react-swc',
-        display: 'JavaScript + SWC',
-        color: yellow,
-      },
-      {
         name: 'react-swc-ts',
         display: 'TypeScript + SWC',
         color: blue,
+      },
+      {
+        name: 'react',
+        display: 'JavaScript',
+        color: yellow,
+      },
+      {
+        name: 'react-swc',
+        display: 'JavaScript + SWC',
+        color: yellow,
       },
     ],
   },
@@ -118,14 +118,14 @@ const FRAMEWORKS: Framework[] = [
     color: magenta,
     variants: [
       {
-        name: 'preact',
-        display: 'JavaScript',
-        color: yellow,
-      },
-      {
         name: 'preact-ts',
         display: 'TypeScript',
         color: blue,
+      },
+      {
+        name: 'preact',
+        display: 'JavaScript',
+        color: yellow,
       },
     ],
   },
@@ -135,14 +135,14 @@ const FRAMEWORKS: Framework[] = [
     color: lightRed,
     variants: [
       {
-        name: 'lit',
-        display: 'JavaScript',
-        color: yellow,
-      },
-      {
         name: 'lit-ts',
         display: 'TypeScript',
         color: blue,
+      },
+      {
+        name: 'lit',
+        display: 'JavaScript',
+        color: yellow,
       },
     ],
   },
@@ -152,14 +152,14 @@ const FRAMEWORKS: Framework[] = [
     color: red,
     variants: [
       {
-        name: 'svelte',
-        display: 'JavaScript',
-        color: yellow,
-      },
-      {
         name: 'svelte-ts',
         display: 'TypeScript',
         color: blue,
+      },
+      {
+        name: 'svelte',
+        display: 'JavaScript',
+        color: yellow,
       },
       {
         name: 'custom-svelte-kit',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
According to The State of JS 2022, TypeScript usage is quite high recently.
https://2022.stateofjs.com/en-US/usage/#js_ts_balance

I think moving TypeScript templates upwards can improve DX slightly.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
