### PR TITLE
fix(define): inconsistent env values in build mode

### DIFF
--- a/playground/env/__tests__/env.spec.ts
+++ b/playground/env/__tests__/env.spec.ts
@@ -49,6 +49,10 @@ test('expand', async () => {
   expect(await page.textContent('.expand')).toBe('expand')
 })
 
+test('ssr', async () => {
+  expect(await page.textContent('.ssr')).toBe('false')
+})
+
 test('env object', async () => {
   const envText = await page.textContent('.env-object')
   expect(JSON.parse(envText)).toMatchObject({
@@ -56,6 +60,8 @@ test('env object', async () => {
     CUSTOM_PREFIX_ENV_VARIABLE: '1',
     VITE_CUSTOM_ENV_VARIABLE: '1',
     BASE_URL: '/env/',
+    VITE_BOOL: true,
+    SSR: false,
     MODE: mode,
     DEV: !isBuild,
     PROD: isBuild,

--- a/playground/env/index.html
+++ b/playground/env/index.html
@@ -15,6 +15,7 @@
 <p>typeof import.meta.env.VITE_BOOL: <code class="bool"></code></p>
 <p>process.env.NODE_ENV: <code class="node-env"></code></p>
 <p>import.meta.env.VITE_EXPAND: <code class="expand"></code></p>
+<p>import.meta.env.SSR: <code class="ssr"></code></p>
 <p>import.meta.env: <span class="pre env-object"></span></p>
 <p>import.meta.url: <span class="pre url"></span></p>
 
@@ -28,6 +29,7 @@
   text('.mode-file', import.meta.env.VITE_EFFECTIVE_MODE_FILE_NAME)
   text('.inline', import.meta.env.VITE_INLINE)
   text('.bool', typeof import.meta.env.VITE_BOOL)
+  text('.ssr', import.meta.env.SSR)
   text('.node-env', process.env.NODE_ENV)
   text('.env-object', JSON.stringify(import.meta.env, null, 2))
   text('.expand', import.meta.env.VITE_EXPAND)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

1. `import.meta.env.KEY` value maybe inconsistent with `KEY` value in `import.meta.env` object in build mode.



```js
// `vite.config.js`:

{
  define: {  'import.meta.env.VITE_BOOL': true }
}
```

```shell
# .env
VITE_BOOL=whatever
```

After building, `import.meta.env.VITE_BOOL` replaced with `true` while `import.meta.env` replaced with `{VITE_BOOL: 'whatever'}`


2. `import.meta.env.SSR` added by vite was not exposed to `import.meta.env` in build mode.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
