### PR TITLE
fix(ssr): print file url in `ssrTransform` parse error

### DIFF
--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -80,7 +80,9 @@ async function ssrTransformScript(
     if (!err.loc || !err.loc.line) throw err
     const line = err.loc.line
     throw new Error(
-      `Parse failure: ${err.message}\nContents of line ${line}: ${
+      `Parse failure: ${
+        err.message
+      }\nAt file: ${url}\nContents of line ${line}: ${
         code.split('\n')[line - 1]
       }`,
     )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The `ssrTransform` error message doesn't print the file url, making debugging difficult.  This simply adds a newline with the url to the file containing the parse error.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
