### PR TITLE
docs(dep-optimization): add disabled API

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -59,7 +59,7 @@ Set to `true` to force dependency pre-bundling, ignoring previously cached optim
 
 Disables dependencies optimizations, `true` disables the optimizer during build and dev. Pass `'build'` or `'dev'` to only disable the optimizer in one of the modes. Dependency optimization is enabled by default in dev only.
 
-::: warning
+:::warning
 Optimizing dependencies in build mode is **experimental**. If enabled, it removes one of the most significant differences between dev and prod. [`@rollup/plugin-commonjs`](https://github.com/rollup/plugins/tree/master/packages/commonjs) is no longer needed in this case since esbuild converts CJS-only dependencies to ESM.
 
 If you want to try this build strategy, you can use `optimizeDeps.disabled: false`. `@rollup/plugin-commonjs` can be removed by passing `build.commonjsOptions: { include: [] }`.

--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -57,11 +57,10 @@ Set to `true` to force dependency pre-bundling, ignoring previously cached optim
 - **Type:** `boolean | 'build' | 'dev'`
 - **Default:** `'build'`
 
-Disables dependencies optimizations, `true` disables the optimizer during build and dev. Pass `'build'` or `'dev'` to only disable the optimizer in one of the modes. Deps optimization is enabled by default in dev only.
+Disables dependencies optimizations, `true` disables the optimizer during build and dev. Pass `'build'` or `'dev'` to only disable the optimizer in one of the modes. Dependency optimization is enabled by default in dev only.
 
-::: tip Note
-Vite allows the use of esbuild to optimize dependencies during build time. If enabled, it removes one of the most significant differences between dev and prod. [`@rollup/plugin-commonjs`](https://github.com/rollup/plugins/tree/master/packages/commonjs) is no longer needed in this case since esbuild converts CJS-only dependencies to ESM.
+::: warning
+Optimizing dependencies in build mode is **experimental**. If enabled, it removes one of the most significant differences between dev and prod. [`@rollup/plugin-commonjs`](https://github.com/rollup/plugins/tree/master/packages/commonjs) is no longer needed in this case since esbuild converts CJS-only dependencies to ESM.
 
-If you want to try this build strategy, you can use `optimizeDeps.disabled: false` (the default is `disabled: 'build'`). `@rollup/plugin-commonjs`
-can be removed by passing `build.commonjsOptions: { include: [] }`
+If you want to try this build strategy, you can use `optimizeDeps.disabled: false`. `@rollup/plugin-commonjs` can be removed by passing `build.commonjsOptions: { include: [] }`.
 :::

--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -51,3 +51,17 @@ Certain options are omitted since changing them would not be compatible with Vit
 - **Type:** `boolean`
 
 Set to `true` to force dependency pre-bundling, ignoring previously cached optimized dependencies.
+
+## optimizeDeps.disabled
+
+- **Type:** `boolean | 'build' | 'dev'`
+- **Default:** `'build'`
+
+Disables dependencies optimizations, `true` disables the optimizer during build and dev. Pass `'build'` or `'dev'` to only disable the optimizer in one of the modes. Deps optimization is enabled by default in dev only.
+
+::: tip Note
+Vite allows the use of esbuild to optimize dependencies during build time. If enabled, it removes one of the most significant differences between dev and prod. [`@rollup/plugin-commonjs`](https://github.com/rollup/plugins/tree/master/packages/commonjs) is no longer needed in this case since esbuild converts CJS-only dependencies to ESM.
+
+If you want to try this build strategy, you can use `optimizeDeps.disabled: false` (the default is `disabled: 'build'`). `@rollup/plugin-commonjs`
+can be removed by passing `build.commonjsOptions: { include: [] }`
+:::


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

There always have some people confused **how to use esbuild or rollup completely at both dev and build time**. These descriptions are displayed at [v3 docs](https://v3.vitejs.dev/guide/migration.html#experimental) but disappears in latest official doc site. I saw it before, so I have some memories. Otherwise I can't even find it.

So I create this PR to add these missings back, please take a review, thanks!

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
