### PR TITLE
fix: update modulePreload polyfill, dedupe same href fetch

### DIFF
--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -35,7 +35,7 @@ export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
 The following polyfill function is meant to run in the browser and adapted from
 https://github.com/guybedford/es-module-shims
 MIT License
-Copyright (C) 2018-2021 Guy Bedford
+Copyright (C) 2018-2023 Guy Bedford
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -62,10 +62,6 @@ function polyfill() {
     return
   }
 
-  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
-    processPreload(link)
-  }
-
   new MutationObserver((mutations: any) => {
     for (const mutation of mutations) {
       if (mutation.type !== 'childList') {
@@ -78,6 +74,10 @@ function polyfill() {
     }
   }).observe(document, { childList: true, subtree: true })
 
+  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+    processPreload(link)
+  }
+
   function getFetchOpts(link: any) {
     const fetchOpts = {} as any
     if (link.integrity) fetchOpts.integrity = link.integrity
@@ -89,12 +89,12 @@ function polyfill() {
     return fetchOpts
   }
 
+  const fetchCache = {} as any
   function processPreload(link: any) {
-    if (link.ep)
-      // ep marker = processed
-      return
+    if (link.ep) return
     link.ep = true
-    // prepopulate the load record
+    if (fetchCache[link.href]) return
+    fetchCache[link.href] = true
     const fetchOpts = getFetchOpts(link)
     fetch(link.href, fetchOpts)
   }


### PR DESCRIPTION
### Description

Apply https://github.com/guybedford/es-module-shims/pull/164. I simplified the cache to use a boolean instead of keeping the promise. I think it is better to avoid that.

We thought with @benmccann that this be related to https://github.com/vitejs/vite/issues/5532, but I tested it and the double request is there. The polyfill is simple in that regard, it is doing a direct fetch, and then the import will ask for the resource again. I was always assuming that the browser is able to work in this scenario as @sapphi-red commented on the issue.

I think we could merge this one just to be closer to the current state of es-module-shims.

This may also be related:
- https://github.com/guybedford/es-module-shims/issues/354

But it is strange because we had the same behavior for the past two years. If we can't find a way around this, we should look into disabling modulepreload when it isn't supported instead of polyfilling it in the next minor or major version.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other