### PR TITLE
fix(css): handle pure css chunk heuristic with special queries

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -464,15 +464,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       let isPureCssChunk = true
       const ids = Object.keys(chunk.modules)
       for (const id of ids) {
-        if (
-          !isCSSRequest(id) ||
-          cssModuleRE.test(id) ||
-          commonjsProxyRE.test(id)
-        ) {
+        if (cssModuleRE.test(id)) {
           isPureCssChunk = false
         }
         if (styles.has(id)) {
           chunkCSS += styles.get(id)
+        } else {
+          isPureCssChunk = false
         }
       }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -464,12 +464,16 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       let isPureCssChunk = true
       const ids = Object.keys(chunk.modules)
       for (const id of ids) {
-        if (cssModuleRE.test(id)) {
-          isPureCssChunk = false
-        }
         if (styles.has(id)) {
           chunkCSS += styles.get(id)
+          // a css module contains JS, so it makes this not a pure css chunk
+          if (cssModuleRE.test(id)) {
+            isPureCssChunk = false
+          }
         } else {
+          // if the module does not have a style, then it's not a pure css chunk.
+          // this is true because in the `transform` hook above, only modules
+          // that are css gets added to the `styles` map.
           isPureCssChunk = false
         }
       }

--- a/playground/css-codesplit/__tests__/css-codesplit.spec.ts
+++ b/playground/css-codesplit/__tests__/css-codesplit.spec.ts
@@ -5,6 +5,7 @@ test('should load all stylesheets', async () => {
   expect(await getColor('h1')).toBe('red')
   expect(await getColor('h2')).toBe('blue')
   expect(await getColor('.dynamic')).toBe('green')
+  expect(await getColor('.chunk')).toBe('magenta')
 })
 
 test('should load dynamic import with inline', async () => {
@@ -39,5 +40,9 @@ describe.runIf(isBuild)('build', () => {
     const manifest = readManifest()
     expect(manifest['index.html'].css.length).toBe(2)
     expect(manifest['other.js'].css.length).toBe(1)
+  })
+
+  test('should not mark a css chunk with ?url and normal import as pure css chunk', () => {
+    expect(findAssetFile(/chunk-.*\.js$/)).toBeTruthy()
   })
 })

--- a/playground/css-codesplit/chunk.css
+++ b/playground/css-codesplit/chunk.css
@@ -1,0 +1,3 @@
+.chunk {
+  color: magenta;
+}

--- a/playground/css-codesplit/index.html
+++ b/playground/css-codesplit/index.html
@@ -12,5 +12,7 @@
   <button class="order-bulk-update">change to green</button>
 </p>
 
+<p class="chunk">This should be magenta</p>
+
 <script type="module" src="/main.js"></script>
 <div id="app"></div>

--- a/playground/css-codesplit/main.js
+++ b/playground/css-codesplit/main.js
@@ -2,6 +2,12 @@ import './style.css'
 import './main.css'
 import './order'
 
+import './chunk.css'
+import chunkCssUrl from './chunk.css?url'
+
+// use this to not treeshake
+globalThis.__test_chunkCssUrl = chunkCssUrl
+
 import('./async.css')
 
 import('./inline.css?inline').then((css) => {

--- a/playground/css-codesplit/other.js
+++ b/playground/css-codesplit/other.js
@@ -1,1 +1,6 @@
 import './style.css'
+import './chunk.css'
+import chunkCssUrl from './chunk.css?url'
+
+// use this to not treeshake
+globalThis.__test_chunkCssUrl = chunkCssUrl

--- a/playground/css-codesplit/vite.config.js
+++ b/playground/css-codesplit/vite.config.js
@@ -8,6 +8,14 @@ module.exports = {
         main: resolve(__dirname, './index.html'),
         other: resolve(__dirname, './other.js'),
       },
+      output: {
+        manualChunks(id) {
+          // make `chunk.css` it's own chunk for easier testing of pure css chunks
+          if (id.includes('chunk.css')) {
+            return 'chunk'
+          }
+        },
+      },
     },
   },
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When deciding whether a chunk is a pure css chunk, it's incorrect when there is `modules` of:

1. `/project/src/style.css`
2. `/project/src/style.css?url`

The `?url` should make this not a pure css chunk, since that includes JS. Otherwise Vite would remove the pure css chunk from the bundle, causing a runtime import error.

Fixes https://github.com/withastro/astro/issues/6203

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This PR should also make detecting pure css chunks slightly optimal.



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
