### PR TITLE
feat(preview): improve error when build output missing

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 import type * as http from 'node:http'
 import sirv from 'sirv'
@@ -84,6 +85,16 @@ export async function preview(
     'production',
   )
 
+  const distDir = path.resolve(config.root, config.build.outDir)
+  if (
+    !fs.existsSync(distDir) &&
+    config.plugins.every((plugin) => !plugin.configurePreviewServer)
+  ) {
+    throw new Error(
+      `The directory "${config.build.outDir}" does not exist. Did you build your project?`,
+    )
+  }
+
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(
     config.preview,
@@ -116,7 +127,6 @@ export async function preview(
     config.base === './' || config.base === '' ? '/' : config.base
 
   // static assets
-  const distDir = path.resolve(config.root, config.build.outDir)
   const headers = config.preview.headers
   const assetServer = sirv(distDir, {
     etag: true,

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -88,7 +88,12 @@ export async function preview(
   const distDir = path.resolve(config.root, config.build.outDir)
   if (
     !fs.existsSync(distDir) &&
-    config.plugins.every((plugin) => !plugin.configurePreviewServer)
+    // error if no plugins implement `configurePreviewServer`
+    config.plugins.every((plugin) => !plugin.configurePreviewServer) &&
+    // error if called in CLI only. programmatic usage could access `httpServer`
+    // and affect file serving
+    process.argv[1]?.endsWith(path.normalize('bin/vite.js')) &&
+    process.argv[2] === 'preview'
   ) {
     throw new Error(
       `The directory "${config.build.outDir}" does not exist. Did you build your project?`,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Re-introduce the feature from https://github.com/vitejs/vite/pull/10564 that was previously reverted as it broke preview servers that uses `configurePreviewServer`, even if there's missing build output.

This PR is the same as #10564, except it only errors if no plugins implement `configurePreviewServer` and if it runs through Vite's CLI. This should help new users who start a simple Vite project.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I noticed they are consistently issues time-to-time regarding this behaviour, and maybe it's good to implement a simple one for now.

Extra context: https://github.com/vitejs/vite/pull/11579#discussion_r1062267509

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
