### PR TITLE
fix(reporter): build.assetsDir should not impact output when in lib mode

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -183,7 +183,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
             path.resolve(config.root, outDir ?? config.build.outDir),
           ),
         )
-        const assetsDir = `${config.build.assetsDir}/`
+        const assetsDir = path.join(config.build.assetsDir, '/')
 
         for (const group of groups) {
           const filtered = entries.filter((e) => e.group === group.name)
@@ -194,14 +194,15 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
             if (isLarge) hasLargeChunks = true
             const sizeColor = isLarge ? colors.yellow : colors.dim
             let log = colors.dim(relativeOutDir + '/')
-            log += entry.name.startsWith(assetsDir)
-              ? colors.dim(assetsDir) +
-                group.color(
-                  entry.name
-                    .slice(assetsDir.length)
-                    .padEnd(longest + 2 - assetsDir.length),
-                )
-              : group.color(entry.name.padEnd(longest + 2))
+            log +=
+              !config.build.lib && entry.name.startsWith(assetsDir)
+                ? colors.dim(assetsDir) +
+                  group.color(
+                    entry.name
+                      .slice(assetsDir.length)
+                      .padEnd(longest + 2 - assetsDir.length),
+                  )
+                : group.color(entry.name.padEnd(longest + 2))
             log += colors.bold(
               sizeColor(displaySize(entry.size).padStart(sizePad)),
             )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- entry name has nothing to do with `config.build.assetsDir` in `lib` mode, so `assetsDir` shouldn’t affect the final output color
- with trailing ‘/‘ (e.g `assets/`), `assetsDir`'s color won’t be dim in the reporter output


~The simple way to show the entry file path would be:~

~`color.dim(entry dirname) + group.color(entry basename)`~


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
