### PR TITLE
chore(deps): update rollup to 3.17.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prompts": "^2.4.2",
     "resolve": "^1.22.1",
     "rimraf": "^4.1.2",
-    "rollup": "^3.17.1",
+    "rollup": "^3.17.2",
     "semver": "^7.3.8",
     "simple-git-hooks": "^2.8.1",
     "tslib": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "prompts": "^2.4.2",
     "resolve": "^1.22.1",
     "rimraf": "^4.1.2",
-    "rollup": "^3.10.0",
+    "rollup": "^3.17.1",
     "semver": "^7.3.8",
     "simple-git-hooks": "^2.8.1",
     "tslib": "^2.5.0",

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-env": "^7.20.2",
     "browserslist": "^4.21.4",
     "core-js": "^3.27.2",
-    "magic-string": "^0.27.0",
+    "magic-string": "^0.29.0",
     "regenerator-runtime": "^0.13.11",
     "systemjs": "^6.13.0"
   },

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -69,7 +69,7 @@
     "esbuild": "^0.16.14",
     "postcss": "^8.4.21",
     "resolve": "^1.22.1",
-    "rollup": "^3.17.1"
+    "rollup": "^3.17.2"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -69,7 +69,7 @@
     "esbuild": "^0.16.14",
     "postcss": "^8.4.21",
     "resolve": "^1.22.1",
-    "rollup": "^3.10.0"
+    "rollup": "^3.17.1"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"
@@ -106,7 +106,7 @@
     "http-proxy": "^1.18.1",
     "json-stable-stringify": "^1.0.2",
     "launch-editor-middleware": "^2.6.0",
-    "magic-string": "^0.27.0",
+    "magic-string": "^0.29.0",
     "micromatch": "^4.0.5",
     "mlly": "^1.1.0",
     "mrmime": "^1.0.1",

--- a/playground/css-sourcemap/package.json
+++ b/playground/css-sourcemap/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "less": "^4.1.3",
-    "magic-string": "^0.27.0",
+    "magic-string": "^0.29.0",
     "sass": "^1.57.1",
     "stylus": "^0.59.0",
     "sugarss": "^4.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
       prompts: ^2.4.2
       resolve: ^1.22.1
       rimraf: ^4.1.2
-      rollup: ^3.17.1
+      rollup: ^3.17.2
       semver: ^7.3.8
       simple-git-hooks: ^2.8.1
       tslib: ^2.5.0
@@ -75,7 +75,7 @@ importers:
     devDependencies:
       '@babel/types': 7.20.7
       '@microsoft/api-extractor': 7.34.1_@types+node@18.11.18
-      '@rollup/plugin-typescript': 11.0.0_a7ifwadavf7dbdvok3nqg6itly
+      '@rollup/plugin-typescript': 11.0.0_yvemnjgk6ajmfkumtk2izoaioa
       '@types/babel__core': 7.20.0
       '@types/babel__standalone': 7.1.4
       '@types/convert-source-map': 2.0.0
@@ -117,7 +117,7 @@ importers:
       prompts: 2.4.2
       resolve: 1.22.1
       rimraf: 4.1.2
-      rollup: 3.17.1
+      rollup: 3.17.2
       semver: 7.3.8
       simple-git-hooks: 2.8.1
       tslib: 2.5.0
@@ -217,7 +217,7 @@ importers:
       postcss-modules: ^6.0.0
       resolve: ^1.22.1
       resolve.exports: ^2.0.0
-      rollup: ^3.17.1
+      rollup: ^3.17.2
       rollup-plugin-license: ^3.0.1
       sirv: ^2.0.2
       source-map-js: ^1.0.2
@@ -233,7 +233,7 @@ importers:
       esbuild: 0.16.14
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.17.1
+      rollup: 3.17.2
     optionalDependencies:
       fsevents: 2.3.2
     devDependencies:
@@ -241,13 +241,13 @@ importers:
       '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
       '@jridgewell/trace-mapping': 0.3.17
-      '@rollup/plugin-alias': 4.0.3_rollup@3.17.1
-      '@rollup/plugin-commonjs': 24.0.1_rollup@3.17.1
-      '@rollup/plugin-dynamic-import-vars': 2.0.3_rollup@3.17.1
-      '@rollup/plugin-json': 6.0.0_rollup@3.17.1
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.17.1
-      '@rollup/plugin-typescript': 11.0.0_rollup@3.17.1+tslib@2.5.0
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      '@rollup/plugin-alias': 4.0.3_rollup@3.17.2
+      '@rollup/plugin-commonjs': 24.0.1_rollup@3.17.2
+      '@rollup/plugin-dynamic-import-vars': 2.0.3_rollup@3.17.2
+      '@rollup/plugin-json': 6.0.0_rollup@3.17.2
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.17.2
+      '@rollup/plugin-typescript': 11.0.0_rollup@3.17.2+tslib@2.5.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
       acorn: 8.8.2
       acorn-walk: 8.2.0_acorn@8.8.2
       cac: 6.7.14
@@ -282,7 +282,7 @@ importers:
       postcss-load-config: 4.0.1_postcss@8.4.21
       postcss-modules: 6.0.0_postcss@8.4.21
       resolve.exports: 2.0.0
-      rollup-plugin-license: 3.0.1_rollup@3.17.1
+      rollup-plugin-license: 3.0.1_rollup@3.17.2
       sirv: 2.0.2_hmoqtj4vy3i7wnpchga2a2mu3y
       source-map-js: 1.0.2
       source-map-support: 0.5.21
@@ -3081,7 +3081,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@rollup/plugin-alias/4.0.3_rollup@3.17.1:
+  /@rollup/plugin-alias/4.0.3_rollup@3.17.2:
     resolution: {integrity: sha512-ZuDWE1q4PQDhvm/zc5Prun8sBpLJy41DMptYrS6MhAy9s9kL/doN1613BWfEchGVfKxzliJ3BjbOPizXX38DbQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3090,11 +3090,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.17.1
+      rollup: 3.17.2
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs/24.0.1_rollup@3.17.1:
+  /@rollup/plugin-commonjs/24.0.1_rollup@3.17.2:
     resolution: {integrity: sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3103,16 +3103,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.17.1
+      rollup: 3.17.2
     dev: true
 
-  /@rollup/plugin-dynamic-import-vars/2.0.3_rollup@3.17.1:
+  /@rollup/plugin-dynamic-import-vars/2.0.3_rollup@3.17.2:
     resolution: {integrity: sha512-0zQV0TDDewilU+7ZLmwc0u44SkeRxSxMdINBuX5isrQGJ6EdTjVL1TcnOZ9In99byaSGAQnHmSFw+6hm0E/jrw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3121,14 +3121,14 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
       estree-walker: 2.0.2
       fast-glob: 3.2.12
       magic-string: 0.27.0
-      rollup: 3.17.1
+      rollup: 3.17.2
     dev: true
 
-  /@rollup/plugin-json/6.0.0_rollup@3.17.1:
+  /@rollup/plugin-json/6.0.0_rollup@3.17.2:
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3137,11 +3137,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
-      rollup: 3.17.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
+      rollup: 3.17.2
     dev: true
 
-  /@rollup/plugin-node-resolve/15.0.1_rollup@3.17.1:
+  /@rollup/plugin-node-resolve/15.0.1_rollup@3.17.2:
     resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3150,16 +3150,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.0
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 3.17.1
+      rollup: 3.17.2
     dev: true
 
-  /@rollup/plugin-replace/5.0.2_rollup@3.17.1:
+  /@rollup/plugin-replace/5.0.2_rollup@3.17.2:
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3168,12 +3168,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
       magic-string: 0.27.0
-      rollup: 3.17.1
+      rollup: 3.17.2
     dev: true
 
-  /@rollup/plugin-typescript/11.0.0_a7ifwadavf7dbdvok3nqg6itly:
+  /@rollup/plugin-typescript/11.0.0_rollup@3.17.2+tslib@2.5.0:
     resolution: {integrity: sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3186,33 +3186,33 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
       resolve: 1.22.1
-      rollup: 3.17.1
+      rollup: 3.17.2
+      tslib: 2.5.0
+    dev: true
+
+  /@rollup/plugin-typescript/11.0.0_yvemnjgk6ajmfkumtk2izoaioa:
+    resolution: {integrity: sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.14.0||^3.0.0
+      tslib: '*'
+      typescript: '>=3.7.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      tslib:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
+      resolve: 1.22.1
+      rollup: 3.17.2
       tslib: 2.5.0
       typescript: 4.9.3
     dev: true
 
-  /@rollup/plugin-typescript/11.0.0_rollup@3.17.1+tslib@2.5.0:
-    resolution: {integrity: sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.14.0||^3.0.0
-      tslib: '*'
-      typescript: '>=3.7.0'
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-      tslib:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
-      resolve: 1.22.1
-      rollup: 3.17.1
-      tslib: 2.5.0
-    dev: true
-
-  /@rollup/pluginutils/5.0.2_rollup@3.17.1:
+  /@rollup/pluginutils/5.0.2_rollup@3.17.2:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3224,7 +3224,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.17.1
+      rollup: 3.17.2
     dev: true
 
   /@rushstack/node-core-library/3.54.0_@types+node@18.11.18:
@@ -8408,7 +8408,7 @@ packages:
     hasBin: true
     dev: true
 
-  /rollup-plugin-dts/5.1.1_bv7xa2yhhbgtooz5dyd2rphopa:
+  /rollup-plugin-dts/5.1.1_wpdpur4kpujfydhh5gfebievia:
     resolution: {integrity: sha512-zpgo52XmnLg8w4k3MScinFHZK1+ro6r7uVe34fJ0Ee8AM45FvgvTuvfWWaRgIpA4pQ1BHJuu2ospncZhkcJVeA==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -8416,13 +8416,13 @@ packages:
       typescript: ^4.1
     dependencies:
       magic-string: 0.27.0
-      rollup: 3.17.1
+      rollup: 3.17.2
       typescript: 4.9.4
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: true
 
-  /rollup-plugin-license/3.0.1_rollup@3.17.1:
+  /rollup-plugin-license/3.0.1_rollup@3.17.2:
     resolution: {integrity: sha512-/lec6Y94Y3wMfTDeYTO/jSXII0GQ/XkDZCiqkMKxyU5D5nGPaxr/2JNYvAgYsoCYuOLGOanKDPjCCQiTT96p7A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -8435,13 +8435,13 @@ packages:
       mkdirp: 1.0.4
       moment: 2.29.3
       package-name-regex: 2.0.6
-      rollup: 3.17.1
+      rollup: 3.17.2
       spdx-expression-validate: 2.0.0
       spdx-satisfies: 5.0.1
     dev: true
 
-  /rollup/3.17.1:
-    resolution: {integrity: sha512-8RnSms6rNqHmZK+wiqgnPCqen+rRnUHXkciGDirh7B00g1rX1vpKbPDhuxCvAG2bburoI+W4Q9/PlUB/zYkiYA==}
+  /rollup/3.17.2:
+    resolution: {integrity: sha512-qMNZdlQPCkWodrAZ3qnJtvCAl4vpQ8q77uEujVCCbC/6CLB7Lcmvjq7HyiOSnf4fxTT9XgsE36oLHJBH49xjqA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -9351,12 +9351,12 @@ packages:
     resolution: {integrity: sha512-HlhHj6cUPBQJmhoczQoU6dzdTFO0Jr9EiGWEZ1EwHGXlGRR6LXcKyfX3PMrkM48uWJjBWiCgTQdkFOAk3tlK6Q==}
     hasBin: true
     dependencies:
-      '@rollup/plugin-alias': 4.0.3_rollup@3.17.1
-      '@rollup/plugin-commonjs': 24.0.1_rollup@3.17.1
-      '@rollup/plugin-json': 6.0.0_rollup@3.17.1
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.17.1
-      '@rollup/plugin-replace': 5.0.2_rollup@3.17.1
-      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      '@rollup/plugin-alias': 4.0.3_rollup@3.17.2
+      '@rollup/plugin-commonjs': 24.0.1_rollup@3.17.2
+      '@rollup/plugin-json': 6.0.0_rollup@3.17.2
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.17.2
+      '@rollup/plugin-replace': 5.0.2_rollup@3.17.2
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.2
       chalk: 5.2.0
       consola: 2.15.3
       defu: 6.1.2
@@ -9372,8 +9372,8 @@ packages:
       pathe: 1.1.0
       pkg-types: 1.0.1
       pretty-bytes: 6.0.0
-      rollup: 3.17.1
-      rollup-plugin-dts: 5.1.1_bv7xa2yhhbgtooz5dyd2rphopa
+      rollup: 3.17.2
+      rollup-plugin-dts: 5.1.1_wpdpur4kpujfydhh5gfebievia
       scule: 1.0.0
       typescript: 4.9.4
       untyped: 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
       prompts: ^2.4.2
       resolve: ^1.22.1
       rimraf: ^4.1.2
-      rollup: ^3.10.0
+      rollup: ^3.17.1
       semver: ^7.3.8
       simple-git-hooks: ^2.8.1
       tslib: ^2.5.0
@@ -75,7 +75,7 @@ importers:
     devDependencies:
       '@babel/types': 7.20.7
       '@microsoft/api-extractor': 7.34.1_@types+node@18.11.18
-      '@rollup/plugin-typescript': 11.0.0_2gll6akdvfeevplygqwbeee6ye
+      '@rollup/plugin-typescript': 11.0.0_a7ifwadavf7dbdvok3nqg6itly
       '@types/babel__core': 7.20.0
       '@types/babel__standalone': 7.1.4
       '@types/convert-source-map': 2.0.0
@@ -117,7 +117,7 @@ importers:
       prompts: 2.4.2
       resolve: 1.22.1
       rimraf: 4.1.2
-      rollup: 3.10.0
+      rollup: 3.17.1
       semver: 7.3.8
       simple-git-hooks: 2.8.1
       tslib: 2.5.0
@@ -148,7 +148,7 @@ importers:
       acorn: ^8.8.2
       browserslist: ^4.21.4
       core-js: ^3.27.2
-      magic-string: ^0.27.0
+      magic-string: ^0.29.0
       picocolors: ^1.0.0
       regenerator-runtime: ^0.13.11
       systemjs: ^6.13.0
@@ -158,7 +158,7 @@ importers:
       '@babel/preset-env': 7.20.2_@babel+core@7.20.12
       browserslist: 4.21.4
       core-js: 3.27.2
-      magic-string: 0.27.0
+      magic-string: 0.29.0
       regenerator-runtime: 0.13.11
       systemjs: 6.13.0
     devDependencies:
@@ -201,7 +201,7 @@ importers:
       http-proxy: ^1.18.1
       json-stable-stringify: ^1.0.2
       launch-editor-middleware: ^2.6.0
-      magic-string: ^0.27.0
+      magic-string: ^0.29.0
       micromatch: ^4.0.5
       mlly: ^1.1.0
       mrmime: ^1.0.1
@@ -217,7 +217,7 @@ importers:
       postcss-modules: ^6.0.0
       resolve: ^1.22.1
       resolve.exports: ^2.0.0
-      rollup: ^3.10.0
+      rollup: ^3.17.1
       rollup-plugin-license: ^3.0.1
       sirv: ^2.0.2
       source-map-js: ^1.0.2
@@ -233,7 +233,7 @@ importers:
       esbuild: 0.16.14
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.10.0
+      rollup: 3.17.1
     optionalDependencies:
       fsevents: 2.3.2
     devDependencies:
@@ -241,13 +241,13 @@ importers:
       '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
       '@jridgewell/trace-mapping': 0.3.17
-      '@rollup/plugin-alias': 4.0.3_rollup@3.10.0
-      '@rollup/plugin-commonjs': 24.0.1_rollup@3.10.0
-      '@rollup/plugin-dynamic-import-vars': 2.0.3_rollup@3.10.0
-      '@rollup/plugin-json': 6.0.0_rollup@3.10.0
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.10.0
-      '@rollup/plugin-typescript': 11.0.0_rollup@3.10.0+tslib@2.5.0
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/plugin-alias': 4.0.3_rollup@3.17.1
+      '@rollup/plugin-commonjs': 24.0.1_rollup@3.17.1
+      '@rollup/plugin-dynamic-import-vars': 2.0.3_rollup@3.17.1
+      '@rollup/plugin-json': 6.0.0_rollup@3.17.1
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.17.1
+      '@rollup/plugin-typescript': 11.0.0_rollup@3.17.1+tslib@2.5.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       acorn: 8.8.2
       acorn-walk: 8.2.0_acorn@8.8.2
       cac: 6.7.14
@@ -268,7 +268,7 @@ importers:
       http-proxy: 1.18.1_debug@4.3.4
       json-stable-stringify: 1.0.2
       launch-editor-middleware: 2.6.0
-      magic-string: 0.27.0
+      magic-string: 0.29.0
       micromatch: 4.0.5
       mlly: 1.1.0
       mrmime: 1.0.1
@@ -282,7 +282,7 @@ importers:
       postcss-load-config: 4.0.1_postcss@8.4.21
       postcss-modules: 6.0.0_postcss@8.4.21
       resolve.exports: 2.0.0
-      rollup-plugin-license: 3.0.1_rollup@3.10.0
+      rollup-plugin-license: 3.0.1_rollup@3.17.1
       sirv: 2.0.2_hmoqtj4vy3i7wnpchga2a2mu3y
       source-map-js: 1.0.2
       source-map-support: 0.5.21
@@ -401,13 +401,13 @@ importers:
   playground/css-sourcemap:
     specifiers:
       less: ^4.1.3
-      magic-string: ^0.27.0
+      magic-string: ^0.29.0
       sass: ^1.57.1
       stylus: ^0.59.0
       sugarss: ^4.0.1
     devDependencies:
       less: 4.1.3
-      magic-string: 0.27.0
+      magic-string: 0.29.0
       sass: 1.57.1
       stylus: 0.59.0
       sugarss: 4.0.1
@@ -3081,7 +3081,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@rollup/plugin-alias/4.0.3_rollup@3.10.0:
+  /@rollup/plugin-alias/4.0.3_rollup@3.17.1:
     resolution: {integrity: sha512-ZuDWE1q4PQDhvm/zc5Prun8sBpLJy41DMptYrS6MhAy9s9kL/doN1613BWfEchGVfKxzliJ3BjbOPizXX38DbQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3090,11 +3090,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.10.0
+      rollup: 3.17.1
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs/24.0.1_rollup@3.10.0:
+  /@rollup/plugin-commonjs/24.0.1_rollup@3.17.1:
     resolution: {integrity: sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3103,16 +3103,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.10.0
+      rollup: 3.17.1
     dev: true
 
-  /@rollup/plugin-dynamic-import-vars/2.0.3_rollup@3.10.0:
+  /@rollup/plugin-dynamic-import-vars/2.0.3_rollup@3.17.1:
     resolution: {integrity: sha512-0zQV0TDDewilU+7ZLmwc0u44SkeRxSxMdINBuX5isrQGJ6EdTjVL1TcnOZ9In99byaSGAQnHmSFw+6hm0E/jrw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3121,14 +3121,14 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       estree-walker: 2.0.2
       fast-glob: 3.2.12
       magic-string: 0.27.0
-      rollup: 3.10.0
+      rollup: 3.17.1
     dev: true
 
-  /@rollup/plugin-json/6.0.0_rollup@3.10.0:
+  /@rollup/plugin-json/6.0.0_rollup@3.17.1:
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3137,11 +3137,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
-      rollup: 3.10.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
+      rollup: 3.17.1
     dev: true
 
-  /@rollup/plugin-node-resolve/15.0.1_rollup@3.10.0:
+  /@rollup/plugin-node-resolve/15.0.1_rollup@3.17.1:
     resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3150,16 +3150,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.0
       is-module: 1.0.0
       resolve: 1.22.1
-      rollup: 3.10.0
+      rollup: 3.17.1
     dev: true
 
-  /@rollup/plugin-replace/5.0.2_rollup@3.10.0:
+  /@rollup/plugin-replace/5.0.2_rollup@3.17.1:
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3168,12 +3168,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       magic-string: 0.27.0
-      rollup: 3.10.0
+      rollup: 3.17.1
     dev: true
 
-  /@rollup/plugin-typescript/11.0.0_2gll6akdvfeevplygqwbeee6ye:
+  /@rollup/plugin-typescript/11.0.0_a7ifwadavf7dbdvok3nqg6itly:
     resolution: {integrity: sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3186,14 +3186,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       resolve: 1.22.1
-      rollup: 3.10.0
+      rollup: 3.17.1
       tslib: 2.5.0
       typescript: 4.9.3
     dev: true
 
-  /@rollup/plugin-typescript/11.0.0_rollup@3.10.0+tslib@2.5.0:
+  /@rollup/plugin-typescript/11.0.0_rollup@3.17.1+tslib@2.5.0:
     resolution: {integrity: sha512-goPyCWBiimk1iJgSTgsehFD5OOFHiAknrRJjqFCudcW8JtWiBlK284Xnn4flqMqg6YAjVG/EE+3aVzrL5qNSzQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3206,13 +3206,13 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       resolve: 1.22.1
-      rollup: 3.10.0
+      rollup: 3.17.1
       tslib: 2.5.0
     dev: true
 
-  /@rollup/pluginutils/5.0.2_rollup@3.10.0:
+  /@rollup/pluginutils/5.0.2_rollup@3.17.1:
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3224,7 +3224,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.10.0
+      rollup: 3.17.1
     dev: true
 
   /@rushstack/node-core-library/3.54.0_@types+node@18.11.18:
@@ -6982,6 +6982,13 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /magic-string/0.29.0:
+    resolution: {integrity: sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
 
   /make-dir/2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
@@ -8401,7 +8408,7 @@ packages:
     hasBin: true
     dev: true
 
-  /rollup-plugin-dts/5.1.1_eymahajmafh3u7vrzmo7ylp2pa:
+  /rollup-plugin-dts/5.1.1_bv7xa2yhhbgtooz5dyd2rphopa:
     resolution: {integrity: sha512-zpgo52XmnLg8w4k3MScinFHZK1+ro6r7uVe34fJ0Ee8AM45FvgvTuvfWWaRgIpA4pQ1BHJuu2ospncZhkcJVeA==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -8409,13 +8416,13 @@ packages:
       typescript: ^4.1
     dependencies:
       magic-string: 0.27.0
-      rollup: 3.10.0
+      rollup: 3.17.1
       typescript: 4.9.4
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: true
 
-  /rollup-plugin-license/3.0.1_rollup@3.10.0:
+  /rollup-plugin-license/3.0.1_rollup@3.17.1:
     resolution: {integrity: sha512-/lec6Y94Y3wMfTDeYTO/jSXII0GQ/XkDZCiqkMKxyU5D5nGPaxr/2JNYvAgYsoCYuOLGOanKDPjCCQiTT96p7A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -8428,13 +8435,13 @@ packages:
       mkdirp: 1.0.4
       moment: 2.29.3
       package-name-regex: 2.0.6
-      rollup: 3.10.0
+      rollup: 3.17.1
       spdx-expression-validate: 2.0.0
       spdx-satisfies: 5.0.1
     dev: true
 
-  /rollup/3.10.0:
-    resolution: {integrity: sha512-JmRYz44NjC1MjVF2VKxc0M1a97vn+cDxeqWmnwyAF4FvpjK8YFdHpaqvQB+3IxCvX05vJxKZkoMDU8TShhmJVA==}
+  /rollup/3.17.1:
+    resolution: {integrity: sha512-8RnSms6rNqHmZK+wiqgnPCqen+rRnUHXkciGDirh7B00g1rX1vpKbPDhuxCvAG2bburoI+W4Q9/PlUB/zYkiYA==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -9344,12 +9351,12 @@ packages:
     resolution: {integrity: sha512-HlhHj6cUPBQJmhoczQoU6dzdTFO0Jr9EiGWEZ1EwHGXlGRR6LXcKyfX3PMrkM48uWJjBWiCgTQdkFOAk3tlK6Q==}
     hasBin: true
     dependencies:
-      '@rollup/plugin-alias': 4.0.3_rollup@3.10.0
-      '@rollup/plugin-commonjs': 24.0.1_rollup@3.10.0
-      '@rollup/plugin-json': 6.0.0_rollup@3.10.0
-      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.10.0
-      '@rollup/plugin-replace': 5.0.2_rollup@3.10.0
-      '@rollup/pluginutils': 5.0.2_rollup@3.10.0
+      '@rollup/plugin-alias': 4.0.3_rollup@3.17.1
+      '@rollup/plugin-commonjs': 24.0.1_rollup@3.17.1
+      '@rollup/plugin-json': 6.0.0_rollup@3.17.1
+      '@rollup/plugin-node-resolve': 15.0.1_rollup@3.17.1
+      '@rollup/plugin-replace': 5.0.2_rollup@3.17.1
+      '@rollup/pluginutils': 5.0.2_rollup@3.17.1
       chalk: 5.2.0
       consola: 2.15.3
       defu: 6.1.2
@@ -9365,8 +9372,8 @@ packages:
       pathe: 1.1.0
       pkg-types: 1.0.1
       pretty-bytes: 6.0.0
-      rollup: 3.10.0
-      rollup-plugin-dts: 5.1.1_eymahajmafh3u7vrzmo7ylp2pa
+      rollup: 3.17.1
+      rollup-plugin-dts: 5.1.1_bv7xa2yhhbgtooz5dyd2rphopa
       scule: 1.0.0
       typescript: 4.9.4
       untyped: 1.2.2


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Update rollup to 3.17.1. Also updates magic-string to 0.29.0 as to make types pass.

[v3.11.0](https://github.com/rollup/rollup/releases/tag/v3.11.0) adds https://github.com/rollup/rollup/issues/4774 that enables us to implement https://github.com/vitejs/vite/issues/9073.
[v3.16.0](https://github.com/rollup/rollup/releases/tag/v3.16.0) adds `output.sourcemapIgnoreList` option that adds `x_google_ignoreList` support.
[v3.17.0](https://github.com/rollup/rollup/releases/tag/v3.17.0) improves chunking performance (https://github.com/rollup/rollup/pull/4862).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
