### PR TITLE
fix(html): respect disable modulepreload

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -737,23 +737,25 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               toScriptTag(chunk, toOutputAssetFilePath, isAsync),
             )
           } else {
+            assetTags = [toScriptTag(chunk, toOutputAssetFilePath, isAsync)]
             const { modulePreload } = config.build
-            const resolveDependencies =
-              typeof modulePreload === 'object' &&
-              modulePreload.resolveDependencies
-            const importsFileNames = imports.map((chunk) => chunk.fileName)
-            const resolvedDeps = resolveDependencies
-              ? resolveDependencies(chunk.fileName, importsFileNames, {
-                  hostId: relativeUrlPath,
-                  hostType: 'html',
-                })
-              : importsFileNames
-            assetTags = [
-              toScriptTag(chunk, toOutputAssetFilePath, isAsync),
-              ...resolvedDeps.map((i) =>
-                toPreloadTag(i, toOutputAssetFilePath),
-              ),
-            ]
+            if (modulePreload !== false) {
+              const resolveDependencies =
+                typeof modulePreload === 'object' &&
+                modulePreload.resolveDependencies
+              const importsFileNames = imports.map((chunk) => chunk.fileName)
+              const resolvedDeps = resolveDependencies
+                ? resolveDependencies(chunk.fileName, importsFileNames, {
+                    hostId: relativeUrlPath,
+                    hostType: 'html',
+                  })
+                : importsFileNames
+              assetTags.push(
+                ...resolvedDeps.map((i) =>
+                  toPreloadTag(i, toOutputAssetFilePath),
+                ),
+              )
+            }
           }
           assetTags.push(...getCssTagsForChunk(chunk, toOutputAssetFilePath))
 

--- a/playground/preload/index.html
+++ b/playground/preload/index.html
@@ -1,4 +1,5 @@
 <h1>preload</h1>
+<div class="chunk"></div>
 <div id="hello">
   <button class="load">Load hello</button>
   <div class="msg"></div>

--- a/playground/preload/src/chunk.js
+++ b/playground/preload/src/chunk.js
@@ -1,0 +1,1 @@
+export default '[success] message from chunk.js'

--- a/playground/preload/src/main.js
+++ b/playground/preload/src/main.js
@@ -1,3 +1,7 @@
+import chunkMsg from './chunk'
+
+document.querySelector('.chunk').textContent = chunkMsg
+
 const ids = {
   hello: async () => {
     await import(/* a comment */ './hello.js')

--- a/playground/preload/vite.config-preload-disabled.ts
+++ b/playground/preload/vite.config-preload-disabled.ts
@@ -12,6 +12,15 @@ export default defineConfig({
         passes: 3,
       },
     },
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('chunk.js')) {
+            return 'chunk'
+          }
+        },
+      },
+    },
     modulePreload: false,
   },
 })

--- a/playground/preload/vite.config-resolve-deps.ts
+++ b/playground/preload/vite.config-resolve-deps.ts
@@ -12,6 +12,15 @@ export default defineConfig({
         passes: 3,
       },
     },
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('chunk.js')) {
+            return 'chunk'
+          }
+        },
+      },
+    },
     modulePreload: {
       resolveDependencies(filename, deps, { hostId, hostType }) {
         if (filename.includes('hello')) {

--- a/playground/preload/vite.config.ts
+++ b/playground/preload/vite.config.ts
@@ -12,5 +12,14 @@ export default defineConfig({
         passes: 3,
       },
     },
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('chunk.js')) {
+            return 'chunk'
+          }
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix #11889

Don't inject `modulepreload` links in html when `build.moduePreload: false`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
