### PR TITLE
docs: build.assetsDir only used in non lib mode

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -78,7 +78,7 @@ Specify the output directory (relative to [project root](/guide/#index-html-and-
 - **Type:** `string`
 - **Default:** `assets`
 
-Specify the directory to nest generated assets under (relative to `build.outDir`).
+Specify the directory to nest generated assets under (relative to `build.outDir`, only used in non-[Library Mode](/guide/build#library-mode)).
 
 ## build.assetsInlineLimit
 

--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -78,7 +78,7 @@ Specify the output directory (relative to [project root](/guide/#index-html-and-
 - **Type:** `string`
 - **Default:** `assets`
 
-Specify the directory to nest generated assets under (relative to `build.outDir`, only used in non-[Library Mode](/guide/build#library-mode)).
+Specify the directory to nest generated assets under (relative to `build.outDir`. This is not used in [Library Mode](/guide/build#library-mode)).
 
 ## build.assetsInlineLimit
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

According to the code below, `build.assetsDir` only used in non lib mode.

https://github.com/vitejs/vite/blob/5f7f5dcb0c006012631c1d5df61d79307d9097f4/packages/vite/src/node/build.ts#L570-L581

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
