### PR TITLE
fix(define): should not stringify vite internal env

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -68,9 +68,10 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     }
     Object.assign(importMetaFallbackKeys, {
       'import.meta.env.': `({}).`,
-      'import.meta.env': JSON.stringify({ ...env, ...userDefineEnv })
-        .replace(/"__vite__/g, '')
-        .replace(/__vite__"/g, ''),
+      'import.meta.env': JSON.stringify({ ...env, ...userDefineEnv }).replace(
+        /"__vite__(.+?)__vite__"/g,
+        (_, val) => val,
+      ),
     })
   }
 

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -69,8 +69,8 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     Object.assign(importMetaFallbackKeys, {
       'import.meta.env.': `({}).`,
       'import.meta.env': JSON.stringify({ ...env, ...userDefineEnv })
-        .replace('"__vite__', '')
-        .replace('__vite__"', ''),
+        .replace(/"__vite__/g, '')
+        .replace(/__vite__"/g, ''),
     })
   }
 

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -8,6 +8,7 @@ import { isHTMLRequest } from './html'
 const nonJsRe = /\.json(?:$|\?)/
 const metaEnvRe = /import\.meta\.env\.(.+)/
 const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)
+const internalEnvs = ['__VITE_IS_LEGACY__']
 
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
@@ -56,9 +57,14 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     for (const key in env) {
       importMetaKeys[`import.meta.env.${key}`] = JSON.stringify(env[key])
     }
+
     Object.assign(importMetaFallbackKeys, {
       'import.meta.env.': `({}).`,
-      'import.meta.env': JSON.stringify(env),
+      // make sure vite internal env won't be stringify
+      'import.meta.env': JSON.stringify(env).replace(
+        new RegExp(`"(${internalEnvs.join('|')})"`, 'g'),
+        '$1',
+      ),
     })
   }
 

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -8,7 +8,6 @@ import { isHTMLRequest } from './html'
 const nonJsRe = /\.json(?:$|\?)/
 const metaEnvRe = /import\.meta\.env\.(.+)/
 const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)
-const internalEnvs = ['__VITE_IS_LEGACY__']
 
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
@@ -32,16 +31,24 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     })
   }
 
-  const env = { ...config.env }
   const userDefine: Record<string, string> = {}
+  const userDefineEnv: Record<string, string> = {}
   for (const key in config.define) {
     const val = config.define[key]
     userDefine[key] = typeof val === 'string' ? val : JSON.stringify(val)
 
     // make sure `import.meta.env` object has user define properties
-    const match = key.match(metaEnvRe)
-    if (match) {
-      env[match[1]] = val
+    if (isBuild) {
+      const match = key.match(metaEnvRe)
+      if (match) {
+        userDefineEnv[match[1]] =
+          // test if value is raw identifier to wrap with __vite__ so when
+          // stringified for `import.meta.env`, we can remove the quotes and
+          // retain being an identifier
+          typeof val === 'string' && /^[\p{L}_$]/u.test(val.trim())
+            ? `__vite__${val}__vite__`
+            : val
+      }
     }
   }
 
@@ -50,21 +57,20 @@ export function definePlugin(config: ResolvedConfig): Plugin {
   const importMetaKeys: Record<string, string> = {}
   const importMetaFallbackKeys: Record<string, string> = {}
   if (isBuild) {
-    env.SSR = !!config.build.ssr
-
+    const env: Record<string, any> = {
+      ...config.env,
+      SSR: !!config.build.ssr,
+    }
     // set here to allow override with config.define
     importMetaKeys['import.meta.hot'] = `undefined`
     for (const key in env) {
       importMetaKeys[`import.meta.env.${key}`] = JSON.stringify(env[key])
     }
-
     Object.assign(importMetaFallbackKeys, {
       'import.meta.env.': `({}).`,
-      // make sure vite internal env won't be stringify
-      'import.meta.env': JSON.stringify(env).replace(
-        new RegExp(`"(${internalEnvs.join('|')})"`, 'g'),
-        '$1',
-      ),
+      'import.meta.env': JSON.stringify({ ...env, ...userDefineEnv })
+        .replace('"__vite__', '')
+        .replace('__vite__"', ''),
     })
   }
 

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -23,6 +23,7 @@ test('import.meta.env.LEGACY', async () => {
     isBuild ? 'true' : 'false',
     true,
   )
+  await untilUpdated(() => page.textContent('#env-equal'), 'true', true)
 })
 
 // https://github.com/vitejs/vite/issues/3400

--- a/playground/legacy/index.html
+++ b/playground/legacy/index.html
@@ -1,5 +1,6 @@
 <h1 id="app"></h1>
 <div id="env"></div>
+<div id="env-equal"></div>
 <div id="iterators"></div>
 <div id="features-after-corejs-3"></div>
 <div id="async-generator"></div>

--- a/playground/legacy/main.js
+++ b/playground/legacy/main.js
@@ -20,6 +20,9 @@ if (import.meta.env.LEGACY) {
 
 text('#env', `is legacy: ${isLegacy}`)
 
+const metaEnvObj = import.meta.env
+text('#env-equal', import.meta.env.LEGACY === metaEnvObj.LEGACY)
+
 // Iterators
 text('#iterators', [...new Set(['hello'])].join(''))
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Some Vite internal env values(e.g plugin-legacy `__VITE_IS_LEGACY__`) will be stringified, which may cause the value type to be incorrect in `import.meta.env` object

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [x] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
