### PR TITLE
fix: support UTF-8 encoding in inline Web Workers (fixes #12117)

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -283,7 +283,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             code: `const encodedJs = "${Buffer.from(chunk.code).toString(
               'base64',
             )}";
-            const base64decode = (ascii) => new TextDecoder().decode(Uint8Array.from(atob(ascii), c => c.charCodeAt(0)));
+            const base64decode = (ascii) => Uint8Array.from(atob(ascii), c => c.charCodeAt(0));
             const blob = typeof window !== "undefined" && window.Blob && new Blob([base64decode(encodedJs)], { type: "text/javascript;charset=utf-8" });
             export default function WorkerWrapper() {
               const objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -283,7 +283,8 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             code: `const encodedJs = "${Buffer.from(chunk.code).toString(
               'base64',
             )}";
-            const blob = typeof window !== "undefined" && window.Blob && new Blob([atob(encodedJs)], { type: "text/javascript;charset=utf-8" });
+            const base64decode = (ascii) => new TextDecoder().decode(Uint8Array.from(atob(ascii), c => c.charCodeAt(0)));
+            const blob = typeof window !== "undefined" && window.Blob && new Blob([base64decode(encodedJs)], { type: "text/javascript;charset=utf-8" });
             export default function WorkerWrapper() {
               const objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);
               try {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #12117

This PR solves issue #12117, where inline Web Workers lose UTF-8 characters due to the atob function, which only supports ASCII. See https://developer.mozilla.org/en-US/docs/Glossary/Base64

The bug can be seen in this reproduction repo: https://stackblitz.com/edit/vitejs-vite-tyt9yp

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
