### PR TITLE
fix(ssr): sourcemap initModule

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -191,7 +191,18 @@ async function instantiateModule(
       ssrImportKey,
       ssrDynamicImportKey,
       ssrExportAllKey,
-      '"use strict";' + result.code + `\n//# sourceURL=${mod.url}`,
+      `"use strict";\n${result.code}\n//# ${
+        result.map && result.map.mappings
+          ? `sourceMappingURL=data:application/json;charset=utf-8;base64,${Buffer.from(
+              JSON.stringify({
+                ...result.map,
+                mappings: `;;;${result.map.mappings}`,
+              }),
+            ).toString(
+              'base64',
+            )}\n//# sourceURL=vite-internal:///./${mod.url.replace(/^\/+/, '')}`
+          : `sourceURL=${mod.url}`
+      }`,
     )
     await initModule(
       context.global,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

this is for debugging `+server.js` when running `Run Script: dev`
, currently, vscode finds the correct file, but when vscode stops at `debugger;` statement, the line number is off by +2.

this is because those two lines are always added:
```js
(async function anonymous(global,__vite_ssr_exports__,__vite_ssr_import_meta__,__vite_ssr_import__,__vite_ssr_dynamic_import__,__vite_ssr_exportAll__
) {
```
I consider this `eval()` but it's `new AsyncFunction`

I assume initModule() is used for debugging only (`vite dev`), and not for prod (`vite build` then `vite preview`)
so my fix is to pad the sourcemap : `mappings` : with `;;`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
