### PR TITLE
fix(optimizer): log unoptimizable entries

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -722,7 +722,7 @@ export async function addManuallyIncludedOptimizeDeps(
               deps[normalizedId] = entry
             }
           } else {
-            unableToOptimize(entry, 'Cannot optimize dependency')
+            unableToOptimize(id, 'Cannot optimize dependency')
           }
         } else {
           unableToOptimize(id, 'Failed to resolve dependency')


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

If a dependency in optimizeDeps.include cannot be optimized, it should be logged. However, the id wasn't passed to the log function, so logging never happened. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

