### PR TITLE
docs: define no longer follows the esbuild rules

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -39,8 +39,6 @@ Define global constant replacements. Entries will be defined as globals during d
 
 - String values will be used as raw expressions, so if defining a string constant, **it needs to be explicitly quoted** (e.g. with `JSON.stringify`).
 
-- To be consistent with [esbuild behavior](https://esbuild.github.io/api/#define), expressions must either be a JSON object (null, boolean, number, string, array, or object) or a single identifier.
-
 - Replacements are performed only when the match isn't surrounded by other letters, numbers, `_` or `$`.
 
 ::: warning


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In Vite 2.x, `config.define` is passed to esbuild to perform the replacement.

https://github.com/vitejs/vite/blob/d4886ea9567106be947538003757ba817976e080/packages/vite/src/node/optimizer/index.ts#L279-L299

For now, `config.define` is no longer passed to esbuild when performing optimization. The line this PR deleted is introduced in https://github.com/vitejs/vite/issues/5570. The reproduction that time works on Vite4 now.

Made a new demo to confirm https://stackblitz.com/edit/vite-nitjua?file=package-lock.json,vite.config.js&file=main.js

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
We should bring this back after https://github.com/vitejs/vite/pull/11151 landed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
