### PR TITLE
fix(plugin-legacy): no `build.target` override on SSR build

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -165,7 +165,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
     name: 'vite:legacy-config',
 
     config(config, env) {
-      if (env.command === 'build' && config.build?.ssr) {
+      if (env.command === 'build' && !config.build?.ssr) {
         if (!config.build) {
           config.build = {}
         }

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -165,7 +165,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
     name: 'vite:legacy-config',
 
     config(config, env) {
-      if (env.command === 'build') {
+      if (env.command === 'build' && config.build?.ssr) {
         if (!config.build) {
           config.build = {}
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

This very simple PR avoid the `plugin-legacy` overriding (and warning if exists) of the `build.target` configuration for SSR.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Sadly, in plugin-legacy, the `build.target` overriding (and warning if exists) happen on SSR build as well.

In addition, some other plugins, like SvelteKit (together with my legacy support PR there - sveltejs/kit#6265), automatically "fixes" the build target for the SSR build, so this will eliminate the warning we get there as a side effect.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
