### PR TITLE
docs: add date to announcement blog posts

### DIFF
--- a/docs/blog/announcing-vite2.md
+++ b/docs/blog/announcing-vite2.md
@@ -4,6 +4,8 @@ sidebar: false
 
 # Announcing Vite 2.0
 
+_February 16, 2021_ - Check out the [Vite 3.0 announcement](./announcing-vite3.md)
+
 <p style="text-align:center">
   <img src="/logo.svg" style="height:200px">
 </p>

--- a/docs/blog/announcing-vite3.md
+++ b/docs/blog/announcing-vite3.md
@@ -23,6 +23,8 @@ head:
 
 # Vite 3.0 is out!
 
+_July 23, 2022_ - Check out the [Vite 4.0 announcement](./announcing-vite4.md)
+
 In February last year, [Evan You](https://twitter.com/youyuxi) released Vite 2. Since then, its adoption has grown non-stop, reaching more than 1 million npm downloads per week. A sprawling ecosystem rapidly formed after the release. Vite is powering a renewed innovation race in Web frameworks. [Nuxt 3](https://v3.nuxtjs.org/) uses Vite by default. [SvelteKit](https://kit.svelte.dev/), [Astro](https://astro.build/), [Hydrogen](https://hydrogen.shopify.dev/), and [SolidStart](https://docs.solidjs.com/start) are all built with Vite. [Laravel has now decided to use Vite by default](https://laravel.com/docs/9.x/vite). [Vite Ruby](https://vite-ruby.netlify.app/) shows how Vite can improve Rails DX. [Vitest](https://vitest.dev) is making strides as a Vite-native alternative to Jest. Vite is behind [Cypress](https://docs.cypress.io/guides/component-testing/writing-your-first-component-test) and [Playwright](https://playwright.dev/docs/test-components)'s new Component Testing features, Storybook has [Vite as an official builder](https://github.com/storybookjs/builder-vite). And [the list goes on](https://patak.dev/vite/ecosystem.html). Maintainers from most of these projects got involved in improving the Vite core itself, working closely with the Vite [team](https://vitejs.dev/team) and other contributors.
 
 ![Vite 3 Announcement Cover Image](/og-image-announcing-vite3.png)

--- a/docs/blog/announcing-vite4.md
+++ b/docs/blog/announcing-vite4.md
@@ -23,6 +23,8 @@ head:
 
 # Vite 4.0 is out!
 
+_December 9, 2022_
+
 Vite 3 [was released](./announcing-vite3.md) five months ago. npm downloads per week have gone from 1 million to 2.5 million since then. The ecosystem has matured too, and continues to grow. In this year's [Jamstack Conf survey](https://twitter.com/vite_js/status/1589665610119585793), usage among the community jumped from 14% to 32% while keeping a high 9.7 satisfaction score. We saw the stable releases of [Astro 1.0](https://astro.build/), [Nuxt 3](https://v3.nuxtjs.org/), and other Vite-powered frameworks that are innovating and collaborating: [SvelteKit](https://kit.svelte.dev/), [Solid Start](https://www.solidjs.com/blog/introducing-solidstart), [Qwik City](https://qwik.builder.io/qwikcity/overview/). Storybook announced first-class support for Vite as one of its main features for [Storybook 7.0](https://storybook.js.org/blog/first-class-vite-support-in-storybook/). Deno now [supports Vite](https://www.youtube.com/watch?v=Zjojo9wdvmY). [Vitest](https://vitest.dev) adoption is exploding, it will soon represent half of Vite's npm downloads. Nx is also investing in the ecosystem, and [officially supports Vite](https://nx.dev/packages/vite).
 
 [![Vite 4 Ecosystem](/ecosystem-vite4.png)](https://viteconf.org/2022/replay)


### PR DESCRIPTION
### Description

See https://github.com/vitejs/vite/pull/12190 for reference

Apart from the date, I added links from each announcement to the next major. I think we can continue doing so as we release the next ones.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
