### PR TITLE
feat(html): support env replacement

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -116,7 +116,7 @@ Vite also supports replacing env variables in HTML files. Any properties in `imp
 <p>Using data from %VITE_API_URL%</p>
 ```
 
-If the env doesn't exist in `import.meta.env`, e.g. `%NON_EXISTENT%`, it will be ignored and not replaced,  unlike `import.meta.env.NON_EXISTENT` in JS where it's replaced as `undefined`.
+If the env doesn't exist in `import.meta.env`, e.g. `%NON_EXISTENT%`, it will be ignored and not replaced, unlike `import.meta.env.NON_EXISTENT` in JS where it's replaced as `undefined`.
 
 ## Modes
 

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -116,6 +116,8 @@ Vite also supports replacing env variables in HTML files. Any properties in `imp
 <p>Using data from %VITE_API_URL%</p>
 ```
 
+If the env doesn't exist in `import.meta.env`, e.g. `%NON_EXISTENT%`, it will be ignored and not replaced,  unlike `import.meta.env.NON_EXISTENT` in JS where it's replaced as `undefined`.
+
 ## Modes
 
 By default, the dev server (`dev` command) runs in `development` mode and the `build` command runs in `production` mode.

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -107,6 +107,15 @@ If your code relies on types from browser environments such as [DOM](https://git
 }
 ```
 
+## HTML Env Replacement
+
+Vite also supports replacing env variables in HTML files. Any properties in `import.meta.env` can be used in HTML files with a special `%ENV_NAME%` syntax:
+
+```html
+<h1>Vite is running in %MODE%</h1>
+<p>Using data from %VITE_API_URL%</p>
+```
+
 ## Modes
 
 By default, the dev server (`dev` command) runs in `development` mode and the `build` command runs in `production` mode.

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -285,6 +285,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     config.plugins,
   )
   preHooks.unshift(preImportMapHook(config))
+  normalHooks.unshift(htmlEnvHook(config))
   postHooks.push(postImportMapHook())
   const processedHtml = new Map<string, string>()
   const isExcludedUrl = (url: string) =>
@@ -939,6 +940,26 @@ export function postImportMapHook(): IndexHtmlTransformHook {
     }
 
     return html
+  }
+}
+
+/**
+ * Support `%ENV_NAME%` syntax in html files
+ */
+export function htmlEnvHook(config: ResolvedConfig): IndexHtmlTransformHook {
+  const pattern = /%(\S+?)%/g
+  const env: Record<string, any> = { ...config.env }
+  // account for user env defines
+  for (const key in config.define) {
+    if (key.startsWith(`import.meta.env.`)) {
+      const val = config.define[key]
+      env[key.slice(16)] = typeof val === 'string' ? val : JSON.stringify(val)
+    }
+  }
+  return (html) => {
+    return html.replace(pattern, (text, key) => {
+      return key in env ? env[key] : text
+    })
   }
 }
 

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -11,6 +11,7 @@ import {
   assetAttrsConfig,
   getAttrKey,
   getScriptInfo,
+  htmlEnvHook,
   nodeIsElement,
   overwriteAttrValue,
   postImportMapHook,
@@ -51,6 +52,7 @@ export function createDevHtmlTransformFn(
       [
         preImportMapHook(server.config),
         ...preHooks,
+        htmlEnvHook(server.config),
         devHtmlHook,
         ...normalHooks,
         ...postHooks,

--- a/playground/html/.env
+++ b/playground/html/.env
@@ -1,0 +1,1 @@
+VITE_FOO=bar

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -262,6 +262,20 @@ describe('Valid HTML', () => {
   })
 })
 
+describe('env', () => {
+  beforeAll(async () => {
+    await page.goto(viteTestUrl + '/env.html')
+  })
+
+  test('env works', async () => {
+    expect(await page.textContent('.env')).toBe('bar')
+    expect(await page.textContent('.env-define')).toBe('5173')
+    expect(await page.textContent('.env-bar')).toBeTruthy()
+    expect(await page.textContent('.env-prod')).toBe(isBuild + '')
+    expect(await page.textContent('.env-dev')).toBe(isServe + '')
+  })
+})
+
 describe('importmap', () => {
   beforeAll(async () => {
     await page.goto(viteTestUrl + '/importmapOrder.html')

--- a/playground/html/env.html
+++ b/playground/html/env.html
@@ -1,0 +1,5 @@
+<p class="env">%VITE_FOO%</p>
+<p class="env-define">%VITE_NUMBER%</p>
+<p class="env-%VITE_FOO%">class name should be env-bar</p>
+<p class="env-prod">%PROD%</p>
+<p class="env-dev">%DEV%</p>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -33,6 +33,10 @@ module.exports = {
     },
   },
 
+  define: {
+    'import.meta.env.VITE_NUMBER': 5173,
+  },
+
   plugins: [
     {
       name: 'pre-transform',

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -29,6 +29,7 @@ module.exports = {
         linkProps: resolve(__dirname, 'link-props/index.html'),
         valid: resolve(__dirname, 'valid.html'),
         importmapOrder: resolve(__dirname, 'importmapOrder.html'),
+        env: resolve(__dirname, 'env.html'),
       },
     },
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Support `%ENV_NAME%` syntax in HTML files. Close https://github.com/vitejs/vite/issues/3105

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
1. I made it a pre-hook for `transformIndexHtml` as otherwise normal-hook transforms like `vite-plugin-html` may get a parse error.
2. It also supports `%MODE%`, `%PROD%`, etc, which are a little short, but maybe that's fine.
3. It doesn't support `%SSR%` as I don't think it makes sense in HTML files.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
