### PR TITLE
feat(css): add support for injecting css into custom elements

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -243,6 +243,26 @@ export default defineConfig({
 })
 ```
 
+## css.inject
+
+- **Type:** `string | ((node: Element) => void)`
+
+A (stringified) function with the signature `(node: Element) => void` that is used to inject CSS style tags when importing CSS in JS.
+
+If passed a function it will be stringified and can therefore not rely on any variables on the outer scopes.
+
+Note this does not affect `<link >` tags added to `index.html`.
+
+```js
+export default defineConfig({
+  css: {
+    inject: (node) => {
+      document.body.querySelector('custom-element').shadowRoot.appendChild(node)
+    },
+  },
+})
+```
+
 ## css.devSourcemap
 
 - **Experimental**

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -337,7 +337,12 @@ const sheetsMap = new Map<string, HTMLStyleElement>()
 // because after build it will be a single css file
 let lastInsertedStyle: HTMLStyleElement | undefined
 
-export function updateStyle(id: string, content: string): void {
+export function updateStyle(
+  id: string,
+  content: string,
+  inject?: (style: HTMLStyleElement) => void,
+): void {
+  console.log('updateStyle', id, content)
   let style = sheetsMap.get(id)
   if (!style) {
     style = document.createElement('style')
@@ -346,7 +351,11 @@ export function updateStyle(id: string, content: string): void {
     style.textContent = content
 
     if (!lastInsertedStyle) {
-      document.head.appendChild(style)
+      if (inject) {
+        inject(style)
+      } else {
+        document.head.appendChild(style)
+      }
 
       // reset lastInsertedStyle after async
       // because dynamically imported css will be splitted into a different file
@@ -366,7 +375,7 @@ export function updateStyle(id: string, content: string): void {
 export function removeStyle(id: string): void {
   const style = sheetsMap.get(id)
   if (style) {
-    document.head.removeChild(style)
+    style.remove()
     sheetsMap.delete(id)
   }
 }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -86,6 +86,13 @@ export interface CSSOptions {
    * @experimental
    */
   devSourcemap?: boolean
+  /**
+   * Stringified function with the signature `(node: Element) => void`
+   * that is used to inject stylesheets.
+   *
+   * By default styles are appended to the document.head.
+   */
+  inject?: string | ((node: Element) => void)
 }
 
 export interface CSSModulesOptions {
@@ -401,7 +408,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           )}`,
           `const __vite__id = ${JSON.stringify(id)}`,
           `const __vite__css = ${JSON.stringify(cssContent)}`,
-          `__vite__updateStyle(__vite__id, __vite__css)`,
+          `const __vite__inject_css = ${config.css?.inject}`,
+          `__vite__updateStyle(__vite__id, __vite__css, __vite__inject_css)`,
           // css modules exports change on edit so it can't self accept
           `${
             modulesCode ||

--- a/playground/css-inject/__tests__/css-inject.spec.ts
+++ b/playground/css-inject/__tests__/css-inject.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+import { editFile, getColor, page, untilUpdated } from '~utils'
+
+test('css inject', async () => {
+  const linkedOutside = await page.$('.linked.outside')
+  const linkedInside = await page.$('.linked.inside')
+  const importedOutside = await page.$('.imported.outside')
+  const importedInside = await page.$('.imported.inside')
+
+  expect(await getColor(linkedOutside)).toBe('red')
+  expect(await getColor(linkedInside)).toBe('black')
+  expect(await getColor(importedOutside)).toBe('black')
+  expect(await getColor(importedInside)).toBe('red')
+
+  editFile('linked.css', (code) => code.replace('color: red', 'color: blue'))
+
+  await untilUpdated(() => getColor(linkedOutside), 'blue')
+  expect(await getColor(linkedInside)).toBe('black')
+
+  editFile('imported.css', (code) => code.replace('color: red', 'color: blue'))
+
+  await untilUpdated(() => getColor(importedInside), 'blue')
+  expect(await getColor(importedOutside)).toBe('black')
+})

--- a/playground/css-inject/imported.css
+++ b/playground/css-inject/imported.css
@@ -1,0 +1,3 @@
+.imported {
+  color: red;
+}

--- a/playground/css-inject/index.html
+++ b/playground/css-inject/index.html
@@ -1,0 +1,37 @@
+<script></script>
+<link rel="stylesheet" href="./linked.css" />
+
+<div class="wrapper">
+  <h1>CSS Inject</h1>
+
+  <p class="linked outside">&lt;linked&gt;</p>
+
+  <p class="imported outside">&lt;imported&gt;</p>
+
+  <custom-element></custom-element>
+</div>
+
+<script type="module">
+  customElements.define(
+    'custom-element',
+    class CustomElement extends HTMLElement {
+      constructor() {
+        super()
+        console.log('ctor')
+        this.attachShadow({ mode: 'open' })
+      }
+
+      connectedCallback() {
+        console.log('connected')
+
+        this.shadowRoot.innerHTML = `
+<p class="linked inside">&lt;linked&gt;</p>
+
+<p class="imported inside">&lt;imported&gt;</p>
+`
+
+        import('./imported.css')
+      }
+    },
+  )
+</script>

--- a/playground/css-inject/linked.css
+++ b/playground/css-inject/linked.css
@@ -1,0 +1,3 @@
+.linked {
+  color: red;
+}

--- a/playground/css-inject/package.json
+++ b/playground/css-inject/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitejs/test-css-sourcemap",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  }
+}

--- a/playground/css-inject/vite.config.js
+++ b/playground/css-inject/vite.config.js
@@ -1,0 +1,19 @@
+/**
+ * @type {import('vite').UserConfig}
+ */
+module.exports = {
+  resolve: {
+    alias: {
+      '@': __dirname,
+    },
+  },
+  css: {
+    devSourcemap: true,
+    inject: (node) => {
+      document.body.querySelector('custom-element').shadowRoot.appendChild(node)
+    },
+  },
+  build: {
+    sourcemap: true,
+  },
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Add support to inject CSS style tags into custom elements.

This is based on #4821

Closes: #4821 

### Additional context

In our microfrontend framework we're rendering our apps into custom elements. In order to migrate from webpack to vite we need a mechanism similar to style-loader's insert option (https://webpack.js.org/loaders/style-loader/#insert) to inject styles into these custom elements.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
  - There is (#4821) but it seems abandoned
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
