### PR TITLE
fix(server): set host name to 127.0.0.1 when listen on all IPs 

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -839,11 +839,13 @@ export async function resolveHostname(
   // Set host name to localhost when possible
   let name = host === undefined || wildcardHosts.has(host) ? 'localhost' : host
 
-  if (host === 'localhost') {
+  if (host === 'localhost' || host === undefined) {
     // See #8647 for more details.
     const localhostAddr = await getLocalhostAddressIfDiffersFromDNS()
     if (localhostAddr) {
-      name = localhostAddr
+      name = host ? localhostAddr : name
+    } else {
+      name = host ? name : '127.0.0.1'
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #12205 

When `localhost`(`vite dev`) is listening on port 5173, it's possible for `127.0.0.1`(`vite dev --host`) to listen on port 5173 again.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
