### PR TITLE
fix(server): use --host duplicate port number (#12205)

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -217,11 +217,6 @@ async function findAvailablePort(
     })
     server.on('error', async (err: NodeJS.ErrnoException) => {
       resolve(port)
-      // if (err.code === 'ECONNREFUSED') {
-      //   resolve(port)
-      // } else {
-      //   resolve(port)
-      // }
     })
   })
 }

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -198,7 +198,7 @@ export function setClientErrorHandler(
 async function findAvailablePort(
   port: number,
   logger: Logger,
-  host = '0.0.0.0',
+  host?: string,
   strictPort?: boolean,
 ): Promise<number> {
   return new Promise((resolve, reject) => {

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -195,6 +195,9 @@ export function setClientErrorHandler(
   })
 }
 
+/**
+ * Try to establish a tcp connection to find an available port
+ */
 async function findAvailablePort(
   port: number,
   logger: Logger,
@@ -204,6 +207,7 @@ async function findAvailablePort(
   return new Promise((resolve, reject) => {
     if (port > 65535) {
       reject(new Error('Port not found'))
+      return
     }
     const server = net.connect(port, host)
     server.on('connect', async () => {

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -214,6 +214,9 @@ async function findAvailablePort(
         const _port = await findAvailablePort(++port, logger, host, strictPort)
         resolve(_port)
       }
+      if (!server.closed) {
+        server.end()
+      }
     })
     server.on('error', async (err: NodeJS.ErrnoException) => {
       resolve(port)


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/12205
fix https://github.com/vitejs/vite/issues/12144
superseds close #10651
close https://github.com/vitejs/vite/issues/10638

When localhost(vite dev) is listening on port 5173, it's possible for 127.0.0.1(vite dev --host) to listen on port 5173 again.

### Additional context

Re: https://github.com/vitejs/vite/pull/12208


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
