### PR TITLE
build: correct d.ts output dir in development

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -62,7 +62,7 @@ const sharedNodeOptions = defineConfig({
     tryCatchDeoptimization: false,
   },
   output: {
-    dir: path.resolve(__dirname, 'dist'),
+    dir: './dist',
     entryFileNames: `node/[name].js`,
     chunkFileNames: 'node/chunks/dep-[hash].js',
     exports: 'named',
@@ -169,7 +169,7 @@ function createNodeConfig(isProduction: boolean) {
       !isProduction,
       // in production we use api-extractor for dts generation
       // in development we need to rely on the rollup ts plugin
-      isProduction ? false : path.resolve(__dirname, 'dist/node'),
+      isProduction ? false : './dist/node',
     ),
   })
 }
@@ -181,7 +181,7 @@ function createCjsConfig(isProduction: boolean) {
       publicUtils: path.resolve(__dirname, 'src/node/publicUtils.ts'),
     },
     output: {
-      dir: path.resolve(__dirname, 'dist'),
+      dir: './dist',
       entryFileNames: `node-cjs/[name].cjs`,
       chunkFileNames: 'node-cjs/chunks/dep-[hash].js',
       exports: 'named',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In dev mode for vite, d.ts is generated to `dist/dist/node` which is not correct.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/12322740/221429767-91100adf-73d7-491d-9a28-09d22c112f8a.png">

While `package.json` is write as https://github.com/vitejs/vite/blob/2aad5522dcd30050ef049170825287dfa0d0aa42/packages/vite/package.json#L20-L31

So no `d.ts` could be found in dev mode.

Change the abs path to a relative path to correct the output behavior. I haven't quite figured out the logic here https://github.com/rollup/plugins/blob/bc5cf91a042b88e14a1da9ba25f501d92591ca8a/packages/typescript/src/index.ts#L152-L182. But seems like it's more conventional to use a relative path as `output.dir`. So I changed it to relative path and everything goes well now. 😅 

<img width="309" alt="image" src="https://user-images.githubusercontent.com/12322740/221430110-51bf3d6f-97fd-4745-bc32-ceb60394fde2.png">



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
