### PR TITLE
chore: add plugin-legacy override to codeflow config

### DIFF
--- a/.stackblitz/codeflow.json
+++ b/.stackblitz/codeflow.json
@@ -1,7 +1,8 @@
 {
   "pnpm": {
     "overrides": {
-      "vite": "./packages/vite"
+      "vite": "./packages/vite",
+      "@vitejs/plugin-legacy": "./packages/plugin-legacy"
     }
   }
 }


### PR DESCRIPTION
### Description

Configure Codeflow so plugin-legacy also gets an override. This will add the override to every reproduction and for most of them it won't be used, but I think it is still better to have it in case someone adds plugin-legacy to try something in the repro and to cover the small percentage of issues that needs this override.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other