### PR TITLE
ci: allow collaborators to trigger ecosystem-ci

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -15,22 +15,19 @@ jobs:
             const user = context.payload.sender.login
             console.log(`Validate user: ${user}`)
 
-            const allowedUsers = new Set([
-              'yyx990803',
-              'patak-dev',
-              'antfu',
-              'sodatea',
-              'Shinigami92',
-              'aleclarson',
-              'bluwy',
-              'poyoho',
-              'sapphi-red',
-              'ygj6',
-              'Niputi',
-              'dominikg'
-            ])
+            let hasTriagePermission = false
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: user,
+              });
+              hasTriagePermission = data.user.permissions.triage
+            } catch (e) {
+              console.warn(e)
+            }
 
-            if (allowedUsers.has(user)) {
+            if (hasTriagePermission) {
               console.log('Allowed')
               await github.rest.reactions.createForIssueComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
### Description
This would allow everyone that has triage permission of this repo to trigger ecosystem-ci by comment.

https://github.com/vitejs/vite/pull/12079#issuecomment-1445028450

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
