### PR TITLE
fix: avoid null sourcePath in `server.sourcemapIgnoreList`

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -277,6 +277,7 @@ async function loadAndTransform(
       ++sourcesIndex
     ) {
       const sourcePath = map.sources[sourcesIndex]
+      if (!sourcePath) continue
 
       const sourcemapPath = `${mod.file}.map`
       const ignoreList = config.server.sourcemapIgnoreList(
@@ -298,11 +299,7 @@ async function loadAndTransform(
       // Rewrite sources to relative paths to give debuggers the chance
       // to resolve and display them in a meaningful way (rather than
       // with absolute paths).
-      if (
-        sourcePath &&
-        path.isAbsolute(sourcePath) &&
-        path.isAbsolute(mod.file)
-      ) {
+      if (path.isAbsolute(sourcePath) && path.isAbsolute(mod.file)) {
         map.sources[sourcesIndex] = path.relative(
           path.dirname(mod.file),
           sourcePath,


### PR DESCRIPTION
### Description

Add missing guard against `null` `sourcePath` after:
- https://github.com/vitejs/vite/pull/12174

Fixes https://github.com/vitejs/vite-ecosystem-ci/actions/runs/4305319550/jobs/7507588927

cc @danielroe @bmeurer 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other