### PR TITLE
fix: unique dep optimizer temp folders

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs'
+import { stat as fsStat, readdir } from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import _debug from 'debug'
@@ -864,7 +865,10 @@ export function getDepsCacheDir(config: ResolvedConfig, ssr: boolean): string {
 
 function getProcessingDepsCacheDir(config: ResolvedConfig, ssr: boolean) {
   return (
-    getDepsCacheDirPrefix(config) + getDepsCacheSuffix(config, ssr) + '_temp'
+    getDepsCacheDirPrefix(config) +
+    getDepsCacheSuffix(config, ssr) +
+    '_temp_' +
+    getHash(Date.now().toString())
   )
 }
 
@@ -1231,4 +1235,27 @@ export async function optimizedDepNeedsInterop(
     )
   }
   return depInfo?.needsInterop
+}
+
+const MAX_TEMP_FOLDER_AGE_MS = 24 * 60 * 60 * 1000
+export async function cleanupTemporalDepsCache(
+  config: ResolvedConfig,
+): Promise<void> {
+  try {
+    const cacheDir = path.resolve(config.cacheDir)
+    if (fs.existsSync(cacheDir)) {
+      const dirents = await readdir(cacheDir, { withFileTypes: true })
+      for (const dirent of dirents) {
+        if (dirent.isDirectory() && dirent.name.includes('_temp_')) {
+          const tempDirPath = path.resolve(config.cacheDir, dirent.name)
+          const { mtime } = await fsStat(tempDirPath)
+          if (Date.now() - mtime.getTime() > MAX_TEMP_FOLDER_AGE_MS) {
+            await removeDir(tempDirPath)
+          }
+        }
+      }
+    }
+  } catch (err) {
+    config.logger.error(err)
+  }
 }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs'
-import { stat as fsStat, readdir } from 'node:fs/promises'
+import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import _debug from 'debug'
@@ -1237,19 +1237,19 @@ export async function optimizedDepNeedsInterop(
   return depInfo?.needsInterop
 }
 
-const MAX_TEMP_FOLDER_AGE_MS = 24 * 60 * 60 * 1000
-export async function cleanupTemporalDepsCache(
+const MAX_TEMP_DIR_AGE_MS = 24 * 60 * 60 * 1000
+export async function cleanupDepsCacheStaleDirs(
   config: ResolvedConfig,
 ): Promise<void> {
   try {
     const cacheDir = path.resolve(config.cacheDir)
     if (fs.existsSync(cacheDir)) {
-      const dirents = await readdir(cacheDir, { withFileTypes: true })
+      const dirents = await fsp.readdir(cacheDir, { withFileTypes: true })
       for (const dirent of dirents) {
         if (dirent.isDirectory() && dirent.name.includes('_temp_')) {
           const tempDirPath = path.resolve(config.cacheDir, dirent.name)
-          const { mtime } = await fsStat(tempDirPath)
-          if (Date.now() - mtime.getTime() > MAX_TEMP_FOLDER_AGE_MS) {
+          const { mtime } = await fsp.stat(tempDirPath)
+          if (Date.now() - mtime.getTime() > MAX_TEMP_DIR_AGE_MS) {
             await removeDir(tempDirPath)
           }
         }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -34,7 +34,7 @@ import { cjsSsrResolveExternals } from '../ssr/ssrExternal'
 import { ssrFixStacktrace, ssrRewriteStacktrace } from '../ssr/ssrStacktrace'
 import { ssrTransform } from '../ssr/ssrTransform'
 import {
-  cleanupTemporalDepsCache,
+  cleanupDepsCacheStaleDirs,
   getDepsOptimizer,
   initDepsOptimizer,
   initDevSsrDepsOptimizer,
@@ -691,9 +691,9 @@ export async function createServer(
     await initServer()
   }
 
-  // Fire a clean up of old temp cache folders, in case old processes didn't
+  // Fire a clean up of stale cache dirs, in case old processes didn't
   // terminate correctly. Don't await this promise
-  cleanupTemporalDepsCache(config)
+  cleanupDepsCacheStaleDirs(config)
 
   return server
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -34,6 +34,7 @@ import { cjsSsrResolveExternals } from '../ssr/ssrExternal'
 import { ssrFixStacktrace, ssrRewriteStacktrace } from '../ssr/ssrStacktrace'
 import { ssrTransform } from '../ssr/ssrTransform'
 import {
+  cleanupTemporalDepsCache,
   getDepsOptimizer,
   initDepsOptimizer,
   initDevSsrDepsOptimizer,
@@ -689,6 +690,10 @@ export async function createServer(
   } else {
     await initServer()
   }
+
+  // Fire a clean up of old temp cache folders, in case old processes didn't
+  // terminate correctly. Don't await this promise
+  cleanupTemporalDepsCache(config)
 
   return server
 }


### PR DESCRIPTION
### Description

Potential fix for https://github.com/vitejs/vite/issues/9986

Temporal folders that weren't properly deleted (because of a process terminating in the middle of an optimization run for example) are cleaned if they are older than one day when the server starts as suggested by @benmccann

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other