### PR TITLE
fix: print urls when dns order change

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -822,12 +822,11 @@ async function restartServer(server: ViteDevServer) {
   } = server.config
   if (!middlewareMode) {
     await server.listen(port, true)
-    const dnsOrderChange = diffDnsOrderChange(oldUrls, newServer.resolvedUrls)
     logger.info('server restarted.', { timestamp: true })
     if (
       (port ?? DEFAULT_DEV_PORT) !== (prevPort ?? DEFAULT_DEV_PORT) ||
       host !== prevHost ||
-      dnsOrderChange
+      diffDnsOrderChange(oldUrls, newServer.resolvedUrls)
     ) {
       logger.info('')
       server.printUrls()

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -819,37 +819,11 @@ export function diffDnsOrderChange(
   oldUrls: ViteDevServer['resolvedUrls'],
   newUrls: ViteDevServer['resolvedUrls'],
 ): boolean {
-  if (oldUrls && newUrls) {
-    const { local: oldLocal, network: oldNetwork } = oldUrls
-    const { local: newLocal, network: newNetwork } = newUrls
-    const localChange = oldLocal.length !== newLocal.length
-    const networkChange = oldNetwork.length !== newNetwork.length
-    if (!localChange) {
-      for (let i = 0; i < oldLocal.length; i++) {
-        if (oldLocal[i] !== newLocal[i]) {
-          return true
-        }
-      }
-    }
-    if (!networkChange) {
-      for (let i = 0; i < oldNetwork.length; i++) {
-        if (oldNetwork[i] !== newNetwork[i]) {
-          return true
-        }
-      }
-    }
-    return localChange || networkChange
-  }
-  if (!oldUrls && !newUrls) {
-    return false
-  }
-  if (oldUrls && !newUrls) {
-    return true
-  }
-  if (!oldUrls && newUrls) {
-    return true
-  }
-  return false
+  return !(
+    oldUrls === newUrls ||
+    (arrayEqual(oldUrls?.local || [], newUrls?.local || []) &&
+      arrayEqual(oldUrls?.network || [], newUrls?.network || []))
+  )
 }
 
 export interface Hostname {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -33,7 +33,7 @@ import {
 } from './constants'
 import type { DepOptimizationConfig } from './optimizer'
 import type { ResolvedConfig } from './config'
-import type { ResolvedServerUrls } from './server'
+import type { ResolvedServerUrls, ViteDevServer } from './server'
 import type { CommonServerOptions } from '.'
 
 /**
@@ -813,6 +813,43 @@ export async function getLocalhostAddressIfDiffersFromDNS(): Promise<
     nodeResult.family === dnsResult.family &&
     nodeResult.address === dnsResult.address
   return isSame ? undefined : nodeResult.address
+}
+
+export function diffDnsOrderChange(
+  oldUrls: ViteDevServer['resolvedUrls'],
+  newUrls: ViteDevServer['resolvedUrls'],
+): boolean {
+  if (oldUrls && newUrls) {
+    const { local: oldLocal, network: oldNetwork } = oldUrls
+    const { local: newLocal, network: newNetwork } = newUrls
+    const localChange = oldLocal.length !== newLocal.length
+    const networkChange = oldNetwork.length !== newNetwork.length
+    if (!localChange) {
+      for (let i = 0; i < oldLocal.length; i++) {
+        if (oldLocal[i] !== newLocal[i]) {
+          return true
+        }
+      }
+    }
+    if (!networkChange) {
+      for (let i = 0; i < oldNetwork.length; i++) {
+        if (oldNetwork[i] !== newNetwork[i]) {
+          return true
+        }
+      }
+    }
+    return localChange || networkChange
+  }
+  if (!oldUrls && !newUrls) {
+    return false
+  }
+  if (oldUrls && !newUrls) {
+    return true
+  }
+  if (!oldUrls && newUrls) {
+    return true
+  }
+  return false
 }
 
 export interface Hostname {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -821,8 +821,10 @@ export function diffDnsOrderChange(
 ): boolean {
   return !(
     oldUrls === newUrls ||
-    (arrayEqual(oldUrls?.local || [], newUrls?.local || []) &&
-      arrayEqual(oldUrls?.network || [], newUrls?.network || []))
+    (oldUrls &&
+      newUrls &&
+      arrayEqual(oldUrls.local, newUrls.local) &&
+      arrayEqual(oldUrls.network, newUrls.network))
   )
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When I start a service, the terminal output is as follows: 
![image](https://user-images.githubusercontent.com/24516654/222354889-4929516b-a6c8-4afb-803c-4cebf45b7805.png)

When I added the configuration `dns.setDefaultResultOrder('verbatim')`, `Local` became `http://localhost:5173/` at this time, but the terminal did not print.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
