### PR TITLE
fix: configure proxy before subscribing to error events

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -47,6 +47,10 @@ export function proxyMiddleware(
     }
     const proxy = httpProxy.createProxyServer(opts) as HttpProxy.Server
 
+    if (opts.configure) {
+      opts.configure(proxy, opts)
+    }
+
     proxy.on('error', (err, req, originalRes) => {
       // When it is ws proxy, res is net.Socket
       const res = originalRes as http.ServerResponse | net.Socket
@@ -75,10 +79,6 @@ export function proxyMiddleware(
         res.end()
       }
     })
-
-    if (opts.configure) {
-      opts.configure(proxy, opts)
-    }
     // clone before saving because http-proxy mutates the options
     proxies[context] = [proxy, { ...opts }]
   })


### PR DESCRIPTION
### Description

Currently, user proxy configuration is actioned after vite subscribes to proxy errors. This means that users cannot provide a custom response when there are proxy errors.

Vite doesn't return a body when responding when an error occurs.

I would like to be able to customize that

Currently, the below doesn't work, as my error handler subscribes after Vite's error handler:

```javascript
export default defineConfig({
  plugins: [react(), tsconfigPaths()],
  server: {
    port: 3000,
    proxy: {
      '/api': {
        target: 'http://0.0.0.0:8000/',
        changeOrigin: true,
        configure: (proxy) => {
          proxy.on('error', (err, req, res, target) => {
            const hostname = req?.headers?.host;
            const requestHref = `${hostname}${req?.url}`;
            const targetHref = `${target?.href}`;
            if (!res.headersSent && !res.writableEnded) {
              res.writeHead(500, {
                'Content-Type': 'text/plain',
              });
              res.end(
                [
                  `Error occurred while proxying request ${requestHref} to ${targetHref} [${
                    err.code || err
                  }]`,
                  `(https://nodejs.org/api/errors.html#errors_common_system_errors).\n`,
                  `Are you sure you're running the API on ${targetHref}?`,
                  `Did you forget to start the Docker container?`,
                ].join(' ')
              );
            }
          });
        },
      },
    },
  },
  test: {
    globals: true,
    environment: 'jsdom',
    css: true,
  },
});
```

This PR changes when Vite subscribes to proxy errors so that users can handle the errors themselves if they wish.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.