### PR TITLE
fix(optimizer): don not call context.rebuild after cancel

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -461,6 +461,8 @@ export function runOptimizeDeps(
   cancel: () => Promise<void>
   result: Promise<DepOptimizationResult>
 } {
+  const optimizerContext = { cancelled: false }
+
   const config: ResolvedConfig = {
     ...resolvedConfig,
     command: 'build',
@@ -536,9 +538,20 @@ export function runOptimizeDeps(
     depsInfo,
     ssr,
     processingCacheDir,
+    optimizerContext,
   )
 
   const result = preparedRun.then(({ context, idToExports }) => {
+    function disposeContext() {
+      return context?.dispose().catch((e) => {
+        config.logger.error('error happed during context.dispose', e)
+      })
+    }
+    if (!context || optimizerContext.cancelled) {
+      disposeContext()
+      return createProcessingResult()
+    }
+
     return context
       .rebuild()
       .then((result) => {
@@ -613,9 +626,7 @@ export function runOptimizeDeps(
         return createProcessingResult()
       })
       .finally(() => {
-        return context.dispose().catch((e) => {
-          config.logger.error('error happed during context.dispose', e)
-        })
+        return disposeContext()
       })
   })
 
@@ -625,8 +636,9 @@ export function runOptimizeDeps(
 
   return {
     async cancel() {
+      optimizerContext.cancelled = true
       const { context } = await preparedRun
-      await context.cancel()
+      await context?.cancel()
       cleanUp()
     },
     result,
@@ -638,8 +650,9 @@ async function prepareEsbuildOptimizerRun(
   depsInfo: Record<string, OptimizedDepInfo>,
   ssr: boolean,
   processingCacheDir: string,
+  optimizerContext: { cancelled: boolean },
 ): Promise<{
-  context: BuildContext
+  context?: BuildContext
   idToExports: Record<string, ExportsData>
 }> {
   const isBuild = resolvedConfig.command === 'build'
@@ -680,6 +693,8 @@ async function prepareEsbuildOptimizerRun(
     idToExports[id] = exportsData
     flatIdToExports[flatId] = exportsData
   }
+
+  if (optimizerContext.cancelled) return { context: undefined, idToExports }
 
   // esbuild automatically replaces process.env.NODE_ENV for platform 'browser'
   // In lib mode, we need to keep process.env.NODE_ENV untouched, so to at build

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -544,7 +544,7 @@ export function runOptimizeDeps(
   const result = preparedRun.then(({ context, idToExports }) => {
     function disposeContext() {
       return context?.dispose().catch((e) => {
-        config.logger.error('error happed during context.dispose', e)
+        config.logger.error('Failed to dispose esbuild context', { error: e })
       })
     }
     if (!context || optimizerContext.cancelled) {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -61,6 +61,8 @@ export function scanImports(config: ResolvedConfig): {
   const missing: Record<string, string> = {}
   let entries: string[]
 
+  const scanContext = { cancelled: false }
+
   const esbuildContext: Promise<BuildContext | undefined> = computeEntries(
     config,
   ).then((computedEntries) => {
@@ -78,14 +80,21 @@ export function scanImports(config: ResolvedConfig): {
       }
       return
     }
+    if (scanContext.cancelled) return
 
     debug(`Crawling dependencies using entries:\n  ${entries.join('\n  ')}`)
-    return prepareEsbuildScanner(config, entries, deps, missing)
+    return prepareEsbuildScanner(config, entries, deps, missing, scanContext)
   })
 
   const result = esbuildContext
     .then((context) => {
-      if (!context) {
+      function disposeContext() {
+        return context?.dispose().catch((e) => {
+          config.logger.error('error happed during context.dispose', e)
+        })
+      }
+      if (!context || scanContext?.cancelled) {
+        disposeContext()
         return { deps: {}, missing: {} }
       }
       return context
@@ -98,9 +107,7 @@ export function scanImports(config: ResolvedConfig): {
           }
         })
         .finally(() => {
-          return context.dispose().catch((e) => {
-            config.logger.error('error happed during context.dispose', e)
-          })
+          return disposeContext()
         })
     })
     .catch(async (e) => {
@@ -128,7 +135,10 @@ export function scanImports(config: ResolvedConfig): {
     })
 
   return {
-    cancel: () => esbuildContext.then((context) => context?.cancel()),
+    cancel: async () => {
+      scanContext.cancelled = true
+      return esbuildContext.then((context) => context?.cancel())
+    },
     result,
   }
 }
@@ -170,8 +180,12 @@ async function prepareEsbuildScanner(
   entries: string[],
   deps: Record<string, string>,
   missing: Record<string, string>,
-) {
+  scanContext?: { cancelled: boolean },
+): Promise<BuildContext | undefined> {
   const container = await createPluginContainer(config)
+
+  if (scanContext?.cancelled) return
+
   const plugin = esbuildScanPlugin(config, container, deps, missing, entries)
 
   const { plugins = [], ...esbuildOptions } =

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -90,7 +90,7 @@ export function scanImports(config: ResolvedConfig): {
     .then((context) => {
       function disposeContext() {
         return context?.dispose().catch((e) => {
-          config.logger.error('error happed during context.dispose', e)
+          config.logger.error('Failed to dispose esbuild context', { error: e })
         })
       }
       if (!context || scanContext?.cancelled) {


### PR DESCRIPTION
### Description

Bail out earlier in `scanImports` and `optimizeDeps` if the process was cancelled.

Possible fix for https://github.com/vitejs/vite-ecosystem-ci/actions/runs/4305319550/jobs/7507584043

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other