### PR TITLE
fix: use relative source path in sourcemapIgnoreList

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -321,19 +321,19 @@ export default defineConfig({
 
 ## server.sourcemapIgnoreList
 
-- **Type:** `false | (sourcePath: string, sourcemapPath: string) => boolean`
-- **Default:** `(sourcePath) => sourcePath.includes('node_modules')`
+- **Type:** `false | (relativeSourcePath: string, sourcemapPath: string) => boolean`
+- **Default:** `(relativeSourcePath) => relativeSourcePath.includes('node_modules')`
 
 Whether or not to ignore source files in the server sourcemap, used to populate the [`x_google_ignoreList` source map extension](https://developer.chrome.com/blog/devtools-better-angular-debugging/#the-x_google_ignorelist-source-map-extension).
 
-By default, it excludes all paths containing `node_modules`. You can pass `false` to disable this behavior, or, for full control, a function that takes the source path and sourcemap path and returns whether to ignore the source path.
+By default, it excludes all paths containing `node_modules`. You can pass `false` to disable this behavior, or, for full control, a function that takes the relative source path and sourcemap path and returns whether to ignore the source path.
 
 ```js
 export default defineConfig({
   server: {
     // This is the default value, and will add all files with node_modules in their paths
     // to the ignore list.
-    sourcemapIgnoreList: (sourcePath, sourcemapPath) => sourcePath.includes('node_modules')
+    sourcemapIgnoreList: (relativeSourcePath, sourcemapPath) => relativeSourcePath.includes('node_modules')
   }
 };
 ```

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -126,7 +126,7 @@ export interface ServerOptions extends CommonServerOptions {
    */
   sourcemapIgnoreList?:
     | false
-    | ((sourcePath: string, sourcemapPath: string) => boolean)
+    | ((relativeSourcePath: string, sourcemapPath: string) => boolean)
   /**
    * Force dep pre-optimization regardless of whether deps have changed.
    *
@@ -771,7 +771,7 @@ export function resolveServerOptions(
       raw?.sourcemapIgnoreList === false
         ? () => false
         : raw?.sourcemapIgnoreList ||
-          ((sourcePath) => sourcePath.includes('node_modules')),
+          ((relativeSourcePath) => relativeSourcePath.includes('node_modules')),
     middlewareMode: !!raw?.middlewareMode,
   }
   let allowDirs = server.fs?.allow

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -276,8 +276,18 @@ async function loadAndTransform(
       sourcesIndex < map.sources.length;
       ++sourcesIndex
     ) {
-      const sourcePath = map.sources[sourcesIndex]
+      let sourcePath = map.sources[sourcesIndex]
       if (!sourcePath) continue
+
+      // Rewrite sources to relative paths to give debuggers the chance
+      // to resolve and display them in a meaningful way (rather than
+      // with absolute paths).
+      if (path.isAbsolute(sourcePath) && path.isAbsolute(mod.file)) {
+        sourcePath = map.sources[sourcesIndex] = path.relative(
+          path.dirname(mod.file),
+          sourcePath,
+        )
+      }
 
       const sourcemapPath = `${mod.file}.map`
       const ignoreList = config.server.sourcemapIgnoreList(
@@ -294,16 +304,6 @@ async function loadAndTransform(
         if (!map.x_google_ignoreList.includes(sourcesIndex)) {
           map.x_google_ignoreList.push(sourcesIndex)
         }
-      }
-
-      // Rewrite sources to relative paths to give debuggers the chance
-      // to resolve and display them in a meaningful way (rather than
-      // with absolute paths).
-      if (path.isAbsolute(sourcePath) && path.isAbsolute(mod.file)) {
-        map.sources[sourcesIndex] = path.relative(
-          path.dirname(mod.file),
-          sourcePath,
-        )
       }
     }
   }


### PR DESCRIPTION
### Description

Context https://github.com/vitejs/vite/pull/12251#discussion_r1123497402

Calls to `sourcemapIgnoreList` for `vite dev` on a create-vite vue ts app after this change
```
sourcePath: overlay.ts
sourcemapPath: /Users/patak/vite-work/packages/vite/dist/client/client.mjs.map

sourcePath: client.ts
sourcemapPath: /Users/patak/vite-work/packages/vite/dist/client/client.mjs.map

sourcePath: main.ts
sourcemapPath: /Users/patak/test/sourcemap-test/src/main.ts.map

sourcePath: env.ts
sourcemapPath: /Users/patak/vite-work/packages/vite/dist/client/env.mjs.map

sourcePath: App.vue
sourcemapPath: /Users/patak/test/sourcemap-test/src/App.vue.map

sourcePath: HelloWorld.vue
sourcemapPath: /Users/patak/test/sourcemap-test/src/components/HelloWorld.vue.map
```

cc @bmeurer @danielroe @bluwy 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other