### PR TITLE
feat: add config.operation

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -223,7 +223,7 @@ describe('preview config', () => {
     const config: InlineConfig = {
       server: serverConfig(),
     }
-    expect(await resolveConfig(config, 'serve')).toMatchObject({
+    expect(await resolveConfig(config, 'serve', 'preview')).toMatchObject({
       preview: {
         ...serverConfig(),
         port: undefined,
@@ -238,7 +238,7 @@ describe('preview config', () => {
         port: 3006,
       },
     }
-    expect(await resolveConfig(config, 'serve')).toMatchObject({
+    expect(await resolveConfig(config, 'serve', 'preview')).toMatchObject({
       preview: {
         ...serverConfig(),
         port: 3006,
@@ -261,7 +261,7 @@ describe('preview config', () => {
       server: serverConfig(),
       preview: previewConfig(),
     }
-    expect(await resolveConfig(config, 'serve')).toMatchObject({
+    expect(await resolveConfig(config, 'serve', 'preview')).toMatchObject({
       preview: previewConfig(),
     })
   })
@@ -293,8 +293,8 @@ describe('resolveConfig', () => {
       clearScreen: true,
     }
 
-    const results1 = await resolveConfig(config1, 'build')
-    const results2 = await resolveConfig(config2, 'build')
+    const results1 = await resolveConfig(config1, 'build', 'build')
+    const results2 = await resolveConfig(config2, 'build', 'build')
 
     expect(results1.clearScreen).toBe(false)
     expect(results2.clearScreen).toBe(false)
@@ -307,8 +307,8 @@ describe('resolveConfig', () => {
       clearScreen: true,
     }
 
-    const results1 = await resolveConfig(config1, 'build')
-    const results2 = await resolveConfig(config2, 'build')
+    const results1 = await resolveConfig(config1, 'build', 'build')
+    const results2 = await resolveConfig(config2, 'build', 'build')
 
     expect(results1.clearScreen).toBe(false)
     expect(results2.clearScreen).toBe(false)

--- a/packages/vite/src/node/__tests__/dev.spec.ts
+++ b/packages/vite/src/node/__tests__/dev.spec.ts
@@ -12,6 +12,7 @@ describe('resolveBuildOptions in dev', () => {
         },
       },
       'serve',
+      'dev',
     )
 
     expect(config.build.rollupOptions).not.toHaveProperty('input')

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -206,7 +206,7 @@ async function createCssPluginTransform(
   files?: Record<string, string>,
   inlineConfig: InlineConfig = {},
 ) {
-  const config = await resolveConfig(inlineConfig, 'serve')
+  const config = await resolveConfig(inlineConfig, 'serve', 'dev')
   const { transform, buildStart } = cssPlugin(config)
 
   // @ts-expect-error buildStart is function

--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -7,7 +7,11 @@ async function createDefinePluginTransform(
   build = true,
   ssr = false,
 ) {
-  const config = await resolveConfig({ define }, build ? 'build' : 'serve')
+  const config = await resolveConfig(
+    { define },
+    build ? 'build' : 'serve',
+    build ? 'build' : 'dev',
+  )
   const instance = definePlugin(config)
   return async (code: string) => {
     const result = await (instance.transform as any).call({}, code, 'foo.ts', {

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -459,6 +459,7 @@ export async function build(
   const config = await resolveConfig(
     inlineConfig,
     'build',
+    'build',
     'production',
     'production',
   )

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -278,6 +278,7 @@ cli
             logLevel: options.logLevel,
           },
           'serve',
+          'optimize',
         )
         await optimizeDeps(config, options.force, true)
       } catch (e) {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -80,7 +80,7 @@ export type {
 export interface ConfigEnv {
   command: 'build' | 'serve'
   mode: string
-  operation: 'build' | 'dev' | 'preview' | 'optimize'
+  cmd: 'build' | 'dev' | 'preview' | 'optimize'
   /**
    * @experimental
    */
@@ -337,7 +337,7 @@ export type ResolvedConfig = Readonly<
     publicDir: string
     cacheDir: string
     command: 'build' | 'serve'
-    operation: 'build' | 'dev' | 'preview' | 'optimize'
+    cmd: 'build' | 'dev' | 'preview' | 'optimize'
     mode: string
     isWorker: boolean
     // in nested worker bundle to find the main config
@@ -382,7 +382,7 @@ export type ResolveFn = (
 export async function resolveConfig(
   inlineConfig: InlineConfig,
   command: 'build' | 'serve',
-  operation: 'build' | 'dev' | 'preview' | 'optimize',
+  cmd: 'build' | 'dev' | 'preview' | 'optimize',
   defaultMode = 'development',
   defaultNodeEnv = 'development',
 ): Promise<ResolvedConfig> {
@@ -400,7 +400,7 @@ export async function resolveConfig(
   const configEnv = {
     mode,
     command,
-    operation,
+    cmd,
     ssrBuild: !!config.build?.ssr,
   }
 
@@ -653,7 +653,7 @@ export async function resolveConfig(
     resolve: resolveOptions,
     publicDir: resolvedPublicDir,
     cacheDir,
-    operation,
+    cmd,
     command,
     mode,
     ssr,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -336,7 +336,7 @@ export type ResolvedConfig = Readonly<
     rawBase: string
     publicDir: string
     cacheDir: string
-    command: 'build' | 'serve'
+    // #12298
     cmd: 'build' | 'dev' | 'preview' | 'optimize'
     mode: string
     isWorker: boolean

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -80,6 +80,7 @@ export type {
 export interface ConfigEnv {
   command: 'build' | 'serve'
   mode: string
+  operation: 'build' | 'dev' | 'preview' | 'optimize'
   /**
    * @experimental
    */
@@ -336,6 +337,7 @@ export type ResolvedConfig = Readonly<
     publicDir: string
     cacheDir: string
     command: 'build' | 'serve'
+    operation: 'build' | 'dev' | 'preview' | 'optimize'
     mode: string
     isWorker: boolean
     // in nested worker bundle to find the main config
@@ -380,6 +382,7 @@ export type ResolveFn = (
 export async function resolveConfig(
   inlineConfig: InlineConfig,
   command: 'build' | 'serve',
+  operation: 'build' | 'dev' | 'preview' | 'optimize',
   defaultMode = 'development',
   defaultNodeEnv = 'development',
 ): Promise<ResolvedConfig> {
@@ -397,6 +400,7 @@ export async function resolveConfig(
   const configEnv = {
     mode,
     command,
+    operation,
     ssrBuild: !!config.build?.ssr,
   }
 
@@ -649,6 +653,7 @@ export async function resolveConfig(
     resolve: resolveOptions,
     publicDir: resolvedPublicDir,
     cacheDir,
+    operation,
     command,
     mode,
     ssr,

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -81,6 +81,7 @@ export async function preview(
   const config = await resolveConfig(
     inlineConfig,
     'serve',
+    'preview',
     'production',
     'production',
   )

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -193,6 +193,7 @@ async function getPluginContainer(
   const config = await resolveConfig(
     { configFile: false, ...inlineConfig },
     'serve',
+    'dev',
   )
 
   // @ts-expect-error This plugin requires a ViteDevServer instance.

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -338,7 +338,7 @@ export interface ResolvedServerUrls {
 export async function createServer(
   inlineConfig: InlineConfig = {},
 ): Promise<ViteDevServer> {
-  const config = await resolveConfig(inlineConfig, 'serve')
+  const config = await resolveConfig(inlineConfig, 'serve', 'dev')
   const { root, server: serverConfig } = config
   const httpsOptions = await resolveHttpsConfig(config.server.https)
   const { middlewareMode } = serverConfig

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -201,6 +201,7 @@ function loadConfigFromDir(dir: string) {
   return loadConfigFromFile(
     {
       command: isBuild ? 'build' : 'serve',
+      operation: isBuild ? 'build' : 'dev',
       mode: isBuild ? 'production' : 'development',
     },
     undefined,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This is solving a long standing problem: there isn't a reliable way to distinguish between `dev` and `preview` (since `config.command === 'serve'` for both `$ vite dev` and `$ vite preview`).

There are workarounds but none of them are reliable. (E.g. checking whether `configureServer()`/`configurePreviewServer()` is called doesn't work in certain situations.)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] ~Ideally, include relevant tests that fail without this PR but pass with it.~ N/A.
