### PR TITLE
fix: enforce absolute path for server.sourcemapIgnoreList

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -326,7 +326,7 @@ export default defineConfig({
 
 Whether or not to ignore source files in the server sourcemap, used to populate the [`x_google_ignoreList` source map extension](https://developer.chrome.com/blog/devtools-better-angular-debugging/#the-x_google_ignorelist-source-map-extension).
 
-`server.sourcemapIgnoreList` is the equivalent of [build.rollupOptions.output.sourcemapIgnoreList](https://rollupjs.org/configuration-options/#output-sourcemapignorelist) for the dev server. A difference between the two config options is that the rollup functions is called with a relative path for `sourcePath` while `server.sourcemapIgnoreList` is called with an absolute path. During dev, most modules have the map and the source on the same folder, so the relative path for `sourcePath` is the file name in these cases. Using absolute paths allow the use of `sourcePath` directly in these cases.
+`server.sourcemapIgnoreList` is the equivalent of [build.rollupOptions.output.sourcemapIgnoreList](https://rollupjs.org/configuration-options/#output-sourcemapignorelist) for the dev server. A difference between the two config options is that the rollup function is called with a relative path for `sourcePath` while `server.sourcemapIgnoreList` is called with an absolute path. During dev, most modules have the map and the source in the same folder, so the relative path for `sourcePath` is the file name itself. In these cases, absolute paths makes it convenient to be used instead.
 
 By default, it excludes all paths containing `node_modules`. You can pass `false` to disable this behavior, or, for full control, a function that takes the source path and sourcemap path and returns whether to ignore the source path.
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -326,6 +326,8 @@ export default defineConfig({
 
 Whether or not to ignore source files in the server sourcemap, used to populate the [`x_google_ignoreList` source map extension](https://developer.chrome.com/blog/devtools-better-angular-debugging/#the-x_google_ignorelist-source-map-extension).
 
+`server.sourcemapIgnoreList` is the equivalent of [build.rollupOptions.output.sourcemapIgnoreList](https://rollupjs.org/configuration-options/#output-sourcemapignorelist) for the dev server. A difference between the two config options is that the rollup functions is called with a relative path for `sourcePath` while `server.sourcemapIgnoreList` is called with an absolute path. During dev, most modules have the map and the source on the same folder, so the relative path for `sourcePath` is the file name in these cases. Using absolute paths allow the use of `sourcePath` directly in these cases.
+
 By default, it excludes all paths containing `node_modules`. You can pass `false` to disable this behavior, or, for full control, a function that takes the source path and sourcemap path and returns whether to ignore the source path.
 
 ```js

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -281,7 +281,9 @@ async function loadAndTransform(
 
       const sourcemapPath = `${mod.file}.map`
       const ignoreList = config.server.sourcemapIgnoreList(
-        sourcePath,
+        path.isAbsolute(sourcePath)
+          ? sourcePath
+          : path.resolve(path.dirname(sourcemapPath), sourcePath),
         sourcemapPath,
       )
       if (typeof ignoreList !== 'boolean') {


### PR DESCRIPTION
### Description

Opposite of:
- https://github.com/vitejs/vite/pull/12281

Following @bluwy's [comment](https://github.com/vitejs/vite/pull/12281#issuecomment-1455673125), it also includes docs to note that the difference with rollup is intentional.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other