### PR TITLE
fix: handle error without line and column in loc

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -454,7 +454,11 @@ export async function createPluginContainer(
         err.frame = err.frame || generateCodeFrame(err.id!, err.loc)
       }
 
-      if (err.loc && ctx instanceof TransformContext) {
+      if (
+        ctx instanceof TransformContext &&
+        typeof err.loc?.line === 'number' &&
+        typeof err.loc?.column === 'number'
+      ) {
         const rawSourceMap = ctx._getCombinedSourcemap()
         if (rawSourceMap) {
           const traced = new TraceMap(rawSourceMap as any)
@@ -462,7 +466,7 @@ export async function createPluginContainer(
             line: Number(err.loc.line),
             column: Number(err.loc.column),
           })
-          if (source && line != null && column != null) {
+          if (source) {
             err.loc = { file: source, line, column }
           }
         }
@@ -483,6 +487,15 @@ export async function createPluginContainer(
         }
       }
     }
+
+    if (
+      typeof err.loc?.column !== 'number' &&
+      typeof err.loc?.line !== 'number' &&
+      !err.loc?.file
+    ) {
+      delete err.loc
+    }
+
     return err
   }
 

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -466,7 +466,7 @@ export async function createPluginContainer(
             line: Number(err.loc.line),
             column: Number(err.loc.column),
           })
-          if (source) {
+          if (source && line != null && column != null) {
             err.loc = { file: source, line, column }
           }
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

fix https://github.com/vitejs/vite/issues/12293



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Delete `err.loc` when all the fields in it are nullish to prevent `undefined` in trace such like `/Users/fi3ework/OSS/vite-repro/i12293/src/components/HelloWorld.vue?vue&type=style&index=0&scoped=e17ea971&lang.css:undefined:undefined`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
