### PR TITLE
fix(resolve): update `resolve.exports` to `2.0.1` to fix `*` resolution issue

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -119,7 +119,7 @@
     "postcss-import": "^15.1.0",
     "postcss-load-config": "^4.0.1",
     "postcss-modules": "^6.0.0",
-    "resolve.exports": "^2.0.0",
+    "resolve.exports": "^2.0.1",
     "rollup-plugin-license": "^3.0.1",
     "sirv": "^2.0.2",
     "source-map-js": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,7 +214,7 @@ importers:
       postcss-load-config: ^4.0.1
       postcss-modules: ^6.0.0
       resolve: ^1.22.1
-      resolve.exports: ^2.0.0
+      resolve.exports: ^2.0.1
       rollup: ^3.18.0
       rollup-plugin-license: ^3.0.1
       sirv: ^2.0.2
@@ -279,7 +279,7 @@ importers:
       postcss-import: 15.1.0_postcss@8.4.21
       postcss-load-config: 4.0.1_postcss@8.4.21
       postcss-modules: 6.0.0_postcss@8.4.21
-      resolve.exports: 2.0.0
+      resolve.exports: 2.0.1
       rollup-plugin-license: 3.0.1_rollup@3.18.0
       sirv: 2.0.2_hmoqtj4vy3i7wnpchga2a2mu3y
       source-map-js: 1.0.2
@@ -8444,8 +8444,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /resolve.exports/2.0.0:
-    resolution: {integrity: sha512-6K/gDlqgQscOlg9fSRpWstA8sYe8rbELsSTNpx+3kTrsVCzvSl0zIvRErM7fdl9ERWDsKnrLnwB+Ne89918XOg==}
+  /resolve.exports/2.0.1:
+    resolution: {integrity: sha512-OEJWVeimw8mgQuj3HfkNl4KqRevH7lzeQNaWRPfx0PPse7Jk6ozcsG4FKVgtzDsC1KUF+YlTHh17NcgHOPykLw==}
     engines: {node: '>=10'}
     dev: true
 


### PR DESCRIPTION
### Description 📝

- Fixes #12284 by updating upstream `resolve.exports` package to `2.0.1`
- Since 4.0.4, Vite has not been able to resolve packages that define exports like the following due to a bug in `resolve.exports@2.0.0`. The maintainer of `resolve.exports` has fixed this in `2.0.1`

```json
  "exports": {
    ".": {
      "import": "./lib/index.js",
      "require": "./lib/index.cjs"
    },
    "./lib": {
      "import": "./lib/index.js",
      "require": "./lib/index.cjs"
    },
    "./lib/*": {
      "import": "./lib/index.js",
      "require": "./lib/index.cjs"
    }
  },
```
- I did not add any tests because tests were added in the upstream package

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
