### PR TITLE
fix(config): watch config even outside of root

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -359,7 +359,8 @@ export async function createServer(
   }
 
   const watcher = chokidar.watch(
-    path.resolve(root),
+    // config file dependencies might be outside of root
+    [path.resolve(root), ...config.configFileDependencies],
     resolvedWatchOptions,
   ) as FSWatcher
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
a repro: https://stackblitz.com/edit/vitejs-vite-cv8sdt?file=vite.config.ts,package.json&terminal=dev. Modify `vite.config.ts` and the server will not restart (Ideally it should).

When config file and its deps are out of `resolvedConfig.root`, it won't be watched.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
