### PR TITLE
fix(indexHtml):  support transform assets url to safe path 

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -245,7 +245,11 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       // /foo -> /fs-root/foo
       if (asSrc && id.startsWith('/')) {
         const fsPath = path.resolve(root, id.slice(1))
-        if ((res = tryFsResolve(fsPath, options))) {
+        const modulePath = path.resolve(root, `node_modules${id}`)
+        if (
+          (res =
+            tryFsResolve(fsPath, options) || tryFsResolve(modulePath, options))
+        ) {
           isDebug && debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           return ensureVersionQuery(res)
         }
@@ -587,7 +591,7 @@ function tryResolveFile(
           // path points to a node package
           const pkg = loadPackageData(pkgPath, options.preserveSymlinks)
           const resolved = resolvePackageEntry(file, pkg, targetWeb, options)
-          return resolved
+          return resolved + postfix
         } catch (e) {
           if (e.code !== 'ENOENT') {
             throw e

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -245,11 +245,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       // /foo -> /fs-root/foo
       if (asSrc && id.startsWith('/')) {
         const fsPath = path.resolve(root, id.slice(1))
-        const modulePath = path.resolve(root, `node_modules${id}`)
-        if (
-          (res =
-            tryFsResolve(fsPath, options) || tryFsResolve(modulePath, options))
-        ) {
+        if ((res = tryFsResolve(fsPath, options))) {
           isDebug && debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           return ensureVersionQuery(res)
         }
@@ -591,7 +587,7 @@ function tryResolveFile(
           // path points to a node package
           const pkg = loadPackageData(pkgPath, options.preserveSymlinks)
           const resolved = resolvePackageEntry(file, pkg, targetWeb, options)
-          return resolved + postfix
+          return resolved
         } catch (e) {
           if (e.code !== 'ENOENT') {
             throw e

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -371,6 +371,8 @@ export async function createServer(
   const container = await createPluginContainer(config, moduleGraph, watcher)
   const closeHttpServer = createServerCloseFn(httpServer)
 
+  moduleGraph.ensureEntryFromUrl(path.resolve(config.root, '_vite_entry_.js'))
+
   let exitProcess: () => void
 
   const server: ViteDevServer = {

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -27,6 +27,7 @@ import {
   ensureWatchedFile,
   fsPathFromId,
   injectQuery,
+  isExternalUrl,
   joinUrlSegments,
   normalizePath,
   processSrcSetSync,
@@ -122,6 +123,37 @@ const processNodeUrl = (
     overwriteAttrValue(s, sourceCodeLocation, processedUrl)
   }
 }
+
+const resolveAssetUrl = async (server: ViteDevServer, rawUrl: string) => {
+  if (isExternalUrl(rawUrl)) {
+    return rawUrl
+  }
+
+  const getUrlFromCode = (code: string) => code.match(/["'](.+)["']/)![1]
+
+  const transform = (url: string) =>
+    server.pluginContainer
+      .transform(
+        `import "${url}"`,
+        path.resolve(server.config.root, '_vite_entry_.js'),
+      )
+      .catch((_) => null)
+
+  rawUrl = rawUrl.replace(/^\//, '')
+
+  // fs-root/rawUrl | fs-root/node_modules/rawUrl
+  const source = (await transform(`./${rawUrl}`)) || (await transform(rawUrl))
+
+  if (!source) {
+    return source
+  }
+
+  return getUrlFromCode(source.code).replace(
+    new RegExp(`^${server.config.base}/`),
+    '/',
+  )
+}
+
 const devHtmlHook: IndexHtmlTransformHook = async (
   html,
   { path: htmlPath, filename, server, originalUrl },
@@ -195,7 +227,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     )
   }
 
-  await traverseHtml(html, filename, (node) => {
+  await traverseHtml(html, filename, async (node) => {
     if (!nodeIsElement(node)) {
       return
     }
@@ -234,6 +266,12 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       for (const p of node.attrs) {
         const attrKey = getAttrKey(p)
         if (p.value && assetAttrs.includes(attrKey)) {
+          const url = await resolveAssetUrl(server!, p.value)
+
+          if (url) {
+            p.value = url
+          }
+
           processNodeUrl(
             p,
             node.sourceCodeLocation!.attrs![attrKey],

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -148,10 +148,11 @@ const resolveAssetUrl = async (server: ViteDevServer, rawUrl: string) => {
     return source
   }
 
-  return getUrlFromCode(source.code).replace(
-    new RegExp(`^${server.config.base}/`),
-    '/',
-  )
+  return getUrlFromCode(source.code)
+    .replace(new RegExp(`^${server.config.base}`), '/')
+    .replace(/[?&](?:import|(t=\d+))(#|$|&)/g, (match) =>
+      match.endsWith('#') ? '#' : match.startsWith('?') ? '?' : '',
+    )
 }
 
 const devHtmlHook: IndexHtmlTransformHook = async (

--- a/playground/html/index.html
+++ b/playground/html/index.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="/main.css" />
+<link rel="stylesheet" href="@/main.css" />
 
 <!-- comment one -->
 <h1>Hello</h1>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -1,8 +1,14 @@
 import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   base: './',
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./', import.meta.url)),
+    },
+  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #12260

~~vite server will try to resolve files from the root directory while receiving assets requests which start with '/'~~, ~~but some requests maybe expect to visit the assets from the `node_modules`~~, ~~this PR is trying to add a fallback to resolve assets from the `node_modules` while requested files don't exist in the root directory~~. 

We could mock a fake entry file `_vite_entry_.js` to import assets URLs, then covert asset URLs to import statement and transform them to the safe URLs via `import-analysis` plugin.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Also, I think we could enhance to resolve asset requests which match the alias pattern for better DX.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
