### PR TITLE
fix(optimizer): transform css require to import directly

### DIFF
--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import type { ImportKind, Plugin } from 'esbuild'
-import { KNOWN_ASSET_TYPES } from '../constants'
+import { CSS_LANGS_RE, KNOWN_ASSET_TYPES } from '../constants'
 import { getDepOptimizationConfig } from '..'
 import type { ResolvedConfig } from '..'
 import {
@@ -153,10 +153,12 @@ export function esbuildDepPlugin(
         { filter: /./, namespace: externalWithConversionNamespace },
         (args) => {
           // import itself with prefix (this is the actual part of require-import conversion)
+          const modulePath = `"${convertedExternalPrefix}${args.path}"`
           return {
-            contents:
-              `export { default } from "${convertedExternalPrefix}${args.path}";` +
-              `export * from "${convertedExternalPrefix}${args.path}";`,
+            contents: CSS_LANGS_RE.test(args.path)
+              ? `import ${modulePath};`
+              : `export { default } from ${modulePath};` +
+                `export * from ${modulePath};`,
             loader: 'js',
           }
         },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

 fix #12304

Since default and named imports from CSS files are deprecated, `require('xxx.css')` should not be pre-bundled as `import * as xxx` or `import {default as default2}`, maybe we could transform it to `import 'xxx.css'`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
