### PR TITLE
fix(types): avoid resolve.exports types for bundling

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import type { Exports, Imports } from 'resolve.exports'
 import { createDebugger, createFilter, resolveFrom } from './utils'
 import type { ResolvedConfig } from './config'
 import type { Plugin } from './plugin'
@@ -28,8 +27,8 @@ export interface PackageData {
     main: string
     module: string
     browser: string | Record<string, string | false>
-    exports: Exports
-    imports: Imports
+    exports: string | Record<string, any> | string[]
+    imports: Record<string, any>
     dependencies: Record<string, string>
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Avoid `resolve.exports` types when bundling types, this causes `tsc` errors downstream as Vite's types is importing from `resolve.exports` (which is a dev dep).

This was introduced from https://github.com/vitejs/vite/pull/7770

Ideally we would vendor `resolve.exports` types like the `src/types` convention, but I found the types written by `resolve.exports` when vendored caused more errors. So I went with this simpler fix.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

