### PR TITLE
docs: add note about using define in envPrefix config

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -397,6 +397,15 @@ Env variables starting with `envPrefix` will be exposed to your client source co
 
 :::warning SECURITY NOTES
 `envPrefix` should not be set as `''`, which will expose all your env variables and cause unexpected leaking of sensitive information. Vite will throw an error when detecting `''`.
+
+If you would like to expose an unprefixed variable, you can use [define](#define) to expose it:
+
+```js
+define: {
+  'import.meta.env.ENV_VARIABLE': JSON.stringify(process.env.ENV_VARIABLE)
+}
+```
+
 :::
 
 ## appType


### PR DESCRIPTION
Closes #9880
Closes #11929

### Description

We discussed with the team, and allowing the use of an empty `envPrefix` isn't something we'd like to support because of security reasons as already stated in the docs. 

We also think that the use case of exposing individual unprefixed env variables through an option like `env.allowed` is also not common enough to justify a new option.

There is also a good [workaround using `define` as @bluwy proposed](https://github.com/vitejs/vite/pull/9880#issuecomment-1237282989). This PR adds a not documenting this option.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other