### PR TITLE
fix(config): watch envDir even outside of root

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -342,7 +342,6 @@ export type ResolvedConfig = Readonly<
     /** @internal */
     mainConfig: ResolvedConfig | null
     isProduction: boolean
-    /** @internal */
     envDir: string
     env: Record<string, any>
     resolve: Required<ResolveOptions> & {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -342,6 +342,8 @@ export type ResolvedConfig = Readonly<
     /** @internal */
     mainConfig: ResolvedConfig | null
     isProduction: boolean
+    /** @internal */
+    envDir: string
     env: Record<string, any>
     resolve: Required<ResolveOptions> & {
       alias: Alias[]
@@ -659,6 +661,7 @@ export async function resolveConfig(
     server,
     build: resolvedBuildOptions,
     preview: resolvePreviewOptions(config.preview, server),
+    envDir,
     env: {
       ...userEnv,
       BASE_URL,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -359,8 +359,8 @@ export async function createServer(
   }
 
   const watcher = chokidar.watch(
-    // config file dependencies might be outside of root
-    [path.resolve(root), ...config.configFileDependencies],
+    // config file dependencies and env file might be outside of root
+    [root, ...config.configFileDependencies, config.envDir],
     resolvedWatchOptions,
   ) as FSWatcher
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
a repro: https://stackblitz.com/edit/vitejs-vite-ux3kxh?file=.env. Modify `.env` and the server will not restart (Ideally it should).

When `envDir` is out of `resolvedConfig.root`, it won't be watched.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Annotate `envDir` as an internal field as it's not required by user so far (I guess :P)
And, I belileve after this PR, we have watched all the things that could trigger a server restart.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
