### PR TITLE
fix(optimizer): suppress esbuild cancel error

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -626,6 +626,14 @@ export function runOptimizeDeps(
 
         return createProcessingResult()
       })
+      .catch((e) => {
+        if (e.errors && e.message.includes('The build was canceled')) {
+          // esbuild logs an error when cancelling, but this is expected so
+          // return an empty result instead
+          return createProcessingResult()
+        }
+        throw e
+      })
       .finally(() => {
         return disposeContext()
       })

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -111,6 +111,12 @@ export function scanImports(config: ResolvedConfig): {
         })
     })
     .catch(async (e) => {
+      if (e.errors && e.message.includes('The build was canceled')) {
+        // esbuild logs an error when cancelling, but this is expected so
+        // return an empty result instead
+        return { deps: {}, missing: {} }
+      }
+
       const prependMessage = colors.red(`\
   Failed to scan for dependencies from entries:
   ${entries.join('\n')}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When `esbuildContext.rebuild()` is called, then `esbuildContext.cancel()` is called, esbuild logs an error, which we don't want as we're intentionally cancelling the build. This PR checks the error message and suppresses it.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This should fix the logs appearing in Astro's ecosystem-ci unit tests, since the unit test runs server restarts consecutively, triggering this error. Though even with the error logs, the test passes, but this change should help avoid confusion.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
