### PR TITLE
feat(docs): add anchor tags to 'api-javascript.md' pointing to the github repo

### DIFF
--- a/docs/.vitepress/theme/components/ApiLink.vue
+++ b/docs/.vitepress/theme/components/ApiLink.vue
@@ -1,0 +1,22 @@
+<template>
+  <span :class="$style.module"
+    >Notice any errors? Please feel free to edit
+    <a :href="url" :alt="label" target="_blank">{{ label }}</a> and issue a pull
+    request.
+  </span>
+</template>
+
+<script>
+export default {
+  props: {
+    label: String,
+    url: String,
+  },
+}
+</script>
+
+<style module>
+span {
+  font-size: 0.8125rem;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import './styles/vars.css'
 import HomeSponsors from './components/HomeSponsors.vue'
 import AsideSponsors from './components/AsideSponsors.vue'
 import SvgImage from './components/SvgImage.vue'
+import ApiLink from './components/ApiLink.vue'
 
 export default {
   ...Theme,
@@ -15,5 +16,6 @@ export default {
   },
   enhanceApp({ app }) {
     app.component('SvgImage', SvgImage)
+    app.component('ApiLink', ApiLink)
   },
 }

--- a/docs/_data/links.data.js
+++ b/docs/_data/links.data.js
@@ -1,0 +1,10 @@
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+export default {
+  load() {
+    const path = fileURLToPath(new URL('./links.json', import.meta.url))
+    const data = fs.readFileSync(path, 'utf-8')
+    return JSON.parse(data)
+  },
+}

--- a/docs/_data/links.json
+++ b/docs/_data/links.json
@@ -1,0 +1,42 @@
+{
+  "build": {
+    "label": "packages/vite/src/node/build.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/build.ts#L466"
+  },
+  "createServer": {
+    "label": "packages/vite/src/node/server/index.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/index.ts#L338"
+  },
+  "loadConfigFromFile": {
+    "label": "packages/vite/src/node/config.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts#L874"
+  },
+  "loadEnv": {
+    "label": "packages/vite/src/node/env.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/env.ts#L7"
+  },
+  "mergeConfig": {
+    "label": "packages/vite/src/node/utils.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L1094"
+  },
+  "normalizePath": {
+    "label": "packages/vite/src/node/utils.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts#L224"
+  },
+  "preview": {
+    "label": "packages/vite/src/node/preview.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/preview.ts#L78"
+  },
+  "resolveConfig": {
+    "label": "packages/vite/src/node/config.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts#L380"
+  },
+  "searchForWorkspaceRoot": {
+    "label": "packages/vite/src/node/server/searchRoot.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/searchRoot.ts#L59"
+  },
+  "transformWithEsbuild": {
+    "label": "packages/vite/src/node/plugins/esbuild.ts",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/esbuild.ts#L66"
+  }
+}

--- a/docs/_scripts/create-link-data.mjs
+++ b/docs/_scripts/create-link-data.mjs
@@ -1,0 +1,174 @@
+/* eslint-env node */
+// import process from 'node:process'
+import path from 'node:path'
+import fs from 'node:fs'
+import fse from 'fs-extra'
+
+const pathRoot = process.cwd()
+const pathDocs = path.resolve(pathRoot, 'docs')
+
+const pathPackagesBase = 'packages/vite/src/node'
+const pathPackages = path.resolve(pathRoot, pathPackagesBase)
+
+const baseUrl = 'https://github.com/vitejs/vite/blob/main/'
+
+const jsonOptions = { spaces: 2 }
+
+const apis = [
+  // hmr api
+  // 'accept',
+  // 'dispose',
+  // 'prune',
+  // 'data',
+  // 'decline',
+  // 'invalidate',
+  // 'on',
+  // 'send',
+
+  // js api
+  'createServer',
+  'build',
+  'preview',
+  'resolveConfig',
+  'mergeConfig',
+  'searchForWorkspaceRoot',
+  'loadEnv',
+  'normalizePath',
+  'transformWithEsbuild',
+  'loadConfigFromFile',
+  // plugins
+]
+
+// const types = [
+//   // js
+//   'InlineConfig',
+//   'ResolvedConfig',
+//   'ViteDevServer',
+// ]
+
+const pathSourceDirectoryData = path.resolve(
+  pathDocs,
+  '_scripts/source-data.json',
+)
+const sourceDirectoryData = readSourceDirectory(pathSourceDirectoryData)
+
+const apiLinksPath = path.resolve(pathDocs, '_data/links.json')
+const apiLinksData = readSourceFileContents(sourceDirectoryData)
+
+outputApiLinks(apiLinksPath, apiLinksData)
+
+// --------- //
+// functions //
+// --------- //
+
+function readSourceDirectory(pathDirectoryData) {
+  let directoryData
+
+  if (fs.existsSync(pathDirectoryData)) {
+    directoryData = fse.readJsonSync(pathDirectoryData)
+    console.log(`Read cached data from ${pathDirectoryData}`)
+  } else {
+    // @todo force
+    directoryData = createSourceDirectoryData(pathPackages)
+    fse.outputJSONSync(pathDirectoryData, directoryData, jsonOptions)
+    console.log(`Written data to ${pathDirectoryData}`)
+  }
+
+  return directoryData
+}
+
+function createSourceDirectoryData(itemPath, obj = {}) {
+  const data = fs.readdirSync(itemPath)
+
+  for (const item of data) {
+    const currentPath = path.resolve(itemPath, item)
+    const currentStat = fs.lstatSync(currentPath)
+
+    // push file
+    if (currentStat.isFile() && item.endsWith('.ts')) {
+      const relativePath = path
+        .relative(pathRoot, currentPath)
+        .split(path.sep)
+        .slice(0, -1)
+        .join('/')
+
+      if (!obj[relativePath]) obj[relativePath] = []
+
+      obj[relativePath].push({
+        name: item,
+        path: relativePath,
+        url: `${baseUrl}${relativePath}/${item}`,
+      })
+      continue
+    }
+
+    // skip
+    if (currentStat.isDirectory() && item === '__tests__') continue
+
+    // read dir
+    if (currentStat.isDirectory()) {
+      createSourceDirectoryData(currentPath, obj)
+    }
+  }
+
+  return Object.values(obj).reduce((all, cur) => [...all, ...cur], [])
+}
+
+function readSourceFileContents(data) {
+  const result = []
+
+  for (const source of data) {
+    const pathSource = path.resolve(pathRoot, source.path, source.name)
+    const content = fs.readFileSync(pathSource)
+    const lines = base64ToLines(content)
+
+    for (const nameFn of apis) {
+      // @todo
+      // regex?
+      // pattern does not match hmr methods
+      // specifiy directory?
+      const pattern = `function ${nameFn}(`
+      const line = getLineNumber(lines, pattern)
+
+      if (line < 0) continue
+
+      const label = `${source.path}/${source.name}`
+      const url = `${source.url}#L${line}`
+
+      result.push([nameFn, label, url])
+    }
+  }
+
+  return result
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    .reduce((all, link) => {
+      const [name, label, url] = link
+      all[name] = {
+        label,
+        url,
+      }
+      return all
+    }, {})
+}
+
+function base64ToLines(content) {
+  return Buffer.from(content, 'base64').toString('utf-8').split('\n')
+}
+
+function getLineNumber(lines, string) {
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].includes(string)) return i + 1
+  }
+
+  return -1
+}
+
+function outputApiLinks(outputPath, outputData) {
+  // @todo
+  // export as .js - do not use stringify (adds double quotes to keys)
+  // const output = `export const links = ${JSON.stringify(outputData, null, 2)}`
+  // fse.outputFileSync(outputPath, output)
+
+  fse.outputJSONSync(outputPath, outputData, jsonOptions)
+  console.log(`Written data to ${outputPath}`)
+}

--- a/docs/_scripts/source-data.json
+++ b/docs/_scripts/source-data.json
@@ -1,0 +1,367 @@
+[
+  {
+    "name": "build.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/build.ts"
+  },
+  {
+    "name": "cli.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/cli.ts"
+  },
+  {
+    "name": "config.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts"
+  },
+  {
+    "name": "constants.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/constants.ts"
+  },
+  {
+    "name": "env.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/env.ts"
+  },
+  {
+    "name": "http.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/http.ts"
+  },
+  {
+    "name": "index.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/index.ts"
+  },
+  {
+    "name": "logger.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/logger.ts"
+  },
+  {
+    "name": "packages.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/packages.ts"
+  },
+  {
+    "name": "plugin.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugin.ts"
+  },
+  {
+    "name": "preview.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/preview.ts"
+  },
+  {
+    "name": "publicUtils.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/publicUtils.ts"
+  },
+  {
+    "name": "shortcuts.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/shortcuts.ts"
+  },
+  {
+    "name": "utils.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/utils.ts"
+  },
+  {
+    "name": "watch.ts",
+    "path": "packages/vite/src/node",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/watch.ts"
+  },
+  {
+    "name": "esbuildDepPlugin.ts",
+    "path": "packages/vite/src/node/optimizer",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/optimizer/esbuildDepPlugin.ts"
+  },
+  {
+    "name": "index.ts",
+    "path": "packages/vite/src/node/optimizer",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/optimizer/index.ts"
+  },
+  {
+    "name": "optimizer.ts",
+    "path": "packages/vite/src/node/optimizer",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/optimizer/optimizer.ts"
+  },
+  {
+    "name": "scan.ts",
+    "path": "packages/vite/src/node/optimizer",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/optimizer/scan.ts"
+  },
+  {
+    "name": "asset.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/asset.ts"
+  },
+  {
+    "name": "assetImportMetaUrl.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/assetImportMetaUrl.ts"
+  },
+  {
+    "name": "clientInjections.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/clientInjections.ts"
+  },
+  {
+    "name": "completeSystemWrap.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/completeSystemWrap.ts"
+  },
+  {
+    "name": "css.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/css.ts"
+  },
+  {
+    "name": "dataUri.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/dataUri.ts"
+  },
+  {
+    "name": "define.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/define.ts"
+  },
+  {
+    "name": "dynamicImportVars.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/dynamicImportVars.ts"
+  },
+  {
+    "name": "ensureWatch.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/ensureWatch.ts"
+  },
+  {
+    "name": "esbuild.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/esbuild.ts"
+  },
+  {
+    "name": "html.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/html.ts"
+  },
+  {
+    "name": "importAnalysis.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/importAnalysis.ts"
+  },
+  {
+    "name": "importAnalysisBuild.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/importAnalysisBuild.ts"
+  },
+  {
+    "name": "importMetaGlob.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/importMetaGlob.ts"
+  },
+  {
+    "name": "index.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/index.ts"
+  },
+  {
+    "name": "json.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/json.ts"
+  },
+  {
+    "name": "loadFallback.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/loadFallback.ts"
+  },
+  {
+    "name": "manifest.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/manifest.ts"
+  },
+  {
+    "name": "metadata.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/metadata.ts"
+  },
+  {
+    "name": "modulePreloadPolyfill.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/modulePreloadPolyfill.ts"
+  },
+  {
+    "name": "optimizedDeps.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/optimizedDeps.ts"
+  },
+  {
+    "name": "preAlias.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/preAlias.ts"
+  },
+  {
+    "name": "reporter.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/reporter.ts"
+  },
+  {
+    "name": "resolve.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/resolve.ts"
+  },
+  {
+    "name": "splitVendorChunk.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/splitVendorChunk.ts"
+  },
+  {
+    "name": "terser.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/terser.ts"
+  },
+  {
+    "name": "wasm.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/wasm.ts"
+  },
+  {
+    "name": "worker.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/worker.ts"
+  },
+  {
+    "name": "workerImportMetaUrl.ts",
+    "path": "packages/vite/src/node/plugins",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/workerImportMetaUrl.ts"
+  },
+  {
+    "name": "hmr.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/hmr.ts"
+  },
+  {
+    "name": "index.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/index.ts"
+  },
+  {
+    "name": "moduleGraph.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/moduleGraph.ts"
+  },
+  {
+    "name": "openBrowser.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/openBrowser.ts"
+  },
+  {
+    "name": "pluginContainer.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/pluginContainer.ts"
+  },
+  {
+    "name": "searchRoot.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/searchRoot.ts"
+  },
+  {
+    "name": "send.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/send.ts"
+  },
+  {
+    "name": "sourcemap.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/sourcemap.ts"
+  },
+  {
+    "name": "transformRequest.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/transformRequest.ts"
+  },
+  {
+    "name": "ws.ts",
+    "path": "packages/vite/src/node/server",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/ws.ts"
+  },
+  {
+    "name": "base.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/base.ts"
+  },
+  {
+    "name": "compression.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/compression.ts"
+  },
+  {
+    "name": "error.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/error.ts"
+  },
+  {
+    "name": "htmlFallback.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/htmlFallback.ts"
+  },
+  {
+    "name": "indexHtml.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/indexHtml.ts"
+  },
+  {
+    "name": "proxy.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts"
+  },
+  {
+    "name": "static.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/static.ts"
+  },
+  {
+    "name": "time.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/time.ts"
+  },
+  {
+    "name": "transform.ts",
+    "path": "packages/vite/src/node/server/middlewares",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/transform.ts"
+  },
+  {
+    "name": "index.ts",
+    "path": "packages/vite/src/node/ssr",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/index.ts"
+  },
+  {
+    "name": "ssrExternal.ts",
+    "path": "packages/vite/src/node/ssr",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/ssrExternal.ts"
+  },
+  {
+    "name": "ssrManifestPlugin.ts",
+    "path": "packages/vite/src/node/ssr",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/ssrManifestPlugin.ts"
+  },
+  {
+    "name": "ssrModuleLoader.ts",
+    "path": "packages/vite/src/node/ssr",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/ssrModuleLoader.ts"
+  },
+  {
+    "name": "ssrStacktrace.ts",
+    "path": "packages/vite/src/node/ssr",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/ssrStacktrace.ts"
+  },
+  {
+    "name": "ssrTransform.ts",
+    "path": "packages/vite/src/node/ssr",
+    "url": "https://github.com/vitejs/vite/blob/main/packages/vite/src/node/ssr/ssrTransform.ts"
+  }
+]

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -1,3 +1,8 @@
+<script setup>
+  // https://vitepress.dev/guide/data-loading#data-from-local-files
+  import { data } from '../_data/links.data.js'
+</script>
+
 # JavaScript API
 
 Vite's JavaScript APIs are fully typed, and it's recommended to use TypeScript or enable JS type checking in VS Code to leverage the intellisense and validation.
@@ -36,6 +41,8 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url))
 ::: tip NOTE
 When using `createServer` and `build` in the same Node.js process, both functions rely on `process.env.NODE_ENV` to work properly, which also depends on the `mode` config option. To prevent conflicting behavior, set `process.env.NODE_ENV` or the `mode` of the two APIs to `development`. Otherwise, you can spawn a child process to run the APIs separately.
 :::
+
+<ApiLink v-bind="data.createServer" />
 
 ## `InlineConfig`
 
@@ -173,6 +180,8 @@ const __dirname = fileURLToPath(new URL('.', import.meta.url))
 })()
 ```
 
+<ApiLink v-bind="data.build" />
+
 ## `preview`
 
 **Type Signature:**
@@ -198,6 +207,8 @@ import { preview } from 'vite'
 })()
 ```
 
+<ApiLink v-bind="data.preview" />
+
 ## `resolveConfig`
 
 **Type Signature:**
@@ -212,6 +223,8 @@ async function resolveConfig(
 
 The `command` value is `serve` in dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases).
 
+<ApiLink v-bind="data.resolveConfig" />
+
 ## `mergeConfig`
 
 **Type Signature:**
@@ -225,6 +238,8 @@ function mergeConfig(
 ```
 
 Deeply merge two Vite configs. `isRoot` represents the level within the Vite config which is being merged. For example, set `false` if you're merging two `build` options.
+
+<ApiLink v-bind="data.mergeConfig" />
 
 ## `searchForWorkspaceRoot`
 
@@ -246,6 +261,8 @@ Search for the root of the potential workspace if it meets the following conditi
   - `lerna.json`
   - `pnpm-workspace.yaml`
 
+<ApiLink v-bind="data.searchForWorkspaceRoot" />
+
 ## `loadEnv`
 
 **Type Signature:**
@@ -262,6 +279,8 @@ function loadEnv(
 
 Load `.env` files within the `envDir`. By default, only env variables prefixed with `VITE_` are loaded, unless `prefixes` is changed.
 
+<ApiLink v-bind="data.loadEnv" />
+
 ## `normalizePath`
 
 **Type Signature:**
@@ -273,6 +292,8 @@ function normalizePath(id: string): string
 **Related:** [Path Normalization](./api-plugin.md#path-normalization)
 
 Normalizes a path to interoperate between Vite plugins.
+
+<ApiLink v-bind="data.normalizePath" />
 
 ## `transformWithEsbuild`
 
@@ -288,6 +309,8 @@ async function transformWithEsbuild(
 ```
 
 Transform JavaScript or TypeScript with esbuild. Useful for plugins that prefer matching Vite's internal esbuild transform.
+
+<ApiLink v-bind="data.transformWithEsbuild" />
 
 ## `loadConfigFromFile`
 
@@ -307,3 +330,5 @@ async function loadConfigFromFile(
 ```
 
 Load a Vite config file manually with esbuild.
+
+<ApiLink v-bind="data.loadConfigFromFile" />

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "docs": "vitepress dev docs",
     "docs-build": "vitepress build docs",
     "docs-serve": "vitepress serve docs",
+    "docs-create-api-links": "node docs/_scripts/create-link-data.mjs",
     "build": "pnpm -r --filter='./packages/*' run build",
     "dev": "pnpm -r --parallel --filter='./packages/*' run dev",
     "release": "tsx scripts/release.ts",


### PR DESCRIPTION
### Description

Hey there,

first of all, this PR is just a mockup of the feature which I'd like to suggest. As the title says I'd suggest to add links to the docs in order to help contributors to get started.

I tried to retrieve the href values dynamically with a script (`pnpm docs-create-api-links`) which 'scrapes' the source files (instead of 'hardcoding' these values). The created data is imported into vitepress and manually inserted as a simple Vuejs Component at the appropriate location in the docs.

After all there are certain things that need to be discussed.
* Unfortunately I wasn't able to find a good solution to implement the links for the HMR and Plugin API yet.
* The text of the anchor tag is a bit too long. At the moment it looks a bit overloaded to me.
* I bet that the structure of the written code can be improved significantly

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
