### PR TITLE
ci: should exit when build-types-check failed

### DIFF
--- a/packages/vite/scripts/checkBuiltTypes.ts
+++ b/packages/vite/scripts/checkBuiltTypes.ts
@@ -55,12 +55,13 @@ if (errors.length <= 0) {
         )}`
       : ''
     console.log(
-      `${colors.cyan(error.file)}:${pos} - importing ${colors.bold(
+      `${colors.cyan(error.file)}:${pos} - importing from ${colors.bold(
         JSON.stringify(error.value),
       )} is not allowed in built files`,
     )
   })
-  console.log()
+
+  process.exit(1)
 }
 
 function collectImportSpecifiers(file: string) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In pull request #11195 of https://github.com/vitejs/vite, `build-types-check` was introduced to prevent importing types from devDeps in dist types. However, it does not cause the CI to fail when detecting an error. Is there a reason for this? 🤔 cc author @sapphi-red 

This is exemplified by a real case:
Detected an error in https://github.com/vitejs/vite/actions/runs/4245724684/jobs/7381608885#step:11:70 but not throw which needs https://github.com/vitejs/vite/pull/12346 to fix it afterward.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
