### PR TITLE
feat: default esbuild jsxDev based on config.isProduction

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -348,6 +348,7 @@ export type ResolvedConfig = Readonly<
       alias: Alias[]
     }
     plugins: readonly Plugin[]
+    esbuild: ESBuildOptions | false
     server: ResolvedServerOptions
     build: ResolvedBuildOptions
     preview: ResolvedPreviewOptions
@@ -657,6 +658,13 @@ export async function resolveConfig(
     mainConfig: null,
     isProduction,
     plugins: userPlugins,
+    esbuild:
+      config.esbuild === false
+        ? false
+        : {
+            jsxDev: !isProduction,
+            ...config.esbuild,
+          },
     server,
     build: resolvedBuildOptions,
     preview: resolvePreviewOptions(config.preview, server),

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -209,7 +209,7 @@ export async function transformWithEsbuild(
   }
 }
 
-export function esbuildPlugin(options: ESBuildOptions = {}): Plugin {
+export function esbuildPlugin(options: ESBuildOptions): Plugin {
   const filter = createFilter(
     options.include || /\.(m?ts|[jt]sx)$/,
     options.exclude || /\.js$/,


### PR DESCRIPTION
As discussed in Discord because the React plugin can't access config.isProduction in the config hook to set it without duplicating some logic from core.