### PR TITLE
chore: update tsconfck to 2.1.0 to add support for typescript 5 config syntax

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -126,7 +126,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.0.1",
     "strip-literal": "^1.0.1",
-    "tsconfck": "^2.0.3",
+    "tsconfck": "^2.1.0",
     "tslib": "^2.5.0",
     "types": "link:./types",
     "ufo": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,7 +222,7 @@ importers:
       source-map-support: ^0.5.21
       strip-ansi: ^7.0.1
       strip-literal: ^1.0.1
-      tsconfck: ^2.0.3
+      tsconfck: ^2.1.0
       tslib: ^2.5.0
       types: link:./types
       ufo: ^1.1.1
@@ -286,7 +286,7 @@ importers:
       source-map-support: 0.5.21
       strip-ansi: 7.0.1
       strip-literal: 1.0.1
-      tsconfck: 2.0.3
+      tsconfck: 2.1.0
       tslib: 2.5.0
       types: link:types
       ufo: 1.1.1
@@ -9270,12 +9270,12 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck/2.0.3:
-    resolution: {integrity: sha512-o3DsPZO1+C98KqHMdAbWs30zpxD30kj8r9OLA4ML1yghx4khNDzaaShNalfluh8ZPPhzKe3qyVCP1HiZszSAsw==}
+  /tsconfck/2.1.0:
+    resolution: {integrity: sha512-lztI9ohwclQHISVWrM/hlcgsRpphsii94DV9AQtAw2XJSVNiv+3ppdEsrL5J+xc5oTeHXe1qDqlOAGw8VSa9+Q==}
     engines: {node: ^14.13.1 || ^16 || >=18}
     hasBin: true
     peerDependencies:
-      typescript: ^4.3.5
+      typescript: ^4.3.5 || ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true


### PR DESCRIPTION
fixes #12380

note: there are new test fixtures in tsconfck validating array extends, but I have not used it with vite or tested it "in the wild" beyond that.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
