### PR TITLE
fix: html env replacement plugin position

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -285,8 +285,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   const [preHooks, normalHooks, postHooks] = resolveHtmlTransforms(
     config.plugins,
   )
-  preHooks.unshift(preImportMapHook(config))
-  normalHooks.unshift(htmlEnvHook(config))
+  preHooks.unshift(htmlEnvHook(config), preImportMapHook(config))
   postHooks.push(postImportMapHook())
   const processedHtml = new Map<string, string>()
   const isExcludedUrl = (url: string) =>

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -285,7 +285,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   const [preHooks, normalHooks, postHooks] = resolveHtmlTransforms(
     config.plugins,
   )
-  preHooks.unshift(htmlEnvHook(config), preImportMapHook(config))
+  preHooks.unshift(preImportMapHook(config))
+  preHooks.push(htmlEnvHook(config))
   postHooks.push(postImportMapHook())
   const processedHtml = new Map<string, string>()
   const isExcludedUrl = (url: string) =>

--- a/playground/html/.env
+++ b/playground/html/.env
@@ -1,1 +1,2 @@
 VITE_FOO=bar
+VITE_FAVICON_URL=/sprite.svg

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -273,6 +273,11 @@ describe('env', () => {
     expect(await page.textContent('.env-bar')).toBeTruthy()
     expect(await page.textContent('.env-prod')).toBe(isBuild + '')
     expect(await page.textContent('.env-dev')).toBe(isServe + '')
+
+    const iconLink = await page.$('link[rel=icon]')
+    expect(await iconLink.getAttribute('href')).toBe(
+      `${isBuild ? './' : '/'}sprite.svg`,
+    )
   })
 })
 

--- a/playground/html/env.html
+++ b/playground/html/env.html
@@ -3,3 +3,4 @@
 <p class="env-%VITE_FOO%">class name should be env-bar</p>
 <p class="env-prod">%PROD%</p>
 <p class="env-dev">%DEV%</p>
+<link rel="icon" href="%VITE_FAVICON_URL%" />


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/pull/12202#issuecomment-1466936983

`normalHooks` are post hooks. We need to apply the env replacement plugin as the first `preHooks`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other