### PR TITLE
fix(optimizer): # symbol in deps id stripped by browser

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -76,6 +76,7 @@ export function unwrapId(id: string): string {
 
 export const flattenId = (id: string): string =>
   id
+    .replace(/\/#/g, '/[sharp]')
     .replace(/[/:]/g, '_')
     .replace(/\./g, '__')
     .replace(/(\s*>\s*)/g, '___')

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -76,10 +76,10 @@ export function unwrapId(id: string): string {
 
 export const flattenId = (id: string): string =>
   id
-    .replace(/\/#/g, '/[sharp]')
     .replace(/[/:]/g, '_')
     .replace(/\./g, '__')
     .replace(/(\s*>\s*)/g, '___')
+    .replace(/#/g, '____')
 
 export const normalizeId = (id: string): string =>
   id.replace(/(\s*>\s*)/g, ' > ')

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -155,7 +155,7 @@ test('resolve.conditions', async () => {
 
 test('resolve package that contains # in path', async () => {
   expect(await page.textContent('.path-contains-sharp-symbol')).toMatch(
-    '[success]',
+    '[success] true',
   )
 })
 

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -334,7 +334,9 @@
   text('.inline-pkg', inlineMsg)
 
   import es5Ext from 'es5-ext'
-  text('.path-contains-sharp-symbol', '[success]')
+  import contains from 'es5-ext/string/#/contains'
+
+  text('.path-contains-sharp-symbol', `[success] ${contains.call('#', '#')}`)
 </script>
 
 <style>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If an optimized deps id contains `#` symbol, it will be stripped as a URL request from the browser, which will make the asset unreachable.

For example

```html
<script type='module'>
import contains from 'es5-ext/string/#/contains'
</script>
```

There will be a file named `es5-ext_string_#_contains.js` in `.vite/deps` after pre-bundle. And this file will be  visited as `http://localhost:5173/node_modules/.vite/deps/es5-ext_string_#_contains.js?v=ebf1e6a3` in the browser. Then the `#` symbol and characters behind it will be stripped by the browser.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

This PR replaced `#` with `[sharp]`, which may confuse the user. But I can't figure out a better replacement :(

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
