### PR TITLE
perf(resolve): improve package.json resolve speed

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -86,6 +86,7 @@
     "@rollup/plugin-node-resolve": "15.0.1",
     "@rollup/plugin-typescript": "^11.0.0",
     "@rollup/pluginutils": "^5.0.2",
+    "@types/pnpapi": "^0.0.2",
     "acorn": "^8.8.2",
     "acorn-walk": "^8.2.0",
     "cac": "^6.7.14",

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -18,7 +18,6 @@ import {
   getHash,
   isOptimizable,
   lookupFile,
-  nestedResolveFrom,
   normalizeId,
   normalizePath,
   removeDir,
@@ -27,6 +26,7 @@ import {
 } from '../utils'
 import { transformWithEsbuild } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET } from '../constants'
+import { resolvePkgJsonPath } from '../packages'
 import { esbuildCjsExternalPlugin, esbuildDepPlugin } from './esbuildDepPlugin'
 import { scanImports } from './scan'
 export {
@@ -855,14 +855,30 @@ function createOptimizeDepsIncludeResolver(
     // 'foo > bar > baz' => 'foo > bar' & 'baz'
     const nestedRoot = id.substring(0, lastArrowIndex).trim()
     const nestedPath = id.substring(lastArrowIndex + 1).trim()
-    const basedir = nestedResolveFrom(
+    const basedir = nestedResolvePkgJsonPath(
       nestedRoot,
       config.root,
       config.resolve.preserveSymlinks,
-      ssr,
     )
     return await resolve(nestedPath, basedir, undefined, ssr)
   }
+}
+
+/**
+ * Like `resolvePkgJsonPath`, but supports resolving nested package names with '>'
+ */
+function nestedResolvePkgJsonPath(
+  id: string,
+  basedir: string,
+  preserveSymlinks = false,
+) {
+  const pkgs = id.split('>').map((pkg) => pkg.trim())
+  try {
+    for (const pkg of pkgs) {
+      basedir = resolvePkgJsonPath(pkg, basedir, preserveSymlinks)
+    }
+  } catch {}
+  return basedir
 }
 
 export function newDepOptimizationProcessing(): DepOptimizationProcessing {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -873,11 +873,9 @@ function nestedResolvePkgJsonPath(
   preserveSymlinks = false,
 ) {
   const pkgs = id.split('>').map((pkg) => pkg.trim())
-  try {
-    for (const pkg of pkgs) {
-      basedir = resolvePkgJsonPath(pkg, basedir, preserveSymlinks)
-    }
-  } catch {}
+  for (const pkg of pkgs) {
+    basedir = resolvePkgJsonPath(pkg, basedir, preserveSymlinks) || basedir
+  }
   return basedir
 }
 

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
-import { createDebugger, createFilter } from './utils'
+import { createDebugger, createFilter, safeRealpathSync } from './utils'
 import type { ResolvedConfig } from './config'
 import type { Plugin } from './plugin'
 
@@ -91,7 +91,7 @@ export function loadPackageData(
   packageCache?: PackageCache,
 ): PackageData {
   if (!preserveSymlinks) {
-    pkgPath = fs.realpathSync.native(pkgPath)
+    pkgPath = safeRealpathSync(pkgPath)
   }
 
   let cached: PackageData | undefined
@@ -200,7 +200,7 @@ export function resolvePkgJsonPath(
     const pkg = path.join(root, 'node_modules', pkgName, 'package.json')
     try {
       if (fs.existsSync(pkg)) {
-        return preserveSymlinks ? pkg : fs.realpathSync.native(pkg)
+        return preserveSymlinks ? pkg : safeRealpathSync(pkg)
       }
     } catch {}
     const nextRoot = path.dirname(root)

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -707,12 +707,9 @@ export function tryNodeResolve(
 
   const rootPkgId = possiblePkgIds[0]
 
-  const rootPkg = resolvePackageData(
-    rootPkgId,
-    basedir,
-    preserveSymlinks,
-    packageCache,
-  )!
+  const rootPkg = rootPkgId
+    ? resolvePackageData(rootPkgId, basedir, preserveSymlinks, packageCache)
+    : undefined
 
   const nearestPkgId = [...possiblePkgIds].reverse().find((pkgId) => {
     nearestPkg = resolvePackageData(
@@ -1298,38 +1295,21 @@ function getRealPath(resolved: string, preserveSymlinks?: boolean): string {
 }
 
 /**
- * if importer was not resolved by vite's resolver previously
- * (when esbuild resolved it)
- * resolve importer's pkg and add to idToPkgMap
+ * Load closest `package.json` to `importer`
  */
 function resolvePkg(importer: string, options: InternalResolveOptions) {
-  const { root, preserveSymlinks, packageCache } = options
+  const { preserveSymlinks, packageCache } = options
 
   if (importer.includes('\x00')) {
     return null
   }
 
-  const possiblePkgIds: string[] = []
-  for (let prevSlashIndex = -1; ; ) {
-    const slashIndex = importer.indexOf(isWindows ? '\\' : '/', prevSlashIndex)
-    if (slashIndex < 0) {
-      break
-    }
-
-    prevSlashIndex = slashIndex + 1
-
-    const possiblePkgId = importer.slice(0, slashIndex)
-    possiblePkgIds.push(possiblePkgId)
-  }
-
-  let pkg: PackageData | undefined
-  possiblePkgIds.reverse().find((pkgId) => {
-    pkg = resolvePackageData(pkgId, root, preserveSymlinks, packageCache)!
-    return pkg
-  })!
-
-  if (pkg) {
+  const pkgPath = lookupFile(importer, ['package.json'], { pathOnly: true })
+  if (pkgPath) {
+    const pkg = loadPackageData(pkgPath, preserveSymlinks, packageCache)
     idToPkgMap.set(importer, pkg)
+    return pkg
   }
-  return pkg
+
+  return undefined
 }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -11,9 +11,9 @@ import {
   isDefined,
   lookupFile,
   normalizePath,
-  resolveFrom,
 } from '../utils'
 import type { Logger, ResolvedConfig } from '..'
+import { resolvePkgJsonPath } from '../packages'
 
 const debug = createDebugger('vite:ssr-external')
 
@@ -258,7 +258,7 @@ function cjsSsrCollectExternals(
     } catch (e) {
       try {
         // no main entry, but deep imports may be allowed
-        const pkgPath = resolveFrom(`${id}/package.json`, root)
+        const pkgPath = resolvePkgJsonPath(id, root)
         if (pkgPath.includes('node_modules')) {
           ssrExternals.add(id)
         } else {
@@ -277,7 +277,7 @@ function cjsSsrCollectExternals(
     }
     // trace the dependencies of linked packages
     else if (!esmEntry.includes('node_modules')) {
-      const pkgPath = resolveFrom(`${id}/package.json`, root)
+      const pkgPath = resolvePkgJsonPath(id, root)
       depsToTrace.add(path.dirname(pkgPath))
     }
     // has separate esm/require entry, assume require entry is cjs
@@ -288,7 +288,7 @@ function cjsSsrCollectExternals(
     // or are there others like SystemJS / AMD that we'd need to handle?
     // for now, we'll just leave this as is
     else if (/\.m?js$/.test(esmEntry)) {
-      const pkgPath = resolveFrom(`${id}/package.json`, root)
+      const pkgPath = resolvePkgJsonPath(id, root)
       const pkgContent = fs.readFileSync(pkgPath, 'utf-8')
 
       if (!pkgContent) {

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -278,7 +278,6 @@ function cjsSsrCollectExternals(
     // trace the dependencies of linked packages
     else if (!esmEntry.includes('node_modules')) {
       const pkgPath = resolvePkgJsonPath(id, root)
-      // NOTE (temp): if pkg not found, we skip instead of error, is this problematic?
       if (pkgPath) {
         depsToTrace.add(path.dirname(pkgPath))
       }
@@ -292,7 +291,6 @@ function cjsSsrCollectExternals(
     // for now, we'll just leave this as is
     else if (/\.m?js$/.test(esmEntry)) {
       const pkgPath = resolvePkgJsonPath(id, root)
-      // NOTE (temp): if pkg not found, we skip instead of error, is this problematic?
       if (!pkgPath) {
         continue
       }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -153,25 +153,6 @@ export function resolveFrom(
   })
 }
 
-/**
- * like `resolveFrom` but supports resolving `>` path in `id`,
- * for example: `foo > bar > baz`
- */
-export function nestedResolveFrom(
-  id: string,
-  basedir: string,
-  preserveSymlinks = false,
-  ssr = false,
-): string {
-  const pkgs = id.split('>').map((pkg) => pkg.trim())
-  try {
-    for (const pkg of pkgs) {
-      basedir = resolveFrom(pkg, basedir, preserveSymlinks, ssr)
-    }
-  } catch {}
-  return basedir
-}
-
 // set in bin/vite.js
 const filter = process.env.VITE_DEBUG_FILTER
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -127,14 +127,8 @@ export function isOptimizable(
 export const bareImportRE = /^[\w@](?!.*:\/\/)/
 export const deepImportRE = /^([^@][^/]*)\/|^(@[^/]+\/[^/]+)\//
 
-export let isRunningWithYarnPnp: boolean
-
 // TODO: use import()
 const _require = createRequire(import.meta.url)
-
-try {
-  isRunningWithYarnPnp = Boolean(_require('pnpapi'))
-} catch {}
 
 const ssrExtensions = ['.js', '.cjs', '.json', '.node']
 
@@ -149,7 +143,7 @@ export function resolveFrom(
     paths: [],
     extensions: ssr ? ssrExtensions : DEFAULT_EXTENSIONS,
     // necessary to work with pnpm
-    preserveSymlinks: preserveSymlinks || isRunningWithYarnPnp || false,
+    preserveSymlinks: preserveSymlinks || !!process.versions.pnp || false,
   })
 }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -592,7 +592,9 @@ export const removeDir = isWindows
     }
 export const renameDir = isWindows ? promisify(gracefulRename) : fs.renameSync
 
-// `fs.realpathSync.native` has a bug in Windows network drive that prepends a slash
+// `fs.realpathSync.native` resolves differently in Windows network drive,
+// causing file read errors. skip for now.
+// https://github.com/nodejs/node/issues/37737
 export const safeRealpathSync = isWindows
   ? fs.realpathSync
   : fs.realpathSync.native

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -592,6 +592,11 @@ export const removeDir = isWindows
     }
 export const renameDir = isWindows ? promisify(gracefulRename) : fs.renameSync
 
+// `fs.realpathSync.native` has a bug in Windows network drive that prepends a slash
+export const safeRealpathSync = isWindows
+  ? fs.realpathSync
+  : fs.realpathSync.native
+
 export function ensureWatchedFile(
   watcher: FSWatcher,
   file: string | null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,7 @@ importers:
       '@rollup/plugin-node-resolve': 15.0.1
       '@rollup/plugin-typescript': ^11.0.0
       '@rollup/pluginutils': ^5.0.2
+      '@types/pnpapi': ^0.0.2
       acorn: ^8.8.2
       acorn-walk: ^8.2.0
       cac: ^6.7.14
@@ -246,6 +247,7 @@ importers:
       '@rollup/plugin-node-resolve': 15.0.1_rollup@3.18.0
       '@rollup/plugin-typescript': 11.0.0_rollup@3.18.0+tslib@2.5.0
       '@rollup/pluginutils': 5.0.2_rollup@3.18.0
+      '@types/pnpapi': 0.0.2
       acorn: 8.8.2
       acorn-walk: 8.2.0_acorn@8.8.2
       cac: 6.7.14
@@ -3476,6 +3478,10 @@ packages:
 
   /@types/picomatch/2.3.0:
     resolution: {integrity: sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g==}
+    dev: true
+
+  /@types/pnpapi/0.0.2:
+    resolution: {integrity: sha512-2lqsQt1iXkiTqwuzw2SS50iduoPZNpV/ou4/vJD443C0weF63Gqd3ErGS811CBNMzLO64zVJ+tiyh+4yimdYkg==}
     dev: true
 
   /@types/prompts/2.4.2:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Should fix https://github.com/vitejs/vite/issues/8850, my benchmarks were based on on the issue's repro.

This PR bring 1.5-4x resolve speed for resolving modules that heavily rely on resolving `package.json`. We only use the `resolve` package to resolve dep `package.json` files, I've implemented a simpler logic for it specifically, extracted from [vitefu](https://github.com/svitejs/vitefu/blob/d5ee41e859ae8fabdb477e03e66dcb19b8a4636f/src/index.js#L197-L220), which has been used by many frameworks so far.

This simpler logic is more straight-forward and prevents the use of errors + try/catch. It also supports yarn pnp. (fun fact: yarn pnp patches the `resolve` package by default)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
It would be easier to review by each commit.

Before merging this, it might be a good idea to run ecosystem-ci.

Here are the cpuprofiles: https://gist.github.com/bluwy/19c6c3ec6fc3479ffa5e679b4c61344e

The `resolve` dep is not removed yet. There's one more place that needs to be fixed before doing so, the work is tracked at https://github.com/vitejs/vite/pull/11410. This shouldn't affect anything though.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
