### PR TITLE
fix: add `virtual:` to virtual module source map ignore

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -12,7 +12,7 @@ const debug = createDebugger('vite:sourcemap', {
 // Virtual modules should be prefixed with a null byte to avoid a
 // false positive "missing source" warning. We also check for certain
 // prefixes used for special handling in esbuildDepPlugin.
-const virtualSourceRE = /^(?:\0|dep:|browser-external:)/
+const virtualSourceRE = /^(?:dep:|browser-external:|virtual:)|\0/
 
 interface SourceMapLike {
   sources: string[]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- add `virtual:` to the virtual module sourcemap ignore
- make `\0` match for any position of the path, as it can't be a real path.

### Additional context

https://github.com/unocss/unocss/issues/2113#issuecomment-1472098481

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
