### PR TITLE
perf(resolve): support # in path only for dependencies

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -476,12 +476,12 @@ function tryFsResolve(
 
   // Dependencies like es5-ext use `#` in their paths. We don't support `#` in user
   // source code so we only need to perform the check for dependencies.
-  const trySharp = fsPath.includes('#') && fsPath.includes('node_modules')
+  const tryUnsplitted = fsPath.includes('#') && fsPath.includes('node_modules')
 
   let res: string | undefined
 
   if (
-    trySharp &&
+    tryUnsplitted &&
     (res = tryResolveFile(
       fsPath,
       '',
@@ -511,7 +511,7 @@ function tryFsResolve(
 
   for (const ext of options.extensions) {
     if (
-      trySharp &&
+      tryUnsplitted &&
       (res = tryResolveFile(
         fsPath + ext,
         '',
@@ -546,7 +546,7 @@ function tryFsResolve(
   if (!tryIndex) return
 
   if (
-    trySharp &&
+    tryUnsplitted &&
     (res = tryResolveFile(
       fsPath,
       '',

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -474,11 +474,14 @@ function tryFsResolve(
 ): string | undefined {
   const { file, postfix } = splitFileAndPostfix(fsPath)
 
+  // Dependencies like es5-ext use `#` in their paths. We don't support `#` in user
+  // source code so we only need to perform the check for dependencies.
+  const trySharp = fsPath.includes('#') && fsPath.includes('node_modules')
+
   let res: string | undefined
 
-  // if there is a postfix, try resolving it as a complete path first (#4703)
   if (
-    postfix &&
+    trySharp &&
     (res = tryResolveFile(
       fsPath,
       '',
@@ -508,7 +511,7 @@ function tryFsResolve(
 
   for (const ext of options.extensions) {
     if (
-      postfix &&
+      trySharp &&
       (res = tryResolveFile(
         fsPath + ext,
         '',
@@ -543,7 +546,7 @@ function tryFsResolve(
   if (!tryIndex) return
 
   if (
-    postfix &&
+    trySharp &&
     (res = tryResolveFile(
       fsPath,
       '',


### PR DESCRIPTION
### Description

@sun0day has been investigating `tryFsResolve` double checks to support paths with `#`. See:
- https://github.com/vitejs/vite/pull/12436

We added the checks to resolve the file path without removing the postfix because of dependencies like [es5-ext](https://www.npmjs.com/package/es5-ext) here: 
- https://github.com/vitejs/vite/pull/4703

But the use of `?` and `#` never worked in user code and this is something we can control. Requiring users to avoid `?` and `#` in their paths is a fair price to pay to avoid double checks.

This PR formalizes that we only support `#` in dependencies paths, and removes the double checks in other cases. Note: I only included support for `#` here, and not `?` so the double checks won't be triggered for every dependency.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other