### PR TITLE
test(resolve): add a test for resolving nested extension

### DIFF
--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -81,7 +81,7 @@ test('nested extension', async () => {
   )
 })
 
-test('', async () => {
+test('exact extension vs. duplicated (.js.js)', async () => {
   expect(await page.textContent('.exact-extension')).toMatch('[success]')
 })
 

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -75,7 +75,13 @@ test('implicit dir/index.js vs explicit file', async () => {
   expect(await page.textContent('.dir-vs-file')).toMatch('[success]')
 })
 
-test('exact extension vs. duplicated (.js.js)', async () => {
+test('nested extension', async () => {
+  expect(await page.textContent('.nested-extension')).toMatch(
+    '[success] file.json.js',
+  )
+})
+
+test('', async () => {
   expect(await page.textContent('.exact-extension')).toMatch('[success]')
 })
 

--- a/playground/resolve/exact-extension/file.json.js
+++ b/playground/resolve/exact-extension/file.json.js
@@ -1,0 +1,1 @@
+export const file = '[success] file.json.js'

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -63,6 +63,9 @@
 <h2>Resolve to non-duplicated file extension</h2>
 <p class="exact-extension">fail</p>
 
+<h2>Resolve nested file extension</h2>
+<p class="nested-extension">fail</p>
+
 <h2>Don't add extensions to directory names</h2>
 <p class="dir-with-ext">fail</p>
 
@@ -232,9 +235,13 @@
   import { file } from './dir'
   text('.dir-vs-file', file)
 
-  // // exact extension vs. duplicated (.js.js)
+  // exact extension vs. duplicated (.js.js)
   import { file as exactExtMsg } from './exact-extension/file.js'
   text('.exact-extension', exactExtMsg)
+
+  // nested extension
+  import { file as fileJsonMsg } from './exact-extension/file.json'
+  text('.nested-extension', fileJsonMsg)
 
   // don't add extensions to dir name (./dir-with-ext.js/index.js)
   import { file as dirWithExtMsg } from './dir-with-ext'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

No need to append extensions to fs paths that already contain one extension

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
