### PR TITLE
perf(resolve): skip absolute paths in root as url checks

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -127,8 +127,8 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
   const { target: ssrTarget, noExternal: ssrNoExternal } = ssrConfig ?? {}
 
   // In unix systems, absolute paths inside root first needs to be checked as an
-  // absolute URL resulting in failed checks before falling back to checking the path
-  // as absolute (/root/root/path-to-file). If /root/root isn't a valid path, we can
+  // absolute URL (/root/root/path-to-file) resulting in failed checks before falling
+  // back to checking the path as absolute. If /root/root isn't a valid path, we can
   // avoid these checks. Absolute paths inside root are common in user code as many
   // paths are resolved by the user. For example for an alias.
   const rootInRoot =

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -126,6 +126,16 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
   const { target: ssrTarget, noExternal: ssrNoExternal } = ssrConfig ?? {}
 
+  // In unix systems, absolute paths inside root first needs to be checked as an
+  // absolute URL resulting in failed checks before falling back to checking the path
+  // as absolute (/root/root/path-to-file). If /root/root isn't a valid path, we can
+  // avoid these checks. Absolute paths inside root are common in user code as many
+  // paths are resolved by the user. For example for an alias.
+  const rootInRoot =
+    fs
+      .statSync(path.join(root, root), { throwIfNoEntry: false })
+      ?.isDirectory() ?? false
+
   return {
     name: 'vite:resolve',
 
@@ -255,7 +265,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
       // URL
       // /foo -> /fs-root/foo
-      if (asSrc && id.startsWith('/')) {
+      if (asSrc && id.startsWith('/') && (rootInRoot || !id.startsWith(root))) {
         const fsPath = path.resolve(root, id.slice(1))
         if ((res = tryFsResolve(fsPath, options))) {
           isDebug && debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)


### PR DESCRIPTION
### Description

Implements @bluwy's idea of a pre-cached `root/root` check when resolving absolute paths, allowing skipping the check as a URL for common absolute paths. See https://github.com/vitejs/vite/pull/12471#issuecomment-1474764800

After this PR, https://github.com/vitejs/vite/pull/12471 still counts as an optimization if we merge https://github.com/vitejs/vite/pull/12450

We could add a watcher to check if `root/root` is created after the server starts but I feel it is a very uncommon edge case and we could keep it simple. Open to adding more complexity if we think that is important here.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other