### PR TITLE
fix(create-vite): updated js & ts templates with new react docs link

### DIFF
--- a/packages/create-vite/template-react-ts/src/App.tsx
+++ b/packages/create-vite/template-react-ts/src/App.tsx
@@ -12,7 +12,7 @@ function App() {
         <a href="https://vitejs.dev" target="_blank">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://react.dev" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>

--- a/packages/create-vite/template-react/src/App.jsx
+++ b/packages/create-vite/template-react/src/App.jsx
@@ -12,7 +12,7 @@ function App() {
         <a href="https://vitejs.dev" target="_blank">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
-        <a href="https://reactjs.org" target="_blank">
+        <a href="https://react.dev" target="_blank">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>


### PR DESCRIPTION
### Description
In this PR, the new changes consist of the react templates that are generated in Javascript and Typescript to point latest react docs link (i.e. react.dev)

### Additional context
As of now, this will not be a breaking/major change, since reactjs.org (the old domain) is redirecting anyway to the new one. But it would be nice to generate the templates with latest URL that is official.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
