### PR TITLE
perf(css): improve postcss config resolve

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1174,6 +1174,9 @@ async function resolvePostcssConfig(
   }
 
   postcssConfigCache.set(config, result)
+  result.then((resolved) => {
+    postcssConfigCache.set(config, resolved)
+  })
   return result
 }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -166,10 +166,10 @@ export const removedPureCssFilesCache = new WeakMap<
   Map<string, RenderedChunk>
 >()
 
-const postcssConfigCache: Record<
-  string,
-  WeakMap<ResolvedConfig, PostCSSConfigResult | null>
-> = {}
+const postcssConfigCache = new WeakMap<
+  ResolvedConfig,
+  PostCSSConfigResult | null | Promise<PostCSSConfigResult | null>
+>()
 
 function encodePublicUrlsInCSS(config: ResolvedConfig) {
   return config.command === 'build'
@@ -187,6 +187,9 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
     tryIndex: false,
     extensions: [],
   })
+
+  // warm up cache for resolved postcss config
+  resolvePostcssConfig(config)
 
   return {
     name: 'vite:css',
@@ -803,7 +806,7 @@ async function compileCSS(
   const needInlineImport = code.includes('@import')
   const hasUrl = cssUrlRE.test(code) || cssImageSetRE.test(code)
   const lang = id.match(CSS_LANGS_RE)?.[1] as CssLang | undefined
-  const postcssConfig = await resolvePostcssConfig(config, getCssDialect(lang))
+  const postcssConfig = await resolvePostcssConfig(config)
 
   // 1. plain css that needs no processing
   if (
@@ -883,14 +886,6 @@ async function compileCSS(
 
   // 3. postcss
   const postcssOptions = (postcssConfig && postcssConfig.options) || {}
-
-  // for sugarss change parser
-  if (lang === 'sss') {
-    postcssOptions.parser = loadPreprocessor(
-      PostCssDialectLang.sss,
-      config.root,
-    )
-  }
 
   const postcssPlugins =
     postcssConfig && postcssConfig.plugins ? postcssConfig.plugins.slice() : []
@@ -974,6 +969,10 @@ async function compileCSS(
       .default(postcssPlugins)
       .process(code, {
         ...postcssOptions,
+        parser:
+          lang === 'sss'
+            ? loadPreprocessor(PostCssDialectLang.sss, config.root)
+            : postcssOptions.parser,
         to: source,
         from: source,
         ...(devSourcemap
@@ -1139,16 +1138,10 @@ interface PostCSSConfigResult {
 
 async function resolvePostcssConfig(
   config: ResolvedConfig,
-  dialect = 'css',
 ): Promise<PostCSSConfigResult | null> {
-  postcssConfigCache[dialect] ??= new WeakMap<
-    ResolvedConfig,
-    PostCSSConfigResult | null
-  >()
-
-  let result = postcssConfigCache[dialect].get(config)
+  let result = postcssConfigCache.get(config)
   if (result !== undefined) {
-    return result
+    return await result
   }
 
   // inline postcss config via vite config
@@ -1164,9 +1157,7 @@ async function resolvePostcssConfig(
   } else {
     const searchPath =
       typeof inlineOptions === 'string' ? inlineOptions : config.root
-    try {
-      result = await postcssrc({}, searchPath)
-    } catch (e) {
+    result = postcssrc({}, searchPath).catch((e) => {
       if (!/No PostCSS Config found/.test(e.message)) {
         if (e instanceof Error) {
           const { name, message, stack } = e
@@ -1178,11 +1169,11 @@ async function resolvePostcssConfig(
           throw new Error(`Failed to load PostCSS config: ${e}`)
         }
       }
-      result = null
-    }
+      return null
+    })
   }
 
-  postcssConfigCache[dialect].set(config, result)
+  postcssConfigCache.set(config, result)
   return result
 }
 
@@ -1976,8 +1967,4 @@ const preProcessors = Object.freeze({
 
 function isPreProcessor(lang: any): lang is PreprocessLang {
   return lang && lang in preProcessors
-}
-
-function getCssDialect(lang: CssLang | undefined): string {
-  return lang === 'sss' ? 'sss' : 'css'
 }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1171,12 +1171,13 @@ async function resolvePostcssConfig(
       }
       return null
     })
+    // replace cached promise to result object when finished
+    result.then((resolved) => {
+      postcssConfigCache.set(config, resolved)
+    })
   }
 
   postcssConfigCache.set(config, result)
-  result.then((resolved) => {
-    postcssConfigCache.set(config, resolved)
-  })
   return result
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

With many parallel CSS file requests (especially with `preTransformRequest`), each CSS will try to resolve the `postcss` config because the cache has not been filled. This is slow as we only need one CSS file to resolve it, while others can wait for that one result. Otherwise all CSS files will resolve their own postcss config at once, causing slowness.

On top of that, `postcss-load-config` takes strangely long to load (2s for me), especially if you don't have a config at all. So we need to reduce calling it.

This PR does the above by caching the promise of the config resolve, instead of it's result.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Debugging the slowness in https://github.com/sveltejs/vite-plugin-svelte/tree/main/packages/playground/big

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
