### PR TITLE
feat(reporter): show gzip info for all compressible files (fix #11288)

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -20,6 +20,8 @@ type LogEntry = {
   mapSize: number | null
 }
 
+const COMPRESSIBLE_ASSETS_RE = /\.(?:html|json|svg|txt|xml|xhtml)$/
+
 export function buildReporterPlugin(config: ResolvedConfig): Plugin {
   const compress = promisify(gzip)
   const chunkLimit = config.build.chunkSizeWarningLimit
@@ -144,12 +146,14 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                 } else {
                   if (chunk.fileName.endsWith('.map')) return null
                   const isCSS = chunk.fileName.endsWith('.css')
+                  const isCompressible =
+                    isCSS || COMPRESSIBLE_ASSETS_RE.test(chunk.fileName)
                   return {
                     name: chunk.fileName,
                     group: isCSS ? 'CSS' : 'Assets',
                     size: chunk.source.length,
                     mapSize: null, // Rollup doesn't support CSS maps?
-                    compressedSize: isCSS
+                    compressedSize: isCompressible
                       ? await getCompressedSize(chunk.source)
                       : null,
                   }


### PR DESCRIPTION
### Description

This is a fix/feature-update for #11288 

The reporter plugin should show gzip information not only for `js` and `css` files but also for other compressible files like `svg`, `html`.

### Additional context

see https://github.com/vitejs/vite/issues/11288#issuecomment-1475356530

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

We need to further discuss the liste of file-extensions we want to show the gzip information for.