### PR TITLE
fix: escape replacements in clientInjections

### DIFF
--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -96,7 +96,8 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
 }
 
 function escapeReplacement(value: string | number | boolean | null) {
-  return () => JSON.stringify(value)
+  const jsonValue = JSON.stringify(value)
+  return () => jsonValue
 }
 
 function serializeDefine(define: Record<string, any>): string {

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -13,54 +13,74 @@ const normalizedEnvEntry = normalizePath(ENV_ENTRY)
  * @server-only
  */
 export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
+  let injectConfigValues: (code: string) => string
+
   return {
     name: 'vite:client-inject',
-    async transform(code, id, options) {
-      if (id === normalizedClientEntry || id === normalizedEnvEntry) {
-        const resolvedServerHostname = (
-          await resolveHostname(config.server.host)
-        ).name
-        const resolvedServerPort = config.server.port!
-        const devBase = config.base
+    async buildStart() {
+      const resolvedServerHostname = (await resolveHostname(config.server.host))
+        .name
+      const resolvedServerPort = config.server.port!
+      const devBase = config.base
 
-        const serverHost = `${resolvedServerHostname}:${resolvedServerPort}${devBase}`
+      const serverHost = `${resolvedServerHostname}:${resolvedServerPort}${devBase}`
 
-        let hmrConfig = config.server.hmr
-        hmrConfig = isObject(hmrConfig) ? hmrConfig : undefined
-        const host = hmrConfig?.host || null
-        const protocol = hmrConfig?.protocol || null
-        const timeout = hmrConfig?.timeout || 30000
-        const overlay = hmrConfig?.overlay !== false
-        const isHmrServerSpecified = !!hmrConfig?.server
+      let hmrConfig = config.server.hmr
+      hmrConfig = isObject(hmrConfig) ? hmrConfig : undefined
+      const host = hmrConfig?.host || null
+      const protocol = hmrConfig?.protocol || null
+      const timeout = hmrConfig?.timeout || 30000
+      const overlay = hmrConfig?.overlay !== false
+      const isHmrServerSpecified = !!hmrConfig?.server
 
-        // hmr.clientPort -> hmr.port
-        // -> (24678 if middleware mode and HMR server is not specified) -> new URL(import.meta.url).port
-        let port = hmrConfig?.clientPort || hmrConfig?.port || null
-        if (config.server.middlewareMode && !isHmrServerSpecified) {
-          port ||= 24678
-        }
+      // hmr.clientPort -> hmr.port
+      // -> (24678 if middleware mode and HMR server is not specified) -> new URL(import.meta.url).port
+      let port = hmrConfig?.clientPort || hmrConfig?.port || null
+      if (config.server.middlewareMode && !isHmrServerSpecified) {
+        port ||= 24678
+      }
 
-        let directTarget = hmrConfig?.host || resolvedServerHostname
-        directTarget += `:${hmrConfig?.port || resolvedServerPort}`
-        directTarget += devBase
+      let directTarget = hmrConfig?.host || resolvedServerHostname
+      directTarget += `:${hmrConfig?.port || resolvedServerPort}`
+      directTarget += devBase
 
-        let hmrBase = devBase
-        if (hmrConfig?.path) {
-          hmrBase = path.posix.join(hmrBase, hmrConfig.path)
-        }
+      let hmrBase = devBase
+      if (hmrConfig?.path) {
+        hmrBase = path.posix.join(hmrBase, hmrConfig.path)
+      }
 
+      const serializedDefines = serializeDefine(config.define || {})
+
+      const modeReplacement = escapeReplacement(config.mode)
+      const baseReplacement = escapeReplacement(devBase)
+      const definesReplacement = () => serializedDefines
+      const serverHostReplacement = escapeReplacement(serverHost)
+      const hmrProtocolReplacement = escapeReplacement(protocol)
+      const hmrHostnameReplacement = escapeReplacement(host)
+      const hmrPortReplacement = escapeReplacement(port)
+      const hmrDirectTargetReplacement = escapeReplacement(directTarget)
+      const hmrBaseReplacement = escapeReplacement(hmrBase)
+      const hmrTimeoutReplacement = escapeReplacement(timeout)
+      const hmrEnableOverlayReplacement = escapeReplacement(overlay)
+
+      injectConfigValues = (code: string) => {
         return code
-          .replace(`__MODE__`, escapeReplacement(config.mode))
-          .replace(/__BASE__/g, escapeReplacement(devBase))
-          .replace(`__DEFINES__`, () => serializeDefine(config.define || {}))
-          .replace(`__SERVER_HOST__`, escapeReplacement(serverHost))
-          .replace(`__HMR_PROTOCOL__`, escapeReplacement(protocol))
-          .replace(`__HMR_HOSTNAME__`, escapeReplacement(host))
-          .replace(`__HMR_PORT__`, escapeReplacement(port))
-          .replace(`__HMR_DIRECT_TARGET__`, escapeReplacement(directTarget))
-          .replace(`__HMR_BASE__`, escapeReplacement(hmrBase))
-          .replace(`__HMR_TIMEOUT__`, escapeReplacement(timeout))
-          .replace(`__HMR_ENABLE_OVERLAY__`, escapeReplacement(overlay))
+          .replace(`__MODE__`, modeReplacement)
+          .replace(/__BASE__/g, baseReplacement)
+          .replace(`__DEFINES__`, definesReplacement)
+          .replace(`__SERVER_HOST__`, serverHostReplacement)
+          .replace(`__HMR_PROTOCOL__`, hmrProtocolReplacement)
+          .replace(`__HMR_HOSTNAME__`, hmrHostnameReplacement)
+          .replace(`__HMR_PORT__`, hmrPortReplacement)
+          .replace(`__HMR_DIRECT_TARGET__`, hmrDirectTargetReplacement)
+          .replace(`__HMR_BASE__`, hmrBaseReplacement)
+          .replace(`__HMR_TIMEOUT__`, hmrTimeoutReplacement)
+          .replace(`__HMR_ENABLE_OVERLAY__`, hmrEnableOverlayReplacement)
+      }
+    },
+    transform(code, id, options) {
+      if (id === normalizedClientEntry || id === normalizedEnvEntry) {
+        return injectConfigValues(code)
       } else if (!options?.ssr && code.includes('process.env.NODE_ENV')) {
         // replace process.env.NODE_ENV instead of defining a global
         // for it to avoid shimming a `process` object during dev,
@@ -75,7 +95,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
-function escapeReplacement(value: any) {
+function escapeReplacement(value: string | number | boolean | null) {
   return () => JSON.stringify(value)
 }
 

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -50,17 +50,17 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
         }
 
         return code
-          .replace(`__MODE__`, JSON.stringify(config.mode))
-          .replace(/__BASE__/g, JSON.stringify(devBase))
-          .replace(`__DEFINES__`, serializeDefine(config.define || {}))
-          .replace(`__SERVER_HOST__`, JSON.stringify(serverHost))
-          .replace(`__HMR_PROTOCOL__`, JSON.stringify(protocol))
-          .replace(`__HMR_HOSTNAME__`, JSON.stringify(host))
-          .replace(`__HMR_PORT__`, JSON.stringify(port))
-          .replace(`__HMR_DIRECT_TARGET__`, JSON.stringify(directTarget))
-          .replace(`__HMR_BASE__`, JSON.stringify(hmrBase))
-          .replace(`__HMR_TIMEOUT__`, JSON.stringify(timeout))
-          .replace(`__HMR_ENABLE_OVERLAY__`, JSON.stringify(overlay))
+          .replace(`__MODE__`, escapeReplacement(config.mode))
+          .replace(/__BASE__/g, escapeReplacement(devBase))
+          .replace(`__DEFINES__`, () => serializeDefine(config.define || {}))
+          .replace(`__SERVER_HOST__`, escapeReplacement(serverHost))
+          .replace(`__HMR_PROTOCOL__`, escapeReplacement(protocol))
+          .replace(`__HMR_HOSTNAME__`, escapeReplacement(host))
+          .replace(`__HMR_PORT__`, escapeReplacement(port))
+          .replace(`__HMR_DIRECT_TARGET__`, escapeReplacement(directTarget))
+          .replace(`__HMR_BASE__`, escapeReplacement(hmrBase))
+          .replace(`__HMR_TIMEOUT__`, escapeReplacement(timeout))
+          .replace(`__HMR_ENABLE_OVERLAY__`, escapeReplacement(overlay))
       } else if (!options?.ssr && code.includes('process.env.NODE_ENV')) {
         // replace process.env.NODE_ENV instead of defining a global
         // for it to avoid shimming a `process` object during dev,
@@ -73,6 +73,10 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
       }
     },
   }
+}
+
+function escapeReplacement(value: any) {
+  return () => JSON.stringify(value);
 }
 
 function serializeDefine(define: Record<string, any>): string {

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -76,7 +76,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
 }
 
 function escapeReplacement(value: any) {
-  return () => JSON.stringify(value);
+  return () => JSON.stringify(value)
 }
 
 function serializeDefine(define: Record<string, any>): string {


### PR DESCRIPTION
### Description

This fixes a bug where [special regex replacement characters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement) are wrongly replaced. This can easily break a build. For example, this configuration always fails to compile:

```ts
import { defineConfig } from "vite";

export default defineConfig({
  define: {
    VAR_FOO: '"$`"'
  }
});
```

I also added the same fix to all other replacements in the same block of code, just to be extra sure.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
