### PR TITLE
fix: simplify prettyUrl

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -378,17 +378,7 @@ export function prettifyUrl(url: string, root: string): string {
   url = removeTimestampQuery(url)
   const isAbsoluteFile = url.startsWith(root)
   if (isAbsoluteFile || url.startsWith(FS_PREFIX)) {
-    let file = path.relative(root, isAbsoluteFile ? url : fsPathFromId(url))
-    const seg = file.split('/')
-    const npmIndex = seg.indexOf(`node_modules`)
-    const isSourceMap = file.endsWith('.map')
-    if (npmIndex > 0) {
-      file = seg[npmIndex + 1]
-      if (file.startsWith('@')) {
-        file = `${file}/${seg[npmIndex + 2]}`
-      }
-      file = `npm: ${colors.dim(file)}${isSourceMap ? ` (source map)` : ``}`
-    }
+    const file = path.relative(root, isAbsoluteFile ? url : fsPathFromId(url))
     return colors.dim(file)
   } else {
     return colors.dim(url)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When debugging locally with `pnpm`, I often get:

```
vite:transform 0.88ms npm: .pnpm +19ms
```

This PR expands it fully to the whole path like:

```
vite:transform 0.37ms ../../../node_modules/.pnpm/svelte-hmr@0.15.1_svelte@3.56.0/node_modules/svelte-hmr/runtime/svelte-hooks.js?v=d5665ff4 +12ms
```

since it's nicer to know which file exactly Vite is working on.






### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
