### PR TITLE
fix: prevent error on not set location href

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1543,7 +1543,7 @@ function cleanScssBugUrl(url: string) {
   if (
     // check bug via `window` and `location` global
     typeof window !== 'undefined' &&
-    typeof location !== 'undefined'
+    typeof location?.href === 'string'
   ) {
     const prefix = location.href.replace(/\/$/, '')
     return url.replace(prefix, '')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The current implementation of the function `cleanScssBugUrl` checks if the 'window' and 'location' globals are defined, and then replaces the prefix of the URL with the location href. However, in some cases, the 'location.href' value can be undefined, resulting in an error.

To resolve this issue, I've updated the code to use optional chaining (?.) to ensure that the 'replace' function only runs if 'location.href' is defined. This modification ensures that the function can handle cases where 'location.href' is undefined and prevents errors from being thrown.

This change has been tested and verified to work as expected.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
