### PR TITLE
Revert "fix(css): inject source content conditionally (#12449)"

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -380,9 +380,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const getContentWithSourcemap = async (content: string) => {
           if (config.css?.devSourcemap) {
             const sourcemap = this.getCombinedSourcemap()
-            if (sourcemap.mappings && !sourcemap.sourcesContent) {
-              await injectSourcesContent(sourcemap, cleanUrl(id), config.logger)
-            }
+            await injectSourcesContent(sourcemap, cleanUrl(id), config.logger)
             return getCodeWithSourcemap('css', content, sourcemap)
           }
           return content


### PR DESCRIPTION
This reverts commit 3e665f6cba8473acc9e13ed6a91614bd92856275.


### Description

This commit was found to cause missing css source files from built storybook bundles.  

### Additional context

I will attempt to create a reproduction, but the way we identified this commit as the problem was by checking out the commit and building vite, moving the `dist` into storybook, and verifying the crash.  Then we checked out the commit immediately prior to this, built it, and storybook worked fine.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
