### PR TITLE
fix: esbuild complains with extra fields

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -161,6 +161,12 @@ export async function transformWithEsbuild(
     tsconfigRaw,
   } as ESBuildOptions
 
+  // Some projects in the ecosystem are calling this function with an ESBuildOptions
+  // object and esbuild throws an error for extra fields
+  delete resolvedOptions.include
+  delete resolvedOptions.exclude
+  delete resolvedOptions.jsxInject
+
   try {
     const result = await transform(code, resolvedOptions)
     let map: SourceMap


### PR DESCRIPTION
### Description

Partial revert of https://github.com/vitejs/vite/pull/12493
Thanks @sapphi-red for spotting the issue in ecosystem-ci

Projects in the ecosystem are also passing an ESBuildOptions object so we need to keep these guards to make esbuild happy.

Note: esbuild also complains if setting `include: undefined` in the object.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
