### PR TITLE
feat: add opus filetype to assets & mime types

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -173,6 +173,11 @@ declare module '*.aac' {
   export default src
 }
 
+declare module '*.opus' {
+  const src: string
+  export default src
+}
+
 // fonts
 declare module '*.woff' {
   const src: string

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -115,6 +115,7 @@ export const KNOWN_ASSET_TYPES = [
   'wav',
   'flac',
   'aac',
+  'opus',
 
   // fonts
   'woff2?',

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -47,6 +47,8 @@ export function registerCustomMime(): void {
   mrmime.mimes['flac'] = 'audio/flac'
   // mrmime and mime-db is not released yet: https://github.com/jshttp/mime-db/commit/c9242a9b7d4bb25d7a0c9244adec74aeef08d8a1
   mrmime.mimes['aac'] = 'audio/aac'
+  // https://wiki.xiph.org/MIME_Types_and_File_Extensions#.opus_-_audio/ogg
+  mrmime.mimes['opus'] = 'audio/ogg'
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
   mrmime.mimes['eot'] = 'application/vnd.ms-fontobject'
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

the web is using the opus codec more and more for audio streaming, to mentally separate these from ogg:vorbis, some people use the .opus file extension. I wanted to do this for a project of mine as well, and figured i'd add it to the main vite repo.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

mostly concerned about whether ive used the mrmime part correctly to add opus?

this failed 1 test that seems unrelated (building on windows might be the culprit), see below:
```
 RUN  v0.29.7 C:/Users/mia/libraries/side-projects/vite

·····-····································································-············x···············-·····················-······································································--·········-···················································-------·····································-·········-·····----·····--··-···--·--········--·······················--·······················-----------·············--····································--··························--·-················--····---·-··············-·--····---···············--···-·······---------------------------

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  playground/preserve-symlinks/__tests__/preserve-symlinks.spec.ts > not-preserve-symlinks
AssertionError: expected '' to be 'hello vite' // Object.is equality
 ❯ playground/preserve-symlinks/__tests__/preserve-symlinks.spec.ts:11:43
      9| 
     10| test('not-preserve-symlinks', async () => {
     11|   expect(await page.textContent('#root')).toBe('hello vite')
       |                                           ^
     12| })
     13| 

  - Expected   "hello vite"
  + Received   ""

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯

 Test Files  1 failed | 56 passed | 10 skipped (67)
      Tests  1 failed | 508 passed | 91 skipped (600)
   Start at  03:11:26
   Duration  87.90s (transform 12.33s, setup 108.59s, collect 25.26s, tests 389.36s)

 ELIFECYCLE  Command failed with exit code 1.
```

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
