### PR TITLE
test: move ssr tests from plugin-react

### DIFF
--- a/playground/ssr/__tests__/serve.ts
+++ b/playground/ssr/__tests__/serve.ts
@@ -1,0 +1,35 @@
+// this is automatically detected by playground/vitestSetup.ts and will replace
+// the default e2e test serve behavior
+
+import path from 'node:path'
+import kill from 'kill-port'
+import { hmrPorts, ports, rootDir } from '~utils'
+
+export const port = ports.ssr
+
+export async function serve(): Promise<{ close(): Promise<void> }> {
+  await kill(port)
+
+  const { createServer } = await import(path.resolve(rootDir, 'server.js'))
+  const { app, vite } = await createServer(rootDir, hmrPorts.ssr)
+
+  return new Promise((resolve, reject) => {
+    try {
+      const server = app.listen(port, () => {
+        resolve({
+          // for test teardown
+          async close() {
+            await new Promise((resolve) => {
+              server.close(resolve)
+            })
+            if (vite) {
+              await vite.close()
+            }
+          },
+        })
+      })
+    } catch (e) {
+      reject(e)
+    }
+  })
+}

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -11,3 +11,9 @@ test(`circular dependencies modules doesn't throw`, async () => {
     'circ-dep-init-a circ-dep-init-b',
   )
 })
+
+test(`deadlock doesn't happen`, async () => {
+  await page.goto(`${url}/forked-deadlock`)
+
+  expect(await page.textContent('.forked-deadlock')).toMatch('rendered')
+})

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { port } from './serve'
+import { page } from '~utils'
+
+const url = `http://localhost:${port}`
+
+test(`circular dependencies modules doesn't throw`, async () => {
+  await page.goto(`${url}/circular-dep`)
+
+  expect(await page.textContent('.circ-dep-init')).toMatch(
+    'circ-dep-init-a circ-dep-init-b',
+  )
+})

--- a/playground/ssr/index.html
+++ b/playground/ssr/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SSR</title>
+  </head>
+  <body>
+    <h1>SSR</h1>
+    <div><!--app-html--></div>
+  </body>
+</html>

--- a/playground/ssr/package.json
+++ b/playground/ssr/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vitejs/test-ssr",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node server",
+    "serve": "NODE_ENV=production node server",
+    "debug": "node --inspect-brk server"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/playground/ssr/server.js
+++ b/playground/ssr/server.js
@@ -1,0 +1,69 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import express from 'express'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const isTest = process.env.VITEST
+
+export async function createServer(root = process.cwd(), hmrPort) {
+  const resolve = (p) => path.resolve(__dirname, p)
+
+  const app = express()
+
+  /**
+   * @type {import('vite').ViteDevServer}
+   */
+  const vite = await (
+    await import('vite')
+  ).createServer({
+    root,
+    logLevel: isTest ? 'error' : 'info',
+    server: {
+      middlewareMode: true,
+      watch: {
+        // During tests we edit the files too fast and sometimes chokidar
+        // misses change events, so enforce polling for consistency
+        usePolling: true,
+        interval: 100,
+      },
+      hmr: {
+        port: hmrPort,
+      },
+    },
+    appType: 'custom',
+  })
+  // use vite's connect instance as middleware
+  app.use(vite.middlewares)
+
+  app.use('*', async (req, res, next) => {
+    try {
+      const url = req.originalUrl
+
+      let template
+      template = fs.readFileSync(resolve('index.html'), 'utf-8')
+      template = await vite.transformIndexHtml(url, template)
+      const render = (await vite.ssrLoadModule('/src/app.js')).render
+
+      const appHtml = await render(url, __dirname)
+
+      const html = template.replace(`<!--app-html-->`, appHtml)
+
+      res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
+    } catch (e) {
+      vite && vite.ssrFixStacktrace(e)
+      console.log(e.stack)
+      res.status(500).end(e.stack)
+    }
+  })
+
+  return { app, vite }
+}
+
+if (!isTest) {
+  createServer().then(({ app }) =>
+    app.listen(5173, () => {
+      console.log('http://localhost:5173')
+    }),
+  )
+}

--- a/playground/ssr/src/app.js
+++ b/playground/ssr/src/app.js
@@ -1,0 +1,34 @@
+import { escapeHtml } from './utils'
+
+const pathRenderers = {
+  '/': renderRoot,
+  '/circular-dep': renderCircularDep,
+}
+
+export async function render(url, rootDir) {
+  const pathname = url.replace(/#[^#]*$/, '').replace(/\?[^?]*$/, '')
+  const renderer = pathRenderers[pathname]
+  if (renderer) {
+    return await renderer(rootDir)
+  }
+  return '404'
+}
+
+async function renderRoot(rootDir) {
+  const paths = Object.keys(pathRenderers).filter((key) => key !== '/')
+  return `
+    <ul>
+      ${paths
+        .map(
+          (path) =>
+            `<li><a href="${escapeHtml(path)}">${escapeHtml(path)}</a></li>`,
+        )
+        .join('\n')}
+    </ul>
+  `
+}
+
+async function renderCircularDep(rootDir) {
+  const { getValueAB } = await import('./circular-dep-init/circular-dep-init')
+  return `<div class="circ-dep-init">${escapeHtml(getValueAB())}</div>`
+}

--- a/playground/ssr/src/app.js
+++ b/playground/ssr/src/app.js
@@ -3,6 +3,7 @@ import { escapeHtml } from './utils'
 const pathRenderers = {
   '/': renderRoot,
   '/circular-dep': renderCircularDep,
+  '/forked-deadlock': renderForkedDeadlock,
 }
 
 export async function render(url, rootDir) {
@@ -31,4 +32,10 @@ async function renderRoot(rootDir) {
 async function renderCircularDep(rootDir) {
   const { getValueAB } = await import('./circular-dep-init/circular-dep-init')
   return `<div class="circ-dep-init">${escapeHtml(getValueAB())}</div>`
+}
+
+async function renderForkedDeadlock(rootDir) {
+  const { commonModuleExport } = await import('./forked-deadlock/common-module')
+  commonModuleExport()
+  return `<div class="forked-deadlock">rendered</div>`
 }

--- a/playground/ssr/src/circular-dep-init/README.md
+++ b/playground/ssr/src/circular-dep-init/README.md
@@ -1,0 +1,1 @@
+This test aim to find out wherever the modules with circular dependencies are correctly initialized

--- a/playground/ssr/src/circular-dep-init/circular-dep-init.js
+++ b/playground/ssr/src/circular-dep-init/circular-dep-init.js
@@ -1,0 +1,2 @@
+export * from './module-a'
+export { getValueAB } from './module-b'

--- a/playground/ssr/src/circular-dep-init/module-a.js
+++ b/playground/ssr/src/circular-dep-init/module-a.js
@@ -1,0 +1,1 @@
+export const valueA = 'circ-dep-init-a'

--- a/playground/ssr/src/circular-dep-init/module-b.js
+++ b/playground/ssr/src/circular-dep-init/module-b.js
@@ -1,0 +1,8 @@
+import { valueA } from './circular-dep-init'
+
+export const valueB = 'circ-dep-init-b'
+export const valueAB = valueA.concat(` ${valueB}`)
+
+export function getValueAB() {
+  return valueAB
+}

--- a/playground/ssr/src/forked-deadlock/README.md
+++ b/playground/ssr/src/forked-deadlock/README.md
@@ -1,0 +1,51 @@
+This test aim to check for a particular type of circular dependency that causes tricky deadlocks, **deadlocks with forked imports stack**
+
+```
+A -> B means: B is imported by A and B has A in its stack
+A ... B means: A is waiting for B to ssrLoadModule()
+
+H -> X ... Y
+H -> X -> Y ... B
+H -> A ... B
+H -> A -> B ... X
+```
+
+### Forked deadlock description:
+
+```
+[X] is waiting for [Y] to resolve
+ ↑                  ↳ is waiting for [A] to resolve
+ │                                    ↳ is waiting for [B] to resolve
+ │                                                      ↳ is waiting for [X] to resolve
+ └────────────────────────────────────────────────────────────────────────┘
+```
+
+This may seems a traditional deadlock, but the thing that makes this special is the import stack of each module:
+
+```
+[X] stack:
+	[H]
+```
+
+```
+[Y] stack:
+	[X]
+	[H]
+```
+
+```
+[A] stack:
+	[H]
+```
+
+```
+[B] stack:
+	[A]
+	[H]
+```
+
+Even if `[X]` is imported by `[B]`, `[B]` is not in `[X]`'s stack because it's imported by `[H]` in first place then it's stack is only composed by `[H]`. `[H]` **forks** the imports **stack** and this make hard to be found.
+
+### Fix description
+
+Vite, when imports `[X]`, should check whether `[X]` is already pending and if it is, it must check that, when it was imported in first place, the stack of `[X]` doesn't have any module in common with the current module; in this case `[B]` has the module `[H]` is common with `[X]` and i can assume that a deadlock is going to happen.

--- a/playground/ssr/src/forked-deadlock/common-module.js
+++ b/playground/ssr/src/forked-deadlock/common-module.js
@@ -1,0 +1,10 @@
+import { stuckModuleExport } from './stuck-module'
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module H
+ */
+export function commonModuleExport() {
+  stuckModuleExport()
+  deadlockfuseModuleExport()
+}

--- a/playground/ssr/src/forked-deadlock/deadlock-fuse-module.js
+++ b/playground/ssr/src/forked-deadlock/deadlock-fuse-module.js
@@ -1,0 +1,8 @@
+import { fuseStuckBridgeModuleExport } from './fuse-stuck-bridge-module'
+
+/**
+ * module A
+ */
+export function deadlockfuseModuleExport() {
+  fuseStuckBridgeModuleExport()
+}

--- a/playground/ssr/src/forked-deadlock/fuse-stuck-bridge-module.js
+++ b/playground/ssr/src/forked-deadlock/fuse-stuck-bridge-module.js
@@ -1,0 +1,8 @@
+import { stuckModuleExport } from './stuck-module'
+
+/**
+ * module C
+ */
+export function fuseStuckBridgeModuleExport() {
+  stuckModuleExport()
+}

--- a/playground/ssr/src/forked-deadlock/middle-module.js
+++ b/playground/ssr/src/forked-deadlock/middle-module.js
@@ -1,0 +1,8 @@
+import { deadlockfuseModuleExport } from './deadlock-fuse-module'
+
+/**
+ * module Y
+ */
+export function middleModuleExport() {
+  void deadlockfuseModuleExport
+}

--- a/playground/ssr/src/forked-deadlock/stuck-module.js
+++ b/playground/ssr/src/forked-deadlock/stuck-module.js
@@ -1,0 +1,8 @@
+import { middleModuleExport } from './middle-module'
+
+/**
+ * module X
+ */
+export function stuckModuleExport() {
+  middleModuleExport()
+}

--- a/playground/ssr/src/utils.js
+++ b/playground/ssr/src/utils.js
@@ -1,0 +1,16 @@
+const escapeHtmlReplaceMap = {
+  '&': '&amp;',
+  "'": '&#x27;',
+  '`': '&#x60;',
+  '"': '&quot;',
+  '<': '&lt;',
+  '>': '&gt;',
+}
+
+/**
+ * @param {string} string
+ * @returns {string}
+ */
+export function escapeHtml(string) {
+  return string.replace(/[&'`"<>]/g, (match) => escapeHtmlReplaceMap[match])
+}

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -22,21 +22,23 @@ export const ports = {
   lib: 9521,
   'optimize-missing-deps': 9522,
   'legacy/client-and-ssr': 9523,
-  'ssr-deps': 9600,
-  'ssr-html': 9601,
-  'ssr-noexternal': 9602,
-  'ssr-pug': 9603,
-  'ssr-webworker': 9606,
+  ssr: 9600,
+  'ssr-deps': 9601,
+  'ssr-html': 9602,
+  'ssr-noexternal': 9603,
+  'ssr-pug': 9604,
+  'ssr-webworker': 9605,
   'css/postcss-caching': 5005,
   'css/postcss-plugins-different-dir': 5006,
   'css/dynamic-import': 5007,
 }
 export const hmrPorts = {
   'optimize-missing-deps': 24680,
-  'ssr-deps': 24681,
-  'ssr-html': 24682,
-  'ssr-noexternal': 24683,
-  'ssr-pug': 24684,
+  ssr: 24681,
+  'ssr-deps': 24682,
+  'ssr-html': 24683,
+  'ssr-noexternal': 24684,
+  'ssr-pug': 24685,
 }
 
 const hexToNameMap: Record<string, string> = {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -927,6 +927,12 @@ importers:
     dependencies:
       es5-ext: 0.10.62
 
+  playground/ssr:
+    specifiers:
+      express: ^4.18.2
+    devDependencies:
+      express: 4.18.2
+
   playground/ssr-deps:
     specifiers:
       '@vitejs/test-css-lib': file:./css-lib
@@ -5124,7 +5130,7 @@ packages:
       is-string: 1.0.7
       is-typed-array: 1.1.10
       is-weakref: 1.0.2
-      object-inspect: 1.12.2
+      object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.4.3
@@ -7357,7 +7363,7 @@ packages:
     dev: true
 
   /ms/2.0.0:
-    resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -7539,10 +7545,6 @@ packages:
   /object-hash/3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-
-  /object-inspect/1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
-    dev: true
 
   /object-inspect/1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -9545,7 +9547,7 @@ packages:
     dev: true
 
   /unpipe/1.0.0:
-    resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
   /untyped/1.2.2:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Move SSR tests added by #3950 from plugin-react.
Currently the circular dep test fails because of https://github.com/vitejs/vite/pull/12274.

refs #12527

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
