### PR TITLE
fix(ssr): hoist re-exports with imports

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -103,9 +103,11 @@ test('export * from', async () => {
     ),
   ).toMatchInlineSnapshot(`
     "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
-    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"react\\");
     __vite_ssr_exportAll__(__vite_ssr_import_0__);
-    __vite_ssr_exportAll__(__vite_ssr_import_1__);"
+    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"react\\");
+    __vite_ssr_exportAll__(__vite_ssr_import_1__);
+
+    "
   `)
 })
 
@@ -132,7 +134,8 @@ test('export then import minified', async () => {
   ).toMatchInlineSnapshot(`
     "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"vue\\");
-    __vite_ssr_exportAll__(__vite_ssr_import_1__);"
+    __vite_ssr_exportAll__(__vite_ssr_import_1__);
+    "
   `)
 })
 

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -164,9 +164,10 @@ async function ssrTransformScript(
         if (node.source) {
           // export { foo, bar } from './foo'
           const importId = defineImport(node.source.value as string)
+          // hoist re-exports near the defined import so they are immediately exported
           for (const spec of node.specifiers) {
             defineExport(
-              node.end,
+              0,
               spec.exported.name,
               `${importId}.${spec.local.name}`,
             )
@@ -213,10 +214,11 @@ async function ssrTransformScript(
     if (node.type === 'ExportAllDeclaration') {
       s.remove(node.start, node.end)
       const importId = defineImport(node.source.value as string)
+      // hoist re-exports near the defined import so they are immediately exported
       if (node.exported) {
-        defineExport(node.end, node.exported.name, `${importId}`)
+        defineExport(0, node.exported.name, `${importId}`)
       } else {
-        s.appendLeft(node.end, `${ssrExportAllKey}(${importId});`)
+        s.appendLeft(0, `${ssrExportAllKey}(${importId});\n`)
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Supersedes https://github.com/vitejs/vite/pull/12527
Should fix ecosystem-ci for nuxt and plugin-react

When hoisting the import statement generated by re-exports by Vite, hoist the other re-exports code together with the import statement.

The snapshot diff should show how this works now.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Should also fix the test at https://github.com/vitejs/vite/pull/12528, which I've verified locally.

cc @sapphi-red 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
