### PR TITLE
perf: replace startsWith with ===

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -560,7 +560,7 @@ export function createHotContext(ownerPath: string): ViteHotContext {
  */
 export function injectQuery(url: string, queryToInject: string): string {
   // skip urls that won't be handled by vite
-  if (!url.startsWith('.') && !url.startsWith('/')) {
+  if (url[0] !== '.' && url[0] !== '/') {
     return url
   }
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -747,7 +747,7 @@ function getPkgJson(root: string): PackageData['data'] {
 }
 
 function getPkgName(name: string) {
-  return name?.startsWith('@') ? name.split('/')[1] : name
+  return name?.[0] === '@' ? name.split('/')[1] : name
 }
 
 type JsExt = 'js' | 'cjs' | 'mjs'

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -828,7 +828,7 @@ export function resolveBaseUrl(
   isBuild: boolean,
   logger: Logger,
 ): string {
-  if (base.startsWith('.')) {
+  if (base[0] === '.') {
     logger.warn(
       colors.yellow(
         colors.bold(
@@ -843,7 +843,7 @@ export function resolveBaseUrl(
   // external URL flag
   const isExternal = isExternalUrl(base)
   // no leading slash warn
-  if (!isExternal && !base.startsWith('/')) {
+  if (!isExternal && base[0] !== '/') {
     logger.warn(
       colors.yellow(
         colors.bold(`(!) "base" option should start with a slash.`),
@@ -855,7 +855,7 @@ export function resolveBaseUrl(
   if (!isBuild || !isExternal) {
     base = new URL(base, 'http://vitejs.dev').pathname
     // ensure leading slash
-    if (!base.startsWith('/')) {
+    if (base[0] !== '/') {
       base = '/' + base
     }
   }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -157,7 +157,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     },
 
     async load(id) {
-      if (id.startsWith('\0')) {
+      if (id[0] === '\0') {
         // Rollup convention, this id should be handled by the
         // plugin that marked it with \0
         return
@@ -221,7 +221,7 @@ export function checkPublicFile(
 ): string | undefined {
   // note if the file is in /public, the resolver would have returned it
   // as-is so it's not going to be a fully resolved path.
-  if (!publicDir || !url.startsWith('/')) {
+  if (!publicDir || url[0] !== '/') {
     return
   }
   const publicFile = path.join(publicDir, cleanUrl(url))
@@ -378,9 +378,10 @@ export async function urlToBuiltUrl(
   if (checkPublicFile(url, config)) {
     return publicFileToBuiltUrl(url, config)
   }
-  const file = url.startsWith('/')
-    ? path.join(config.root, url)
-    : path.join(path.dirname(importer), url)
+  const file =
+    url[0] === '/'
+      ? path.join(config.root, url)
+      : path.join(path.dirname(importer), url)
   return fileToBuiltUrl(
     file,
     config,

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -72,7 +72,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
           const url = rawUrl.slice(1, -1)
           let file: string | undefined
-          if (url.startsWith('.')) {
+          if (url[0] === '.') {
             file = slash(path.resolve(path.dirname(id), url))
           } else {
             assetResolver ??= config.createResolver({

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -505,9 +505,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const toRelative = (filename: string, importer: string) => {
           // relative base + extracted CSS
           const relativePath = path.posix.relative(cssAssetDirname!, filename)
-          return relativePath.startsWith('.')
-            ? relativePath
-            : './' + relativePath
+          return relativePath[0] === '.' ? relativePath : './' + relativePath
         }
 
         // replace asset url references with resolved url.
@@ -1314,7 +1312,7 @@ async function doUrlReplace(
   if (
     isExternalUrl(rawUrl) ||
     isDataUrl(rawUrl) ||
-    rawUrl.startsWith('#') ||
+    rawUrl[0] === '#' ||
     varRE.test(rawUrl)
   ) {
     return matched
@@ -1339,7 +1337,7 @@ async function doImportCSSReplace(
     wrap = first
     rawUrl = rawUrl.slice(1, -1)
   }
-  if (isExternalUrl(rawUrl) || isDataUrl(rawUrl) || rawUrl.startsWith('#')) {
+  if (isExternalUrl(rawUrl) || isDataUrl(rawUrl) || rawUrl[0] === '#') {
     return matched
   }
 
@@ -1690,7 +1688,7 @@ async function rebaseUrls(
 
   let rebased
   const rebaseFn = (url: string) => {
-    if (url.startsWith('/')) return url
+    if (url[0] === '/') return url
     // ignore url's starting with variable
     if (url.startsWith(variablePrefix)) return url
     // match alias, no need to rewrite

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -291,7 +291,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   postHooks.push(postImportMapHook())
   const processedHtml = new Map<string, string>()
   const isExcludedUrl = (url: string) =>
-    url.startsWith('#') ||
+    url[0] === '#' ||
     isExternalUrl(url) ||
     isDataUrl(url) ||
     checkPublicFile(url, config)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -338,7 +338,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           )
         }
 
-        const isRelative = url.startsWith('.')
+        const isRelative = url[0] === '.'
         const isSelfImport = !isRelative && cleanUrl(url) === cleanUrl(importer)
 
         // normalize all imports into resolved URLs
@@ -364,7 +364,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         // if the resolved id is not a valid browser import specifier,
         // prefix it to make it valid. We will strip this before feeding it
         // back into the transform pipeline
-        if (!url.startsWith('.') && !url.startsWith('/')) {
+        if (url[0] !== '.' && url[0] !== '/') {
           url = wrapId(resolved.id)
         }
 
@@ -496,7 +496,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           // warn imports to non-asset /public files
           if (
-            specifier.startsWith('/') &&
+            specifier[0] === '/' &&
             !config.assetsInclude(cleanUrl(specifier)) &&
             !specifier.endsWith('.json') &&
             checkPublicFile(specifier, config)

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -44,7 +44,7 @@ const optimizedDepDynamicRE = /-[A-Z\d]{8}\.js/
 
 function toRelativePath(filename: string, importer: string) {
   const relPath = path.relative(path.dirname(importer), filename)
-  return relPath.startsWith('.') ? relPath : `./${relPath}`
+  return relPath[0] === '.' ? relPath : `./${relPath}`
 }
 
 /**

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -412,7 +412,7 @@ export async function transformGlobImport(
             ? options.query
             : stringifyQuery(options.query as any)
 
-          if (query && !query.startsWith('?')) query = `?${query}`
+          if (query && query[0] !== '?') query = `?${query}`
 
           const resolvePaths = (file: string) => {
             if (!dir) {
@@ -425,14 +425,14 @@ export async function transformGlobImport(
             }
 
             let importPath = relative(dir, file)
-            if (!importPath.startsWith('.')) importPath = `./${importPath}`
+            if (importPath[0] !== '.') importPath = `./${importPath}`
 
             let filePath: string
             if (isRelative) {
               filePath = importPath
             } else {
               filePath = relative(root, file)
-              if (!filePath.startsWith('.')) filePath = `/${filePath}`
+              if (filePath[0] !== '.') filePath = `/${filePath}`
             }
 
             return { filePath, importPath }
@@ -583,13 +583,13 @@ export async function toAbsoluteGlob(
   resolveId: IdResolver,
 ): Promise<string> {
   let pre = ''
-  if (glob.startsWith('!')) {
+  if (glob[0] === '!') {
     pre = '!'
     glob = glob.slice(1)
   }
   root = globSafePath(root)
   const dir = importer ? globSafePath(dirname(importer)) : root
-  if (glob.startsWith('/')) return pre + posix.join(root, glob.slice(1))
+  if (glob[0] === '/') return pre + posix.join(root, glob.slice(1))
   if (glob.startsWith('./')) return pre + posix.join(dir, glob.slice(2))
   if (glob.startsWith('../')) return pre + posix.join(dir, glob)
   if (glob.startsWith('**')) return pre + glob
@@ -606,7 +606,7 @@ export async function toAbsoluteGlob(
 
 export function getCommonBase(globsResolved: string[]): null | string {
   const bases = globsResolved
-    .filter((g) => !g.startsWith('!'))
+    .filter((g) => g[0] !== '!')
     .map((glob) => {
       let { base } = scan(glob)
       // `scan('a/foo.js')` returns `base: 'a/foo.js'`
@@ -632,5 +632,5 @@ export function getCommonBase(globsResolved: string[]): null | string {
 
 export function isVirtualModule(id: string): boolean {
   // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
-  return id.startsWith('virtual:') || id.startsWith('\0') || !id.includes('/')
+  return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
 }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -184,13 +184,13 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
           'imports',
         )
 
-        if (importsPath?.startsWith('.')) {
+        if (importsPath?.[0] === '.') {
           importsPath = path.relative(
             basedir,
             path.join(pkgData.dir, importsPath),
           )
 
-          if (!importsPath.startsWith('.')) {
+          if (importsPath[0] !== '.') {
             importsPath = `./${importsPath}`
           }
         }
@@ -270,7 +270,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
       // URL
       // /foo -> /fs-root/foo
-      if (asSrc && id.startsWith('/') && (rootInRoot || !id.startsWith(root))) {
+      if (asSrc && id[0] === '/' && (rootInRoot || !id.startsWith(root))) {
         const fsPath = path.resolve(root, id.slice(1))
         if ((res = tryFsResolve(fsPath, options))) {
           isDebug && debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
@@ -280,7 +280,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
       // relative
       if (
-        id.startsWith('.') ||
+        id[0] === '.' ||
         ((preferRelative || importer?.endsWith('.html')) &&
           startsWithWordCharRE.test(id))
       ) {
@@ -330,7 +330,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       }
 
       // drive relative fs paths (only windows)
-      if (isWindows && id.startsWith('/')) {
+      if (isWindows && id[0] === '/') {
         const basedir = importer ? path.dirname(importer) : process.cwd()
         const fsPath = path.resolve(basedir, id)
         if ((res = tryFsResolve(fsPath, options))) {

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -141,7 +141,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           )
           const url = rawUrl.slice(1, -1)
           let file: string | undefined
-          if (url.startsWith('.')) {
+          if (url[0] === '.') {
             file = path.resolve(path.dirname(id), url)
           } else {
             workerResolver ??= config.createResolver({
@@ -150,9 +150,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               preferRelative: true,
             })
             file = await workerResolver(url, id)
-            file ??= url.startsWith('/')
-              ? slash(path.join(config.publicDir, url))
-              : slash(path.resolve(path.dirname(id), url))
+            file ??=
+              url[0] === '/'
+                ? slash(path.join(config.publicDir, url))
+                : slash(path.resolve(path.dirname(id), url))
           }
 
           let builtUrl: string

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -475,7 +475,7 @@ export function lexAcceptedHmrExports(
 }
 
 export function normalizeHmrUrl(url: string): string {
-  if (!url.startsWith('.') && !url.startsWith('/')) {
+  if (url[0] !== '.' && url[0] !== '/') {
     url = wrapId(url)
   }
   return url

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -102,7 +102,7 @@ const processNodeUrl = (
     const fullUrl = path.posix.join(devBase, url)
     overwriteAttrValue(s, sourceCodeLocation, fullUrl)
   } else if (
-    url.startsWith('.') &&
+    url[0] === '.' &&
     originalUrl &&
     originalUrl !== '/' &&
     htmlPath === '/index.html'
@@ -166,7 +166,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     const code = contentNode.value
 
     let map: SourceMapInput | undefined
-    if (!proxyModulePath.startsWith('\0')) {
+    if (proxyModulePath[0] !== '\0') {
       map = new MagicString(html)
         .snip(
           contentNode.sourceCodeLocation!.startOffset,

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -141,7 +141,7 @@ export function proxyMiddleware(
 
 function doesProxyContextMatchUrl(context: string, url: string): boolean {
   return (
-    (context.startsWith('^') && new RegExp(context).test(url)) ||
+    (context[0] === '^' && new RegExp(context).test(url)) ||
     url.startsWith(context)
   )
 }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -199,7 +199,7 @@ function createIsSsrExternal(
       return processedIds.get(id)
     }
     let external = false
-    if (!id.startsWith('.') && !path.isAbsolute(id)) {
+    if (id[0] !== '.' && !path.isAbsolute(id)) {
       external = isBuiltin(id) || isConfiguredAsExternal(id)
     }
     processedIds.set(id, external)
@@ -339,7 +339,7 @@ export function cjsShouldExternalizeForSSR(
 
 function getNpmPackageName(importPath: string): string | null {
   const parts = importPath.split('/')
-  if (parts[0].startsWith('@')) {
+  if (parts[0][0] === '@') {
     if (!parts[1]) return null
     return `${parts[0]}/${parts[1]}`
   } else {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -211,9 +211,7 @@ export function fsPathFromId(id: string): string {
   const fsPath = normalizePath(
     id.startsWith(FS_PREFIX) ? id.slice(FS_PREFIX.length) : id,
   )
-  return fsPath.startsWith('/') || fsPath.match(VOLUME_RE)
-    ? fsPath
-    : `/${fsPath}`
+  return fsPath[0] === '/' || fsPath.match(VOLUME_RE) ? fsPath : `/${fsPath}`
 }
 
 export function fsPathFromUrl(url: string): string {
@@ -1190,7 +1188,7 @@ const windowsDrivePathPrefixRE = /^[A-Za-z]:[/\\]/
  * this function returns false for them but true for absolute paths (e.g. C:/something)
  */
 export const isNonDriveRelativeAbsolutePath = (p: string): boolean => {
-  if (!isWindows) return p.startsWith('/')
+  if (!isWindows) return p[0] === '/'
   return windowsDrivePathPrefixRE.test(p)
 }
 
@@ -1228,7 +1226,7 @@ export function joinUrlSegments(a: string, b: string): string {
   if (a.endsWith('/')) {
     a = a.substring(0, a.length - 1)
   }
-  if (!b.startsWith('/')) {
+  if (b[0] !== '/') {
     b = '/' + b
   }
   return a + b


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This pr use `str[0] === 'x'` instead of `str.startsWith('x')` for better perf. We can prove that:

 - `===` should be faster according to [`startsWith` source](https://github.com/zloirock/core-js/blob/446aa802ebc37831c14c5f18be17d01189374bd5/packages/core-js/modules/es.string.starts-with.js#L26-L36) in theory

- [perf test](https://perf.link/#eyJpZCI6InFmNmVhMmwzMTNnIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IGRhdGEgPSAnYWFhJyIsInRlc3RzIjpbeyJuYW1lIjoiVGVzdCBDYXNlIiwiY29kZSI6ImRhdGEuc3RhcnRzV2l0aCgnYicpIiwicnVucyI6WzM5MzAwMCwxNDI2MDAwLDkwMDAsMjQ1NjAwMCwzNjUyMDAwLDQ1MDQwMDAsNDgzNjAwMCwxODA4MDAwLDMwNDEwMDAsMjE5MjAwMCw0NTU4MDAwLDIyMjgwMDAsMjY0NzAwMCw0MzEwMDAwLDI1MzcwMDAsMTg5NTAwMCw1Mzc5MDAwLDQ5NTMwMDAsMzMyNjAwMCw1MjE5MDAwLDQ4NzIwMDAsMzEwMzAwMCwxNjQ2MDAwLDQwMzcwMDAsNDYwMDAwMCwzNjUxMDAwLDI1MTkwMDAsMTM2OTAwMCw1MjM1MDAwLDIzNTAwMDAsNDc1NDAwMCw1NDI4MDAwLDI3MDAwMDAsNDc0MjAwMCw4MzgzMDAwLDQyMDQwMDAsNDYwMjAwMCwyNjczMDAwLDU1NjAwMCwyNzUyMDAwLDIxNDUwMDAsNTM1MzAwMCw0NDExMDAwLDM1NDAwMDAsNTA0MjAwMCw1NDI4MDAwLDIxODQwMDAsNDA4MjAwMCw1ODcwMDAsMzMxOTAwMCw1MzgxMDAwLDQ1MDcwMDAsMzIwMzAwMCwxODQzMDAwLDIxMTYwMDAsMjkxNjAwMCwyMTM4MDAwLDIxMjAwMDAsMzM2ODAwMCw0MjM4MDAwLDYzMDAwMCwxNDAyMDAwLDQ2MTcwMDAsNjk0MDAwLDQ4MDUwMDAsNjY2OTAwMCwyNjg3MDAwLDI2MjkwMDAsMzcyNzAwMCw1MDE5MDAwLDMzMDIwMDAsNTE1MzAwMCw0MjYwMDAwLDgxNzUwMDAsNDU4OTAwMCw2ODA5MDAwLDQxMjUwMDAsMzAzNDAwMCw1MjEzMDAwLDQ5MjYwMDAsMTQwNTAwMCwzODc0MDAwLDE4NzAwMDAsMzc2MjAwMCwzOTY1MDAwLDM4MzAwMCw0NTUxMDAwLDMzNjcwMDAsMjY3NDAwMCwyOTg3MDAwLDQzODcwMDAsMzgxMjAwMCw1MTEyMDAwLDY3NjcwMDAsMzQyODAwMCwyNjk3MDAwLDQxMTYwMDAsNDI0NzAwMCw3NjE2MDAwLDE1MzEwMDBdLCJvcHMiOjM1ODQ4MjB9LHsibmFtZSI6IlRlc3QgQ2FzZSIsImNvZGUiOiJkYXRhWzBdID09PSAnYiciLCJydW5zIjpbMTM3MzAwMCw0NDY4MDAwLDMxNDIwMDAsMTA5NDAwMCwyNDc3MDAwLDMxMjgwMDAsMTQ1ODAwMCw0OTAzMDAwLDg1NTEwMDAsMjA0MDAwMCwxMzMzMDAwLDg5NDAwMCw1NzczMDAwLDIyMTYwMDAsODYyMDAwLDkxODkwMDAsMjE4NTAwMCw2MTE2MDAwLDc3MDcwMDAsMzI0NTAwMCwzOTg0MDAwLDM2ODAwMCw3NDQ0MDAwLDcwMTAwMCw3NzI2MDAwLDExMTMwMDAsODk2ODAwMCw5NDc1MDAwLDMwMzUwMDAsNzgwNTAwMCwzNjIyMDAwLDg0NTgwMDAsODk3MjAwMCw0MjQ0MDAwLDUxODEwMDAsOTAxOTAwMCwyODA5MDAwLDg1MjAwMDAsODc0MDAwLDQ3MDAwLDkxOTMwMDAsNjQwNTAwMCw0MTQ2MDAwLDIxNDgwMDAsMTA3MjAwMCw0MDQ2MDAwLDg1NTgwMDAsMTc0ODAwMCwyMjYzMDAwLDI3NzQwMDAsMjUyNzAwMCwxMzMwMDAsOTM0NjAwMCwyMjUwMDAsODEyMDAwMCw1NzczMDAwLDg0NzIwMDAsMzQxNTAwMCw4MjIwMDAwLDIxNzIwMDAsMjcyMDAwLDc1NzEwMDAsNjIzOTAwMCw5NzQ4MDAwLDIxNjkwMDAsMzMyNTAwMCw5NzAwMCw0MDAwMDAsMzc2MDAwLDMwOTcwMDAsNDcwMDAsMTgzOTAwMCwxOTQ3MDAwLDQ2MzkwMDAsMTUzODAwMCwzNTMwMDAwLDMyOTcwMDAsNjIzNDAwMCw0MDc5MDAwLDE4MzkwMDAsODYwMzAwMCwyMjMxMDAwLDI4MTAwMCwxNTc4MDAwLDEwNjEwMDAsODcwNjAwMCwyMzA4MDAwLDE1NjQwMDAsNzA1MDAwLDk1NjEwMDAsMjMzMzAwMCwyMDk5MDAwLDE4NTkwMDAsNTIxNDAwMCw2MzgwMDAsOTIxNDAwMCwxNjg0MDAwLDgwMzAwMCw1OTgxMDAwLDg0MzIwMDBdLCJvcHMiOjQwMjQxMzB9XSwidXBkYXRlZCI6IjIwMjMtMDMtMjJUMDY6MzA6MzUuMDQ1WiJ9) `data[0] === 'x'` wins most of the time

I also test the initial `vite dev` startup time five times with [this repo](https://github.com/Lani/vite-2.7-slow) before and after this PR

|test(ms)|1st|2nd|3rd|4th|5th|
|----|-----|----|----|-----|----|
|before pr|2406| 2314| 2079| 1914| 1686|
|after pr|2305| 2216| 2025| 1949| 1565|

It improves!

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

I guess we can use `str[str.length - 1] === 'x'` rather than `str.endsWith('x')` too.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
