### PR TITLE
perf(esbuild): update tsconfck to consume faster find-all implementation

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -127,7 +127,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.0.1",
     "strip-literal": "^1.0.1",
-    "tsconfck": "^2.1.0",
+    "tsconfck": "^2.1.1",
     "tslib": "^2.5.0",
     "types": "link:./types",
     "ufo": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
       source-map-support: ^0.5.21
       strip-ansi: ^7.0.1
       strip-literal: ^1.0.1
-      tsconfck: ^2.1.0
+      tsconfck: ^2.1.1
       tslib: ^2.5.0
       types: link:./types
       ufo: ^1.1.1
@@ -288,7 +288,7 @@ importers:
       source-map-support: 0.5.21
       strip-ansi: 7.0.1
       strip-literal: 1.0.1
-      tsconfck: 2.1.0
+      tsconfck: 2.1.1
       tslib: 2.5.0
       types: link:types
       ufo: 1.1.1
@@ -9307,8 +9307,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck/2.1.0:
-    resolution: {integrity: sha512-lztI9ohwclQHISVWrM/hlcgsRpphsii94DV9AQtAw2XJSVNiv+3ppdEsrL5J+xc5oTeHXe1qDqlOAGw8VSa9+Q==}
+  /tsconfck/2.1.1:
+    resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
     engines: {node: ^14.13.1 || ^16 || >=18}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
the previous implementation of find-all used yield, which yielded in bad performance in some situations, esp. with large directory trees and if there was pressure on the node process already.

The new implementation uses classic callbacks and is more consistent/faster. This should lead to shorter startup times for vite.

fixes #12519 

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
