### PR TITLE
perf(resolve): fix browser mapping nearest package.json check

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -842,8 +842,8 @@ export function tryNodeResolve(
       !(
         ext === '.cjs' ||
         (ext === '.js' &&
-          findNearestPackageData(resolved, options.packageCache)?.data.type !==
-            'module')
+          findNearestPackageData(path.dirname(resolved), options.packageCache)
+            ?.data.type !== 'module')
       ) &&
       !(include?.includes(pkgId) || include?.includes(id)))
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1214,7 +1214,7 @@ function tryResolveBrowserMapping(
   const pkg =
     importer &&
     (idToPkgMap.get(importer) ||
-      findNearestPackageData(importer, options.packageCache))
+      findNearestPackageData(path.dirname(importer), options.packageCache))
   if (pkg && isObject(pkg.data.browser)) {
     const mapId = isFilePath ? './' + slash(path.relative(pkg.dir, id)) : id
     const browserMappedPath = mapWithBrowserField(mapId, pkg.data.browser)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
We're passing a file path to `findNearestPackageData` which causes it to stat `/Users/foo/bar.js/package.json` constantly, and `fs.statSync` even with `throwIfNoEntry` throws an error in that case with `ENOTDIR: not a directory, stat`.

This PR ensures we're passing a dir path instead to prevent the issue, so it's one less directory to check, and no errors will happen from `fs.statSync`.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This brings down my previous tests of prebundling speed, from 2s to 1.4s

(100ms comes from recent refactors from patak it seems 🎉 )

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
