### PR TITLE
fix: avoid crash because of no access permission

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -138,10 +138,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
   // back to checking the path as absolute. If /root/root isn't a valid path, we can
   // avoid these checks. Absolute paths inside root are common in user code as many
   // paths are resolved by the user. For example for an alias.
-  const rootInRoot =
-    fs
-      .statSync(path.join(root, root), { throwIfNoEntry: false })
-      ?.isDirectory() ?? false
+  const rootInRoot = tryStatSync(path.join(root, root))?.isDirectory() ?? false
 
   return {
     name: 'vite:resolve',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
If a user have `/root/root` directory but didn't have a read permission, this line throws an error and Vite will crash.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
