### PR TITLE
fix: throw error on build optimizeDeps issue

### DIFF
--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -116,35 +116,21 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
       // If all the inputs are dependencies, we aren't going to get any
       const info = optimizedDepInfoFromFile(depsOptimizer.metadata, file)
       if (info) {
-        try {
-          // This is an entry point, it may still not be bundled
-          await info.processing
-        } catch {
-          // If the refresh has not happened after timeout, Vite considers
-          // something unexpected has happened. In this case, Vite
-          // returns an empty response that will error.
-          throwBuildProcessingError(id)
-        }
+        await info.processing
         isDebug && debug(`load ${colors.cyan(file)}`)
       } else {
-        throwBuildProcessingError(id)
+        throw new Error(
+          `Something unexpected happened while optimizing "${id}".`,
+        )
       }
 
       // Load the file from the cache instead of waiting for other plugin
       // load hooks to avoid race conditions, once processing is resolved,
       // we are sure that the file has been properly save to disk
-      try {
-        return await fs.readFile(file, 'utf-8')
-      } catch (e) {
-        // Outdated non-entry points (CHUNK), loaded after a rerun
-        throwBuildProcessingError(id)
-      }
+
+      return await fs.readFile(file, 'utf-8')
     },
   }
-}
-
-function throwBuildProcessingError(id: string): never {
-  throw new Error(`Something unexpected happened while optimizing "${id}".`)
 }
 
 function throwProcessingError(id: string): never {

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -123,13 +123,11 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
           // If the refresh has not happened after timeout, Vite considers
           // something unexpected has happened. In this case, Vite
           // returns an empty response that will error.
-          // throwProcessingError(id)
-          return
+          throwBuildProcessingError(id)
         }
         isDebug && debug(`load ${colors.cyan(file)}`)
       } else {
-        // TODO: error
-        return
+        throwBuildProcessingError(id)
       }
 
       // Load the file from the cache instead of waiting for other plugin
@@ -139,10 +137,14 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
         return await fs.readFile(file, 'utf-8')
       } catch (e) {
         // Outdated non-entry points (CHUNK), loaded after a rerun
-        return ''
+        throwBuildProcessingError(id)
       }
     },
   }
+}
+
+function throwBuildProcessingError(id: string): never {
+  throw new Error(`Something unexpected happened while optimizing "${id}".`)
 }
 
 function throwProcessingError(id: string): never {


### PR DESCRIPTION
### Description

Missing errors. These only apply to optimizeDeps build issues. We could review one more for Vite 5 if we should try to push for deps optimization at build time instead of using plugin commonjs. And more now that esbuild pre-bundling got a lot faster.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other