### PR TITLE
perf(resolve): use internalModuleStat

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -539,8 +539,6 @@ export const FAST_STAT_IS_FILE = 0
 export const FAST_STAT_IS_DIRECTORY = 1
 export type FastStatResult = number
 
-export let fastStatSync: (file: string) => FastStatResult
-
 function fallbackStatSync(file: string): FastStatResult {
   try {
     const stat = fs.statSync(file, { throwIfNoEntry: false })
@@ -551,6 +549,7 @@ function fallbackStatSync(file: string): FastStatResult {
   return -1
 }
 
+export let fastStatSync = fallbackStatSync
 try {
   // @ts-expect-error node internals
   const { internalModuleStat } = process.binding('fs')
@@ -564,9 +563,7 @@ try {
           return internalModuleStat(path.toNamespacedPath(file))
         }
   }
-} catch {
-  fastStatSync = fallbackStatSync
-}
+} catch {}
 
 const splitFirstDirRE = /(.+?)[\\/](.+)/
 


### PR DESCRIPTION
### Description

Implement @sapphi-red's [idea](https://github.com/vitejs/vite/pull/11436#issuecomment-1359161295) of using `process.binding('fs').internalModuleStat`

We first test against a file and directory path to see if the function is available. On my M1, this works as expected. We need to review the perf improvements to decide if this complexity is worthy it. The speed-up should come from avoiding the creation of Stat and Error objects.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other