### PR TITLE
perf(resolve): avoid isWorkerRequest and clean up .ts imported a .js

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -5,7 +5,6 @@ import {
   asyncFlatten,
   getHash,
   getLocalhostAddressIfDiffersFromDNS,
-  getPotentialTsSrcPaths,
   injectQuery,
   isFileReadable,
   isWindows,
@@ -135,42 +134,6 @@ describe('resolveHostname', () => {
       name: 'localhost',
     })
   })
-})
-
-test('ts import of file with .js extension', () => {
-  expect(getPotentialTsSrcPaths('test-file.js')).toEqual([
-    'test-file.ts',
-    'test-file.tsx',
-  ])
-})
-
-test('ts import of file with .jsx extension', () => {
-  expect(getPotentialTsSrcPaths('test-file.jsx')).toEqual(['test-file.tsx'])
-})
-
-test('ts import of file .mjs,.cjs extension', () => {
-  expect(getPotentialTsSrcPaths('test-file.cjs')).toEqual([
-    'test-file.cts',
-    'test-file.ctsx',
-  ])
-  expect(getPotentialTsSrcPaths('test-file.mjs')).toEqual([
-    'test-file.mts',
-    'test-file.mtsx',
-  ])
-})
-
-test('ts import of file with .js before extension', () => {
-  expect(getPotentialTsSrcPaths('test-file.js.js')).toEqual([
-    'test-file.js.ts',
-    'test-file.js.tsx',
-  ])
-})
-
-test('ts import of file with .js and query param', () => {
-  expect(getPotentialTsSrcPaths('test-file.js.js?lee=123')).toEqual([
-    'test-file.js.ts?lee=123',
-    'test-file.js.tsx?lee=123',
-  ])
 })
 
 describe('posToNumber', () => {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -551,19 +551,19 @@ function tryCleanFsResolve(
     const dirStat = tryStatSync(dirPath)
     if (dirStat?.isDirectory()) {
       if (possibleJsToTs) {
-        // try resolve .js, .mjs, .mts or .jsx import to typescript file
-        const type = path.extname(file)
-        const fileName = file.slice(0, -type.length)
+        // try resolve .js, .mjs, .cjs or .jsx import to typescript file
+        const fileExt = path.extname(file)
+        const fileName = file.slice(0, -fileExt.length)
         if (
           (res = tryResolveRealFile(
-            fileName + type.replace('js', 'ts'),
+            fileName + fileExt.replace('js', 'ts'),
             preserveSymlinks,
           ))
         )
           return res
         // for .js, also try .tsx
         if (
-          type === '.js' &&
+          fileExt === '.js' &&
           (res = tryResolveRealFile(fileName + '.tsx', preserveSymlinks))
         )
           return res

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -48,7 +48,6 @@ import {
   loadPackageData,
   resolvePackageData,
 } from '../packages'
-import { isWorkerRequest } from './worker'
 
 const normalizedClientEntry = normalizePath(CLIENT_ENTRY)
 const normalizedEnvEntry = normalizePath(ENV_ENTRY)
@@ -177,16 +176,13 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       }
 
       if (importer) {
-        const _importer = isWorkerRequest(importer)
-          ? splitFileAndPostfix(importer).file
-          : importer
         if (
-          isTsRequest(_importer) ||
+          isTsRequest(cleanUrl(importer)) ||
           resolveOpts.custom?.depScan?.loader?.startsWith('ts')
         ) {
           options.isFromTsImporter = true
         } else {
-          const moduleLang = this.getModuleInfo(_importer)?.meta?.vite?.lang
+          const moduleLang = this.getModuleInfo(importer)?.meta?.vite?.lang
           options.isFromTsImporter = moduleLang && isTsRequest(`.${moduleLang}`)
         }
       }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -32,14 +32,6 @@ export type WorkerType = 'classic' | 'module' | 'ignore'
 export const WORKER_FILE_ID = 'worker_file'
 const workerCache = new WeakMap<ResolvedConfig, WorkerCache>()
 
-export function isWorkerRequest(id: string): boolean {
-  const query = parseRequest(id)
-  if (query && query[WORKER_FILE_ID] != null) {
-    return true
-  }
-  return false
-}
-
 function saveEmitWorkerAsset(
   config: ResolvedConfig,
   asset: EmittedAsset,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -282,21 +282,8 @@ export const isJSRequest = (url: string): boolean => {
   return false
 }
 
-const knownTsRE = /\.(?:ts|mts|cts|tsx)$/
-const knownTsOutputRE = /\.(?:js|mjs|cjs|jsx)$/
+const knownTsRE = /\.(?:ts|mts|cts|tsx)(?:$|\?)/
 export const isTsRequest = (url: string): boolean => knownTsRE.test(url)
-export const isPossibleTsOutput = (url: string): boolean =>
-  knownTsOutputRE.test(cleanUrl(url))
-
-const splitFilePathAndQueryRE = /(\.(?:[cm]?js|jsx))(\?.*)?$/
-export function getPotentialTsSrcPaths(filePath: string): string[] {
-  const [name, type, query = ''] = filePath.split(splitFilePathAndQueryRE)
-  const paths = [name + type.replace('js', 'ts') + query]
-  if (type[type.length - 1] !== 'x') {
-    paths.push(name + type.replace('js', 'tsx') + query)
-  }
-  return paths
-}
 
 const importQueryRE = /(\?|&)import=?(?:&|$)/
 const directRequestRE = /(\?|&)direct=?(?:&|$)/


### PR DESCRIPTION
### Description

Alternative to https://github.com/vitejs/vite/pull/10273

`isWorkerRequest` is costly, and it was showing in the profiles. There is an internal call to `parseRequest`, a function we should also review because it uses a regex that for this particular case wasn't needed for example (it is useful with dynamic variables in imports)

Using `cleanUrl` should work here. The original issue of having `.ts?query` is more general than just in workers.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other