### PR TITLE
fix: splitFileAndPostfix works as cleanUrl

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -489,8 +489,10 @@ function tryFsResolve(
   // Dependencies like es5-ext use `#` in their paths. We don't support `#` in user
   // source code so we only need to perform the check for dependencies.
   // We don't support `?` in node_modules paths, so we only need to check in this branch.
-  if (fsPath.includes('#') && fsPath.includes('node_modules')) {
-    const file = fsPath.replace(queryRE, '')
+  const hashIndex = fsPath.indexOf('#')
+  if (hashIndex > 0 && fsPath.includes('node_modules')) {
+    const queryIndex = fsPath.indexOf('?')
+    const file = queryIndex > hashIndex ? fsPath.slice(0, queryIndex) : fsPath
     const res = tryCleanFsResolve(
       file,
       options,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -484,15 +484,18 @@ function tryFsResolve(
   const hashIndex = fsPath.indexOf('#')
   if (hashIndex > 0 && isInNodeModules(fsPath)) {
     const queryIndex = fsPath.indexOf('?')
-    const file = queryIndex > hashIndex ? fsPath.slice(0, queryIndex) : fsPath
-    const res = tryCleanFsResolve(
-      file,
-      options,
-      tryIndex,
-      targetWeb,
-      skipPackageJson,
-    )
-    if (res) return res + fsPath.slice(file.length)
+    // We only need to check foo#bar?baz and foo#bar, ignore foo?bar#baz
+    if (queryIndex < 0 || queryIndex > hashIndex) {
+      const file = queryIndex > hashIndex ? fsPath.slice(0, queryIndex) : fsPath
+      const res = tryCleanFsResolve(
+        file,
+        options,
+        tryIndex,
+        targetWeb,
+        skipPackageJson,
+      )
+      if (res) return res + fsPath.slice(file.length)
+    }
   }
 
   const { file, postfix } = splitFileAndPostfix(fsPath)

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -482,7 +482,7 @@ function tryFsResolve(
   // source code so we only need to perform the check for dependencies.
   // We don't support `?` in node_modules paths, so we only need to check in this branch.
   const hashIndex = fsPath.indexOf('#')
-  if (hashIndex > 0 && isInNodeModules(fsPath)) {
+  if (hashIndex >= 0 && isInNodeModules(fsPath)) {
     const queryIndex = fsPath.indexOf('?')
     // We only need to check foo#bar?baz and foo#bar, ignore foo?bar#baz
     if (queryIndex < 0 || queryIndex > hashIndex) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -35,7 +35,6 @@ import {
   isWindows,
   lookupFile,
   normalizePath,
-  queryRE,
   resolveFrom,
   safeRealpathSync,
   slash,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -258,8 +258,11 @@ export function ensureVolumeInPath(file: string): string {
 export const queryRE = /\?.*$/s
 export const hashRE = /#.*$/s
 
-export const cleanUrl = (url: string): string =>
-  url.replace(hashRE, '').replace(queryRE, '')
+// remove query and hash, a # before ? is valid
+export function cleanUrl(url: string): string {
+  const u = url.replace(queryRE, '')
+  return u === url ? u.replace(hashRE, '') : u
+}
 
 export const externalRE = /^(https?:)?\/\//
 export const isExternalUrl = (url: string): boolean => externalRE.test(url)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -256,12 +256,10 @@ export function ensureVolumeInPath(file: string): string {
 }
 
 export const queryRE = /\?.*$/s
-export const hashRE = /#.*$/s
 
-// remove query and hash, a # before ? is valid
+const postfixRE = /[?#].*$/s
 export function cleanUrl(url: string): string {
-  const u = url.replace(queryRE, '')
-  return u === url ? u.replace(hashRE, '') : u
+  return url.replace(postfixRE, '')
 }
 
 export const externalRE = /^(https?:)?\/\//


### PR DESCRIPTION
### Description

`cleanUrl` and `splitFileAndPostfix` where working in different ways.

```js
cleanUrl('/hello#hash?query') -> '/hello'
splitFileAndPostfix('/hello#hash?query') -> '/hello#hash'
```

This PR makes `cleanUrl` make them both work in the same way, possibly fixing issues with dependencies having `#` in their path. The new `cleanUrl` also avoids the second regex if it isn't needed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other