### PR TITLE
chore: disable reactivityTransform in vitepress

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -94,10 +94,6 @@ export default defineConfig({
     pt: { label: 'Português', link: 'https://pt.vitejs.dev' },
   },
 
-  vue: {
-    reactivityTransform: true,
-  },
-
   themeConfig: {
     logo: '/logo.svg',
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Disabled reactivity transform in vitepress for the following reasons:

- reactivity transform will be removed from Vue core
- we weren't using it at all

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
