### PR TITLE
refactor: tryStatSync as util

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -23,6 +23,7 @@ import {
   removeDir,
   removeLeadingSlash,
   renameDir,
+  tryStatSync,
   writeFile,
 } from '../utils'
 import { transformWithEsbuild } from '../plugins/esbuild'
@@ -1212,11 +1213,9 @@ export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
     if (checkPatches) {
       // Default of https://github.com/ds300/patch-package
       const fullPath = path.join(path.dirname(lockfilePath), 'patches')
-      if (fs.existsSync(fullPath)) {
-        const stats = fs.statSync(fullPath)
-        if (stats.isDirectory()) {
-          content += stats.mtimeMs.toString()
-        }
+      const stat = tryStatSync(fullPath)
+      if (stat?.isDirectory()) {
+        content += stat.mtimeMs.toString()
       }
     }
   }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -38,6 +38,7 @@ import {
   resolveFrom,
   safeRealpathSync,
   slash,
+  tryStatSync,
 } from '../utils'
 import { optimizedDepInfoFromFile, optimizedDepInfoFromId } from '../optimizer'
 import type { DepsOptimizer } from '../optimizer'
@@ -645,14 +646,6 @@ function tryResolveRealFileWithExtensions(
   for (const ext of extensions) {
     const res = tryResolveRealFile(filePath + ext, preserveSymlinks)
     if (res) return res
-  }
-}
-
-function tryStatSync(file: string): fs.Stats | undefined {
-  try {
-    return fs.statSync(file, { throwIfNoEntry: false })
-  } catch {
-    // Ignore errors
   }
 }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -392,6 +392,13 @@ export function isDefined<T>(value: T | undefined | null): value is T {
   return value != null
 }
 
+export function tryStatSync(file: string): fs.Stats | undefined {
+  try {
+    return fs.statSync(file, { throwIfNoEntry: false })
+  } catch {
+    // Ignore errors
+  }
+}
 interface LookupFileOptions {
   pathOnly?: boolean
   rootDir?: string
@@ -405,7 +412,7 @@ export function lookupFile(
 ): string | undefined {
   for (const format of formats) {
     const fullPath = path.join(dir, format)
-    if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
+    if (tryStatSync(fullPath)?.isFile()) {
       const result = options?.pathOnly
         ? fullPath
         : fs.readFileSync(fullPath, 'utf-8')


### PR DESCRIPTION
### Description

We didn't merge https://github.com/vitejs/vite/pull/12568, but we discussed with @bluwy that we should still move `tryStatSync` as an util to use it in more places

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other