### PR TITLE
perf(resolve): findNearestMainPackageData instead of lookupFile

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -143,6 +143,20 @@ export function findNearestPackageData(
   return null
 }
 
+// Finds the nearest package.json with a `name` field
+export function findNearestMainPackageData(
+  basedir: string,
+  packageCache?: PackageCache,
+): PackageData | null {
+  const nearestPackage = findNearestPackageData(basedir, packageCache)
+  return (
+    nearestPackage &&
+    (nearestPackage.data.name
+      ? nearestPackage
+      : findNearestMainPackageData(path.dirname(basedir), packageCache))
+  )
+}
+
 export function loadPackageData(pkgPath: string): PackageData {
   const data = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
   const pkgDir = path.dirname(pkgPath)

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -153,7 +153,7 @@ export function findNearestMainPackageData(
     nearestPackage &&
     (nearestPackage.data.name
       ? nearestPackage
-      : findNearestMainPackageData(path.dirname(basedir), packageCache))
+      : findNearestMainPackageData(path.dirname(nearestPackage.dir), packageCache))
   )
 }
 

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -153,7 +153,10 @@ export function findNearestMainPackageData(
     nearestPackage &&
     (nearestPackage.data.name
       ? nearestPackage
-      : findNearestMainPackageData(path.dirname(nearestPackage.dir), packageCache))
+      : findNearestMainPackageData(
+          path.dirname(nearestPackage.dir),
+          packageCache,
+        ))
   )
 }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -704,14 +704,14 @@ export function tryNodeResolve(
       !id.includes('\0') &&
       bareImportRE.test(id)
     ) {
-      const mainPkg = findNearestMainPackageData(basedir, packageCache)
+      const mainPkg = findNearestMainPackageData(basedir, packageCache)?.data
       if (mainPkg) {
         if (
-          mainPkg.data.peerDependencies?.[id] &&
-          mainPkg.data.peerDependenciesMeta?.[id]?.optional
+          mainPkg.peerDependencies?.[id] &&
+          mainPkg.peerDependenciesMeta?.[id]?.optional
         ) {
           return {
-            id: `${optionalPeerDepId}:${id}:${mainPkg.data.name}`,
+            id: `${optionalPeerDepId}:${id}:${mainPkg.name}`,
           }
         }
       }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -33,7 +33,6 @@ import {
   isPossibleTsOutput,
   isTsRequest,
   isWindows,
-  lookupFile,
   normalizePath,
   resolveFrom,
   safeRealpathSync,
@@ -44,6 +43,7 @@ import type { DepsOptimizer } from '../optimizer'
 import type { SSROptions } from '..'
 import type { PackageCache, PackageData } from '../packages'
 import {
+  findNearestMainPackageData,
   findNearestPackageData,
   loadPackageData,
   resolvePackageData,
@@ -704,18 +704,14 @@ export function tryNodeResolve(
       !id.includes('\0') &&
       bareImportRE.test(id)
     ) {
-      // find package.json with `name` as main
-      const mainPackageJson = lookupFile(basedir, ['package.json'], {
-        predicate: (content) => !!JSON.parse(content).name,
-      })
-      if (mainPackageJson) {
-        const mainPkg = JSON.parse(mainPackageJson)
+      const mainPkg = findNearestMainPackageData(basedir, packageCache)
+      if (mainPkg) {
         if (
-          mainPkg.peerDependencies?.[id] &&
-          mainPkg.peerDependenciesMeta?.[id]?.optional
+          mainPkg.data.peerDependencies?.[id] &&
+          mainPkg.data.peerDependenciesMeta?.[id]?.optional
         ) {
           return {
-            id: `${optionalPeerDepId}:${id}:${mainPkg.name}`,
+            id: `${optionalPeerDepId}:${id}:${mainPkg.data.name}`,
           }
         }
       }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -395,7 +395,6 @@ export function isDefined<T>(value: T | undefined | null): value is T {
 interface LookupFileOptions {
   pathOnly?: boolean
   rootDir?: string
-  predicate?: (file: string) => boolean
 }
 
 export function lookupFile(
@@ -406,12 +405,7 @@ export function lookupFile(
   for (const format of formats) {
     const fullPath = path.join(dir, format)
     if (fs.existsSync(fullPath) && fs.statSync(fullPath).isFile()) {
-      const result = options?.pathOnly
-        ? fullPath
-        : fs.readFileSync(fullPath, 'utf-8')
-      if (!options?.predicate || options.predicate(result)) {
-        return result
-      }
+      return options?.pathOnly ? fullPath : fs.readFileSync(fullPath, 'utf-8')
     }
   }
   const parentDir = path.dirname(dir)


### PR DESCRIPTION
### Description

Use the `packageCache` instead of a clean lookupFile and parse.

I think normally the first hit should return the cache we already have as most package json files have a `name`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other