### PR TITLE
refactor: use findNearestPackageData in more places

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -62,6 +62,7 @@ import type { JsonOptions } from './plugins/json'
 import type { PluginContainer } from './server/pluginContainer'
 import { createPluginContainer } from './server/pluginContainer'
 import type { PackageCache } from './packages'
+import { findNearestPackageData } from './packages'
 import { loadEnv, resolveEnvPrefix } from './env'
 import type { ResolvedSSROptions, SSROptions } from './ssr'
 import { resolveSSROptions } from './ssr'
@@ -390,6 +391,7 @@ export async function resolveConfig(
   let configFileDependencies: string[] = []
   let mode = inlineConfig.mode || defaultMode
   const isNodeEnvSet = !!process.env.NODE_ENV
+  const packageCache: PackageCache = new Map()
 
   // some dependencies e.g. @vue/compiler-* relies on NODE_ENV for getting
   // production-specific behavior, so set it early on
@@ -539,7 +541,7 @@ export async function resolveConfig(
   )
 
   // resolve cache directory
-  const pkgPath = lookupFile(resolvedRoot, [`package.json`], { pathOnly: true })
+  const pkgPath = findNearestPackageData(resolvedRoot, packageCache)?.dir
   const cacheDir = normalizePath(
     config.cacheDir
       ? path.resolve(resolvedRoot, config.cacheDir)
@@ -681,7 +683,7 @@ export async function resolveConfig(
       return DEFAULT_ASSETS_RE.test(file) || assetsFilter(file)
     },
     logger,
-    packageCache: new Map(),
+    packageCache,
     createResolver,
     optimizeDeps: {
       disabled: 'build',

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -541,12 +541,12 @@ export async function resolveConfig(
   )
 
   // resolve cache directory
-  const pkgPath = findNearestPackageData(resolvedRoot, packageCache)?.dir
+  const pkgDir = findNearestPackageData(resolvedRoot, packageCache)?.dir
   const cacheDir = normalizePath(
     config.cacheDir
       ? path.resolve(resolvedRoot, config.cacheDir)
-      : pkgPath
-      ? path.join(path.dirname(pkgPath), `node_modules/.vite`)
+      : pkgDir
+      ? path.join(pkgDir, `node_modules/.vite`)
       : path.join(resolvedRoot, `.vite`),
   )
 


### PR DESCRIPTION
### Description

There shouldn't be a noticeable perf diff, but I think it is better if we start using a single function to get the nearest package.json instead of custom lookupFile calls.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other