### PR TITLE
perf(chokidar): avoid fs calls on ignored files

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
     },
     "patchedDependencies": {
       "dotenv-expand@9.0.0": "patches/dotenv-expand@9.0.0.patch",
-      "sirv@2.0.2": "patches/sirv@2.0.2.patch"
+      "sirv@2.0.2": "patches/sirv@2.0.2.patch",
+      "chokidar@3.5.3": "patches/chokidar@3.5.3.patch"
     }
   },
   "stackblitz": {

--- a/patches/chokidar@3.5.3.patch
+++ b/patches/chokidar@3.5.3.patch
@@ -1,0 +1,14 @@
+diff --git a/lib/fsevents-handler.js b/lib/fsevents-handler.js
+index 0f7f2cba857e0dbe001a5597061b11a9268d1e0e..5e99d97b917f8e2616cd3deb48b7a19d8b038928 100644
+--- a/lib/fsevents-handler.js
++++ b/lib/fsevents-handler.js
+@@ -303,7 +303,8 @@ _watchWithFsEvents(watchPath, realPath, transform, globFilter) {
+   if (this.fsw.closed || this.fsw._isIgnored(watchPath)) return;
+   const opts = this.fsw.options;
+   const watchCallback = async (fullPath, flags, info) => {
+-    if (this.fsw.closed) return;
++    // PATCH: bypass the callback for better perf when fullPath hit the ignored file list 
++    if (this.fsw.closed || this.fsw._isIgnored(fullPath)) return;
+     if (
+       opts.depth !== undefined &&
+       calcDepth(fullPath, realPath) > opts.depth

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,7 +254,7 @@ importers:
       acorn: 8.8.2
       acorn-walk: 8.2.0_acorn@8.8.2
       cac: 6.7.14
-      chokidar: 3.5.3
+      chokidar: 3.5.3_dzxbf3kgof5pdmbsyih2x43sq4
       connect: 3.7.0
       connect-history-api-fallback: 2.0.0
       convert-source-map: 2.0.0
@@ -4384,7 +4384,7 @@ packages:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
     dev: true
 
-  /chokidar/3.5.3:
+  /chokidar/3.5.3_dzxbf3kgof5pdmbsyih2x43sq4:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
     dependencies:
@@ -7229,7 +7229,7 @@ packages:
       '@iarna/toml': 2.2.5
       '@mrbbot/node-fetch': 4.6.0
       '@peculiar/webcrypto': 1.3.3
-      chokidar: 3.5.3
+      chokidar: 3.5.3_dzxbf3kgof5pdmbsyih2x43sq4
       cjstoesm: 1.1.4_typescript@4.6.4
       dotenv: 8.6.0
       env-paths: 2.2.1
@@ -8622,7 +8622,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 3.5.3_dzxbf3kgof5pdmbsyih2x43sq4
       immutable: 4.0.0
       source-map-js: 1.0.2
     dev: true
@@ -9100,7 +9100,7 @@ packages:
     hasBin: true
     dependencies:
       arg: 5.0.2
-      chokidar: 3.5.3
+      chokidar: 3.5.3_dzxbf3kgof5pdmbsyih2x43sq4
       color-name: 1.1.4
       detective: 5.2.1
       didyoumean: 1.2.2
@@ -9131,7 +9131,7 @@ packages:
     hasBin: true
     dependencies:
       arg: 5.0.2
-      chokidar: 3.5.3
+      chokidar: 3.5.3_dzxbf3kgof5pdmbsyih2x43sq4
       color-name: 1.1.4
       detective: 5.2.1
       didyoumean: 1.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ patchedDependencies:
   sirv@2.0.2:
     hash: hmoqtj4vy3i7wnpchga2a2mu3y
     path: patches/sirv@2.0.2.patch
+  chokidar@3.5.3:
+    hash: dzxbf3kgof5pdmbsyih2x43sq4
+    path: patches/chokidar@3.5.3.patch
 
 importers:
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

There are will be some extra fs calls on the ignored files (e.g especially when generating `.vite` cache) in chokidar. I think we could optimize it. But I also notice that https://github.com/paulmillr/chokidar is less active now, so maybe we can add  a `pnpm patch` for it.

This pr will avoid unnecessary calculations when ignored files change. I tested https://github.com/Lani/vite-2.7-slow before and after this pr. There will be 20-50ms faster after this pr when initial startup.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

I will send a PR to fix this upstream later. And once it gets merged, we can revert this and upgrade chokidar to the new one.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
