### PR TITLE
refactor: simplify lookupFile

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -927,8 +927,9 @@ export async function loadConfigFromFile(
   } else {
     // check package.json for type: "module" and set `isESM` to true
     try {
-      const pkg = lookupFile(configRoot, ['package.json'])
-      isESM = !!pkg && JSON.parse(pkg).type === 'module'
+      const pkg = lookupFile(configRoot, 'package.json')
+      isESM =
+        !!pkg && JSON.parse(fs.readFileSync(pkg, 'utf-8')).type === 'module'
     } catch (e) {}
   }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -927,7 +927,7 @@ export async function loadConfigFromFile(
   } else {
     // check package.json for type: "module" and set `isESM` to true
     try {
-      const pkg = lookupFile(configRoot, 'package.json')
+      const pkg = lookupFile(configRoot, ['package.json'])
       isESM =
         !!pkg && JSON.parse(fs.readFileSync(pkg, 'utf-8')).type === 'module'
     } catch (e) {}

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs'
+import path from 'node:path'
 import { parse } from 'dotenv'
 import { expand } from 'dotenv-expand'
-import { arraify, lookupFile } from './utils'
+import { arraify, tryStatSync } from './utils'
 import type { UserConfig } from './config'
 
 export function loadEnv(
@@ -26,12 +27,10 @@ export function loadEnv(
 
   const parsed = Object.fromEntries(
     envFiles.flatMap((file) => {
-      const path = lookupFile(envDir, [file], {
-        pathOnly: true,
-        rootDir: envDir,
-      })
-      if (!path) return []
-      return Object.entries(parse(fs.readFileSync(path)))
+      const filePath = path.join(envDir, file)
+      if (!tryStatSync(filePath)?.isFile()) return []
+
+      return Object.entries(parse(fs.readFileSync(filePath)))
     }),
   )
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -17,6 +17,7 @@ import {
   flattenId,
   getHash,
   isOptimizable,
+  lookupFile,
   normalizeId,
   normalizePath,
   removeDir,
@@ -1200,21 +1201,8 @@ const lockfileFormats = [
 ]
 const lockfileNames = lockfileFormats.map((l) => l.name)
 
-function findNearestLockfile(dir: string) {
-  while (dir) {
-    for (const fileName of lockfileNames) {
-      const fullPath = path.join(dir, fileName)
-      if (tryStatSync(fullPath)?.isFile()) return fullPath
-    }
-    const parentDir = path.dirname(dir)
-    if (parentDir === dir) return
-
-    dir = parentDir
-  }
-}
-
 export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
-  const lockfilePath = findNearestLockfile(config.root)
+  const lockfilePath = lookupFile(config.root, lockfileNames)
   let content = lockfilePath ? fs.readFileSync(lockfilePath, 'utf-8') : ''
   if (lockfilePath) {
     const lockfileName = path.basename(lockfilePath)

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -216,7 +216,11 @@ function cjsSsrCollectExternals(
   seen: Set<string>,
   logger: Logger,
 ) {
-  const rootPkgContent = lookupFile(root, ['package.json'])
+  const rootPkgPath = lookupFile(root, 'package.json')
+  if (!rootPkgPath) {
+    return
+  }
+  const rootPkgContent = fs.readFileSync(rootPkgPath, 'utf-8')
   if (!rootPkgContent) {
     return
   }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -216,7 +216,7 @@ function cjsSsrCollectExternals(
   seen: Set<string>,
   logger: Logger,
 ) {
-  const rootPkgPath = lookupFile(root, 'package.json')
+  const rootPkgPath = lookupFile(root, ['package.json'])
   if (!rootPkgPath) {
     return
   }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -387,28 +387,16 @@ export function tryStatSync(file: string): fs.Stats | undefined {
     // Ignore errors
   }
 }
-interface LookupFileOptions {
-  pathOnly?: boolean
-  rootDir?: string
-}
 
-export function lookupFile(
-  dir: string,
-  formats: string[],
-  options?: LookupFileOptions,
-): string | undefined {
-  for (const format of formats) {
-    const fullPath = path.join(dir, format)
-    if (tryStatSync(fullPath)?.isFile()) {
-      return options?.pathOnly ? fullPath : fs.readFileSync(fullPath, 'utf-8')
-    }
-  }
-  const parentDir = path.dirname(dir)
-  if (
-    parentDir !== dir &&
-    (!options?.rootDir || parentDir.startsWith(options?.rootDir))
-  ) {
-    return lookupFile(parentDir, formats, options)
+export function lookupFile(dir: string, fileName: string): string | undefined {
+  while (dir) {
+    const fullPath = path.join(dir, fileName)
+    if (tryStatSync(fullPath)?.isFile()) return fullPath
+
+    const parentDir = path.dirname(dir)
+    if (parentDir === dir) return
+
+    dir = parentDir
   }
 }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -388,11 +388,15 @@ export function tryStatSync(file: string): fs.Stats | undefined {
   }
 }
 
-export function lookupFile(dir: string, fileName: string): string | undefined {
+export function lookupFile(
+  dir: string,
+  fileNames: string[],
+): string | undefined {
   while (dir) {
-    const fullPath = path.join(dir, fileName)
-    if (tryStatSync(fullPath)?.isFile()) return fullPath
-
+    for (const fileName of fileNames) {
+      const fullPath = path.join(dir, fileName)
+      if (tryStatSync(fullPath)?.isFile()) return fullPath
+    }
     const parentDir = path.dirname(dir)
     if (parentDir === dir) return
 


### PR DESCRIPTION
### Description

After #12577 and #12576, there are only a few places where we are using `lookupFile`. Its API got quite complex and I think it is hiding the caller intention in some places. This PR simplifies the function. We may remove it later on, once we remove the CJS SSR build, it only will have a single use case (that could be replaced by a `findNearestPackageData`)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other