### PR TITLE
refactor: isInNodeModules util

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -18,6 +18,7 @@ import {
   createDebugger,
   dataUrlRE,
   externalRE,
+  isInNodeModules,
   isObject,
   isOptimizable,
   moduleListContains,
@@ -360,7 +361,7 @@ function esbuildScanPlugin(
         // If we can optimize this html type, skip it so it's handled by the
         // bare import resolve, and recorded as optimization dep.
         if (
-          resolved.includes('node_modules') &&
+          isInNodeModules(resolved) &&
           isOptimizable(resolved, config.optimizeDeps)
         )
           return
@@ -501,7 +502,7 @@ function esbuildScanPlugin(
             if (shouldExternalizeDep(resolved, id)) {
               return externalUnlessEntry({ path: id })
             }
-            if (resolved.includes('node_modules') || include?.includes(id)) {
+            if (isInNodeModules(resolved) || include?.includes(id)) {
               // dependency or forced included, externalize and stop crawling
               if (isOptimizable(resolved, config.optimizeDeps)) {
                 depImports[id] = resolved

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -32,6 +32,7 @@ import {
   isBuiltin,
   isDataUrl,
   isExternalUrl,
+  isInNodeModules,
   isJSRequest,
   joinUrlSegments,
   moduleListContains,
@@ -618,7 +619,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             staticImportedUrls.add({ url: hmrUrl, id: resolvedId })
           }
         } else if (!importer.startsWith(clientDir)) {
-          if (!importer.includes('node_modules')) {
+          if (!isInNodeModules(importer)) {
             // check @vite-ignore which suppresses dynamic import warning
             const hasViteIgnore = hasViteIgnoreRE.test(
               // complete expression inside parens

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -11,6 +11,7 @@ import {
   combineSourcemaps,
   isDataUrl,
   isExternalUrl,
+  isInNodeModules,
   moduleListContains,
 } from '../utils'
 import type { Plugin } from '../plugin'
@@ -185,10 +186,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer) {
-      if (
-        importer.includes('node_modules') &&
-        !dynamicImportPrefixRE.test(source)
-      ) {
+      if (isInNodeModules(importer) && !dynamicImportPrefixRE.test(source)) {
         return
       }
 

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -11,6 +11,7 @@ import { createIsConfiguredAsSsrExternal } from '../ssr/ssrExternal'
 import {
   bareImportRE,
   cleanUrl,
+  isInNodeModules,
   isOptimizable,
   moduleListContains,
 } from '../utils'
@@ -60,7 +61,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
               fs.existsSync(resolvedId) &&
               !moduleListContains(optimizeDeps.exclude, id) &&
               path.isAbsolute(resolvedId) &&
-              (resolvedId.includes('node_modules') ||
+              (isInNodeModules(resolvedId) ||
                 optimizeDeps.include?.includes(id)) &&
               isOptimizable(resolvedId, optimizeDeps) &&
               !(isBuild && ssr && isConfiguredAsExternal(id)) &&

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -4,6 +4,7 @@ import type {
   ManualChunkMeta,
   OutputOptions,
 } from 'rollup'
+import { isInNodeModules } from '../utils'
 import type { UserConfig } from '../../node'
 import type { Plugin } from '../plugin'
 
@@ -41,7 +42,7 @@ export function splitVendorChunk(
   const cache = options.cache ?? new SplitVendorChunkCache()
   return (id, { getModuleInfo }) => {
     if (
-      id.includes('node_modules') &&
+      isInNodeModules(id) &&
       !isCSSRequest(id) &&
       staticImportedByEntry(id, getModuleInfo, cache.cache)
     ) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -24,6 +24,7 @@ import type { InlineConfig, ResolvedConfig } from '../config'
 import { isDepsOptimizerEnabled, resolveConfig } from '../config'
 import {
   diffDnsOrderChange,
+  isInNodeModules,
   isParentDirectory,
   mergeConfig,
   normalizePath,
@@ -767,8 +768,7 @@ export function resolveServerOptions(
     sourcemapIgnoreList:
       raw?.sourcemapIgnoreList === false
         ? () => false
-        : raw?.sourcemapIgnoreList ||
-          ((sourcePath) => sourcePath.includes('node_modules')),
+        : raw?.sourcemapIgnoreList || isInNodeModules,
     middlewareMode: !!raw?.middlewareMode,
   }
   let allowDirs = server.fs?.allow

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -9,6 +9,7 @@ import {
   createFilter,
   isBuiltin,
   isDefined,
+  isInNodeModules,
   lookupFile,
   normalizePath,
 } from '../utils'
@@ -259,7 +260,7 @@ function cjsSsrCollectExternals(
       // no main entry, but deep imports may be allowed
       const pkgDir = resolvePackageData(id, root)?.dir
       if (pkgDir) {
-        if (pkgDir.includes('node_modules')) {
+        if (isInNodeModules(pkgDir)) {
           ssrExternals.add(id)
         } else {
           depsToTrace.add(path.dirname(pkgDir))
@@ -276,7 +277,7 @@ function cjsSsrCollectExternals(
       ssrExternals.add(id)
     }
     // trace the dependencies of linked packages
-    else if (!esmEntry.includes('node_modules')) {
+    else if (!isInNodeModules(esmEntry)) {
       const pkgDir = resolvePackageData(id, root)?.dir
       if (pkgDir) {
         depsToTrace.add(pkgDir)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -116,6 +116,10 @@ export function isBuiltin(id: string): boolean {
   )
 }
 
+export function isInNodeModules(id: string): boolean {
+  return id.includes('node_modules')
+}
+
 export function moduleListContains(
   moduleList: string[] | undefined,
   id: string,


### PR DESCRIPTION
### Description

@bluwy has been pushing for using the same check for node_modules everywhere. This PR creates a new util so we centralize it. It is using `.includes('node_modules')` which is the most common check we currently do.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other