### PR TITLE
fix(create-vite): skip lib check in tsconfig templates

### DIFF
--- a/packages/create-vite/template-preact-ts/tsconfig.node.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
+    "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true

--- a/packages/create-vite/template-react-ts/tsconfig.node.json
+++ b/packages/create-vite/template-react-ts/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
+    "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true

--- a/packages/create-vite/template-svelte-ts/tsconfig.node.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
+    "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Node"
   },

--- a/packages/create-vite/template-vue-ts/tsconfig.node.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
+    "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When type checking configs using `npx tsc --project tsconfig.node.json --noEmit`, eg. [in CI](https://github.com/karlhorky/archive-webpage-browser-extension/blob/9e3a83e0ef50d52e53774c744d2b4e404c29528e/.github/workflows/lint-check-types-and-build.yml#L21), there are a number of failures from `node_modules` types (see output below).

This PR sets `"skipLibCheck": true"` in all TS templates with the extra Node.js `tsconfig` to avoid this.

```bash
$ npx tsc --project tsconfig.node.json --noEmit
node_modules/.pnpm/@types+prop-types@15.7.5/node_modules/@types/prop-types/index.d.ts:20:41 - error TS2304: Cannot find name 'Iterable'.

20 export interface ReactNodeArray extends Iterable<ReactNodeLike> {}
                                           ~~~~~~~~

node_modules/.pnpm/@types+react@18.0.29/node_modules/@types/react/index.d.ts:230:10 - error TS2456: Type alias 'ReactFragment' circularly references itself.

230     type ReactFragment = Iterable<ReactNode>;
             ~~~~~~~~~~~~~

node_modules/.pnpm/@types+react@18.0.29/node_modules/@types/react/index.d.ts:230:26 - error TS2304: Cannot find name 'Iterable'.

230     type ReactFragment = Iterable<ReactNode>;
                             ~~~~~~~~

node_modules/.pnpm/@types+react@18.0.29/node_modules/@types/react/index.d.ts:231:10 - error TS2456: Type alias 'ReactNode' circularly references itself.

231     type ReactNode = ReactElement | string | number | ReactFragment | ReactPortal | boolean | null | undefined;
             ~~~~~~~~~

node_modules/.pnpm/@types+react@18.0.29/node_modules/@types/react/index.d.ts:414:23 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

414         interactions: Set<SchedulerInteraction>,
                          ~~~

node_modules/.pnpm/@types+scheduler@0.16.3/node_modules/@types/scheduler/tracing.d.ts:64:35 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

64   onWorkScheduled: (interactions: Set<Interaction>, threadID: number) => void;
                                     ~~~

node_modules/.pnpm/@types+scheduler@0.16.3/node_modules/@types/scheduler/tracing.d.ts:70:34 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

70   onWorkCanceled: (interactions: Set<Interaction>, threadID: number) => void;
                                    ~~~

node_modules/.pnpm/@types+scheduler@0.16.3/node_modules/@types/scheduler/tracing.d.ts:80:33 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

80   onWorkStarted: (interactions: Set<Interaction>, threadID: number) => void;
                                   ~~~

node_modules/.pnpm/@types+scheduler@0.16.3/node_modules/@types/scheduler/tracing.d.ts:86:33 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

86   onWorkStopped: (interactions: Set<Interaction>, threadID: number) => void;
                                   ~~~

node_modules/.pnpm/@types+scheduler@0.16.3/node_modules/@types/scheduler/tracing.d.ts:90:12 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

90   current: Set<Interaction>;
              ~~~

node_modules/.pnpm/@types+scheduler@0.16.3/node_modules/@types/scheduler/tracing.d.ts:102:40 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

102 export function unstable_getCurrent(): Set<Interaction> | null;
                                           ~~~

node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/lazy-result.d.ts:60:28 - error TS2339: Property 'finally' does not exist on type 'Promise<Result>'.

60   finally: Promise<Result>['finally']
                              ~~~~~~~~~

node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/lazy-result.d.ts:73:8 - error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

73   get [Symbol.toStringTag](): string
          ~~~~~~

node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/no-work-result.d.ts:23:28 - error TS2339: Property 'finally' does not exist on type 'Promise<Result>'.

23   finally: Promise<Result>['finally']
                              ~~~~~~~~~

node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/no-work-result.d.ts:25:8 - error TS2585: 'Symbol' only refers to a type, but is being used as a value here. Do you need to change your target library? Try changing the 'lib' compiler option to es2015 or later.

25   get [Symbol.toStringTag](): string
          ~~~~~~

node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/rollup.d.ts:191:22 - error TS2304: Cannot find name 'IterableIterator'.

191  getModuleIds: () => IterableIterator<string>;
                         ~~~~~~~~~~~~~~~~

node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/rollup.d.ts:198:13 - error TS2304: Cannot find name 'IterableIterator'.

198  moduleIds: IterableIterator<string>;
                ~~~~~~~~~~~~~~~~

node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/rollup.d.ts:493:22 - error TS2304: Cannot find name 'IterableIterator'.

493  getModuleIds: () => IterableIterator<string>;
                         ~~~~~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1:23 - error TS2688: Cannot find type definition file for 'node'.

1 /// <reference types="node" />
                        ~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3:28 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

3 import type { Agent } from 'node:http';
                             ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:6:36 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

6 import type { ClientRequest } from 'node:http';
                                     ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:7:40 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

7 import type { ClientRequestArgs } from 'node:http';
                                         ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:12:29 - error TS2307: Cannot find module 'node:stream' or its corresponding type declarations.

12 import type { Duplex } from 'node:stream';
                               ~~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:13:36 - error TS2307: Cannot find module 'node:stream' or its corresponding type declarations.

13 import type { DuplexOptions } from 'node:stream';
                                      ~~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:17:30 - error TS2307: Cannot find module 'node:events' or its corresponding type declarations.

17 import { EventEmitter } from 'node:events';
                                ~~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:18:25 - error TS2307: Cannot find module 'node:events' or its corresponding type declarations.

18 import * as events from 'node:events';
                           ~~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:20:26 - error TS2307: Cannot find module 'node:fs' or its corresponding type declarations.

20 import type * as fs from 'node:fs';
                            ~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:25:23 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

25 import * as http from 'node:http';
                         ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:29:38 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

29 import type { IncomingMessage } from 'node:http';
                                        ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:39:27 - error TS2307: Cannot find module 'node:net' or its corresponding type declarations.

39 import type * as net from 'node:net';
                             ~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:41:42 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

41 import type { OutgoingHttpHeaders } from 'node:http';
                                            ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:57:43 - error TS2307: Cannot find module 'node:tls' or its corresponding type declarations.

57 import type { SecureContextOptions } from 'node:tls';
                                             ~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:58:29 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

58 import type { Server } from 'node:http';
                               ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:59:41 - error TS2307: Cannot find module 'node:https' or its corresponding type declarations.

59 import type { Server as Server_2 } from 'node:https';
                                           ~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:60:55 - error TS2307: Cannot find module 'node:https' or its corresponding type declarations.

60 import type { ServerOptions as ServerOptions_2 } from 'node:https';
                                                         ~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:61:37 - error TS2307: Cannot find module 'node:http' or its corresponding type declarations.

61 import type { ServerResponse } from 'node:http';
                                       ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:65:30 - error TS2307: Cannot find module 'node:stream' or its corresponding type declarations.

65 import type * as stream from 'node:stream';
                                ~~~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:71:27 - error TS2307: Cannot find module 'node:url' or its corresponding type declarations.

71 import type * as url from 'node:url';
                             ~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:72:35 - error TS2307: Cannot find module 'node:url' or its corresponding type declarations.

72 import type { URL as URL_2 } from 'node:url';
                                     ~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:74:34 - error TS2307: Cannot find module 'node:zlib' or its corresponding type declarations.

74 import type { ZlibOptions } from 'node:zlib';
                                    ~~~~~~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:422:37 - error TS2503: Cannot find namespace 'NodeJS'.

422     export interface Server extends NodeJS.EventEmitter {
                                        ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:902:15 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

902         pfx?: Buffer | string | undefined
                  ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1316:21 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1316     urlToModuleMap: Map<string, ModuleNode>;
                         ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1317:20 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1317     idToModuleMap: Map<string, ModuleNode>;
                        ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1318:23 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1318     fileToModulesMap: Map<string, Set<ModuleNode>>;
                           ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1318:35 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1318     fileToModulesMap: Map<string, Set<ModuleNode>>;
                                       ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1319:22 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1319     safeModulesPath: Set<string>;
                          ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1323:37 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1323     getModulesByFile(file: string): Set<ModuleNode> | undefined;
                                         ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1325:46 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1325     invalidateModule(mod: ModuleNode, seen?: Set<ModuleNode>, timestamp?: number, isHmr?: boolean): void;
                                                  ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1332:56 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1332     updateModuleInfo(mod: ModuleNode, importedModules: Set<string | ModuleNode>, importedBindings: Map<string, Set<string>> | null, acceptedModules: Set<string | ModuleNode>, acceptedExports: Set<string> | null, isSelfAccepting: boolean, ssr?: boolean): Promise<Set<ModuleNode> | undefined>;
                                                            ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1332:100 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1332     updateModuleInfo(mod: ModuleNode, importedModules: Set<string | ModuleNode>, importedBindings: Map<string, Set<string>> | null, acceptedModules: Set<string | ModuleNode>, acceptedExports: Set<string> | null, isSelfAccepting: boolean, ssr?: boolean): Promise<Set<ModuleNode> | undefined>;
                                                                                                        ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1332:112 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1332     updateModuleInfo(mod: ModuleNode, importedModules: Set<string | ModuleNode>, importedBindings: Map<string, Set<string>> | null, acceptedModules: Set<string | ModuleNode>, acceptedExports: Set<string> | null, isSelfAccepting: boolean, ssr?: boolean): Promise<Set<ModuleNode> | undefined>;
                                                                                                                    ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1332:150 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1332     updateModuleInfo(mod: ModuleNode, importedModules: Set<string | ModuleNode>, importedBindings: Map<string, Set<string>> | null, acceptedModules: Set<string | ModuleNode>, acceptedExports: Set<string> | null, isSelfAccepting: boolean, ssr?: boolean): Promise<Set<ModuleNode> | undefined>;
                                                                                                                                                          ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1332:193 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1332     updateModuleInfo(mod: ModuleNode, importedModules: Set<string | ModuleNode>, importedBindings: Map<string, Set<string>> | null, acceptedModules: Set<string | ModuleNode>, acceptedExports: Set<string> | null, isSelfAccepting: boolean, ssr?: boolean): Promise<Set<ModuleNode> | undefined>;
                                                                                                                                                                                                     ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1332:263 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1332     updateModuleInfo(mod: ModuleNode, importedModules: Set<string | ModuleNode>, importedBindings: Map<string, Set<string>> | null, acceptedModules: Set<string | ModuleNode>, acceptedExports: Set<string> | null, isSelfAccepting: boolean, ssr?: boolean): Promise<Set<ModuleNode> | undefined>;
                                                                                                                                                                                                                                                                           ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1351:16 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1351     importers: Set<ModuleNode>;
                    ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1352:22 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1352     importedModules: Set<ModuleNode>;
                          ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1353:22 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1353     acceptedHmrDeps: Set<ModuleNode>;
                          ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1354:25 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1354     acceptedHmrExports: Set<string> | null;
                             ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1355:23 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1355     importedBindings: Map<string, Set<string>> | null;
                           ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1355:35 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1355     importedBindings: Map<string, Set<string>> | null;
                                       ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1411:36 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1411 export declare type PackageCache = Map<string, PackageData>;
                                        ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1563:16 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1563         skip?: Set<Plugin_2>;
                    ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1594:12 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

1594     deps?: Set<string>;
                ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2040:91 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2040 export declare function send(req: IncomingMessage, res: ServerResponse, content: string | Buffer, type: string, options: SendOptions): void;
                                                                                               ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2111:12 - error TS2583: Cannot find name 'Map'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

2111     cache: Map<string, boolean>;
                ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2805:42 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2805     close(code?: number, data?: string | Buffer): void
                                              ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2875:57 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2875     listener: (this: WebSocket_2, code: number, reason: Buffer) => void,
                                                             ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2893:41 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2893     listener: (this: WebSocket_2, data: Buffer) => void,
                                             ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2910:57 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2910     listener: (this: WebSocket_2, code: number, reason: Buffer) => void,
                                                             ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2928:41 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2928     listener: (this: WebSocket_2, data: Buffer) => void,
                                             ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2945:57 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2945     listener: (this: WebSocket_2, code: number, reason: Buffer) => void,
                                                             ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2963:41 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2963     listener: (this: WebSocket_2, data: Buffer) => void,
                                             ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2980:38 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2980     listener: (code: number, reason: Buffer) => void,
                                          ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:2992:58 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

2992     addListener(event: 'ping' | 'pong', listener: (data: Buffer) => void): this
                                                              ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3001:38 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3001     listener: (code: number, reason: Buffer) => void,
                                          ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3013:61 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3013     removeListener(event: 'ping' | 'pong', listener: (data: Buffer) => void): this
                                                                 ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3028:20 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3028     type RawData = Buffer | ArrayBuffer | Buffer[]
                        ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3028:43 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3028     type RawData = Buffer | ArrayBuffer | Buffer[]
                                               ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3033:26 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3033     type Data = string | Buffer | ArrayBuffer | Buffer[]
                              ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3033:49 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3033     type Data = string | Buffer | ArrayBuffer | Buffer[]
                                                     ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3038:41 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3038     type CertMeta = string | string[] | Buffer | Buffer[]
                                             ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3038:50 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3038     type CertMeta = string | string[] | Buffer | Buffer[]
                                                      ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3069:29 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3069         generateMask?(mask: Buffer): void
                                 ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3100:26 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3100             dictionary?: Buffer | Buffer[] | DataView | undefined
                              ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3100:35 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3100             dictionary?: Buffer | Buffer[] | DataView | undefined
                                       ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3149:20 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

3149         protocols: Set<string>,
                        ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3171:18 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

3171         clients: Set<T>
                      ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3180:22 - error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.

3180         upgradeHead: Buffer,
                          ~~~~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:3310:14 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

3310     clients: Set<WebSocketClient>;
                  ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/types/metadata.d.ts:2:19 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

2   importedAssets: Set<string>
                    ~~~

node_modules/.pnpm/vite@4.2.1/node_modules/vite/types/metadata.d.ts:3:16 - error TS2583: Cannot find name 'Set'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2015' or later.

3   importedCss: Set<string>
                 ~~~


Found 92 errors in 8 files.

Errors  Files
     1  node_modules/.pnpm/@types+prop-types@15.7.5/node_modules/@types/prop-types/index.d.ts:20
     4  node_modules/.pnpm/@types+react@18.0.29/node_modules/@types/react/index.d.ts:230
     6  node_modules/.pnpm/@types+scheduler@0.16.3/node_modules/@types/scheduler/tracing.d.ts:64
     2  node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/lazy-result.d.ts:60
     2  node_modules/.pnpm/postcss@8.4.21/node_modules/postcss/lib/no-work-result.d.ts:23
     3  node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/rollup.d.ts:191
    72  node_modules/.pnpm/vite@4.2.1/node_modules/vite/dist/node/index.d.ts:1
     2  node_modules/.pnpm/vite@4.2.1/node_modules/vite/types/metadata.d.ts:2
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I changed all files that I saw in the templates, but if there are any others that I should change, happy to do so.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
