### PR TITLE
perf(optimizer): start optimizer early

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -26,6 +26,7 @@ import {
 import { transformWithEsbuild } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET } from '../constants'
 import { resolvePackageData } from '../packages'
+import type { ViteDevServer } from '../server'
 import { esbuildCjsExternalPlugin, esbuildDepPlugin } from './esbuildDepPlugin'
 import { scanImports } from './scan'
 export {
@@ -71,6 +72,7 @@ export interface DepsOptimizer {
   close: () => Promise<void>
 
   options: DepOptimizationOptions
+  server?: ViteDevServer
 }
 
 export interface DepOptimizationConfig {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -1,7 +1,7 @@
 import colors from 'picocolors'
 import _debug from 'debug'
 import { getHash } from '../utils'
-import { getDepOptimizationConfig } from '..'
+import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig, ViteDevServer } from '..'
 import {
   addManuallyIncludedOptimizeDeps,

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -122,6 +122,7 @@ async function createDepsOptimizer(
     ensureFirstRun,
     close,
     options: getDepOptimizationConfig(config, ssr),
+    server,
   }
 
   depsOptimizerMap.set(config, depsOptimizer)
@@ -475,13 +476,13 @@ async function createDepsOptimizer(
   }
 
   function fullReload() {
-    if (server) {
+    if (depsOptimizer.server) {
       // Cached transform results have stale imports (resolved to
       // old locations) so they need to be invalidated before the page is
       // reloaded.
-      server.moduleGraph.invalidateAll()
+      depsOptimizer.server.moduleGraph.invalidateAll()
 
-      server.ws.send({
+      depsOptimizer.server.ws.send({
         type: 'full-reload',
         path: '*',
       })

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -11,6 +11,9 @@ async function createDevServer() {
     configFile: false,
     root,
     logLevel: 'silent',
+    optimizeDeps: {
+      disabled: true,
+    },
   })
   server.pluginContainer.buildStart({})
   return server

--- a/packages/vite/src/node/ssr/__tests__/ssrStacktrace.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrStacktrace.spec.ts
@@ -9,6 +9,9 @@ async function createDevServer() {
     configFile: false,
     root,
     logLevel: 'silent',
+    optimizeDeps: {
+      disabled: true,
+    },
   })
   server.pluginContainer.buildStart({})
   return server

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     ],
     testTimeout: 20000,
     // node14 segfaults often with threads
-    threads: process.versions.node.startsWith('14'),
+    threads: !process.versions.node.startsWith('14'),
   },
   esbuild: {
     target: 'node14',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
       './playground-temp/**/*.*',
     ],
     testTimeout: 20000,
+    // node14 segfaults often with threads
+    threads: process.versions.node.startsWith('14'),
   },
   esbuild: {
     target: 'node14',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently the deps optimizer is inited only after the server is created and listening. However, the deps optimizer only relies on the server for module graph invalidation and page reload.

As these are technically optional if the server isn't ready yet, we should be able to init the optimizer before the server is created, which is what this PR does.

When the server is ready, we pass the server to the optimizer again for future server handling.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Without this, we can't call `server.transformRequest` early on to pre-cache things, as we need the optimizer to properly resolve paths.

With this PR, the optimizer can start 260ms earlier on a project I'm testing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

