### PR TITLE
perf: non-blocking write of optimized dep files

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -639,7 +639,7 @@ export function runOptimizeDeps(
 
           const newFilesPaths = new Set<string>()
           const files: Promise<void>[] = []
-          const write = (filePath: string, content: string) => {
+          const write = (filePath: string, content: string | Uint8Array) => {
             newFilesPaths.add(filePath)
             files.push(fsp.writeFile(filePath, content))
           }
@@ -658,7 +658,7 @@ export function runOptimizeDeps(
           )
 
           for (const outputFile of result.outputFiles!)
-            write(outputFile.path, outputFile.text)
+            write(outputFile.path, outputFile.contents)
 
           // Clean up old files in the background
           for (const filePath of oldFilesPaths)

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -613,15 +613,6 @@ export function runOptimizeDeps(
         async function commitFiles() {
           // Write this run of pre-bundled dependencies to the deps cache
 
-          // Keep the output files in memory while we write them to disk in the
-          // background. These files are going to be sent right away to the browser
-          optimizedDepsCache.set(
-            metadata,
-            new Map(
-              result.outputFiles!.map((f) => [normalizePath(f.path), f.text]),
-            ),
-          )
-
           // Get a list of old files in the deps directory to delete the stale ones
           const oldFilesPaths: string[] = []
           if (!fs.existsSync(depsCacheDir)) {
@@ -679,8 +670,17 @@ export function runOptimizeDeps(
         return {
           metadata,
           async commit() {
+            // Keep the output files in memory while we write them to disk in the
+            // background. These files are going to be sent right away to the browser
+            optimizedDepsCache.set(
+              metadata,
+              new Map(
+                result.outputFiles!.map((f) => [normalizePath(f.path), f.text]),
+              ),
+            )
+
             // No need to wait, files are written in the background
-            commitFiles()
+            setTimeout(commitFiles, 0)
           },
           cancel: () => {},
         }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -616,6 +616,7 @@ export function runOptimizeDeps(
           }
 
           const newFilesPaths = new Set<string>()
+          newFilesPaths.add(writingFilePath)
           const files: Promise<void>[] = []
           const write = (filePath: string, content: string | Uint8Array) => {
             newFilesPaths.add(filePath)

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -360,11 +360,8 @@ export async function loadCachedDepOptimizationMetadata(
 
   const depsCacheDir = getDepsCacheDir(config, ssr)
 
-  const unlockSuccess = await waitOptimizerWriteLock(
-    depsCacheDir,
-    config.logger,
-  )
-  if (!unlockSuccess) {
+  // If the lock timed out, we cancel and return undefined
+  if (!(await waitOptimizerWriteLock(depsCacheDir, config.logger))) {
     return
   }
 

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -195,7 +195,7 @@ async function createDepsOptimizer(
     const deps: Record<string, string> = {}
     await addManuallyIncludedOptimizeDeps(deps, config, ssr)
 
-    const discovered = await toDiscoveredDependencies(
+    const discovered = toDiscoveredDependencies(
       config,
       deps,
       ssr,

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -1,10 +1,13 @@
-import { promises as fs } from 'node:fs'
 import colors from 'picocolors'
 import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
 import { DEP_VERSION_RE } from '../constants'
 import { cleanUrl, createDebugger } from '../utils'
-import { getDepsOptimizer, optimizedDepInfoFromFile } from '../optimizer'
+import {
+  getDepsOptimizer,
+  loadOptimizedDep,
+  optimizedDepInfoFromFile,
+} from '../optimizer'
 
 export const ERR_OPTIMIZE_DEPS_PROCESSING_ERROR =
   'ERR_OPTIMIZE_DEPS_PROCESSING_ERROR'
@@ -67,7 +70,7 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
         // load hooks to avoid race conditions, once processing is resolved,
         // we are sure that the file has been properly save to disk
         try {
-          return await fs.readFile(file, 'utf-8')
+          return loadOptimizedDep(file, depsOptimizer)
         } catch (e) {
           // Outdated non-entry points (CHUNK), loaded after a rerun
           throwOutdatedRequest(id)
@@ -128,7 +131,7 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
       // load hooks to avoid race conditions, once processing is resolved,
       // we are sure that the file has been properly save to disk
 
-      return await fs.readFile(file, 'utf-8')
+      return loadOptimizedDep(file, depsOptimizer)
     },
   }
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -341,10 +341,9 @@ export async function createServer(
 ): Promise<ViteDevServer> {
   const config = await resolveConfig(inlineConfig, 'serve')
 
-  // start optimizer in the background
-  let depsOptimizerReady: Promise<void> | undefined
   if (isDepsOptimizerEnabled(config, false)) {
-    depsOptimizerReady = initDepsOptimizer(config)
+    // start optimizer in the background, we still need to await the setup
+    await initDepsOptimizer(config)
   }
 
   const { root, server: serverConfig } = config
@@ -665,13 +664,9 @@ export async function createServer(
 
   // when the optimizer is ready, hook server so that it can reload the page
   // or invalidate the module graph when needed
-  if (depsOptimizerReady) {
-    depsOptimizerReady.then(() => {
-      const depsOptimizer = getDepsOptimizer(config)
-      if (depsOptimizer) {
-        depsOptimizer.server = server
-      }
-    })
+  const depsOptimizer = getDepsOptimizer(config)
+  if (depsOptimizer) {
+    depsOptimizer.server = server
   }
 
   if (!middlewareMode && httpServer) {

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import type { Connect } from 'dep-types/connect'
 import colors from 'picocolors'
@@ -34,7 +33,7 @@ import {
   ERR_OPTIMIZE_DEPS_PROCESSING_ERROR,
   ERR_OUTDATED_OPTIMIZED_DEP,
 } from '../../plugins/optimizedDeps'
-import { getDepsOptimizer } from '../../optimizer'
+import { getDepsOptimizer, loadOptimizedDep } from '../../optimizer'
 
 const debugCache = createDebugger('vite:cache')
 const isDebug = !!process.env.DEBUG
@@ -81,7 +80,7 @@ export function transformMiddleware(
                 ensureVolumeInPath(path.resolve(root, url.slice(1))),
               )
           try {
-            const map = await fs.readFile(mapFile, 'utf-8')
+            const map = await loadOptimizedDep(mapFile, depsOptimizer)
             return send(req, res, map, 'json', {
               headers: server.config.server.headers,
             })


### PR DESCRIPTION
### Description

Keep the esbuild output files in memory so we can avoid waiting for the write of all optimized deps and then read from disk.

Implements a `_writing` lock of the deps cache that is checked when reading the cached deps to avoid issues if the user stopped the process in the middle of writing the optimized deps. @dominikg thinks this isn't enough, but given that two processes shouldn't be working with the same cache dir in the same root I think this is enough.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other