### PR TITLE
perf: reduce runOptimizerIfIdleAfterMs time

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -670,7 +670,7 @@ async function createDepsOptimizer(
     }
   }
 
-  const runOptimizerIfIdleAfterMs = 100
+  const runOptimizerIfIdleAfterMs = 50
 
   let registeredIds: { id: string; done: () => Promise<any> }[] = []
   let seenIds = new Set<string>()


### PR DESCRIPTION
### Description

On cold start, we are awaiting an extra 100ms after the last transform promise is resolved. These are all the files statically imported, or dynamically if they are called fast enough. Given the current reductions in processing time, 100ms is starting to feel too conservative. I think we can try to reduce it to 50ms during the beta and see how it works.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other