### PR TITLE
perf(moduleGraph): resolve dep urls in parallel

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -148,27 +148,32 @@ export class ModuleGraph {
   ): Promise<Set<ModuleNode> | undefined> {
     mod.isSelfAccepting = isSelfAccepting
     const prevImports = mod.importedModules
-    const nextImports = (mod.importedModules = new Set())
     let noLongerImported: Set<ModuleNode> | undefined
+
     let resolvePromises = []
+    let resolveResults = new Array(importedModules.size)
+    let index = 0
     // update import graph
     for (const imported of importedModules) {
+      const nextIndex = index++
       if (typeof imported === 'string') {
         resolvePromises.push(
           this.ensureEntryFromUrl(imported, ssr).then((dep) => {
             dep.importers.add(mod)
-            nextImports.add(dep)
+            resolveResults[nextIndex] = dep
           }),
         )
       } else {
         imported.importers.add(mod)
-        nextImports.add(imported)
+        resolveResults[nextIndex] = imported
       }
     }
 
     if (resolvePromises.length) {
       await Promise.all(resolvePromises)
     }
+
+    const nextImports = (mod.importedModules = new Set(resolveResults))
 
     // remove the importer from deps that were imported but no longer are.
     prevImports.forEach((dep) => {
@@ -182,21 +187,27 @@ export class ModuleGraph {
     })
 
     // update accepted hmr deps
-    const deps = (mod.acceptedHmrDeps = new Set())
     resolvePromises = []
+    resolveResults = new Array(acceptedModules.size)
+    index = 0
     for (const accepted of acceptedModules) {
+      const nextIndex = index++
       if (typeof accepted === 'string') {
         resolvePromises.push(
-          this.ensureEntryFromUrl(accepted, ssr).then((dep) => deps.add(dep)),
+          this.ensureEntryFromUrl(accepted, ssr).then((dep) => {
+            resolveResults[nextIndex] = dep
+          }),
         )
       } else {
-        deps.add(accepted)
+        resolveResults[nextIndex] = accepted
       }
     }
 
     if (resolvePromises.length) {
       await Promise.all(resolvePromises)
     }
+
+    mod.acceptedHmrDeps = new Set(resolveResults)
 
     // update accepted hmr exports
     mod.acceptedHmrExports = acceptedExports

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -166,7 +166,9 @@ export class ModuleGraph {
       }
     }
 
-    resolvePromises.length && (await Promise.all(resolvePromises))
+    if (resolvePromises.length) {
+      await Promise.all(resolvePromises)
+    }
 
     // remove the importer from deps that were imported but no longer are.
     prevImports.forEach((dep) => {
@@ -192,7 +194,9 @@ export class ModuleGraph {
       }
     }
 
-    resolvePromises.length && (await Promise.all(resolvePromises))
+    if (resolvePromises.length) {
+      await Promise.all(resolvePromises)
+    }
 
     // update accepted hmr exports
     mod.acceptedHmrExports = acceptedExports


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Resolve deps' URLs in parallel in `ModuleGraph.updateModuleInfo`.

I tested this pr perf both in [sapphi's repo](https://github.com/sapphi-red/performance-compare/tree/65d51a32b0282593f1b75def25075a02b28f6397) and [mine](https://github.com/sun0day/vite-2.7-slow), there will be 10-50ms faster in the startup.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
