### PR TITLE
test: don't share cacheDir among different configs

### DIFF
--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -21,4 +21,5 @@ export default defineConfig({
   testConfig: {
     baseRoute: '/relative-base/',
   },
+  cacheDir: 'node_modules/.vite-relative-base',
 })

--- a/playground/assets/vite.config-runtime-base.js
+++ b/playground/assets/vite.config-runtime-base.js
@@ -57,4 +57,5 @@ export default defineConfig({
       }
     },
   },
+  cacheDir: 'node_modules/.vite-runtime-base',
 })

--- a/playground/assets/vite.config-url-base.js
+++ b/playground/assets/vite.config-url-base.js
@@ -21,4 +21,5 @@ export default defineConfig({
   testConfig: {
     baseRoute: '/url-base/',
   },
+  cacheDir: 'node_modules/.vite-url-base',
 })

--- a/playground/css/vite.config-no-css-minify.js
+++ b/playground/css/vite.config-no-css-minify.js
@@ -9,4 +9,5 @@ export default defineConfig({
     minify: true,
     cssMinify: false,
   },
+  cacheDir: 'node_modules/.vite-no-css-minify',
 })

--- a/playground/css/vite.config-relative-base.js
+++ b/playground/css/vite.config-relative-base.js
@@ -21,4 +21,5 @@ export default defineConfig({
   testConfig: {
     baseRoute: '/relative-base/',
   },
+  cacheDir: 'node_modules/.vite-relative-base',
 })

--- a/playground/lib/vite.dyimport.config.js
+++ b/playground/lib/vite.dyimport.config.js
@@ -11,4 +11,5 @@ export default defineConfig({
     },
     outDir: 'dist/lib',
   },
+  cacheDir: 'node_modules/.vite-dyimport',
 })

--- a/playground/lib/vite.nominify.config.js
+++ b/playground/lib/vite.nominify.config.js
@@ -9,4 +9,5 @@ export default defineConfig({
     outDir: 'dist/nominify',
   },
   plugins: [],
+  cacheDir: 'node_modules/.vite-nominify',
 })

--- a/playground/preload/vite.config-preload-disabled.ts
+++ b/playground/preload/vite.config-preload-disabled.ts
@@ -23,4 +23,5 @@ export default defineConfig({
     },
     modulePreload: false,
   },
+  cacheDir: 'node_modules/.vite-preload-disabled',
 })

--- a/playground/preload/vite.config-resolve-deps.ts
+++ b/playground/preload/vite.config-resolve-deps.ts
@@ -38,4 +38,5 @@ export default defineConfig({
       return { relative: true }
     },
   },
+  cacheDir: 'node_modules/.vite-resolve-deps',
 })

--- a/playground/worker/vite.config-es.js
+++ b/playground/worker/vite.config-es.js
@@ -44,4 +44,5 @@ export default vite.defineConfig({
       },
     },
   ],
+  cacheDir: 'node_modules/.vite-es',
 })

--- a/playground/worker/vite.config-iife.js
+++ b/playground/worker/vite.config-iife.js
@@ -47,4 +47,5 @@ export default vite.defineConfig({
     },
   },
   plugins: [workerPluginTestPlugin()],
+  cacheDir: 'node_modules/.vite-iife',
 })

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -46,4 +46,5 @@ export default vite.defineConfig({
       },
     },
   ],
+  cacheDir: 'node_modules/.vite-relative-base',
 })

--- a/playground/worker/vite.config-sourcemap.js
+++ b/playground/worker/vite.config-sourcemap.js
@@ -12,10 +12,11 @@ export default (sourcemap) => {
     sourcemap = true
   }
 
+  const typeName =
+    typeof sourcemap === 'boolean' ? 'sourcemap' : 'sourcemap-' + sourcemap
+
   return vite.defineConfig({
-    base: `/iife-${
-      typeof sourcemap === 'boolean' ? 'sourcemap' : 'sourcemap-' + sourcemap
-    }/`,
+    base: `/iife-${typeName}/`,
     resolve: {
       alias: {
         '@': __dirname,
@@ -33,9 +34,7 @@ export default (sourcemap) => {
       },
     },
     build: {
-      outDir: `dist/iife-${
-        typeof sourcemap === 'boolean' ? 'sourcemap' : 'sourcemap-' + sourcemap
-      }/`,
+      outDir: `dist/iife-${typeName}/`,
       sourcemap: sourcemap,
       rollupOptions: {
         output: {
@@ -46,5 +45,6 @@ export default (sourcemap) => {
       },
     },
     plugins: [workerPluginTestPlugin()],
+    cacheDir: `node_modules/.vite-sourcemap-${typeName}`,
   })
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The test was sometimes failing with dep optimizer related errors. I guess this is caused by sharing `cacheDir` among different configs since we run tests with different configs parallelly.

Maybe we can include the config file path in `cacheDir` automatically in Vite 5?

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
