### PR TITLE
test: fix flaky assets/url-base test fail

### DIFF
--- a/playground/assets/__tests__/url-base/url-base-assets.spec.ts
+++ b/playground/assets/__tests__/url-base/url-base-assets.spec.ts
@@ -10,17 +10,17 @@ import {
 } from '~utils'
 
 const urlAssetMatch = isBuild
-  ? /http:\/\/localhost:4173\/other-assets\/asset-\w{8}\.png/
+  ? /http:\/\/localhost:\d+\/other-assets\/asset-\w{8}\.png/
   : '/nested/asset.png'
 
 const iconMatch = '/icon.png'
 
 const absoluteIconMatch = isBuild
-  ? /http:\/\/localhost:4173\/.*\/icon-\w{8}\.png/
+  ? /http:\/\/localhost:\d+\/.*\/icon-\w{8}\.png/
   : '/nested/icon.png'
 
 const absolutePublicIconMatch = isBuild
-  ? /http:\/\/localhost:4173\/icon\.png/
+  ? /http:\/\/localhost:\d+\/icon\.png/
   : '/icon.png'
 
 test('should have no 404s', () => {
@@ -185,9 +185,7 @@ test('?raw import', async () => {
 
 test('?url import', async () => {
   expect(await page.textContent('.url')).toMatch(
-    isBuild
-      ? /http:\/\/localhost:4173\/other-assets\/foo-\w{8}\.js/
-      : '/foo.js',
+    isBuild ? /http:\/\/localhost:\d+\/other-assets\/foo-\w{8}\.js/ : '/foo.js',
   )
 })
 
@@ -195,7 +193,7 @@ test('?url import on css', async () => {
   const txt = await page.textContent('.url-css')
   expect(txt).toMatch(
     isBuild
-      ? /http:\/\/localhost:4173\/other-assets\/icons-\w{8}\.css/
+      ? /http:\/\/localhost:\d+\/other-assets\/icons-\w{8}\.css/
       : '/css/icons.css',
   )
 })

--- a/playground/assets/vite.config-url-base.js
+++ b/playground/assets/vite.config-url-base.js
@@ -1,9 +1,16 @@
 import { defineConfig } from 'vite'
 import baseConfig from './vite.config.js'
 
+/** see `ports` variable in test-utils.ts */
+const port = 9524
+
 export default defineConfig({
   ...baseConfig,
-  base: 'http://localhost:4173/',
+  base: `http://localhost:${port}/`,
+  server: {
+    port,
+    strictPort: true,
+  },
   build: {
     ...baseConfig.build,
     outDir: 'dist/url-base',
@@ -17,6 +24,10 @@ export default defineConfig({
         assetFileNames: 'other-assets/[name]-[hash][extname]',
       },
     },
+  },
+  preview: {
+    port,
+    strictPort: true,
   },
   testConfig: {
     baseRoute: '/url-base/',

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -22,6 +22,7 @@ export const ports = {
   lib: 9521,
   'optimize-missing-deps': 9522,
   'legacy/client-and-ssr': 9523,
+  'assets/url-base': 9524, // not imported but used in `assets/vite.config-url-base.js`
   ssr: 9600,
   'ssr-deps': 9601,
   'ssr-html': 9602,


### PR DESCRIPTION
### Description
`assets/url-base` test may use a different port than 4173 when the port is occupied but the build was always generating with 4173.

This PR makes `assets/url-base` test to use a dedicated port to avoid that fails.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
