### PR TITLE
fix: use nearest pkg to resolved for moduleSideEffects

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -254,19 +254,20 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         }
 
         if ((res = tryFsResolve(fsPath, options))) {
+          const resPkg = findNearestPackageData(
+            path.dirname(res),
+            options.packageCache,
+          )
           res = ensureVersionQuery(res, id, options, depsOptimizer)
           isDebug &&
             debug(`[relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
-          const pkg =
-            importer &&
-            findNearestPackageData(path.dirname(importer), options.packageCache)
-          if (pkg) {
-            return {
-              id: res,
-              moduleSideEffects: pkg.hasSideEffects(res),
-            }
-          }
-          return res
+
+          return resPkg
+            ? {
+                id: res,
+                moduleSideEffects: resPkg.hasSideEffects(res),
+              }
+            : res
         }
       }
 
@@ -1191,10 +1192,16 @@ function tryResolveBrowserMapping(
       ) {
         isDebug &&
           debug(`[browser mapped] ${colors.cyan(id)} -> ${colors.dim(res)}`)
-        const result = {
-          id: res,
-          moduleSideEffects: pkg.hasSideEffects(res),
-        }
+        const resPkg = findNearestPackageData(
+          path.dirname(res),
+          options.packageCache,
+        )
+        const result = resPkg
+          ? {
+              id: res,
+              moduleSideEffects: resPkg.hasSideEffects(res),
+            }
+          : { id: res }
         return externalize ? { ...result, external: true } : result
       }
     } else if (browserMappedPath === false) {


### PR DESCRIPTION
### Description

@bluwy checked that this is how it works in [rollup](https://github.com/rollup/plugins/blob/bc5cf91a042b88e14a1da9ba25f501d92591ca8a/packages/node-resolve/src/index.js#L231-L245). And it is also how it already works inside `tryNodeResolve`. 

close #6740
close #7979

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other