### PR TITLE
fix(worker): worker import.meta.url should not depends on document in iife mode

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -58,6 +58,7 @@ import { ESBUILD_MODULES_TARGET, VERSION } from './constants'
 import { resolveChokidarOptions } from './watch'
 import { completeSystemWrapPlugin } from './plugins/completeSystemWrap'
 import { mergeConfig } from './publicUtils'
+import { webWorkerPostPlugin } from './plugins/worker'
 
 export interface BuildOptions {
   /**
@@ -445,6 +446,7 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
             : [rollupOptionsPlugins],
         )
       ).filter(Boolean) as Plugin[]),
+      ...(config.isWorker ? [webWorkerPostPlugin()] : []),
     ],
     post: [
       buildImportAnalysisPlugin(config),

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -67,7 +67,7 @@ export async function bundleWorkerEntry(
 const workerPostPlugin: Plugin = {
   name: 'vite:worker-post',
   resolveImportMeta(property, { chunkId, format }) {
-    // document is undefined in the worker, so we need to avoid iife generate it
+    // document is undefined in the worker, so we need to avoid it in iife
     if (property === 'url' && format === 'iife') {
       return `new URL('${chunkId}', self.location.href).href`
     }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -191,7 +191,7 @@ export function webWorkerPostPlugin(): Plugin {
     resolveImportMeta(property, { chunkId, format }) {
       // document is undefined in the worker, so we need to avoid it in iife
       if (property === 'url' && format === 'iife') {
-        return `new URL('${chunkId}', self.location.href).href`
+        return 'self.location.href'
       }
 
       return null

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -152,14 +152,19 @@ export function readManifest(base = ''): Manifest {
  */
 export async function untilUpdated(
   poll: () => string | Promise<string>,
-  expected: string,
+  expected: string | RegExp,
   runInBuild = false,
 ): Promise<void> {
   if (isBuild && !runInBuild) return
   const maxTries = process.env.CI ? 200 : 50
   for (let tries = 0; tries < maxTries; tries++) {
     const actual = (await poll()) ?? ''
-    if (actual.indexOf(expected) > -1 || tries === maxTries - 1) {
+    if (
+      (typeof expected === 'string'
+        ? actual.indexOf(expected) > -1
+        : actual.match(expected)) ||
+      tries === maxTries - 1
+    ) {
       expect(actual).toMatch(expected)
       break
     } else {

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -85,11 +85,11 @@ describe.runIf(isBuild)('build', () => {
 test('module worker', async () => {
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url'),
-    'A string',
+    /A\sstring.*\/iife\/.+\/url-worker\.js\?type=ignore&worker_file/,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-resolve'),
-    'A string',
+    /A\sstring.*\/iife\/.+\/url-worker\.js\?type=ignore&worker_file/,
   )
   await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -84,16 +84,19 @@ describe.runIf(isBuild)('build', () => {
 
 test('module worker', async () => {
   await untilUpdated(
-    () => page.textContent('.worker-import-meta-url'),
-    /A\sstring.*\/iife\/.+\/url-worker\.js\?type=ignore&worker_file/,
+    async () => page.textContent('.worker-import-meta-url'),
+    /A\sstring.*\/iife\/.+url-worker\.js/,
+    true,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-resolve'),
-    /A\sstring.*\/iife\/.+\/url-worker\.js\?type=ignore&worker_file/,
+    /A\sstring.*\/iife\/.+url-worker\.js/,
+    true,
   )
   await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
+    true,
   )
 })
 

--- a/playground/worker/url-worker.js
+++ b/playground/worker/url-worker.js
@@ -1,4 +1,11 @@
-self.postMessage('A string' + import.meta.env.BASE_URL + self.location.url)
+self.postMessage(
+  [
+    'A string',
+    import.meta.env.BASE_URL,
+    self.location.url,
+    import.meta.url,
+  ].join(' '),
+)
 
 // for sourcemap
 console.log('url-worker.js')


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/12611

`import.meta.url` will be transformed to something like `document.currentScript&&document.currentScript.src||new URL("a.js",document.baseURI).href` in iife mode. But `document` is undefined in the worker context. 

This PR directly transforms it to `new URL('a.js', self.location.href).href`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
