### PR TITLE
fix: output combined sourcemap in importAnalysisBuild plugin

### DIFF
--- a/playground/js-sourcemap/after-preload-dynamic.js
+++ b/playground/js-sourcemap/after-preload-dynamic.js
@@ -1,0 +1,3 @@
+import('./dynamic/dynamic-foo')
+
+console.log('after preload dynamic')

--- a/playground/js-sourcemap/dynamic/dynamic-foo.css
+++ b/playground/js-sourcemap/dynamic/dynamic-foo.css
@@ -1,0 +1,3 @@
+.dynamic-foo {
+  color: red;
+}

--- a/playground/js-sourcemap/dynamic/dynamic-foo.js
+++ b/playground/js-sourcemap/dynamic/dynamic-foo.js
@@ -1,0 +1,3 @@
+import './dynamic-foo.css'
+
+console.log('dynamic/dynamic-foo')

--- a/playground/js-sourcemap/index.html
+++ b/playground/js-sourcemap/index.html
@@ -1,6 +1,8 @@
 <div class="wrapper">
   <h1>JS Sourcemap</h1>
+  <div class="dynamic-foo">dynamic</div>
 </div>
 
 <script type="module" src="./foo.js"></script>
 <script type="module" src="./bar.ts"></script>
+<script type="module" src="./after-preload-dynamic.js"></script>

--- a/playground/js-sourcemap/vite.config.js
+++ b/playground/js-sourcemap/vite.config.js
@@ -3,5 +3,14 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(name) {
+          if (name.includes('after-preload-dynamic')) {
+            return 'after-preload-dynamic'
+          }
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Rollup v3 changed the way sourcemaps were handled (https://github.com/rollup/rollup/pull/4605) but Vite's importAnalysisBuild plugin wasn't updated.
In rollup v2, editing `chunk.map` affected the output, but in v3 it's not the case.

fixes #12047
fixes #12634

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
