### PR TITLE
feat(server): allow to import `data:` uris

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -235,7 +235,7 @@ async function nodeImport(
   resolveOptions: InternalResolveOptionsWithOverrideConditions,
 ) {
   let url: string
-  if (id.startsWith('node:') || isBuiltin(id)) {
+  if (id.startsWith('node:') || id.startsWith('data:') || isBuiltin(id)) {
     url = id
   } else {
     const resolved = tryNodeResolve(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fix allows to use data uri imports like this:

```ts
const modules = import('data:application/javascript;base64,ZXhwb3J0IGNvbnN0IHZpdGUgPSAnZ3JlYXQn')
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Coming from a `SvelteKit` aplication, currently the code tries to resolve it like a node module and I got following error:
```
errno: -36,
syscall: 'stat',
code: 'ENAMETOOLONG',
path: '/home/projects/my-app/src/node_modules/data:application/javascript;base64,...'
```

I'm able to import the module correctly with the fix in this PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
