### PR TITLE
fix(html): dont pretransform public scripts

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -35,6 +35,7 @@ import {
   unwrapId,
   wrapId,
 } from '../../utils'
+import { checkPublicFile } from '../../plugins/asset'
 
 interface AssetNode {
   start: number
@@ -103,7 +104,9 @@ const processNodeUrl = (
     // prefix with base (dev only, base is never relative)
     const fullUrl = path.posix.join(devBase, url)
     overwriteAttrValue(s, sourceCodeLocation, fullUrl)
-    if (server) preTransformRequest(server, fullUrl, devBase)
+    if (server && !checkPublicFile(url, config)) {
+      preTransformRequest(server, fullUrl, devBase)
+    }
   } else if (
     url[0] === '.' &&
     originalUrl &&
@@ -113,7 +116,9 @@ const processNodeUrl = (
     // prefix with base (dev only, base is never relative)
     const replacer = (url: string) => {
       const fullUrl = path.posix.join(devBase, url)
-      if (server) preTransformRequest(server, fullUrl, devBase)
+      if (server && !checkPublicFile(url, config)) {
+        preTransformRequest(server, fullUrl, devBase)
+      }
       return fullUrl
     }
 

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -115,7 +115,7 @@ const processNodeUrl = (
     // prefix with base (dev only, base is never relative)
     const replacer = (url: string) => {
       const fullUrl = path.posix.join(devBase, url)
-      if (server) {
+      if (server && !checkPublicFile(url, config)) {
         preTransformRequest(server, fullUrl, devBase)
       }
       return fullUrl

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -81,7 +81,6 @@ function getHtmlFilename(url: string, server: ViteDevServer) {
   }
 }
 
-const startsWithSingleSlashRE = /^\/(?!\/)/
 const processNodeUrl = (
   attr: Token.Attribute,
   sourceCodeLocation: Token.Location,
@@ -100,7 +99,7 @@ const processNodeUrl = (
     }
   }
   const devBase = config.base
-  if (startsWithSingleSlashRE.test(url)) {
+  if (url[0] === '/' && url[1] !== '/') {
     // prefix with base (dev only, base is never relative)
     const fullUrl = path.posix.join(devBase, url)
     overwriteAttrValue(s, sourceCodeLocation, fullUrl)
@@ -116,7 +115,7 @@ const processNodeUrl = (
     // prefix with base (dev only, base is never relative)
     const replacer = (url: string) => {
       const fullUrl = path.posix.join(devBase, url)
-      if (server && !checkPublicFile(url, config)) {
+      if (server) {
         preTransformRequest(server, fullUrl, devBase)
       }
       return fullUrl


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #12643

Skip pre-transforming public scripts by checking with `checkPublicFile` for transformed URLs first.

While this leads to a potential fs check, I think it's still faster than a roundtrip browser request.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
