### PR TITLE
fix(ssr): show ssr module loader error stack

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -147,7 +147,10 @@ async function instantiateModule(
         context,
         urlStack,
         fixStacktrace,
-      )
+      ).catch((err) => {
+        err.importee = dep
+        throw err
+      })
       if (pendingDeps.length === 1) {
         pendingImports.delete(url)
       } else {
@@ -222,7 +225,6 @@ async function instantiateModule(
       },
     )
 
-    delete e.importee
     throw e
   }
 

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -160,14 +160,8 @@ async function instantiateModule(
       }
       return moduleGraph.urlToModuleMap.get(dep)?.ssrModule
     } catch (err) {
-      let errorData = importErrors.get(err)
       // tell external error handler which mod was imported with error
-      if (errorData) {
-        errorData.importee = dep
-      } else {
-        errorData = { importee: dep }
-      }
-      importErrors.set(err, errorData)
+      importErrors.set(err, { importee: dep })
 
       throw err
     }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -160,7 +160,9 @@ async function instantiateModule(
       return moduleGraph.urlToModuleMap.get(dep)?.ssrModule
     } catch (err) {
       // tell external error handler which mod was imported with error
+      // add a counter to infer importer count, once counter = 0, remove the importee prop
       err.importee = dep
+      err.importerCount = (err.importerCount || 0) + 1
       throw err
     }
   }
@@ -227,6 +229,13 @@ async function instantiateModule(
         error: e,
       },
     )
+
+    e.importerCount--
+
+    if (!e.importerCount) {
+      delete e.importee
+      delete e.importerCount
+    }
 
     throw e
   }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -212,7 +212,8 @@ async function instantiateModule(
     server.config.logger.error(
       colors.red(
         `Error when evaluating SSR module ${url}:` +
-          (e.importee ? ` failed to import "${e.importee}"\n` : '\n'),
+          (e.importee ? ` failed to import "${e.importee}"` : '') +
+          `\n|- ${e.stack}\n`,
       ),
       {
         timestamp: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #12631

This pr contains 3 parts:

1. add the original error stack to the output
2. propagate the `importee` info from `ssrLoadModule`
3. avoid removing the  error's `importee` info 

<img width="1153" alt="image" src="https://user-images.githubusercontent.com/102238922/228615567-21edea67-ee56-4b82-b984-b03fa09c824d.png">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Maybe we can combine the errors via the `urlStack` and emit it only once. It will provide a better DX.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
