### PR TITLE
perf: avoid new URL() in hot path

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -239,7 +239,7 @@ export class ModuleGraph {
   }
 
   // for incoming urls, it is important to:
-  // 1. remove the HMR timestamp query (?t=xxxx)
+  // 1. remove the HMR timestamp query (?t=xxxx) and the ?import query
   // 2. resolve its extension so that urls with or without extension all map to
   // the same module
   async resolveUrl(url: string, ssr?: boolean): Promise<ResolvedUrl> {

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -252,9 +252,11 @@ export class ModuleGraph {
       !url.startsWith(`virtual:`)
     ) {
       const ext = extname(cleanUrl(resolvedId))
-      const { pathname, search, hash } = new URL(url, 'relative://')
-      if (ext && !pathname!.endsWith(ext)) {
-        url = pathname + ext + search + hash
+      if (ext) {
+        const pathname = cleanUrl(url)
+        if (!pathname.endsWith(ext)) {
+          url = pathname + ext + url.slice(pathname.length)
+        }
       }
     }
     return [url, resolvedId, resolved?.meta]


### PR DESCRIPTION
### Description

@ArnaudBarre mentioned that `new URL` is [a bottleneck in his tests](https://github.com/vitejs/vite/pull/12638#discussion_r1151865898). We don't really need to use `new URL` here because to resolve the Id we are already using `cleanUrl` which is a simple regex. 

This path was first using `parseUrl`, then changed by @sapphi-red to use `new URL` here
- https://github.com/vitejs/vite/pull/9188

@sapphi-red maybe this should also have an effect on your perf benchmark, although it should have less impact once we merge 
- https://github.com/vitejs/vite/pull/12635

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other