### PR TITLE
fix(worker): disable manifest plugins in worker build

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -450,9 +450,13 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
       buildImportAnalysisPlugin(config),
       ...(config.esbuild !== false ? [buildEsbuildPlugin(config)] : []),
       ...(options.minify ? [terserPlugin(config)] : []),
-      ...(options.manifest ? [manifestPlugin(config)] : []),
-      ...(options.ssrManifest ? [ssrManifestPlugin(config)] : []),
-      ...(!config.isWorker ? [buildReporterPlugin(config)] : []),
+      ...(!config.isWorker
+        ? [
+            ...(options.manifest ? [manifestPlugin(config)] : []),
+            ...(options.ssrManifest ? [ssrManifestPlugin(config)] : []),
+            buildReporterPlugin(config),
+          ]
+        : []),
       loadFallbackPlugin(),
     ],
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When building worker files with Vite plugins, disable the manifest plugins as workers don't need a manifest file. Otherwise the manifest gets emitted into the main Vite build bundle here: 

https://github.com/vitejs/vite/blob/273c032f8d977f6f401451f9674bbac469620748/packages/vite/src/node/plugins/worker.ts#L389-L399

So when the actual manifest plugin on the main build runs, you would get this warning from Rollup:

```
The emitted file "manifest.json" overwrites a previously emitted file of the same name.
```


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
In most case, this is harmless, but there seems to be an fs race condition where the worker manifest gets written down in a SvelteKit build 🤔 

It isn't easy to write a test for this too, the logs come from Rollup, and we don't have a setup to track Rollup logs.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
