### PR TITLE
docs: rephrase configuration of Client Types

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -96,7 +96,7 @@ Vite's default types are for its Node.js API. To shim the environment of client 
 /// <reference types="vite/client" />
 ```
 
-Also, you can add `vite/client` to `compilerOptions.types` of your `tsconfig`:
+Alternatively, you can add `vite/client` to `compilerOptions.types` inside `tsconfig.json`:
 
 ```json
 {


### PR DESCRIPTION


### Description

The docs seem to imply that both adding a `d.ts` file _and_ changing `tsconfig.json` are necessary.

This change makes it clear that they are alternative methods of including client types.

### Additional context

Our project included the client types both ways; the developer porting our project from CRA to Vite thought _both_ were needed due to the word "Also".

This caused a problem when using an external plugin that only had documentation about overriding the types in `tsconfig.json`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
