### PR TITLE
test: throw element not found error

### DIFF
--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -71,7 +71,12 @@ const timeout = (n: number) => new Promise((r) => setTimeout(r, n))
 
 async function toEl(el: string | ElementHandle): Promise<ElementHandle> {
   if (typeof el === 'string') {
-    return await page.$(el)
+    const realEl = await page.$(el)
+    if (realEl == null) {
+      throw new Error(`can not find element: "${el}"`)
+    }
+
+    return realEl
   }
   return el
 }

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -73,9 +73,8 @@ async function toEl(el: string | ElementHandle): Promise<ElementHandle> {
   if (typeof el === 'string') {
     const realEl = await page.$(el)
     if (realEl == null) {
-      throw new Error(`can not find element: "${el}"`)
+      throw new Error(`Cannot find element: "${el}"`)
     }
-
     return realEl
   }
   return el


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Sometimes `toEl` fails to find the element in CI, which will cause `el.evaluate` throw the error `Cannot read properties of null (reading 'evaluate')` and the error stack position is incorrect, it's hard to debug which test case fails.

e.g 

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/102238922/228892864-39d4c297-2ee1-482c-ab2e-cefcb143af31.png">

There is no `getBg` call in this test case actually 😢 


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
