### PR TITLE
feat: reuse existing style elements in dev

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -333,6 +333,13 @@ async function waitForSuccessfulPing(
 }
 
 const sheetsMap = new Map<string, HTMLStyleElement>()
+
+// collect existing style elements that may have been inserted during SSR
+// to avoid FOUC or duplicate styles
+document.querySelectorAll('style[data-vite-dev-id]').forEach((el) => {
+  sheetsMap.set(el.getAttribute('data-vite-dev-id')!, el as HTMLStyleElement)
+})
+
 // all css imports should be inserted at the same position
 // because after build it will be a single css file
 let lastInsertedStyle: HTMLStyleElement | undefined


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

During dev, Vite injects imported CSS files' contents into the document inside style tags. When doing SSR, this causes FOUC until the JavaScript is loaded.

In Rakkas, I solve this by scanning the module graph for the route that is being rendered to discover which CSS files will be needed and I inject link elements to them into the HTML. Since Vite doesn't know about this, it goes on and adds its style tags anyway, causing duplicate styles. It becomes a problem when CSS files are HMRed: The original link doesn't get updated so some styles start clashing. So  Rakkas has to remove the links from the document once the styles are loaded. Most other Vite-based frameworks must be doing something similar. 

Although it works, it would be much cleaner if we inserted style tags just like Vite does and Vite picked them up at startup. This PR implements this.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
