### PR TITLE
refactor: make debugger nullable

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -775,16 +775,14 @@ export async function resolveConfig(
     )
   }
 
-  if (debug.enabled) {
-    debug(`using resolved config: %O`, {
-      ...resolved,
-      plugins: resolved.plugins.map((p) => p.name),
-      worker: {
-        ...resolved.worker,
-        plugins: resolved.worker.plugins.map((p) => p.name),
-      },
-    })
-  }
+  debug?.(`using resolved config: %O`, {
+    ...resolved,
+    plugins: resolved.plugins.map((p) => p.name),
+    worker: {
+      ...resolved.worker,
+      plugins: resolved.worker.plugins.map((p) => p.name),
+    },
+  })
 
   if (config.build?.terserOptions && config.build.minify !== 'terser') {
     logger.warn(
@@ -915,7 +913,7 @@ export async function loadConfigFromFile(
   }
 
   if (!resolvedPath) {
-    debug('no config file found.')
+    debug?.('no config file found.')
     return null
   }
 
@@ -940,7 +938,7 @@ export async function loadConfigFromFile(
       bundled.code,
       isESM,
     )
-    debug(`bundled config file loaded in ${getTime()}`)
+    debug?.(`bundled config file loaded in ${getTime()}`)
 
     const config = await (typeof userConfig === 'function'
       ? userConfig(configEnv)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -775,7 +775,7 @@ export async function resolveConfig(
     )
   }
 
-  if (process.env.DEBUG) {
+  if (debug.enabled) {
     debug(`using resolved config: %O`, {
       ...resolved,
       plugins: resolved.plugins.map((p) => p.name),

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -3,7 +3,6 @@ import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { promisify } from 'node:util'
 import { performance } from 'node:perf_hooks'
-import _debug from 'debug'
 import colors from 'picocolors'
 import type { BuildContext, BuildOptions as EsbuildBuildOptions } from 'esbuild'
 import esbuild, { build } from 'esbuild'
@@ -37,9 +36,7 @@ export {
   getDepsOptimizer,
 } from './optimizer'
 
-export const debuggerViteDeps = createDebugger('vite:deps')
-const debug = debuggerViteDeps
-const isDebugEnabled = _debug('vite:deps').enabled
+const debug = createDebugger('vite:deps')
 
 const jsExtensionRE = /\.js$/i
 const jsMapExtensionRE = /\.js\.map$/i
@@ -448,7 +445,7 @@ export function toDiscoveredDependencies(
 }
 
 export function depsLogString(qualifiedIds: string[]): string {
-  if (isDebugEnabled) {
+  if (debug.enabled) {
     return colors.yellow(qualifiedIds.join(`, `))
   } else {
     const total = qualifiedIds.length

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -248,7 +248,7 @@ export async function optimizeDeps(
   const deps = await discoverProjectDependencies(config).result
 
   const depsString = depsLogString(Object.keys(deps))
-  log(colors.green(`Optimizing dependencies:\n  ${depsString}`))
+  log?.(colors.green(`Optimizing dependencies:\n  ${depsString}`))
 
   await addManuallyIncludedOptimizeDeps(deps, config, ssr)
 
@@ -374,7 +374,7 @@ export async function loadCachedDepOptimizationMetadata(
     } catch (e) {}
     // hash is consistent, no need to re-bundle
     if (cachedMetadata && cachedMetadata.hash === getDepHash(config, ssr)) {
-      log('Hash is consistent. Skipping. Use --force to override.')
+      log?.('Hash is consistent. Skipping. Use --force to override.')
       // Nothing to commit or cancel as we are using the cache, we only
       // need to resolve the processing promise so requests can move on
       return cachedMetadata
@@ -445,7 +445,7 @@ export function toDiscoveredDependencies(
 }
 
 export function depsLogString(qualifiedIds: string[]): string {
-  if (debug.enabled) {
+  if (debug) {
     return colors.yellow(qualifiedIds.join(`, `))
   } else {
     const total = qualifiedIds.length
@@ -655,7 +655,7 @@ export function runOptimizeDeps(
           }
         }
 
-        debug(
+        debug?.(
           `Dependencies bundled in ${(performance.now() - start).toFixed(2)}ms`,
         )
 
@@ -1162,7 +1162,7 @@ export async function extractExportsData(
     parseResult = parse(entryContent)
   } catch {
     const loader = esbuildOptions.loader?.[path.extname(filePath)] || 'jsx'
-    debug(
+    debug?.(
       `Unable to parse: ${filePath}.\n Trying again with a ${loader} transform.`,
     )
     const transformed = await transformWithEsbuild(entryContent, filePath, {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -1,6 +1,5 @@
 import colors from 'picocolors'
-import _debug from 'debug'
-import { getHash } from '../utils'
+import { createDebugger, getHash } from '../utils'
 import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig, ViteDevServer } from '..'
 import {
@@ -8,7 +7,6 @@ import {
   addOptimizedDepInfo,
   createIsOptimizedDepFile,
   createIsOptimizedDepUrl,
-  debuggerViteDeps as debug,
   depsFromOptimizedDepInfo,
   depsLogString,
   discoverProjectDependencies,
@@ -28,7 +26,7 @@ import type {
   OptimizedDepInfo,
 } from '.'
 
-const isDebugEnabled = _debug('vite:deps').enabled
+const debug = createDebugger('vite:deps')
 
 /**
  * The amount to wait for requests to register newly found dependencies before triggering
@@ -398,7 +396,7 @@ async function createDepsOptimizer(
       if (!needsReload) {
         await commitProcessing()
 
-        if (!isDebugEnabled) {
+        if (!debug.enabled) {
           if (newDepsToLogHandle) clearTimeout(newDepsToLogHandle)
           newDepsToLogHandle = setTimeout(() => {
             newDepsToLogHandle = undefined
@@ -431,7 +429,7 @@ async function createDepsOptimizer(
         } else {
           await commitProcessing()
 
-          if (!isDebugEnabled) {
+          if (!debug.enabled) {
             if (newDepsToLogHandle) clearTimeout(newDepsToLogHandle)
             newDepsToLogHandle = undefined
             logNewlyDiscoveredDeps()

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -214,7 +214,7 @@ async function createDepsOptimizer(
         // Ensure server listen is called before the scanner
         setTimeout(async () => {
           try {
-            debug(colors.green(`scanning for dependencies...`))
+            debug?.(colors.green(`scanning for dependencies...`))
 
             discover = discoverProjectDependencies(config)
             const deps = await discover.result
@@ -396,7 +396,7 @@ async function createDepsOptimizer(
       if (!needsReload) {
         await commitProcessing()
 
-        if (!debug.enabled) {
+        if (!debug) {
           if (newDepsToLogHandle) clearTimeout(newDepsToLogHandle)
           newDepsToLogHandle = setTimeout(() => {
             newDepsToLogHandle = undefined
@@ -421,7 +421,7 @@ async function createDepsOptimizer(
           // once a rerun is committed
           processingResult.cancel()
 
-          debug(
+          debug?.(
             colors.green(
               `✨ delaying reload as new dependencies have been found...`,
             ),
@@ -429,7 +429,7 @@ async function createDepsOptimizer(
         } else {
           await commitProcessing()
 
-          if (!debug.enabled) {
+          if (!debug) {
             if (newDepsToLogHandle) clearTimeout(newDepsToLogHandle)
             newDepsToLogHandle = undefined
             logNewlyDiscoveredDeps()
@@ -493,7 +493,7 @@ async function createDepsOptimizer(
     // optimizeDeps processing is finished
     const deps = Object.keys(metadata.discovered)
     const depsString = depsLogString(deps)
-    debug(colors.green(`new dependencies found: ${depsString}`))
+    debug?.(colors.green(`new dependencies found: ${depsString}`))
     runOptimizer()
   }
 
@@ -587,7 +587,7 @@ async function createDepsOptimizer(
   }
 
   async function onCrawlEnd() {
-    debug(colors.green(`✨ static imports crawl ended`))
+    debug?.(colors.green(`✨ static imports crawl ended`))
     if (firstRunCalled) {
       return
     }
@@ -607,7 +607,7 @@ async function createDepsOptimizer(
       const scanDeps = Object.keys(result.metadata.optimized)
 
       if (scanDeps.length === 0 && crawlDeps.length === 0) {
-        debug(
+        debug?.(
           colors.green(
             `✨ no dependencies found by the scanner or crawling static imports`,
           ),
@@ -636,16 +636,16 @@ async function createDepsOptimizer(
           }
         }
         if (scannerMissedDeps) {
-          debug(
+          debug?.(
             colors.yellow(
               `✨ new dependencies were found while crawling that weren't detected by the scanner`,
             ),
           )
         }
-        debug(colors.green(`✨ re-running optimizer`))
+        debug?.(colors.green(`✨ re-running optimizer`))
         debouncedProcessing(0)
       } else {
-        debug(
+        debug?.(
           colors.green(
             `✨ using post-scan optimizer result, the scanner found every used dependency`,
           ),
@@ -655,7 +655,7 @@ async function createDepsOptimizer(
       }
     } else {
       if (crawlDeps.length === 0) {
-        debug(
+        debug?.(
           colors.green(
             `✨ no dependencies found while crawling the static imports`,
           ),
@@ -809,7 +809,7 @@ function findInteropMismatches(
         // This only happens when a discovered dependency has mixed ESM and CJS syntax
         // and it hasn't been manually added to optimizeDeps.needsInterop
         needsInteropMismatch.push(dep)
-        debug(colors.cyan(`✨ needsInterop mismatch detected for ${dep}`))
+        debug?.(colors.cyan(`✨ needsInterop mismatch detected for ${dep}`))
       }
     }
   }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -34,7 +34,6 @@ import { transformGlobImport } from '../plugins/importMetaGlob'
 
 type ResolveIdOptions = Parameters<PluginContainer['resolveId']>[2]
 
-const isDebug = process.env.DEBUG
 const debug = createDebugger('vite:deps')
 
 const htmlTypesRE = /\.(html|vue|svelte|astro|imba)$/
@@ -141,7 +140,7 @@ export function scanImports(config: ResolvedConfig): {
       throw e
     })
     .finally(() => {
-      if (isDebug) {
+      if (debug.enabled) {
         const duration = (performance.now() - start).toFixed(2)
         const depsStr =
           Object.keys(orderedDependencies(deps))

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -84,7 +84,7 @@ export function scanImports(config: ResolvedConfig): {
     }
     if (scanContext.cancelled) return
 
-    debug(
+    debug?.(
       `Crawling dependencies using entries: ${entries
         .map((entry) => `\n  ${colors.dim(entry)}`)
         .join('')}`,
@@ -140,7 +140,7 @@ export function scanImports(config: ResolvedConfig): {
       throw e
     })
     .finally(() => {
-      if (debug.enabled) {
+      if (debug) {
         const duration = (performance.now() - start).toFixed(2)
         const depsStr =
           Object.keys(orderedDependencies(deps))

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -24,7 +24,6 @@ import type { ResolvedConfig, ViteDevServer } from '..'
 import type { Plugin } from '../plugin'
 import { searchForWorkspaceRoot } from '..'
 
-const isDebug = process.env.DEBUG
 const debug = createDebugger('vite:esbuild')
 
 const INJECT_HELPERS_IIFE_RE =
@@ -455,7 +454,7 @@ function initTSConfck(root: string, force = false) {
 }
 
 async function initTSConfckParseOptions(workspaceRoot: string) {
-  const start = isDebug ? performance.now() : 0
+  const start = debug.enabled ? performance.now() : 0
 
   const options: TSConfckParseOptions = {
     cache: new Map(),
@@ -468,7 +467,8 @@ async function initTSConfckParseOptions(workspaceRoot: string) {
     resolveWithEmptyIfConfigNotFound: true,
   }
 
-  isDebug && debug(timeFrom(start), 'tsconfck init', colors.dim(workspaceRoot))
+  debug.enabled &&
+    debug(timeFrom(start), 'tsconfck init', colors.dim(workspaceRoot))
 
   return options
 }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -192,7 +192,7 @@ export async function transformWithEsbuild(
       map,
     }
   } catch (e: any) {
-    debug(`esbuild error with options used: `, resolvedOptions)
+    debug?.(`esbuild error with options used: `, resolvedOptions)
     // patch error information
     if (e.errors) {
       e.frame = ''
@@ -454,7 +454,7 @@ function initTSConfck(root: string, force = false) {
 }
 
 async function initTSConfckParseOptions(workspaceRoot: string) {
-  const start = debug.enabled ? performance.now() : 0
+  const start = debug ? performance.now() : 0
 
   const options: TSConfckParseOptions = {
     cache: new Map(),
@@ -467,8 +467,7 @@ async function initTSConfckParseOptions(workspaceRoot: string) {
     resolveWithEmptyIfConfigNotFound: true,
   }
 
-  debug.enabled &&
-    debug(timeFrom(start), 'tsconfck init', colors.dim(workspaceRoot))
+  debug?.(timeFrom(start), 'tsconfck init', colors.dim(workspaceRoot))
 
   return options
 }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -62,7 +62,6 @@ import {
 import { isCSSRequest, isDirectCSSRequest, isModuleCSSRequest } from './css'
 import { browserExternalId } from './resolve'
 
-const isDebug = !!process.env.DEBUG
 const debug = createDebugger('vite:import-analysis')
 
 const clientDir = normalizePath(CLIENT_DIR)
@@ -207,7 +206,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const prettyImporter = prettifyUrl(importer, root)
 
       if (canSkipImportAnalysis(importer)) {
-        isDebug && debug(colors.dim(`[skipped] ${prettyImporter}`))
+        debug.enabled && debug(colors.dim(`[skipped] ${prettyImporter}`))
         return null
       }
 
@@ -259,7 +258,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
       if (!imports.length && !(this as any)._addedImports) {
         importerModule.isSelfAccepting = false
-        isDebug &&
+        debug.enabled &&
           debug(
             `${timeFrom(start)} ${colors.dim(
               `[no imports] ${prettyImporter}`,
@@ -752,7 +751,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
       }
 
-      isDebug &&
+      debug.enabled &&
         debug(
           `${timeFrom(start)} ${colors.dim(
             `[${importedUrls.size} imports rewritten] ${prettyImporter}`,

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -206,7 +206,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const prettyImporter = prettifyUrl(importer, root)
 
       if (canSkipImportAnalysis(importer)) {
-        debug.enabled && debug(colors.dim(`[skipped] ${prettyImporter}`))
+        debug?.(colors.dim(`[skipped] ${prettyImporter}`))
         return null
       }
 
@@ -258,12 +258,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
       if (!imports.length && !(this as any)._addedImports) {
         importerModule.isSelfAccepting = false
-        debug.enabled &&
-          debug(
-            `${timeFrom(start)} ${colors.dim(
-              `[no imports] ${prettyImporter}`,
-            )}`,
-          )
+        debug?.(
+          `${timeFrom(start)} ${colors.dim(`[no imports] ${prettyImporter}`)}`,
+        )
         return source
       }
 
@@ -572,7 +569,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                   )
                 }
               } else if (needsInterop) {
-                debug(`${url} needs interop`)
+                debug?.(`${url} needs interop`)
                 interopNamedImports(str(), imports[index], url, index)
                 rewriteDone = true
               }
@@ -667,7 +664,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       if (hasHMR && !ssr) {
-        debugHmr(
+        debugHmr?.(
           `${
             isSelfAccepting
               ? `[self-accepts]`
@@ -751,12 +748,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
       }
 
-      debug.enabled &&
-        debug(
-          `${timeFrom(start)} ${colors.dim(
-            `[${importedUrls.size} imports rewritten] ${prettyImporter}`,
-          )}`,
-        )
+      debug?.(
+        `${timeFrom(start)} ${colors.dim(
+          `[${importedUrls.size} imports rewritten] ${prettyImporter}`,
+        )}`,
+      )
 
       // pre-transform known direct imports
       // These requests will also be registered in transformRequest to be awaited

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -10,7 +10,6 @@ export const ERR_OPTIMIZE_DEPS_PROCESSING_ERROR =
   'ERR_OPTIMIZE_DEPS_PROCESSING_ERROR'
 export const ERR_OUTDATED_OPTIMIZED_DEP = 'ERR_OUTDATED_OPTIMIZED_DEP'
 
-const isDebug = process.env.DEBUG
 const debug = createDebugger('vite:optimize-deps')
 
 export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
@@ -62,7 +61,7 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
             }
           }
         }
-        isDebug && debug(`load ${colors.cyan(file)}`)
+        debug.enabled && debug(`load ${colors.cyan(file)}`)
         // Load the file from the cache instead of waiting for other plugin
         // load hooks to avoid race conditions, once processing is resolved,
         // we are sure that the file has been properly save to disk
@@ -117,7 +116,7 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
       const info = optimizedDepInfoFromFile(depsOptimizer.metadata, file)
       if (info) {
         await info.processing
-        isDebug && debug(`load ${colors.cyan(file)}`)
+        debug.enabled && debug(`load ${colors.cyan(file)}`)
       } else {
         throw new Error(
           `Something unexpected happened while optimizing "${id}".`,

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -61,7 +61,7 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
             }
           }
         }
-        debug.enabled && debug(`load ${colors.cyan(file)}`)
+        debug?.(`load ${colors.cyan(file)}`)
         // Load the file from the cache instead of waiting for other plugin
         // load hooks to avoid race conditions, once processing is resolved,
         // we are sure that the file has been properly save to disk
@@ -116,7 +116,7 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
       const info = optimizedDepInfoFromFile(depsOptimizer.metadata, file)
       if (info) {
         await info.processing
-        debug.enabled && debug(`load ${colors.cyan(file)}`)
+        debug?.(`load ${colors.cyan(file)}`)
       } else {
         throw new Error(
           `Something unexpected happened while optimizing "${id}".`,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -210,7 +210,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       if (asSrc && id.startsWith(FS_PREFIX)) {
         const fsPath = fsPathFromId(id)
         res = tryFsResolve(fsPath, options)
-        debug.enabled && debug(`[@fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug?.(`[@fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         // always return here even if res doesn't exist since /@fs/ is explicit
         // if the file doesn't exist it should be a 404
         return ensureVersionQuery(res || fsPath, id, options, depsOptimizer)
@@ -221,8 +221,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       if (asSrc && id[0] === '/' && (rootInRoot || !id.startsWith(root))) {
         const fsPath = path.resolve(root, id.slice(1))
         if ((res = tryFsResolve(fsPath, options))) {
-          debug.enabled &&
-            debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+          debug?.(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           return ensureVersionQuery(res, id, options, depsOptimizer)
         }
       }
@@ -268,8 +267,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
             options.packageCache,
           )
           res = ensureVersionQuery(res, id, options, depsOptimizer)
-          debug.enabled &&
-            debug(`[relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+          debug?.(`[relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
 
           return resPkg
             ? {
@@ -285,8 +283,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         const basedir = importer ? path.dirname(importer) : process.cwd()
         const fsPath = path.resolve(basedir, id)
         if ((res = tryFsResolve(fsPath, options))) {
-          debug.enabled &&
-            debug(`[drive-relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+          debug?.(`[drive-relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           return ensureVersionQuery(res, id, options, depsOptimizer)
         }
       }
@@ -296,7 +293,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         isNonDriveRelativeAbsolutePath(id) &&
         (res = tryFsResolve(id, options))
       ) {
-        debug.enabled && debug(`[fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug?.(`[fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         return ensureVersionQuery(res, id, options, depsOptimizer)
       }
 
@@ -377,7 +374,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
             }
           } else {
             if (!asSrc) {
-              debug(
+              debug?.(
                 `externalized node built-in "${id}" to empty module. ` +
                   `(imported by: ${colors.white(colors.dim(importer))})`,
               )
@@ -389,7 +386,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         }
       }
 
-      debug.enabled && debug(`[fallthrough] ${colors.dim(id)}`)
+      debug?.(`[fallthrough] ${colors.dim(id)}`)
     },
 
     load(id) {
@@ -757,8 +754,7 @@ export function tryNodeResolve(
     let resolvedId = id
     if (deepMatch && !pkg?.data.exports && path.extname(id) !== resolvedExt) {
       resolvedId = resolved.id.slice(resolved.id.indexOf(id))
-      debug.enabled &&
-        debug(`[processResult] ${colors.cyan(id)} -> ${colors.dim(resolvedId)}`)
+      debug?.(`[processResult] ${colors.cyan(id)} -> ${colors.dim(resolvedId)}`)
     }
     return { ...resolved, id: resolvedId, external: true }
   }
@@ -1027,12 +1023,11 @@ export function resolvePackageEntry(
         skipPackageJson,
       )
       if (resolvedEntryPoint) {
-        debug.enabled &&
-          debug(
-            `[package entry] ${colors.cyan(id)} -> ${colors.dim(
-              resolvedEntryPoint,
-            )}`,
-          )
+        debug?.(
+          `[package entry] ${colors.cyan(id)} -> ${colors.dim(
+            resolvedEntryPoint,
+          )}`,
+        )
         setResolvedCache('.', resolvedEntryPoint, targetWeb)
         return resolvedEntryPoint
       }
@@ -1169,10 +1164,9 @@ function resolveDeepImport(
       targetWeb,
     )
     if (resolved) {
-      debug.enabled &&
-        debug(
-          `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`,
-        )
+      debug?.(
+        `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`,
+      )
       setResolvedCache(id, resolved, targetWeb)
       return resolved
     }
@@ -1199,8 +1193,7 @@ function tryResolveBrowserMapping(
           ? tryNodeResolve(browserMappedPath, importer, options, true)?.id
           : tryFsResolve(path.join(pkg.dir, browserMappedPath), options))
       ) {
-        debug.enabled &&
-          debug(`[browser mapped] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug?.(`[browser mapped] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         const resPkg = findNearestPackageData(
           path.dirname(res),
           options.packageCache,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -62,7 +62,6 @@ const subpathImportsPrefix = '#'
 
 const startsWithWordCharRE = /^\w/
 
-const isDebug = process.env.DEBUG
 const debug = createDebugger('vite:resolve-details', {
   onlyWhenFocused: true,
 })
@@ -211,7 +210,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       if (asSrc && id.startsWith(FS_PREFIX)) {
         const fsPath = fsPathFromId(id)
         res = tryFsResolve(fsPath, options)
-        isDebug && debug(`[@fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug.enabled && debug(`[@fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         // always return here even if res doesn't exist since /@fs/ is explicit
         // if the file doesn't exist it should be a 404
         return ensureVersionQuery(res || fsPath, id, options, depsOptimizer)
@@ -222,7 +221,8 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       if (asSrc && id[0] === '/' && (rootInRoot || !id.startsWith(root))) {
         const fsPath = path.resolve(root, id.slice(1))
         if ((res = tryFsResolve(fsPath, options))) {
-          isDebug && debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+          debug.enabled &&
+            debug(`[url] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           return ensureVersionQuery(res, id, options, depsOptimizer)
         }
       }
@@ -268,7 +268,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
             options.packageCache,
           )
           res = ensureVersionQuery(res, id, options, depsOptimizer)
-          isDebug &&
+          debug.enabled &&
             debug(`[relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
 
           return resPkg
@@ -285,7 +285,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         const basedir = importer ? path.dirname(importer) : process.cwd()
         const fsPath = path.resolve(basedir, id)
         if ((res = tryFsResolve(fsPath, options))) {
-          isDebug &&
+          debug.enabled &&
             debug(`[drive-relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
           return ensureVersionQuery(res, id, options, depsOptimizer)
         }
@@ -296,7 +296,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         isNonDriveRelativeAbsolutePath(id) &&
         (res = tryFsResolve(id, options))
       ) {
-        isDebug && debug(`[fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
+        debug.enabled && debug(`[fs] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         return ensureVersionQuery(res, id, options, depsOptimizer)
       }
 
@@ -389,7 +389,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         }
       }
 
-      isDebug && debug(`[fallthrough] ${colors.dim(id)}`)
+      debug.enabled && debug(`[fallthrough] ${colors.dim(id)}`)
     },
 
     load(id) {
@@ -757,7 +757,7 @@ export function tryNodeResolve(
     let resolvedId = id
     if (deepMatch && !pkg?.data.exports && path.extname(id) !== resolvedExt) {
       resolvedId = resolved.id.slice(resolved.id.indexOf(id))
-      isDebug &&
+      debug.enabled &&
         debug(`[processResult] ${colors.cyan(id)} -> ${colors.dim(resolvedId)}`)
     }
     return { ...resolved, id: resolvedId, external: true }
@@ -1027,7 +1027,7 @@ export function resolvePackageEntry(
         skipPackageJson,
       )
       if (resolvedEntryPoint) {
-        isDebug &&
+        debug.enabled &&
           debug(
             `[package entry] ${colors.cyan(id)} -> ${colors.dim(
               resolvedEntryPoint,
@@ -1169,7 +1169,7 @@ function resolveDeepImport(
       targetWeb,
     )
     if (resolved) {
-      isDebug &&
+      debug.enabled &&
         debug(
           `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`,
         )
@@ -1199,7 +1199,7 @@ function tryResolveBrowserMapping(
           ? tryNodeResolve(browserMappedPath, importer, options, true)?.id
           : tryFsResolve(path.join(pkg.dir, browserMappedPath), options))
       ) {
-        isDebug &&
+        debug.enabled &&
           debug(`[browser mapped] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         const resPkg = findNearestPackageData(
           path.dirname(res),

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -59,7 +59,7 @@ export async function handleHMRUpdate(
     (fileName === '.env' || fileName.startsWith('.env.'))
   if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
-    debugHmr(`[config change] ${colors.dim(shortFile)}`)
+    debugHmr?.(`[config change] ${colors.dim(shortFile)}`)
     config.logger.info(
       colors.green(
         `${path.relative(process.cwd(), file)} changed, restarting server...`,
@@ -78,7 +78,7 @@ export async function handleHMRUpdate(
     return
   }
 
-  debugHmr(`[file change] ${colors.dim(shortFile)}`)
+  debugHmr?.(`[file change] ${colors.dim(shortFile)}`)
 
   // (dev only) the client itself cannot be hot updated.
   if (file.startsWith(normalizedClientDir)) {
@@ -123,7 +123,7 @@ export async function handleHMRUpdate(
       })
     } else {
       // loaded but not in the module graph, probably not js
-      debugHmr(`[no modules matched] ${colors.dim(shortFile)}`)
+      debugHmr?.(`[no modules matched] ${colors.dim(shortFile)}`)
     }
     return
   }
@@ -184,7 +184,7 @@ export function updateModules(
   }
 
   if (updates.length === 0) {
-    debugHmr(colors.yellow(`no update happened `) + colors.dim(file))
+    debugHmr?.(colors.yellow(`no update happened `) + colors.dim(file))
     return
   }
 
@@ -241,7 +241,7 @@ function propagateUpdate(
   // if the imports of `node` have not been analyzed, then `node` has not
   // been loaded in the browser and we should stop propagation.
   if (node.id && node.isSelfAccepting === undefined) {
-    debugHmr(
+    debugHmr?.(
       `[propagate update] stop propagation because not analyzed: ${colors.dim(
         node.id,
       )}`,
@@ -334,7 +334,7 @@ export function handlePrunedModules(
   const t = Date.now()
   mods.forEach((mod) => {
     mod.lastHMRTimestamp = t
-    debugHmr(`[dispose] ${colors.dim(mod.file)}`)
+    debugHmr?.(`[dispose] ${colors.dim(mod.file)}`)
   })
   ws.send({
     type: 'prune',

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -98,7 +98,7 @@ export function proxyMiddleware(
             if (opts.rewrite) {
               req.url = opts.rewrite(url)
             }
-            debug(`${req.url} -> ws ${opts.target}`)
+            debug?.(`${req.url} -> ws ${opts.target}`)
             proxy.ws(req, socket, head)
             return
           }
@@ -119,15 +119,15 @@ export function proxyMiddleware(
           const bypassResult = opts.bypass(req, res, opts)
           if (typeof bypassResult === 'string') {
             req.url = bypassResult
-            debug(`bypass: ${req.url} -> ${bypassResult}`)
+            debug?.(`bypass: ${req.url} -> ${bypassResult}`)
             return next()
           } else if (bypassResult === false) {
-            debug(`bypass: ${req.url} -> 404`)
+            debug?.(`bypass: ${req.url} -> 404`)
             return res.end(404)
           }
         }
 
-        debug(`${req.url} -> ${opts.target || opts.forward}`)
+        debug?.(`${req.url} -> ${opts.target || opts.forward}`)
         if (opts.rewrite) {
           req.url = opts.rewrite(req.url!)
         }

--- a/packages/vite/src/node/server/middlewares/time.ts
+++ b/packages/vite/src/node/server/middlewares/time.ts
@@ -10,7 +10,7 @@ export function timeMiddleware(root: string): Connect.NextHandleFunction {
     const start = performance.now()
     const end = res.end
     res.end = (...args: readonly [any, any?, any?]) => {
-      logTime(`${timeFrom(start)} ${prettifyUrl(req.url!, root)}`)
+      logTime?.(`${timeFrom(start)} ${prettifyUrl(req.url!, root)}`)
       return end.call(res, ...args)
     }
     next()

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -39,7 +39,6 @@ import {
 import { getDepsOptimizer } from '../../optimizer'
 
 const debugCache = createDebugger('vite:cache')
-const isDebug = !!process.env.DEBUG
 
 const knownIgnoreList = new Set(['/', '/favicon.ico'])
 
@@ -188,7 +187,7 @@ export function transformMiddleware(
           (await moduleGraph.getModuleByUrl(url, false))?.transformResult
             ?.etag === ifNoneMatch
         ) {
-          isDebug && debugCache(`[304] ${prettifyUrl(url, root)}`)
+          debugCache.enabled && debugCache(`[304] ${prettifyUrl(url, root)}`)
           res.statusCode = 304
           return res.end()
         }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -187,7 +187,7 @@ export function transformMiddleware(
           (await moduleGraph.getModuleByUrl(url, false))?.transformResult
             ?.etag === ifNoneMatch
         ) {
-          debugCache.enabled && debugCache(`[304] ${prettifyUrl(url, root)}`)
+          debugCache?.(`[304] ${prettifyUrl(url, root)}`)
           res.statusCode = 304
           return res.end()
         }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -507,7 +507,7 @@ export async function createPluginContainer(
       this.filename = filename
       this.originalCode = code
       if (inMap) {
-        if (debugSourcemapCombine.enabled) {
+        if (debugSourcemapCombine) {
           // @ts-expect-error inject name for debug purpose
           inMap.name = '$inMap'
         }
@@ -517,6 +517,7 @@ export async function createPluginContainer(
 
     _getCombinedSourcemap(createIfNull = false) {
       if (
+        debugSourcemapCombine &&
         debugSourcemapCombineFilter &&
         this.filename.includes(debugSourcemapCombineFilter)
       ) {
@@ -606,7 +607,7 @@ export async function createPluginContainer(
       ctx.ssr = !!ssr
       ctx._scan = scan
       ctx._resolveSkips = skip
-      const resolveStart = debugPluginResolve.enabled ? performance.now() : 0
+      const resolveStart = debugPluginResolve ? performance.now() : 0
 
       let id: string | null = null
       const partial: Partial<PartialResolvedId> = {}
@@ -616,9 +617,7 @@ export async function createPluginContainer(
 
         ctx._activePlugin = plugin
 
-        const pluginResolveStart = debugPluginResolve.enabled
-          ? performance.now()
-          : 0
+        const pluginResolveStart = debugPluginResolve ? performance.now() : 0
         const handler =
           'handler' in plugin.resolveId
             ? plugin.resolveId.handler
@@ -639,22 +638,17 @@ export async function createPluginContainer(
           Object.assign(partial, result)
         }
 
-        debugPluginResolve.enabled &&
-          debugPluginResolve(
-            timeFrom(pluginResolveStart),
-            plugin.name,
-            prettifyUrl(id, root),
-          )
+        debugPluginResolve?.(
+          timeFrom(pluginResolveStart),
+          plugin.name,
+          prettifyUrl(id, root),
+        )
 
         // resolveId() is hookFirst - first non-null result is returned.
         break
       }
 
-      if (
-        debugResolve.enabled &&
-        rawId !== id &&
-        !rawId.startsWith(FS_PREFIX)
-      ) {
+      if (debugResolve && rawId !== id && !rawId.startsWith(FS_PREFIX)) {
         const key = rawId + id
         // avoid spamming
         if (!seenResolves[key]) {
@@ -705,7 +699,7 @@ export async function createPluginContainer(
         ctx._activePlugin = plugin
         ctx._activeId = id
         ctx._activeCode = code
-        const start = debugPluginTransform.enabled ? performance.now() : 0
+        const start = debugPluginTransform ? performance.now() : 0
         let result: TransformResult | string | undefined
         const handler =
           'handler' in plugin.transform
@@ -717,17 +711,16 @@ export async function createPluginContainer(
           ctx.error(e)
         }
         if (!result) continue
-        debugPluginTransform.enabled &&
-          debugPluginTransform(
-            timeFrom(start),
-            plugin.name,
-            prettifyUrl(id, root),
-          )
+        debugPluginTransform?.(
+          timeFrom(start),
+          plugin.name,
+          prettifyUrl(id, root),
+        )
         if (isObject(result)) {
           if (result.code !== undefined) {
             code = result.code
             if (result.map) {
-              if (debugSourcemapCombine.enabled) {
+              if (debugSourcemapCombine) {
                 // @ts-expect-error inject plugin name for debug purpose
                 result.map.name = plugin.name
               }

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -4,7 +4,6 @@ import type { ExistingRawSourceMap, SourceMap } from 'rollup'
 import type { Logger } from '../logger'
 import { createDebugger } from '../utils'
 
-const isDebug = !!process.env.DEBUG
 const debug = createDebugger('vite:sourcemap', {
   onlyWhenFocused: true,
 })
@@ -55,7 +54,7 @@ export async function injectSourcesContent(
   // …to log the missing sources.
   if (missingSources.length) {
     logger.warnOnce(`Sourcemap for "${file}" points to missing source files`)
-    isDebug && debug(`Missing sources:\n  ` + missingSources.join(`\n  `))
+    debug.enabled && debug(`Missing sources:\n  ` + missingSources.join(`\n  `))
   }
 }
 
@@ -71,7 +70,7 @@ export function getCodeWithSourcemap(
   code: string,
   map: SourceMap,
 ): string {
-  if (isDebug) {
+  if (debug.enabled) {
     code += `\n/*${JSON.stringify(map, null, 2).replace(/\*\//g, '*\\/')}*/\n`
   }
 

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -54,7 +54,7 @@ export async function injectSourcesContent(
   // …to log the missing sources.
   if (missingSources.length) {
     logger.warnOnce(`Sourcemap for "${file}" points to missing source files`)
-    debug.enabled && debug(`Missing sources:\n  ` + missingSources.join(`\n  `))
+    debug?.(`Missing sources:\n  ` + missingSources.join(`\n  `))
   }
 }
 
@@ -70,7 +70,7 @@ export function getCodeWithSourcemap(
   code: string,
   map: SourceMap,
 ): string {
-  if (debug.enabled) {
+  if (debug) {
     code += `\n/*${JSON.stringify(map, null, 2).replace(/\*\//g, '*\\/')}*/\n`
   }
 

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -163,7 +163,10 @@ async function loadAndTransform(
 ) {
   const { config, pluginContainer, moduleGraph, watcher } = server
   const { root, logger } = config
-  const prettyUrl = debugLoad.enabled ? prettifyUrl(url, config.root) : ''
+  const prettyUrl =
+    debugLoad.enabled || debugTransform.enabled
+      ? prettifyUrl(url, config.root)
+      : ''
   const ssr = !!options.ssr
 
   const file = cleanUrl(id)

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -27,7 +27,6 @@ export const ERR_LOAD_PUBLIC_URL = 'ERR_LOAD_PUBLIC_URL'
 const debugLoad = createDebugger('vite:load')
 const debugTransform = createDebugger('vite:transform')
 const debugCache = createDebugger('vite:cache')
-const isDebug = !!process.env.DEBUG
 
 export interface TransformResult {
   code: string
@@ -123,7 +122,7 @@ async function doTransform(
   url = removeTimestampQuery(url)
 
   const { config, pluginContainer } = server
-  const prettyUrl = isDebug ? prettifyUrl(url, config.root) : ''
+  const prettyUrl = debugCache.enabled ? prettifyUrl(url, config.root) : ''
   const ssr = !!options.ssr
 
   const module = await server.moduleGraph.getModuleByUrl(url, ssr)
@@ -138,7 +137,7 @@ async function doTransform(
     // in this case, we can reuse its previous cached result and only update
     // its import timestamps.
 
-    isDebug && debugCache(`[memory] ${prettyUrl}`)
+    debugCache.enabled && debugCache(`[memory] ${prettyUrl}`)
     return cached
   }
 
@@ -164,7 +163,7 @@ async function loadAndTransform(
 ) {
   const { config, pluginContainer, moduleGraph, watcher } = server
   const { root, logger } = config
-  const prettyUrl = isDebug ? prettifyUrl(url, config.root) : ''
+  const prettyUrl = debugLoad.enabled ? prettifyUrl(url, config.root) : ''
   const ssr = !!options.ssr
 
   const file = cleanUrl(id)
@@ -173,7 +172,7 @@ async function loadAndTransform(
   let map: SourceDescription['map'] = null
 
   // load
-  const loadStart = isDebug ? performance.now() : 0
+  const loadStart = debugLoad.enabled ? performance.now() : 0
   const loadResult = await pluginContainer.load(id, { ssr })
   if (loadResult == null) {
     // if this is an html request and there is no load result, skip ahead to
@@ -189,7 +188,8 @@ async function loadAndTransform(
     if (options.ssr || isFileServingAllowed(file, server)) {
       try {
         code = await fs.readFile(file, 'utf-8')
-        isDebug && debugLoad(`${timeFrom(loadStart)} [fs] ${prettyUrl}`)
+        debugLoad.enabled &&
+          debugLoad(`${timeFrom(loadStart)} [fs] ${prettyUrl}`)
       } catch (e) {
         if (e.code !== 'ENOENT') {
           throw e
@@ -214,7 +214,8 @@ async function loadAndTransform(
       }
     }
   } else {
-    isDebug && debugLoad(`${timeFrom(loadStart)} [plugin] ${prettyUrl}`)
+    debugLoad.enabled &&
+      debugLoad(`${timeFrom(loadStart)} [plugin] ${prettyUrl}`)
     if (isObject(loadResult)) {
       code = loadResult.code
       map = loadResult.map
@@ -247,7 +248,7 @@ async function loadAndTransform(
   ensureWatchedFile(watcher, mod.file, root)
 
   // transform
-  const transformStart = isDebug ? performance.now() : 0
+  const transformStart = debugTransform.enabled ? performance.now() : 0
   const transformResult = await pluginContainer.transform(code, id, {
     inMap: map,
     ssr,
@@ -258,12 +259,13 @@ async function loadAndTransform(
     (isObject(transformResult) && transformResult.code == null)
   ) {
     // no transform applied, keep code as-is
-    isDebug &&
+    debugTransform.enabled &&
       debugTransform(
         timeFrom(transformStart) + colors.dim(` [skipped] ${prettyUrl}`),
       )
   } else {
-    isDebug && debugTransform(`${timeFrom(transformStart)} ${prettyUrl}`)
+    debugTransform.enabled &&
+      debugTransform(`${timeFrom(transformStart)} ${prettyUrl}`)
     code = transformResult.code!
     map = transformResult.map
   }

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -146,7 +146,7 @@ export function createIsConfiguredAsSsrExternal(
         !!configuredAsExternal,
       )?.external
     } catch (e) {
-      debug(
+      debug?.(
         `Failed to node resolve "${id}". Skipping externalizing it by default.`,
       )
       // may be an invalid import that's resolved by a plugin
@@ -273,7 +273,7 @@ function cjsSsrCollectExternals(
       }
 
       // resolve failed, assume include
-      debug(`Failed to resolve entries for package "${id}"\n`, e)
+      debug?.(`Failed to resolve entries for package "${id}"\n`, e)
       continue
     }
     // no esm entry but has require entry

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -172,15 +172,10 @@ interface DebuggerOptions {
 
 export type ViteDebugScope = `vite:${string}`
 
-export interface Debugger {
-  (...args: any[]): void
-  enabled: boolean
-}
-
 export function createDebugger(
   namespace: ViteDebugScope,
   options: DebuggerOptions = {},
-): Debugger {
+): debug.Debugger['log'] | undefined {
   const log = debug(namespace)
   const { onlyWhenFocused } = options
 
@@ -190,16 +185,13 @@ export function createDebugger(
     enabled = !!DEBUG?.includes(ns)
   }
 
-  const fn = ((msg: string, ...args: any[]) => {
-    if (!enabled || (filter && !msg.includes(filter))) {
-      return
+  if (enabled) {
+    return (msg: string, ...args: any[]) => {
+      if (!filter || msg.includes(filter)) {
+        log(msg, ...args)
+      }
     }
-    log(msg, ...args)
-  }) as Debugger
-
-  fn.enabled = enabled
-
-  return fn
+  }
 }
 
 function testCaseInsensitiveFS() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Often times we do:

```js
isDebug && debug('...')

const start = isDebug ? performance.now() : 0
```

Where `isDebug` is `process.env.DEBUG`, however that doesn't always mean the `debug` will run if `DEBUG="blabla"` and we're logging with the `vite:time` namespace.

To simplify this, the PR refactors as `debug?.('...')` instead.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Might make debug logs slightly more accurate.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
