### PR TITLE
fix(import-analysis): escape quotes correctly

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -588,9 +588,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               rewriteDone = true
             }
             if (!rewriteDone) {
-              let rewrittenUrl = JSON.stringify(url)
-              if (!isDynamicImport) rewrittenUrl = rewrittenUrl.slice(1, -1)
-              str().overwrite(start, end, rewrittenUrl, {
+              const rewrittenUrl = JSON.stringify(url)
+              const s = isDynamicImport ? start : start - 1
+              const e = isDynamicImport ? end : end + 1
+              str().overwrite(s, e, rewrittenUrl, {
                 contentOnly: true,
               })
             }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -342,9 +342,10 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 rewriteDone = true
               }
               if (!rewriteDone) {
-                let rewrittenUrl = JSON.stringify(file)
-                if (!isDynamicImport) rewrittenUrl = rewrittenUrl.slice(1, -1)
-                str().update(start, end, rewrittenUrl)
+                const rewrittenUrl = JSON.stringify(file)
+                const s = isDynamicImport ? start : start - 1
+                const e = isDynamicImport ? end : end + 1
+                str().update(s, e, rewrittenUrl)
               }
             }
           }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This won't happen normally. This only happens when the import didn't contain single quotes in the specifier and quoted with single quotes and Vite needs to rewrite that to a path including single quotes.
For example, you'll need to place your project inside a path containing `'` and change the root somewhere to make Vite replace the path with `/@fs/`.

fixes #12667
refs #9729

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
