### PR TITLE
refactor: remove `ensureVolumeInPath`

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -20,7 +20,6 @@ import {
   cleanUrl,
   createDebugger,
   deepImportRE,
-  ensureVolumeInPath,
   fsPathFromId,
   injectQuery,
   isBuiltin,
@@ -203,7 +202,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       if (asSrc && depsOptimizer?.isOptimizedDepUrl(id)) {
         const optimizedPath = id.startsWith(FS_PREFIX)
           ? fsPathFromId(id)
-          : normalizePath(ensureVolumeInPath(path.resolve(root, id.slice(1))))
+          : normalizePath(path.resolve(root, id.slice(1)))
         return optimizedPath
       }
 
@@ -1250,7 +1249,6 @@ function equalWithoutSuffix(path: string, key: string, suffix: string) {
 }
 
 function getRealPath(resolved: string, preserveSymlinks?: boolean): string {
-  resolved = ensureVolumeInPath(resolved)
   if (!preserveSymlinks && browserExternalId !== resolved) {
     resolved = safeRealpathSync(resolved)
   }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -7,7 +7,6 @@ import type { ViteDevServer } from '..'
 import {
   cleanUrl,
   createDebugger,
-  ensureVolumeInPath,
   fsPathFromId,
   injectQuery,
   isImportRequest,
@@ -79,9 +78,7 @@ export function transformMiddleware(
           // means that the dependency has already been pre-bundled and loaded
           const sourcemapPath = url.startsWith(FS_PREFIX)
             ? fsPathFromId(url)
-            : normalizePath(
-                ensureVolumeInPath(path.resolve(root, url.slice(1))),
-              )
+            : normalizePath(path.resolve(root, url.slice(1)))
           try {
             const map = JSON.parse(
               await fsp.readFile(sourcemapPath, 'utf-8'),

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -255,10 +255,6 @@ export function isParentDirectory(dir: string, file: string): boolean {
   )
 }
 
-export function ensureVolumeInPath(file: string): string {
-  return isWindows ? path.resolve(file) : file
-}
-
 export const queryRE = /\?.*$/s
 
 const postfixRE = /[?#].*$/s


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`ensureVolumeInPath` calls `path.resolve` on Windows and does nothing on other OSs. But at every place the path passed to `ensureVolumeInPath` was an absolute path (e.g. `ensureVolumeInPath(path.resolve(dir, './foo.js'))`).

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
