### PR TITLE
feat: skip pinging the server when the tab is not shown

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -328,6 +328,10 @@ async function waitForSuccessfulPing(
     return false
   }
 
+  if (await ping()) {
+    return
+  }
+
   let waitForWindowShowPromise: Promise<void> | undefined
 
   // eslint-disable-next-line no-constant-condition

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -332,8 +332,6 @@ async function waitForSuccessfulPing(
     return
   }
 
-  let waitForWindowShowPromise: Promise<void> | undefined
-
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (document.visibilityState === 'visible') {
@@ -342,12 +340,7 @@ async function waitForSuccessfulPing(
       }
       await wait(ms)
     } else {
-      if (!waitForWindowShowPromise) {
-        waitForWindowShowPromise = waitForWindowShow().then(() => {
-          waitForWindowShowPromise = undefined
-        })
-      }
-      await Promise.race([wait(ms), waitForWindowShowPromise])
+      await waitForWindowShow()
     }
   }
 }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -315,21 +315,46 @@ async function waitForSuccessfulPing(
 ) {
   const pingHostProtocol = socketProtocol === 'wss' ? 'https' : 'http'
 
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
+  const ping = async () => {
+    // A fetch on a websocket URL will return a successful promise with status 400,
+    // but will reject a networking error.
+    // When running on middleware mode, it returns status 426, and an cors error happens if mode is not no-cors
     try {
-      // A fetch on a websocket URL will return a successful promise with status 400,
-      // but will reject a networking error.
-      // When running on middleware mode, it returns status 426, and an cors error happens if mode is not no-cors
       await fetch(`${pingHostProtocol}://${hostAndPath}`, {
         mode: 'no-cors',
       })
-      break
-    } catch (e) {
-      // wait ms before attempting to ping again
-      await new Promise((resolve) => setTimeout(resolve, ms))
+      return true
+    } catch {}
+    return false
+  }
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (document.visibilityState === 'visible') {
+      if (await ping()) {
+        break
+      }
+      await wait(ms)
+    } else {
+      await Promise.race([wait(ms), waitForWindowShow()])
     }
   }
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function waitForWindowShow() {
+  return new Promise<void>((resolve) => {
+    const onChange = async () => {
+      if (document.visibilityState === 'visible') {
+        resolve()
+        document.removeEventListener('visibilitychange', onChange)
+      }
+    }
+    document.addEventListener('visibilitychange', onChange)
+  })
 }
 
 const sheetsMap = new Map<string, HTMLStyleElement>()

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -328,6 +328,8 @@ async function waitForSuccessfulPing(
     return false
   }
 
+  let waitForWindowShowPromise: Promise<void> | undefined
+
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (document.visibilityState === 'visible') {
@@ -336,7 +338,12 @@ async function waitForSuccessfulPing(
       }
       await wait(ms)
     } else {
-      await Promise.race([wait(ms), waitForWindowShow()])
+      if (!waitForWindowShowPromise) {
+        waitForWindowShowPromise = waitForWindowShow().then(() => {
+          waitForWindowShowPromise = undefined
+        })
+      }
+      await Promise.race([wait(ms), waitForWindowShowPromise])
     }
   }
 }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -331,6 +331,7 @@ async function waitForSuccessfulPing(
   if (await ping()) {
     return
   }
+  await wait(ms)
 
   // eslint-disable-next-line no-constant-condition
   while (true) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR makes `@vite/client` to skip pinging the server when the tab is not shown.
By doing this, we can reduce non-necessary pings (#5228) and thus reduce the logs output in browser console (#12693).

close #5228
close #12693
similar to #6791

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
