### PR TITLE
fix(optimizer): load the correct lock file

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1233,16 +1233,19 @@ function isSingleDefaultExport(exports: readonly string[]) {
 }
 
 const lockfileFormats = [
-  { name: 'package-lock.json', checkPatches: true },
-  { name: 'yarn.lock', checkPatches: true }, // Included in lockfile for v2+
-  { name: 'pnpm-lock.yaml', checkPatches: false }, // Included in lockfile
-  { name: 'bun.lockb', checkPatches: true },
-]
+  { name: 'package-lock.json', checkPatches: true, manager: 'npm' },
+  { name: 'yarn.lock', checkPatches: true, manager: 'yarn' }, // Included in lockfile for v2+
+  { name: 'pnpm-lock.yaml', checkPatches: false, manager: 'pnpm' }, // Included in lockfile
+  { name: 'bun.lockb', checkPatches: true, manager: 'bun' },
+].sort((_, { manager }) => {
+  return process.env.npm_config_user_agent?.startsWith(manager) ? 1 : -1
+})
 const lockfileNames = lockfileFormats.map((l) => l.name)
 
 export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
   const lockfilePath = lookupFile(config.root, lockfileNames)
   let content = lockfilePath ? fs.readFileSync(lockfilePath, 'utf-8') : ''
+
   if (lockfilePath) {
     const lockfileName = path.basename(lockfilePath)
     const { checkPatches } = lockfileFormats.find(

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1245,7 +1245,6 @@ const lockfileNames = lockfileFormats.map((l) => l.name)
 export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
   const lockfilePath = lookupFile(config.root, lockfileNames)
   let content = lockfilePath ? fs.readFileSync(lockfilePath, 'utf-8') : ''
-
   if (lockfilePath) {
     const lockfileName = path.basename(lockfilePath)
     const { checkPatches } = lockfileFormats.find(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The pre-bundling hash source may be wrong if there is more than one lock file. 

e.g: both `package-lock.json` and `pnpm-lock.json` exist in the root, when running `vite dev` via `pnpm`, vite will always read the `package-lock.json` as part of the final pre-bundling hash.

This PR will use the package-manager-related lock file first.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
