### PR TITLE
chore: revert custom license resolve

### DIFF
--- a/packages/vite/rollupLicensePlugin.ts
+++ b/packages/vite/rollupLicensePlugin.ts
@@ -1,9 +1,6 @@
 import fs from 'node:fs'
-import path from 'node:path'
 import license from 'rollup-plugin-license'
 import colors from 'picocolors'
-import fg from 'fast-glob'
-import resolve from 'resolve'
 import type { Plugin } from 'rollup'
 
 export default function licensePlugin(
@@ -65,21 +62,6 @@ export default function licensePlugin(
               text += `Repository: ${
                 typeof repository === 'string' ? repository : repository.url
               }\n`
-            }
-            if (!licenseText && name) {
-              try {
-                const pkgDir = path.dirname(
-                  resolve.sync(path.join(name, 'package.json'), {
-                    preserveSymlinks: false,
-                  }),
-                )
-                const licenseFile = fg.sync(`${pkgDir}/LICENSE*`, {
-                  caseSensitiveMatch: false,
-                })[0]
-                if (licenseFile) {
-                  licenseText = fs.readFileSync(licenseFile, 'utf-8')
-                }
-              } catch {}
             }
             if (licenseText) {
               text +=


### PR DESCRIPTION
### Description
This part of the code was introduced by #4149. But the generated license file was same on my machine.
Maybe there was a bug in dependency and got fixed. I wonder if we can remove this part.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
