### PR TITLE
refactor: use `resolvePackageData` in `requireResolveFromRootWithFallback`

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { exec } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { URL, URLSearchParams } from 'node:url'
+import { URL, URLSearchParams, fileURLToPath } from 'node:url'
 import { builtinModules, createRequire } from 'node:module'
 import { promises as dns } from 'node:dns'
 import { performance } from 'node:perf_hooks'
@@ -34,6 +34,7 @@ import {
 import type { DepOptimizationConfig } from './optimizer'
 import type { ResolvedConfig } from './config'
 import type { ResolvedServerUrls, ViteDevServer } from './server'
+import { resolvePackageData } from './packages'
 import type { CommonServerOptions } from '.'
 
 /**
@@ -963,21 +964,23 @@ export function getHash(text: Buffer | string): string {
   return createHash('sha256').update(text).digest('hex').substring(0, 8)
 }
 
+const _dirname = path.dirname(fileURLToPath(import.meta.url))
+
 export const requireResolveFromRootWithFallback = (
   root: string,
   id: string,
 ): string => {
-  const paths = _require.resolve.paths?.(id) || []
-  // Search in the root directory first, and fallback to the default require paths.
-  paths.unshift(root)
-
-  // Use `resolve` package to check existence first, so if the package is not found,
+  // check existence first, so if the package is not found,
   // it won't be cached by nodejs, since there isn't a way to invalidate them:
   // https://github.com/nodejs/node/issues/44663
-  resolve.sync(id, { basedir: root, paths })
+  const found = resolvePackageData(id, root) || resolvePackageData(id, _dirname)
+  if (!found) {
+    throw new Error(`${JSON.stringify(id)} not found.`)
+  }
 
-  // Use `require.resolve` again as the `resolve` package doesn't support the `exports` field
-  return _require.resolve(id, { paths })
+  // actually resolve
+  // Search in the root directory first, and fallback to the default require paths.
+  return _require.resolve(id, { paths: [root, _dirname] })
 }
 
 export function emptyCssComments(raw: string): string {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -975,7 +975,9 @@ export const requireResolveFromRootWithFallback = (
   // https://github.com/nodejs/node/issues/44663
   const found = resolvePackageData(id, root) || resolvePackageData(id, _dirname)
   if (!found) {
-    throw new Error(`${JSON.stringify(id)} not found.`)
+    const error = new Error(`${JSON.stringify(id)} not found.`)
+    ;(error as any).code = 'MODULE_NOT_FOUND'
+    throw error
   }
 
   // actually resolve


### PR DESCRIPTION
### Description
This PR changes `requireResolveFromRootWithFallback` to use `resolvePackageData` instead of `resolve.sync`.

This function was introduced by https://github.com/vitejs/vite/commit/ddfcbce05753da3e525c1bb9bdf449a322e997f4 and changed by #3988 and #10812.

Previously, this function was using `require.resolve.paths` and was passing this to `resolve.sync` and `require.resolve`. Now this function simply passes `root` and `__dirname`. IIUC this behaves same because

- [`require.resolve.paths`](https://nodejs.org/api/modules.html#requireresolvepathsrequest) returns the value of `NODE_MODULES_PATHS` in [this all together section](https://nodejs.org/api/modules.html#all-together)
- [`require.resolve`](https://nodejs.org/api/modules.html#requireresolverequest-options) uses `paths` option as a starting point for the module resolution algorithm. Also `require.resolve` always uses `GLOBAL_FOLDERS`. In other words, `require.resolve` will use `paths.flatMap(p => NODE_MODULES_PATHS(p))` as candidates.

So passing `root` to `paths` option of `require.resolve` is same with passing `createRequire(root).resolve.paths` to `paths` option.

I tested this PR by the way written in #2612 and #10812.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
