### PR TITLE
perf(css): cache lazy import

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -892,7 +892,7 @@ async function compileCSS(
   if (needInlineImport) {
     postcssPlugins.unshift(
       (
-        await lazyImport('postcss-import', () => import('postcss-import'))
+        await cachedImport('postcss-import', () => import('postcss-import'))
       ).default({
         async resolve(id, basedir) {
           const publicFile = checkPublicFile(id, config)
@@ -929,7 +929,7 @@ async function compileCSS(
   if (isModule) {
     postcssPlugins.unshift(
       (
-        await lazyImport('postcss-modules', () => import('postcss-modules'))
+        await cachedImport('postcss-modules', () => import('postcss-modules'))
       ).default({
         ...modulesOptions,
         localsConvention: modulesOptions?.localsConvention,
@@ -967,7 +967,7 @@ async function compileCSS(
   let postcssResult: PostCSS.Result
   try {
     const source = removeDirectQuery(id)
-    const postcss = await lazyImport('postcss', () => import('postcss'))
+    const postcss = await cachedImport('postcss', () => import('postcss'))
     // postcss is an unbundled dep and should be lazy imported
     postcssResult = await postcss.default(postcssPlugins).process(code, {
       ...postcssOptions,
@@ -1059,7 +1059,7 @@ async function compileCSS(
 }
 
 const lazyImportCache = new Map()
-function lazyImport<T>(name: string, imp: () => Promise<T>): T | Promise<T> {
+function cachedImport<T>(name: string, imp: () => Promise<T>): T | Promise<T> {
   const cached = lazyImportCache.get(name)
   if (cached) return cached
 


### PR DESCRIPTION
### Description
Similar to https://github.com/vitejs/vite-plugin-react/pull/141.
`compileCSS` function was taking 500ms with my project and was cut down to 300ms with this change.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
