### PR TITLE
fix: avoid clean up while committing deps folder

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -510,8 +510,11 @@ export function runOptimizeDeps(
 
   const qualifiedIds = Object.keys(depsInfo)
   let cleaned = false
+  let committed = false
   const cleanUp = () => {
-    if (!cleaned) {
+    // If commit was already called, ignore the clean up even if a cancel was requested
+    // This minimizes the chances of leaving the deps cache in a corrupted state
+    if (!cleaned && !committed) {
       cleaned = true
       // No need to wait, we can clean up in the background because temp folders
       // are unique per run
@@ -525,9 +528,12 @@ export function runOptimizeDeps(
     metadata,
     cancel: cleanUp,
     commit: async () => {
+      // Ignore clean up requests after this point so the temp folder isn't deleted before
+      // we finish commiting the new deps cache files to the deps folder
+      committed = true
+
       // Write metadata file, then commit the processing folder to the global deps cache
       // Rewire the file paths from the temporal processing dir to the final deps cache dir
-
       const dataPath = path.join(processingCacheDir, '_metadata.json')
       fs.writeFileSync(
         dataPath,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -165,9 +165,6 @@ export interface DepOptimizationResult {
    * to be able to discard the result
    */
   commit: () => Promise<void>
-  /**
-   * @deprecated noop
-   */
   cancel: () => void
 }
 


### PR DESCRIPTION
### Description

Reported [error in Discord](https://discord.com/channels/804011606160703521/804439875226173480/1091719367714148362) by @bluwy:
```
Error: ENOENT: no such file or directory, open '/Users/bjorn/Work/repros/vite-scss-slow/node_modules/.vite/deps_temp_f7b967e0/_metadata.json'
    at Object.openSync (node:fs:590:3)
    at Object.writeFileSync (node:fs:2202:35)
    at Object.commit (file:///Users/bjorn/Work/repros/vite-scss-slow/node_modules/.pnpm/vite@4.3.0-beta.1_sass@1.49.7/node_modules/vite/dist/node/chunks/dep-f365bad6.js:44771:18)
```

This [cancel()](https://github.com/vitejs/vite/blob/2d30ae5a008c755f9220dd9ef57ec6e39dec4dc5/packages/vite/src/node/optimizer/optimizer.ts#L184) could be called after the result is committed.

I added a guard to avoid this issue but also refactored the optimizer code, so the cancel wouldn't be called after this PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other