### PR TITLE
perf: skip es-module-lexer if have no dynamic imports

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -20,6 +20,11 @@ import { toAbsoluteGlob } from './importMetaGlob'
 export const dynamicImportHelperId = '\0vite/dynamic-import-helper'
 
 const relativePathRE = /^\.{1,2}\//
+// fast path to check if source contains a dynamic import. we check for a
+// trailing slash too as a dynamic import statement can have comments between
+// the `import` and the `(`.
+const hasDynamicImportRE = /\bimport\s*[(/]/
+
 interface DynamicImportRequest {
   as?: keyof KnownAsTypeMap
 }
@@ -162,7 +167,7 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer) {
-      if (!filter(importer)) {
+      if (!filter(importer) || !hasDynamicImportRE.test(source)) {
         return
       }
 

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -7,6 +7,7 @@ import { dynamicImportToGlob } from '@rollup/plugin-dynamic-import-vars'
 import type { KnownAsTypeMap } from 'types/importGlob'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
+import { CLIENT_ENTRY } from '../constants'
 import {
   createFilter,
   normalizePath,
@@ -167,7 +168,11 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(source, importer) {
-      if (!filter(importer) || !hasDynamicImportRE.test(source)) {
+      if (
+        !filter(importer) ||
+        importer === CLIENT_ENTRY ||
+        !hasDynamicImportRE.test(source)
+      ) {
         return
       }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Do a quick regex check for dynamic imports before using es-module-lexer to parse for dynamic import vars.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I'm testing with https://github.com/sapphi-red/performance-compare, but it doesn't yield much improvements because React's HMR code has this: cc @ArnaudBarre 

```js
import(/* @vite-ignore */ import.meta.url).then((currentExports) => {
  RefreshRuntime.registerExportsForReactRefresh(__SOURCE__, currentExports);
  import.meta.hot.accept((nextExports) => {
    if (!nextExports) return;
    const invalidateMessage = RefreshRuntime.validateRefreshBoundaryAndEnqueueUpdate(currentExports, nextExports);
    if (invalidateMessage) import.meta.hot.invalidate(invalidateMessage);
  });
});
```

But for other cases, less files will be transformed with es-module-lexer now, which should make things faster.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
