### PR TITLE
perf: use package cache for one off resolve

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1001,6 +1001,7 @@ async function bundleConfigFile(
             dedupe: [],
             extensions: DEFAULT_EXTENSIONS,
             preserveSymlinks: false,
+            packageCache: new Map(),
           }
 
           // externalize bare imports

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -878,6 +878,7 @@ function createOptimizeDepsIncludeResolver(
     scan: true,
     ssrOptimizeCheck: ssr,
     ssrConfig: config.ssr,
+    packageCache: new Map(),
   })
   return async (id: string) => {
     const lastArrowIndex = id.lastIndexOf('>')

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -10,6 +10,7 @@ import {
   slash,
   transformStableResult,
 } from '../utils'
+import { CLIENT_ENTRY } from '../constants'
 import { fileToUrl } from './asset'
 import { preloadHelperId } from './importAnalysisBuild'
 
@@ -33,6 +34,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
       if (
         !options?.ssr &&
         id !== preloadHelperId &&
+        id !== CLIENT_ENTRY &&
         code.includes('new URL') &&
         code.includes(`import.meta.url`)
       ) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
I noticed on startup there are some places we're resolving package data without cache. These are only one-off resolves, so the cache would help minimize fs access, and when done, cleared to free memory.

I also made an unrelated change to `assetImportMetaUrl` 😬 That should remove calling `stripLiteral` on the `client.mjs` file.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I didn't notice much improvement on startup time however, ~20ms. Though it might be more obvious on other machines where fs access are more expensive.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
