### PR TITLE
docs(ssr): add example of running devserver with https

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -148,6 +148,49 @@ The `dev` script in `package.json` should also be changed to use the server scri
   }
 ```
 
+## Running the Dev Server with HTTPS
+
+To run the devserver with HTTPS, we can use the helpful [`mkcert()` plugin](https://github.com/liuweiGL/vite-plugin-mkcert).
+
+**vite.config.js**
+
+```diff
++ import mkcert from 'vite-plugin-mkcert';
+```
+
+```diff
+plugins: [
++ mkcert({ hosts: ["example.com", "localhost"], force: true })
+],
+```
+
+**server.js**
+
+```diff
++ import https from 'node:https';
+```
+
+```diff
+server: { 
++ https: true,
+  middlewareMode: true
+},
+```
+
+```diff
+- app.listen(5173)
++ const SSL_PORT = 3443
++ const YOUR_DOMAIN = 'example.com'
++ const cert = vite?.config?.server?.https?.cert;
++ const key = vite?.config?.server?.https?.key;
++ if (!cert || !key) {
++   throw new Error("There is a problem with your cert");
++ }
++ https.createServer({ cert, key }, app).listen(SSL_PORT, () => {
++   console.log(`> HTTPS ready on https://${YOUR_DOMAIN}:${SSL_PORT}`);
++ });
+```
+
 ## Building for Production
 
 To ship an SSR project for production, we need to:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

* Add an example that covers running the local devserver with https
* 
### Additional context

It took me a really long time to figure out how to do this by stepping through the devserver in the debugger, but in the end the solution was simple, so I hope having it documented will help a fellow traveler in the future.

Interestingly, the documentation is significantly different from the example repo. I'm not sure which is more correct, but I'd be happy to update one of the other to match if that is preferable. In my opinion the repo is more correct, although it does not actually run without some modifications. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
