### PR TITLE
fix: use self

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -535,7 +535,7 @@ export async function build(
   }
 
   const rollupOptions: RollupOptions = {
-    context: 'globalThis',
+    context: 'self',
     preserveEntrySignatures: ssr
       ? 'allow-extension'
       : libOptions


### PR DESCRIPTION
### Description

our web app met a js-error when runs on chrome m69, like below.
![image](https://user-images.githubusercontent.com/19543313/230287268-6c703349-8855-4327-a900-80ee99a02942.png). Other guy does a thing to resolve this problem by rollup's context option, introduced in #5312.

But `globalThis` API is supported until chrome m71, therefore we met a error on chrome m69. -_-

![image](https://user-images.githubusercontent.com/19543313/230288291-c20b70b0-1637-4918-8018-7e84396fb411.png)

Inspired by #5312, `self` maybe more appropriate because of browser compatibility, and `self` maybe more semantic.

![image](https://user-images.githubusercontent.com/19543313/230290134-23938b89-82c6-4aea-a1d0-580ac4e725c8.png)


### Additional context

I tested this opinions on chrome console, there is the result.

![image](https://user-images.githubusercontent.com/19543313/230289164-455d0b40-87af-48ae-a728-ee59165b20b1.png)


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
