### PR TITLE
chore: improve debug log filtering

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -187,9 +187,9 @@ export function createDebugger(
   }
 
   if (enabled) {
-    return (msg: string, ...args: any[]) => {
-      if (!filter || msg.includes(filter)) {
-        log(msg, ...args)
+    return (...args: [string, ...any[]]) => {
+      if (!filter || args.some((a) => a?.includes(filter))) {
+        log(...args)
       }
     }
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When I start Vite with `vite --debug plugin-transform --filter import-analysis`, it doesn't really work because the `filter` is applied to the first arg passed to `debug()` only. So given this debug log:

```
vite:plugin-transform 2.71ms vite:import-analysis src/app.ts +16ms
```

The first arg is `2.71ms` which isn't really useful for filtering. This PR checks all args for filtering instead.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

