### PR TITLE
refactor: use simpler resolve for nested optimized deps

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -68,7 +68,6 @@
   "dependencies": {
     "esbuild": "^0.17.5",
     "postcss": "^8.4.21",
-    "resolve": "^1.22.1",
     "rollup": "^3.20.2"
   },
   "optionalDependencies": {

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -120,6 +120,13 @@ function createNodePlugins(
           pattern: /^var json = typeof JSON.+require\('jsonify'\);$/gm,
           replacement: 'var json = JSON',
         },
+        // postcss-import uses the `resolve` dep if the `resolve` option is not passed.
+        // However, we always pass the `resolve` option. Remove this import to avoid
+        // bundling the `resolve` dep.
+        'postcss-import/index.js': {
+          src: 'const resolveId = require("./lib/resolve-id")',
+          replacement: 'const resolveId = undefined',
+        },
       }),
 
     commonjs({

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -43,6 +43,8 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
             depsOptimizer,
             id,
             importer,
+            config.resolve.preserveSymlinks,
+            config.packageCache,
           )
           if (optimizedId) {
             return optimizedId // aliased dep already optimized

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -8,7 +8,6 @@ import { builtinModules, createRequire } from 'node:module'
 import { promises as dns } from 'node:dns'
 import { performance } from 'node:perf_hooks'
 import type { AddressInfo, Server } from 'node:net'
-import resolve from 'resolve'
 import type { FSWatcher } from 'chokidar'
 import remapping from '@ampproject/remapping'
 import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping'
@@ -22,7 +21,6 @@ import { createFilter as _createFilter } from '@rollup/pluginutils'
 import {
   CLIENT_ENTRY,
   CLIENT_PUBLIC_PATH,
-  DEFAULT_EXTENSIONS,
   ENV_PUBLIC_PATH,
   FS_PREFIX,
   NULL_BYTE_PLACEHOLDER,
@@ -144,23 +142,6 @@ export const deepImportRE = /^([^@][^/]*)\/|^(@[^/]+\/[^/]+)\//
 
 // TODO: use import()
 const _require = createRequire(import.meta.url)
-
-const ssrExtensions = ['.js', '.cjs', '.json', '.node']
-
-export function resolveFrom(
-  id: string,
-  basedir: string,
-  preserveSymlinks = false,
-  ssr = false,
-): string {
-  return resolve.sync(id, {
-    basedir,
-    paths: [],
-    extensions: ssr ? ssrExtensions : DEFAULT_EXTENSIONS,
-    // necessary to work with pnpm
-    preserveSymlinks: preserveSymlinks || !!process.versions.pnp || false,
-  })
-}
 
 // set in bin/vite.js
 const filter = process.env.VITE_DEBUG_FILTER

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,7 +211,6 @@ importers:
       postcss-import: ^15.1.0
       postcss-load-config: ^4.0.1
       postcss-modules: ^6.0.0
-      resolve: ^1.22.1
       resolve.exports: ^2.0.1
       rollup: ^3.20.2
       rollup-plugin-license: ^3.0.1
@@ -228,7 +227,6 @@ importers:
     dependencies:
       esbuild: 0.17.5
       postcss: 8.4.21
-      resolve: 1.22.1
       rollup: 3.20.2
     optionalDependencies:
       fsevents: 2.3.2


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When `tryFsResolve` tries to match `id` to `foo > bar` syntaxes, use `resolvePackageData` instead of the `resolve` dep to match paths.

We don't actually need to do a full resolve as matching with `startsWith` is sufficient in most case. It is even riskier doing a full resolve as the resolve algorithim in `resolve` can differ from Vite's resolver algorithm used to derive `optimizedData.src`. (Partly an issue being solved in https://github.com/vitejs/vite/pull/11410)

This PR also removes the `resolve` dep 🎉 It needs a tweak to `postcss-import` as it imports `resolve` too (which otherwise would've bundled `resolve`), but we're able to avoid that as explained in the comments.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
I'm trying to fix https://github.com/vitejs/vite/pull/11410, and figured to do this change as a stop gap as the next changes will be a bit large.

Existing tests should pass.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
