### PR TITLE
test(css): deterministic css emit with the same file basename

### DIFF
--- a/playground/css/__tests__/same-file-name/same-file-name.spec.ts
+++ b/playground/css/__tests__/same-file-name/same-file-name.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest'
+import { findAssetFile, isBuild } from '~utils'
+
+describe.runIf(isBuild)('css files has same basename', () => {
+  test('emit file name should consistent', () => {
+    expect(findAssetFile('sub.css', 'same-file-name', '.')).toMatch('.sub1-sub')
+    expect(findAssetFile('sub2.css', 'same-file-name', '.')).toMatch(
+      '.sub2-sub',
+    )
+  })
+})

--- a/playground/css/__tests__/same-file-name/same-file-name.spec.ts
+++ b/playground/css/__tests__/same-file-name/same-file-name.spec.ts
@@ -1,11 +1,19 @@
-import { describe, expect, test } from 'vitest'
-import { findAssetFile, isBuild } from '~utils'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { findAssetFile, isBuild, startDefaultServe } from '~utils'
 
-describe.runIf(isBuild)('css files has same basename', () => {
-  test('emit file name should consistent', () => {
-    expect(findAssetFile('sub.css', 'same-file-name', '.')).toMatch('.sub1-sub')
-    expect(findAssetFile('sub2.css', 'same-file-name', '.')).toMatch(
-      '.sub2-sub',
-    )
-  })
+beforeEach(async () => {
+  await startDefaultServe()
 })
+
+for (let i = 0; i < 5; i++) {
+  describe.runIf(isBuild)('css files has same basename', () => {
+    test('emit file name should consistent', () => {
+      expect(findAssetFile('sub.css', 'same-file-name', '.')).toMatch(
+        '.sub1-sub',
+      )
+      expect(findAssetFile('sub2.css', 'same-file-name', '.')).toMatch(
+        '.sub2-sub',
+      )
+    })
+  })
+}

--- a/playground/css/__tests__/same-file-name/vite.config.js
+++ b/playground/css/__tests__/same-file-name/vite.config.js
@@ -1,0 +1,2 @@
+import config from '../../vite.config-same-file-name'
+export default config

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -117,3 +117,6 @@ document
 import './unsupported.css'
 
 import './async/index'
+
+import('./same-name/sub1/sub')
+import('./same-name/sub2/sub')

--- a/playground/css/same-name/sub1/sub.css
+++ b/playground/css/same-name/sub1/sub.css
@@ -1,0 +1,3 @@
+.sub1-sub {
+  color: red;
+}

--- a/playground/css/same-name/sub1/sub.js
+++ b/playground/css/same-name/sub1/sub.js
@@ -1,0 +1,3 @@
+import './sub.css'
+
+export default 'sub1-name'

--- a/playground/css/same-name/sub2/sub.css
+++ b/playground/css/same-name/sub2/sub.css
@@ -1,0 +1,3 @@
+.sub2-sub {
+  color: blue;
+}

--- a/playground/css/same-name/sub2/sub.js
+++ b/playground/css/same-name/sub2/sub.js
@@ -1,0 +1,3 @@
+import './sub.css'
+
+export default 'sub2-name'

--- a/playground/css/vite.config-same-file-name.js
+++ b/playground/css/vite.config-same-file-name.js
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default defineConfig({
+  ...baseConfig,
+  build: {
+    ...baseConfig.build,
+    outDir: 'dist/same-file-name',
+    rollupOptions: {
+      output: {
+        entryFileNames: '[name].js',
+        chunkFileNames: '[name].[hash].js',
+        assetFileNames: '[name].[ext]',
+      },
+    },
+  },
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

refs #12256

The CSS emission's file name should be deterministic when multiple CSS files have the same file basename.

e.g:

`index.css` vs `sub1/index.css` vs `sub2/index.css`

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
