### PR TITLE
feat(perf): collect server performance metrics

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -115,7 +115,9 @@ cli
     '--force',
     `[boolean] force the optimizer to ignore the cache and re-bundle`,
   )
+  .option('--perf', `[boolean] collect server performance metrics`)
   .action(async (root: string, options: ServerOptions & GlobalCLIOptions) => {
+    perf.enabled = !!options.perf
     filterDuplicateOptions(options)
     // output structure is preserved even after bundling so require()
     // is ok here

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks'
 import path from 'node:path'
 import fs from 'node:fs'
 import { cac } from 'cac'

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -1,6 +1,5 @@
 import path from 'node:path'
 import fs from 'node:fs'
-import { performance } from 'node:perf_hooks'
 import { cac } from 'cac'
 import colors from 'picocolors'
 import type { BuildOptions } from './build'
@@ -9,6 +8,7 @@ import type { LogLevel } from './logger'
 import { createLogger } from './logger'
 import { VERSION } from './constants'
 import { bindShortcuts } from './shortcuts'
+import perf from './perf'
 import { resolveConfig } from '.'
 
 const cli = cac('vite')
@@ -29,6 +29,7 @@ interface GlobalCLIOptions {
   m?: string
   mode?: string
   force?: boolean
+  perf?: boolean
 }
 
 let profileSession = global.__vite_profile_session
@@ -139,6 +140,7 @@ cli
 
       const info = server.config.logger.info
 
+      perf.collect('startUp')
       const viteStartTime = global.__vite_start_time ?? false
       const startupDurationString = viteStartTime
         ? colors.dim(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -67,6 +67,7 @@ import { findNearestPackageData } from './packages'
 import { loadEnv, resolveEnvPrefix } from './env'
 import type { ResolvedSSROptions, SSROptions } from './ssr'
 import { resolveSSROptions } from './ssr'
+import perf from './perf'
 
 const debug = createDebugger('vite:config')
 
@@ -945,6 +946,7 @@ export async function loadConfigFromFile(
       bundled.code,
       isESM,
     )
+    perf.collect('loadConfig', start)
     debug?.(`bundled config file loaded in ${getTime()}`)
 
     const config = await (typeof userConfig === 'function'

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -14,6 +14,7 @@ export { buildErrorMessage } from './server/middlewares/error'
 export * from './publicUtils'
 
 // additional types
+export type { VitePerf, VitePerfMetric } from './perf'
 export type { FilterPattern } from './utils'
 export type { CorsOptions, CorsOrigin, CommonServerOptions } from './http'
 export type {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -28,6 +28,7 @@ import { transformWithEsbuild } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET } from '../constants'
 import { resolvePackageData } from '../packages'
 import type { ViteDevServer } from '../server'
+import perf from '../perf'
 import { esbuildCjsExternalPlugin, esbuildDepPlugin } from './esbuildDepPlugin'
 import { scanImports } from './scan'
 export {
@@ -641,7 +642,7 @@ export function runOptimizeDeps(
             }
           }
         }
-
+        perf.collect('prebundle', start)
         debug?.(
           `Dependencies bundled in ${(performance.now() - start).toFixed(2)}ms`,
         )

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -31,6 +31,7 @@ import {
 import type { PluginContainer } from '../server/pluginContainer'
 import { createPluginContainer } from '../server/pluginContainer'
 import { transformGlobImport } from '../plugins/importMetaGlob'
+import perf from '../perf'
 
 type ResolveIdOptions = Parameters<PluginContainer['resolveId']>[2]
 
@@ -140,6 +141,7 @@ export function scanImports(config: ResolvedConfig): {
       throw e
     })
     .finally(() => {
+      perf.collect('scan', start)
       if (debug) {
         const duration = (performance.now() - start).toFixed(2)
         const depsStr =

--- a/packages/vite/src/node/perf.ts
+++ b/packages/vite/src/node/perf.ts
@@ -15,7 +15,7 @@ interface Metric {
 export class VitePerf {
   mode: 'server' | 'build' = 'server'
   metric: Metric = {}
-  enabled: boolean = true
+  enabled: boolean = false
   middlewares: string[] = []
 
   collect(

--- a/packages/vite/src/node/perf.ts
+++ b/packages/vite/src/node/perf.ts
@@ -2,7 +2,7 @@ import { performance } from 'node:perf_hooks'
 import type { Connect } from 'dep-types/connect'
 import { removeTimestampQuery } from './utils'
 
-interface Metric {
+export interface VitePerfMetric {
   startUp?: number
   scan?: number
   prebundle?: number
@@ -12,11 +12,11 @@ interface Metric {
 }
 
 export class VitePerf {
-  metric: Metric = {}
+  metric: VitePerfMetric = {}
   enabled: boolean = false
 
   collect(
-    metric: keyof Metric | string,
+    metric: keyof VitePerfMetric | string,
     start = global.__vite_start_time,
     end?: number,
   ): void {
@@ -38,7 +38,7 @@ export class VitePerf {
         return obj[m]
       }, this.metric)
     } else {
-      ;(this.metric[metric as keyof Metric] as number) = duration
+      ;(this.metric[metric as keyof VitePerfMetric] as number) = duration
     }
   }
 

--- a/packages/vite/src/node/perf.ts
+++ b/packages/vite/src/node/perf.ts
@@ -4,7 +4,6 @@ import { removeTimestampQuery } from './utils'
 
 interface Metric {
   startUp?: number
-  built?: number
   scan?: number
   prebundle?: number
   loadConfig?: number
@@ -13,10 +12,8 @@ interface Metric {
 }
 
 export class VitePerf {
-  mode: 'server' | 'build' = 'server'
   metric: Metric = {}
   enabled: boolean = false
-  middlewares: string[] = []
 
   collect(
     metric: keyof Metric | string,
@@ -52,7 +49,6 @@ export class VitePerf {
     if (!this.enabled) {
       return middleware
     }
-    this.middlewares.push(name)
     return (req, res, next) => {
       const start = performance.now()
       const end = res.end

--- a/packages/vite/src/node/perf.ts
+++ b/packages/vite/src/node/perf.ts
@@ -1,0 +1,75 @@
+import { performance } from 'node:perf_hooks'
+import type { Connect } from 'dep-types/connect'
+import { removeTimestampQuery } from './utils'
+
+interface Metric {
+  startUp?: number
+  built?: number
+  scan?: number
+  prebundle?: number
+  loadConfig?: number
+  initTsconfck?: number
+  middleware?: Record<string, Record<string, number>>
+}
+
+export class VitePerf {
+  mode: 'server' | 'build' = 'server'
+  metric: Metric = {}
+  enabled: boolean = true
+  middlewares: string[] = []
+
+  collect(
+    metric: keyof Metric | string,
+    start = global.__vite_start_time,
+    end?: number,
+  ): void {
+    if (!this.enabled || !start) {
+      return
+    }
+
+    const duration = Math.ceil((end ?? performance.now()) - start)
+
+    if (metric.includes('::')) {
+      const paths = metric.split('::')
+      paths.reduce((obj: any, m, index) => {
+        if (index === paths.length - 1) {
+          obj[m] = duration
+        } else {
+          obj[m] ??= {}
+        }
+
+        return obj[m]
+      }, this.metric)
+    } else {
+      ;(this.metric[metric as keyof Metric] as number) = duration
+    }
+  }
+
+  collectMiddleware(
+    name: string,
+    middleware: Connect.NextHandleFunction,
+  ): Connect.NextHandleFunction {
+    if (!this.enabled) {
+      return middleware
+    }
+    this.middlewares.push(name)
+    return (req, res, next) => {
+      const start = performance.now()
+      const end = res.end
+      res.end = (...args: readonly [any, any?, any?]) => {
+        this.collect(
+          `middleware::${removeTimestampQuery(req.url!)}::${name}`,
+          start,
+        )
+        return end.call(res, ...args)
+      }
+      const perfNext = () => {
+        this.collect(`middleware::${req.url!}::${name}`, start)
+        next()
+      }
+      return middleware(req, res, perfNext)
+    }
+  }
+}
+
+export default new VitePerf()

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { performance } from 'node:perf_hooks'
 import colors from 'picocolors'
 import type {
   Loader,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -23,6 +23,7 @@ import {
 import type { ResolvedConfig, ViteDevServer } from '..'
 import type { Plugin } from '../plugin'
 import { searchForWorkspaceRoot } from '..'
+import perf from '../perf'
 
 const debug = createDebugger('vite:esbuild')
 
@@ -454,7 +455,7 @@ function initTSConfck(root: string, force = false) {
 }
 
 async function initTSConfckParseOptions(workspaceRoot: string) {
-  const start = debug ? performance.now() : 0
+  const start = performance.now()
 
   const options: TSConfckParseOptions = {
     cache: new Map(),
@@ -466,6 +467,8 @@ async function initTSConfckParseOptions(workspaceRoot: string) {
     ),
     resolveWithEmptyIfConfigNotFound: true,
   }
+
+  perf.collect('initTsconfck', start)
 
   debug?.(timeFrom(start), 'tsconfck init', colors.dim(workspaceRoot))
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -46,6 +46,8 @@ import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
 import { resolveChokidarOptions } from '../watch'
+import perf from '../perf'
+import type { VitePerf } from '../perf'
 import type { PluginContainer } from './pluginContainer'
 import { createPluginContainer } from './pluginContainer'
 import type { WebSocketServer } from './ws'
@@ -180,6 +182,10 @@ export type ServerHook = (
 ) => (() => void) | void | Promise<(() => void) | void>
 
 export interface ViteDevServer {
+  /**
+   * performance collector
+   */
+  perf: VitePerf
   /**
    * The resolved vite config object
    */
@@ -388,6 +394,7 @@ export async function _createServer(
 
   const server: ViteDevServer = {
     config,
+    perf,
     middlewares,
     httpServer,
     watcher,

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -1,6 +1,7 @@
 import type { Connect } from 'dep-types/connect'
 import type { ViteDevServer } from '..'
 import { joinUrlSegments, stripBase } from '../../utils'
+import perf from '../../perf'
 
 // this middleware is only active when (base !== '/')
 
@@ -8,45 +9,48 @@ export function baseMiddleware({
   config,
 }: ViteDevServer): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return function viteBaseMiddleware(req, res, next) {
-    const url = req.url!
-    const parsed = new URL(url, 'http://vitejs.dev')
-    const path = parsed.pathname || '/'
-    const base = config.rawBase
+  return perf.collectMiddleware(
+    'base',
+    function viteBaseMiddleware(req, res, next) {
+      const url = req.url!
+      const parsed = new URL(url, 'http://vitejs.dev')
+      const path = parsed.pathname || '/'
+      const base = config.rawBase
 
-    if (path.startsWith(base)) {
-      // rewrite url to remove base. this ensures that other middleware does
-      // not need to consider base being prepended or not
-      req.url = stripBase(url, base)
-      return next()
-    }
+      if (path.startsWith(base)) {
+        // rewrite url to remove base. this ensures that other middleware does
+        // not need to consider base being prepended or not
+        req.url = stripBase(url, base)
+        return next()
+      }
 
-    // skip redirect and error fallback on middleware mode, #4057
-    if (config.server.middlewareMode) {
-      return next()
-    }
+      // skip redirect and error fallback on middleware mode, #4057
+      if (config.server.middlewareMode) {
+        return next()
+      }
 
-    if (path === '/' || path === '/index.html') {
-      // redirect root visit to based url with search and hash
-      res.writeHead(302, {
-        Location: base + (parsed.search || '') + (parsed.hash || ''),
-      })
-      res.end()
-      return
-    } else if (req.headers.accept?.includes('text/html')) {
-      // non-based page visit
-      const redirectPath =
-        url + '/' !== base ? joinUrlSegments(base, url) : base
-      res.writeHead(404, {
-        'Content-Type': 'text/html',
-      })
-      res.end(
-        `The server is configured with a public base URL of ${base} - ` +
-          `did you mean to visit <a href="${redirectPath}">${redirectPath}</a> instead?`,
-      )
-      return
-    }
+      if (path === '/' || path === '/index.html') {
+        // redirect root visit to based url with search and hash
+        res.writeHead(302, {
+          Location: base + (parsed.search || '') + (parsed.hash || ''),
+        })
+        res.end()
+        return
+      } else if (req.headers.accept?.includes('text/html')) {
+        // non-based page visit
+        const redirectPath =
+          url + '/' !== base ? joinUrlSegments(base, url) : base
+        res.writeHead(404, {
+          'Content-Type': 'text/html',
+        })
+        res.end(
+          `The server is configured with a public base URL of ${base} - ` +
+            `did you mean to visit <a href="${redirectPath}">${redirectPath}</a> instead?`,
+        )
+        return
+      }
 
-    next()
-  }
+      next()
+    },
+  )
 }

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -9,48 +9,47 @@ export function baseMiddleware({
   config,
 }: ViteDevServer): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return perf.collectMiddleware(
-    'base',
-    function viteBaseMiddleware(req, res, next) {
-      const url = req.url!
-      const parsed = new URL(url, 'http://vitejs.dev')
-      const path = parsed.pathname || '/'
-      const base = config.rawBase
+  const viteBaseMiddleware: Connect.NextHandleFunction = (req, res, next) => {
+    const url = req.url!
+    const parsed = new URL(url, 'http://vitejs.dev')
+    const path = parsed.pathname || '/'
+    const base = config.rawBase
 
-      if (path.startsWith(base)) {
-        // rewrite url to remove base. this ensures that other middleware does
-        // not need to consider base being prepended or not
-        req.url = stripBase(url, base)
-        return next()
-      }
+    if (path.startsWith(base)) {
+      // rewrite url to remove base. this ensures that other middleware does
+      // not need to consider base being prepended or not
+      req.url = stripBase(url, base)
+      return next()
+    }
 
-      // skip redirect and error fallback on middleware mode, #4057
-      if (config.server.middlewareMode) {
-        return next()
-      }
+    // skip redirect and error fallback on middleware mode, #4057
+    if (config.server.middlewareMode) {
+      return next()
+    }
 
-      if (path === '/' || path === '/index.html') {
-        // redirect root visit to based url with search and hash
-        res.writeHead(302, {
-          Location: base + (parsed.search || '') + (parsed.hash || ''),
-        })
-        res.end()
-        return
-      } else if (req.headers.accept?.includes('text/html')) {
-        // non-based page visit
-        const redirectPath =
-          url + '/' !== base ? joinUrlSegments(base, url) : base
-        res.writeHead(404, {
-          'Content-Type': 'text/html',
-        })
-        res.end(
-          `The server is configured with a public base URL of ${base} - ` +
-            `did you mean to visit <a href="${redirectPath}">${redirectPath}</a> instead?`,
-        )
-        return
-      }
+    if (path === '/' || path === '/index.html') {
+      // redirect root visit to based url with search and hash
+      res.writeHead(302, {
+        Location: base + (parsed.search || '') + (parsed.hash || ''),
+      })
+      res.end()
+      return
+    } else if (req.headers.accept?.includes('text/html')) {
+      // non-based page visit
+      const redirectPath =
+        url + '/' !== base ? joinUrlSegments(base, url) : base
+      res.writeHead(404, {
+        'Content-Type': 'text/html',
+      })
+      res.end(
+        `The server is configured with a public base URL of ${base} - ` +
+          `did you mean to visit <a href="${redirectPath}">${redirectPath}</a> instead?`,
+      )
+      return
+    }
 
-      next()
-    },
-  )
+    next()
+  }
+
+  return perf.collectMiddleware('base', viteBaseMiddleware)
 }

--- a/packages/vite/src/node/server/middlewares/compression.ts
+++ b/packages/vite/src/node/server/middlewares/compression.ts
@@ -5,6 +5,7 @@
 // This is based on https://github.com/preactjs/wmr/blob/main/packages/wmr/src/lib/polkompress.js
 // MIT Licensed https://github.com/preactjs/wmr/blob/main/LICENSE
 import zlib from 'node:zlib'
+import perf from '../../perf'
 
 /* global Buffer */
 
@@ -25,7 +26,7 @@ export default function compression() {
   // disable Brotli on Node<12.7 where it is unsupported:
   if (!zlib.createBrotliCompress) brotli = false
 
-  return (req, res, next = noop) => {
+  return perf.collectMiddleware('compression', (req, res, next = noop) => {
     const accept = req.headers['accept-encoding'] + ''
     const encoding = ((brotli && accept.match(/\bbr\b/)) ||
       (gzip && accept.match(/\bgzip\b/)) ||
@@ -113,5 +114,5 @@ export default function compression() {
     }
 
     next()
-  }
+  })
 }

--- a/packages/vite/src/node/server/middlewares/compression.ts
+++ b/packages/vite/src/node/server/middlewares/compression.ts
@@ -26,7 +26,7 @@ export default function compression() {
   // disable Brotli on Node<12.7 where it is unsupported:
   if (!zlib.createBrotliCompress) brotli = false
 
-  return perf.collectMiddleware('compression', (req, res, next = noop) => {
+  const compressionMiddleware = (req, res, next = noop) => {
     const accept = req.headers['accept-encoding'] + ''
     const encoding = ((brotli && accept.match(/\bbr\b/)) ||
       (gzip && accept.match(/\bgzip\b/)) ||
@@ -114,5 +114,7 @@ export default function compression() {
     }
 
     next()
-  })
+  }
+
+  return perf.collectMiddleware('compression', compressionMiddleware)
 }

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -30,10 +30,13 @@ export function htmlFallbackMiddleware(
   })
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return perf.collectMiddleware(
-    'htmlFallback',
-    function viteHtmlFallbackMiddleware(req, res, next) {
-      return historyHtmlFallbackMiddleware(req, res, next)
-    },
-  )
+  const viteHtmlFallbackMiddleware: Connect.NextHandleFunction = (
+    req,
+    res,
+    next,
+  ) => {
+    return historyHtmlFallbackMiddleware(req, res, next)
+  }
+
+  return perf.collectMiddleware('htmlFallback', viteHtmlFallbackMiddleware)
 }

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import history from 'connect-history-api-fallback'
 import type { Connect } from 'dep-types/connect'
 import { createDebugger } from '../../utils'
+import perf from '../../perf'
 
 export function htmlFallbackMiddleware(
   root: string,
@@ -29,7 +30,10 @@ export function htmlFallbackMiddleware(
   })
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return function viteHtmlFallbackMiddleware(req, res, next) {
-    return historyHtmlFallbackMiddleware(req, res, next)
-  }
+  return perf.collectMiddleware(
+    'htmlFallback',
+    function viteHtmlFallbackMiddleware(req, res, next) {
+      return historyHtmlFallbackMiddleware(req, res, next)
+    },
+  )
 }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -36,6 +36,7 @@ import {
   ERR_OUTDATED_OPTIMIZED_DEP,
 } from '../../plugins/optimizedDeps'
 import { getDepsOptimizer } from '../../optimizer'
+import perf from '../../perf'
 
 const debugCache = createDebugger('vite:cache')
 
@@ -50,197 +51,200 @@ export function transformMiddleware(
   } = server
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return async function viteTransformMiddleware(req, res, next) {
-    if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
-      return next()
-    }
-
-    let url: string
-    try {
-      url = decodeURI(removeTimestampQuery(req.url!)).replace(
-        NULL_BYTE_PLACEHOLDER,
-        '\0',
-      )
-    } catch (e) {
-      return next(e)
-    }
-
-    const withoutQuery = cleanUrl(url)
-
-    try {
-      const isSourceMap = withoutQuery.endsWith('.map')
-      // since we generate source map references, handle those requests here
-      if (isSourceMap) {
-        const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
-        if (depsOptimizer?.isOptimizedDepUrl(url)) {
-          // If the browser is requesting a source map for an optimized dep, it
-          // means that the dependency has already been pre-bundled and loaded
-          const sourcemapPath = url.startsWith(FS_PREFIX)
-            ? fsPathFromId(url)
-            : normalizePath(path.resolve(root, url.slice(1)))
-          try {
-            const map = JSON.parse(
-              await fsp.readFile(sourcemapPath, 'utf-8'),
-            ) as ExistingRawSourceMap
-
-            applySourcemapIgnoreList(
-              map,
-              sourcemapPath,
-              server.config.server.sourcemapIgnoreList,
-              logger,
-            )
-
-            return send(req, res, JSON.stringify(map), 'json', {
-              headers: server.config.server.headers,
-            })
-          } catch (e) {
-            // Outdated source map request for optimized deps, this isn't an error
-            // but part of the normal flow when re-optimizing after missing deps
-            // Send back an empty source map so the browser doesn't issue warnings
-            const dummySourceMap = {
-              version: 3,
-              file: sourcemapPath.replace(/\.map$/, ''),
-              sources: [],
-              sourcesContent: [],
-              names: [],
-              mappings: ';;;;;;;;;',
-            }
-            return send(req, res, JSON.stringify(dummySourceMap), 'json', {
-              cacheControl: 'no-cache',
-              headers: server.config.server.headers,
-            })
-          }
-        } else {
-          const originalUrl = url.replace(/\.map($|\?)/, '$1')
-          const map = (await moduleGraph.getModuleByUrl(originalUrl, false))
-            ?.transformResult?.map
-          if (map) {
-            return send(req, res, JSON.stringify(map), 'json', {
-              headers: server.config.server.headers,
-            })
-          } else {
-            return next()
-          }
-        }
-      }
-
-      // check if public dir is inside root dir
-      const publicDir = normalizePath(server.config.publicDir)
-      const rootDir = normalizePath(server.config.root)
-      if (publicDir.startsWith(rootDir)) {
-        const publicPath = `${publicDir.slice(rootDir.length)}/`
-        // warn explicit public paths
-        if (url.startsWith(publicPath)) {
-          let warning: string
-
-          if (isImportRequest(url)) {
-            const rawUrl = removeImportQuery(url)
-
-            warning =
-              'Assets in public cannot be imported from JavaScript.\n' +
-              `Instead of ${colors.cyan(
-                rawUrl,
-              )}, put the file in the src directory, and use ${colors.cyan(
-                rawUrl.replace(publicPath, '/src/'),
-              )} instead.`
-          } else {
-            warning =
-              `files in the public directory are served at the root path.\n` +
-              `Instead of ${colors.cyan(url)}, use ${colors.cyan(
-                url.replace(publicPath, '/'),
-              )}.`
-          }
-
-          logger.warn(colors.yellow(warning))
-        }
-      }
-
-      if (
-        isJSRequest(url) ||
-        isImportRequest(url) ||
-        isCSSRequest(url) ||
-        isHTMLProxy(url)
-      ) {
-        // strip ?import
-        url = removeImportQuery(url)
-        // Strip valid id prefix. This is prepended to resolved Ids that are
-        // not valid browser import specifiers by the importAnalysis plugin.
-        url = unwrapId(url)
-
-        // for CSS, we need to differentiate between normal CSS requests and
-        // imports
-        if (
-          isCSSRequest(url) &&
-          !isDirectRequest(url) &&
-          req.headers.accept?.includes('text/css')
-        ) {
-          url = injectQuery(url, 'direct')
-        }
-
-        // check if we can return 304 early
-        const ifNoneMatch = req.headers['if-none-match']
-        if (
-          ifNoneMatch &&
-          (await moduleGraph.getModuleByUrl(url, false))?.transformResult
-            ?.etag === ifNoneMatch
-        ) {
-          debugCache?.(`[304] ${prettifyUrl(url, root)}`)
-          res.statusCode = 304
-          return res.end()
-        }
-
-        // resolve, load and transform using the plugin container
-        const result = await transformRequest(url, server, {
-          html: req.headers.accept?.includes('text/html'),
-        })
-        if (result) {
-          const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
-          const type = isDirectCSSRequest(url) ? 'css' : 'js'
-          const isDep =
-            DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
-          return send(req, res, result.code, type, {
-            etag: result.etag,
-            // allow browser to cache npm deps!
-            cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
-            headers: server.config.server.headers,
-            map: result.map,
-          })
-        }
-      }
-    } catch (e) {
-      if (e?.code === ERR_OPTIMIZE_DEPS_PROCESSING_ERROR) {
-        // Skip if response has already been sent
-        if (!res.writableEnded) {
-          res.statusCode = 504 // status code request timeout
-          res.statusMessage = 'Optimize Deps Processing Error'
-          res.end()
-        }
-        // This timeout is unexpected
-        logger.error(e.message)
-        return
-      }
-      if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
-        // Skip if response has already been sent
-        if (!res.writableEnded) {
-          res.statusCode = 504 // status code request timeout
-          res.statusMessage = 'Outdated Optimize Dep'
-          res.end()
-        }
-        // We don't need to log an error in this case, the request
-        // is outdated because new dependencies were discovered and
-        // the new pre-bundle dependencies have changed.
-        // A full-page reload has been issued, and these old requests
-        // can't be properly fulfilled. This isn't an unexpected
-        // error but a normal part of the missing deps discovery flow
-        return
-      }
-      if (e?.code === ERR_LOAD_URL) {
-        // Let other middleware handle if we can't load the url via transformRequest
+  return perf.collectMiddleware(
+    'transform',
+    async function viteTransformMiddleware(req, res, next) {
+      if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
         return next()
       }
-      return next(e)
-    }
 
-    next()
-  }
+      let url: string
+      try {
+        url = decodeURI(removeTimestampQuery(req.url!)).replace(
+          NULL_BYTE_PLACEHOLDER,
+          '\0',
+        )
+      } catch (e) {
+        return next(e)
+      }
+
+      const withoutQuery = cleanUrl(url)
+
+      try {
+        const isSourceMap = withoutQuery.endsWith('.map')
+        // since we generate source map references, handle those requests here
+        if (isSourceMap) {
+          const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
+          if (depsOptimizer?.isOptimizedDepUrl(url)) {
+            // If the browser is requesting a source map for an optimized dep, it
+            // means that the dependency has already been pre-bundled and loaded
+            const sourcemapPath = url.startsWith(FS_PREFIX)
+              ? fsPathFromId(url)
+              : normalizePath(path.resolve(root, url.slice(1)))
+            try {
+              const map = JSON.parse(
+                await fsp.readFile(sourcemapPath, 'utf-8'),
+              ) as ExistingRawSourceMap
+
+              applySourcemapIgnoreList(
+                map,
+                sourcemapPath,
+                server.config.server.sourcemapIgnoreList,
+                logger,
+              )
+
+              return send(req, res, JSON.stringify(map), 'json', {
+                headers: server.config.server.headers,
+              })
+            } catch (e) {
+              // Outdated source map request for optimized deps, this isn't an error
+              // but part of the normal flow when re-optimizing after missing deps
+              // Send back an empty source map so the browser doesn't issue warnings
+              const dummySourceMap = {
+                version: 3,
+                file: sourcemapPath.replace(/\.map$/, ''),
+                sources: [],
+                sourcesContent: [],
+                names: [],
+                mappings: ';;;;;;;;;',
+              }
+              return send(req, res, JSON.stringify(dummySourceMap), 'json', {
+                cacheControl: 'no-cache',
+                headers: server.config.server.headers,
+              })
+            }
+          } else {
+            const originalUrl = url.replace(/\.map($|\?)/, '$1')
+            const map = (await moduleGraph.getModuleByUrl(originalUrl, false))
+              ?.transformResult?.map
+            if (map) {
+              return send(req, res, JSON.stringify(map), 'json', {
+                headers: server.config.server.headers,
+              })
+            } else {
+              return next()
+            }
+          }
+        }
+
+        // check if public dir is inside root dir
+        const publicDir = normalizePath(server.config.publicDir)
+        const rootDir = normalizePath(server.config.root)
+        if (publicDir.startsWith(rootDir)) {
+          const publicPath = `${publicDir.slice(rootDir.length)}/`
+          // warn explicit public paths
+          if (url.startsWith(publicPath)) {
+            let warning: string
+
+            if (isImportRequest(url)) {
+              const rawUrl = removeImportQuery(url)
+
+              warning =
+                'Assets in public cannot be imported from JavaScript.\n' +
+                `Instead of ${colors.cyan(
+                  rawUrl,
+                )}, put the file in the src directory, and use ${colors.cyan(
+                  rawUrl.replace(publicPath, '/src/'),
+                )} instead.`
+            } else {
+              warning =
+                `files in the public directory are served at the root path.\n` +
+                `Instead of ${colors.cyan(url)}, use ${colors.cyan(
+                  url.replace(publicPath, '/'),
+                )}.`
+            }
+
+            logger.warn(colors.yellow(warning))
+          }
+        }
+
+        if (
+          isJSRequest(url) ||
+          isImportRequest(url) ||
+          isCSSRequest(url) ||
+          isHTMLProxy(url)
+        ) {
+          // strip ?import
+          url = removeImportQuery(url)
+          // Strip valid id prefix. This is prepended to resolved Ids that are
+          // not valid browser import specifiers by the importAnalysis plugin.
+          url = unwrapId(url)
+
+          // for CSS, we need to differentiate between normal CSS requests and
+          // imports
+          if (
+            isCSSRequest(url) &&
+            !isDirectRequest(url) &&
+            req.headers.accept?.includes('text/css')
+          ) {
+            url = injectQuery(url, 'direct')
+          }
+
+          // check if we can return 304 early
+          const ifNoneMatch = req.headers['if-none-match']
+          if (
+            ifNoneMatch &&
+            (await moduleGraph.getModuleByUrl(url, false))?.transformResult
+              ?.etag === ifNoneMatch
+          ) {
+            debugCache?.(`[304] ${prettifyUrl(url, root)}`)
+            res.statusCode = 304
+            return res.end()
+          }
+
+          // resolve, load and transform using the plugin container
+          const result = await transformRequest(url, server, {
+            html: req.headers.accept?.includes('text/html'),
+          })
+          if (result) {
+            const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
+            const type = isDirectCSSRequest(url) ? 'css' : 'js'
+            const isDep =
+              DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
+            return send(req, res, result.code, type, {
+              etag: result.etag,
+              // allow browser to cache npm deps!
+              cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
+              headers: server.config.server.headers,
+              map: result.map,
+            })
+          }
+        }
+      } catch (e) {
+        if (e?.code === ERR_OPTIMIZE_DEPS_PROCESSING_ERROR) {
+          // Skip if response has already been sent
+          if (!res.writableEnded) {
+            res.statusCode = 504 // status code request timeout
+            res.statusMessage = 'Optimize Deps Processing Error'
+            res.end()
+          }
+          // This timeout is unexpected
+          logger.error(e.message)
+          return
+        }
+        if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
+          // Skip if response has already been sent
+          if (!res.writableEnded) {
+            res.statusCode = 504 // status code request timeout
+            res.statusMessage = 'Outdated Optimize Dep'
+            res.end()
+          }
+          // We don't need to log an error in this case, the request
+          // is outdated because new dependencies were discovered and
+          // the new pre-bundle dependencies have changed.
+          // A full-page reload has been issued, and these old requests
+          // can't be properly fulfilled. This isn't an unexpected
+          // error but a normal part of the missing deps discovery flow
+          return
+        }
+        if (e?.code === ERR_LOAD_URL) {
+          // Let other middleware handle if we can't load the url via transformRequest
+          return next()
+        }
+        return next(e)
+      }
+
+      next()
+    },
+  )
 }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -51,200 +51,202 @@ export function transformMiddleware(
   } = server
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
-  return perf.collectMiddleware(
-    'transform',
-    async function viteTransformMiddleware(req, res, next) {
-      if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
-        return next()
-      }
+  const viteTransformMiddleware: Connect.NextHandleFunction = async (
+    req,
+    res,
+    next,
+  ) => {
+    if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
+      return next()
+    }
 
-      let url: string
-      try {
-        url = decodeURI(removeTimestampQuery(req.url!)).replace(
-          NULL_BYTE_PLACEHOLDER,
-          '\0',
-        )
-      } catch (e) {
-        return next(e)
-      }
+    let url: string
+    try {
+      url = decodeURI(removeTimestampQuery(req.url!)).replace(
+        NULL_BYTE_PLACEHOLDER,
+        '\0',
+      )
+    } catch (e) {
+      return next(e)
+    }
 
-      const withoutQuery = cleanUrl(url)
+    const withoutQuery = cleanUrl(url)
 
-      try {
-        const isSourceMap = withoutQuery.endsWith('.map')
-        // since we generate source map references, handle those requests here
-        if (isSourceMap) {
-          const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
-          if (depsOptimizer?.isOptimizedDepUrl(url)) {
-            // If the browser is requesting a source map for an optimized dep, it
-            // means that the dependency has already been pre-bundled and loaded
-            const sourcemapPath = url.startsWith(FS_PREFIX)
-              ? fsPathFromId(url)
-              : normalizePath(path.resolve(root, url.slice(1)))
-            try {
-              const map = JSON.parse(
-                await fsp.readFile(sourcemapPath, 'utf-8'),
-              ) as ExistingRawSourceMap
+    try {
+      const isSourceMap = withoutQuery.endsWith('.map')
+      // since we generate source map references, handle those requests here
+      if (isSourceMap) {
+        const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
+        if (depsOptimizer?.isOptimizedDepUrl(url)) {
+          // If the browser is requesting a source map for an optimized dep, it
+          // means that the dependency has already been pre-bundled and loaded
+          const sourcemapPath = url.startsWith(FS_PREFIX)
+            ? fsPathFromId(url)
+            : normalizePath(path.resolve(root, url.slice(1)))
+          try {
+            const map = JSON.parse(
+              await fsp.readFile(sourcemapPath, 'utf-8'),
+            ) as ExistingRawSourceMap
 
-              applySourcemapIgnoreList(
-                map,
-                sourcemapPath,
-                server.config.server.sourcemapIgnoreList,
-                logger,
-              )
+            applySourcemapIgnoreList(
+              map,
+              sourcemapPath,
+              server.config.server.sourcemapIgnoreList,
+              logger,
+            )
 
-              return send(req, res, JSON.stringify(map), 'json', {
-                headers: server.config.server.headers,
-              })
-            } catch (e) {
-              // Outdated source map request for optimized deps, this isn't an error
-              // but part of the normal flow when re-optimizing after missing deps
-              // Send back an empty source map so the browser doesn't issue warnings
-              const dummySourceMap = {
-                version: 3,
-                file: sourcemapPath.replace(/\.map$/, ''),
-                sources: [],
-                sourcesContent: [],
-                names: [],
-                mappings: ';;;;;;;;;',
-              }
-              return send(req, res, JSON.stringify(dummySourceMap), 'json', {
-                cacheControl: 'no-cache',
-                headers: server.config.server.headers,
-              })
-            }
-          } else {
-            const originalUrl = url.replace(/\.map($|\?)/, '$1')
-            const map = (await moduleGraph.getModuleByUrl(originalUrl, false))
-              ?.transformResult?.map
-            if (map) {
-              return send(req, res, JSON.stringify(map), 'json', {
-                headers: server.config.server.headers,
-              })
-            } else {
-              return next()
-            }
-          }
-        }
-
-        // check if public dir is inside root dir
-        const publicDir = normalizePath(server.config.publicDir)
-        const rootDir = normalizePath(server.config.root)
-        if (publicDir.startsWith(rootDir)) {
-          const publicPath = `${publicDir.slice(rootDir.length)}/`
-          // warn explicit public paths
-          if (url.startsWith(publicPath)) {
-            let warning: string
-
-            if (isImportRequest(url)) {
-              const rawUrl = removeImportQuery(url)
-
-              warning =
-                'Assets in public cannot be imported from JavaScript.\n' +
-                `Instead of ${colors.cyan(
-                  rawUrl,
-                )}, put the file in the src directory, and use ${colors.cyan(
-                  rawUrl.replace(publicPath, '/src/'),
-                )} instead.`
-            } else {
-              warning =
-                `files in the public directory are served at the root path.\n` +
-                `Instead of ${colors.cyan(url)}, use ${colors.cyan(
-                  url.replace(publicPath, '/'),
-                )}.`
-            }
-
-            logger.warn(colors.yellow(warning))
-          }
-        }
-
-        if (
-          isJSRequest(url) ||
-          isImportRequest(url) ||
-          isCSSRequest(url) ||
-          isHTMLProxy(url)
-        ) {
-          // strip ?import
-          url = removeImportQuery(url)
-          // Strip valid id prefix. This is prepended to resolved Ids that are
-          // not valid browser import specifiers by the importAnalysis plugin.
-          url = unwrapId(url)
-
-          // for CSS, we need to differentiate between normal CSS requests and
-          // imports
-          if (
-            isCSSRequest(url) &&
-            !isDirectRequest(url) &&
-            req.headers.accept?.includes('text/css')
-          ) {
-            url = injectQuery(url, 'direct')
-          }
-
-          // check if we can return 304 early
-          const ifNoneMatch = req.headers['if-none-match']
-          if (
-            ifNoneMatch &&
-            (await moduleGraph.getModuleByUrl(url, false))?.transformResult
-              ?.etag === ifNoneMatch
-          ) {
-            debugCache?.(`[304] ${prettifyUrl(url, root)}`)
-            res.statusCode = 304
-            return res.end()
-          }
-
-          // resolve, load and transform using the plugin container
-          const result = await transformRequest(url, server, {
-            html: req.headers.accept?.includes('text/html'),
-          })
-          if (result) {
-            const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
-            const type = isDirectCSSRequest(url) ? 'css' : 'js'
-            const isDep =
-              DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
-            return send(req, res, result.code, type, {
-              etag: result.etag,
-              // allow browser to cache npm deps!
-              cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
+            return send(req, res, JSON.stringify(map), 'json', {
               headers: server.config.server.headers,
-              map: result.map,
+            })
+          } catch (e) {
+            // Outdated source map request for optimized deps, this isn't an error
+            // but part of the normal flow when re-optimizing after missing deps
+            // Send back an empty source map so the browser doesn't issue warnings
+            const dummySourceMap = {
+              version: 3,
+              file: sourcemapPath.replace(/\.map$/, ''),
+              sources: [],
+              sourcesContent: [],
+              names: [],
+              mappings: ';;;;;;;;;',
+            }
+            return send(req, res, JSON.stringify(dummySourceMap), 'json', {
+              cacheControl: 'no-cache',
+              headers: server.config.server.headers,
             })
           }
-        }
-      } catch (e) {
-        if (e?.code === ERR_OPTIMIZE_DEPS_PROCESSING_ERROR) {
-          // Skip if response has already been sent
-          if (!res.writableEnded) {
-            res.statusCode = 504 // status code request timeout
-            res.statusMessage = 'Optimize Deps Processing Error'
-            res.end()
+        } else {
+          const originalUrl = url.replace(/\.map($|\?)/, '$1')
+          const map = (await moduleGraph.getModuleByUrl(originalUrl, false))
+            ?.transformResult?.map
+          if (map) {
+            return send(req, res, JSON.stringify(map), 'json', {
+              headers: server.config.server.headers,
+            })
+          } else {
+            return next()
           }
-          // This timeout is unexpected
-          logger.error(e.message)
-          return
         }
-        if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
-          // Skip if response has already been sent
-          if (!res.writableEnded) {
-            res.statusCode = 504 // status code request timeout
-            res.statusMessage = 'Outdated Optimize Dep'
-            res.end()
-          }
-          // We don't need to log an error in this case, the request
-          // is outdated because new dependencies were discovered and
-          // the new pre-bundle dependencies have changed.
-          // A full-page reload has been issued, and these old requests
-          // can't be properly fulfilled. This isn't an unexpected
-          // error but a normal part of the missing deps discovery flow
-          return
-        }
-        if (e?.code === ERR_LOAD_URL) {
-          // Let other middleware handle if we can't load the url via transformRequest
-          return next()
-        }
-        return next(e)
       }
 
-      next()
-    },
-  )
+      // check if public dir is inside root dir
+      const publicDir = normalizePath(server.config.publicDir)
+      const rootDir = normalizePath(server.config.root)
+      if (publicDir.startsWith(rootDir)) {
+        const publicPath = `${publicDir.slice(rootDir.length)}/`
+        // warn explicit public paths
+        if (url.startsWith(publicPath)) {
+          let warning: string
+
+          if (isImportRequest(url)) {
+            const rawUrl = removeImportQuery(url)
+
+            warning =
+              'Assets in public cannot be imported from JavaScript.\n' +
+              `Instead of ${colors.cyan(
+                rawUrl,
+              )}, put the file in the src directory, and use ${colors.cyan(
+                rawUrl.replace(publicPath, '/src/'),
+              )} instead.`
+          } else {
+            warning =
+              `files in the public directory are served at the root path.\n` +
+              `Instead of ${colors.cyan(url)}, use ${colors.cyan(
+                url.replace(publicPath, '/'),
+              )}.`
+          }
+
+          logger.warn(colors.yellow(warning))
+        }
+      }
+
+      if (
+        isJSRequest(url) ||
+        isImportRequest(url) ||
+        isCSSRequest(url) ||
+        isHTMLProxy(url)
+      ) {
+        // strip ?import
+        url = removeImportQuery(url)
+        // Strip valid id prefix. This is prepended to resolved Ids that are
+        // not valid browser import specifiers by the importAnalysis plugin.
+        url = unwrapId(url)
+
+        // for CSS, we need to differentiate between normal CSS requests and
+        // imports
+        if (
+          isCSSRequest(url) &&
+          !isDirectRequest(url) &&
+          req.headers.accept?.includes('text/css')
+        ) {
+          url = injectQuery(url, 'direct')
+        }
+
+        // check if we can return 304 early
+        const ifNoneMatch = req.headers['if-none-match']
+        if (
+          ifNoneMatch &&
+          (await moduleGraph.getModuleByUrl(url, false))?.transformResult
+            ?.etag === ifNoneMatch
+        ) {
+          debugCache?.(`[304] ${prettifyUrl(url, root)}`)
+          res.statusCode = 304
+          return res.end()
+        }
+
+        // resolve, load and transform using the plugin container
+        const result = await transformRequest(url, server, {
+          html: req.headers.accept?.includes('text/html'),
+        })
+        if (result) {
+          const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr
+          const type = isDirectCSSRequest(url) ? 'css' : 'js'
+          const isDep =
+            DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
+          return send(req, res, result.code, type, {
+            etag: result.etag,
+            // allow browser to cache npm deps!
+            cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
+            headers: server.config.server.headers,
+            map: result.map,
+          })
+        }
+      }
+    } catch (e) {
+      if (e?.code === ERR_OPTIMIZE_DEPS_PROCESSING_ERROR) {
+        // Skip if response has already been sent
+        if (!res.writableEnded) {
+          res.statusCode = 504 // status code request timeout
+          res.statusMessage = 'Optimize Deps Processing Error'
+          res.end()
+        }
+        // This timeout is unexpected
+        logger.error(e.message)
+        return
+      }
+      if (e?.code === ERR_OUTDATED_OPTIMIZED_DEP) {
+        // Skip if response has already been sent
+        if (!res.writableEnded) {
+          res.statusCode = 504 // status code request timeout
+          res.statusMessage = 'Outdated Optimize Dep'
+          res.end()
+        }
+        // We don't need to log an error in this case, the request
+        // is outdated because new dependencies were discovered and
+        // the new pre-bundle dependencies have changed.
+        // A full-page reload has been issued, and these old requests
+        // can't be properly fulfilled. This isn't an unexpected
+        // error but a normal part of the missing deps discovery flow
+        return
+      }
+      if (e?.code === ERR_LOAD_URL) {
+        // Let other middleware handle if we can't load the url via transformRequest
+        return next()
+      }
+      return next(e)
+    }
+
+    next()
+  }
+  return perf.collectMiddleware('transform', viteTransformMiddleware)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR exposes a API `server.perf` to collect vite dev server's perfs includes:

- config and tsconfck load time
- server start up time
- dependencies pre-bundle and scan time
- middleware handle request time

Also there will be a new server option `--perf` to control the perf  feature is enabled.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
