### PR TITLE
perf: avoid side effects resolving in dev and in the optimizer/scanner

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -594,6 +594,7 @@ export async function resolveConfig(
                 preferRelative: false,
                 tryIndex: true,
                 ...options,
+                idOnly: true,
               }),
             ],
           }))

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -314,12 +314,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
       // external
       if (isExternalUrl(id)) {
-        return options.idOnly
-          ? id
-          : {
-              id,
-              external: true,
-            }
+        return options.idOnly ? id : { id, external: true }
       }
 
       // data uri: pass through (this only happens during build and will be
@@ -391,12 +386,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
               this.error(message)
             }
 
-            return options.idOnly
-              ? id
-              : {
-                  id,
-                  external: true,
-                }
+            return options.idOnly ? id : { id, external: true }
           } else {
             if (!asSrc) {
               debug?.(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -274,6 +274,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
           // hints so the non-used code is properly tree-shaken during build time.
           if (
             !options.idOnly &&
+            !options.scan &&
             options.isBuild &&
             !importer?.endsWith('.html')
           ) {
@@ -788,7 +789,10 @@ export function tryNodeResolve(
     return { ...resolved, id: resolvedId, external: true }
   }
 
-  if (!options.idOnly && ((isBuild && !depsOptimizer) || externalize)) {
+  if (
+    !options.idOnly &&
+    ((!options.scan && isBuild && !depsOptimizer) || externalize)
+  ) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return processResult({
@@ -868,7 +872,7 @@ export function tryNodeResolve(
     resolved = depsOptimizer!.getOptimizedDepId(optimizedInfo)
   }
 
-  if (!options.idOnly && isBuild) {
+  if (!options.idOnly && !options.scan && isBuild) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return {
@@ -1229,7 +1233,7 @@ function tryResolveBrowserMapping(
         if (options.idOnly) {
           return result
         }
-        if (options.isBuild) {
+        if (!options.scan && options.isBuild) {
           const resPkg = findNearestPackageData(
             path.dirname(res),
             options.packageCache,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -115,6 +115,13 @@ export interface InternalResolveOptions extends Required<ResolveOptions> {
   // Resolve using esbuild deps optimization
   getDepsOptimizer?: (ssr: boolean) => DepsOptimizer | undefined
   shouldExternalize?: (id: string) => boolean | undefined
+
+  /**
+   * Set by createResolver, we only care about the resolved id. moduleSideEffects
+   * and other fields are discarded so we can avoid computing them.
+   * @internal
+   */
+  idOnly?: boolean
 }
 
 export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
@@ -266,7 +273,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
           // If this isn't a script imported from a .html file, include side effects
           // hints so the non-used code is properly tree-shaken during build time.
           if (
-            !options.scan &&
+            !options.idOnly &&
             options.isBuild &&
             !importer?.endsWith('.html')
           ) {
@@ -306,10 +313,12 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
       // external
       if (isExternalUrl(id)) {
-        return {
-          id,
-          external: true,
-        }
+        return options.idOnly
+          ? id
+          : {
+              id,
+              external: true,
+            }
       }
 
       // data uri: pass through (this only happens during build and will be
@@ -381,10 +390,12 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
               this.error(message)
             }
 
-            return {
-              id,
-              external: true,
-            }
+            return options.idOnly
+              ? id
+              : {
+                  id,
+                  external: true,
+                }
           } else {
             if (!asSrc) {
               debug?.(
@@ -777,7 +788,7 @@ export function tryNodeResolve(
     return { ...resolved, id: resolvedId, external: true }
   }
 
-  if ((!options.scan && isBuild && !depsOptimizer) || externalize) {
+  if (!options.idOnly && ((isBuild && !depsOptimizer) || externalize)) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return processResult({
@@ -857,7 +868,7 @@ export function tryNodeResolve(
     resolved = depsOptimizer!.getOptimizedDepId(optimizedInfo)
   }
 
-  if (!options.scan && isBuild) {
+  if (!options.idOnly && isBuild) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return {
@@ -1215,7 +1226,10 @@ function tryResolveBrowserMapping(
       ) {
         debug?.(`[browser mapped] ${colors.cyan(id)} -> ${colors.dim(res)}`)
         let result: PartialResolvedId = { id: res }
-        if (!options.scan && options.isBuild) {
+        if (options.idOnly) {
+          return result
+        }
+        if (options.isBuild) {
           const resPkg = findNearestPackageData(
             path.dirname(res),
             options.packageCache,


### PR DESCRIPTION
### Description

We already had some `isBuild` checks but they weren't in all the places we resolved side effects. I think we should also avoid resolving side effects during deps optimization (both in the scanner and in esbuild).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other