### PR TITLE
docs: yarn link and outdated dependencies

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -121,6 +121,12 @@ See [Reason: CORS request not HTTP - HTTP | MDN](https://developer.mozilla.org/e
 
 You will need to access the file with `http` protocol. The easiest way to achieve this is to run `npx vite preview`.
 
+## Optimized Dependencies
+
+### Outdated pre-bundled deps when linking to a local package
+
+The hash key used to invalidate optimized dependencies depend on the package lock contents, the patches applied to dependencies, and the options in the Vite config file that affects bundling of node modules. This means that Vite will detect when a dependency is overriden using a feature as [pnpm overrides](https://pnpm.io/package_json#pnpmoverrides), and re-bundle your dependencies on the next server start. Vite won't invalidate the dependencies when you use a feature like [yarn link](https://classic.yarnpkg.com/lang/en/docs/cli/link/). In case you link a dependency, you'll need to force re-optimization on the next server start by using `vite --force`.
+
 ## Others
 
 ### Module externalized for browser compatibility

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -125,7 +125,7 @@ You will need to access the file with `http` protocol. The easiest way to achiev
 
 ### Outdated pre-bundled deps when linking to a local package
 
-The hash key used to invalidate optimized dependencies depend on the package lock contents, the patches applied to dependencies, and the options in the Vite config file that affects bundling of node modules. This means that Vite will detect when a dependency is overriden using a feature as [pnpm overrides](https://pnpm.io/package_json#pnpmoverrides), and re-bundle your dependencies on the next server start. Vite won't invalidate the dependencies when you use a feature like [yarn link](https://classic.yarnpkg.com/lang/en/docs/cli/link/). In case you link a dependency, you'll need to force re-optimization on the next server start by using `vite --force`.
+The hash key used to invalidate optimized dependencies depend on the package lock contents, the patches applied to dependencies, and the options in the Vite config file that affects the bundling of node modules. This means that Vite will detect when a dependency is overridden using a feature as [npm overrides](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#overrides), and re-bundle your dependencies on the next server start. Vite won't invalidate the dependencies when you use a feature like [npm link](https://docs.npmjs.com/cli/v9/commands/npm-link). In case you link or unlink a dependency, you'll need to force re-optimization on the next server start by using `vite --force`. We recommend using overrides instead, which are supported now by every package manager (see also [pnpm overrides](https://pnpm.io/package_json#pnpmoverrides) and [yarn resolutions](https://yarnpkg.com/configuration/manifest/#resolutions)).
 
 ## Others
 


### PR DESCRIPTION
Closes #6718

### Description

Reference https://github.com/vitejs/vite/issues/6718#issuecomment-1090376205

I don't think the complexity of supporting invalidating optimized deps after `yarn link` is justified. This PR adds a new troubleshooting section to explain this.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other