### PR TITLE
fix(css): resolve at import from dependency basedir

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -125,7 +125,7 @@ function createNodePlugins(
         // bundling the `resolve` dep.
         'postcss-import/index.js': {
           src: 'const resolveId = require("./lib/resolve-id")',
-          replacement: 'const resolveId = undefined',
+          replacement: 'const resolveId = (id) => id',
         },
       }),
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -929,6 +929,18 @@ async function compileCSS(
           if (resolved) {
             return path.resolve(resolved)
           }
+
+          // postcss-import falls back to `resolve` dep if this is unresolved,
+          // but we've shimmed to remove the `resolve` dep to cut on bundle size.
+          // warn here to provide a better error message.
+          if (!path.isAbsolute(id)) {
+            config.logger.error(
+              colors.red(
+                `Unable to resolve \`@import "${id}"\` from ${basedir}`,
+              ),
+            )
+          }
+
           return id
         },
         nameLayer(index) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -695,12 +695,11 @@ export function tryNodeResolve(
   let basedir: string
   if (dedupe?.includes(pkgId)) {
     basedir = root
-  } else if (
-    importer &&
-    path.isAbsolute(importer) &&
-    fs.existsSync(cleanUrl(importer))
-  ) {
+  } else if (importer && path.isAbsolute(importer)) {
     basedir = path.dirname(importer)
+    if (!fs.existsSync(basedir)) {
+      basedir = root
+    }
   } else {
     basedir = root
   }

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -297,6 +297,10 @@ test('@import dependency w/ sass export mapping', async () => {
   expect(await getColor('.css-dep-exports-sass')).toBe('orange')
 })
 
+test('@import dependency that @import another dependency', async () => {
+  expect(await getColor('.css-proxy-dep')).toBe('purple')
+})
+
 test('@import dependency w/out package scss', async () => {
   expect(await getColor('.sass-dep')).toBe('lavender')
 })

--- a/playground/css/css-proxy-dep-nested/index.css
+++ b/playground/css/css-proxy-dep-nested/index.css
@@ -1,0 +1,3 @@
+.css-proxy-dep {
+  color: purple;
+}

--- a/playground/css/css-proxy-dep-nested/package.json
+++ b/playground/css/css-proxy-dep-nested/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-css-proxy-dep-nested",
+  "private": true,
+  "version": "1.0.0",
+  "style": "index.css"
+}

--- a/playground/css/css-proxy-dep/index.css
+++ b/playground/css/css-proxy-dep/index.css
@@ -1,0 +1,1 @@
+@import '@vitejs/test-css-proxy-dep-nested';

--- a/playground/css/css-proxy-dep/package.json
+++ b/playground/css/css-proxy-dep/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-css-proxy-dep",
+  "private": true,
+  "version": "1.0.0",
+  "style": "index.css",
+  "dependencies": {
+    "@vitejs/test-css-proxy-dep-nested": "file:../css-proxy-dep-nested"
+  }
+}

--- a/playground/css/dep.css
+++ b/playground/css/dep.css
@@ -1,2 +1,3 @@
 @import '@vitejs/test-css-dep';
 @import '@vitejs/test-css-dep-exports';
+@import '@vitejs/test-css-proxy-dep';

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -140,6 +140,10 @@
     @import dependency w/ sass export mapping: this should be orange
   </p>
 
+  <p class="css-proxy-dep">
+    @import dependency that @import another dependency: this should be purple
+  </p>
+
   <p class="dir-dep">PostCSS dir-dependency: this should be grey</p>
   <p class="dir-dep-2">
     PostCSS dir-dependency (file 2): this should be grey too

--- a/playground/css/package.json
+++ b/playground/css/package.json
@@ -18,6 +18,7 @@
     "@vitejs/test-css-dep": "link:./css-dep",
     "@vitejs/test-css-dep-exports": "link:./css-dep-exports",
     "@vitejs/test-css-js-dep": "file:./css-js-dep",
+    "@vitejs/test-css-proxy-dep": "file:./css-proxy-dep",
     "fast-glob": "^3.2.12",
     "less": "^4.1.3",
     "postcss-nested": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,7 @@ importers:
       '@vitejs/test-css-dep': link:./css-dep
       '@vitejs/test-css-dep-exports': link:./css-dep-exports
       '@vitejs/test-css-js-dep': file:./css-js-dep
+      '@vitejs/test-css-proxy-dep': file:./css-proxy-dep
       fast-glob: ^3.2.12
       less: ^4.1.3
       postcss-nested: ^6.0.1
@@ -379,6 +380,7 @@ importers:
       '@vitejs/test-css-dep': link:css-dep
       '@vitejs/test-css-dep-exports': link:css-dep-exports
       '@vitejs/test-css-js-dep': file:playground/css/css-js-dep
+      '@vitejs/test-css-proxy-dep': file:playground/css/css-proxy-dep
       fast-glob: 3.2.12
       less: 4.1.3
       postcss-nested: 6.0.1
@@ -416,6 +418,15 @@ importers:
     specifiers: {}
 
   playground/css/css-js-dep:
+    specifiers: {}
+
+  playground/css/css-proxy-dep:
+    specifiers:
+      '@vitejs/test-css-proxy-dep-nested': file:../css-proxy-dep-nested
+    dependencies:
+      '@vitejs/test-css-proxy-dep-nested': file:playground/css/css-proxy-dep-nested
+
+  playground/css/css-proxy-dep-nested:
     specifiers: {}
 
   playground/css/pkg-dep:
@@ -10094,6 +10105,19 @@ packages:
     name: '@vitejs/test-css-js-dep'
     version: 1.0.0
     dev: true
+
+  file:playground/css/css-proxy-dep:
+    resolution: {directory: playground/css/css-proxy-dep, type: directory}
+    name: '@vitejs/test-css-proxy-dep'
+    version: 1.0.0
+    dependencies:
+      '@vitejs/test-css-proxy-dep-nested': file:playground/css/css-proxy-dep-nested
+    dev: true
+
+  file:playground/css/css-proxy-dep-nested:
+    resolution: {directory: playground/css/css-proxy-dep-nested, type: directory}
+    name: '@vitejs/test-css-proxy-dep-nested'
+    version: 1.0.0
 
   file:playground/define/commonjs-dep:
     resolution: {directory: playground/define/commonjs-dep, type: directory}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix https://github.com/vitejs/vite/issues/12795

Whenever we resolve a `@import`, respect `basedir` passed.

Previously, `basedir` is always the `root` because we append the importer with a `*`:

https://github.com/vitejs/vite/blob/a2b7a51eb09acf794b3696e448eb4839ef80a3c9/packages/vite/src/node/plugins/css.ts#L926

But we check the importer existence when resolving a `basedir`:

https://github.com/vitejs/vite/blob/a2b7a51eb09acf794b3696e448eb4839ef80a3c9/packages/vite/src/node/plugins/resolve.ts#L696-L706

Because the `*` always make this not exists, `basedir` is always `root`.

This PR fixes this.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
