### PR TITLE
fix(worker): return null for shouldTransformCachedModule

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -91,6 +91,10 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       startTime = Date.now()
     },
 
+    buildStart() {
+      transformedCount = 0
+    },
+
     buildEnd() {
       if (shouldLogInfo) {
         if (tty) {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -240,11 +240,12 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       }
     },
 
+    // @ts-expect-error return void to fallback to other plugins, even though
+    // the types doesn't allow it. https://github.com/rollup/rollup/pull/4932
     shouldTransformCachedModule({ id }) {
       if (isBuild && isWorkerQueryId(id) && config.build.watch) {
         return true
       }
-      return false
     },
 
     async transform(raw, id, options) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/12791

context: https://github.com/rollup/rollup/pull/4932

This should allow other plugin's `shouldTransformCachedModule` hook to run as well, preventing the hanging presumably caused by `plugin-commonjs`'s `shouldTransformCachedModule` hook.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
