### PR TITLE
fix: handle try-catch for fs promise when resolve https config

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -137,9 +137,7 @@ export async function resolveHttpsConfig(
 
 async function readFileIfExists(value?: string | Buffer | any[]) {
   if (typeof value === 'string') {
-    return fsp.readFile(path.resolve(value)).catch((e) => {
-      return value
-    })
+    return fsp.readFile(path.resolve(value)).catch(() => value)
   }
   return value
 }

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -137,11 +137,9 @@ export async function resolveHttpsConfig(
 
 async function readFileIfExists(value?: string | Buffer | any[]) {
   if (typeof value === 'string') {
-    try {
-      return fsp.readFile(path.resolve(value))
-    } catch (e) {
+    return fsp.readFile(path.resolve(value)).catch((e) => {
       return value
-    }
+    })
   }
   return value
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Since PR: #12553, it use fsp to replace fs.

And, in [http.ts](https://github.com/vitejs/vite/blob/ad358daad25933a487701c73a1d3ac3a671db1d1/packages/vite/src/node/http.ts#L140), the try-catch can't catch promise's error.

This makes that when these config maybe not a actual path (such as `@vitejs/plugin-basic-ssl`), it will throw an error and try-catch can NOT catch this error then http server start fail.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
