### PR TITLE
fix(resolve): use different importer check for css imports

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -695,11 +695,13 @@ export function tryNodeResolve(
   let basedir: string
   if (dedupe?.includes(pkgId)) {
     basedir = root
-  } else if (importer && path.isAbsolute(importer)) {
+  } else if (
+    importer &&
+    path.isAbsolute(importer) &&
+    // css processing appends `*` for importer
+    (importer[importer.length - 1] === '*' || fs.existsSync(cleanUrl(importer)))
+  ) {
     basedir = path.dirname(importer)
-    if (!fs.existsSync(basedir)) {
-      basedir = root
-    }
   } else {
     basedir = root
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This should fix the ecosystem CI failures using the vue jsx plugin. Alternative fix for https://github.com/vitejs/vite/pull/12796.

Previously, the checking method would convert `basedir` of `/__vue-jsx-ssr-register-helper` to `/`, which would always exist, causing issues. I've changed to check the trailing `*` specifically from CSS processing to handle the issue in the linked PR above instead.

CSS processing appends `*` because the tooling only provides the importer directory for resolving, which is an issue for the resolver as it expects a file.

I initially tried to avoid this, but I don't think there's another safer way besides hardcoding it.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
