### PR TITLE
feat: server.sourcemapRelativeSources config option

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -128,6 +128,14 @@ export interface ServerOptions extends CommonServerOptions {
     | false
     | ((sourcePath: string, sourcemapPath: string) => boolean)
   /**
+   * By default Vite uses relative paths against the sourcemap file in sourcemap sources as
+   * browser devtools expect this. In node, tools like Vitest aren't ready for this yet, so
+   * they can set this option to keep absolute paths as Vite had before 4.2. This option is
+   * marked as experimental, it may be removed in a future version once the ecosystem is ready.
+   * @experimental
+   */
+  sourcemapRelativeSources?: boolean
+  /**
    * Force dep pre-optimization regardless of whether deps have changed.
    *
    * @deprecated Use optimizeDeps.force instead, this option may be removed
@@ -770,6 +778,7 @@ export function resolveServerOptions(
 ): ResolvedServerOptions {
   const server: ResolvedServerOptions = {
     preTransformRequests: true,
+    sourcemapRelativeSources: true,
     ...(raw as Omit<ResolvedServerOptions, 'sourcemapIgnoreList'>),
     sourcemapIgnoreList:
       raw?.sourcemapIgnoreList === false

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -283,7 +283,7 @@ async function loadAndTransform(
       logger,
     )
 
-    if (path.isAbsolute(mod.file)) {
+    if (config.server.sourcemapRelativeSources && path.isAbsolute(mod.file)) {
       for (
         let sourcesIndex = 0;
         sourcesIndex < map.sources.length;


### PR DESCRIPTION
### Description

Reference https://github.com/vitejs/vite/pull/12079#issuecomment-1498766877

I agree with @bmeurer that it would be better if we use relative paths consistently and we review the cases that @sheremet-va is listing in the discussion. We should be able to infer the sourcemapPath every time we use relative paths.
The change was big for a minor though, and this may take some time, so I think it is a good idea we add a temporary escape hatch. This PR adds an experimental `server.sourcemapRelativeSources` option that defaults to true. Vitest (and others) can use this flag while we work on resolving the issues and we can review if the open can safely be removed in Vite 5.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other