### PR TITLE
fix(build): correctly handle warning ignore list

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -894,7 +894,7 @@ export function onRollupWarning(
       return
     }
 
-    if (!warningIgnoreList.includes(warning.code!)) {
+    if (warningIgnoreList.includes(warning.code!)) {
       return
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description


ref https://github.com/vitejs/vite/pull/12757

I think the condition check is inverted, otherwise we only log warnings that are [`CIRCULAR_DEPENDENCY`, `THIS_IS_UNDEFINED`]
