### PR TITLE
fix(optimizer): start optimizer after buildStart

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -27,7 +27,6 @@ import {
 import { transformWithEsbuild } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET } from '../constants'
 import { resolvePackageData } from '../packages'
-import type { ViteDevServer } from '../server'
 import { esbuildCjsExternalPlugin, esbuildDepPlugin } from './esbuildDepPlugin'
 import { scanImports } from './scan'
 export {
@@ -66,7 +65,6 @@ export interface DepsOptimizer {
   close: () => Promise<void>
 
   options: DepOptimizationOptions
-  server?: ViteDevServer
 }
 
 export interface DepOptimizationConfig {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -120,7 +120,6 @@ async function createDepsOptimizer(
     ensureFirstRun,
     close,
     options: getDepOptimizationConfig(config, ssr),
-    server,
   }
 
   depsOptimizerMap.set(config, depsOptimizer)
@@ -471,13 +470,13 @@ async function createDepsOptimizer(
   }
 
   function fullReload() {
-    if (depsOptimizer.server) {
+    if (server) {
       // Cached transform results have stale imports (resolved to
       // old locations) so they need to be invalidated before the page is
       // reloaded.
-      depsOptimizer.server.moduleGraph.invalidateAll()
+      server.moduleGraph.invalidateAll()
 
-      depsOptimizer.server.ws.send({
+      server.ws.send({
         type: 'full-reload',
         path: '*',
       })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Partial revert of https://github.com/vitejs/vite/pull/12593

As discussed, it's safer to init the optimizer after `buildStart` so that plugins are properly initialized before we start invoking the plugin hooks.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
