### PR TITLE
fix: correct vite config temporary name

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1093,7 +1093,7 @@ async function loadConfigFromBundledFile(
   if (isESM) {
     const fileBase = `${fileName}.timestamp-${Date.now()}-${Math.random()
       .toString(16)
-      .slice(2)})}`
+      .slice(2)}`
     const fileNameTmp = `${fileBase}.mjs`
     const fileUrl = `${pathToFileURL(fileBase)}.mjs`
     await fsp.writeFile(fileNameTmp, bundledCode)


### PR DESCRIPTION
tiny typo, the `)}` is a string that's accidentally added as a file name, e.g. `vite.config.ts.timestamp-1681225323623-b77fdface573)}.mjs`