### PR TITLE
perf: use async fs.realpath

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -565,7 +565,9 @@ export async function build(
 
   let bundle: RollupBuild | undefined
   try {
-    const buildOutputOptions = (output: OutputOptions = {}): OutputOptions => {
+    const buildOutputOptions = async (
+      output: OutputOptions = {},
+    ): Promise<OutputOptions> => {
       // @ts-expect-error See https://github.com/vitejs/vite/issues/5812#issuecomment-984345618
       if (output.output) {
         config.logger.warn(
@@ -637,10 +639,10 @@ export async function build(
 
     if (Array.isArray(outputs)) {
       for (const resolvedOutput of outputs) {
-        normalizedOutputs.push(buildOutputOptions(resolvedOutput))
+        normalizedOutputs.push(await buildOutputOptions(resolvedOutput))
       }
     } else {
-      normalizedOutputs.push(buildOutputOptions(outputs))
+      normalizedOutputs.push(await buildOutputOptions(outputs))
     }
 
     const outDirs = normalizedOutputs.map(({ dir }) => resolve(dir!))
@@ -934,7 +936,7 @@ async function cjsSsrResolveExternal(
     // no dev deps optimization data, do a fresh scan
     knownImports = await findKnownImports(config, false) // needs to use non-ssr
   }
-  const ssrExternals = cjsSsrResolveExternals(config, knownImports)
+  const ssrExternals = await cjsSsrResolveExternals(config, knownImports)
 
   return (id, parentId, isResolved) => {
     const isExternal = cjsShouldExternalizeForSSR(id, ssrExternals)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1030,11 +1030,13 @@ async function bundleConfigFile(
               }
 
               const isIdESM = isESM || kind === 'dynamic-import'
-              let idFsPath = tryNodeResolve(
-                id,
-                importer,
-                { ...options, isRequire: !isIdESM },
-                false,
+              let idFsPath = (
+                await tryNodeResolve(
+                  id,
+                  importer,
+                  { ...options, isRequire: !isIdESM },
+                  false,
+                )
               )?.id
               if (idFsPath && isIdESM) {
                 idFsPath = pathToFileURL(idFsPath).href

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -876,7 +876,7 @@ function createOptimizeDepsIncludeResolver(
     // 'foo > bar > baz' => 'foo > bar' & 'baz'
     const nestedRoot = id.substring(0, lastArrowIndex).trim()
     const nestedPath = id.substring(lastArrowIndex + 1).trim()
-    const basedir = nestedResolveBasedir(
+    const basedir = await nestedResolveBasedir(
       nestedRoot,
       config.root,
       config.resolve.preserveSymlinks,
@@ -888,14 +888,15 @@ function createOptimizeDepsIncludeResolver(
 /**
  * Continously resolve the basedir of packages separated by '>'
  */
-function nestedResolveBasedir(
+async function nestedResolveBasedir(
   id: string,
   basedir: string,
   preserveSymlinks = false,
 ) {
   const pkgs = id.split('>').map((pkg) => pkg.trim())
   for (const pkg of pkgs) {
-    basedir = resolvePackageData(pkg, basedir, preserveSymlinks)?.dir || basedir
+    basedir =
+      (await resolvePackageData(pkg, basedir, preserveSymlinks))?.dir || basedir
   }
   return basedir
 }

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { createRequire } from 'node:module'
-import { createFilter, isInNodeModules, safeRealpathSync } from './utils'
+import { createFilter, isInNodeModules, safeRealpath } from './utils'
 import type { Plugin } from './plugin'
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -48,12 +48,12 @@ function invalidatePackageData(
   })
 }
 
-export function resolvePackageData(
+export async function resolvePackageData(
   pkgName: string,
   basedir: string,
   preserveSymlinks = false,
   packageCache?: PackageCache,
-): PackageData | null {
+): Promise<PackageData | null> {
   if (pnp) {
     const cacheKey = getRpdCacheKey(pkgName, basedir, preserveSymlinks)
     if (packageCache?.has(cacheKey)) return packageCache.get(cacheKey)!
@@ -88,7 +88,7 @@ export function resolvePackageData(
     const pkg = path.join(basedir, 'node_modules', pkgName, 'package.json')
     try {
       if (fs.existsSync(pkg)) {
-        const pkgPath = preserveSymlinks ? pkg : safeRealpathSync(pkg)
+        const pkgPath = preserveSymlinks ? pkg : await safeRealpath(pkg)
         const pkgData = loadPackageData(pkgPath)
 
         if (packageCache) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -491,7 +491,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                 ) {
                   return
                 }
-              } else if (shouldExternalizeForSSR(specifier, config)) {
+              } else if (await shouldExternalizeForSSR(specifier, config)) {
                 return
               }
               if (isBuiltin(specifier)) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -659,18 +659,29 @@ async function tryResolveRealFile(
   file: string,
   preserveSymlinks: boolean,
 ): Promise<string | undefined> {
-  const stat = await tryStatSync(file)
+  const stat = tryStatSync(file)
   if (stat?.isFile()) return getRealPath(file, preserveSymlinks)
 }
 
+function tryFindRealFileWithExtensions(
+  filePath: string,
+  extensions: string[],
+): string | undefined {
+  for (const ext of extensions) {
+    const file = filePath + ext
+    if (tryStatSync(file)?.isFile()) {
+      return file
+    }
+  }
+}
 async function tryResolveRealFileWithExtensions(
   filePath: string,
   extensions: string[],
   preserveSymlinks: boolean,
 ): Promise<string | undefined> {
-  for (const ext of extensions) {
-    const res = await tryResolveRealFile(filePath + ext, preserveSymlinks)
-    if (res) return res
+  const file = tryFindRealFileWithExtensions(filePath, extensions)
+  if (file) {
+    return getRealPath(file, preserveSymlinks)
   }
 }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -886,6 +886,9 @@ async function updateCjsSsrExternals(server: ViteDevServer) {
         ...Object.keys(depsOptimizer.metadata.discovered),
       ]
     }
-    server._ssrExternals = cjsSsrResolveExternals(server.config, knownImports)
+    server._ssrExternals = await cjsSsrResolveExternals(
+      server.config,
+      knownImports,
+    )
   }
 }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -271,7 +271,7 @@ async function nodeImport(
   if (id.startsWith('node:') || id.startsWith('data:') || isBuiltin(id)) {
     url = id
   } else {
-    const resolved = tryNodeResolve(
+    const resolved = await tryNodeResolve(
       id,
       importer,
       // Non-external modules can import ESM-only modules, but only outside


### PR DESCRIPTION
### Description

Rework usage of `fs.realpathSync.native` to use `fsp.realPath` (same as the `.native` version).

Sending the PR for future reference, because I don't think it may be worth it. But good to know what is needed if we want to use an async function in the resolve plugin `resolveId`. 
I also tried to use async versions of `statSync` and `existsSync` but the results are slower because we can't use the `throwIfNoError` option.

Maybe it would be worth doing this if we find other places to convert to async in resolveId.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other