### PR TITLE
feat(build): warn dynamic import module with a static import alongside

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -115,7 +115,8 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       for (const id of chunk.moduleIds) {
         const module = this.getModuleInfo(id)
         if (!module) continue
-        // warn if a module is imported both dynamically and statically in a chunk
+        // When a dynamic importer shares a chunk with the imported module,
+        // warn that the dynamic imported module will not be moved to another chunk (#12850).
         if (module.importers.length && module.dynamicImporters.length) {
           for (const dynamicImporter of module.dynamicImporters) {
             if (chunk.moduleIds.includes(dynamicImporter)) {

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -118,26 +118,24 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
         // When a dynamic importer shares a chunk with the imported module,
         // warn that the dynamic imported module will not be moved to another chunk (#12850).
         if (module.importers.length && module.dynamicImporters.length) {
-          for (const dynamicImporter of module.dynamicImporters) {
-            // Filter out the intersection of dynamic importers and sibling modules in
-            // the same chunk. The intersecting dynamic importers' dynamic import is not
-            // expected to work. Note we're only detecting the direct ineffective
-            // dynamic import here.
-            if (chunk.moduleIds.includes(dynamicImporter)) {
-              this.warn(
-                `\n(!) ${
-                  module.id
-                } is dynamically imported by ${module.dynamicImporters
-                  .map((m) => m)
-                  .join(
-                    ', ',
-                  )} but also statically imported by ${module.importers
-                  .map((m) => m)
-                  .join(
-                    ', ',
-                  )}, dynamic import will not move module into another chunk.\n`,
-              )
-            }
+          // Filter out the intersection of dynamic importers and sibling modules in
+          // the same chunk. The intersecting dynamic importers' dynamic import is not
+          // expected to work. Note we're only detecting the direct ineffective
+          // dynamic import here.
+          if (
+            module.dynamicImporters.some((m) => chunk.moduleIds.includes(m))
+          ) {
+            this.warn(
+              `\n(!) ${
+                module.id
+              } is dynamically imported by ${module.dynamicImporters
+                .map((m) => m)
+                .join(', ')} but also statically imported by ${module.importers
+                .map((m) => m)
+                .join(
+                  ', ',
+                )}, dynamic import will not move module into another chunk.\n`,
+            )
           }
         }
       }

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -111,7 +111,24 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       compressedCount = 0
     },
 
-    renderChunk() {
+    renderChunk(code, chunk) {
+      for (const id of chunk.moduleIds) {
+        const module = this.getModuleInfo(id)
+        if (!module) continue
+        if (module.importers.length && module.dynamicImporters.length) {
+          this.warn(
+            `\n(!) ${
+              module.id
+            } is dynamically imported by ${module.dynamicImporters
+              .map((m) => m)
+              .join(', ')} but also statically imported by ${module.importers
+              .map((m) => m)
+              .join(
+                ', ',
+              )}, dynamic import will not move module into another chunk.\n`,
+          )
+        }
+      }
       chunkCount++
       if (shouldLogInfo) {
         if (!tty) {

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -115,20 +115,28 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       for (const id of chunk.moduleIds) {
         const module = this.getModuleInfo(id)
         if (!module) continue
+        // warn if a module is imported both dynamically and statically in a chunk
         if (module.importers.length && module.dynamicImporters.length) {
-          this.warn(
-            `\n(!) ${
-              module.id
-            } is dynamically imported by ${module.dynamicImporters
-              .map((m) => m)
-              .join(', ')} but also statically imported by ${module.importers
-              .map((m) => m)
-              .join(
-                ', ',
-              )}, dynamic import will not move module into another chunk.\n`,
-          )
+          for (const dynamicImporter of module.dynamicImporters) {
+            if (chunk.moduleIds.includes(dynamicImporter)) {
+              this.warn(
+                `\n(!) ${
+                  module.id
+                } is dynamically imported by ${module.dynamicImporters
+                  .map((m) => m)
+                  .join(
+                    ', ',
+                  )} but also statically imported by ${module.importers
+                  .map((m) => m)
+                  .join(
+                    ', ',
+                  )}, dynamic import will not move module into another chunk.\n`,
+              )
+            }
+          }
         }
       }
+
       chunkCount++
       if (shouldLogInfo) {
         if (!tty) {

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -119,6 +119,10 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
         // warn that the dynamic imported module will not be moved to another chunk (#12850).
         if (module.importers.length && module.dynamicImporters.length) {
           for (const dynamicImporter of module.dynamicImporters) {
+            // Filter out the intersection of dynamic importers and sibling modules in
+            // the same chunk. The intersecting dynamic importers' dynamic import is not
+            // expected to work. Note we're only detecting the direct ineffective
+            // dynamic import here.
             if (chunk.moduleIds.includes(dynamicImporter)) {
               this.warn(
                 `\n(!) ${

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -129,3 +129,14 @@ test('should work with load ../ and contain itself directory', async () => {
     true,
   )
 })
+
+test.runIf(isBuild)(
+  'should rollup warn when static and dynamic import a module in same chunk',
+  async () => {
+    await untilUpdated(
+      () => serverLogs.join('\n'),
+      'dynamic import will not move module into another chunk',
+      true,
+    )
+  },
+)

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -133,10 +133,18 @@ test('should work with load ../ and contain itself directory', async () => {
 test.runIf(isBuild)(
   'should rollup warn when static and dynamic import a module in same chunk',
   async () => {
-    await untilUpdated(
-      () => serverLogs.join('\n'),
+    const log = serverLogs.join('\n')
+    expect(log).toContain(
       'dynamic import will not move module into another chunk',
-      true,
+    )
+    expect(log).toMatch(
+      /\(!\).*\/dynamic-import\/files\/mxd\.js is dynamically imported by/,
+    )
+    expect(log).toMatch(
+      /\(!\).*\/dynamic-import\/files\/mxd\.json is dynamically imported by/,
+    )
+    expect(log).not.toMatch(
+      /\(!\).*\/dynamic-import\/nested\/shared\.js is dynamically imported by/,
     )
   },
 )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/12706. As @bluwy suggested, use rollup's warn to warn the ineffective dynamic import.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
