### PR TITLE
fix: build time deps optimization, and ensure single crawl end call

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -504,6 +504,11 @@ export function runOptimizeDeps(
     metadata,
     cancel: cleanUp,
     commit: async () => {
+      if (cleaned) {
+        throw new Error(
+          'Can not commit a Deps Optimization run as it was cancelled',
+        )
+      }
       // Ignore clean up requests after this point so the temp folder isn't deleted before
       // we finish commiting the new deps cache files to the deps folder
       committed = true

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -155,6 +155,8 @@ async function createDepsOptimizer(
   let enqueuedRerun: (() => void) | undefined
   let currentlyProcessing = false
 
+  let firstRunCalled = !!cachedMetadata
+
   // During build, we wait for every module to be scanned before resolving
   // optimized deps loading for rollup on each rebuild.
   // During dev, if this is a cold run, we wait for static imports discovered
@@ -163,8 +165,9 @@ async function createDepsOptimizer(
   // debounce strategy each time a new dep is discovered.
   // Initialized by resetRegisteredIds, called at buildStart
   let crawlEndFinder: CrawlEndFinder | undefined
-
-  let firstRunCalled = !!cachedMetadata
+  if (!isBuild && !cachedMetadata) {
+    crawlEndFinder = setupOnCrawlEnd(onCrawlEnd)
+  }
 
   let optimizationResult:
     | {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -771,15 +771,17 @@ function setupOnCrawlEnd(onCrawlEnd: () => void): {
       let resolve: () => void
       const waitUntilDone = new Promise<void>((_resolve) => {
         resolve = _resolve
-        registeredId.done().finally(() => resolve())
+        registeredId
+          .done()
+          .catch(() => {
+            // Ignore errors
+          })
+          .finally(() => resolve())
       })
       waitingOn.set(registeredId.id, () => resolve())
 
-      try {
-        await waitUntilDone
-      } finally {
-        waitingOn.delete(registeredId.id)
-      }
+      await waitUntilDone
+      waitingOn.delete(registeredId.id)
     })
 
     const afterLoad = () => {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -802,11 +802,8 @@ function setupOnCrawlEnd(onCrawlEnd: () => void): {
       }
     }
 
-    const results = await Promise.allSettled(donePromises)
-    if (
-      registeredIds.length > 0 ||
-      results.some((result) => result.status === 'rejected')
-    ) {
+    await Promise.allSettled(donePromises)
+    if (registeredIds.length > 0) {
       afterLoad()
     } else {
       setTimeout(afterLoad, runOptimizerIfIdleAfterMs)

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -693,16 +693,9 @@ async function createDepsOptimizer(
   }
 
   // Called during buildStart at build time, when build --watch is used.
-  // Once during dev mode.
   function resetRegisteredIds() {
     crawlEndFinder?.cancel()
     crawlEndFinder = setupOnCrawlEnd(onCrawlEnd)
-
-    // Cancel on-fly queued reruns. This shouldn't currently happen but makes
-    // the API of the optimizer more robust in case resetRegisteredIds wouldn't
-    // be called before the first request in dev mode
-    if (debounceProcessingHandle) clearTimeout(debounceProcessingHandle)
-    enqueuedRerun = undefined
   }
 
   function registerWorkersSource(id: string) {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -158,14 +158,14 @@ async function createDepsOptimizer(
   let firstRunCalled = !!cachedMetadata
 
   // During build, we wait for every module to be scanned before resolving
-  // optimized deps loading for rollup on each rebuild.
+  // optimized deps loading for rollup on each rebuild. It will be recreated
+  // after each buildStart.
   // During dev, if this is a cold run, we wait for static imports discovered
   // from the first request before resolving to minimize full page reloads.
   // On warm start or after the first optimization is run, we use a simpler
   // debounce strategy each time a new dep is discovered.
-  // Initialized by resetRegisteredIds, called at buildStart
   let crawlEndFinder: CrawlEndFinder | undefined
-  if (!isBuild && !cachedMetadata) {
+  if (isBuild || !cachedMetadata) {
     crawlEndFinder = setupOnCrawlEnd(onCrawlEnd)
   }
 

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -40,6 +40,14 @@ export async function resolvePlugins(
   const { modulePreload } = config.build
 
   return [
+    ...(isDepsOptimizerEnabled(config, false) ||
+    isDepsOptimizerEnabled(config, true)
+      ? [
+          isBuild
+            ? optimizedDepsBuildPlugin(config)
+            : optimizedDepsPlugin(config),
+        ]
+      : []),
     isWatch ? ensureWatchPlugin() : null,
     isBuild ? metadataPlugin() : null,
     watchPackageDataPlugin(config.packageCache),
@@ -50,14 +58,6 @@ export async function resolvePlugins(
     (typeof modulePreload === 'object' && modulePreload.polyfill)
       ? modulePreloadPolyfillPlugin(config)
       : null,
-    ...(isDepsOptimizerEnabled(config, false) ||
-    isDepsOptimizerEnabled(config, true)
-      ? [
-          isBuild
-            ? optimizedDepsBuildPlugin(config)
-            : optimizedDepsPlugin(config),
-        ]
-      : []),
     resolvePlugin({
       ...config.resolve,
       root: config.root,

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -86,12 +86,6 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:optimized-deps-build',
 
-    buildStart() {
-      if (!config.isWorker) {
-        getDepsOptimizer(config)?.resetRegisteredIds()
-      }
-    },
-
     resolveId(id, importer, { ssr }) {
       if (getDepsOptimizer(config, ssr)?.isOptimizedDepFile(id)) {
         return id

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -16,12 +16,6 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:optimized-deps',
 
-    buildStart() {
-      if (!config.isWorker) {
-        getDepsOptimizer(config)?.resetRegisteredIds()
-      }
-    },
-
     resolveId(id, source, { ssr }) {
       if (getDepsOptimizer(config, ssr)?.isOptimizedDepFile(id)) {
         return id
@@ -85,6 +79,12 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
 export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:optimized-deps-build',
+
+    buildStart() {
+      if (!config.isWorker) {
+        getDepsOptimizer(config)?.resetRegisteredIds()
+      }
+    },
 
     resolveId(id, importer, { ssr }) {
       if (getDepsOptimizer(config, ssr)?.isOptimizedDepFile(id)) {

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -77,31 +77,45 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
 }
 
 export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
+  let buildStartCalled = false
+
   return {
     name: 'vite:optimized-deps-build',
 
     buildStart() {
-      if (!config.isWorker) {
+      // Only reset the registered ids after a rebuild during build --watch
+      if (!config.isWorker && buildStartCalled) {
         getDepsOptimizer(config)?.resetRegisteredIds()
       }
+      buildStartCalled = true
     },
 
-    resolveId(id, importer, { ssr }) {
-      if (getDepsOptimizer(config, ssr)?.isOptimizedDepFile(id)) {
+    async resolveId(id, importer, options) {
+      const depsOptimizer = getDepsOptimizer(config)
+      if (!depsOptimizer) return
+
+      if (depsOptimizer.isOptimizedDepFile(id)) {
         return id
+      } else {
+        if (options?.custom?.['vite:pre-alias']) {
+          // Skip registering the id if it is being resolved from the pre-alias plugin
+          // When a optimized dep is aliased, we need to avoid waiting for it before optimizing
+          return
+        }
+        const resolved = await this.resolve(id, importer, {
+          ...options,
+          skipSelf: true,
+        })
+        if (resolved) {
+          depsOptimizer.delayDepsOptimizerUntil(resolved.id, async () => {
+            await this.load(resolved)
+          })
+        }
       }
     },
 
-    transform(_code, id, options) {
-      const ssr = options?.ssr === true
-      getDepsOptimizer(config, ssr)?.delayDepsOptimizerUntil(id, async () => {
-        await this.load({ id })
-      })
-    },
-
-    async load(id, options) {
-      const ssr = options?.ssr === true
-      const depsOptimizer = getDepsOptimizer(config, ssr)
+    async load(id) {
+      const depsOptimizer = getDepsOptimizer(config)
       if (!depsOptimizer?.isOptimizedDepFile(id)) {
         return
       }

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -16,6 +16,12 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:optimized-deps',
 
+    buildStart() {
+      if (!config.isWorker) {
+        getDepsOptimizer(config)?.resetRegisteredIds()
+      }
+    },
+
     resolveId(id, source, { ssr }) {
       if (getDepsOptimizer(config, ssr)?.isOptimizedDepFile(id)) {
         return id
@@ -82,8 +88,6 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
 
     buildStart() {
       if (!config.isWorker) {
-        // This will be run for the current active optimizer, during build
-        // it will be the SSR optimizer if config.build.ssr is defined
         getDepsOptimizer(config)?.resetRegisteredIds()
       }
     },

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -51,8 +51,9 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
           }
 
           const resolved = await this.resolve(id, importer, {
-            skipSelf: true,
             ...options,
+            custom: { ...options.custom, 'vite:pre-alias': true },
+            skipSelf: true,
           })
           if (resolved && !depsOptimizer.isOptimizedDepFile(resolved.id)) {
             const optimizeDeps = depsOptimizer.options

--- a/playground/worker/classic-shared-worker.js
+++ b/playground/worker/classic-shared-worker.js
@@ -1,5 +1,5 @@
 let base = `/${self.location.pathname.split('/')[1]}`
-if (base === `/worker-entries`) base = '' // relative base
+if (base.endsWith('.js') || base === `/worker-entries`) base = '' // for dev
 
 importScripts(`${base}/classic.js`)
 

--- a/playground/worker/classic-worker.js
+++ b/playground/worker/classic-worker.js
@@ -1,5 +1,5 @@
 let base = `/${self.location.pathname.split('/')[1]}`
-if (base === `/worker-entries`) base = '' // relative base
+if (base.endsWith('.js') || base === `/worker-entries`) base = '' // for dev
 
 importScripts(`${base}/classic.js`)
 


### PR DESCRIPTION
### Description

Fix regression introduced by:
- #12609

The awaited promise for registered ids that start a worker bundle process where there is an import for a dependency internally will not be resolved. So when `registerWorkersSource` is called, we need to stop waiting for it. This worked fine when we awaited one id at a time, but #12609 added a `Promise.allSettled` that could contain one of these ids. This PRs adds a new Promise indirection so we can resolve these ids promises and let the `allSettled` finish.

The PR also implements a potential fix for #12836, I think we may not need #12848 after this PR, still needs more testing. And a clean-up of the onCrawlEnd scheme, adding a way to cancel the current crawling.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other