### PR TITLE
test: relax tsconfig json load error regex

### DIFF
--- a/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
+++ b/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
@@ -14,7 +14,7 @@ describe.runIf(isBuild)('build', () => {
   test('should throw an error on build', () => {
     expect(serveError).toBeTruthy()
     expect(serveError.message).toMatch(
-      /^parsing .* failed: SyntaxError: Unexpected token \} in JSON at position \d+$/,
+      /^parsing .* failed: SyntaxError: Unexpected token/,
     )
     clearServeError() // got expected error, null it here so testsuite does not fail from rethrow in afterAll
   })
@@ -45,9 +45,7 @@ describe.runIf(isServe)('server', () => {
       return m[0].innerHTML
     })
     // use regex with variable filename and position values because they are different on win
-    expect(message).toMatch(
-      /^parsing .* failed: SyntaxError: Unexpected token \} in JSON at position \d+$/,
-    )
+    expect(message).toMatch(/^parsing .* failed: SyntaxError: Unexpected token/)
   })
 
   test('should reload when tsconfig is changed', async () => {

--- a/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
+++ b/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
@@ -10,12 +10,13 @@ import {
   untilUpdated,
 } from '~utils'
 
+const unexpectedTokenSyntaxErrorRE =
+  /^parsing .* failed: SyntaxError: Unexpected token.*\}.*/
+
 describe.runIf(isBuild)('build', () => {
   test('should throw an error on build', () => {
     expect(serveError).toBeTruthy()
-    expect(serveError.message).toMatch(
-      /^parsing .* failed: SyntaxError: Unexpected token/,
-    )
+    expect(serveError.message).toMatch(unexpectedTokenSyntaxErrorRE)
     clearServeError() // got expected error, null it here so testsuite does not fail from rethrow in afterAll
   })
 
@@ -45,7 +46,7 @@ describe.runIf(isServe)('server', () => {
       return m[0].innerHTML
     })
     // use regex with variable filename and position values because they are different on win
-    expect(message).toMatch(/^parsing .* failed: SyntaxError: Unexpected token/)
+    expect(message).toMatch(unexpectedTokenSyntaxErrorRE)
   })
 
   test('should reload when tsconfig is changed', async () => {


### PR DESCRIPTION
### Description

The error I get locally on M1 doesn't match the regex in the test
```
[vite] Internal server error: parsing /[path]/tsconfig-json-load-error/has-error/tsconfig.json failed: SyntaxError: Unexpected token '}', ..."Options":
}" is not valid JSON
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other