### PR TITLE
perf: parallelize await exportsData from depsInfo

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -711,23 +711,25 @@ async function prepareEsbuildOptimizerRun(
   const { plugins: pluginsFromConfig = [], ...esbuildOptions } =
     optimizeDeps?.esbuildOptions ?? {}
 
-  for (const id in depsInfo) {
-    const src = depsInfo[id].src!
-    const exportsData = await (depsInfo[id].exportsData ??
-      extractExportsData(src, config, ssr))
-    if (exportsData.jsxLoader && !esbuildOptions.loader?.['.js']) {
-      // Ensure that optimization won't fail by defaulting '.js' to the JSX parser.
-      // This is useful for packages such as Gatsby.
-      esbuildOptions.loader = {
-        '.js': 'jsx',
-        ...esbuildOptions.loader,
+  await Promise.all(
+    Object.keys(depsInfo).map(async (id) => {
+      const src = depsInfo[id].src!
+      const exportsData = await (depsInfo[id].exportsData ??
+        extractExportsData(src, config, ssr))
+      if (exportsData.jsxLoader && !esbuildOptions.loader?.['.js']) {
+        // Ensure that optimization won't fail by defaulting '.js' to the JSX parser.
+        // This is useful for packages such as Gatsby.
+        esbuildOptions.loader = {
+          '.js': 'jsx',
+          ...esbuildOptions.loader,
+        }
       }
-    }
-    const flatId = flattenId(id)
-    flatIdDeps[flatId] = src
-    idToExports[id] = exportsData
-    flatIdToExports[flatId] = exportsData
-  }
+      const flatId = flattenId(id)
+      flatIdDeps[flatId] = src
+      idToExports[id] = exportsData
+      flatIdToExports[flatId] = exportsData
+    }),
+  )
 
   if (optimizerContext.cancelled) return { context: undefined, idToExports }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

As the title described. IIUC, orders of keys in depsInfo does need to be sorted so they could be parallelized.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
