### PR TITLE
fix: broken middleware name

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -161,22 +161,24 @@ export async function preview(
 
   // static assets
   const headers = config.preview.headers
-  const assetServer = sirv(distDir, {
-    etag: true,
-    dev: true,
-    single: config.appType === 'spa',
-    setHeaders(res) {
-      if (headers) {
-        for (const name in headers) {
-          res.setHeader(name, headers[name]!)
+  const viteAssetMiddleware = (...args: readonly [any, any?, any?]) =>
+    sirv(distDir, {
+      etag: true,
+      dev: true,
+      single: config.appType === 'spa',
+      setHeaders(res) {
+        if (headers) {
+          for (const name in headers) {
+            res.setHeader(name, headers[name]!)
+          }
         }
-      }
-    },
-    shouldServe(filePath) {
-      return shouldServeFile(filePath, distDir)
-    },
-  })
-  app.use(previewBase, assetServer)
+      },
+      shouldServe(filePath) {
+        return shouldServeFile(filePath, distDir)
+      },
+    })(...args)
+
+  app.use(previewBase, viteAssetMiddleware)
 
   // apply post server hooks from plugins
   postHooks.forEach((fn) => fn && fn())

--- a/packages/vite/src/node/server/middlewares/compression.ts
+++ b/packages/vite/src/node/server/middlewares/compression.ts
@@ -25,7 +25,7 @@ export default function compression() {
   // disable Brotli on Node<12.7 where it is unsupported:
   if (!zlib.createBrotliCompress) brotli = false
 
-  return (req, res, next = noop) => {
+  return function viteCompressionMiddleware(req, res, next = noop) {
     const accept = req.headers['accept-encoding'] + ''
     const encoding = ((brotli && accept.match(/\bbr\b/)) ||
       (gzip && accept.match(/\bgzip\b/)) ||


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `compression` and `sirv` middlewares' names are broken when `DEBUG=connect:dispatcher`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
