### PR TITLE
fix(build): do not warn when URL in CSS is externalized

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -947,12 +947,12 @@ async function cjsSsrResolveExternal(
   }
 }
 
-function resolveUserExternal(
+export function resolveUserExternal(
   user: ExternalOption,
   id: string,
   parentId: string | undefined,
   isResolved: boolean,
-) {
+): boolean | null | void {
   if (typeof user === 'function') {
     return user(id, parentId, isResolved)
   } else if (Array.isArray(user)) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/10766.

Do not warn when a URL match externalized in `build.rollupOptions.external`. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
