### PR TITLE
fix: yarn pnp considerBuiltins

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -60,7 +60,9 @@ export function resolvePackageData(
 
     let pkg: string | null
     try {
-      pkg = pnp.resolveToUnqualified(pkgName, basedir)
+      pkg = pnp.resolveToUnqualified(pkgName, basedir, {
+        considerBuiltins: false,
+      })
     } catch {
       return null
     }


### PR DESCRIPTION
Fixes #12888

### Description

Regression introduced by https://github.com/vitejs/vite/pull/12441

See [`pnp.resolveToUnqualified` docs](https://yarnpkg.com/advanced/pnpapi#resolveunqualified). By default `considerBuiltins` is `true` and this call then fails to resolve `buffer` and `string_decoder` which are packages in the project.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other