### PR TITLE
refactor: remove unnecessary setUnresolvedUrlToModule, and update types

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -64,17 +64,11 @@ export class ModuleGraph {
   /**
    * @internal
    */
-  _unresolvedUrlToModuleMap = new Map<
-    string,
-    Promise<ModuleNode> | ModuleNode
-  >()
+  _unresolvedUrlToModuleMap = new Map<string, Promise<ModuleNode>>()
   /**
    * @internal
    */
-  _ssrUnresolvedUrlToModuleMap = new Map<
-    string,
-    Promise<ModuleNode> | ModuleNode
-  >()
+  _ssrUnresolvedUrlToModuleMap = new Map<string, Promise<ModuleNode>>()
 
   constructor(
     private resolveId: (
@@ -257,7 +251,7 @@ export class ModuleGraph {
   ): Promise<ModuleNode> {
     // Quick path, if we already have a module for this rawUrl (even without extension)
     rawUrl = removeImportQuery(removeTimestampQuery(rawUrl))
-    let mod = this._getUnresolvedUrlToModule(rawUrl, ssr)
+    let mod: Promise<ModuleNode> | ModuleNode | undefined = this._getUnresolvedUrlToModule(rawUrl, ssr)
     if (mod) {
       return mod
     }
@@ -287,7 +281,6 @@ export class ModuleGraph {
       else if (!this.urlToModuleMap.has(url)) {
         this.urlToModuleMap.set(url, mod)
       }
-      this._setUnresolvedUrlToModule(rawUrl, mod, ssr)
       return mod
     })()
 
@@ -341,7 +334,7 @@ export class ModuleGraph {
   _getUnresolvedUrlToModule(
     url: string,
     ssr?: boolean,
-  ): Promise<ModuleNode> | ModuleNode | undefined {
+  ): Promise<ModuleNode> | undefined {
     return (
       ssr ? this._ssrUnresolvedUrlToModuleMap : this._unresolvedUrlToModuleMap
     ).get(url)
@@ -351,7 +344,7 @@ export class ModuleGraph {
    */
   _setUnresolvedUrlToModule(
     url: string,
-    mod: Promise<ModuleNode> | ModuleNode,
+    mod: Promise<ModuleNode>,
     ssr?: boolean,
   ): void {
     ;(ssr


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

removed unnecessary `_setUnresolvedUrlToModule()`, and update a few of types.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
