### PR TITLE
fix(create-vite): fix h1 css selector in lit templates

### DIFF
--- a/packages/create-vite/template-lit-ts/src/my-element.ts
+++ b/packages/create-vite/template-lit-ts/src/my-element.ts
@@ -76,7 +76,7 @@ export class MyElement extends LitElement {
       color: #888;
     }
 
-    h1 {
+    ::slotted(h1) {
       font-size: 3.2em;
       line-height: 1.1;
     }

--- a/packages/create-vite/template-lit/src/my-element.js
+++ b/packages/create-vite/template-lit/src/my-element.js
@@ -92,11 +92,11 @@ export class MyElement extends LitElement {
         color: #535bf2;
       }
 
-      h1 {
+      ::slotted(h1) {
         font-size: 3.2em;
         line-height: 1.1;
       }
-
+      
       button {
         border-radius: 8px;
         border: 1px solid transparent;

--- a/packages/create-vite/template-lit/src/my-element.js
+++ b/packages/create-vite/template-lit/src/my-element.js
@@ -96,7 +96,7 @@ export class MyElement extends LitElement {
         font-size: 3.2em;
         line-height: 1.1;
       }
-      
+
       button {
         border-radius: 8px;
         border: 1px solid transparent;


### PR DESCRIPTION
### Description
This PR will go fix a css selector of h1 into slot tag from Lit template in JS and TS.

Fixes #12950 

The MDN Documentation say this:
[https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted](https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->
- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
