### PR TITLE
chore(create-vite): bump vue-tsc

### DIFF
--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -15,6 +15,6 @@
     "@vitejs/plugin-vue": "^4.1.0",
     "typescript": "^5.0.2",
     "vite": "^4.3.0",
-    "vue-tsc": "^1.2.0"
+    "vue-tsc": "^1.4.2"
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The default stackblitz vue-ts template (https://vite.new/vue-ts) has a lockfile that locks `vue-tsc` to 1.2.0 while with a 5.0 version of typescript. That could cause error when running `pnpm vue-tsc --watch` throw error even without any modification. vue-tsc is compatible with typescript 5.0 now at latest version. 

I have to upgrade it manually cause https://github.com/vitejs/vite/pull/12805 does not going to bump it. I don't know when it will, vue-tsc@1.2.1 is released 2 months ago. So I decide to bump it manually.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
