### PR TITLE
fix(legacy): import `@babel/preset-env`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@microsoft/api-extractor": "^7.34.4",
     "@rollup/plugin-typescript": "^11.0.0",
     "@types/babel__core": "^7.20.0",
+    "@types/babel__preset-env": "^7.9.2",
     "@types/babel__standalone": "^7.1.4",
     "@types/convert-source-map": "^2.0.0",
     "@types/cross-spawn": "^6.0.2",

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -438,7 +438,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
             }),
           ],
           [
-            '@babel/preset-env',
+            (await import('@babel/preset-env')).default,
             createBabelPresetEnvOptions(targets, {
               needPolyfills,
               ignoreBrowserslistConfig: options.ignoreBrowserslistConfig,
@@ -608,7 +608,7 @@ export async function detectPolyfills(
     configFile: false,
     presets: [
       [
-        '@babel/preset-env',
+        (await import('@babel/preset-env')).default,
         createBabelPresetEnvOptions(targets, {
           ignoreBrowserslistConfig: true,
         }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.0
         version: 7.20.0
+      '@types/babel__preset-env':
+        specifier: ^7.9.2
+        version: 7.9.2
       '@types/babel__standalone':
         specifier: ^7.1.4
         version: 7.1.4
@@ -3537,6 +3540,10 @@ packages:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
       '@babel/types': 7.21.3
+    dev: true
+
+  /@types/babel__preset-env@7.9.2:
+    resolution: {integrity: sha512-epEgKQiqTDZdPgYwtriYK1GVAGcyVZVvvw2UatX3+95mogKGimebApcMEWLF12uhUbNIvX284CSQEavnV/OIgw==}
     dev: true
 
   /@types/babel__standalone@7.1.4:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`@vitejs/plugin-legacy` specifies that Babel should use `@babel/preset-env` but doesn't specify where it should resolve it from so Babel defaults to `process.cwd()`, usually the current project, making it rely on hoisting.

This PR fixes that by dynamically importing `@babel/preset-env` and passing the result to Babel.

Alternatively one could use the Babel option `cwd` to make it resolve relative to `@vitejs/plugin-legacy` or use `require.resolve` to give Babel an absolute path to the preset.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
