### PR TITLE
fix: `esbuild.charset` not work with css plugin.

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1408,10 +1408,14 @@ async function doImportCSSReplace(
 
 async function minifyCSS(css: string, config: ResolvedConfig) {
   try {
+    const charset =
+      typeof config.esbuild === 'object' && config.esbuild?.charset
+        ? config.esbuild.charset
+        : 'utf8'
     const { code, warnings } = await transform(css, {
       loader: 'css',
       target: config.build.cssTarget || undefined,
-      charset: 'utf8',
+      charset,
       ...resolveEsbuildMinifyOptions(config.esbuild || {}),
     })
     if (warnings.length) {


### PR DESCRIPTION
### Description

Vite@4 has set the default config `esbuild.charset` to `utf8`, and in #12565 , the default configuration for `plugin:css` has also been set to `utf8`

This operation may lead to the generation of iconfont files being escaped, causing display errors in some cases. Although I can modify the `esbuild.charset` in `vite.config.ts`, it seems that the parameter is not passed to the `plugin:css`. I need to make it work.

### Additional context

This is the effect of using iconfont(css) after Vite 4.

![image](https://user-images.githubusercontent.com/6757303/234218586-240eee81-f0af-4658-837f-75628c3d5bce.png)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
