### PR TITLE
fix(worker): prevent load vite client

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -365,9 +365,11 @@ const sheetsMap = new Map<string, HTMLStyleElement>()
 
 // collect existing style elements that may have been inserted during SSR
 // to avoid FOUC or duplicate styles
-document.querySelectorAll('style[data-vite-dev-id]').forEach((el) => {
-  sheetsMap.set(el.getAttribute('data-vite-dev-id')!, el as HTMLStyleElement)
-})
+if ('document' in globalThis) {
+  document.querySelectorAll('style[data-vite-dev-id]').forEach((el) => {
+    sheetsMap.set(el.getAttribute('data-vite-dev-id')!, el as HTMLStyleElement)
+  })
+}
 
 // all css imports should be inserted at the same position
 // because after build it will be a single css file

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -591,22 +591,4 @@ export function createHotContext(ownerPath: string): ViteHotContext {
   return hot
 }
 
-/**
- * urls here are dynamic import() urls that couldn't be statically analyzed
- */
-export function injectQuery(url: string, queryToInject: string): string {
-  // skip urls that won't be handled by vite
-  if (url[0] !== '.' && url[0] !== '/') {
-    return url
-  }
-
-  // can't use pathname from URL since it may be relative like ../
-  const pathname = url.replace(/#.*$/, '').replace(/\?.*$/, '')
-  const { search, hash } = new URL(url, 'http://vitejs.dev')
-
-  return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
-    hash || ''
-  }`
-}
-
 export { ErrorOverlay }

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -135,6 +135,9 @@ code {
 const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
 const codeframeRE = /^(?:>?\s+\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
+// Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
+// `HTMLElement` was not originally defined.
+const { HTMLElement = class {} as typeof globalThis.HTMLElement } = globalThis
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot
 
@@ -205,6 +208,7 @@ export class ErrorOverlay extends HTMLElement {
 }
 
 export const overlayId = 'vite-error-overlay'
+const { customElements } = globalThis // Ensure `customElements` is defined before the next line.
 if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay)
 }

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -135,9 +135,6 @@ code {
 const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
 const codeframeRE = /^(?:>?\s+\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
-// Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
-// `HTMLElement` was not originally defined.
-const { HTMLElement = class {} as typeof globalThis.HTMLElement } = globalThis
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot
 
@@ -208,7 +205,6 @@ export class ErrorOverlay extends HTMLElement {
 }
 
 export const overlayId = 'vite-error-overlay'
-const { customElements } = globalThis // Ensure `customElements` is defined before the next line.
 if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay)
 }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -81,6 +81,7 @@ const cleanUpRawUrlRE = /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm
 const urlIsStringRE = /^(?:'.*'|".*"|`.*`)$/
 
 const importAnalysisHelperId = '\0vite/import-analysis-helper'
+const wrapppedImportAnalysisHelperId = wrapId(importAnalysisHelperId)
 
 /**
  * urls here are dynamic import() urls that couldn't be statically analyzed.
@@ -767,9 +768,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
       if (needQueryInjectHelper) {
         str().prepend(
-          `import { __vite__injectQuery } from "${wrapId(
-            importAnalysisHelperId,
-          )}";`,
+          `import { __vite__injectQuery } from "${wrapppedImportAnalysisHelperId}";`,
         )
       }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description


fix https://github.com/vitejs/vite/issues/12970

Make sure `__vite__injectQuery` util does not bring in `/@vite/client` in worker file context. This PR makes `__vite__injectQuery` it's own virtual module to prevent it.

~~I also reverted the worker guards introduce in #9064~~ (Preserve for now to not break things as they could still be loaded by HMR code)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
