### PR TITLE
feat: optimize deps option to turn off auto discovery

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -125,6 +125,18 @@ export interface DepOptimizationConfig {
    * @experimental
    */
   disabled?: boolean | 'build' | 'dev'
+  /**
+   * Automatic dependency discovery. When enabled, every dependency discovered
+   * while processing the user modules will be optimized if not `excluded`.
+   * Vite also scans the module graph on cold start using esbuild, speeding up
+   * the discovery process for modules reachable from `entries`.
+   * When `autoDiscovery` is disabled, only dependencies listed in `include` will
+   * be optimized. The scanner isn't run for cold start in this case. CJS-only
+   * dependencies must be present in `include` during dev.
+   * @default true
+   * @experimental
+   */
+  autoDiscovery?: boolean
 }
 
 export type DepOptimizationOptions = DepOptimizationConfig & {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -126,17 +126,13 @@ export interface DepOptimizationConfig {
    */
   disabled?: boolean | 'build' | 'dev'
   /**
-   * Automatic dependency discovery. When enabled, every dependency discovered
-   * while processing the user modules will be optimized if not `excluded`.
-   * Vite also scans the module graph on cold start using esbuild, speeding up
-   * the discovery process for modules reachable from `entries`.
-   * When `autoDiscovery` is disabled, only dependencies listed in `include` will
-   * be optimized. The scanner isn't run for cold start in this case. CJS-only
-   * dependencies must be present in `include` during dev.
-   * @default true
+   * Automatic dependency discovery. When `noDiscovery` is true, only dependencies
+   * listed in `include` will be optimized. The scanner isn't run for cold start
+   * in this case. CJS-only dependencies must be present in `include` during dev.
+   * @default false
    * @experimental
    */
-  autoDiscovery?: boolean
+  noDiscovery?: boolean
 }
 
 export type DepOptimizationOptions = DepOptimizationConfig & {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -217,7 +217,11 @@ async function createDepsOptimizer(
       newDepsDiscovered = true
     }
 
-    if (!isBuild) {
+    if (!config.optimizeDeps.autoDiscovery) {
+      // We don't need to scan for dependencies or wait for the static crawl to end
+      // Run the first optimization run immediately
+      runOptimizer()
+    } else if (!isBuild) {
       // Important, the scanner is dev only
       depsOptimizer.scanProcessing = new Promise((resolve) => {
         // Runs in the background in case blocking high priority tasks

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -217,7 +217,7 @@ async function createDepsOptimizer(
       newDepsDiscovered = true
     }
 
-    if (!config.optimizeDeps.autoDiscovery) {
+    if (config.optimizeDeps.noDiscovery) {
       // We don't need to scan for dependencies or wait for the static crawl to end
       // Run the first optimization run immediately
       runOptimizer()

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -49,7 +49,9 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
           if (optimizedId) {
             return optimizedId // aliased dep already optimized
           }
-
+          if (!depsOptimizer.options.autoDiscovery) {
+            return
+          }
           const resolved = await this.resolve(id, importer, {
             ...options,
             custom: { ...options.custom, 'vite:pre-alias': true },

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -49,7 +49,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
           if (optimizedId) {
             return optimizedId // aliased dep already optimized
           }
-          if (!depsOptimizer.options.autoDiscovery) {
+          if (depsOptimizer.options.noDiscovery) {
             return
           }
           const resolved = await this.resolve(id, importer, {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -816,7 +816,7 @@ export function tryNodeResolve(
   }
 
   const skipOptimization =
-    !depsOptimizer?.options.autoDiscovery ||
+    depsOptimizer?.options.noDiscovery ||
     !isJsType ||
     (importer && isInNodeModules(importer)) ||
     exclude?.includes(pkgId) ||

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -816,6 +816,7 @@ export function tryNodeResolve(
   }
 
   const skipOptimization =
+    !depsOptimizer?.options.autoDiscovery ||
     !isJsType ||
     (importer && isInNodeModules(importer)) ||
     exclude?.includes(pkgId) ||

--- a/playground/optimize-deps-no-discovery/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps-no-discovery/__tests__/optimize-deps.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from 'vitest'
+import { isBuild, page, readFile } from '~utils'
+
+test('optimized dep', async () => {
+  expect(await page.textContent('.optimized-dep')).toBe('[success]')
+})
+
+test('vue + vuex', async () => {
+  expect(await page.textContent('.vue')).toMatch(`[success]`)
+})
+
+test.runIf(!isBuild)('metadata', async () => {
+  const meta = await readFile('node_modules/.vite/deps/_metadata.json')
+  expect(meta).toMatch(`"@vitejs/test-dep-no-discovery"`)
+  expect(meta).not.toMatch(`"vue"`)
+  expect(meta).not.toMatch(`"vuex"`)
+})

--- a/playground/optimize-deps-no-discovery/dep-no-discovery/index.js
+++ b/playground/optimize-deps-no-discovery/dep-no-discovery/index.js
@@ -1,0 +1,2 @@
+// written in cjs, optimization should convert this to esm
+module.exports = '[success]'

--- a/playground/optimize-deps-no-discovery/dep-no-discovery/package.json
+++ b/playground/optimize-deps-no-discovery/dep-no-discovery/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-dep-no-discovery",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/playground/optimize-deps-no-discovery/index.html
+++ b/playground/optimize-deps-no-discovery/index.html
@@ -1,0 +1,24 @@
+<h1>Optimize Deps</h1>
+
+<h2>Optimized Dep</h2>
+<div class="optimized-dep"></div>
+
+<h2>Vue & Vuex</h2>
+<div class="vue"></div>
+
+<script>
+  function text(el, text) {
+    document.querySelector(el).textContent = text
+  }
+</script>
+
+<script type="module">
+  import msg from '@vitejs/test-dep-no-discovery'
+  text('.optimized-dep', msg)
+
+  import { createApp } from 'vue'
+  import { createStore } from 'vuex'
+  if (typeof createApp === 'function' && typeof createStore === 'function') {
+    text('.vue', '[success]')
+  }
+</script>

--- a/playground/optimize-deps-no-discovery/package.json
+++ b/playground/optimize-deps-no-discovery/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@vitejs/test-optimize-deps-no-discovery",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@vitejs/test-dep-no-discovery": "file:./dep-no-discovery",
+    "vue": "^3.2.47",
+    "vuex": "^4.1.0"
+  }
+}

--- a/playground/optimize-deps-no-discovery/vite.config.js
+++ b/playground/optimize-deps-no-discovery/vite.config.js
@@ -6,7 +6,7 @@ process.env.NODE_ENV = ''
 export default defineConfig({
   optimizeDeps: {
     disabled: false,
-    autoDiscovery: false,
+    noDiscovery: true,
     include: ['@vitejs/test-dep-no-discovery'],
   },
 

--- a/playground/optimize-deps-no-discovery/vite.config.js
+++ b/playground/optimize-deps-no-discovery/vite.config.js
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vite'
+
+// Overriding the NODE_ENV set by vitest
+process.env.NODE_ENV = ''
+
+export default defineConfig({
+  optimizeDeps: {
+    disabled: false,
+    autoDiscovery: false,
+    include: ['@vitejs/test-dep-no-discovery'],
+  },
+
+  build: {
+    // to make tests faster
+    minify: false,
+    // Avoid @rollup/plugin-commonjs
+    commonjsOptions: {
+      include: [],
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,6 +862,20 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(vue@3.2.47)
 
+  playground/optimize-deps-no-discovery:
+    dependencies:
+      '@vitejs/test-dep-no-discovery':
+        specifier: file:./dep-no-discovery
+        version: file:playground/optimize-deps-no-discovery/dep-no-discovery
+      vue:
+        specifier: ^3.2.47
+        version: 3.2.47
+      vuex:
+        specifier: ^4.1.0
+        version: 4.1.0(vue@3.2.47)
+
+  playground/optimize-deps-no-discovery/dep-no-discovery: {}
+
   playground/optimize-deps/added-in-entries: {}
 
   playground/optimize-deps/dep-alias-using-absolute-path:
@@ -3935,17 +3949,12 @@ packages:
       '@vue/compiler-dom': 3.2.47
       '@vue/shared': 3.2.47
 
-  /@vue/devtools-api@6.4.4:
-    resolution: {integrity: sha512-Ku31WzpOV/8cruFaXaEZKF81WkNnvCSlBY4eOGtz5WMSdJvX1v1WWlSMGZeqUwPtQ27ZZz7B62erEMq8JDjcXw==}
-    dev: false
-
   /@vue/devtools-api@6.4.5:
     resolution: {integrity: sha512-JD5fcdIuFxU4fQyXUu3w2KpAJHzTVdN+p4iOX2lMWSHMOoQdMAcpFLZzm9Z/2nmsoZ1a96QEhZ26e50xLBsgOQ==}
     dev: false
 
   /@vue/devtools-api@6.5.0:
     resolution: {integrity: sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q==}
-    dev: true
 
   /@vue/reactivity-transform@3.2.47:
     resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
@@ -9980,7 +9989,7 @@ packages:
     peerDependencies:
       vue: ^3.2.0
     dependencies:
-      '@vue/devtools-api': 6.4.4
+      '@vue/devtools-api': 6.5.0
       vue: 3.2.47
     dev: false
 
@@ -10292,6 +10301,12 @@ packages:
     name: '@vitejs/test-json-module'
     version: 0.0.0
     dev: true
+
+  file:playground/optimize-deps-no-discovery/dep-no-discovery:
+    resolution: {directory: playground/optimize-deps-no-discovery/dep-no-discovery, type: directory}
+    name: '@vitejs/test-dep-no-discovery'
+    version: 1.0.0
+    dev: false
 
   file:playground/optimize-deps/added-in-entries:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}


### PR DESCRIPTION
### Description

Edit: I ended up renaming it to `noDiscovery`.

Adds a new experimental boolean option `optimizeDeps.noDiscovery`, defaulting to `true`
```js
  /*
   * Automatic dependency discovery. When `noDiscovery` is true, only dependencies 
   * listed in `include` will be optimized. The scanner isn't run for cold start 
   * in this case. CJS-only dependencies must be present in `include` during dev.
   * @default false
   * @experimental
   */
  noDiscovery?: boolean
```

@sheremet-va is exploring replacing [Vitest `deps.inline`](https://vitest.dev/config/#deps-inline) feature with Vite's deps optimization. To make this work, they need auto-discovery of dependencies to be turned off. They would like to have full control of what dependencies get optimized using `optimizeDeps.include`. We should also merge https://github.com/vitejs/vite/pull/12414 to add glob support to `optimizeDeps.include`

Some other options we evaluated [in this gist](https://gist.github.com/patak-dev/0c2c1b445b02509c6398d50549ef8e75).

Edit: scratch the next paragraph, as it simplified the logic to rename at the end.
@bluwy also proposed we use `noDiscovery` instead of `autoDiscovery` so we can have the option be false by default. I think this is a good idea in general but in this case, I find it a bit more confusing. @bluwy I checked and we have a lot of boolean options that default to true. `preTransformRequests` for example. Let's see what others think.

It is experimental because @sheremet-va will need to play with this and we may end up changing this feature later. I think we could move forward so they can check what we are missing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other