### PR TITLE
feat: add file size for code chunk in manifest

### DIFF
--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -12,6 +12,7 @@ export type Manifest = Record<string, ManifestChunk>
 export interface ManifestChunk {
   src?: string
   file: string
+  size?: number
   css?: string[]
   assets?: string[]
   isEntry?: boolean
@@ -66,6 +67,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
       function createChunk(chunk: OutputChunk): ManifestChunk {
         const manifestChunk: ManifestChunk = {
           file: chunk.fileName,
+          size: chunk.code.length,
         }
 
         if (chunk.facadeModuleId) {


### PR DESCRIPTION
### Description

If you can to have an overview of what you are generating (comparing chunk and stuff) 
manifest file is pretty usefull.... but it could be more usefull if we had the code size at hand.
Since it's really not a big deal to add, we can really make use of it.

### Additional context

---

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
