### PR TITLE
fix(server): should respect hmr port when middlewareMode=false

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -675,6 +675,8 @@ export async function _createServer(
     const listen = httpServer.listen.bind(httpServer)
     httpServer.listen = (async (port: number, ...args: any[]) => {
       try {
+        // ensure ws server started
+        ws.listen()
         await initServer()
       } catch (e) {
         httpServer.emit('error', e)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #12964
refs #12734

### Additional context

There are server init & restart steps below:

(1) create new vite-server instance
(2) new vite-server listening
(3) close old vite-server


(4) create new ws-server instance
(5) new ws-server listening
(6) close old ws-server 

After this PR and #12734, (vite-server & ws-server)'s init  and restart flows become:

 **`middlewareMode=false`, sharing vite-server**

- init flow: (4) (1)  (2)
- restart flow: (4) (1)  (3) (2)

 **`middlewareMode=false`, splitting vite-server & ws-server**

- init flow: (4) (1)  (5) (2)
- restart flow: (4) (1)  (6) (3) (5) (2)

 **`middlewareMode=true`**

- init flow: (4) (5) (1) 
- restart flow: (4) (1) (6) (5)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->



<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
