### PR TITLE
fix: use consistent virtual module ID in module graph

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -34,7 +34,6 @@ import {
   isExternalUrl,
   isInNodeModules,
   isJSRequest,
-  isVirtualModule,
   joinUrlSegments,
   moduleListContains,
   normalizePath,
@@ -282,9 +281,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const importedBindings = enablePartialAccept
         ? new Map<string, Set<string>>()
         : null
-      const toAbsoluteUrl = (url: string) => {
-        return path.posix.resolve(path.posix.dirname(importerModule.url), url)
-      }
+      const toAbsoluteUrl = (url: string) =>
+        path.posix.resolve(path.posix.dirname(importerModule.url), url)
 
       const normalizeUrl = async (
         url: string,
@@ -743,8 +741,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // normalize and rewrite accepted urls
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
+        const isRelative = url[0] === '.'
         const [normalized] = await moduleGraph.resolveUrl(
-          isVirtualModule(url) ? url : toAbsoluteUrl(url),
+          isRelative ? toAbsoluteUrl(url) : url,
           ssr,
         )
         normalizedAcceptedUrls.add(normalized)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -34,6 +34,7 @@ import {
   isExternalUrl,
   isInNodeModules,
   isJSRequest,
+  isVirtualModule,
   joinUrlSegments,
   moduleListContains,
   normalizePath,
@@ -281,8 +282,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const importedBindings = enablePartialAccept
         ? new Map<string, Set<string>>()
         : null
-      const toAbsoluteUrl = (url: string) =>
-        path.posix.resolve(path.posix.dirname(importerModule.url), url)
+      const toAbsoluteUrl = (url: string) => {
+        return path.posix.resolve(path.posix.dirname(importerModule.url), url)
+      }
 
       const normalizeUrl = async (
         url: string,
@@ -742,7 +744,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
         const [normalized] = await moduleGraph.resolveUrl(
-          toAbsoluteUrl(url),
+          isVirtualModule(url) ? url : toAbsoluteUrl(url),
           ssr,
         )
         normalizedAcceptedUrls.add(normalized)

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -25,6 +25,7 @@ import type { ModuleNode } from '../server/moduleGraph'
 import type { ResolvedConfig } from '../config'
 import {
   evalValue,
+  isVirtualModule,
   normalizePath,
   slash,
   transformStableResult,
@@ -628,9 +629,4 @@ export function getCommonBase(globsResolved: string[]): null | string {
   if (!commonAncestor) commonAncestor = '/'
 
   return commonAncestor
-}
-
-export function isVirtualModule(id: string): boolean {
-  // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
-  return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
 }

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -25,7 +25,6 @@ import type { ModuleNode } from '../server/moduleGraph'
 import type { ResolvedConfig } from '../config'
 import {
   evalValue,
-  isVirtualModule,
   normalizePath,
   slash,
   transformStableResult,
@@ -355,7 +354,7 @@ export async function transformGlobImport(
 ): Promise<TransformGlobImportResult | null> {
   id = slash(id)
   root = slash(root)
-  const isVirtual = isVirtualModule(id)
+  const isVirtual = !isAbsolute(id)
   const dir = isVirtual ? undefined : dirname(id)
   const matches = await parseImportGlob(
     code,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1214,3 +1214,8 @@ const escapeRegexRE = /[-/\\^$*+?.()|[\]{}]/g
 export function escapeRegex(str: string): string {
   return str.replace(escapeRegexRE, '\\$&')
 }
+
+export function isVirtualModule(id: string): boolean {
+  // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
+  return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
+}

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1214,8 +1214,3 @@ const escapeRegexRE = /[-/\\^$*+?.()|[\]{}]/g
 export function escapeRegex(str: string): string {
   return str.replace(escapeRegexRE, '\\$&')
 }
-
-export function isVirtualModule(id: string): boolean {
-  // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
-  return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
-}

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -9,6 +9,7 @@ import {
   removeFile,
   untilBrowserLogAfter,
   untilUpdated,
+  viteServer,
   viteTestUrl,
 } from '~utils'
 
@@ -670,6 +671,14 @@ if (!isBuild) {
     await page.waitForNavigation()
     btn = await page.$('button')
     expect(await btn.textContent()).toBe('Compteur 0')
+  })
+
+  test('virtual module in module graph', async () => {
+    const moduleGraph = viteServer.moduleGraph
+    const virtualId = Array.from(moduleGraph.idToModuleMap.keys()).filter(
+      (id: string) => id.includes('virtual'),
+    )
+    expect(virtualId).toEqual(['\x00virtual:file', '/@id/__x00__virtual:file'])
   })
 
   test('handle virtual module updates', async () => {

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -42,6 +42,13 @@ if (import.meta.hot) {
     handleDep('multi deps', foo, nestedFoo)
   })
 
+  import.meta.hot.accept(
+    ['virtual:file', '/@id/__x00__virtual:file'],
+    ([rawVirtualPath, acceptedVirtualPath]) => {
+      text('.virtual', acceptedVirtualPath.virtual)
+    },
+  )
+
   import.meta.hot.dispose(() => {
     console.log(`foo was:`, foo)
   })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When investigating https://github.com/vitejs/vite/issues/12912, I found that when accepting `virtual:my-plugin:foo` like below

```ts
import.meta.hot.accept(['virtual:my-plugin:foo'], { /** code */ })
```

This will lead to adding a `/src/virtual:my-plugin:foo` generated by the following code to the module graph, however, IIUC, virtual module's URL should not be calculated with the importer. 

https://github.com/vitejs/vite/blob/229c5925c8c84709b8e06e8092a255cb820dafc9/packages/vite/src/node/plugins/importAnalysis.ts#L744-L747

---

In this PR, the test case is modified to only update the virtual module as below.

```ts
import.meta.hot.accept(
    ['virtual:file', '/@id/__x00__virtual:file'],
```

To fix #12912 ideally, we shall only use `'virtual:file'` but the HMR dilemma now is like this:

- `acceptedPath` send to the client is `"/@id/__x00__virtual:file"`
- the `acceptedPath` defined in `main.js` must include `"/@id/__x00__virtual:file"` to receive the update.

I'm not sure what's the best way to fix this, but I think it's straightforward to avoid assembling URL for virtual file with the importer in this PR. Looking forward to some feedback 🙌.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
