### PR TITLE
fix: set Content-Type when serving .wasm files

### DIFF
--- a/packages/vite/src/node/server/send.ts
+++ b/packages/vite/src/node/server/send.ts
@@ -12,6 +12,7 @@ const alias: Record<string, string | undefined> = {
   css: 'text/css',
   html: 'text/html',
   json: 'application/json',
+  wasm: 'application/wasm',
 }
 
 export interface SendOptions {


### PR DESCRIPTION
### Description

I'm running into the same issue as https://github.com/mycelial/mycelial-js/issues/25. It seems the vite dev-server doesn't serve .wasm files with the `application/wasm` Content-Type, so `WebAssembly.instantiateStreaming` doesn't work.

In https://github.com/mycelial/mycelial-js/issues/25#issuecomment-1209464719 the author suggests either patching over this or contributing a fix back to Vite, but I guess they ended up doing the former.

### Additional context

I assume this change does the trick but I haven't tested it 😄  I'd like to add a test but I don't know how.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
