### PR TITLE
fix: unwrapId and pass ssr flag when adding to moduleGraph in this.load

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -76,6 +76,7 @@ import {
   numberToPos,
   prettifyUrl,
   timeFrom,
+  unwrapId,
 } from '../utils'
 import { FS_PREFIX } from '../constants'
 import type { ResolvedConfig } from '../config'
@@ -313,7 +314,7 @@ export async function createPluginContainer(
       } & Partial<PartialNull<ModuleOptions>>,
     ): Promise<ModuleInfo> {
       // We may not have added this to our module graph yet, so ensure it exists
-      await moduleGraph?.ensureEntryFromUrl(options.id)
+      await moduleGraph?.ensureEntryFromUrl(unwrapId(options.id), this.ssr)
       // Not all options passed to this function make sense in the context of loading individual files,
       // but we can at least update the module info properties we support
       updateModuleInfo(options.id, options)


### PR DESCRIPTION
### Description

Found while checking #13030. It may be a possible cause of the issue if Playwright started using the `this.load` function with virtual modules in dev mode.

We should do the same as we are doing here:
- [in import-analysis](https://github.com/vitejs/vite/blob/21dd28dd648b6d043eaad2f31efdd379e5134635/packages/vite/src/node/plugins/importAnalysis.ts#L389)
- [in transformRequest](https://github.com/vitejs/vite/blob/21dd28dd648b6d043eaad2f31efdd379e5134635/packages/vite/src/node/server/transformRequest.ts#LL246C3-L246C3)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other