### PR TITLE
fix(ssr): ignore __esModule for ssrExportAll

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -189,7 +189,7 @@ async function instantiateModule(
 
   function ssrExportAll(sourceModule: any) {
     for (const key in sourceModule) {
-      if (key !== 'default') {
+      if (key !== 'default' && key !== '__esModule') {
         Object.defineProperty(ssrModule, key, {
           enumerable: true,
           configurable: true,


### PR DESCRIPTION
Ignores the __esModule property when building up the SSR module

### Description

Currently `ssrExportAll` copies all properties, except for `default` from the module.
This throws an error if `__esModule` is already declared in the module that is being imported since `__esModule` is already set on `ssrModule`

Fixes: https://github.com/vitejs/vite/issues/13075

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
