### PR TITLE
fix(pluginContainer): should not exclude client sourcemap source content

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -77,7 +77,7 @@ import {
   prettifyUrl,
   timeFrom,
 } from '../utils'
-import { FS_PREFIX } from '../constants'
+import { CLIENT_ENTRY, ENV_ENTRY, FS_PREFIX } from '../constants'
 import type { ResolvedConfig } from '../config'
 import { createPluginHookUtils } from '../plugins'
 import { buildErrorMessage } from './middlewares/error'
@@ -133,6 +133,9 @@ type PluginContext = Omit<
   // deprecated
   | 'moduleIds'
 >
+
+const normalizedClientEntry = normalizePath(CLIENT_ENTRY)
+const normalizedEnvEntry = normalizePath(ENV_ENTRY)
 
 export let parser = acorn.Parser
 
@@ -539,13 +542,18 @@ export async function createPluginContainer(
         if (!combinedMap) {
           combinedMap = m as SourceMap
         } else {
-          combinedMap = combineSourcemaps(cleanUrl(this.filename), [
-            {
-              ...(m as RawSourceMap),
-              sourcesContent: combinedMap.sourcesContent,
-            },
-            combinedMap as RawSourceMap,
-          ]) as SourceMap
+          combinedMap = combineSourcemaps(
+            cleanUrl(this.filename),
+            [
+              {
+                ...(m as RawSourceMap),
+                sourcesContent: combinedMap.sourcesContent,
+              },
+              combinedMap as RawSourceMap,
+            ],
+            this.filename !== normalizedClientEntry &&
+              this.filename !== normalizedEnvEntry,
+          ) as SourceMap
         }
       }
       if (!combinedMap) {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -531,6 +531,9 @@ export async function createPluginContainer(
       }
 
       let combinedMap = this.combinedMap
+      const excludeContent =
+        this.filename !== normalizedClientEntry &&
+        this.filename !== normalizedEnvEntry
       for (let m of this.sourcemapChain) {
         if (typeof m === 'string') m = JSON.parse(m)
         if (!('version' in (m as SourceMap))) {
@@ -551,8 +554,7 @@ export async function createPluginContainer(
               },
               combinedMap as RawSourceMap,
             ],
-            this.filename !== normalizedClientEntry &&
-              this.filename !== normalizedEnvEntry,
+            excludeContent,
           ) as SourceMap
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #12916

Since  neither `client.ts` nor `env.ts` exist in the vite package, their sourcemaps' source content shouldn't be excluded when combining sourcemaps

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
