### PR TITLE
fix(build): declare moduleSideEffects for vite:modulepreload-polyfill

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/__snapshots__/modulePreloadPolyfill.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/__snapshots__/modulePreloadPolyfill.spec.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`load > doesn't load modulepreload polyfill when format is cjs 1`] = `
+"\\"use strict\\";
+"
+`;
+
+exports[`load > loads modulepreload polyfill 1`] = `
+"(function polyfill() {
+  const relList = document.createElement(\\"link\\").relList;
+  if (relList && relList.supports && relList.supports(\\"modulepreload\\")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel=\\"modulepreload\\"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== \\"childList\\") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === \\"LINK\\" && node.rel === \\"modulepreload\\")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(link) {
+    const fetchOpts = {};
+    if (link.integrity)
+      fetchOpts.integrity = link.integrity;
+    if (link.referrerPolicy)
+      fetchOpts.referrerPolicy = link.referrerPolicy;
+    if (link.crossOrigin === \\"use-credentials\\")
+      fetchOpts.credentials = \\"include\\";
+    else if (link.crossOrigin === \\"anonymous\\")
+      fetchOpts.credentials = \\"omit\\";
+    else
+      fetchOpts.credentials = \\"same-origin\\";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+})();
+"
+`;

--- a/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/modulePreloadPolyfill.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/modulePreloadPolyfill.spec.ts
@@ -1,0 +1,58 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it } from 'vitest'
+import type { ModuleFormat, RollupOutput } from 'rollup'
+import { build } from '../../../build'
+import { modulePreloadPolyfillId } from '../../../plugins/modulePreloadPolyfill'
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..')
+
+const buildProject = ({ format = 'es' as ModuleFormat } = {}) =>
+  build({
+    root: resolve(__dirname, 'packages/build-project'),
+    logLevel: 'silent',
+    build: {
+      write: false,
+      rollupOptions: {
+        input: 'main.js',
+        output: {
+          format,
+        },
+        treeshake: {
+          moduleSideEffects: false,
+        },
+      },
+      minify: false,
+    },
+    plugins: [
+      {
+        name: 'test',
+        resolveId(id) {
+          if (id === 'main.js') {
+            return `\0${id}`
+          }
+        },
+        load(id) {
+          if (id === '\0main.js') {
+            return `import '${modulePreloadPolyfillId}'`
+          }
+        },
+      },
+    ],
+  }) as Promise<RollupOutput>
+
+describe('load', () => {
+  it('loads modulepreload polyfill', async ({ expect }) => {
+    const { output } = await buildProject()
+    expect(output).toHaveLength(1)
+    expect(output[0].code).toMatchSnapshot()
+  })
+
+  it("doesn't load modulepreload polyfill when format is cjs", async ({
+    expect,
+  }) => {
+    const { output } = await buildProject({ format: 'cjs' })
+    expect(output).toHaveLength(1)
+    expect(output[0].code).toMatchSnapshot()
+  })
+})

--- a/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/modulePreloadPolyfill.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/modulePreloadPolyfill.spec.ts
@@ -5,11 +5,8 @@ import type { ModuleFormat, RollupOutput } from 'rollup'
 import { build } from '../../../build'
 import { modulePreloadPolyfillId } from '../../../plugins/modulePreloadPolyfill'
 
-const __dirname = resolve(fileURLToPath(import.meta.url), '..')
-
 const buildProject = ({ format = 'es' as ModuleFormat } = {}) =>
   build({
-    root: resolve(__dirname, 'packages/build-project'),
     logLevel: 'silent',
     build: {
       write: false,

--- a/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/modulePreloadPolyfill.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/modulePreloadPolyfill.spec.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { describe, it } from 'vitest'
 import type { ModuleFormat, RollupOutput } from 'rollup'
 import { build } from '../../../build'

--- a/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/package/package.json
+++ b/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/package/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "modulepreload-polyfill-test",
-  "type": "module"
-}

--- a/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/package/package.json
+++ b/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "modulepreload-polyfill-test",
+  "type": "module"
+}

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -25,7 +25,7 @@ export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
         if (!polyfillString) {
           polyfillString = `${isModernFlag}&&(${polyfill.toString()}());`
         }
-        return polyfillString
+        return { code: polyfillString, moduleSideEffects: true }
       }
     },
   }


### PR DESCRIPTION
### Description

Add `moduleSideEffects: true` property to `vite:modulepreload-polyfill`. The polyfill is effectful so it needs be declared as such otherwise it could be removed by Rollup.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
