### PR TITLE
fix: location is not defined error in cleanScssBugUrl

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1600,6 +1600,7 @@ function cleanScssBugUrl(url: string) {
   if (
     // check bug via `window` and `location` global
     typeof window !== 'undefined' &&
+    typeof location !== 'undefined' &&
     typeof location?.href === 'string'
   ) {
     const prefix = location.href.replace(/\/$/, '')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix `location is not defined` error in `cleanScssBugUrl` function.

In PR #12494 condition was changed.
Optional changing doesn't work on not declared variables and condition fails.


### Additional context

I find this problem in my svelte kit project with scss. When I upgrade vite 4.2.1 to 4.3.4.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
