### PR TITLE
fix(scan): handle html script tag attributes that contain ">"

### DIFF
--- a/playground/optimize-deps/generics.vue
+++ b/playground/optimize-deps/generics.vue
@@ -1,0 +1,22 @@
+<!--
+https://github.com/vuejs/core/issues/8171
+https://github.com/vitejs/vite-plugin-vue/issues/162
+generic attribute includes angle brackets which breaks scanning
+This file only verifies that the scanner can work with such usage and nothing
+else.
+-->
+
+<script lang="ts">
+export class Item<TValue> {
+  value: TValue
+}
+</script>
+
+<script setup lang="ts" generic="TItem extends Item<TValue>, TValue">
+defineProps<{
+  items: TItem[]
+  modelValue: TItem[]
+}>()
+</script>
+
+<template>{{ items }}</template>

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -165,6 +165,7 @@
   )
 
   import './index.astro'
+  import './generics.vue'
 
   // All these imports should end up resolved to the same URL (same ?v= injected on them)
   import { add as addFromDirectAbsolutePath } from '/node_modules/@vitejs/test-dep-non-optimized/index.js'

--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -121,6 +121,11 @@ export default defineComponent({
 `.trim(),
         }
       }
+
+      // fallback to empty module for other vue files
+      if (id.endsWith('.vue')) {
+        return { code: `export default {}` }
+      }
     },
   }
 }


### PR DESCRIPTION
The case occurs with Vue 3 generics usage but is technically possible in other scenarios as well. E.g. for `<script foo=">">console.log(1)</script>`, the previous regex matches `">console.log(1)` as the script content and causes a esbuild parse error.

ref: https://github.com/vuejs/core/issues/8171

This PR uses a more complex regex that accounts for arbitrary attributes on the `<script tag>`. Also refactored the logic to use a single regex for both HTML and HTML-like file types.