### PR TITLE
fix: upgrade svelte-check preventing unmet peer deps errors

### DIFF
--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -13,7 +13,7 @@
     "@sveltejs/vite-plugin-svelte": "^2.0.4",
     "@tsconfig/svelte": "^4.0.1",
     "svelte": "^3.58.0",
-    "svelte-check": "^2.10.3",
+    "svelte-check": "^3.3.1",
     "tslib": "^2.5.0",
     "typescript": "^5.0.2",
     "vite": "^4.3.2"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The svelte-ts template installs Typescript in v5.x, although svelte-preprocess, which is defined as v4.x and is a dependency of svelte-check, does not mention Typescript 5 as a valid peer dependency. Bumping svelte-check to v3 resolves the issue, because then svelte-preprocess v5 is used under the hood, which defines Typescript 5 as a valid peer dependency. Package managers, which throw an error for unmet peer dependencies, will not fail anymore.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
