### PR TITLE
fix: don't inject CSS sourcemap for direct requests

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -404,7 +404,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
 
         if (isDirectCSSRequest(id)) {
-          return await getContentWithSourcemap(css)
+          return htmlProxyRE.test(id) ? await getContentWithSourcemap(css) : css
         }
         // server only
         if (options?.ssr) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -404,7 +404,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
 
         if (isDirectCSSRequest(id)) {
-          return htmlProxyRE.test(id) ? await getContentWithSourcemap(css) : css
+          return null
         }
         // server only
         if (options?.ssr) {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -117,7 +117,7 @@ export interface PluginContainer {
       inMap?: SourceDescription['map']
       ssr?: boolean
     },
-  ): Promise<SourceDescription | null>
+  ): Promise<{ code: string; map: SourceMap | null }>
   load(
     id: string,
     options?: {

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -29,7 +29,7 @@ describe.runIf(isServe)('serve', () => {
 
   test('linked css', async () => {
     const res = await page.request.get(
-      new URL('./linked.css', page.url()).href,
+      new URL('./linked-with-import.css', page.url()).href,
       {
         headers: {
           accept: 'text/css',
@@ -40,12 +40,19 @@ describe.runIf(isServe)('serve', () => {
     const map = extractSourcemap(css)
     expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
       {
-        "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACT,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACb,CAAC;",
+        "mappings": "AAAA;EACE,UAAU;AACZ;;ACAA;EACE,UAAU;AACZ",
         "sources": [
-          "/root/linked.css",
+          "be-imported.css",
+          "linked-with-import.css",
         ],
         "sourcesContent": [
-          ".linked {
+          ".be-imported {
+        color: red;
+      }
+      ",
+          "@import '@/be-imported.css';
+
+      .linked-with-import {
         color: red;
       }
       ",

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -29,7 +29,7 @@ describe.runIf(isServe)('serve', () => {
 
   test('linked css', async () => {
     const res = await page.request.get(
-      new URL('./linked-with-import.css', page.url()).href,
+      new URL('./linked.css', page.url()).href,
       {
         headers: {
           accept: 'text/css',
@@ -37,29 +37,7 @@ describe.runIf(isServe)('serve', () => {
       },
     )
     const css = await res.text()
-    const map = extractSourcemap(css)
-    expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
-      {
-        "mappings": "AAAA;EACE,UAAU;AACZ;;ACAA;EACE,UAAU;AACZ",
-        "sources": [
-          "be-imported.css",
-          "linked-with-import.css",
-        ],
-        "sourcesContent": [
-          ".be-imported {
-        color: red;
-      }
-      ",
-          "@import '@/be-imported.css';
-
-      .linked-with-import {
-        color: red;
-      }
-      ",
-        ],
-        "version": 3,
-      }
-    `)
+    expect(css).not.toContain('sourceMappingURL')
   })
 
   test('linked css with import', async () => {


### PR DESCRIPTION
Introduced in #8094

You can this this kind of output in the `css-sourcemap` playground
<img width="602" alt="Screenshot 2023-05-07 at 21 54 38" src="https://user-images.githubusercontent.com/14235743/236699894-8061fce0-c10c-47fd-a8e5-b46a823bb0c0.png">

The default linked.css should not have sourcemap because there is no transformation happening, but the one with import gets correct source map

I don't know exactly why, but the plugin container will inject sourcemap in the case of direct request but not proxy request. 