### PR TITLE
fix(assetImportMetaUrl): allow ternary operator in template literal urls

### DIFF
--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -57,12 +57,13 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           // potential dynamic template string
           if (rawUrl[0] === '`' && rawUrl.includes('${')) {
             const queryDelimiterIndex = getQueryDelimiterIndex(rawUrl)
-            let pureUrl = rawUrl.slice(0, queryDelimiterIndex)
-            let queryString = rawUrl.slice(queryDelimiterIndex)
-            if (queryString) {
-              pureUrl += '`'
-              queryString = queryString.slice(0, -1)
-            }
+            const hasQueryDelimiter = queryDelimiterIndex !== -1
+            const pureUrl = hasQueryDelimiter
+              ? rawUrl.slice(0, queryDelimiterIndex) + '`'
+              : rawUrl
+            const queryString = hasQueryDelimiter
+              ? rawUrl.slice(queryDelimiterIndex, -1)
+              : ''
             const ast = this.parse(pureUrl)
             const templateLiteral = (ast as any).body[0].expression
             if (templateLiteral.expressions.length) {

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -335,6 +335,17 @@ test('new URL(`./${dynamic}?abc`, import.meta.url)', async () => {
   )
 })
 
+test('new URL(`./${1 === 0 ? static : dynamic}?abc`, import.meta.url)', async () => {
+  expect(await page.textContent('.dynamic-import-meta-url-1-ternary')).toMatch(
+    isBuild ? 'data:image/png;base64' : '/foo/nested/icon.png?abc',
+  )
+  expect(await page.textContent('.dynamic-import-meta-url-2-ternary')).toMatch(
+    isBuild
+      ? /\/foo\/assets\/asset-\w{8}\.png\?abc/
+      : '/foo/nested/asset.png?abc',
+  )
+})
+
 test('new URL(`non-existent`, import.meta.url)', async () => {
   expect(await page.textContent('.non-existent-import-meta-url')).toMatch(
     new URL('non-existent', page.url()).pathname,

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -231,6 +231,16 @@
   <code class="dynamic-import-meta-url-2-query"></code>
 </p>
 
+<h2>new URL(`./${1 === 0 ? static : dynamic}?abc`, import.meta.url)</h2>
+<p>
+  <img class="dynamic-import-meta-url-img-1-ternary" />
+  <code class="dynamic-import-meta-url-1-ternary"></code>
+</p>
+<p>
+  <img class="dynamic-import-meta-url-img-2-ternary" />
+  <code class="dynamic-import-meta-url-2-ternary"></code>
+</p>
+
 <h2>new URL(`non-existent`, import.meta.url)</h2>
 <p>
   <code class="non-existent-import-meta-url"></code>
@@ -452,6 +462,17 @@
 
   testDynamicImportMetaUrlWithQuery('icon', 1)
   testDynamicImportMetaUrlWithQuery('asset', 2)
+
+  function testDynamicImportMetaUrlWithTernaryOperator(name, i) {
+    // prettier-ignore
+    const metaUrl = new URL(`./nested/${1 === 0 ? 'failed' : name}.png?abc`, import.meta.url,)
+    text(`.dynamic-import-meta-url-${i}-ternary`, metaUrl)
+    document.querySelector(`.dynamic-import-meta-url-img-${i}-ternary`).src =
+      metaUrl
+  }
+
+  testDynamicImportMetaUrlWithTernaryOperator('icon', 1)
+  testDynamicImportMetaUrlWithTernaryOperator('asset', 2)
 
   {
     const name = 'test'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The recent fix to query parameters in template literals (#13034) broke some imports in our project which use ternary operators in template literal strings. This change keeps the fix to query parameters while allowing ternary operators by finding the first '?' character that is not in between curly brackets. 

This was valid before:
```
new URL(`./resources/image${this.isHighContrastModeActive ? '-white' : ''}.svg`, import.meta.url).href
```
But now breaks the build because a split is performed on the '?' in the ternary operator.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

We could simply move the ternary operator outside of the template literal, which fixes our issues. As the change in #13034 might affect others, this fix can prevent the need for code refactoring due to a regression.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
