### PR TITLE
fix(optimized-deps-build): avoid deadlock when loading register id and optimized id

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -56,7 +56,10 @@ export interface DepsOptimizer {
   isOptimizedDepFile: (id: string) => boolean
   isOptimizedDepUrl: (url: string) => boolean
   getOptimizedDepId: (depInfo: OptimizedDepInfo) => string
-  delayDepsOptimizerUntil: (id: string, done: () => Promise<any>) => void
+  delayDepsOptimizerUntil: (
+    id: string,
+    done: () => Promise<any>,
+  ) => void | Promise<void>
   registerWorkersSource: (id: string) => void
   resetRegisteredIds: () => void
   ensureFirstRun: () => void

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -707,7 +707,7 @@ async function createDepsOptimizer(
   }
   function delayDepsOptimizerUntil(id: string, done: () => Promise<any>) {
     if (crawlEndFinder && !depsOptimizer.isOptimizedDepFile(id)) {
-      crawlEndFinder.delayDepsOptimizerUntil(id, done)
+      return crawlEndFinder.delayDepsOptimizerUntil(id, done)
     }
   }
   function ensureFirstRun() {
@@ -720,7 +720,10 @@ const callCrawlEndIfIdleAfterMs = 50
 interface CrawlEndFinder {
   ensureFirstRun: () => void
   registerWorkersSource: (id: string) => void
-  delayDepsOptimizerUntil: (id: string, done: () => Promise<any>) => void
+  delayDepsOptimizerUntil: (
+    id: string,
+    done: () => Promise<any>,
+  ) => void | Promise<void>
   cancel: () => void
 }
 
@@ -768,12 +771,15 @@ function setupOnCrawlEnd(onCrawlEnd: () => void): CrawlEndFinder {
     checkIfCrawlEndAfterTimeout()
   }
 
-  function delayDepsOptimizerUntil(id: string, done: () => Promise<any>): void {
+  function delayDepsOptimizerUntil(
+    id: string,
+    done: () => Promise<any>,
+  ): void | Promise<void> {
     if (!seenIds.has(id)) {
       seenIds.add(id)
       if (!workersSources.has(id)) {
         registeredIds.add(id)
-        done()
+        return done()
           .catch(() => {})
           .finally(() => markIdAsDone(id))
       }

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -107,9 +107,18 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
           skipSelf: true,
         })
         if (resolved) {
-          depsOptimizer.delayDepsOptimizerUntil(resolved.id, async () => {
-            await this.load(resolved)
-          })
+          // must wait for all the register ids loaded,
+          // otherwise there would be a deadlock
+          const promise = depsOptimizer.delayDepsOptimizerUntil(
+            resolved.id,
+            async () => {
+              await this.load(resolved)
+            },
+          )
+          if (promise?.then) {
+            await promise
+          }
+
           return resolved
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #13018

Calling `load(id)` hook on  `registerId` and `optimizedId` are currently async, this might lead to a deadlock.

The `load` task queue would be like `[loadRegisterId1, loadOptimizedId, loadRegisterId2]` according to 

https://github.com/rollup/rollup/blob/742317579d7ca861047fa8320631c7e061f98c02/src/ModuleLoader.ts#L261-L263

https://github.com/rollup/rollup/blob/742317579d7ca861047fa8320631c7e061f98c02/src/utils/Queue.ts#L17-L40

`loadOptimizedId` should wait until all the `loadRegisterId` tasks finish, but it's called before `loadRegisterId2`, thus `loadOptimizedId` would never be resolved.

This PR make sure `optimizedId` is loaded after all the `loadRegisterId` finish.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
