### PR TITLE
fix(mergeConfig): don't accept callback config

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -266,6 +266,10 @@ function mergeConfig(
 
 Deeply merge two Vite configs. `isRoot` represents the level within the Vite config which is being merged. For example, set `false` if you're merging two `build` options.
 
+::: tip NOTE
+`mergeConfig` accepts only config in object form. If you have a config in callback form, you should call it before passing into `mergeConfig`.
+:::
+
 ## `searchForWorkspaceRoot`
 
 **Type Signature:**

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import type { InlineConfig } from '..'
 import type { PluginOption, UserConfig, UserConfigExport } from '../config'
-import { resolveConfig } from '../config'
+import { defineConfig, resolveConfig } from '../config'
 import { resolveEnvPrefix } from '../env'
 import { mergeConfig } from '../publicUtils'
 
@@ -183,6 +183,27 @@ describe('mergeConfig', () => {
     // merging either ways, `ssr.noExternal: true` should take highest priority
     expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
     expect(mergeConfig(newConfig, baseConfig)).toEqual(mergedConfig)
+  })
+
+  test('throws error with functions', () => {
+    const baseConfig = defineConfig(() => ({ base: 'base' }))
+    const newConfig = defineConfig(() => ({ base: 'new' }))
+
+    expect(() =>
+      mergeConfig(
+        // @ts-expect-error TypeScript shouldn't give you to pass a function as argument
+        baseConfig,
+        newConfig,
+      ),
+    ).toThrowError('Cannot merge config in form of callback')
+
+    expect(() =>
+      mergeConfig(
+        {},
+        // @ts-expect-error TypeScript shouldn't give you to pass a function as argument
+        newConfig,
+      ),
+    ).toThrowError('Cannot merge config in form of callback')
   })
 })
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1037,11 +1037,18 @@ function mergeConfigRecursively(
   return merged
 }
 
-export function mergeConfig(
-  defaults: Record<string, any>,
-  overrides: Record<string, any>,
+export function mergeConfig<
+  D extends Record<string, any>,
+  O extends Record<string, any>,
+>(
+  defaults: D extends Function ? never : D,
+  overrides: O extends Function ? never : O,
   isRoot = true,
 ): Record<string, any> {
+  if (typeof defaults === 'function' || typeof overrides === 'function') {
+    throw new Error(`Cannot merge config in form of callback`)
+  }
+
   return mergeConfigRecursively(defaults, overrides, isRoot ? '' : '.')
 }
 


### PR DESCRIPTION
### Description

`mergeConfig` function doesn't work with config in callback form. To make the error more transparent added both a runtime and type checks. More info https://github.com/vitejs/vite/pull/12977

### Additional context

It's also possible to solve it by auto calling callbacks. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
