### PR TITLE
fix: call `tryFsResolve` for relative `new URL(foo, import.meta.url)`

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -498,7 +498,7 @@ function splitFileAndPostfix(path: string) {
   return { file, postfix: path.slice(file.length) }
 }
 
-function tryFsResolve(
+export function tryFsResolve(
   fsPath: string,
   options: InternalResolveOptions,
   tryIndex = true,

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -312,6 +312,15 @@ test('new URL("/...", import.meta.url)', async () => {
   )
 })
 
+test('new URL(..., import.meta.url) without extension', async () => {
+  expect(await page.textContent('.import-meta-url-without-extension')).toMatch(
+    isBuild ? 'data:application/javascript' : 'nested/test.js',
+  )
+  expect(
+    await page.textContent('.import-meta-url-content-without-extension'),
+  ).toContain('export default class')
+})
+
 test('new URL(`${dynamic}`, import.meta.url)', async () => {
   expect(await page.textContent('.dynamic-import-meta-url-1')).toMatch(
     isBuild ? 'data:image/png;base64' : '/foo/nested/icon.png',

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -190,6 +190,14 @@
 <img class="import-meta-url-base-path-img" />
 <code class="import-meta-url-base-path"></code>
 
+<h2>new URL('...', import.meta.url (without extension))</h2>
+<p>
+  <code class="import-meta-url-content-without-extension"></code>
+</p>
+<p>
+  <code class="import-meta-url-without-extension"></code>
+</p>
+
 <h2>new URL('...', import.meta.url,) (with comma)</h2>
 <img class="import-meta-url-img-comma" />
 <code class="import-meta-url-comma"></code>
@@ -392,6 +400,13 @@
   const metaUrlBasePath = new URL('/icon.png', import.meta.url)
   text('.import-meta-url-base-path', metaUrlBasePath)
   document.querySelector('.import-meta-url-base-path-img').src = metaUrlBasePath
+
+  const metaUrlWithoutExtension = new URL('./nested/test', import.meta.url)
+  text('.import-meta-url-without-extension', metaUrlWithoutExtension)
+  ;(async () => {
+    const res = await fetch(metaUrlWithoutExtension)
+    text('.import-meta-url-content-without-extension', await res.text())
+  })()
 
   // prettier-ignore
   const metaUrlWithComma = new URL('./nested/asset.png', import.meta.url,)

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -114,6 +114,11 @@ test('module worker', async () => {
     true,
   )
   await untilUpdated(
+    () => page.textContent('.worker-import-meta-url-without-extension'),
+    'A string',
+    true,
+  )
+  await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
     true,

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -99,6 +99,11 @@ test('module worker', async () => {
     true,
   )
   await untilUpdated(
+    () => page.textContent('.worker-import-meta-url-without-extension'),
+    'A string',
+    true,
+  )
+  await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
     true,

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -57,6 +57,12 @@
 <code class="worker-import-meta-url-resolve"></code>
 
 <p>
+  new Worker(new URL('./url-worker', import.meta.url), { type: 'module' })
+  <span class="classname">.worker-import-meta-url-without-extension</span>
+</p>
+<code class="worker-import-meta-url-without-extension"></code>
+
+<p>
   new SharedWorker(new URL('./url-shared-worker.js', import.meta.url), { type:
   'module' })
   <span class="classname">.shared-worker-import-meta-url</span>

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -90,6 +90,15 @@ wResolve.addEventListener('message', (ev) =>
   text('.worker-import-meta-url-resolve', JSON.stringify(ev.data)),
 )
 
+// url import worker without extension
+const wWithoutExt = new Worker(
+  new URL('../url-worker', import.meta.url),
+  /* @vite-ignore */ workerOptions,
+)
+wWithoutExt.addEventListener('message', (ev) =>
+  text('.worker-import-meta-url-without-extension', JSON.stringify(ev.data)),
+)
+
 const genWorkerName = () => 'module'
 const w2 = new SharedWorker(
   new URL('../url-shared-worker.js', import.meta.url),


### PR DESCRIPTION
### Description
`new URL('./path-without-extension', import.meta.url)` was supported in past but wasn't working since 4.3. This was caused by #12450.

fixes #13141

refs #7837

### Additional context

I wonder if we should remove these resolvings from `new URL(foo, import.meta.url)` (i.e. only support relative paths with extensions) as `new URL` is a constructor that simply resolves relative paths. Instead to introduce `import.meta.resolve` for that usage as `import.meta.resolve` will resolve like node and it works with Node.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
