### PR TITLE
feat: Add plain copy option

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -92,6 +92,15 @@ Defining `publicDir` as `false` disables this feature.
 
 See [The `public` Directory](/guide/assets#the-public-directory) for more details.
 
+## plainCopyDir
+
+- **Type:** `string | false`
+- **Default:** `"js"`
+
+Plain copy every file recursively in this directory into distribution directory and keep the relative original path tree. This option is especially useful if a project needs to use bundled, non-ESM js files. With this option this kind of file can be automatically copied into the distribution folder.
+
+Defining `plainCopyDir` as `false` disables this feature.
+
 ## cacheDir
 
 - **Type:** `string`

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -30,6 +30,7 @@ import { terserPlugin } from './plugins/terser'
 import {
   asyncFlatten,
   copyDir,
+  copyFile,
   emptyDir,
   joinUrlSegments,
   normalizePath,
@@ -753,6 +754,9 @@ function prepareOutDir(
       fs.existsSync(config.publicDir)
     ) {
       copyDir(config.publicDir, outDir)
+    }
+    if (config.plainCopyDir && fs.existsSync(config.plainCopyDir)) {
+      copyFile(config.plainCopyDir, outDir)
     }
   }
 }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -151,6 +151,14 @@ export interface UserConfig {
    * Default to `.vite` when no `package.json` is detected.
    * @default 'node_modules/.vite'
    */
+  plainCopyDir?: string | false
+  /**
+   * Plain copy every file recursively in this directory into distribution directory
+   * and keep the relative original path tree. This option is especially useful if
+   * a project needs to use bundled, non-ESM js files. With this option this kind
+   * of file can be automatically copied into the distribution folder.
+   * @default 'js'
+   */
   cacheDir?: string
   /**
    * Explicitly set a mode to run in. This will override the default mode for
@@ -339,6 +347,7 @@ export type ResolvedConfig = Readonly<
     /** @internal */
     rawBase: string
     publicDir: string
+    plainCopyDir: string
     cacheDir: string
     command: 'build' | 'serve'
     mode: string
@@ -619,6 +628,15 @@ export async function resolveConfig(
         )
       : ''
 
+  const { plainCopyDir } = config
+  const resolvedplainCopyDir =
+    plainCopyDir !== false && plainCopyDir !== ''
+      ? path.resolve(
+          resolvedRoot,
+          typeof plainCopyDir === 'string' ? plainCopyDir : 'public',
+        )
+      : ''
+
   const server = resolveServerOptions(resolvedRoot, config.server, logger)
   const ssr = resolveSSROptions(
     config.ssr,
@@ -663,6 +681,7 @@ export async function resolveConfig(
     rawBase: resolvedBase,
     resolve: resolveOptions,
     publicDir: resolvedPublicDir,
+    plainCopyDir: resolvedplainCopyDir,
     cacheDir,
     command,
     mode,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -555,6 +555,35 @@ export function copyDir(srcDir: string, destDir: string): void {
   }
 }
 
+export function mkdir(filePath: string): void {
+  const dirCache = new Map()
+  const filePathParts = filePath.split('/')
+  let dir = filePathParts[0]
+  for (let i = 1; i < filePathParts.length; i++) {
+    if (!dirCache.get(dir) && !fs.existsSync(dir)) {
+      dirCache.set(dir, true)
+      fs.mkdirSync(dir)
+    }
+    dir = dir + '/' + filePathParts[i]
+  }
+}
+
+export function copyFile(start: string, end: string): void {
+  if (!fs.existsSync(end)) {
+    mkdir(end)
+  }
+
+  fs.stat(start, (e, s) => {
+    if (s.isFile()) {
+      fs.writeFileSync(end, fs.readFileSync(start))
+    } else {
+      fs.readdirSync(start, 'utf8').forEach((f) => {
+        copyFile(start + '/' + f, end + '/' + f)
+      })
+    }
+  })
+}
+
 // `fs.realpathSync.native` resolves differently in Windows network drive,
 // causing file read errors. skip for now.
 // https://github.com/nodejs/node/issues/37737


### PR DESCRIPTION
* Add plain copy utils
* Add plain copy build logic
* Add plain copy doc into shared-options
* Add plain copy config

## Why plain copy?
Plain copy every file recursively in this directory into distribution directory and keep the relative original path tree. This option is especially useful if a project needs to use bundled, non-ESM js files. With this option this kind of file can be automatically copied into the distribution folder.

Here is a bug about Vite doesn't support plain copy: #13146. With plain copy option Vite can still distribute a correct distribution.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
