### PR TITLE
fix: handle more yarn pnp load errors

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -58,20 +58,18 @@ export function resolvePackageData(
     const cacheKey = getRpdCacheKey(pkgName, basedir, preserveSymlinks)
     if (packageCache?.has(cacheKey)) return packageCache.get(cacheKey)!
 
-    let pkg: string | null
     try {
-      pkg = pnp.resolveToUnqualified(pkgName, basedir, {
+      const pkg = pnp.resolveToUnqualified(pkgName, basedir, {
         considerBuiltins: false,
       })
+      if (!pkg) return null
+
+      const pkgData = loadPackageData(path.join(pkg, 'package.json'))
+      packageCache?.set(cacheKey, pkgData)
+      return pkgData
     } catch {
       return null
     }
-    if (!pkg) return null
-
-    const pkgData = loadPackageData(path.join(pkg, 'package.json'))
-    packageCache?.set(cacheKey, pkgData)
-
-    return pkgData
   }
 
   const originalBasedir = basedir


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Yarn returns `C:` from `pnp.resolveToUnqualified` even if `C:\\package.json` doesn't exist and therefore `loadPackageData` was throwing `no such file or directory, open 'C:\package.json'`.

fixes #13158

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
