### PR TITLE
perf: skip windows absolute paths for node resolve

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import {
   asyncFlatten,
+  bareImportRE,
   getHash,
   getLocalhostAddressIfDiffersFromDNS,
   injectQuery,
@@ -12,6 +13,25 @@ import {
   processSrcSetSync,
   resolveHostname,
 } from '../utils'
+
+describe('bareImportRE', () => {
+  test('should work with normal package name', () => {
+    expect(bareImportRE.test('vite')).toBe(true)
+  })
+  test('should work with scoped package name', () => {
+    expect(bareImportRE.test('@vitejs/plugin-vue')).toBe(true)
+  })
+
+  test('should work with absolute paths', () => {
+    expect(bareImportRE.test('/foo')).toBe(false)
+    expect(bareImportRE.test('C:/foo')).toBe(false)
+    expect(bareImportRE.test('C:\\foo')).toBe(false)
+  })
+  test('should work with relative path', () => {
+    expect(bareImportRE.test('./foo')).toBe(false)
+    expect(bareImportRE.test('.\\foo')).toBe(false)
+  })
+})
 
 describe('injectQuery', () => {
   if (isWindows) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -137,7 +137,7 @@ export function isOptimizable(
   )
 }
 
-export const bareImportRE = /^[\w@](?!.*:\/\/)/
+export const bareImportRE = /^(?![a-zA-Z]:)[\w@](?!.*:\/\/)/
 export const deepImportRE = /^([^@][^/]*)\/|^(@[^/]+\/[^/]+)\//
 
 // TODO: use import()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I found that `C:/non-existent-path` goes through this part while debugging #13158.
https://github.com/vitejs/vite/blob/23096b19998978803c132021eee175153fa6078d/packages/vite/src/node/plugins/resolve.ts#L326-L407

`vite-tsconfig-paths` seems to call `this.resolve('C:/project/packageName')`. I guess it's for `tsconfig.compilerOptions.baseUrl`

I'm not sure if this is worth doing. I don't have a good test case for this. I guess it would improve perf for a large project using `vite-tsconfig-paths`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
