### PR TITLE
fix: setupCounter misspelling

### DIFF
--- a/packages/create-vite/template-vanilla-ts/src/counter.ts
+++ b/packages/create-vite/template-vanilla-ts/src/counter.ts
@@ -1,4 +1,4 @@
-export function setupCounter(element: HTMLButtonElement) {
+export function setUpCounter(element: HTMLButtonElement) {
   let counter = 0
   const setCounter = (count: number) => {
     counter = count

--- a/packages/create-vite/template-vanilla-ts/src/main.ts
+++ b/packages/create-vite/template-vanilla-ts/src/main.ts
@@ -1,7 +1,7 @@
 import './style.css'
 import typescriptLogo from './typescript.svg'
 import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.ts'
+import { setUpCounter } from './counter.ts'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
@@ -21,4 +21,4 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   </div>
 `
 
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+setUpCounter(document.querySelector<HTMLButtonElement>('#counter')!)

--- a/packages/create-vite/template-vanilla/counter.js
+++ b/packages/create-vite/template-vanilla/counter.js
@@ -1,4 +1,4 @@
-export function setupCounter(element) {
+export function setUpCounter(element) {
   let counter = 0
   const setCounter = (count) => {
     counter = count

--- a/packages/create-vite/template-vanilla/main.js
+++ b/packages/create-vite/template-vanilla/main.js
@@ -1,7 +1,7 @@
 import './style.css'
 import javascriptLogo from './javascript.svg'
 import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.js'
+import { setUpCounter } from './counter.js'
 
 document.querySelector('#app').innerHTML = `
   <div>
@@ -21,4 +21,4 @@ document.querySelector('#app').innerHTML = `
   </div>
 `
 
-setupCounter(document.querySelector('#counter'))
+setUpCounter(document.querySelector('#counter'))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes the misspelling of the `setupCounter` functions provided in the vanilla and vanilla-ts template projects, and corrects it so `setUpCounter`. Alternatively, we could go for `counterSetup`, but I prefer my functions to be verbs.

Alternatively, if `setUpCounter` sounds too much like we're trying to set an "UpCounter", `doCounterSetup` or `runCounterSetup` are a great and unambiguous middleground with correct grammar.

This is quite a common misspelling, and can also be seen with other [phrasal verbs](https://en.wikipedia.org/wiki/English_phrasal_verbs) like "log in", "work out", etc. These verbs are often confused with their noun equivalent, e.g. setup, login or workout.
https://en.wiktionary.org/wiki/setup#Verb

I think it's important to use fanatically correct grammar for public projects like these.

### Additional context

"setup" seems to be used in other places in this repo as a verb, such as `setupSideEffect` in the HMR API. Maybe we should hunt those down as well. But fixing the spelling of a function in a template project is much less invasive than breaking an API.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other