### PR TITLE
chore: remove useless dep

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -124,7 +124,6 @@
     "resolve.exports": "^2.0.2",
     "rollup-plugin-license": "^3.0.1",
     "sirv": "^2.0.2",
-    "source-map-js": "^1.0.2",
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.0.1",
     "strip-literal": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,9 +392,6 @@ importers:
       sirv:
         specifier: ^2.0.2
         version: 2.0.2(patch_hash=hmoqtj4vy3i7wnpchga2a2mu3y)
-      source-map-js:
-        specifier: ^1.0.2
-        version: 1.0.2
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Came across an obsolete dep `source-map-js` introduced in https://github.com/vitejs/vite/pull/7173/files#diff-949e137b027a941e9a8dabb980971ab5b7147f895fc06ab2ff0bb0923d981606R112 when doing some sourcemap stuff. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
