### PR TITLE
fix: revert only watch .env files in envDir (#12587)

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -366,7 +366,7 @@ export async function _createServer(
 
   const watcher = chokidar.watch(
     // config file dependencies and env file might be outside of root
-    [root, ...config.configFileDependencies, path.join(config.envDir, '.env*')],
+    [root, ...config.configFileDependencies, config.envDir],
     resolvedWatchOptions,
   ) as FSWatcher
 


### PR DESCRIPTION
This reverts https://github.com/vitejs/vite/pull/12587, commit 26d8e720f0ac8076dced7c5efd4d3da397fefebe.

### Description

@bartlomieju reported Windows crashes and he tracked the issue down to this PR.

`disableGlobbing: true` is used above, so we can't use globbing. @sapphi-red was `disableGlobbing` needed when implementing https://github.com/vitejs/vite/pull/8939, or it was an optimization because globbing was used anymore? @sun0day I think we could revert and then review how to reapply the optimization (if it is worth doing so).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other