### PR TITLE
fix(ssr): skip updateCjsSsrExternals if legacy flag disabled

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -404,7 +404,9 @@ export async function _createServer(
       if (isDepsOptimizerEnabled(config, true)) {
         await initDevSsrDepsOptimizer(config, server)
       }
-      await updateCjsSsrExternals(server)
+      if (config.legacy?.buildSsrCjsExternalHeuristics) {
+        await updateCjsSsrExternals(server)
+      }
       return ssrLoadModule(
         url,
         server,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `updateCjsSsrExternals` function updates `server._ssrExternals` that's only used here:

https://github.com/vitejs/vite/blob/3224a51702b97fe9d51b07b38c03ec188db750c2/packages/vite/src/node/plugins/importAnalysis.ts#L488-L493

Since that code only runs on `config.legacy?.buildSsrCjsExternalHeuristics: true`, we can also add the same guard for `updateCjsSsrExternals`

### Additional context

cc @delucis who found this. It was logging the `... doesn't appear to be written in CJS ...` warning unnecessarily.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
