### PR TITLE
perf(ssr): calculate stacktrace offset lazily

### DIFF
--- a/packages/vite/src/node/ssr/ssrStacktrace.ts
+++ b/packages/vite/src/node/ssr/ssrStacktrace.ts
@@ -2,20 +2,28 @@ import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
 import type { ModuleGraph } from '../server/moduleGraph'
 
 let offset: number
-try {
-  new Function('throw new Error(1)')()
-} catch (e) {
-  // in Node 12, stack traces account for the function wrapper.
-  // in Node 13 and later, the function wrapper adds two lines,
-  // which must be subtracted to generate a valid mapping
-  const match = /:(\d+):\d+\)$/.exec(e.stack.split('\n')[1])
-  offset = match ? +match[1] - 1 : 0
+
+function calculateOffsetOnce() {
+  if (offset !== undefined) {
+    return
+  }
+
+  try {
+    new Function('throw new Error(1)')()
+  } catch (e) {
+    // in Node 12, stack traces account for the function wrapper.
+    // in Node 13 and later, the function wrapper adds two lines,
+    // which must be subtracted to generate a valid mapping
+    const match = /:(\d+):\d+\)$/.exec(e.stack.split('\n')[1])
+    offset = match ? +match[1] - 1 : 0
+  }
 }
 
 export function ssrRewriteStacktrace(
   stack: string,
   moduleGraph: ModuleGraph,
 ): string {
+  calculateOffsetOnce()
   return stack
     .split('\n')
     .map((line) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I'm working on a cli which uses vite as a dependency.
I'm also using the `source-map-support` package to transform error stacktrace frames.

When running the cli, the vite module is loaded. During the load, it eagerly creates an `Error` and accesses its `stack` property, which triggers source mapping.
This is pretty slow and incurs a few hundred ms on my cli's startup time (might be different numbers on different hardware).

Proposed solution - calculate the offset (which accesses `stack`) lazily - only when we actually need to rewrite an ssr stacktrace.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

1. I didn't add a test that will break without this change, don't know if it's possible and/or worth it. Will be happy to add with some help.
2. I labeled the PR as a refactor, I didn't really know what is the category for that. Is this considered a perf improvement?
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
