### PR TITLE
fix(legacy): style insert order

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -636,10 +636,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             `${style}.textContent = ${cssString};` +
             `document.head.appendChild(${style});`
           const wrapIdx = code.indexOf('System.register')
-          const insertMark = "'use strict';"
-          const insertIdx = code.indexOf(insertMark, wrapIdx)
+          const executeFnStart = code.indexOf('{', code.indexOf('execute:', wrapIdx)) + 1
           const s = new MagicString(code)
-          s.appendLeft(insertIdx + insertMark.length, injectCode)
+          s.appendRight(executeFnStart, injectCode)
           if (config.build.sourcemap) {
             // resolve public URL from CSS paths, we need to use absolute paths
             return {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -636,7 +636,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             `${style}.textContent = ${cssString};` +
             `document.head.appendChild(${style});`
           const wrapIdx = code.indexOf('System.register')
-          const executeFnStart = code.indexOf('{', code.indexOf('execute:', wrapIdx)) + 1
+          const executeFnStart =
+            code.indexOf('{', code.indexOf('execute:', wrapIdx)) + 1
           const s = new MagicString(code)
           s.appendRight(executeFnStart, injectCode)
           if (config.build.sourcemap) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #13265 

Moves style inserting code into the `execute` function aligns the style insertion order with the module execution order.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
