### PR TITLE
test: respect commonjs options in playgrounds

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -457,7 +457,12 @@ export async function resolveConfig(
   const userPlugins = [...prePlugins, ...normalPlugins, ...postPlugins]
   config = await runConfigHook(config, userPlugins, configEnv)
 
-  if (process.env.VITE_TEST_WITHOUT_PLUGIN_COMMONJS) {
+  // If there are custom commonjsOptions, don't force optimized deps for this test
+  // even if the env var is set as it would interfere with the playground specs.
+  if (
+    !config.build?.commonjsOptions &&
+    process.env.VITE_TEST_WITHOUT_PLUGIN_COMMONJS
+  ) {
     config = mergeConfig(config, {
       optimizeDeps: { disabled: false },
       ssr: { optimizeDeps: { disabled: false } },


### PR DESCRIPTION
### Description

Avoid forcing deps optimization for playgrounds that define custom `commonjsOptions`. When running `pnpm run test-build-without-plugin-commonjs`, this test: `playground/external/__tests__/external.spec.ts` was failing and is working now after the PR.

Note: in case you run the tests, we have another test in main failing with this env flag in `playground/ssr-resolve` that is unrelated to this issue.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other