### PR TITLE
fix: optimizeDeps during build and external ids

### DIFF
--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -106,12 +106,12 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
           ...options,
           skipSelf: true,
         })
-        if (resolved) {
+        if (resolved && !resolved.external) {
           depsOptimizer.delayDepsOptimizerUntil(resolved.id, async () => {
             await this.load(resolved)
           })
-          return resolved
         }
+        return resolved
       }
     },
 


### PR DESCRIPTION
### Description

Follow up to [#12851](https://github.com/vitejs/vite/pull/12851/files#diff-0648e3b1da8ac697354cfca37ada638d3a353be4b3312211c6b131597f6ca101R109). `playground/ssr-resolve` was failing when using `test-build-without-commonjs-plugin` (forcing optimizing deps).

We should find a good way to test optimized deps during build for all playgrounds, maybe as part of ecosystem-ci. After this PR and #13273, all tests are green locally.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other