### PR TITLE
fix: avoid optimized deps during build in worker bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "run-s test-unit test-serve test-build",
     "test-serve": "vitest run -c vitest.config.e2e.ts",
     "test-build": "VITE_TEST_BUILD=1 vitest run -c vitest.config.e2e.ts",
-    "test-build-without-plugin-commonjs": "VITE_TEST_WITHOUT_PLUGIN_COMMONJS=1 pnpm test-build",
+    "test-build-optimized-deps": "VITE_TEST_BUILD_OPTIMIZED_DEPS=1 pnpm test-build",
     "test-unit": "vitest run",
     "test-docs": "pnpm run docs-build",
     "debug-serve": "VITE_DEBUG_SERVE=1 vitest run -c vitest.config.e2e.ts",

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -427,10 +427,9 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
   post: Plugin[]
 }> {
   const options = config.build
-  const { commonjsOptions } = options
+  // We don't use optimized dependencies while bundling workers
   const usePluginCommonjs =
-    !Array.isArray(commonjsOptions?.include) ||
-    commonjsOptions?.include.length !== 0
+    !isDepsOptimizerEnabled(config, !!config.build.ssr) || config.isWorker
   const rollupOptionsPlugins = options.rollupOptions.plugins
   return {
     pre: [

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -457,13 +457,11 @@ export async function resolveConfig(
   const userPlugins = [...prePlugins, ...normalPlugins, ...postPlugins]
   config = await runConfigHook(config, userPlugins, configEnv)
 
-  if (process.env.VITE_TEST_WITHOUT_PLUGIN_COMMONJS) {
+  if (process.env.VITE_TEST_BUILD_OPTIMIZED_DEPS) {
     config = mergeConfig(config, {
       optimizeDeps: { disabled: false },
       ssr: { optimizeDeps: { disabled: false } },
     })
-    config.build ??= {}
-    config.build.commonjsOptions = { include: [] }
   }
 
   // Define logger

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -57,7 +57,6 @@ export interface DepsOptimizer {
   isOptimizedDepUrl: (url: string) => boolean
   getOptimizedDepId: (depInfo: OptimizedDepInfo) => string
   delayDepsOptimizerUntil: (id: string, done: () => Promise<any>) => void
-  registerWorkersSource: (id: string) => void
   resetRegisteredIds: () => void
   ensureFirstRun: () => void
 

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -11,7 +11,6 @@ import {
   onRollupWarning,
   toOutputFilePathInJS,
 } from '../build'
-import { getDepsOptimizer } from '../optimizer'
 import { fileToUrl } from './asset'
 
 interface WorkerCache {
@@ -247,7 +246,6 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(raw, id, options) {
-      const ssr = options?.ssr === true
       const query = parseRequest(id)
       if (query && query[WORKER_FILE_ID] != null) {
         // if import worker by worker constructor will have query.type
@@ -294,7 +292,6 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       const workerOptions = workerType === 'classic' ? '' : ',{type: "module"}'
 
       if (isBuild) {
-        getDepsOptimizer(config, ssr)?.registerWorkersSource(id)
         if (query.inline != null) {
           const chunk = await bundleWorkerEntry(config, id, query)
           const encodedJs = `const encodedJs = "${Buffer.from(

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -12,7 +12,6 @@ import {
   slash,
   transformStableResult,
 } from '../utils'
-import { getDepsOptimizer } from '../optimizer'
 import type { ResolveFn } from '..'
 import type { WorkerType } from './worker'
 import { WORKER_FILE_ID, workerFileToUrl } from './worker'
@@ -115,7 +114,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:worker-import-meta-url',
 
     async transform(code, id, options) {
-      const ssr = options?.ssr === true
       if (
         !options?.ssr &&
         (code.includes('new Worker') || code.includes('new SharedWorker')) &&
@@ -171,7 +169,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
           let builtUrl: string
           if (isBuild) {
-            getDepsOptimizer(config, ssr)?.registerWorkersSource(id)
             builtUrl = await workerFileToUrl(config, file, query)
           } else {
             builtUrl = await fileToUrl(cleanUrl(file), config, this)


### PR DESCRIPTION
### Description

After https://github.com/vitejs/vite/pull/11218, we introduced a regression when deps optimization is enabled during build. Since v3, the way deps optimization works is that dependencies imported in workers are optimized together with the dependencies of the main app. For this to work, given that each worker is bundled by a different rollup process, we were awaiting for all the workers to be bundled before doing the optimization run with esbuild (as we need to know during build every dep that should be optimized before, we don't have reloads at build time). We had then a `registerWorkerSource` scheme so we avoid waiting for the worker id, and instead wait for the registered ids inside the worker. For this scheme to work, all the workers need to be processed in parallel and #11218 serialized the workers. This means that there could potentially be a deadlock if there are deps imported by several workers.

Unrelated to #11218, we have an issue with `maxParallelFileOps`. Rollup is willing to give us better tools to avoid this problem (see https://github.com/rollup/rollup/issues/4985). Using `delayLoading` would be very clean, but if we need to also use it to await for the worker bundles, we are back to registering worker sources and adding extra complexity. It should be doable though, but we also need to revert #11218.

This PR explores not using deps optimization when bundling workers. I still don't know if this is acceptable, but I don't know how we can work out optimizing deps for them if they aren't bundled in parallel. Even if we force the user to include all the deps in the worker by hand, it won't work. Sending the PR in case others would like to also check this problem, I don't think we should merge it yet.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other