### PR TITLE
docs: preview not for production on CLI guide

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -98,7 +98,7 @@ vite optimize [root]
 
 ### `vite preview`
 
-Locally preview production build. This command is only for previewing the build locally and not designed as a production server.
+Locally preview the production build. Do not use this as a production server as it's not designed for it.
 
 #### Usage
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -98,7 +98,7 @@ vite optimize [root]
 
 ### `vite preview`
 
-Locally preview production build.
+Locally preview production build. This command is only for previewing the build locally and not designed as a production server.
 
 #### Usage
 


### PR DESCRIPTION
### Description

We have a note in the deploying guide too. But the first mention in the docs about the preview command is in the CLI guide. Today someone asked if `preview` could be used as a production server in Discord.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other