### PR TITLE
feat(client): add WebSocket connections events

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -176,6 +176,8 @@ The following HMR events are dispatched by Vite automatically:
 - `'vite:beforePrune'` when modules that are no longer needed are about to be pruned
 - `'vite:invalidate'` when a module is invalidated with `import.meta.hot.invalidate()`
 - `'vite:error'` when an error occurs (e.g. syntax error)
+- `'vite:ws:disconnect'` when the WebSocket connection is lost
+- `'vite:ws:connect'` when the WebSocket connection is (re-)established
 
 Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plugin#handlehotupdate) for more details.
 

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -81,6 +81,7 @@ function setupWebSocket(
     'open',
     () => {
       isOpened = true
+      notifyListeners('vite:ws:connect', socket)
     },
     { once: true },
   )
@@ -98,6 +99,8 @@ function setupWebSocket(
       onCloseWithoutOpen()
       return
     }
+
+    notifyListeners('vite:ws:disconnect', socket)
 
     console.log(`[vite] server connection lost. polling for restart...`)
     await waitForSuccessfulPing(protocol, hostAndPath)

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -81,7 +81,7 @@ function setupWebSocket(
     'open',
     () => {
       isOpened = true
-      notifyListeners('vite:ws:connect', socket)
+      notifyListeners('vite:ws:connect', { webSocket: socket })
     },
     { once: true },
   )
@@ -100,7 +100,7 @@ function setupWebSocket(
       return
     }
 
-    notifyListeners('vite:ws:disconnect', socket)
+    notifyListeners('vite:ws:disconnect', { webSocket: socket })
 
     console.log(`[vite] server connection lost. polling for restart...`)
     await waitForSuccessfulPing(protocol, hostAndPath)

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -12,8 +12,18 @@ export interface CustomEventMap {
   'vite:beforeFullReload': FullReloadPayload
   'vite:error': ErrorPayload
   'vite:invalidate': InvalidatePayload
-  'vite:ws:connect': WebSocket
-  'vite:ws:disconnect': WebSocket
+  'vite:ws:connect': WebSocketConnectionPayload
+  'vite:ws:disconnect': WebSocketConnectionPayload
+}
+
+export interface WebSocketConnectionPayload {
+  /**
+   * @experimental
+   * We expose this instance experimentally to see potential usage.
+   * This might be removed in the future if we didn't find reasonable use cases.
+   * If you find this useful, please open an issue with details so we can discuss and make it stable API.
+   */
+  webSocket: WebSocket
 }
 
 export interface InvalidatePayload {

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -12,6 +12,8 @@ export interface CustomEventMap {
   'vite:beforeFullReload': FullReloadPayload
   'vite:error': ErrorPayload
   'vite:invalidate': InvalidatePayload
+  'vite:ws:connect': WebSocket
+  'vite:ws:disconnect': WebSocket
 }
 
 export interface InvalidatePayload {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently, when Vite's WS connection close/reconnects, it only prints to the console, but no way for other integrations to know it programmatically.

This PR introduced two client events, `vite:ws:connect` and `vite:ws:disconnect`. This would allow plugins and meta frameworks to display better connection indicators within UI, improving the DX by some extent.

### Additional context

Motivation on my side is: https://github.com/nuxt/devtools/pull/243

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
