### PR TITLE
fix: rollup watch crash on Windows

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -131,6 +131,10 @@ export function renderAssetUrlInJS(
   return s
 }
 
+// During build, if we don't use a virtual file for public assets, rollup will
+// watch for these ids resulting in watching the root of the file system in Windows,
+const viteBuildPublicIdPrefix = '\0vite:asset:public'
+
 /**
  * Also supports loading plain strings with import text from './foo.txt?raw'
  */
@@ -153,11 +157,17 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       // will fail to resolve in the main resolver. handle them here.
       const publicFile = checkPublicFile(id, config)
       if (publicFile) {
-        return id
+        return config.command === 'build'
+          ? `${viteBuildPublicIdPrefix}${id}`
+          : id
       }
     },
 
     async load(id) {
+      if (id.startsWith(viteBuildPublicIdPrefix)) {
+        id = id.slice(viteBuildPublicIdPrefix.length)
+      }
+
       if (id[0] === '\0') {
         // Rollup convention, this id should be handled by the
         // plugin that marked it with \0
@@ -252,7 +262,7 @@ export async function fileToUrl(
 function fileToDevUrl(id: string, config: ResolvedConfig) {
   let rtn: string
   if (checkPublicFile(id, config)) {
-    // in public dir, keep the url as-is
+    // in public dir during dev, keep the url as-is
     rtn = id
   } else if (id.startsWith(config.root)) {
     // in project root, infer short public path


### PR DESCRIPTION
### Description

Potential fix for #13234. We may not be able to apply this fix until Vite 5 though. Credits go to @sapphi-red for discovering the issue.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other