### PR TITLE
fix(css): return deps if have no postcss plugins

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1003,6 +1003,7 @@ async function compileCSS(
     return {
       code,
       map: preprocessorMap,
+      deps,
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

After we preprocess but there's no postcss plugins to apply, we should still return the `deps` it relies on.

The `deps` could be populated at https://github.com/vitejs/vite/blob/42b3434bdf53a1377badd8b4636c5ce8079b5730/packages/vite/src/node/plugins/css.ts#L910-L917

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Found this while investigating https://github.com/withastro/astro/issues/7035

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
