### PR TITLE
fix: fs.deny with leading double slash

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -100,7 +100,7 @@ export function serveStaticMiddleware(
       return next()
     }
 
-    const url = new URL(req.url!, 'http://example.com')
+    const url = new URL(req.url!.replace(/^\/+/, '/'), 'http://example.com')
     const pathname = decodeURIComponent(url.pathname)
 
     // apply aliases to static requests as well
@@ -153,7 +153,7 @@ export function serveRawFsMiddleware(
 
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteServeRawFsMiddleware(req, res, next) {
-    const url = new URL(req.url!, 'http://example.com')
+    const url = new URL(req.url!.replace(/^\/+/, '/'), 'http://example.com')
     // In some cases (e.g. linked monorepos) files outside of root will
     // reference assets that are also out of served root. In such cases
     // the paths are rewritten to `/@fs/` prefixed paths and must be served by

--- a/playground/assets-sanitize/.env
+++ b/playground/assets-sanitize/.env
@@ -1,0 +1,1 @@
+KEY=unsafe

--- a/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
+++ b/playground/assets-sanitize/__tests__/assets-sanitize.spec.ts
@@ -25,3 +25,8 @@ if (!isBuild) {
     expect(Object.keys(manifest).length).toBe(3) // 2 svg, 1 index.js
   })
 }
+
+test.runIf(!isBuild)('denied .env', async () => {
+  expect(await page.textContent('.unsafe-dotenv')).toBe('403')
+  expect(await page.textContent('.unsafe-dotenv-double-slash')).toBe('403')
+})

--- a/playground/assets-sanitize/index.html
+++ b/playground/assets-sanitize/index.html
@@ -6,6 +6,35 @@
     margin-bottom: 1rem;
   }
 </style>
-<h1>test elements below should show circles and their url</h1>
+<h3>test elements below should show circles and their url</h3>
 <div class="test-el plus-circle"></div>
 <div class="test-el underscore-circle"></div>
+
+<h3>Denied .env</h3>
+<div class="unsafe-dotenv"></div>
+<div class="unsafe-dotenv-double-slash"></div>
+
+<script type="module">
+  // .env, denied by default. See fs-serve playground for other fs tests
+  // these checks ensure that a project without a custom root respects fs.deny
+
+  fetch('/.env')
+    .then((r) => {
+      text('.unsafe-dotenv', r.status)
+    })
+    .catch((e) => {
+      console.error(e)
+    })
+
+  fetch(window.location + '/.env')
+    .then((r) => {
+      text('.unsafe-dotenv-double-slash', r.status)
+    })
+    .catch((e) => {
+      console.error(e)
+    })
+
+  function text(el, text) {
+    document.querySelector(el).textContent = text
+  }
+</script>


### PR DESCRIPTION
### Description

The new tests are in assets-sanitize because the issue can't be reproduced with a custom root. Only files in the root of the project will trigger the issue.

Reference: https://github.com/vitejs/vite/pull/9173

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other