### PR TITLE
docs: update working solutions to watch a package inside `node_modules/`

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -245,6 +245,12 @@ Limit for chunk size warnings (in kbs). It is compared against the uncompressed 
 
 Set to `{}` to enable rollup watcher. This is mostly used in cases that involve build-only plugins or integrations processes.
 
+::: warning Watch a package inside `node_modules/`
+
+It's currently not possible to watch a package inside `node_modules/` until https://github.com/vitejs/vite/issues/8619 is resolved. There isn't a known workaround for Vite build yet.
+
+:::
+
 ::: warning Using Vite on Windows Subsystem for Linux (WSL) 2
 
 There are cases that file system watching does not work with WSL2.

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -173,22 +173,31 @@ The error that appears in the Browser when the fallback happens can be ignored. 
 
 File system watcher options to pass on to [chokidar](https://github.com/paulmillr/chokidar#api).
 
-The Vite server watcher skips `.git/` and `node_modules/` directories by default. If you want to watch a package inside `node_modules/`, you can pass a negated glob pattern to `server.watch.ignored`. That is:
+The Vite server watcher skips `.git/` and `node_modules/` directories by default.
+
+::: warning Watch a package inside `node_modules/`
+
+It's currently not possible to watch a package inside `node_modules/` until https://github.com/vitejs/vite/issues/8619 is resolved.
+
+You can work around this by adding the following to your `vite.config.js`:
 
 ```js
 export default defineConfig({
-  server: {
-    watch: {
-      ignored: ['!**/node_modules/your-package-name/**'],
+  plugins: [
+    {
+      name: 'watch-node-modules',
+      configureServer: (server: ViteDevServer): void => {
+        server.watcher.options = {
+          ...server.watcher.options,
+          ignored: [/node_modules\/(?!my-package-name).*/, '**/.git/**'],
+        }
+      },
     },
-  },
-  // The watched package must be excluded from optimization,
-  // so that it can appear in the dependency graph and trigger hot reload.
-  optimizeDeps: {
-    exclude: ['your-package-name'],
-  },
+  ],
 })
 ```
+
+:::
 
 ::: warning Using Vite on Windows Subsystem for Linux (WSL) 2
 


### PR DESCRIPTION
Document working solutions to watch a package inside `node_modules/`

The current `server.watch` docs aren't accurate and the solution proposed just doesn't work, see https://github.com/vitejs/vite/issues/8619. There is a [different workaround in the issue using a custom Vite plugin](https://github.com/vitejs/vite/issues/8619#issuecomment-1170762244) if you're using the Vite dev server which this PR points to instead.

There isn't a known workaround for Vite build though (`build.watch`)


<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
