### PR TITLE
feat: emit CSS sourcemap in build mode

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -318,6 +318,33 @@ Repository: https://github.com/jridgewell/set-array
 
 ---------------------------------------
 
+## @jridgewell/source-map
+License: MIT
+By: Justin Ridgewell
+Repository: https://github.com/jridgewell/source-map
+
+> Copyright 2019 Justin Ridgewell <jridgewell@google.com>
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+---------------------------------------
+
 ## @jridgewell/sourcemap-codec
 License: MIT
 By: Rich Harris

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -77,6 +77,8 @@
     "@ampproject/remapping": "^2.2.1",
     "@babel/parser": "^7.21.4",
     "@babel/types": "^7.21.4",
+    "@jridgewell/gen-mapping": "^0.3.2",
+    "@jridgewell/source-map": "^0.3.3",
     "@jridgewell/trace-mapping": "^0.3.18",
     "@rollup/plugin-alias": "^4.0.4",
     "@rollup/plugin-commonjs": "^24.1.0",

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -11,12 +11,19 @@ import type { AddressInfo, Server } from 'node:net'
 import type { FSWatcher } from 'chokidar'
 import remapping from '@ampproject/remapping'
 import type { DecodedSourceMap, RawSourceMap } from '@ampproject/remapping'
+import {
+  GenMapping,
+  addMapping,
+  setSourceContent,
+} from '@jridgewell/gen-mapping'
+import { SourceMapConsumer } from '@jridgewell/source-map'
 import colors from 'picocolors'
 import debug from 'debug'
 import type { Alias, AliasOptions } from 'dep-types/alias'
 import type MagicString from 'magic-string'
+import { eachMapping } from '@jridgewell/trace-mapping'
 
-import type { TransformResult } from 'rollup'
+import type { SourceMap, TransformResult } from 'rollup'
 import { createFilter as _createFilter } from '@rollup/pluginutils'
 import {
   CLIENT_ENTRY,
@@ -776,6 +783,7 @@ export function combineSourcemaps(
       excludeContent,
     )
   }
+
   if (!map.file) {
     delete map.file
   }
@@ -1213,4 +1221,155 @@ export function evalValue<T = any>(rawValue: string): T {
 const escapeRegexRE = /[-/\\^$*+?.()|[\]{}]/g
 export function escapeRegex(str: string): string {
   return str.replace(escapeRegexRE, '\\$&')
+}
+
+// based on https://github.com/floridoo/concat-with-sourcemaps
+export class ConcatSourcemaps {
+  public lineOffset: number = 0
+  public columnOffset: number = 0
+  public sourceMapping: boolean
+  public contentParts: Buffer[]
+  public separator: Buffer
+  public separatorLineOffset: number = 0
+  public separatorColumnOffset: number = 0
+  public sourceMap: GenMapping | null = null
+
+  public constructor(
+    generateSourceMap: boolean,
+    fileName: string,
+    separator: string,
+  ) {
+    this.lineOffset = 0
+    this.columnOffset = 0
+    this.sourceMapping = generateSourceMap
+    this.contentParts = []
+
+    if (separator === undefined) {
+      this.separator = bufferFrom('')
+    } else {
+      this.separator = bufferFrom(separator)
+    }
+
+    if (this.sourceMapping) {
+      this.sourceMap = new GenMapping({
+        file: unixStylePath(fileName),
+      })
+      this.separatorLineOffset = 0
+      this.separatorColumnOffset = 0
+      const separatorString = this.separator.toString()
+      for (let i = 0; i < separatorString.length; i++) {
+        this.separatorColumnOffset++
+        if (separatorString[i] === '\n') {
+          this.separatorLineOffset++
+          this.separatorColumnOffset = 0
+        }
+      }
+    }
+  }
+
+  public add(
+    filePath: string,
+    content: string | Buffer,
+    sourceMap: SourceMap,
+  ): void {
+    filePath = filePath && unixStylePath(filePath)
+
+    if (!Buffer.isBuffer(content)) {
+      content = bufferFrom(content)
+    }
+
+    if (this.contentParts.length !== 0) {
+      this.contentParts.push(this.separator)
+    }
+    this.contentParts.push(content)
+
+    if (this.sourceMapping) {
+      const contentString = content.toString()
+      const lines = contentString.split('\n').length
+
+      if (sourceMap && sourceMap.mappings && sourceMap.mappings.length > 0) {
+        const upstreamSM = new SourceMapConsumer(
+          sourceMap.toString(),
+          undefined,
+        )
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const _this = this
+        // @ts-expect-error internal property
+        eachMapping(upstreamSM._map, (mapping) => {
+          if (mapping.source && mapping.originalLine) {
+            addMapping(_this.sourceMap!, {
+              generated: {
+                line: _this.lineOffset + mapping.generatedLine,
+                column:
+                  (mapping.generatedLine === 1 ? _this.columnOffset : 0) +
+                  mapping.generatedColumn,
+              },
+              original: {
+                line: mapping.originalLine,
+                column: mapping.originalColumn,
+              },
+              source: mapping.source,
+              // @ts-expect-error too strict overload
+              name: mapping.name,
+            })
+          }
+        })
+        if (upstreamSM.sourcesContent) {
+          upstreamSM.sourcesContent.forEach(function (sourceContent, i) {
+            setSourceContent(
+              _this.sourceMap!,
+              upstreamSM.sources[i]!,
+              sourceContent,
+            )
+          })
+        }
+      } else {
+        if (sourceMap && sourceMap.sources && sourceMap.sources.length > 0)
+          filePath = sourceMap.sources[0]
+        if (filePath) {
+          for (let i = 1; i <= lines; i++) {
+            addMapping(this.sourceMap!, {
+              generated: {
+                line: this.lineOffset + i,
+                column: i === 1 ? this.columnOffset : 0,
+              },
+              original: {
+                line: i,
+                column: 0,
+              },
+              source: filePath,
+            })
+          }
+          if (sourceMap && sourceMap.sourcesContent)
+            setSourceContent(
+              this.sourceMap!,
+              filePath,
+              sourceMap.sourcesContent[0],
+            )
+        }
+      }
+      if (lines > 1) this.columnOffset = 0
+      if (this.separatorLineOffset === 0)
+        this.columnOffset +=
+          contentString.length -
+          Math.max(0, contentString.lastIndexOf('\n') + 1)
+      this.columnOffset += this.separatorColumnOffset
+      this.lineOffset += lines - 1 + this.separatorLineOffset
+    }
+  }
+}
+
+function bufferFrom(content: string) {
+  try {
+    return Buffer.from(content)
+  } catch (e) {
+    if (Object.prototype.toString.call(content) !== '[object String]') {
+      throw new TypeError('separator must be a string')
+    }
+    return new Buffer(content)
+  }
+}
+
+function unixStylePath(filePath: string) {
+  return filePath.replace(/\\/g, '/')
 }

--- a/playground/css-sourcemap/__tests__/__snapshots__/css-sourcemap.spec.ts.snap
+++ b/playground/css-sourcemap/__tests__/__snapshots__/css-sourcemap.spec.ts.snap
@@ -1,0 +1,34 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`build > external sourcemap 1`] = `
+{
+  "mappings": "AAAA,sIACE,UCAA,iBACE,aCDF,kBACE,qBCDF",
+  "sources": [
+    "/root/linked.css",
+    "/root/imported.module.sass?used",
+    "/root/imported.less",
+    "/root/imported.styl",
+  ],
+  "sourcesContent": [
+    ".linked {
+  color: red;
+}
+",
+    ".imported
+  &-sass-module
+    color: red
+",
+    ".imported {
+  &-less {
+    color: @color;
+  }
+}
+",
+    ".imported
+  &-stylus
+    color blue-red-mixed
+",
+  ],
+  "version": 3,
+}
+`;

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -2,18 +2,13 @@ import { URL } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import {
   extractSourcemap,
+  findAssetFile,
   formatSourcemapForSnapshot,
   isBuild,
   isServe,
   page,
   serverLogs,
 } from '~utils'
-
-test.runIf(isBuild)('should not output sourcemap warning (#4939)', () => {
-  serverLogs.forEach((log) => {
-    expect(log).not.toMatch('Sourcemap is likely to be incorrect')
-  })
-})
 
 describe.runIf(isServe)('serve', () => {
   const getStyleTagContentIncluding = async (content: string) => {
@@ -239,5 +234,18 @@ describe.runIf(isServe)('serve', () => {
     serverLogs.forEach((log) => {
       expect(log).not.toMatch(/Sourcemap for .+ points to missing source files/)
     })
+  })
+})
+
+describe.runIf(isBuild)('build', () => {
+  test('should not output sourcemap warning (#4939)', () => {
+    serverLogs.forEach((log) => {
+      expect(log).not.toMatch('Sourcemap is likely to be incorrect')
+    })
+  })
+
+  test('external sourcemap', () => {
+    const map = findAssetFile(/index-.*\.css\.map/)
+    expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchSnapshot()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,12 @@ importers:
       '@babel/types':
         specifier: ^7.21.4
         version: 7.21.4
+      '@jridgewell/gen-mapping':
+        specifier: ^0.3.2
+        version: 0.3.2
+      '@jridgewell/source-map':
+        specifier: ^0.3.3
+        version: 0.3.3
       '@jridgewell/trace-mapping':
         specifier: ^0.3.18
         version: 0.3.18
@@ -3203,8 +3209,8 @@ packages:
     resolution: {integrity: sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==}
     engines: {node: '>=6.0.0'}
 
-  /@jridgewell/source-map@0.3.2:
-    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
+  /@jridgewell/source-map@0.3.3:
+    resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.18
@@ -9475,7 +9481,7 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      '@jridgewell/source-map': 0.3.2
+      '@jridgewell/source-map': 0.3.3
       acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Resolve https://github.com/vitejs/vite/issues/2830, implement CSS sourcemap in build mapping in build mode.
Although this PR is currently a work in progress and is marked as a draft, any early feedback would be appreciated to ensure it's on the right track. The to-do list must be completed before it can be changed from draft status.

- [x] emit linked sourcemap
- [ ] combine source map for `?used`
- [ ] implement inline sourcemap
- [ ] mark CSS sourcemap in build mode as experimental
- [ ] adding more test case

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
