### PR TITLE
fix: remove extra path shorten when resolving from a dir

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -892,7 +892,12 @@ function createOptimizeDepsIncludeResolver(
       config.root,
       config.resolve.preserveSymlinks,
     )
-    return await resolve(nestedPath, basedir, undefined, ssr)
+    return await resolve(
+      nestedPath,
+      path.resolve(basedir, 'package.json'),
+      undefined,
+      ssr,
+    )
   }
 }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -700,11 +700,7 @@ export function tryNodeResolve(
     // css processing appends `*` for importer
     (importer[importer.length - 1] === '*' || fs.existsSync(cleanUrl(importer)))
   ) {
-    if (tryStatSync(importer)?.isFile()) {
-      basedir = path.dirname(importer)
-    } else {
-      basedir = importer
-    }
+    basedir = path.dirname(importer)
   } else {
     basedir = root
   }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -700,7 +700,11 @@ export function tryNodeResolve(
     // css processing appends `*` for importer
     (importer[importer.length - 1] === '*' || fs.existsSync(cleanUrl(importer)))
   ) {
-    basedir = path.dirname(importer)
+    if (tryStatSync(importer)?.isFile()) {
+      basedir = path.dirname(importer)
+    } else {
+      basedir = importer
+    }
   } else {
     basedir = root
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix https://github.com/vitejs/vite/issues/13320

When resolving nested packages, `path.dirname` inadvertently shortens the initial resolving path. Although pnpm tolerates this due to its topological structure, Yarn3 does not. To fix this, the proposed PR prevents `path.dirname` from being invoked when the importer is already a directory.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
