### PR TITLE
fix: nested worker error

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -173,7 +173,7 @@ export async function workerFileToUrl(
   const workerMap = workerCache.get(config.mainConfig || config)!
   let fileName = workerMap.bundle.get(id)
   if (!fileName) {
-    const outputChunk = await bundleWorkerEntry(config, id, query)
+    const outputChunk = await serialBundleWorkerEntry(config, id, query)
     fileName = outputChunk.fileName
     saveEmitWorkerAsset(config, {
       fileName,

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -61,7 +61,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(28)
+    expect(files.length).toBe(30)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -50,7 +50,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/iife/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(16)
+    expect(files.length).toBe(18)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/playground/worker/__tests__/sourcemap-hidden/sourcemap-hidden-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/sourcemap-hidden-worker.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(32)
+    expect(files.length).toBe(36)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap-inline/sourcemap-inline-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/sourcemap-inline-worker.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(16)
+    expect(files.length).toBe(18)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
+++ b/playground/worker/__tests__/sourcemap/sourcemap-worker.spec.ts
@@ -9,7 +9,7 @@ describe.runIf(isBuild)('build', () => {
     const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap/assets')
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(32)
+    expect(files.length).toBe(36)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/worker-nested-worker.js
+++ b/playground/worker/worker-nested-worker.js
@@ -21,6 +21,10 @@ subWorker.onmessage = (ev) => {
 const classicWorker = new Worker(new URL('./url-worker.js', import.meta.url), {
   type: 'module',
 })
+
+new Worker(new URL('./worker-nested-worker1.js', import.meta.url), {
+  type: 'module',
+})
 classicWorker.addEventListener('message', (ev) => {
   self.postMessage({
     type: 'constructor',

--- a/playground/worker/worker-nested-worker1.js
+++ b/playground/worker/worker-nested-worker1.js
@@ -1,0 +1,3 @@
+new Worker(new URL('./worker-nested-worker2.js', import.meta.url), {
+  type: 'module',
+})

--- a/playground/worker/worker-nested-worker2.js
+++ b/playground/worker/worker-nested-worker2.js
@@ -1,0 +1,1 @@
+console.log('worker-nested-worker2')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
closed #13367
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Seems `bundleWorkerEntry` wants to serialize `nested workers` bundle, but it blocks each other.In this pr, I replace `bundleWorkerEntry` with `serialBundleWorkerEntry`, it will recursively bundle nested workers


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
