### PR TITLE
fix(create-vite): support bun as a script runner

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -324,16 +324,26 @@ async function init() {
 
   if (customCommand) {
     const fullCustomCommand = customCommand
-      .replace(/^npm create/, `${pkgManager} create`)
+      .replace(/^npm create /, () => {
+        // `bun create` uses it's own set of templates,
+        // the closest alternative is using `bun x` directly on the package
+        if (pkgManager === 'bun') {
+          return 'bun x create-'
+        }
+        return `${pkgManager} create `
+      })
       // Only Yarn 1.x doesn't support `@version` in the `create` command
       .replace('@latest', () => (isYarn1 ? '' : '@latest'))
       .replace(/^npm exec/, () => {
-        // Prefer `pnpm dlx` or `yarn dlx`
+        // Prefer `pnpm dlx`, `yarn dlx`, or `bun x`
         if (pkgManager === 'pnpm') {
           return 'pnpm dlx'
         }
         if (pkgManager === 'yarn' && !isYarn1) {
           return 'yarn dlx'
+        }
+        if (pkgManager === 'bun') {
+          return 'bun x'
         }
         // Use `npm exec` in all other cases,
         // including Yarn 1.x and other custom npm clients.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes some edge cases when using `bun x create-vite` to initialize projects. create-vote already detects Bun, but if you chose an option like `customize with create-vue` (which runs `create-vue`), it would run the incorrect command.

### Additional context

`bun create` doesn't work like `npm|yarn|pnpm create`; instead of using the npm registry it has it's own set of templates. This is the main change.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
