### PR TITLE
fix: trigger double resolving for wrapped ids

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -15,6 +15,7 @@ import {
   CLIENT_PUBLIC_PATH,
   DEP_VERSION_RE,
   FS_PREFIX,
+  VALID_ID_PREFIX,
 } from '../constants'
 import {
   debugHmr,
@@ -390,7 +391,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               unwrapId(url),
               ssr,
               canSkipImportAnalysis(url) || forceSkipImportAnalysis,
-              resolved,
+              // Only reuse the resolved result if it isn't a virtual module or bare import
+              // These require double resolution after the import is rewritten
+              url.startsWith(VALID_ID_PREFIX) ? undefined : resolved,
             )
             if (depModule.lastHMRTimestamp > 0) {
               url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)

--- a/playground/alias/__tests__/alias.spec.ts
+++ b/playground/alias/__tests__/alias.spec.ts
@@ -45,6 +45,12 @@ test('aliased module', async () => {
   )
 })
 
+test('dep with ts paths', async () => {
+  expect(await page.textContent('.dep-with-ts-paths')).toMatch(
+    '[success] dep with ts paths',
+  )
+})
+
 test('custom resolver', async () => {
   expect(await page.textContent('.custom-resolver')).toMatch(
     '[success] alias to custom-resolver path',

--- a/playground/alias/index.html
+++ b/playground/alias/index.html
@@ -6,6 +6,7 @@
 <p class="dep"></p>
 <p class="from-script-src"></p>
 <p class="aliased-module"></p>
+<p class="dep-with-ts-paths"></p>
 <p class="custom-resolver"></p>
 
 <div class="optimized"></div>
@@ -17,6 +18,7 @@
   import { msg as regexMsg } from 'regex/test'
   import { msg as depMsg } from 'dep'
   import { msg as moduleMsg } from 'aliased-module/index.js'
+  import { msg as depWithTsPathsMsg } from '@vitejs/test-resolve-linked-with-ts-paths'
   import { msg as customResolverMsg } from 'custom-resolver'
 
   function text(el, text) {
@@ -28,6 +30,7 @@
   text('.regex', regexMsg + ' via regex')
   text('.dep', depMsg)
   text('.aliased-module', moduleMsg)
+  text('.dep-with-ts-paths', depWithTsPathsMsg)
   text('.custom-resolver', customResolverMsg)
 
   import { createApp } from 'vue'

--- a/playground/alias/package.json
+++ b/playground/alias/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "aliased-module": "file:./dir/module",
+    "@vitejs/test-resolve-linked-with-ts-paths": "workspace:*",
     "vue": "^3.2.47",
     "@vue/shared": "^3.2.47"
   },

--- a/playground/alias/vite.config.js
+++ b/playground/alias/vite.config.js
@@ -24,6 +24,11 @@ export default defineConfig({
       },
       // aliasing one unoptimized dep to an optimized dep
       { find: 'foo', replacement: 'vue' },
+      // For dep-with-fs-paths
+      {
+        find: '@core',
+        replacement: '@vitejs/test-resolve-linked-with-ts-paths/src',
+      },
       {
         find: 'custom-resolver',
         replacement: path.resolve(__dirname, 'test.js'),

--- a/playground/resolve-linked-with-ts-paths/package.json
+++ b/playground/resolve-linked-with-ts-paths/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@vitejs/test-resolve-linked-with-ts-paths",
+  "version": "1.0.0",
+  "private": true,
+  "main": "src/index.ts",
+  "type": "module",
+  "module": "src/index.ts",
+  "devDependencies": {
+    "typescript": "^5.0.2"
+  }
+}

--- a/playground/resolve-linked-with-ts-paths/package.json
+++ b/playground/resolve-linked-with-ts-paths/package.json
@@ -7,5 +7,8 @@
   "module": "src/index.ts",
   "devDependencies": {
     "typescript": "^5.0.2"
+  },
+  "exports": {
+    ".": "./src/index.ts"
   }
 }

--- a/playground/resolve-linked-with-ts-paths/src/index.ts
+++ b/playground/resolve-linked-with-ts-paths/src/index.ts
@@ -1,0 +1,1 @@
+export { msg } from '@core/utils'

--- a/playground/resolve-linked-with-ts-paths/src/utils/index.ts
+++ b/playground/resolve-linked-with-ts-paths/src/utils/index.ts
@@ -1,0 +1,1 @@
+export const msg = '[success] dep with ts paths'

--- a/playground/resolve-linked-with-ts-paths/tsconfig.json
+++ b/playground/resolve-linked-with-ts-paths/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "moduleResolution": "bundler",
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,9 @@ importers:
 
   playground/alias:
     dependencies:
+      '@vitejs/test-resolve-linked-with-ts-paths':
+        specifier: workspace:*
+        version: link:../resolve-linked-with-ts-paths
       '@vue/shared':
         specifier: ^3.2.47
         version: 3.2.47
@@ -1043,6 +1046,12 @@ importers:
   playground/resolve-config: {}
 
   playground/resolve-linked: {}
+
+  playground/resolve-linked-with-ts-paths:
+    devDependencies:
+      typescript:
+        specifier: ^5.0.2
+        version: 5.0.2
 
   playground/resolve/browser-field:
     dependencies:
@@ -4595,7 +4604,7 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /cjstoesm@1.1.4(typescript@4.6.4):
+  /cjstoesm@1.1.4(typescript@4.8.4):
     resolution: {integrity: sha512-cixLJwK2HS8R8J1jJcYwlrLxWUbdNms5EmVQuvP3O0CGvHNv2WVd2gnqTP/tbTEYzbgWiSYQBZDoAakqsSl94Q==}
     engines: {node: '>=10.0.0'}
     hasBin: true
@@ -4605,13 +4614,13 @@ packages:
       '@wessberg/stringutil': 1.0.19
       chalk: 4.1.2
       commander: 7.2.0
-      compatfactory: 0.0.6(typescript@4.6.4)
+      compatfactory: 0.0.6(typescript@4.8.4)
       crosspath: 0.0.8
       fast-glob: 3.2.12
       helpertypes: 0.0.2
       reserved-words: 0.1.2
       resolve: 1.22.2
-      typescript: 4.6.4
+      typescript: 4.8.4
     dev: true
 
   /clean-stack@2.2.0:
@@ -4741,14 +4750,14 @@ packages:
       dot-prop: 5.3.0
     dev: true
 
-  /compatfactory@0.0.6(typescript@4.6.4):
+  /compatfactory@0.0.6(typescript@4.8.4):
     resolution: {integrity: sha512-F1LpdNxgxay4UdanmeL75+guJPDg2zu8bFZDVih/kse5hA3oa+aMgvk4tLwq7AFBpy3S0ilnPdSfYsTl/L9NXA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       typescript: '>=3.x || >= 4.x'
     dependencies:
       helpertypes: 0.0.2
-      typescript: 4.6.4
+      typescript: 4.8.4
     dev: true
 
   /concat-map@0.0.1:
@@ -7479,7 +7488,7 @@ packages:
       '@mrbbot/node-fetch': 4.6.0
       '@peculiar/webcrypto': 1.3.3
       chokidar: 3.5.3(patch_hash=dzxbf3kgof5pdmbsyih2x43sq4)
-      cjstoesm: 1.1.4(typescript@4.6.4)
+      cjstoesm: 1.1.4(typescript@4.8.4)
       dotenv: 8.6.0
       env-paths: 2.2.1
       event-target-shim: 6.0.2
@@ -7495,7 +7504,7 @@ packages:
       semiver: 1.1.0
       source-map-support: 0.5.21
       tslib: 2.5.0
-      typescript: 4.6.4
+      typescript: 4.8.4
       typeson: 6.1.0
       typeson-registry: 1.0.0-alpha.39
       web-streams-polyfill: 3.2.1
@@ -9728,12 +9737,6 @@ packages:
       call-bind: 1.0.2
       for-each: 0.3.3
       is-typed-array: 1.1.10
-    dev: true
-
-  /typescript@4.6.4:
-    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
     dev: true
 
   /typescript@4.8.4:


### PR DESCRIPTION
### Description

Fixes #13404

I don't know if this fix is really needed. At least if it should count as a regression for the reproduction provided. The reproduction works if the alias is resolved instead of being pointed to `"@vite-test/core/src"`:
```js
  resolve: {
    alias: {
      "@core": path.resolve("../core/src/"),
    },
  },
```

But we have some examples of aliases like this one in our playground (for example `{ find: 'dep', replacement: '@vitejs/test-resolve-linked' }`).

I think these cases could lead to duplicated modules in the browser. The path is rewritten as `/@id/@vite-test/core/src/...` and later on the browser could load the same module under a different URL (if it is resolved without starting from the @core alias).

I think it is safer to still apply this as a patch, and break it in Vite 5 if we consider that should be the path forward.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other