### PR TITLE
test: rewrite `waitForNavigation` to `waitForEvent('load')`

### DIFF
--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -408,12 +408,13 @@ test('inline style test', async () => {
 if (!isBuild) {
   test('@import in html style tag hmr', async () => {
     await untilUpdated(() => getColor('.import-css'), 'rgb(0, 136, 255)')
+    const loadPromise = page.waitForEvent('load')
     editFile(
       './css/import.css',
       (code) => code.replace('#0088ff', '#00ff88'),
       true,
     )
-    await page.waitForNavigation()
+    await loadPromise
     await untilUpdated(() => getColor('.import-css'), 'rgb(0, 255, 136)')
   })
 }

--- a/playground/css/postcss-caching/css.spec.ts
+++ b/playground/css/postcss-caching/css.spec.ts
@@ -33,7 +33,7 @@ test.runIf(isServe)('postcss config', async () => {
 
     blueApp = await startServer(blueAppDir)
 
-    await page.goto(`http://localhost:${port}`)
+    await page.goto(`http://localhost:${port}`, { waitUntil: 'load' })
     const blueA = await page.$('.postcss-a')
     expect(await getColor(blueA)).toBe('blue')
     const blueB = await page.$('.postcss-b')
@@ -44,9 +44,9 @@ test.runIf(isServe)('postcss config', async () => {
     await blueApp.close()
     blueApp = null
 
-    const navigationPromise = page.waitForNavigation() // wait for server restart auto reload
+    const loadPromise = page.waitForEvent('load') // wait for server restart auto reload
     greenApp = await startServer(greenAppDir)
-    await navigationPromise
+    await loadPromise
 
     const greenA = await page.$('.postcss-a')
     expect(await getColor(greenA)).toBe('black')

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -48,10 +48,13 @@ describe.runIf(isServe)('hmr', () => {
     await page.goto(url)
     const el = await page.$('.virtual')
     expect(await el.textContent()).toBe('[success]')
+
+    const loadPromise = page.waitForEvent('load')
     editFile('src/importedVirtual.js', (code) =>
       code.replace('[success]', '[wow]'),
     )
-    await page.waitForNavigation()
+    await loadPromise
+
     await untilUpdated(async () => {
       const el = await page.$('.virtual')
       return await el.textContent()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
[`waitForNavigation`](https://playwright.dev/docs/api/class-page#page-wait-for-navigation) is deprecated. The document suggests to use `waitForURL` but that doesn't work for reloads. This PR replaces `waitForNavigation` with `waitForEvent('load')`

`waitForURL` resolves immediately if the page is already showing that URL.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
