### PR TITLE
docs(chunkSplitting): add `manualChunks` object form syntax warning when it is used with the `splitVendorChunk` plugin

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -61,7 +61,7 @@ export default defineConfig({
 This strategy is also provided as a `splitVendorChunk({ cache: SplitVendorChunkCache })` factory, in case composition with custom logic is needed. `cache.reset()` needs to be called at `buildStart` for build watch mode to work correctly in this case.
 
 ::: warning
-You should use `build.rollupOptions.output.manualChunks` function form when using this plugin. If the object form is used, the plugin won't have any effect. 
+You should use `build.rollupOptions.output.manualChunks` function form when using this plugin. If the object form is used, the plugin won't have any effect.
 :::
 
 ## Rebuild on files changes

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -61,7 +61,7 @@ export default defineConfig({
 This strategy is also provided as a `splitVendorChunk({ cache: SplitVendorChunkCache })` factory, in case composition with custom logic is needed. `cache.reset()` needs to be called at `buildStart` for build watch mode to work correctly in this case.
 
 ::: warning
-You should use `build.rollupOptions.output.manualChunks` function form when using this plugin for correct work
+You should use `build.rollupOptions.output.manualChunks` function form when using this plugin. If the object form is used, the plugin won't have any effect. 
 :::
 
 ## Rebuild on files changes

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -63,6 +63,7 @@ This strategy is also provided as a `splitVendorChunk({ cache: SplitVendorChunkC
 ::: warning
 You should use `build.rollupOptions.output.manualChunks` function form when using this plugin for correct work
 :::
+
 ## Rebuild on files changes
 
 You can enable rollup watcher with `vite build --watch`. Or, you can directly adjust the underlying [`WatcherOptions`](https://rollupjs.org/configuration-options/#watch) via `build.watch`:

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -60,6 +60,9 @@ export default defineConfig({
 
 This strategy is also provided as a `splitVendorChunk({ cache: SplitVendorChunkCache })` factory, in case composition with custom logic is needed. `cache.reset()` needs to be called at `buildStart` for build watch mode to work correctly in this case.
 
+::: warning
+You should use `build.rollupOptions.output.manualChunks` function form when using this plugin for correct work
+:::
 ## Rebuild on files changes
 
 You can enable rollup watcher with `vite build --watch`. Or, you can directly adjust the underlying [`WatcherOptions`](https://rollupjs.org/configuration-options/#watch) via `build.watch`:

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -118,7 +118,7 @@ export function splitVendorChunkPlugin(): Plugin {
               // we can't safely replicate rollup handling.
               // eslint-disable-next-line no-console
               console.warn(
-                '(!) the `splitVendorChunk` plugin doesn't have any effect when using the object form of `build.rollupOptions.manualChunks`. Consider using the function form instead.',
+                "(!) the `splitVendorChunk` plugin doesn't have any effect when using the object form of `build.rollupOptions.manualChunks`. Consider using the function form instead.",
               )
             } else {
               output.manualChunks = viteManualChunks

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -118,7 +118,7 @@ export function splitVendorChunkPlugin(): Plugin {
               // we can't safely replicate rollup handling.
               // eslint-disable-next-line no-console
               console.warn(
-                '(!) `build.rollupOptions.manualChunks` object form is ignored when used with the `splitVendorChunk` plugin. Consider using the function form instead.',
+                '(!) the `splitVendorChunk` plugin doesn't have any effect when using the object form of `build.rollupOptions.manualChunks`. Consider using the function form instead.',
               )
             } else {
               output.manualChunks = viteManualChunks

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -116,6 +116,10 @@ export function splitVendorChunkPlugin(): Plugin {
               }
               // else, leave the object form of manualChunks untouched, as
               // we can't safely replicate rollup handling.
+              // eslint-disable-next-line no-console
+              console.warn(
+                '(!) `build.rollupOptions.manualChunks` object form is ignored when used with the `splitVendorChunk` plugin. Consider using the function form instead.',
+              )
             } else {
               output.manualChunks = viteManualChunks
             }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Resolves #12639 
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
