### PR TITLE
test(hmr): remove timeout causing flakiness

### DIFF
--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -712,20 +712,19 @@ if (!isBuild) {
     const file = 'missing-import/a.js'
     const importCode = "import 'missing-modules'"
     const unImportCode = `// ${importCode}`
-    const timeout = 2000
 
     await page.goto(viteTestUrl + '/missing-import/index.html', {
       waitUntil: 'load',
     })
 
     await untilBrowserLogAfter(async () => {
-      const loadPromise = page.waitForEvent('load', { timeout })
+      const loadPromise = page.waitForEvent('load')
       editFile(file, (code) => code.replace(importCode, unImportCode))
       await loadPromise
     }, 'missing test')
 
     await untilBrowserLogAfter(async () => {
-      const loadPromise = page.waitForEvent('load', { timeout })
+      const loadPromise = page.waitForEvent('load')
       editFile(file, (code) => code.replace(unImportCode, importCode))
       await loadPromise
     }, /500/)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The `keep hmr reload after missing import on server startup` test has been flaky recently. I think removing the timeout should fix it. If it really fails, the test has it's own timeout that also causes a fail.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
