### PR TITLE
feat: config.framework

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -321,6 +321,11 @@ export interface ResolveWorkerOptions extends PluginHookUtils {
 }
 
 export interface InlineConfig extends UserConfig {
+  /**
+   * To be set by framework building on top of Vite (Astro, Nuxt, ...) or tools
+   * using Vite pipeline (Vitest) so that plugins can adapt to the context
+   */
+  framework?: string
   configFile?: string | false
   envFile?: false
 }
@@ -330,6 +335,7 @@ export type ResolvedConfig = Readonly<
     configFile: string | undefined
     configFileDependencies: string[]
     inlineConfig: InlineConfig
+    framework?: string
     root: string
     base: string
     /** @internal */


### PR DESCRIPTION
Just an API proposal. Open to better naming or other solutions.

## Problem

I'm trying to automatically disable HMR for React plugins when the transformation are only needed for unit testing. (original issue https://github.com/vitejs/vite-plugin-react-swc/issues/111)
My first idea was to use `process.env.(VI)TEST`, but this then also disable HMR for people that spawn a Vite dev server to test Vite HMR (like the Babel plugin itself or vite-plugin-ssr).

What I want is to reliably know that the plugin was created by Vitest (and not running in a Vitest process).

Discord ecosystem thread: https://discord.com/channels/804011606160703521/1115145671159336960

## Proposed solution

Given than more and more tools are building on top of Vite, I think it will be great to generalise this so that plugin can have more context to whether they are running in default Vite (undefined) or in a more focused toolchain.

My idea will be to add this only to the inline API so that it doesn't pollute the default user config