### PR TITLE
fix(debug): import performance from perf_hooks

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { performance } from 'node:perf_hooks'
 import colors from 'picocolors'
 import type {
   Loader,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

noticed this from the error logs at https://github.com/vitejs/vite/issues/13463. we're accidentally using the global `performance` object, which only [exist in node 16](https://nodejs.org/api/globals.html#performance). Causing `vite --debug` to fail in node 14.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
