### PR TITLE
docs: link to the config and using plugin sections from getting started

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -12,7 +12,9 @@ Vite (French word for "quick", pronounced `/vit/`<button style="border:none;padd
 
 - A build command that bundles your code with [Rollup](https://rollupjs.org), pre-configured to output highly optimized static assets for production.
 
-Vite is opinionated and comes with sensible defaults out of the box, but is also highly extensible via its [Plugin API](./api-plugin) and [JavaScript API](./api-javascript) with full typing support.
+Vite is opinionated and comes with sensible defaults out of the box. Read about what's possible in the [Features Guide](./features). Support for frameworks or integration with other tools is possible through [Plugins](./using-plugins). The [Config Section](../config/) explains how to adapt Vite to your project if needed.
+
+Vite is also highly extensible via its [Plugin API](./api-plugin) and [JavaScript API](./api-javascript) with full typing support.
 
 You can learn more about the rationale behind the project in the [Why Vite](./why) section.
 


### PR DESCRIPTION
### Description

Trying to get people to read how to configure Vite and how plugins are used early on.

We could have a map of all the docs sections here too, but I'm afraid of adding too many links that could confuse the user when getting started.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other