### PR TITLE
feat(html): support image set in inline style

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -463,13 +463,15 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               }
             }
           }
-          // <tag style="... url(...) ..."></tag>
+          // <tag style="... url(...) or image-set(...) ..."></tag>
           // extract inline styles as virtual css and add class attribute to tag for selecting
           const inlineStyle = node.attrs.find(
             (prop) =>
               prop.prefix === undefined &&
               prop.name === 'style' &&
-              prop.value.includes('url('), // only url(...) in css need to emit file
+              // only url(...) or image-set(...) in css need to emit file
+              (prop.value.includes('url(') ||
+                prop.value.includes('image-set(')),
           )
           if (inlineStyle) {
             inlineModuleIndex++

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -148,13 +148,22 @@ describe('css url() references', () => {
     expect(imageSet).toContain('image-set(url("data:image/png;base64,')
   })
 
-  test('image-set with multiple descriptor', async () => {
+  test('image-set with gradient', async () => {
     const imageSet = await getBg('.css-image-set-gradient')
     expect(imageSet).toContain('image-set(url("data:image/png;base64,')
   })
 
   test('image-set with multiple descriptor', async () => {
     const imageSet = await getBg('.css-image-set-multiple-descriptor')
+    imageSet.split(', ').forEach((s) => {
+      expect(s).toMatch(assetMatch)
+    })
+  })
+
+  test('image-set with multiple descriptor as inline style', async () => {
+    const imageSet = await getBg(
+      '.css-image-set-multiple-descriptor-inline-style',
+    )
     imageSet.split(', ').forEach((s) => {
       expect(s).toMatch(assetMatch)
     })

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -71,8 +71,8 @@
     CSS background image-set() (with multiple descriptor)
   </span>
 </div>
-<!-- image-set in style tags is not supported in Vite yet -->
-<!-- <div
+<div
+  class="css-image-set-multiple-descriptor-inline-style"
   style="
     background-image: -webkit-image-set(
       './nested/asset.png' type('image/png') 1x,
@@ -82,9 +82,9 @@
   "
 >
   <span style="background: #fff">
-    CSS background image-set() (with multiple descriptor)
+    CSS background image-set() inline style (with multiple descriptor)
   </span>
-</div> -->
+</div>
 <div class="css-url-relative-at-imported">
   <span style="background: #fff"
     >CSS background (relative from @imported file in different dir)</span


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Continuation from https://github.com/vitejs/vite/pull/13059, support `image-set` in inline `style="..."` too. The handling is already in place for `url(...)`, so it was a matter of updating the checks to detect `image-set(...)` too.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
