### PR TITLE
fix: remove deprecated config.server.base

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -247,12 +247,6 @@ async function createServer() {
 createServer()
 ```
 
-## server.base
-
-- **Type:** `string | undefined`
-
-Prepend this folder to http requests, for use when proxying vite as a subfolder. Should start with the `/` character.
-
 ## server.fs.strict
 
 - **Type:** `boolean`

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -95,11 +95,6 @@ export interface ServerOptions extends CommonServerOptions {
    */
   middlewareMode?: boolean | 'html' | 'ssr'
   /**
-   * Prepend this folder to http requests, for use when proxying vite as a subfolder
-   * Should start and end with the `/` character
-   */
-  base?: string
-  /**
    * Options for files served via '/\@fs/'.
    */
   fs?: FileSystemServeOptions


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I randomly found `server.base` (https://vitejs.dev/config/server-options.html#server-base), but it seems like it is not being used anymore. The code was introduced in [this pull request](https://github.com/vitejs/vite/pull/1556) (before vite2 was released), but it appears to have not been invoked after a long period of code iteration. The documentation was introduced in [this pull request](https://github.com/vitejs/vite/pull/7289). I suppose the root `base` config has superseded `server.base` now.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
