### PR TITLE
fix: esm detection with `export const { A, B }` pattern

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -100,7 +100,7 @@
     "dep-types": "link:./src/types",
     "dotenv": "^16.1.4",
     "dotenv-expand": "^9.0.0",
-    "es-module-lexer": "^1.2.1",
+    "es-module-lexer": "^1.3.0",
     "escape-html": "^1.0.3",
     "estree-walker": "^3.0.3",
     "etag": "^1.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,8 +325,8 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0(patch_hash=dccccn23nvejzy75sgiosdt2au)
       es-module-lexer:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^1.3.0
+        version: 1.3.0
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -5541,8 +5541,8 @@ packages:
       which-typed-array: 1.1.9
     dev: true
 
-  /es-module-lexer@1.2.1:
-    resolution: {integrity: sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==}
+  /es-module-lexer@1.3.0:
+    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
     dev: true
 
   /es-set-tostringtag@2.0.1:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Update es-module-lexer. See https://github.com/guybedford/es-module-lexer/issues/153.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
vite interprets the ESM build of `vscode-uri` as a CJS dependency and rewrites it to a default import. Since `vscode-uri` has no default export, it fails in browswer.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
