### PR TITLE
fix: respect `resolve.conditions` during `nodeResolve`

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -121,7 +121,7 @@ async function instantiateModule(
 
   const {
     isProduction,
-    resolve: { dedupe, preserveSymlinks },
+    resolve: { dedupe, preserveSymlinks, conditions },
     root,
   } = server.config
 
@@ -129,7 +129,7 @@ async function instantiateModule(
     mainFields: ['main'],
     browserField: true,
     conditions: [],
-    overrideConditions: ['production', 'development'],
+    overrideConditions: [...conditions, 'production', 'development'],
     extensions: ['.js', '.cjs', '.json'],
     dedupe,
     preserveSymlinks,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Respect user's `resolve.conditions` while doing the internal node resolve. This is required by "react-server" components. They need the internal node resolve to also use the "react-server" condition. I am passing it in the vite config but its not being used by the `nodeResolve` function. This adds it to the override conditions, so its used by the nodeResolve function.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
