### PR TITLE
fix: make optimize error available to meta-framework

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -665,7 +665,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                   return
                 }
                 // Unexpected error, log the issue but avoid an unhandled exception
-                config.logger.error(e.message)
+                config.logger.error(e.message, { error: e })
               })
             }
           } else if (!importer.startsWith(clientDir)) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Vite-plugin-ssr needs to be able to access the error thrown while optimizing the deps.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

The error handling of vite-plugin-ssr is currently being refactored and it needs to be able to access the original error, so that vite-plugin-ssr can properly handle optimization errors.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
