### PR TITLE
feat(create-vite): add preact path alias in preact-ts template

### DIFF
--- a/packages/create-vite/template-preact-ts/tsconfig.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.json
@@ -5,7 +5,12 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-
+    "baseUrl": "./",
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    },
+      
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
### Description

When adding `react-redux` package to a vite preact-ts project created from the template I got stuck on a cryptic error message: https://stackoverflow.com/questions/76440285/error-property-children-is-missing-in-type-vnodeany-but-required-in-type?noredirect=1#comment134806152_76440285

```
Type 'Element' is not assignable to type 'ReactNode'.
  Property 'children' is missing in type 'VNode<any>' but required in type 'ReactPortal'.ts(2322)
index.d.ts(166, 9): 'children' is declared here.
Provider.d.ts(19, 5): The expected type comes from property 'children' which is declared here on type 'IntrinsicAttributes & ProviderProps<AnyAction, unknown>'
(property) JSXInternal.IntrinsicElements.div: JSXInternal.HTMLAttributes<HTMLDivElement>
```

This was resolved by following the typescript preact/compat config guidelines here: https://preactjs.com/guide/v10/typescript/#typescript-preactcompat-configuration

This PR adds the preact/compat config to the preact-ts template for future users of create-vite.

### Additional context

n/a

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature (but perhaps treat as `other` because its improved default behaviour?)
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
