### PR TITLE
fix: timestamp config dynamicImport

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1144,10 +1144,16 @@ async function loadConfigFromBundledFile(
   // convert to base64, load it with native Node ESM.
   if (isESM) {
     try {
+      // Postfix the bundled code with a timestamp to avoid Node's ESM loader cache
+      const configTimestamp = `${fileName}.timestamp:${Date.now()}-${Math.random()
+        .toString(16)
+        .slice(2)}`
       return (
         await dynamicImport(
           'data:text/javascript;base64,' +
-            Buffer.from(bundledCode).toString('base64'),
+            Buffer.from(`${bundledCode}\n//${configTimestamp}`).toString(
+              'base64',
+            ),
         )
       ).default
     } catch (e) {


### PR DESCRIPTION
### Description

SvelteKit [is failing](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/5254445525/jobs/9493052687) after #13269, as `config.build.ssr` is mutated then the object is cached by Node. This PR makes sure the dynamic import config module is always different by adding a timestamp.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other