### PR TITLE
fix: 'module' is not defined eslint error in template-react (fix #13517)

### DIFF
--- a/packages/create-vite/template-react-ts/.eslintrc.cjs
+++ b/packages/create-vite/template-react-ts/.eslintrc.cjs
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 module.exports = {
   env: { browser: true, es2020: true },
   extends: [

--- a/packages/create-vite/template-react/.eslintrc.cjs
+++ b/packages/create-vite/template-react/.eslintrc.cjs
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 module.exports = {
   env: { browser: true, es2020: true },
   extends: [


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/issues/13517

This adds the `node` env to the `.eslintrc.cjs` file in `packages/create-vite/template-react` and `packages/create-vite/template-react-ts` templates to fix the linter error `'module' is not defined`

There are a few other ways to fix this, but I think this way makes the most sense and does not affect the linting of other files in the project.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
