### PR TITLE
feat: update eslint config in React templates

### DIFF
--- a/packages/create-vite/template-preact-ts/src/main.tsx
+++ b/packages/create-vite/template-preact-ts/src/main.tsx
@@ -2,4 +2,4 @@ import { render } from 'preact'
 import { App } from './app.tsx'
 import './index.css'
 
-render(<App />, document.getElementById('app') as HTMLElement)
+render(<App />, document.getElementById('app')!)

--- a/packages/create-vite/template-react-ts/.eslintrc.cjs
+++ b/packages/create-vite/template-react-ts/.eslintrc.cjs
@@ -21,7 +21,5 @@ module.exports = {
       { allowConstantExport: true },
     ],
     '@typescript-eslint/no-non-null-assertion': 'off',
-    '@typescript-eslint/no-unnecessary-condition': 'warn',
-    '@typescript-eslint/non-nullable-type-assertion-style': 'warn',
   },
 }

--- a/packages/create-vite/template-react-ts/.eslintrc.cjs
+++ b/packages/create-vite/template-react-ts/.eslintrc.cjs
@@ -1,14 +1,27 @@
 module.exports = {
+  root: true,
   env: { browser: true, es2020: true },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:react-hooks/recommended',
   ],
   parser: '@typescript-eslint/parser',
-  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    project: true,
+    tsconfigRootDir: __dirname,
+  },
   plugins: ['react-refresh'],
   rules: {
-    'react-refresh/only-export-components': 'warn',
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-unnecessary-condition': 'warn',
+    '@typescript-eslint/non-nullable-type-assertion-style': 'warn',
   },
 }

--- a/packages/create-vite/template-react-ts/src/main.tsx
+++ b/packages/create-vite/template-react-ts/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,

--- a/packages/create-vite/template-react/.eslintrc.cjs
+++ b/packages/create-vite/template-react/.eslintrc.cjs
@@ -10,6 +10,9 @@ module.exports = {
   settings: { react: { version: '18.2' } },
   plugins: ['react-refresh'],
   rules: {
-    'react-refresh/only-export-components': 'warn',
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
   },
 }


### PR DESCRIPTION
Closes #10772

I wanted to improve a bit the ling rules for the TS template, adding more type aware rules. The strict set is too strict for a starter, but I added manually my preferred one: `@typescript-eslint/no-unnecessary-condition` (catches so much dead branch when refactoring). Also added one to remove this `as` I wanted to remove since way to long (see #10772) 

Also discovered that `no-non-null-assertion` is enabled by default, which is bad IMO. I don't agree with the [opinion of the TS-ESLint team](https://github.com/typescript-eslint/typescript-eslint/discussions/6010#discussioncomment-4168801). TS will never be a sound type system (can't find the issue/discussion from the core team that says it's out of scope). This tool is a sharp knife, but a useful one, we use ourself quite a lot in the Vite codebase. And the diff in the TS template clearly shows that this is a better assertion than a `as`.