### PR TITLE
feat: allow function in noExternal

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -290,7 +290,7 @@ export async function optimizeServerSsrDeps(
         resolve: false,
       })
       if (typeof noExternal === 'function') {
-        noExternalFilter = (dep: any) => excludeFilter(dep) && !noExternal(dep)
+        noExternalFilter = (dep: any) => excludeFilter(dep) && noExternal(dep)
       } else {
         noExternalFilter = excludeFilter
       }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -283,12 +283,18 @@ export async function optimizeServerSsrDeps(
     alsoInclude = arraify(noExternal).filter(
       (ne) => typeof ne === 'string',
     ) as string[]
-    noExternalFilter =
-      noExternal === true
-        ? (dep: unknown) => true
-        : createFilter(undefined, exclude, {
-            resolve: false,
-          })
+    if (noExternal === true) {
+      noExternalFilter = (dep: unknown) => true
+    } else {
+      const excludeFilter = createFilter(undefined, exclude, {
+        resolve: false,
+      })
+      if (typeof noExternal === 'function') {
+        noExternalFilter = (dep: any) => excludeFilter(dep) && !noExternal(dep)
+      } else {
+        noExternalFilter = excludeFilter
+      }
+    }
   }
 
   const deps: Record<string, string> = {}

--- a/packages/vite/src/node/ssr/index.ts
+++ b/packages/vite/src/node/ssr/index.ts
@@ -6,7 +6,12 @@ export type SSRFormat = 'esm' | 'cjs'
 export type SsrDepOptimizationOptions = DepOptimizationConfig
 
 export interface SSROptions {
-  noExternal?: string | RegExp | (string | RegExp)[] | true
+  noExternal?:
+    | string
+    | ((id: string) => boolean)
+    | RegExp
+    | (string | RegExp)[]
+    | true
   external?: string[]
   /**
    * Define the target for the ssr build. The browser field in package.json

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -77,9 +77,13 @@ export function cjsSsrResolveExternals(
 
   let externals = [...ssrExternals]
   if (ssrConfig?.noExternal) {
-    externals = externals.filter(
-      createFilter(undefined, ssrConfig.noExternal, { resolve: false }),
-    )
+    if (typeof ssrConfig.noExternal === 'function') {
+      externals = externals.filter(ssrConfig.noExternal)
+    } else {
+      externals = externals.filter(
+        createFilter(undefined, ssrConfig.noExternal, { resolve: false }),
+      )
+    }
   }
   return externals
 }
@@ -113,11 +117,13 @@ export function createIsConfiguredAsSsrExternal(
 ): (id: string, importer?: string) => boolean {
   const { ssr, root } = config
   const noExternal = ssr?.noExternal
-  const noExternalFilter =
-    noExternal !== 'undefined' &&
-    typeof noExternal !== 'boolean' &&
-    createFilter(undefined, noExternal, { resolve: false })
 
+  let noExternalFilter: (id: any) => boolean | undefined
+  if (typeof noExternal === 'function') {
+    noExternalFilter = noExternal
+  } else if (noExternal !== 'undefined' && typeof noExternal !== 'boolean') {
+    noExternalFilter = createFilter(undefined, noExternal, { resolve: false })
+  }
   const resolveOptions: InternalResolveOptions = {
     ...config.resolve,
     root,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: false


### PR DESCRIPTION

### Description

noExternal only supports array of string, or Regex, but this is not enough to more dynamic things like skipping noBuiltin node dependencies. In addition the underlining api from rollup allows to define the `external` configuration as a function

### Additional context

Allow things like:
```
{
  noExternal: everythingButNodeBuiltins
}
```

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
