### PR TITLE
workflow: add commit messages validated before commit

### DIFF
--- a/.github/commit-convention.md
+++ b/.github/commit-convention.md
@@ -8,7 +8,7 @@ Messages must be matched by the following regex:
 
 <!-- prettier-ignore -->
 ```js
-/^(revert: )?(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\(.+\))?!?: .{1,50}/
+/^(revert: )?(feat|fix|docs|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release)(\(.+\))?: .{1,50}/
 ```
 
 #### Examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,7 +187,7 @@ You can set the `DEBUG` environment variable to turn on debugging logs (e.g. `DE
 
 - No need to worry about code style as long as you have installed the dev dependencies. Modified files are automatically formatted with Prettier on commit (by invoking [Git Hooks](https://git-scm.com/docs/githooks) via [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks)).
 
-- PR title must follow the [commit message convention](./.github/commit-convention.md) so that changelogs can be automatically generated.
+- PR title and commit messages must follow the [commit message convention](./.github/commit-convention.md) so that changelogs can be automatically generated. Commit messages are automatically validated before commit (by invoking [Git Hooks](https://git-scm.com/docs/githooks) via [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks)).
 
 ## Maintenance Guidelines
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "vue": "^3.3.4"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm exec lint-staged --concurrent false"
+    "pre-commit": "pnpm exec lint-staged --concurrent false",
+    "commit-msg": "node scripts/verifyCommit.js"
   },
   "lint-staged": {
     "*": [

--- a/scripts/verifyCommit.js
+++ b/scripts/verifyCommit.js
@@ -1,0 +1,25 @@
+// @ts-check
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import colors from 'picocolors'
+
+const msgPath = path.resolve('.git/COMMIT_EDITMSG')
+const msg = readFileSync(msgPath, 'utf-8').trim()
+
+const commitRE =
+  /^(?:revert: )?(?:feat|fix|docs|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release)(?:\(.+\))?: .{1,50}/
+
+if (!commitRE.test(msg)) {
+  console.error(
+    `  ${colors.bgRed(colors.white(' ERROR '))} ${colors.red(
+      `invalid commit message format.`,
+    )}\n\n` +
+      colors.red(
+        `  Proper commit message format is required for automated changelog generation. Examples:\n\n`,
+      ) +
+      `    ${colors.green(`feat(dev): add 'comments' option`)}\n` +
+      `    ${colors.green(`fix: handle events on blur (close #28)`)}\n\n` +
+      colors.red(`  See .github/commit-convention.md for more details.\n`),
+  )
+  process.exit(1)
+}


### PR DESCRIPTION
add commit messages validated before commit

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
