### PR TITLE
Fix: HMR + vite can't map null payload.updates variable

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -171,7 +171,7 @@ async function handleMessage(payload: HMRPayload) {
         isFirstUpdate = false
       }
       await Promise.all(
-        payload.updates.map(async (update): Promise<void> => {
+        (payload.updates || []).map(async (update): Promise<void> => {
           if (update.type === 'js-update') {
             return queueUpdate(fetchUpdate(update))
           }


### PR DESCRIPTION
It would fix the fact that payload.updates.map is trying to iterate over a null variable

<!-- Thank you for contributing! -->

### Description

This PR is trying to solve an issue, where payload.updates is null and the source code seems to iterate over a null variable.

### Additional context

Let me know if you need further info

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
