### PR TITLE
chore: upgrade rollup to 3.25.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prettier": "2.8.8",
     "resolve": "^1.22.2",
     "rimraf": "^5.0.1",
-    "rollup": "^3.25.1",
+    "rollup": "^3.25.2",
     "simple-git-hooks": "^2.8.1",
     "tslib": "^2.5.3",
     "tsx": "^3.12.7",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prettier": "2.8.8",
     "resolve": "^1.22.2",
     "rimraf": "^5.0.1",
-    "rollup": "^3.21.0",
+    "rollup": "^3.25.1",
     "simple-git-hooks": "^2.8.1",
     "tslib": "^2.5.3",
     "tsx": "^3.12.7",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "esbuild": "^0.18.6",
     "postcss": "^8.4.24",
-    "rollup": "^3.25.1"
+    "rollup": "^3.25.2"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "esbuild": "^0.18.6",
     "postcss": "^8.4.24",
-    "rollup": "^3.21.0"
+    "rollup": "^3.25.1"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -5,16 +5,17 @@ import type {
   ExternalOption,
   InputOption,
   InternalModuleFormat,
+  LoggingFunction,
   ModuleFormat,
   OutputOptions,
   Plugin,
   RollupBuild,
   RollupError,
+  RollupLog,
   RollupOptions,
   RollupOutput,
   RollupWarning,
   RollupWatcher,
-  WarningHandler,
   WatcherOptions,
 } from 'rollup'
 import type { Terser } from 'dep-types/terser'
@@ -867,47 +868,58 @@ const dynamicImportWarningIgnoreList = [
 
 export function onRollupWarning(
   warning: RollupWarning,
-  warn: WarningHandler,
+  warn: LoggingFunction,
   config: ResolvedConfig,
 ): void {
-  function viteWarn(warning: RollupWarning) {
-    if (warning.code === 'UNRESOLVED_IMPORT') {
-      const id = warning.id
-      const exporter = warning.exporter
-      // throw unless it's commonjs external...
-      if (!id || !/\?commonjs-external$/.test(id)) {
-        throw new Error(
-          `[vite]: Rollup failed to resolve import "${exporter}" from "${id}".\n` +
-            `This is most likely unintended because it can break your application at runtime.\n` +
-            `If you do want to externalize this module explicitly add it to\n` +
-            `\`build.rollupOptions.external\``,
+  const viteWarn: LoggingFunction = (warnLog) => {
+    let warning: string | RollupLog
+
+    if (typeof warnLog === 'function') {
+      warning = warnLog()
+    } else {
+      warning = warnLog
+    }
+
+    if (typeof warning === 'object') {
+      if (warning.code === 'UNRESOLVED_IMPORT') {
+        const id = warning.id
+        const exporter = warning.exporter
+        // throw unless it's commonjs external...
+        if (!id || !/\?commonjs-external$/.test(id)) {
+          throw new Error(
+            `[vite]: Rollup failed to resolve import "${exporter}" from "${id}".\n` +
+              `This is most likely unintended because it can break your application at runtime.\n` +
+              `If you do want to externalize this module explicitly add it to\n` +
+              `\`build.rollupOptions.external\``,
+          )
+        }
+      }
+
+      if (
+        warning.plugin === 'rollup-plugin-dynamic-import-variables' &&
+        dynamicImportWarningIgnoreList.some((msg) =>
+          // @ts-expect-error warning is RollupLog
+          warning.message.includes(msg),
         )
+      ) {
+        return
+      }
+
+      if (warningIgnoreList.includes(warning.code!)) {
+        return
+      }
+
+      if (warning.code === 'PLUGIN_WARNING') {
+        config.logger.warn(
+          `${colors.bold(
+            colors.yellow(`[plugin:${warning.plugin}]`),
+          )} ${colors.yellow(warning.message)}`,
+        )
+        return
       }
     }
 
-    if (
-      warning.plugin === 'rollup-plugin-dynamic-import-variables' &&
-      dynamicImportWarningIgnoreList.some((msg) =>
-        warning.message.includes(msg),
-      )
-    ) {
-      return
-    }
-
-    if (warningIgnoreList.includes(warning.code!)) {
-      return
-    }
-
-    if (warning.code === 'PLUGIN_WARNING') {
-      config.logger.warn(
-        `${colors.bold(
-          colors.yellow(`[plugin:${warning.plugin}]`),
-        )} ${colors.yellow(warning.message)}`,
-      )
-      return
-    }
-
-    warn(warning)
+    warn(warnLog)
   }
 
   const tty = process.stdout.isTTY && !process.env.CI

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -606,6 +606,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
     async generateBundle(options, bundle) {
       const analyzedChunk: Map<OutputChunk, number> = new Map()
+      const inlineEntryChunk: Map<string, number> = new Map()
       const getImportedChunks = (
         chunk: OutputChunk,
         seen: Set<string> = new Set(),
@@ -827,7 +828,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
         if (chunk && canInlineEntry) {
           // all imports from entry have been inlined to html, prevent rollup from outputting it
-          delete bundle[chunk.fileName]
+          const importNum = inlineEntryChunk.get(chunk.fileName) || 0
+          inlineEntryChunk.set(chunk.fileName, importNum + 1)
         }
 
         const shortEmitName = normalizePath(path.relative(config.root, id))
@@ -836,6 +838,13 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           fileName: shortEmitName,
           source: result,
         })
+      }
+
+      for (const [fileName, importNum] of inlineEntryChunk) {
+        // #13436, only remove the independent inline entry chunk
+        if (importNum === 1) {
+          delete bundle[fileName]
+        }
       }
     },
   }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -221,7 +221,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       try {
         imports = parseImports(source)[0]
       } catch (e: any) {
-        this.error(e, e.idx)
+        this.error(e)
       }
 
       if (!imports.length) {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -462,7 +462,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           try {
             imports = parseImports(code)[0].filter((i) => i.d > -1)
           } catch (e: any) {
-            this.error(e, e.idx)
+            this.error(e)
           }
 
           const s = new MagicString(code)

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -15,7 +15,7 @@ export function prepareError(err: Error | RollupError): ErrorPayload['err'] {
     id: (err as RollupError).id,
     frame: strip((err as RollupError).frame || ''),
     plugin: (err as RollupError).plugin,
-    pluginCode: (err as RollupError).pluginCode,
+    pluginCode: (err as RollupError).pluginCode?.toString(),
     loc: (err as RollupError).loc,
   }
 }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -504,7 +504,7 @@ export async function createPluginContainer(
           }
         }
         if (code) {
-          err.frame = generateCodeFrame(code, err.loc)
+          err.frame = generateCodeFrame(`${code}`, err.loc)
         }
       }
     }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -54,7 +54,8 @@ import type {
   PluginContext as RollupPluginContext,
   SourceDescription,
   SourceMap,
- TransformResult} from 'rollup'
+  TransformResult,
+} from 'rollup'
 import * as acorn from 'acorn'
 import type { RawSourceMap } from '@ampproject/remapping'
 import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'

--- a/packages/vite/src/node/ssr/ssrManifestPlugin.ts
+++ b/packages/vite/src/node/ssr/ssrManifestPlugin.ts
@@ -42,7 +42,7 @@ export function ssrManifestPlugin(config: ResolvedConfig): Plugin {
             try {
               imports = parseImports(code)[0].filter((i) => i.n && i.d > -1)
             } catch (e: any) {
-              this.error(e, e.idx)
+              this.error(e)
             }
             if (imports.length) {
               for (let index = 0; index < imports.length; index++) {

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -150,7 +150,7 @@ describe.runIf(isBuild)('build', () => {
     const countPreloadTags = _countTags.bind(this, 'link[rel=modulepreload]')
 
     test('is inlined', async () => {
-      await page.goto(viteTestUrl + '/inline/shared-1.html?v=1')
+      await page.goto(viteTestUrl + '/inline/shared-2.html?v=1')
       expect(await countScriptTags()).toBeGreaterThan(1)
       expect(await countPreloadTags()).toBe(0)
     })
@@ -162,6 +162,10 @@ describe.runIf(isBuild)('build', () => {
     })
 
     test('execution order when inlined', async () => {
+      await page.goto(viteTestUrl + '/inline/shared-1.html?v=1')
+      expect((await page.textContent('#output')).trim()).toBe(
+        'dep1 common dep2 dep3 shared',
+      )
       await page.goto(viteTestUrl + '/inline/shared-2.html?v=1')
       expect((await page.textContent('#output')).trim()).toBe(
         'dep1 common dep2 dep3 shared',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 7.35.4(@types/node@18.16.18)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.21.0)(tslib@2.5.3)(typescript@5.0.2)
+        version: 11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.0.2)
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.1
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       rollup:
-        specifier: ^3.21.0
-        version: 3.21.0
+        specifier: ^3.25.1
+        version: 3.25.1
       simple-git-hooks:
         specifier: ^2.8.1
         version: 2.8.1
@@ -239,8 +239,8 @@ importers:
         specifier: ^8.4.24
         version: 8.4.24
       rollup:
-        specifier: ^3.21.0
-        version: 3.21.0
+        specifier: ^3.25.1
+        version: 3.25.1
     optionalDependencies:
       fsevents:
         specifier: ~2.3.2
@@ -260,25 +260,25 @@ importers:
         version: 0.3.18
       '@rollup/plugin-alias':
         specifier: ^4.0.4
-        version: 4.0.4(rollup@3.21.0)
+        version: 4.0.4(rollup@3.25.1)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.1
-        version: 25.0.1(rollup@3.21.0)
+        version: 25.0.1(rollup@3.25.1)
       '@rollup/plugin-dynamic-import-vars':
         specifier: ^2.0.3
-        version: 2.0.3(rollup@3.21.0)
+        version: 2.0.3(rollup@3.25.1)
       '@rollup/plugin-json':
         specifier: ^6.0.0
-        version: 6.0.0(rollup@3.21.0)
+        version: 6.0.0(rollup@3.25.1)
       '@rollup/plugin-node-resolve':
         specifier: 15.1.0
-        version: 15.1.0(rollup@3.21.0)
+        version: 15.1.0(rollup@3.25.1)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.21.0)(tslib@2.5.3)(typescript@5.0.2)
+        version: 11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.0.2)
       '@rollup/pluginutils':
         specifier: ^5.0.2
-        version: 5.0.2(rollup@3.21.0)
+        version: 5.0.2(rollup@3.25.1)
       '@types/escape-html':
         specifier: ^1.0.2
         version: 1.0.2
@@ -395,7 +395,7 @@ importers:
         version: 2.0.2
       rollup-plugin-license:
         specifier: ^3.0.1
-        version: 3.0.1(rollup@3.21.0)
+        version: 3.0.1(rollup@3.25.1)
       sirv:
         specifier: ^2.0.3
         version: 2.0.3(patch_hash=z45f224eewh2pgpijxcc3aboqm)
@@ -3475,7 +3475,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@rollup/plugin-alias@4.0.4(rollup@3.21.0):
+  /@rollup/plugin-alias@4.0.4(rollup@3.25.1):
     resolution: {integrity: sha512-0CaAY238SMtYAWEXXptWSR8iz8NYZnH7zNBKuJ14xFJSGwLtPgjvXYsoApAHfzYXXH1ejxpVw7WlHss3zhh9SQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3484,11 +3484,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.21.0
+      rollup: 3.25.1
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-alias@5.0.0(rollup@3.21.0):
+  /@rollup/plugin-alias@5.0.0(rollup@3.25.1):
     resolution: {integrity: sha512-l9hY5chSCjuFRPsnRm16twWBiSApl2uYFLsepQYwtBuAxNMQ/1dJqADld40P0Jkqm65GRTLy/AC6hnpVebtLsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3497,11 +3497,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.21.0
+      rollup: 3.25.1
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs@24.1.0(rollup@3.21.0):
+  /@rollup/plugin-commonjs@24.1.0(rollup@3.25.1):
     resolution: {integrity: sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3510,16 +3510,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.21.0
+      rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-commonjs@25.0.1(rollup@3.21.0):
+  /@rollup/plugin-commonjs@25.0.1(rollup@3.25.1):
     resolution: {integrity: sha512-2DJ4kv4b1xfTJopWhu61ANdNRHvzQZ2fpaIrlgaP2jOfUv1wDJ0Ucqy8AZlbFmn/iUjiwKoqki9j55Y6L8kyNQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3528,16 +3528,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.21.0
+      rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-dynamic-import-vars@2.0.3(rollup@3.21.0):
+  /@rollup/plugin-dynamic-import-vars@2.0.3(rollup@3.25.1):
     resolution: {integrity: sha512-0zQV0TDDewilU+7ZLmwc0u44SkeRxSxMdINBuX5isrQGJ6EdTjVL1TcnOZ9In99byaSGAQnHmSFw+6hm0E/jrw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3546,14 +3546,14 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
       estree-walker: 2.0.2
       fast-glob: 3.2.12
       magic-string: 0.27.0
-      rollup: 3.21.0
+      rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-json@6.0.0(rollup@3.21.0):
+  /@rollup/plugin-json@6.0.0(rollup@3.25.1):
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3562,11 +3562,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
-      rollup: 3.21.0
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.21.0):
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.25.1):
     resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3575,16 +3575,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.2
-      rollup: 3.21.0
+      rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-replace@5.0.2(rollup@3.21.0):
+  /@rollup/plugin-replace@5.0.2(rollup@3.25.1):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3593,12 +3593,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
       magic-string: 0.27.0
-      rollup: 3.21.0
+      rollup: 3.25.1
     dev: true
 
-  /@rollup/plugin-typescript@11.1.1(rollup@3.21.0)(tslib@2.5.3)(typescript@5.0.2):
+  /@rollup/plugin-typescript@11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.0.2):
     resolution: {integrity: sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3611,14 +3611,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
       resolve: 1.22.2
-      rollup: 3.21.0
+      rollup: 3.25.1
       tslib: 2.5.3
       typescript: 5.0.2
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.21.0):
+  /@rollup/pluginutils@5.0.2(rollup@3.25.1):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3630,7 +3630,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.21.0
+      rollup: 3.25.1
     dev: true
 
   /@rushstack/node-core-library@3.59.4(@types/node@18.16.18):
@@ -9061,7 +9061,7 @@ packages:
       glob: 10.2.7
     dev: true
 
-  /rollup-plugin-dts@5.3.0(rollup@3.21.0)(typescript@5.0.4):
+  /rollup-plugin-dts@5.3.0(rollup@3.25.1)(typescript@5.0.4):
     resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -9069,13 +9069,13 @@ packages:
       typescript: ^4.1 || ^5.0
     dependencies:
       magic-string: 0.30.0
-      rollup: 3.21.0
+      rollup: 3.25.1
       typescript: 5.0.4
     optionalDependencies:
       '@babel/code-frame': 7.22.5
     dev: true
 
-  /rollup-plugin-license@3.0.1(rollup@3.21.0):
+  /rollup-plugin-license@3.0.1(rollup@3.25.1):
     resolution: {integrity: sha512-/lec6Y94Y3wMfTDeYTO/jSXII0GQ/XkDZCiqkMKxyU5D5nGPaxr/2JNYvAgYsoCYuOLGOanKDPjCCQiTT96p7A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -9088,13 +9088,13 @@ packages:
       mkdirp: 1.0.4
       moment: 2.29.3
       package-name-regex: 2.0.6
-      rollup: 3.21.0
+      rollup: 3.25.1
       spdx-expression-validate: 2.0.0
       spdx-satisfies: 5.0.1
     dev: true
 
-  /rollup@3.21.0:
-    resolution: {integrity: sha512-ANPhVcyeHvYdQMUyCbczy33nbLzI7RzrBje4uvNiTDJGIMtlKoOStmympwr9OtS1LZxiDmE2wvxHyVhoLtf1KQ==}
+  /rollup@3.25.1:
+    resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -10027,12 +10027,12 @@ packages:
     resolution: {integrity: sha512-J4efk69Aye43tWcBPCsLK7TIRppGrEN4pAlDzRKo3HSE6MgTSTBxSEuE3ccx7ixc62JvGQ/CoFXYqqF2AHozow==}
     hasBin: true
     dependencies:
-      '@rollup/plugin-alias': 5.0.0(rollup@3.21.0)
-      '@rollup/plugin-commonjs': 24.1.0(rollup@3.21.0)
-      '@rollup/plugin-json': 6.0.0(rollup@3.21.0)
-      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.21.0)
-      '@rollup/plugin-replace': 5.0.2(rollup@3.21.0)
-      '@rollup/pluginutils': 5.0.2(rollup@3.21.0)
+      '@rollup/plugin-alias': 5.0.0(rollup@3.25.1)
+      '@rollup/plugin-commonjs': 24.1.0(rollup@3.25.1)
+      '@rollup/plugin-json': 6.0.0(rollup@3.25.1)
+      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.25.1)
+      '@rollup/plugin-replace': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
       chalk: 5.2.0
       consola: 3.1.0
       defu: 6.1.2
@@ -10047,8 +10047,8 @@ packages:
       pathe: 1.1.0
       pkg-types: 1.0.2
       pretty-bytes: 6.1.0
-      rollup: 3.21.0
-      rollup-plugin-dts: 5.3.0(rollup@3.21.0)(typescript@5.0.4)
+      rollup: 3.25.1
+      rollup-plugin-dts: 5.3.0(rollup@3.25.1)(typescript@5.0.4)
       scule: 1.0.0
       typescript: 5.0.4
       untyped: 1.3.2
@@ -10973,3 +10973,7 @@ packages:
     name: '@vitejs/test-dep-to-optimize'
     version: 1.0.0
     dev: false
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10973,7 +10973,3 @@ packages:
     name: '@vitejs/test-dep-to-optimize'
     version: 1.0.0
     dev: false
-
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 7.35.4(@types/node@18.16.18)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.0.2)
+        version: 11.1.1(rollup@3.25.2)(tslib@2.5.3)(typescript@5.0.2)
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.1
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       rollup:
-        specifier: ^3.25.1
-        version: 3.25.1
+        specifier: ^3.25.2
+        version: 3.25.2
       simple-git-hooks:
         specifier: ^2.8.1
         version: 2.8.1
@@ -239,8 +239,8 @@ importers:
         specifier: ^8.4.24
         version: 8.4.24
       rollup:
-        specifier: ^3.25.1
-        version: 3.25.1
+        specifier: ^3.25.2
+        version: 3.25.2
     optionalDependencies:
       fsevents:
         specifier: ~2.3.2
@@ -260,25 +260,25 @@ importers:
         version: 0.3.18
       '@rollup/plugin-alias':
         specifier: ^4.0.4
-        version: 4.0.4(rollup@3.25.1)
+        version: 4.0.4(rollup@3.25.2)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.1
-        version: 25.0.1(rollup@3.25.1)
+        version: 25.0.1(rollup@3.25.2)
       '@rollup/plugin-dynamic-import-vars':
         specifier: ^2.0.3
-        version: 2.0.3(rollup@3.25.1)
+        version: 2.0.3(rollup@3.25.2)
       '@rollup/plugin-json':
         specifier: ^6.0.0
-        version: 6.0.0(rollup@3.25.1)
+        version: 6.0.0(rollup@3.25.2)
       '@rollup/plugin-node-resolve':
         specifier: 15.1.0
-        version: 15.1.0(rollup@3.25.1)
+        version: 15.1.0(rollup@3.25.2)
       '@rollup/plugin-typescript':
         specifier: ^11.1.1
-        version: 11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.0.2)
+        version: 11.1.1(rollup@3.25.2)(tslib@2.5.3)(typescript@5.0.2)
       '@rollup/pluginutils':
         specifier: ^5.0.2
-        version: 5.0.2(rollup@3.25.1)
+        version: 5.0.2(rollup@3.25.2)
       '@types/escape-html':
         specifier: ^1.0.2
         version: 1.0.2
@@ -395,7 +395,7 @@ importers:
         version: 2.0.2
       rollup-plugin-license:
         specifier: ^3.0.1
-        version: 3.0.1(rollup@3.25.1)
+        version: 3.0.1(rollup@3.25.2)
       sirv:
         specifier: ^2.0.3
         version: 2.0.3(patch_hash=z45f224eewh2pgpijxcc3aboqm)
@@ -3475,7 +3475,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@rollup/plugin-alias@4.0.4(rollup@3.25.1):
+  /@rollup/plugin-alias@4.0.4(rollup@3.25.2):
     resolution: {integrity: sha512-0CaAY238SMtYAWEXXptWSR8iz8NYZnH7zNBKuJ14xFJSGwLtPgjvXYsoApAHfzYXXH1ejxpVw7WlHss3zhh9SQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3484,11 +3484,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.25.1
+      rollup: 3.25.2
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-alias@5.0.0(rollup@3.25.1):
+  /@rollup/plugin-alias@5.0.0(rollup@3.25.2):
     resolution: {integrity: sha512-l9hY5chSCjuFRPsnRm16twWBiSApl2uYFLsepQYwtBuAxNMQ/1dJqADld40P0Jkqm65GRTLy/AC6hnpVebtLsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3497,11 +3497,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.25.1
+      rollup: 3.25.2
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs@24.1.0(rollup@3.25.1):
+  /@rollup/plugin-commonjs@24.1.0(rollup@3.25.2):
     resolution: {integrity: sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3510,16 +3510,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.25.1
+      rollup: 3.25.2
     dev: true
 
-  /@rollup/plugin-commonjs@25.0.1(rollup@3.25.1):
+  /@rollup/plugin-commonjs@25.0.1(rollup@3.25.2):
     resolution: {integrity: sha512-2DJ4kv4b1xfTJopWhu61ANdNRHvzQZ2fpaIrlgaP2jOfUv1wDJ0Ucqy8AZlbFmn/iUjiwKoqki9j55Y6L8kyNQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3528,16 +3528,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.25.1
+      rollup: 3.25.2
     dev: true
 
-  /@rollup/plugin-dynamic-import-vars@2.0.3(rollup@3.25.1):
+  /@rollup/plugin-dynamic-import-vars@2.0.3(rollup@3.25.2):
     resolution: {integrity: sha512-0zQV0TDDewilU+7ZLmwc0u44SkeRxSxMdINBuX5isrQGJ6EdTjVL1TcnOZ9In99byaSGAQnHmSFw+6hm0E/jrw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3546,14 +3546,14 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
       estree-walker: 2.0.2
       fast-glob: 3.2.12
       magic-string: 0.27.0
-      rollup: 3.25.1
+      rollup: 3.25.2
     dev: true
 
-  /@rollup/plugin-json@6.0.0(rollup@3.25.1):
+  /@rollup/plugin-json@6.0.0(rollup@3.25.2):
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3562,11 +3562,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
-      rollup: 3.25.1
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      rollup: 3.25.2
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.25.1):
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.25.2):
     resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3575,16 +3575,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.2
-      rollup: 3.25.1
+      rollup: 3.25.2
     dev: true
 
-  /@rollup/plugin-replace@5.0.2(rollup@3.25.1):
+  /@rollup/plugin-replace@5.0.2(rollup@3.25.2):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3593,12 +3593,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
       magic-string: 0.27.0
-      rollup: 3.25.1
+      rollup: 3.25.2
     dev: true
 
-  /@rollup/plugin-typescript@11.1.1(rollup@3.25.1)(tslib@2.5.3)(typescript@5.0.2):
+  /@rollup/plugin-typescript@11.1.1(rollup@3.25.2)(tslib@2.5.3)(typescript@5.0.2):
     resolution: {integrity: sha512-Ioir+x5Bejv72Lx2Zbz3/qGg7tvGbxQZALCLoJaGrkNXak/19+vKgKYJYM3i/fJxvsb23I9FuFQ8CUBEfsmBRg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3611,14 +3611,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
       resolve: 1.22.2
-      rollup: 3.25.1
+      rollup: 3.25.2
       tslib: 2.5.3
       typescript: 5.0.2
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.25.1):
+  /@rollup/pluginutils@5.0.2(rollup@3.25.2):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3630,7 +3630,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.25.1
+      rollup: 3.25.2
     dev: true
 
   /@rushstack/node-core-library@3.59.4(@types/node@18.16.18):
@@ -9061,7 +9061,7 @@ packages:
       glob: 10.2.7
     dev: true
 
-  /rollup-plugin-dts@5.3.0(rollup@3.25.1)(typescript@5.0.4):
+  /rollup-plugin-dts@5.3.0(rollup@3.25.2)(typescript@5.0.4):
     resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -9069,13 +9069,13 @@ packages:
       typescript: ^4.1 || ^5.0
     dependencies:
       magic-string: 0.30.0
-      rollup: 3.25.1
+      rollup: 3.25.2
       typescript: 5.0.4
     optionalDependencies:
       '@babel/code-frame': 7.22.5
     dev: true
 
-  /rollup-plugin-license@3.0.1(rollup@3.25.1):
+  /rollup-plugin-license@3.0.1(rollup@3.25.2):
     resolution: {integrity: sha512-/lec6Y94Y3wMfTDeYTO/jSXII0GQ/XkDZCiqkMKxyU5D5nGPaxr/2JNYvAgYsoCYuOLGOanKDPjCCQiTT96p7A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -9088,13 +9088,13 @@ packages:
       mkdirp: 1.0.4
       moment: 2.29.3
       package-name-regex: 2.0.6
-      rollup: 3.25.1
+      rollup: 3.25.2
       spdx-expression-validate: 2.0.0
       spdx-satisfies: 5.0.1
     dev: true
 
-  /rollup@3.25.1:
-    resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
+  /rollup@3.25.2:
+    resolution: {integrity: sha512-VLnkxZMDr3jpxgtmS8pQZ0UvhslmF4ADq/9w4erkctbgjCqLW9oa89fJuXEs4ZmgyoF7Dm8rMDKSS5b5u2hHUg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -10027,12 +10027,12 @@ packages:
     resolution: {integrity: sha512-J4efk69Aye43tWcBPCsLK7TIRppGrEN4pAlDzRKo3HSE6MgTSTBxSEuE3ccx7ixc62JvGQ/CoFXYqqF2AHozow==}
     hasBin: true
     dependencies:
-      '@rollup/plugin-alias': 5.0.0(rollup@3.25.1)
-      '@rollup/plugin-commonjs': 24.1.0(rollup@3.25.1)
-      '@rollup/plugin-json': 6.0.0(rollup@3.25.1)
-      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.25.1)
-      '@rollup/plugin-replace': 5.0.2(rollup@3.25.1)
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.1)
+      '@rollup/plugin-alias': 5.0.0(rollup@3.25.2)
+      '@rollup/plugin-commonjs': 24.1.0(rollup@3.25.2)
+      '@rollup/plugin-json': 6.0.0(rollup@3.25.2)
+      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.25.2)
+      '@rollup/plugin-replace': 5.0.2(rollup@3.25.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
       chalk: 5.2.0
       consola: 3.1.0
       defu: 6.1.2
@@ -10047,8 +10047,8 @@ packages:
       pathe: 1.1.0
       pkg-types: 1.0.2
       pretty-bytes: 6.1.0
-      rollup: 3.25.1
-      rollup-plugin-dts: 5.3.0(rollup@3.25.1)(typescript@5.0.4)
+      rollup: 3.25.2
+      rollup-plugin-dts: 5.3.0(rollup@3.25.2)(typescript@5.0.4)
       scule: 1.0.0
       typescript: 5.0.4
       untyped: 1.3.2


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Adjust [rollup log API](https://github.com/rollup/rollup/pull/5026) calls
- Adjust [rollup error code](https://github.com/rollup/rollup/pull/5042)
- Delay removing the independent inline entry chunk in MPA since `rollup@3.25.1` would share entry chunks. ps: vite already contains the test cases in `playground/html`
   - fix #13436
   - refs https://github.com/rollup/rollup/pull/4989
   - refs https://github.com/vitejs/vite/pull/4555

- fix https://github.com/vitejs/vite/issues/13571

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context


   

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
