### PR TITLE
docs: fix typo and unresolvable link in Lightning CSS guide

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -271,7 +271,7 @@ To configure CSS Modules, you'll use [`css.lightningcss.cssModules`](https://lig
 By default, Vite uses esbuild to minify CSS. Lightning CSS can also be used as the CSS minifier with [`build.cssMinify: 'lightningcss'`](../config/build-options.md#css-minify).
 
 ::: tip NOTE
-[CSS Pre-processors](/#css-pre-processors) aren't supported when using Lightning CSS.
+[CSS Pre-processors](#css-pre-processors) aren't supported when using Lightning CSS.
 :::
 
 ## Static Assets

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -266,7 +266,7 @@ npm add -D lightningcss
 
 If enabled, CSS files will be processed by Lightning CSS instead of PostCSS. To configure it, you can pass Lightining CSS options to the [`css.lightingcss`](../config/shared-options.md#css-lightningcss) config option.
 
-To configue CSS Modules, you'll use [`css.lightningcss.cssModules`](https://lightningcss.dev/css-modules.html) instead of [`css.modules`](../config/shared-options.md#css-modules) (wich configures the way PostCSS handles CSS modules).
+To configure CSS Modules, you'll use [`css.lightningcss.cssModules`](https://lightningcss.dev/css-modules.html) instead of [`css.modules`](../config/shared-options.md#css-modules) (which configures the way PostCSS handles CSS modules).
 
 By default, Vite uses esbuild to minify CSS. Lightning CSS can also be used as the CSS minifier with [`build.cssMinify: 'lightningcss'`](../config/build-options.md#css-minify).
 


### PR DESCRIPTION
Hi there!  I found a typo in the documentation added by the PR here: https://github.com/vitejs/vite/pull/13583 which has been corrected.

- docs: fix typo in Lightning CSS guide
- docs: fix unresolvable link in Lightning CSS guide
