### PR TITLE
fix(server): do not create server if there is no entry

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -160,7 +160,9 @@ export function scanImports(config: ResolvedConfig): {
   }
 }
 
-async function computeEntries(config: ResolvedConfig) {
+export async function computeEntries(
+  config: ResolvedConfig,
+): Promise<string[]> {
   let entries: string[] = []
 
   const explicitEntryPatterns = config.optimizeDeps.entries

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -40,6 +40,7 @@ import {
   initDepsOptimizer,
   initDevSsrDepsOptimizer,
 } from '../optimizer'
+import { computeEntries } from '../optimizer/scan'
 import { bindShortcuts } from '../shortcuts'
 import type { BindShortcutsOptions } from '../shortcuts'
 import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
@@ -339,6 +340,13 @@ export async function _createServer(
   options: { ws: boolean },
 ): Promise<ViteDevServer> {
   const config = await resolveConfig(inlineConfig, 'serve')
+
+  const entries = await computeEntries(config)
+  if (!entries.length) {
+    throw new Error(
+      `Could not auto-determine entry point from rollupOptions or html files in project.`,
+    )
+  }
 
   const { root, server: serverConfig } = config
   const httpsOptions = await resolveHttpsConfig(config.server.https)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -341,11 +341,13 @@ export async function _createServer(
 ): Promise<ViteDevServer> {
   const config = await resolveConfig(inlineConfig, 'serve')
 
-  const entries = await computeEntries(config)
-  if (!entries.length) {
-    throw new Error(
-      `Could not auto-determine entry point from rollupOptions or html files in project.`,
-    )
+  if (inlineConfig.configFile !== false) {
+    const entries = await computeEntries(config)
+    if (!entries.length) {
+      throw new Error(
+        `Could not auto-determine entry point from rollupOptions or html files in project.`,
+      )
+    }
   }
 
   const { root, server: serverConfig } = config

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -341,7 +341,7 @@ export async function _createServer(
 ): Promise<ViteDevServer> {
   const config = await resolveConfig(inlineConfig, 'serve')
 
-  if (inlineConfig.configFile !== false) {
+  if (inlineConfig.configFile !== false && config.mode !== 'test') {
     const entries = await computeEntries(config)
     if (!entries.length) {
       throw new Error(

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -341,13 +341,11 @@ export async function _createServer(
 ): Promise<ViteDevServer> {
   const config = await resolveConfig(inlineConfig, 'serve')
 
-  if (inlineConfig.configFile !== false && config.mode !== 'test') {
-    const entries = await computeEntries(config)
-    if (!entries.length) {
-      throw new Error(
-        `Could not auto-determine entry point from rollupOptions or html files in project.`,
-      )
-    }
+  const entries = await computeEntries(config)
+  if (!entries.length) {
+    config.logger.warn(
+      `Could not auto-determine entry point from rollupOptions or html files.`,
+    )
   }
 
   const { root, server: serverConfig } = config


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Now even if the entry is not determined, the server will create , and when it is opened directly in the browser, it will appear as shown in the figure below.

<img width="400" src="https://github.com/vitejs/vite/assets/24516654/b613b735-a0a6-4207-bf44-95c82f953b12">


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
