### PR TITLE
chore: show error position

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -279,7 +279,7 @@ export async function createPluginContainer(
   // active plugin in that pipeline can be tracked in a concurrency-safe manner.
   // using a class to make creating new contexts more efficient
   class Context implements PluginContext {
-    meta = minimalContext.meta!
+    meta = minimalContext.meta
     ssr = false
     _scan = false
     _activePlugin: Plugin | null


### PR DESCRIPTION
### Description
Follow up to #13608.

#13608 removed the second argument of `this.error` in some places. This is correct as [`this.error` only receives the second argument in the `transform` hook](https://rollupjs.org/plugin-development/#this-error:~:text=%7D%0A%09%7D%3B%0A%7D-,When%20used%20in%20the%20transform%20hook%2C%20the%20id%20of%20the%20current%20module%20will%20also%20be%20added%20and%20a%20position%20can%20be%20supplied.,-This%20is%20a).
That said, it would be better to pass the `pos` and other properties to give rollup more information to generate a friendly error.
This PR adds those information.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
