### PR TITLE
fix(ssr): transform superclass identifier

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -907,11 +907,28 @@ for (const test in tests) {
 
 test('avoid binding ClassExpression', async () => {
   const result = await ssrTransformSimple(
-    `import Foo, {Bar} from './foo';console.log(Foo, Bar);const obj = {foo: class Foo{}, bar: class Bar{}}`,
+    `
+import Foo, { Bar } from './foo';
+
+console.log(Foo, Bar);
+const obj = {
+  foo: class Foo {},
+  bar: class Bar {}
+}
+const Baz = class extends Foo {}
+`,
   )
   expect(result?.code).toMatchInlineSnapshot(`
-
     "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./foo\\");
-    console.log(__vite_ssr_import_0__.default, __vite_ssr_import_0__.Bar);const obj = {foo: class Foo{}, bar: class Bar{}}"
+
+
+
+    console.log(__vite_ssr_import_0__.default, __vite_ssr_import_0__.Bar);
+    const obj = {
+      foo: class Foo {},
+      bar: class Bar {}
+    }
+    const Baz = class extends __vite_ssr_import_0__.default {}
+    "
   `)
 })

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -256,7 +256,10 @@ async function ssrTransformScript(
           const topNode = parentStack[parentStack.length - 2]
           s.prependRight(topNode.start, `const ${id.name} = ${binding};\n`)
         }
-      } else if (parent.type !== 'ClassExpression') {
+      } else if (
+        // don't transform class name identifier
+        !(parent.type === 'ClassExpression' && id === parent.id)
+      ) {
         s.update(id.start, id.end, binding)
       }
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Following up on #13572, when transforming `let foo = class extends Bar {}`, the `Bar` is not transformed to the import used. `Bar` is considered a superclass in the AST.

Fixed the issue by checking if `Bar` is a class name id and not a superclass id.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This is causing a fail in Astro's lit element test after transpiled by esbuild: 

```js
let MyElement = class extends LitElement {
```
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
