### PR TITLE
perf: move up external url check before fs path checks

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -330,10 +330,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           )
         }
 
-        url = resolved.id
-
-        if (isExternalUrl(url)) {
-          return [url, url]
+        if (isExternalUrl(resolved.id)) {
+          return [resolved.id, resolved.id]
         }
 
         const isRelative = url[0] === '.'
@@ -351,6 +349,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // an optimized deps may not yet exists in the filesystem, or
           // a regular file exists but is out of root: rewrite to absolute /@fs/ paths
           url = path.posix.join(FS_PREFIX, resolved.id)
+        } else {
+          url = resolved.id
         }
 
         // if the resolved id is not a valid browser import specifier,

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -330,6 +330,12 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           )
         }
 
+        url = resolved.id
+
+        if (isExternalUrl(url)) {
+          return [url, url]
+        }
+
         const isRelative = url[0] === '.'
         const isSelfImport = !isRelative && cleanUrl(url) === cleanUrl(importer)
 
@@ -345,12 +351,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // an optimized deps may not yet exists in the filesystem, or
           // a regular file exists but is out of root: rewrite to absolute /@fs/ paths
           url = path.posix.join(FS_PREFIX, resolved.id)
-        } else {
-          url = resolved.id
-        }
-
-        if (isExternalUrl(url)) {
-          return [url, url]
         }
 
         // if the resolved id is not a valid browser import specifier,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The real problem:
I was developing a plugin that can distribute the optimizied dependencies, so the resolved id will like this: `https://xxx/react@18.2.0/jsx-runtime`, for vite perspective, the optimized dependencies should all local files, the resolved id will become something like this `/@fs/https:/xxx/react@18.2.0/jsx-runtime?v=628f3470`

 I can not ask vite community to consider my use case, but I think we could optimize this code since there is no meaning that we put the external condition after some file related conditions.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
