### PR TITLE
fix: "EISDIR: illegal operation on a directory, realpath" error on RA…

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -614,7 +614,7 @@ function optimizeSafeRealPathSync() {
   try {
     fs.realpathSync.native(path.resolve('./'))
   } catch (error) {
-    if (~error.message.indexOf('EISDIR: illegal operation on a directory')) {
+    if (error.message.includes('EISDIR: illegal operation on a directory')) {
       safeRealpathSync = fs.realpathSync
       return
     }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -578,14 +578,11 @@ export function copyDir(srcDir: string, destDir: string): void {
  * @returns {string}
  */
 function wrapRealpathSyncNative(path: string): string {
-  if (typeof fs.realpathSync.native === 'function') {
-    try {
-      return fs.realpathSync.native(path)
-    } catch {
-      // Ignore errors
-    }
+  try {
+    return fs.realpathSync.native(path)
+  } catch {
+    return fs.realpathSync(path)
   }
-  return fs.realpathSync(path)
 }
 
 // `fs.realpathSync.native` resolves differently in Windows network drive,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -571,6 +571,23 @@ export function copyDir(srcDir: string, destDir: string): void {
   }
 }
 
+/**
+ * Wrapper to prevent `fs.realpathSync.native` errors in Windows virtual and RAM disks
+ * that bypass the Volume Mount Manager, in programs such as imDisk
+ * @param path - a path to a file
+ * @returns {string}
+ */
+function wrapRealpathSyncNative(path: string): string {
+  if (typeof fs.realpathSync.native === 'function') {
+    try {
+      return fs.realpathSync.native(path)
+    } catch {
+      // Ignore errors
+    }
+  }
+  return fs.realpathSync(path)
+}
+
 // `fs.realpathSync.native` resolves differently in Windows network drive,
 // causing file read errors. skip for now.
 // https://github.com/nodejs/node/issues/37737
@@ -582,7 +599,7 @@ export let safeRealpathSync = isWindows
 // MIT License, Copyright (c) 2017 Larry Bahr
 const windowsNetworkMap = new Map()
 function windowsMappedRealpathSync(path: string) {
-  const realPath = fs.realpathSync.native(path)
+  const realPath = wrapRealpathSyncNative(path)
   if (realPath.startsWith('\\\\')) {
     for (const [network, volume] of windowsNetworkMap) {
       if (realPath.startsWith(network)) return realPath.replace(network, volume)
@@ -619,7 +636,7 @@ function optimizeSafeRealPathSync() {
       if (m) windowsNetworkMap.set(m[3], m[2])
     }
     if (windowsNetworkMap.size === 0) {
-      safeRealpathSync = fs.realpathSync.native
+      safeRealpathSync = wrapRealpathSyncNative
     } else {
       safeRealpathSync = windowsMappedRealpathSync
     }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -571,20 +571,6 @@ export function copyDir(srcDir: string, destDir: string): void {
   }
 }
 
-/**
- * Wrapper to prevent `fs.realpathSync.native` errors in Windows virtual and RAM disks
- * that bypass the Volume Mount Manager, in programs such as imDisk
- * @param path - a path to a file
- * @returns {string}
- */
-function wrapRealpathSyncNative(path: string): string {
-  try {
-    return fs.realpathSync.native(path)
-  } catch {
-    return fs.realpathSync(path)
-  }
-}
-
 // `fs.realpathSync.native` resolves differently in Windows network drive,
 // causing file read errors. skip for now.
 // https://github.com/nodejs/node/issues/37737
@@ -592,11 +578,15 @@ export let safeRealpathSync = isWindows
   ? windowsSafeRealPathSync
   : fs.realpathSync.native
 
+// when using `fs.realpathSync.native` get errors in Windows virtual and RAM disks
+// that bypass the Volume Mount Manager, in programs such as imDisk
+let supportedRealpathSync = fs.realpathSync.native
+
 // Based on https://github.com/larrybahr/windows-network-drive
 // MIT License, Copyright (c) 2017 Larry Bahr
 const windowsNetworkMap = new Map()
 function windowsMappedRealpathSync(path: string) {
-  const realPath = wrapRealpathSyncNative(path)
+  const realPath = supportedRealpathSync(path)
   if (realPath.startsWith('\\\\')) {
     for (const [network, volume] of windowsNetworkMap) {
       if (realPath.startsWith(network)) return realPath.replace(network, volume)
@@ -622,7 +612,16 @@ function optimizeSafeRealPathSync() {
     safeRealpathSync = fs.realpathSync
     return
   }
-
+  // Check the availability `fs.realpathSync.native`
+  // in Windows virtual and RAM disks that bypass the Volume Mount Manager
+  // get the error EISDIR: illegal operation on a directory
+  try {
+    fs.realpathSync.native(path.resolve('./'))
+  } catch (error) {
+    if (~error.message.indexOf('EISDIR: illegal operation on a directory')) {
+      supportedRealpathSync = fs.realpathSync
+    }
+  }
   exec('net use', (error, stdout) => {
     if (error) return
     const lines = stdout.split('\n')
@@ -633,7 +632,7 @@ function optimizeSafeRealPathSync() {
       if (m) windowsNetworkMap.set(m[3], m[2])
     }
     if (windowsNetworkMap.size === 0) {
-      safeRealpathSync = wrapRealpathSyncNative
+      safeRealpathSync = supportedRealpathSync
     } else {
       safeRealpathSync = windowsMappedRealpathSync
     }


### PR DESCRIPTION
Fix "EISDIR: illegal operation on a directory, realpath" error on RAM and virtual disks in Windows, which bypass Mounting Manager (like ImDisk).

### Description

On virtual and RAM disks in Windows which bypass the Mounting Manager (e.g. ImDisk), the error "EISDIR: illegal operation on a directory, realpath" occurs when calling fs.realpathSync.native.
These functions require the disk volume to be managed by the Mount Manager to find mount points, etc. ImDisk does not interact with Mount Manager at all, so all such operations will end in an error.
The solution to this problem is the try catch code wrapper.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
