### PR TITLE
fix(css): use esbuild legalComments config when minifying CSS

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1521,6 +1521,7 @@ function resolveMinifyCssEsbuildOptions(
     logLevel: options.logLevel,
     logLimit: options.logLimit,
     logOverride: options.logOverride,
+    legalComments: options.legalComments,
   }
 
   if (

--- a/playground/minify/__tests__/minify.spec.ts
+++ b/playground/minify/__tests__/minify.spec.ts
@@ -14,5 +14,8 @@ test.runIf(isBuild)('no minifySyntax', () => {
   const cssContent = readFile(path.resolve(assetsDir, cssFile))
 
   expect(jsContent).toContain('{console.log("hello world")}')
+  expect(jsContent).not.toContain('/*! explicit comment */')
+
   expect(cssContent).toContain('color:#ff0000')
+  expect(cssContent).not.toContain('/*! explicit comment */')
 })

--- a/playground/minify/dir/module/index.css
+++ b/playground/minify/dir/module/index.css
@@ -1,0 +1,4 @@
+/*! explicit comment */
+h2 {
+  color: #ff00ff;
+}

--- a/playground/minify/dir/module/index.js
+++ b/playground/minify/dir/module/index.js
@@ -1,0 +1,2 @@
+/*! explicit comment */
+export const msg = `[success] minified module`

--- a/playground/minify/dir/module/package.json
+++ b/playground/minify/dir/module/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@vitejs/test-minify",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0"
+}

--- a/playground/minify/main.js
+++ b/playground/minify/main.js
@@ -1,4 +1,7 @@
 import './test.css'
+import { msg } from 'minified-module'
+
+console.log(msg)
 
 if (window) {
   console.log('hello world')

--- a/playground/minify/package.json
+++ b/playground/minify/package.json
@@ -8,5 +8,8 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
+  },
+  "dependencies": {
+    "minified-module": "file:./dir/module"
   }
 }

--- a/playground/minify/test.css
+++ b/playground/minify/test.css
@@ -1,3 +1,5 @@
+@import 'minified-module/index.css';
+
 h1 {
   /* do not minify as red text */
   color: #ff0000;

--- a/playground/minify/vite.config.js
+++ b/playground/minify/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   esbuild: {
+    legalComments: 'none',
     minifySyntax: false,
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,7 +709,13 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3(patch_hash=z45f224eewh2pgpijxcc3aboqm)
 
-  playground/minify: {}
+  playground/minify:
+    dependencies:
+      minified-module:
+        specifier: file:./dir/module
+        version: file:playground/minify/dir/module
+
+  playground/minify/dir/module: {}
 
   playground/multiple-entrypoints:
     devDependencies:
@@ -10637,6 +10643,11 @@ packages:
     resolution: {directory: playground/json/json-module, type: directory}
     name: '@vitejs/test-json-module'
     dev: true
+
+  file:playground/minify/dir/module:
+    resolution: {directory: playground/minify/dir/module, type: directory}
+    name: '@vitejs/test-minify'
+    dev: false
 
   file:playground/optimize-deps-no-discovery/dep-no-discovery:
     resolution: {directory: playground/optimize-deps-no-discovery/dep-no-discovery, type: directory}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

If you set esbuild configuration with additional [transform options](https://esbuild.github.io/api/#transform), those options are [passed down to JS minification process](https://github.com/vitejs/vite/blob/bfad16cd1365e578ce4adff30d805009c13b4fb4/packages/vite/src/node/plugins/esbuild.ts#L340-L344), but they’re ignored for CSS minification, resulting in situations where you can e.g. set `legalComments` option to different value and expect that it will be applied to both JS and CSS files, but it’s applied only to JS files.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
