### PR TITLE
fix(cli): convert the sourcemap option to boolean (fix #13638)

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -70,9 +70,9 @@ const filterDuplicateOptions = <T extends object>(options: T) => {
 /**
  * removing global flags before passing as command specific sub-configs
  */
-function cleanOptions<Options extends GlobalCLIOptions>(
-  options: Options,
-): Omit<Options, keyof GlobalCLIOptions> {
+function cleanOptions<
+  Options extends GlobalCLIOptions & (ServerOptions | BuildOptions),
+>(options: Options): Omit<Options, keyof GlobalCLIOptions> {
   const ret = { ...options }
   delete ret['--']
   delete ret.c
@@ -87,6 +87,18 @@ function cleanOptions<Options extends GlobalCLIOptions>(
   delete ret.filter
   delete ret.m
   delete ret.mode
+
+  // convert the sourcemap option to a boolean if necessary
+  if ('sourcemap' in ret) {
+    const sourcemap = ret.sourcemap as `${boolean}` | 'inline' | 'hidden'
+    ret.sourcemap =
+      sourcemap === 'true'
+        ? true
+        : sourcemap === 'false'
+        ? false
+        : ret.sourcemap
+  }
+
   return ret
 }
 

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -70,9 +70,9 @@ const filterDuplicateOptions = <T extends object>(options: T) => {
 /**
  * removing global flags before passing as command specific sub-configs
  */
-function cleanOptions<
-  Options extends GlobalCLIOptions & (ServerOptions | BuildOptions),
->(options: Options): Omit<Options, keyof GlobalCLIOptions> {
+function cleanOptions<Options extends GlobalCLIOptions>(
+  options: Options,
+): Omit<Options, keyof GlobalCLIOptions> {
   const ret = { ...options }
   delete ret['--']
   delete ret.c


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix https://github.com/vitejs/vite/issues/13638

https://github.com/vitejs/vite/commit/ee3b90a812e863fc92f485ce53a4e764a2c34708 added `'inline'` and `'hidden'` as options to `--sourcemap` in the CLI and broke the behavior of booleans, i.e. `true` and `false` became strings. This resulted in `--sourcemap false` to still output sourcemaps.

### Additional context

There's not really a clean way to convert `'true'` and `'false'` to a boolean. Feel free to suggest a different approach.  
Also, I'm not sure if a test case should be added for this. It's my first contribution and didn't see tests related to CLI options.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
