### PR TITLE
docs(ssr): Running plugins during ssr on non local files

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -215,6 +215,10 @@ If a dependency needs to be transformed by Vite's pipeline, for example, because
 
 For linked dependencies, they are not externalized by default to take advantage of Vite's HMR. If this isn't desired, for example, to test dependencies as if they aren't linked, you can add it to [`ssr.external`](../config/ssr-options.md#ssr-external).
 
+:::warning Running plugins in SSR
+Plugins hooks are only executed for local files (starting with `.` or `/`) during SSR, if you want to run plugins on `node_modules` files you should resolve them to a path starting with `/` in the `resolveId` hook.
+:::
+
 :::warning Working with Aliases
 If you have configured aliases that redirect one package to another, you may want to alias the actual `node_modules` packages instead to make it work for SSR externalized dependencies. Both [Yarn](https://classic.yarnpkg.com/en/docs/cli/add/#toc-yarn-add-alias) and [pnpm](https://pnpm.io/aliases/) support aliasing via the `npm:` prefix.
 :::


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Docs about running plugins during ssr on non local files

### Additional context

I discovered this in #13588 and it took a while to understand how Vite run plugins for SSR code
https://github.com/vitejs/vite/blob/c8a741adec14568f2ba9599056cb2eebab52215f/packages/vite/src/node/ssr/ssrModuleLoader.ts#L147

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
