### PR TITLE
fix(build): style insert order for UMD builds (fix #13668)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -683,7 +683,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             `${style}.textContent = ${cssString};` +
             `document.head.appendChild(${style});`
           const wrapIdx = code.indexOf('System.register')
-          const executeFnStart = wrapIdx >= 0 ? code.indexOf('execute:', wrapIdx) : 0
+          const executeFnStart =
+            wrapIdx >= 0 ? code.indexOf('execute:', wrapIdx) : 0
           const injectionPoint = code.indexOf('{', executeFnStart) + 1
           const s = new MagicString(code)
           s.appendRight(injectionPoint, injectCode)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -683,10 +683,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             `${style}.textContent = ${cssString};` +
             `document.head.appendChild(${style});`
           const wrapIdx = code.indexOf('System.register')
-          const executeFnStart =
-            code.indexOf('{', code.indexOf('execute:', wrapIdx)) + 1
+          const executeFnStart = wrapIdx >= 0 ? code.indexOf('execute:', wrapIdx) : 0
+          const injectionPoint = code.indexOf('{', executeFnStart) + 1
           const s = new MagicString(code)
-          s.appendRight(executeFnStart, injectCode)
+          s.appendRight(injectionPoint, injectCode)
           if (config.build.sourcemap) {
             // resolve public URL from CSS paths, we need to use absolute paths
             return {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -682,10 +682,15 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             `var ${style} = document.createElement('style');` +
             `${style}.textContent = ${cssString};` +
             `document.head.appendChild(${style});`
+          let injectionPoint
           const wrapIdx = code.indexOf('System.register')
-          const executeFnStart =
-            wrapIdx >= 0 ? code.indexOf('execute:', wrapIdx) : 0
-          const injectionPoint = code.indexOf('{', executeFnStart) + 1
+          if (wrapIdx >= 0) {
+            const executeFnStart = code.indexOf('execute:', wrapIdx)
+            injectionPoint = code.indexOf('{', executeFnStart) + 1
+          } else {
+            const insertMark = "'use strict';"
+            injectionPoint = code.indexOf(insertMark) + insertMark.length
+          }
           const s = new MagicString(code)
           s.appendRight(injectionPoint, injectCode)
           if (config.build.sourcemap) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes https://github.com/vitejs/vite/issues/13668

The previous fix in https://github.com/vitejs/vite/pull/13266 can break the insertion order for UMD builds when a dependency containing the string `execute:` is added. This updates the logic to only check for `execute:` when `System.register` is found, which should be a more robust way to find the insertion point.

TLDR
* Legacy builds which generate `System.register` calls will insert the CSS in the `execute` function
* Builds which don't have that format will consistently insert the CSS at the top of the IIFE

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

-----
<a href="https://stackblitz.com/~/github.com/binary-koan/vite/tree/codeflow%2Fissue13668"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github.com/binary-koan/vite/tree/codeflow%2Fissue13668)._