### PR TITLE
chore: update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,10 +1,9 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", "schedule:weekly", "group:allNonMajor"],
   "labels": ["dependencies"],
   "ignorePaths": ["**/__tests__/**"],
-  "pin": false,
   "rangeStrategy": "bump",
-  "node": false,
   "packageRules": [
     {
       "depTypeList": ["peerDependencies"],


### PR DESCRIPTION
Small chore to add autocompletion for `renovate.json5` and remove the incorrectly configured properties. `pin` and `node` accepts an object but we pass `false` to it. Should be safe to remove:

- https://docs.renovatebot.com/configuration-options/#pin
- https://docs.renovatebot.com/configuration-options/#node