### PR TITLE
fix: lightningCSS should load external URL in CSS file

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1420,6 +1420,14 @@ async function rewriteCssImageSet(
     return url
   })
 }
+function skipUrlReplacer(rawUrl: string) {
+  return (
+    isExternalUrl(rawUrl) ||
+    isDataUrl(rawUrl) ||
+    rawUrl[0] === '#' ||
+    varRE.test(rawUrl)
+  )
+}
 async function doUrlReplace(
   rawUrl: string,
   matched: string,
@@ -1433,12 +1441,7 @@ async function doUrlReplace(
     rawUrl = rawUrl.slice(1, -1)
   }
 
-  if (
-    isExternalUrl(rawUrl) ||
-    isDataUrl(rawUrl) ||
-    rawUrl[0] === '#' ||
-    varRE.test(rawUrl)
-  ) {
+  if (skipUrlReplacer(rawUrl)) {
     return matched
   }
 
@@ -2184,6 +2187,10 @@ async function compileLightningCSS(
   for (const dep of res.dependencies!) {
     switch (dep.type) {
       case 'url':
+        if (skipUrlReplacer(dep.url)) {
+          css = css.replace(dep.placeholder, dep.url)
+          break
+        }
         deps.add(dep.url)
         if (urlReplacer) {
           css = css.replace(dep.placeholder, await urlReplacer(dep.url, id))

--- a/playground/css-lightningcss/__tests__/lightningcss.spec.ts
+++ b/playground/css-lightningcss/__tests__/lightningcss.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import {
   editFile,
   findAssetFile,
+  getBg,
   getColor,
   isBuild,
   page,
@@ -64,4 +65,9 @@ test.runIf(isBuild)('minify css', async () => {
   const cssFile = findAssetFile(/index-\w+\.css$/)
   expect(cssFile).toMatch('rgba(')
   expect(cssFile).not.toMatch('#ffff00b3')
+})
+
+test('css with external url', async () => {
+  const css = await page.$('.external')
+  expect(await getBg(css)).toMatch('url("https://vitejs.dev/logo.svg")')
 })

--- a/playground/css-lightningcss/external-url.css
+++ b/playground/css-lightningcss/external-url.css
@@ -1,0 +1,7 @@
+.external {
+  background-image: url('https://vitejs.dev/logo.svg');
+  background-size: 100%;
+  width: 200px;
+  height: 200px;
+  background-color: #bed;
+}

--- a/playground/css-lightningcss/index.html
+++ b/playground/css-lightningcss/index.html
@@ -23,6 +23,9 @@
 
   <p>Inline CSS module:</p>
   <pre class="modules-inline"></pre>
+
+  <p>External URL</p>
+  <div class="external"></div>
 </div>
 
 <script type="module" src="./main.js"></script>

--- a/playground/css-lightningcss/main.js
+++ b/playground/css-lightningcss/main.js
@@ -1,6 +1,7 @@
 import './minify.css'
 import './imported.css'
 import mod from './mod.module.css'
+import './external-url.css'
 
 document.querySelector('.modules').classList.add(mod['apply-color'])
 text('.modules-code', JSON.stringify(mod, null, 2))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes a bug when using LightningCSS as CSS processor and the CSS file includes an `url()` pointing to an external asset. 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Fixes #13650 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
