### PR TITLE
fix(template): bump react-swc plugin version

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -483,7 +483,7 @@ function setupReactSwc(root: string, isTs: boolean) {
   editFile(path.resolve(root, 'package.json'), (content) => {
     return content.replace(
       /"@vitejs\/plugin-react": ".+?"/,
-      `"@vitejs/plugin-react-swc": "^3.0.0"`,
+      `"@vitejs/plugin-react-swc": "^3.3.2"`,
     )
   })
   editFile(


### PR DESCRIPTION
[Some users](https://github.com/vitejs/vite-plugin-react-swc/issues/125) have been hit by https://github.com/pnpm/pnpm/issues/6463

I think we should reconsider the usage of `pnpm create` in docs because plugins evolves more than the published templates (cc @patak-dev)