### PR TITLE
fix(esbuild): use `useDefineForClassFields: false` when no `compilerOptions.target` is declared

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -378,6 +378,11 @@ describe('transformWithEsbuild', () => {
       })
       expect(actual).toBe(defineForClassFieldsTrueTransformedCode)
     })
+
+    test('target: es2022 and tsconfig.target: undefined => false', async () => {
+      const actual = await transformClassCode('es2022', {})
+      expect(actual).toBe(defineForClassFieldsFalseTransformedCode)
+    })
   })
 })
 

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -132,6 +132,16 @@ export async function transformWithEsbuild(
       ...tsconfigRaw?.compilerOptions,
     }
 
+    // esbuild uses `useDefineForClassFields: true` when `tsconfig.compilerOptions.target` isn't declared
+    // but we want `useDefineForClassFields: false` when `tsconfig.compilerOptions.target` isn't declared
+    // to align with the TypeScript's behavior
+    if (
+      compilerOptions.useDefineForClassFields === undefined &&
+      compilerOptions.target === undefined
+    ) {
+      compilerOptions.useDefineForClassFields = false
+    }
+
     // esbuild uses tsconfig fields when both the normal options and tsconfig was set
     // but we want to prioritize the normal options
     if (options) {


### PR DESCRIPTION
### Description
esbuild seems to use `useDefineForClassFields: true` when `target` isn't declared in tsconfig. (TypeScript uses `useDefineForClassFields: false` in that case)
https://esbuild.github.io/try/#dAAwLjE4LjExAC0tbG9hZGVyPXRzICctLXRzY29uZmlnLXJhdz17ImNvbXBpbGVyT3B0aW9ucyI6e319JwBjbGFzcyBGb28gewogIGZvbyA9ICdmb28nCn0

refs #13525

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
