### PR TITLE
fix(legacy): add guard to modern polyfill chunk

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -247,7 +247,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           opts,
           true,
         )
-        if (polyfillChunk) {
+        if (genLegacy && polyfillChunk) {
           polyfillChunk.code = modernChunkLegacyGuard + polyfillChunk.code
         }
         return

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -237,7 +237,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
             `[@vitejs/plugin-legacy] modern polyfills:`,
             modernPolyfills,
           )
-        await buildPolyfillChunk(
+        const polyfillChunk = await buildPolyfillChunk(
           config.mode,
           modernPolyfills,
           bundle,
@@ -247,6 +247,9 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           opts,
           true,
         )
+        if (polyfillChunk) {
+          polyfillChunk.code = modernChunkLegacyGuard + polyfillChunk.code
+        }
         return
       }
 
@@ -734,6 +737,8 @@ async function buildPolyfillChunk(
 
   // add the chunk to the bundle
   bundle[polyfillChunk.fileName] = polyfillChunk
+
+  return polyfillChunk
 }
 
 const polyfillId = '\0vite/legacy-polyfills'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Modern polyfills should not run on legacy targeted browsers.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
