### PR TITLE
fix: revert import config module as data

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1153,16 +1153,10 @@ async function loadConfigFromBundledFile(
   // convert to base64, load it with native Node ESM.
   if (isESM) {
     try {
-      // Postfix the bundled code with a timestamp to avoid Node's ESM loader cache
-      const configTimestamp = `${fileName}.timestamp:${Date.now()}-${Math.random()
-        .toString(16)
-        .slice(2)}`
       return (
         await dynamicImport(
           'data:text/javascript;base64,' +
-            Buffer.from(`${bundledCode}\n//${configTimestamp}`).toString(
-              'base64',
-            ),
+            Buffer.from(bundledCode).toString('base64'),
         )
       ).default
     } catch (e) {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1150,17 +1150,18 @@ async function loadConfigFromBundledFile(
 ): Promise<UserConfigExport> {
   // for esm, before we can register loaders without requiring users to run node
   // with --experimental-loader themselves, we have to do a hack here:
-  // convert to base64, load it with native Node ESM.
+  // write it to disk, load it with native Node ESM, then delete the file.
   if (isESM) {
+    const fileBase = `${fileName}.timestamp-${Date.now()}-${Math.random()
+      .toString(16)
+      .slice(2)}`
+    const fileNameTmp = `${fileBase}.mjs`
+    const fileUrl = `${pathToFileURL(fileBase)}.mjs`
+    await fsp.writeFile(fileNameTmp, bundledCode)
     try {
-      return (
-        await dynamicImport(
-          'data:text/javascript;base64,' +
-            Buffer.from(bundledCode).toString('base64'),
-        )
-      ).default
-    } catch (e) {
-      throw new Error(`${e.message} at ${fileName}`)
+      return (await dynamicImport(fileUrl)).default
+    } finally {
+      fs.unlink(fileNameTmp, () => {}) // Ignore errors
     }
   }
   // for cjs, we can register a custom loader via `_require.extensions`


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/issues/13730. See issue for description. If we want to move forward with using `data:text/javascript`, we would need to consider more edge cases. I think reverting is the best move right now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other