### PR TITLE
fix: revert #13073, use consistent virtual module ID in module graph

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -751,9 +751,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // normalize and rewrite accepted urls
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
-        const isRelative = url[0] === '.'
         const [normalized] = await moduleGraph.resolveUrl(
-          isRelative ? toAbsoluteUrl(url) : url,
+          toAbsoluteUrl(url),
           ssr,
         )
         normalizedAcceptedUrls.add(normalized)

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -355,7 +355,7 @@ export async function transformGlobImport(
 ): Promise<TransformGlobImportResult | null> {
   id = slash(id)
   root = slash(root)
-  const isVirtual = !isAbsolute(id)
+  const isVirtual = isVirtualModule(id)
   const dir = isVirtual ? undefined : dirname(id)
   const matches = await parseImportGlob(
     code,
@@ -644,4 +644,9 @@ export function getCommonBase(globsResolved: string[]): null | string {
   if (!commonAncestor) commonAncestor = '/'
 
   return commonAncestor
+}
+
+export function isVirtualModule(id: string): boolean {
+  // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
+  return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
 }

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -9,7 +9,6 @@ import {
   removeFile,
   untilBrowserLogAfter,
   untilUpdated,
-  viteServer,
   viteTestUrl,
 } from '~utils'
 
@@ -675,14 +674,6 @@ if (!isBuild) {
     await loadPromise
     btn = await page.$('button')
     expect(await btn.textContent()).toBe('Compteur 0')
-  })
-
-  test('virtual module in module graph', async () => {
-    const moduleGraph = viteServer.moduleGraph
-    const virtualId = Array.from(moduleGraph.idToModuleMap.keys()).filter(
-      (id: string) => id.includes('virtual'),
-    )
-    expect(virtualId).toEqual(['\x00virtual:file', '/@id/__x00__virtual:file'])
   })
 
   test('handle virtual module updates', async () => {

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -42,13 +42,6 @@ if (import.meta.hot) {
     handleDep('multi deps', foo, nestedFoo)
   })
 
-  import.meta.hot.accept(
-    ['virtual:file', '/@id/__x00__virtual:file'],
-    ([rawVirtualPath, acceptedVirtualPath]) => {
-      text('.virtual', acceptedVirtualPath.virtual)
-    },
-  )
-
   import.meta.hot.dispose(() => {
     console.log(`foo was:`, foo)
   })


### PR DESCRIPTION
This reverts commit aa1776f2db687cdeef2ee27eacc85fd3ae71d4b1.

Fixes https://github.com/storybookjs/storybook/issues/23338

### Description

Let's revert #13073 so we can patch vite 4.4. We can check why Storybook is failing with more time and reapply the fix. cc @fi3ework 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other