### PR TITLE
fix: warn when publicDir and outDir are nested

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -753,14 +753,12 @@ function prepareOutDir(
       config.publicDir &&
       fs.existsSync(config.publicDir)
     ) {
-      if (areSeparateFolders(outDir, config.publicDir)) {
-        copyDir(config.publicDir, outDir)
-      } else {
+      if (!areSeparateFolders(outDir, config.publicDir)) {
         config.logger.warn(
           colors.yellow(
             `\n${colors.bold(
               `(!)`,
-            )} The public directory feature is disabled. outDir ${colors.white(
+            )} The public directory feature may not work correctly. outDir ${colors.white(
               colors.dim(outDir),
             )} and publicDir ${colors.white(
               colors.dim(config.publicDir),
@@ -768,6 +766,7 @@ function prepareOutDir(
           ),
         )
       }
+      copyDir(config.publicDir, outDir)
     }
   }
 }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1238,14 +1238,8 @@ export function toOutputFilePathWithoutRuntime(
 export const toOutputFilePathInCss = toOutputFilePathWithoutRuntime
 export const toOutputFilePathInHtml = toOutputFilePathWithoutRuntime
 
-function isSameOrSubfolder(parent: string, dir: string) {
-  const relative = path.relative(parent, dir)
-  return (
-    relative === '' ||
-    (!relative.startsWith('..') && !path.isAbsolute(relative))
-  )
-}
-
 function areSeparateFolders(a: string, b: string) {
-  return !isSameOrSubfolder(a, b) && !isSameOrSubfolder(b, a)
+  const na = normalizePath(a)
+  const nb = normalizePath(b)
+  return na !== nb && !na.startsWith(nb + '/') && !nb.startsWith(na + '/')
 }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -760,7 +760,7 @@ function prepareOutDir(
           colors.yellow(
             `\n${colors.bold(
               `(!)`,
-            )} The public directory feature is diabled. outDir ${colors.white(
+            )} The public directory feature is disabled. outDir ${colors.white(
               colors.dim(outDir),
             )} and publicDir ${colors.white(
               colors.dim(config.publicDir),

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -753,7 +753,21 @@ function prepareOutDir(
       config.publicDir &&
       fs.existsSync(config.publicDir)
     ) {
-      copyDir(config.publicDir, outDir)
+      if (areSeparateFolders(outDir, config.publicDir)) {
+        copyDir(config.publicDir, outDir)
+      } else {
+        config.logger.warn(
+          colors.yellow(
+            `\n${colors.bold(
+              `(!)`,
+            )} The public directory feature is diabled. outDir ${colors.white(
+              colors.dim(outDir),
+            )} and publicDir ${colors.white(
+              colors.dim(config.publicDir),
+            )} are not separate folders.\n`,
+          ),
+        )
+      }
     }
   }
 }
@@ -1223,3 +1237,15 @@ export function toOutputFilePathWithoutRuntime(
 
 export const toOutputFilePathInCss = toOutputFilePathWithoutRuntime
 export const toOutputFilePathInHtml = toOutputFilePathWithoutRuntime
+
+function isSameOrSubfolder(parent: string, dir: string) {
+  const relative = path.relative(parent, dir)
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !path.isAbsolute(relative))
+  )
+}
+
+function areSeparateFolders(a: string, b: string) {
+  return !isSameOrSubfolder(a, b) && !isSameOrSubfolder(b, a)
+}


### PR DESCRIPTION
### Description

There have been a few reports of people having issues debugging after setting an `outDir` and `publicDir` that are nested. I think Vite should disable the public dir feature and warn the user in this case.

Example:
```js
export default {
  build: {
    outDir: 'public/assets/dist',
  },
};
```

See discussion [at Discord](https://discord.com/channels/804011606160703521/804011606160703524/1126185049969147938) from @fvsch and a previous issue https://github.com/vitejs/vite/issues/3173