### PR TITLE
feat(client): avoid overlay flicker

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -167,8 +167,7 @@ async function handleMessage(payload: HMRPayload) {
         window.location.reload()
         return
       } else {
-        if (clearErrorOverlayTimeout) clearTimeout(clearErrorOverlayTimeout)
-        clearErrorOverlayTimeout = setTimeout(clearErrorOverlay, 50)
+        clearErrorOverlay()
         isFirstUpdate = false
       }
       await Promise.all(
@@ -289,11 +288,8 @@ function notifyListeners(event: string, data: any): void {
 
 const enableOverlay = __HMR_ENABLE_OVERLAY__
 
-let clearErrorOverlayTimeout: ReturnType<typeof setTimeout> | undefined
-
 function createErrorOverlay(err: ErrorPayload['err']) {
   if (!enableOverlay) return
-  if (clearErrorOverlayTimeout) clearTimeout(clearErrorOverlayTimeout)
   clearErrorOverlay()
   document.body.appendChild(new ErrorOverlay(err))
 }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -167,7 +167,8 @@ async function handleMessage(payload: HMRPayload) {
         window.location.reload()
         return
       } else {
-        clearErrorOverlay()
+        if (clearErrorOverlayTimeout) clearTimeout(clearErrorOverlayTimeout)
+        clearErrorOverlayTimeout = setTimeout(clearErrorOverlay, 50)
         isFirstUpdate = false
       }
       await Promise.all(
@@ -288,8 +289,11 @@ function notifyListeners(event: string, data: any): void {
 
 const enableOverlay = __HMR_ENABLE_OVERLAY__
 
+let clearErrorOverlayTimeout: ReturnType<typeof setTimeout> | undefined
+
 function createErrorOverlay(err: ErrorPayload['err']) {
   if (!enableOverlay) return
+  if (clearErrorOverlayTimeout) clearTimeout(clearErrorOverlayTimeout)
   clearErrorOverlay()
   document.body.appendChild(new ErrorOverlay(err))
 }


### PR DESCRIPTION
re: #13220

Solution 1: First commit: Debounce. This is safe but could not ne enough for big updates or add too much delay on successful updates.
Solution 2: Third commit: Wait for successful updates. This is more prone to race conditions, I think `lastErrorTime` make it safe but it could lead to uncleaned error overlay in case of a successful update that follow a still running failed update.