### PR TITLE
fix(ssr): handle error from restart

### DIFF
--- a/playground/ssr/server.js
+++ b/playground/ssr/server.js
@@ -57,6 +57,7 @@ export async function createServer(
       res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
     } catch (e) {
       vite && vite.ssrFixStacktrace(e)
+      if (isTest) throw e
       console.log(e.stack)
       res.status(500).end(e.stack)
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #13735

The bug comes from this [SvelteKit code](https://github.com/sveltejs/kit/blob/6cb283e19a304bb6efe9971554a488cf77b9c41a/packages/kit/src/exports/vite/dev/index.js#L345-L368), which runs `ssrLoadModule` immediately on reload request.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
It's hard to make the test error reliably, so added a very simple one for now. I noticed it may happen once in a while which we could catch.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
