### PR TITLE
fix: avoid early error when server is closed in ssr

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -464,9 +464,11 @@ export async function _createServer(
         closeHttpServer(),
       ])
       // Await pending requests. We throw early in transformRequest
-      // and in hooks if the server is closing, so the import analysis
-      // plugin stops pre-transforming static imports and this block
-      // is resolved sooner.
+      // and in hooks if the server is closing for non-ssr requests,
+      // so the import analysis plugin stops pre-transforming static
+      // imports and this block is resolved sooner.
+      // During SSR, we let pending requests finish to avoid exposing
+      // the server closed error to the users.
       while (server._pendingRequests.size > 0) {
         await Promise.allSettled(
           [...server._pendingRequests.values()].map(

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -649,7 +649,7 @@ export async function createPluginContainer(
       let id: string | null = null
       const partial: Partial<PartialResolvedId> = {}
       for (const plugin of getSortedPlugins('resolveId')) {
-        if (closed) throwClosedServerError()
+        if (closed && !ssr) throwClosedServerError()
         if (!plugin.resolveId) continue
         if (skip?.has(plugin)) continue
 
@@ -714,7 +714,7 @@ export async function createPluginContainer(
       const ctx = new Context()
       ctx.ssr = !!ssr
       for (const plugin of getSortedPlugins('load')) {
-        if (closed) throwClosedServerError()
+        if (closed && !ssr) throwClosedServerError()
         if (!plugin.load) continue
         ctx._activePlugin = plugin
         const handler =
@@ -738,7 +738,7 @@ export async function createPluginContainer(
       const ctx = new TransformContext(id, code, inMap as SourceMap)
       ctx.ssr = !!ssr
       for (const plugin of getSortedPlugins('transform')) {
-        if (closed) throwClosedServerError()
+        if (closed && !ssr) throwClosedServerError()
         if (!plugin.transform) continue
         ctx._activePlugin = plugin
         ctx._activeId = id

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -47,7 +47,7 @@ export function transformRequest(
   server: ViteDevServer,
   options: TransformOptions = {},
 ): Promise<TransformResult | null> {
-  if (server._restartPromise) throwClosedServerError()
+  if (server._restartPromise && !options.ssr) throwClosedServerError()
 
   const cacheKey = (options.ssr ? 'ssr:' : options.html ? 'html:' : '') + url
 
@@ -256,7 +256,7 @@ async function loadAndTransform(
     throw err
   }
 
-  if (server._restartPromise) throwClosedServerError()
+  if (server._restartPromise && !ssr) throwClosedServerError()
 
   // ensure module in graph after successful load
   mod ??= await moduleGraph._ensureEntryFromUrl(url, ssr, undefined, resolved)
@@ -319,7 +319,7 @@ async function loadAndTransform(
     }
   }
 
-  if (server._restartPromise) throwClosedServerError()
+  if (server._restartPromise && !ssr) throwClosedServerError()
 
   const result =
     ssr && !server.config.experimental.skipSsrTransform

--- a/playground/ssr/server.js
+++ b/playground/ssr/server.js
@@ -57,6 +57,7 @@ export async function createServer(
       res.status(200).set({ 'Content-Type': 'text/html' }).end(html)
     } catch (e) {
       vite && vite.ssrFixStacktrace(e)
+      if (isTest) throw e
       console.log(e.stack)
       res.status(500).end(e.stack)
     }


### PR DESCRIPTION
Fixes #13735
Fixes #13786
Closes #13767

### Description

Throwing an error during SSR would force the users to handle it on every call to `ssrLoadModule`. What is safer long term is something we should discuss for Vite 5. At least for 4.4 (and I'm leaning towards this approach for 5 too), it is better to avoid the error during SSR. The only reason it was added was to speed up server restart. During SSR, the requests should be fast enough.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
