### PR TITLE
fix(server): remove restart guard on restart

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -852,9 +852,7 @@ async function restartServer(server: ViteDevServer) {
 
   await server.close()
 
-  // prevent new server `restart` function from calling
-  newServer._restartPromise = server._restartPromise
-
+  // Assign new server props to existing server instance
   Object.assign(server, newServer)
 
   const {
@@ -881,9 +879,6 @@ async function restartServer(server: ViteDevServer) {
     shortcutsOptions.print = false
     bindShortcuts(newServer, shortcutsOptions)
   }
-
-  // new server (the current server) can restart now
-  newServer._restartPromise = null
 }
 
 async function updateCjsSsrExternals(server: ViteDevServer) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/13735

On server restart, we assign the `_restartPromise` of the old server to the new server to prevent the new server's `restart()` from working (to prevent chaos like port collision, proper server listen/teardown). This was done in https://github.com/vitejs/vite/pull/7004 (the guard)

However, https://github.com/vitejs/vite/pull/13262 uses `_restartPromise` for another purpose -- throw on outdated request. That means there's a short interim during server listen that `_restartPromise` exist as a guard, but the server isn't actually outdated.

https://github.com/vitejs/vite/issues/13735 showed an edge case in SvelteKit where it calls `ssrLoadModule` in this interim causing it to falsely error.

This PR removes that guard as I don't think it's useful? On initial server startup we aren't guarding it either.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
