### PR TITLE
fix(types): narrow down the return type of `defineConfig`

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -7,7 +7,7 @@ import { mergeConfig } from '../publicUtils'
 
 describe('mergeConfig', () => {
   test('handles configs with different alias schemas', () => {
-    const baseConfig: UserConfigExport = {
+    const baseConfig = defineConfig({
       resolve: {
         alias: [
           {
@@ -16,16 +16,16 @@ describe('mergeConfig', () => {
           },
         ],
       },
-    }
+    })
 
-    const newConfig: UserConfigExport = {
+    const newConfig = defineConfig({
       resolve: {
         alias: {
           bar: 'bar-value',
           baz: 'baz-value',
         },
       },
-    }
+    })
 
     const mergedConfig: UserConfigExport = {
       resolve: {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -100,8 +100,16 @@ export interface ConfigEnv {
  */
 export type AppType = 'spa' | 'mpa' | 'custom'
 
+export type UserConfigFnObject = (env: ConfigEnv) => UserConfig
+export type UserConfigFnPromise = (env: ConfigEnv) => Promise<UserConfig>
 export type UserConfigFn = (env: ConfigEnv) => UserConfig | Promise<UserConfig>
-export type UserConfigExport = UserConfig | Promise<UserConfig> | UserConfigFn
+
+export type UserConfigExport =
+  | UserConfig
+  | Promise<UserConfig>
+  | UserConfigFnObject
+  | UserConfigFnPromise
+  | UserConfigFn
 
 /**
  * Type helper to make it easier to use vite.config.ts
@@ -109,7 +117,10 @@ export type UserConfigExport = UserConfig | Promise<UserConfig> | UserConfigFn
  * The function receives a {@link ConfigEnv} object that exposes two properties:
  * `command` (either `'build'` or `'serve'`), and `mode`.
  */
-export function defineConfig<T extends UserConfigExport>(config: T): T {
+export function defineConfig(config: UserConfig): UserConfig
+export function defineConfig(config: Promise<UserConfig>): Promise<UserConfig>
+export function defineConfig(config: UserConfigExport): UserConfigExport
+export function defineConfig(config: UserConfigExport): UserConfigExport {
   return config
 }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -109,7 +109,7 @@ export type UserConfigExport = UserConfig | Promise<UserConfig> | UserConfigFn
  * The function receives a {@link ConfigEnv} object that exposes two properties:
  * `command` (either `'build'` or `'serve'`), and `mode`.
  */
-export function defineConfig(config: UserConfigExport): UserConfigExport {
+export function defineConfig<T extends UserConfigExport>(config: T): T {
   return config
 }
 

--- a/playground/assets/vite.config.js
+++ b/playground/assets/vite.config.js
@@ -1,8 +1,6 @@
 import path from 'node:path'
 import { defineConfig } from 'vite'
 
-/** @type {import('vite').UserConfig} */
-// @ts-expect-error typecast
 export default defineConfig({
   base: '/foo',
   publicDir: 'static',

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -9,8 +9,6 @@ globalThis.window = {}
 // @ts-expect-error refer to https://github.com/vitejs/vite/pull/11079
 globalThis.location = new URL('http://localhost/')
 
-/** @type {import('vite').UserConfig} */
-// @ts-expect-error typecast
 export default defineConfig({
   build: {
     cssTarget: 'chrome61',

--- a/playground/define/vite.config.js
+++ b/playground/define/vite.config.js
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite'
 
-/** @type {import('vite').UserConfig} */
-// @ts-expect-error typecast
 export default defineConfig({
   define: {
     __EXP__: 'false',

--- a/playground/lib/vite.config.js
+++ b/playground/lib/vite.config.js
@@ -2,8 +2,6 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { defineConfig } from 'vite'
 
-/** @type {import('vite').UserConfig} */
-// @ts-expect-error typecast
 export default defineConfig({
   esbuild: {
     supported: {


### PR DESCRIPTION
### Description

Fixes compatibility with `mergeConfig`, as reported in https://github.com/vuejs/create-vue/issues/313

Before the change, `defineConfig` would return `UserConfigExport`, which is a union type. This would cause `mergeConfig` to fail, as it doesn't accept the `UserConfigFn` type in the union. (https://github.com/vitejs/vite/pull/13135)

After the change, `defineConfig` returns the same type that it receives, so it would exclude `UserConfigFn` from the return type whenever possible.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
