### PR TITLE
feat(client): close `vite-error-overlay` with Escape key

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -140,6 +140,7 @@ const codeframeRE = /^(?:>?\s+\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 const { HTMLElement = class {} as typeof globalThis.HTMLElement } = globalThis
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot
+  closeOnEsc: (e: KeyboardEvent) => void
 
   constructor(err: ErrorPayload['err'], links = true) {
     super()
@@ -172,22 +173,17 @@ export class ErrorOverlay extends HTMLElement {
       e.stopPropagation()
     })
 
-    const close = () => {
-      this.parentNode?.removeChild(this)
-      document.removeEventListener('keydown', closeOnEsc)
-    }
-
     this.addEventListener('click', () => {
-      close()
+      this.close()
     })
 
-    const closeOnEsc = (e: KeyboardEvent) => {
+    this.closeOnEsc = ((e: KeyboardEvent) => {
       if (e.key === 'Escape' || e.code === 'Escape') {
-        close()
+        this.close()
       }
-    }
+    }).bind(this)
 
-    document.addEventListener('keydown', closeOnEsc)
+    document.addEventListener('keydown', this.closeOnEsc)
   }
 
   text(selector: string, text: string, linkFiles = false): void {
@@ -214,6 +210,10 @@ export class ErrorOverlay extends HTMLElement {
         }
       }
     }
+  }
+  close(): void {
+    this.parentNode?.removeChild(this)
+    document.removeEventListener('keydown', this.closeOnEsc)
   }
 }
 

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -174,6 +174,8 @@ export class ErrorOverlay extends HTMLElement {
     this.addEventListener('click', () => {
       this.close()
     })
+
+    document.addEventListener('keydown', this.pressEscToClose)
   }
 
   text(selector: string, text: string, linkFiles = false): void {
@@ -204,6 +206,13 @@ export class ErrorOverlay extends HTMLElement {
 
   close(): void {
     this.parentNode?.removeChild(this)
+    document.removeEventListener('keydown', this.pressEscToClose)
+  }
+
+  pressEscToClose(e: KeyboardEvent): void {
+    if (e.key === 'Escape' || e.code === 'Escape') {
+      this.close()
+    }
   }
 }
 

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -177,11 +177,11 @@ export class ErrorOverlay extends HTMLElement {
       this.close()
     })
 
-    this.closeOnEsc = ((e: KeyboardEvent) => {
+    this.closeOnEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape' || e.code === 'Escape') {
         this.close()
       }
-    }).bind(this)
+    }
 
     document.addEventListener('keydown', this.closeOnEsc)
   }

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -171,11 +171,23 @@ export class ErrorOverlay extends HTMLElement {
     this.root.querySelector('.window')!.addEventListener('click', (e) => {
       e.stopPropagation()
     })
+
+    const close = () => {
+      this.parentNode?.removeChild(this)
+      document.removeEventListener('keydown', closeOnEsc)
+    }
+
     this.addEventListener('click', () => {
-      this.close()
+      close()
     })
 
-    document.addEventListener('keydown', this.pressEscToClose)
+    const closeOnEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.code === 'Escape') {
+        close()
+      }
+    }
+
+    document.addEventListener('keydown', closeOnEsc)
   }
 
   text(selector: string, text: string, linkFiles = false): void {
@@ -201,17 +213,6 @@ export class ErrorOverlay extends HTMLElement {
           curIndex += frag.length + file.length
         }
       }
-    }
-  }
-
-  close(): void {
-    this.parentNode?.removeChild(this)
-    document.removeEventListener('keydown', this.pressEscToClose)
-  }
-
-  pressEscToClose(e: KeyboardEvent): void {
-    if (e.key === 'Escape' || e.code === 'Escape') {
-      this.close()
     }
   }
 }

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -245,6 +245,26 @@ describe.runIf(isServe)('invalid', () => {
     expect(message).toMatch(/^Unable to parse HTML/)
   })
 
+  test('should close overlay when clicked away', async () => {
+    await page.goto(viteTestUrl + '/invalid.html')
+    const errorOverlay = await page.waitForSelector('vite-error-overlay')
+    expect(errorOverlay).toBeTruthy()
+
+    await page.click('html')
+    const isVisbleOverlay = await errorOverlay.isVisible()
+    expect(isVisbleOverlay).toBeFalsy()
+  })
+
+  test('should close overlay when escape key is pressed', async () => {
+    await page.goto(viteTestUrl + '/invalid.html')
+    const errorOverlay = await page.waitForSelector('vite-error-overlay')
+    expect(errorOverlay).toBeTruthy()
+
+    await page.keyboard.press('Escape')
+    const isVisbleOverlay = await errorOverlay.isVisible()
+    expect(isVisbleOverlay).toBeFalsy()
+  })
+
   test('should reload when fixed', async () => {
     await page.goto(viteTestUrl + '/invalid.html')
     await editFile('invalid.html', (content) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #13748 

Pressing `esc` key closes the error overlay.

I made sure to remove the EventListener after the overlay is closed.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I added an `'keydown'` EventListener to `document`.

Please let me know if it is inappropriate.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
