### PR TITLE
fix: display manualChunks warning only when a function is not used (#13797)

### DIFF
--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -118,7 +118,7 @@ export function splitVendorChunkPlugin(): Plugin {
                 // we can't safely replicate rollup handling.
                 // eslint-disable-next-line no-console
                 console.warn(
-                  "(!) the `splitVendorChunk` plugin doesn't have any effect when using the object form of `build.rollupOptions.manualChunks`. Consider using the function form instead.",
+                  "(!) the `splitVendorChunk` plugin doesn't have any effect when using the object form of `build.rollupOptions.output.manualChunks`. Consider using the function form instead.",
                 )
               }
             } else {

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -113,13 +113,14 @@ export function splitVendorChunkPlugin(): Plugin {
                 output.manualChunks = (id: string, api: ManualChunkMeta) => {
                   return userManualChunks(id, api) ?? viteManualChunks(id, api)
                 }
+              } else {
+                // else, leave the object form of manualChunks untouched, as
+                // we can't safely replicate rollup handling.
+                // eslint-disable-next-line no-console
+                console.warn(
+                  "(!) the `splitVendorChunk` plugin doesn't have any effect when using the object form of `build.rollupOptions.manualChunks`. Consider using the function form instead.",
+                )
               }
-              // else, leave the object form of manualChunks untouched, as
-              // we can't safely replicate rollup handling.
-              // eslint-disable-next-line no-console
-              console.warn(
-                "(!) the `splitVendorChunk` plugin doesn't have any effect when using the object form of `build.rollupOptions.manualChunks`. Consider using the function form instead.",
-              )
             } else {
               output.manualChunks = viteManualChunks
             }


### PR DESCRIPTION
### Description

Fixes Error logged to console when using manualChunkSplitting and function is used (fix #13797)

### Additional context


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it. 
