### PR TITLE
fix(esbuild): enable experimentalDecorators by default

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -205,8 +205,11 @@ async function prepareEsbuildScanner(
 
   const plugin = esbuildScanPlugin(config, container, deps, missing, entries)
 
-  const { plugins = [], ...esbuildOptions } =
-    config.optimizeDeps?.esbuildOptions ?? {}
+  const {
+    plugins = [],
+    tsconfigRaw,
+    ...esbuildOptions
+  } = config.optimizeDeps?.esbuildOptions ?? {}
 
   return await esbuild.context({
     absWorkingDir: process.cwd(),
@@ -219,6 +222,16 @@ async function prepareEsbuildScanner(
     format: 'esm',
     logLevel: 'silent',
     plugins: [...plugins, plugin],
+    tsconfigRaw:
+      typeof tsconfigRaw === 'string'
+        ? tsconfigRaw
+        : {
+            ...tsconfigRaw,
+            compilerOptions: {
+              experimentalDecorators: true,
+              ...tsconfigRaw?.compilerOptions,
+            },
+          },
     ...esbuildOptions,
   })
 }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -142,6 +142,14 @@ export async function transformWithEsbuild(
       compilerOptions.useDefineForClassFields = false
     }
 
+    // esbuild v0.18 only transforms decorators when `experimentalDecorators` is set to `true`.
+    // To preserve compat with the esbuild breaking change, we set `experimentalDecorators` to
+    // `true` by default if it's unset.
+    // TODO: Remove this in Vite 5
+    if (compilerOptions.experimentalDecorators === undefined) {
+      compilerOptions.experimentalDecorators = true
+    }
+
     // esbuild uses tsconfig fields when both the normal options and tsconfig was set
     // but we want to prioritize the normal options
     if (options) {

--- a/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
+++ b/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
@@ -67,4 +67,16 @@ describe('transformWithEsbuild', () => {
       'import { MainTypeOnlyClass } from "./not-used-type";',
     )
   })
+
+  test('experimentalDecorators', async () => {
+    const main = path.resolve(__dirname, '../src/decorator.ts')
+    const mainContent = fs.readFileSync(main, 'utf-8')
+    // Should not error when transpiling decorators
+    // TODO: In Vite 5, this should require setting `tsconfigRaw.experimentalDecorators`
+    // or via the closest `tsconfig.json`
+    const result = await transformWithEsbuild(mainContent, main, {
+      target: 'es2020',
+    })
+    expect(result.code).toContain('__decorateClass')
+  })
 })

--- a/playground/tsconfig-json/src/decorator.ts
+++ b/playground/tsconfig-json/src/decorator.ts
@@ -1,0 +1,8 @@
+function first() {
+  return function (...args: any[]) {}
+}
+
+export class Foo {
+  @first()
+  method() {}
+}

--- a/playground/tsconfig-json/src/decorator.ts
+++ b/playground/tsconfig-json/src/decorator.ts
@@ -4,5 +4,8 @@ function first() {
 
 export class Foo {
   @first()
-  method() {}
+  // @ts-expect-error we intentionally not enable `experimentalDecorators` to test esbuild compat
+  method(@first test: string) {
+    return test
+  }
 }

--- a/playground/tsconfig-json/src/main.ts
+++ b/playground/tsconfig-json/src/main.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import '../nested/main'
 import '../nested-with-extends/main'
+import './decorator'
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { MainTypeOnlyClass } from './not-used-type'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

(potential) fix https://github.com/vitejs/vite/issues/13736. however there were some reports that this doesn't work, so probably worth holding off this PR for now.

follow up on https://github.com/vitejs/vite/pull/13525, not setting `experimentalDecorators` by default seems to be causing issues at the moment, it might be better to turn this on by default for now and disable it in Vite 5 again.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
