### PR TITLE
test: ignore order of HMR updates in tailwind spec

### DIFF
--- a/playground/tailwind/__test__/tailwind.spec.ts
+++ b/playground/tailwind/__test__/tailwind.spec.ts
@@ -59,7 +59,7 @@ if (!isBuild) {
         '[vite] css hot updated: /index.css',
         '[vite] hot updated: /src/App.vue',
       ],
-      true,
+      false,
     )
     await untilUpdated(() => getColor(el), 'rgb(11, 22, 33)')
   })
@@ -77,6 +77,7 @@ if (!isBuild) {
         '[vite] css hot updated: /index.css',
         '[vite] hot updated: /src/components/PugTemplate.vue?vue&type=template&lang.js',
       ],
+      false,
     )
     await untilUpdated(() => getBgColor(el), 'rgb(220, 38, 38)')
   })


### PR DESCRIPTION
### Description

Continuation from https://github.com/vitejs/vite/pull/13793, looks like the updates could also unordered in [other test cases](https://github.com/vitejs/vite/actions/runs/5529948812/jobs/10088702026?pr=13742). The fail seems a lot more uncommon though. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other