### PR TITLE
fix(scan): skip tsconfigRaw fallback if tsconfig is set

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -207,6 +207,7 @@ async function prepareEsbuildScanner(
 
   const {
     plugins = [],
+    tsconfig,
     tsconfigRaw,
     ...esbuildOptions
   } = config.optimizeDeps?.esbuildOptions ?? {}
@@ -222,8 +223,9 @@ async function prepareEsbuildScanner(
     format: 'esm',
     logLevel: 'silent',
     plugins: [...plugins, plugin],
+    tsconfig,
     tsconfigRaw:
-      typeof tsconfigRaw === 'string'
+      tsconfig || typeof tsconfigRaw === 'string'
         ? tsconfigRaw
         : {
             ...tsconfigRaw,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Followup on https://github.com/vitejs/vite/pull/13805#discussion_r1262511746

Skip settings `tsconfigRaw` if `tsconfig` option is already set.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other


