### PR TITLE
fix(optimizer): avoid double-commit of optimized deps when discovery is disabled

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -220,8 +220,7 @@ async function createDepsOptimizer(
     if (config.optimizeDeps.noDiscovery) {
       // We don't need to scan for dependencies or wait for the static crawl to end
       // Run the first optimization run immediately
-      const knownDeps = prepareKnownDeps()
-      optimizationResult = runOptimizeDeps(config, knownDeps)
+      runOptimizer()
     } else if (!isBuild) {
       // Important, the scanner is dev only
       depsOptimizer.scanProcessing = new Promise((resolve) => {
@@ -626,7 +625,7 @@ async function createDepsOptimizer(
     // It normally should be over by the time crawling of user code ended
     await depsOptimizer.scanProcessing
 
-    if (!isBuild && optimizationResult) {
+    if (!isBuild && optimizationResult && !config.optimizeDeps.noDiscovery) {
       const result = await optimizationResult.result
       optimizationResult = undefined
       currentlyProcessing = false

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -220,7 +220,8 @@ async function createDepsOptimizer(
     if (config.optimizeDeps.noDiscovery) {
       // We don't need to scan for dependencies or wait for the static crawl to end
       // Run the first optimization run immediately
-      runOptimizer()
+      const knownDeps = prepareKnownDeps()
+      optimizationResult = runOptimizeDeps(config, knownDeps)
     } else if (!isBuild) {
       // Important, the scanner is dev only
       depsOptimizer.scanProcessing = new Promise((resolve) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fixes #13864

This prevents the optimizer from attempting to rename the `processingCacheDir` -> `depsCacheDir` twice for the initial build.

---

When configured with `noDiscovery: true`, the optimizer is initialized with a procedure (`runOptimizer()`) to optimize dependencies and then immediately commit the result. This would be safe, but there a 2 things going on that cause  this to break down
* with discovery enabled, the initial scan and optimize step doesn't normally lead to a commit. This permits `runOptimizer()` to behave correctly when an existing scan or optimizer run is in progress.
* the `onCrawlEnd` hook that runs after request transformation is missing the necessary condition to skip re-running the optimizer when discovery is disabled. The existing code leads to a double-commit

To summarize the issue - calling `runOptimizer()` will always lead to committing dependencies, regardless of any in-flight requests. When noDiscovery is set to true it's called twice - once at server start, and again when the first request is transformed

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

There's a fix that works equally well by adding a condition to the `onCrawlEnd` hook here:

https://github.com/kherock/vite/blob/132a5a40a295fc68fdf5e2eb260631ccc13df8a1/packages/vite/src/node/optimizer/optimizer.ts#L629

```js
    if (!isBuild && optimizationResult && !config.optimizeDeps.noDiscovery) {
```

However, I feel like this would have consequences on dependencies that receive changes while the server is active, so I think the proposed change in this PR is the better fix.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
