### PR TITLE
fix: omit 'plugins' since it has no effect

### DIFF
--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -71,7 +71,11 @@ export interface Plugin extends RollupPlugin {
       this: void,
       config: UserConfig,
       env: ConfigEnv,
-    ) => UserConfig | null | void | Promise<UserConfig | null | void>
+    ) =>
+      | Omit<UserConfig, 'plugins'>
+      | null
+      | void
+      | Promise<Omit<UserConfig, 'plugins'> | null | void>
   >
   /**
    * Use this hook to read and store the final resolved vite config.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Since it's noted that injecting other plugins inside the `config` hook will has no effect, I think we should let the type also saids so to keep users from doing this. It could be very confusing when people didn't see the note.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [x] Other

type enhancement

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
