### PR TITLE
feat(client): add guide to press Esc for closing the overlay

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -118,18 +118,18 @@ code {
   cursor: pointer;
 }
 
-.keyboard-key {
+.kbd {
   line-height: 1.5;
   font-family: ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.75rem;
   font-weight: 700;
-  background-color: rgb(66, 69 ,76);
-  color: rgb(193, 194, 197);
+  background-color: rgb(38, 40, 44);
+  color: rgb(166, 167, 171);
   padding: 0.15rem 0.3rem;
   border-radius: 0.25rem;
   border-width: 0.0625rem 0.0625rem 0.1875rem;
   border-style: solid;
-  border-color: rgb(70, 74, 83);
+  border-color: rgb(54, 57, 64);
   border-image: initial;
 }
 </style>
@@ -140,7 +140,7 @@ code {
     <pre class="frame" part="frame"></pre>
     <pre class="stack" part="stack"></pre>
     <div class="tip" part="tip">
-      Click outside, press <span class="keyboard-key">Esc</span> key or fix the code to dismiss.<br>
+      Click outside, press <span class="kbd">Esc</span> key or fix the code to dismiss.<br>
       You can also disable this overlay by setting
       <code part="config-option-name">server.hmr.overlay</code> to <code part="config-option-value">false</code> in <code part="config-file-name">vite.config.js.</code>
     </div>

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -140,7 +140,7 @@ code {
     <pre class="frame" part="frame"></pre>
     <pre class="stack" part="stack"></pre>
     <div class="tip" part="tip">
-      Click outside, press <span class="kbd">Esc</span> key or fix the code to dismiss.<br>
+      Click outside, press <span class="kbd">Esc</span> key, or fix the code to dismiss.<br>
       You can also disable this overlay by setting
       <code part="config-option-name">server.hmr.overlay</code> to <code part="config-option-value">false</code> in <code part="config-file-name">vite.config.js.</code>
     </div>

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -118,7 +118,7 @@ code {
   cursor: pointer;
 }
 
-.kbd {
+kbd {
   line-height: 1.5;
   font-family: ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 0.75rem;
@@ -140,7 +140,7 @@ code {
     <pre class="frame" part="frame"></pre>
     <pre class="stack" part="stack"></pre>
     <div class="tip" part="tip">
-      Click outside, press <span class="kbd">Esc</span> key, or fix the code to dismiss.<br>
+      Click outside, press <kbd>Esc</kbd> key, or fix the code to dismiss.<br>
       You can also disable this overlay by setting
       <code part="config-option-name">server.hmr.overlay</code> to <code part="config-option-value">false</code> in <code part="config-file-name">vite.config.js.</code>
     </div>

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -104,6 +104,7 @@ pre::-webkit-scrollbar {
   color: #999;
   border-top: 1px dotted #999;
   padding-top: 13px;
+  line-height: 1.8;
 }
 
 code {
@@ -116,6 +117,21 @@ code {
   text-decoration: underline;
   cursor: pointer;
 }
+
+.keyboard-key {
+  line-height: 1.5;
+  font-family: ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  background-color: rgb(66, 69 ,76);
+  color: rgb(193, 194, 197);
+  padding: 0.15rem 0.3rem;
+  border-radius: 0.25rem;
+  border-width: 0.0625rem 0.0625rem 0.1875rem;
+  border-style: solid;
+  border-color: rgb(70, 74, 83);
+  border-image: initial;
+}
 </style>
 <div class="backdrop" part="backdrop">
   <div class="window" part="window">
@@ -124,7 +140,7 @@ code {
     <pre class="frame" part="frame"></pre>
     <pre class="stack" part="stack"></pre>
     <div class="tip" part="tip">
-      Click outside or fix the code to dismiss.<br>
+      Click outside, press <span class="keyboard-key">Esc</span> key or fix the code to dismiss.<br>
       You can also disable this overlay by setting
       <code part="config-option-name">server.hmr.overlay</code> to <code part="config-option-value">false</code> in <code part="config-file-name">vite.config.js.</code>
     </div>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Follow up of the PR https://github.com/vitejs/vite/pull/13795.

The feature for closing the `vite-error-overlay` with Esc key has been added.

However, the overlay doesn't say it can be closed with Esc key.

Therefore, I added little guide to let users know about this feature.

### Additional context

Below is how it looks

<img width="892" alt="Screenshot 2023-07-19 at 23 28 34" src="https://github.com/vitejs/vite/assets/48273875/87915148-0194-4ac7-bb1f-963db4a2e939">


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
