### PR TITLE
fix: do not append `browserHash` on optimized deps during build

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -250,7 +250,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         if (depsOptimizer?.isOptimizedDepFile(normalizedFsPath)) {
           // Optimized files could not yet exist in disk, resolve to the full path
           // Inject the current browserHash version if the path doesn't have one
-          if (!normalizedFsPath.match(DEP_VERSION_RE)) {
+          if (!resolveOptions.isBuild && !normalizedFsPath.match(DEP_VERSION_RE)) {
             const browserHash = optimizedDepInfoFromFile(
               depsOptimizer.metadata,
               normalizedFsPath,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -250,7 +250,10 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         if (depsOptimizer?.isOptimizedDepFile(normalizedFsPath)) {
           // Optimized files could not yet exist in disk, resolve to the full path
           // Inject the current browserHash version if the path doesn't have one
-          if (!resolveOptions.isBuild && !normalizedFsPath.match(DEP_VERSION_RE)) {
+          if (
+            !resolveOptions.isBuild &&
+            !normalizedFsPath.match(DEP_VERSION_RE)
+          ) {
             const browserHash = optimizedDepInfoFromFile(
               depsOptimizer.metadata,
               normalizedFsPath,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Do not append `browserHash` on optmized deps during build. It is unnecessary and on some occasions would cause duplicate files bundled. For example, if we have multiple entries, vite will "discover and optimize new deps" and re-compute the `browserHash`, so it could end up with both `.vite/deps_build-dist/chunk-ABCDEFGH.js?v=11111111` and `.vite/deps_build-dist/chunk-ABCDEFGH.js?v=22222222` in the final bundles. They have the same content but different ids, so rollup treats them as different modules.


In fact, "entry" optmized deps have no `browserHash` suffix currently. Only chunks imported by "entry" optimized deps have that. For example, `.vite/deps_build-dist/vue-demi.js` imports `vite/deps_build-dist/chunk-ABCDEFGH.js?v=11111111` and `.vite/deps_build-dist/vue.js` imports `.vite/deps_build-dist/chunk-ABCDEFGH.js?v=22222222`.


I think this happens when the user cannot correctly configure the entries for deps optimization, which is possible for complicated and highly customized projects.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
