### PR TITLE
chore(eslint): allow type annotations

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -77,7 +77,7 @@ module.exports = defineConfig({
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/consistent-type-imports': [
       'error',
-      { prefer: 'type-imports' },
+      { prefer: 'type-imports', disallowTypeAnnotations: false },
     ],
     // disable rules set in @typescript-eslint/stylistic v6 that wasn't set in @typescript-eslint/recommended v5 and which conflict with current code
     // maybe we should turn them on in a new PR

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -36,7 +36,6 @@ import {
 } from './snippets'
 
 // lazy load babel since it's not used during dev
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 let babel: typeof import('@babel/core') | undefined
 async function loadBabel() {
   if (!babel) {

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -4,7 +4,6 @@ import { createRequire } from 'node:module'
 import { createFilter, isInNodeModules, safeRealpathSync } from './utils'
 import type { Plugin } from './plugin'
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 let pnp: typeof import('pnpapi') | undefined
 if (process.versions.pnp) {
   try {


### PR DESCRIPTION
reference: 

https://typescript-eslint.io/rules/consistent-type-imports/#disallowtypeannotations

https://stackoverflow.com/questions/75952182/import-type-annotations-are-forbidden