### PR TITLE
fix: `optimizeDeps.include` not working with paths inside packages

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -21,6 +21,7 @@ import {
   createDebugger,
   deepImportRE,
   fsPathFromId,
+  getNpmPackageName,
   injectQuery,
   isBuiltin,
   isDataUrl,
@@ -923,8 +924,10 @@ export async function tryOptimizedResolve(
 
     // lazily initialize idPkgDir
     if (idPkgDir == null) {
+      const pkgName = getNpmPackageName(id)
+      if (!pkgName) break
       idPkgDir = resolvePackageData(
-        id,
+        pkgName,
         importer,
         preserveSymlinks,
         packageCache,


### PR DESCRIPTION
### Description

Currently using something like:

```ts
config: () => ({
  optimizeDeps: {
    include: [
      'vitepress > @vueuse/integrations/useFocusTrap',
      'vitepress > mark.js/src/vanilla.js',
      'vitepress > minisearch'
    ]
  }
}),
```

doesn't work consistently across projects. In case of monorepos, it fails to resolve deps when the include contains some path other than the package name itself - (e.g. `@vueuse/integrations/useFocusTrap` and `mark.js/src/vanilla.js` in this case). It works fine for `minisearch` because that's the package name itself.

The cause of this issue seems to be the fact that `tryOptimizedResolve` calls `resolvePackageData` with `id` instead of package name (e.g. `@vueuse/integrations/useFocusTrap` instead of `@vueuse/integrations`). Which results in `resolvePackageData` searching for package.json in wrong directories (e.g. `'/Users/brc-dd/vitepress/node_modules/@vueuse/integrations/useFocusTrap/package.json'` instead of `'/Users/brc-dd/vitepress/node_modules/@vueuse/integrations/package.json'`).

This PR fixes that by passing npm package name instead of passing id directly.

### Additional context

[internal discord thread](https://discord.com/channels/804011606160703521/831456449632534538/1131981646674002062)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
