### PR TITLE
fix(proxy): handle error when proxy itself errors

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -51,6 +51,10 @@ export function proxyMiddleware(
     }
 
     proxy.on('error', (err, req, originalRes) => {
+      // originalRes can be falsy if the proxy itself errored
+      if (!originalRes) {
+        httpServer?.emit('error', err)
+      }
       // When it is ws proxy, res is net.Socket
       const res = originalRes as http.ServerResponse | net.Socket
       if ('req' in res) {

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -51,13 +51,18 @@ export function proxyMiddleware(
     }
 
     proxy.on('error', (err, req, originalRes) => {
-      // originalRes can be falsy if the proxy itself errored
-      if (!originalRes) {
-        httpServer?.emit('error', err)
-      }
       // When it is ws proxy, res is net.Socket
-      const res = originalRes as http.ServerResponse | net.Socket
-      if ('req' in res) {
+      // originalRes can be falsy if the proxy itself errored
+      const res = originalRes as http.ServerResponse | net.Socket | undefined
+      if (!res) {
+        config.logger.error(
+          `${colors.red(`http proxy error: ${err.message}`)}\n${err.stack}`,
+          {
+            timestamp: true,
+            error: err,
+          },
+        )
+      } else if ('req' in res) {
         config.logger.error(
           `${colors.red(`http proxy error at ${originalRes.req.url}:`)}\n${
             err.stack


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

closes #13703 

Add error handling to the point when the proxy itself errors.

Right now, the `proxy` expects that the `res` is never `undefined` or other falsy value but there are some cases when the `res` is.

When the `res` is falsy, the thrown error becomes the error of accessing `undefined` value, not the original error.

This makes it hard for developers to trace the original error.

Therefore, I added a logic to handle error case when the `res` is falsy.

### Additional context

My particular case of the problem was passing `server.proxy`'s `target` as falsy value (`null` or `undefined`).

```js
import { defineConfig } from 'vite';

// https://vitejs.dev/config/
export default defineConfig({
  server: {
    proxy: {
      '^/undefined': {
        target: undefined, // this one
      },
      '^/null': {
        target: null, // and this one
      },
    },
  },
});
```

#### AS-IS

<img width="880" alt="Screenshot 2023-07-03 at 11 55 38" src="https://github.com/vitejs/vite/assets/48273875/8e0e686a-a66b-4c65-891b-09cf4c83dcbf">

Just seeing the error above, it is hard to track where the error started from.

#### TO-BE

<img width="1256" alt="Screenshot 2023-07-23 at 17 21 46" src="https://github.com/vitejs/vite/assets/48273875/925418ed-d2a8-4d53-aea8-179e406d9ce7">

The above error can give developers more specific information about where the error started from.

I believe that my fix can cover so much more errors. Due to the fact that it is caused by an incorrect expectation of the type of `res`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
