### PR TITLE
feat(server.proxy): rewrite(path, req) - Added "request" object as parameter (like Webpack pathRewrite)

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -94,6 +94,8 @@ Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). A
 
 In some cases, you might also want to configure the underlying dev server (e.g. to add custom middlewares to the internal [connect](https://github.com/senchalabs/connect) app). In order to do that, you need to write your own [plugin](/guide/using-plugins.html) and use [configureServer](/guide/api-plugin.html#configureserver) function.
 
+The `rewrite: (path, req)` method takes two parameters. The `path` parameter is the relative path of the processed URL, including GET parameters. (e.g. /api/v2/news or /api/v2/search?query=something). `req` (optional) allows access to additional request data such as `req.query`, `req.method`, `req.headers.host` (which contains the host including subdomain and port, e.g. `subdomain.localhost:5173`), and more. See the "Rewrite req parameter" documentation below for more details.
+
 **Example:**
 
 ```js
@@ -114,6 +116,15 @@ export default defineConfig({
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/fallback/, ''),
       },
+      // with req data: http://subdomain.localhost:5173/api/v1/ -> http://localhost:4567/subdomain/api/v1/
+      '^/api/.*': {
+        target: 'http://localhost:4567/',
+        changeOrigin: true,
+        rewrite: (path, req) => {
+          const subdomain = req.headers.host.split('.')[0]
+          return path.replace(/^\/api/, `/${subdomain}/api`)
+        },
+      },
       // Using the proxy instance
       '/api': {
         target: 'http://jsonplaceholder.typicode.com',
@@ -130,6 +141,26 @@ export default defineConfig({
     },
   },
 })
+```
+
+**Rewrite req parameter**
+
+`rewrite: (path, req)` gives you access to the `req` object. It contains data about the request being handled, such as `req.query`, `req.method`, `req.headers.host`, and more. The object is read-only. The contained keys/contents of the `req.headers` object may vary depending on the client's request.
+
+Example URL: `https://subdomain.localhost:5173/api?query=something&order=desc`
+
+```js
+{
+  'pathname': '/api',
+  'query': 'query=something&order=desc',
+  'method': 'GET',
+  'headers': {
+    'host': 'subdomain.localhost:5173',
+    'user-agent': 'Mozilla/5.0 ...',
+    'accept-encoding': 'gzip, deflate, br',
+    // ...
+  }
+}
 ```
 
 ## server.cors

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -11,9 +11,9 @@ const debug = createDebugger('vite:proxy')
 
 export interface ProxyOptions extends HttpProxy.ServerOptions {
   /**
-   * rewrite path
+   * rewrite path (req contains the request data)
    */
-  rewrite?: (path: string) => string
+  rewrite?: (path: string, req?: object) => string
   /**
    * configure the proxy server (e.g. listen to events)
    */
@@ -118,7 +118,7 @@ export function proxyMiddleware(
             opts.target?.toString().startsWith('wss:')
           ) {
             if (opts.rewrite) {
-              req.url = opts.rewrite(url)
+              req.url = opts.rewrite(url, collectRequestData(req))
             }
             debug?.(`${req.url} -> ws ${opts.target}`)
             proxy.ws(req, socket, head)
@@ -151,7 +151,7 @@ export function proxyMiddleware(
 
         debug?.(`${req.url} -> ${opts.target || opts.forward}`)
         if (opts.rewrite) {
-          req.url = opts.rewrite(req.url!)
+          req.url = opts.rewrite(req.url!, collectRequestData(req))
         }
         proxy.web(req, res, options)
         return
@@ -166,4 +166,13 @@ function doesProxyContextMatchUrl(context: string, url: string): boolean {
     (context[0] === '^' && new RegExp(context).test(url)) ||
     url.startsWith(context)
   )
+}
+
+function collectRequestData(req: any) {
+  return {
+    pathname: req._parsedUrl.pathname,
+    query: req._parsedUrl.query,
+    method: req.method,
+    headers: req.headers,
+  }
 }


### PR DESCRIPTION
### Description

- **Added feature:** This PR extends the [server.proxy](https://vitejs.dev/config/server-options.html#server-proxy) `rewrite(path, req)` method by adding an optional `req` parameter. This variable contains the current request object, e.g. you can access `req.query`, `req.method`, `req.headers.host`, ... (see detailed explanation below).

- **Use case:** The website uses subdomains. (e.g. `http://subdomain.localhost:5173/api/v1/ `) The new path generated in server.proxy rewrite must include the given subdomain. (e.g. `http://localhost:4567/subdomain/api/v1/`)

- **Addressed problem**:  In **Webpack**, the proxy method `pathRewrite(path, req)` supports using the request via `req` parameter. This PR allows to access the request data in Vite too. 

**Details (PR contains updated documentation)**

The `rewrite: (path, req)` method takes two parameters. The `path` parameter is the relative path of the processed URL, including GET parameters. (e.g. /api/v2/news or /api/v2/search?query=something). `req` (optional) allows access to additional request data such as `req.query`, `req.method`, `req.headers.host` (which contains the host including subdomain and port, e.g. `subdomain.localhost:5173`), and more. See the "Rewrite req parameter" documentation below for more details.

**Example:**

```js
export default defineConfig({
  server: {
    proxy: {
      // with req data: http://subdomain.localhost:5173/api/v1/ -> http://localhost:4567/subdomain/api/v1/
      '^/api/.*': {
        target: 'http://localhost:4567/',
        changeOrigin: true,
        rewrite: (path, req) => {
          const subdomain = req.headers.host.split('.')[0]
          return path.replace(/^\/api/, `/${subdomain}/api`)
        },
      },
    },
  },
})
```

**Rewrite req parameter**

`rewrite: (path, req)` gives you access to the `req` object. It contains data about the request being handled, such as `req.query`, `req.method`, `req.headers.host`, and more. The object is read-only. The contained keys/contents of the `req.headers` object may vary depending on the client's request.

Example URL: `http://subdomain.localhost:5173/api?query=something&order=desc
`
```js
{
  'pathname': '/api',
  'query': 'query=something&order=desc',
  'method': 'GET',
  'headers': {
    'host': 'subdomain.localhost:5173',
    'user-agent': 'Mozilla/5.0 ...',
    'accept-encoding': 'gzip, deflate, br',
    // ...
  }
}
```

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
