### PR TITLE
fix: nest deps chunk cannot be loaded when optimizing deps in build mode

### DIFF
--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -130,16 +130,18 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
       if (info) {
         await info.processing
         debug?.(`load ${colors.cyan(file)}`)
-      } else {
-        throw new Error(
-          `Something unexpected happened while optimizing "${id}".`,
-        )
       }
 
       // Load the file from the cache instead of waiting for other plugin
       // load hooks to avoid race conditions, once processing is resolved,
       // we are sure that the file has been properly save to disk
-      return fsp.readFile(file, 'utf-8')
+      try {
+        return await fsp.readFile(file, 'utf-8')
+      } catch (e) {
+        throw new Error(
+          `Something unexpected happened while optimizing "${id}".`,
+        )
+      }
     },
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #13933 
Align the `load` logic of `optimizedDepsBuildPlugin` with `optimizedDepsPlugin`. After loading the file from the cache, throw an exception if an error is encountered.

### Additional context

As mentioned in the last context I provided in the issue. I noticed that the `file` field for the `chunks` in the `.vite/deps/_metadata.json` is processed with `flattenId`. But the chunk files generated by esbuild on the disk do not undergo the `flattenId` process. Is this behavior expected? If it's necessary to flatten the chunk filenames, would it be better to flatten the filenames when generating the chunk files with esbuild? However, at the moment, I'm not sure how to flatten the generated chunks.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
