### PR TITLE
fix: prepend `config.base` to vite/env path

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -255,10 +255,12 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         const workerType = query['type']! as WorkerType
         let injectEnv = ''
 
+        const scriptPath = JSON.stringify(path.posix.join(config.base, ENV_PUBLIC_PATH))
+
         if (workerType === 'classic') {
-          injectEnv = `importScripts('${ENV_PUBLIC_PATH}')\n`
+          injectEnv = `importScripts(${scriptPath})\n`
         } else if (workerType === 'module') {
-          injectEnv = `import '${ENV_PUBLIC_PATH}'\n`
+          injectEnv = `import ${scriptPath}\n`
         } else if (workerType === 'ignore') {
           if (isBuild) {
             injectEnv = ''

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -255,7 +255,9 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         const workerType = query['type']! as WorkerType
         let injectEnv = ''
 
-        const scriptPath = JSON.stringify(path.posix.join(config.base, ENV_PUBLIC_PATH))
+        const scriptPath = JSON.stringify(
+          path.posix.join(config.base, ENV_PUBLIC_PATH),
+        )
 
         if (workerType === 'classic') {
           injectEnv = `importScripts(${scriptPath})\n`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

https://github.com/nuxt/nuxt/issues/20771
https://github.com/tomayac/sqlite-wasm/pull/8

This PR prepends `/@vite/env` with the configured base path, which is required to import this properly in Nuxt, which adds a `/_nuxt` base path. I think this should also be a bug in other contexts, not just Nuxt.

This is what we are doing for the client path:

https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/css.ts#L463-L466

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
