### PR TITLE
fix(template): eliminate the error that occurs when enabling eslint-plugin-markdown

### DIFF
--- a/packages/create-vite/template-react-ts/README.md
+++ b/packages/create-vite/template-react-ts/README.md
@@ -14,12 +14,15 @@ If you are developing a production application, we recommend updating the config
 - Configure the top-level `parserOptions` property like this:
 
 ```js
-   parserOptions: {
+export default {
+  // other rules...
+  parserOptions: {
     ecmaVersion: 'latest',
     sourceType: 'module',
     project: ['./tsconfig.json', './tsconfig.node.json'],
     tsconfigRootDir: __dirname,
-   },
+  },
+}
 ```
 
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The following code generated by Vite will encounter an error when the project is enabled with https://github.com/eslint/eslint-plugin-markdown.

![image](https://github.com/vitejs/vite/assets/38807139/12490bbb-b51c-4c2e-9e2d-3b2d59cceb0d)

### Additional context

It doesn't seem necessary to introduce https://github.com/eslint/eslint-plugin-markdown for the Vite project. I have checked other code generated by Vite and haven't found other similar issues so far.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
