### PR TITLE
fix: use file extensions on type imports so they work with `moduleResolution: 'node16'`

### DIFF
--- a/packages/vite/scripts/postPatchTypes.ts
+++ b/packages/vite/scripts/postPatchTypes.ts
@@ -10,9 +10,9 @@ const nodeDts = resolve(dir, '../dist/node/index.d.ts')
 // rewrite `types/*` import to relative import with file extension
 rewriteImports(nodeDts, (importPath) => {
   if (importPath.startsWith('types/')) {
-    return '../../' + importPath.endsWith('.js')
-      ? importPath
-      : importPath + '.js'
+    return (
+      '../../' + (importPath.endsWith('.js') ? importPath : importPath + '.js')
+    )
   }
 })
 

--- a/packages/vite/scripts/postPatchTypes.ts
+++ b/packages/vite/scripts/postPatchTypes.ts
@@ -7,10 +7,12 @@ import { rewriteImports, walkDir } from './util'
 const dir = dirname(fileURLToPath(import.meta.url))
 const nodeDts = resolve(dir, '../dist/node/index.d.ts')
 
-// rewrite `types/*` import to relative import
+// rewrite `types/*` import to relative import with file extension
 rewriteImports(nodeDts, (importPath) => {
   if (importPath.startsWith('types/')) {
-    return '../../' + importPath
+    return '../../' + importPath.endsWith('.js')
+      ? importPath
+      : importPath + '.js'
   }
 })
 


### PR DESCRIPTION
### Description

[At Astro we're currently (attempting) to migrate our `tsconfig.json` to `moduleResolution: 'node16'`](https://github.com/withastro/astro/pull/7787). We got it mostly figured out, apart from one thing: We can't import types from Vite. Investigating led me to realize that it was because Vite's type imports don't have file extensions, so they always resolve as `any` under `moduleResolution: 'node16'`. I tried to workaround this by importing the files in the `types` folder individually, but they're not part of the `exports` map so.

This PR adds file extensions to all the imports, easy enough. I tested it downstream and it works. Per https://github.com/vitejs/vite/issues/11552, it seems like many users were patching Vite manually for this already.

### Additional context

Downstream is currently not able to migrate to `moduleResolution: 'node16'`, so this is kinda blocking.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
