### PR TITLE
fix: node path normalization uses query parameters (fix #13957)

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -9,6 +9,7 @@ import {
   injectQuery,
   isFileReadable,
   isWindows,
+  normalizePath,
   posToNumber,
   processSrcSetSync,
   resolveHostname,
@@ -258,5 +259,14 @@ describe('processSrcSetSync', () => {
         ({ url }) => path.posix.join(devBase, url),
       ),
     ).toBe('/base/nested/asset.png 1x, /base/nested/asset.png 2x')
+  })
+})
+
+describe('normalizePath', () => {
+  test('ignores paths in query parameters', async () => {
+    const importPath = '/base/file?param=../../../other/path'
+    expect(normalizePath(importPath)).toBe(
+      '/base/file?param=../../../other/path',
+    )
   })
 })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -207,7 +207,12 @@ export const isWindows = os.platform() === 'win32'
 const VOLUME_RE = /^[A-Z]:/i
 
 export function normalizePath(id: string): string {
-  return path.posix.normalize(isWindows ? slash(id) : id)
+  const [importPath, params] = id.split('?')
+  const importSuffix = `${params ? `?${params}` : ''}`
+  const normalized = path.posix.normalize(
+    isWindows ? slash(importPath) : importPath,
+  )
+  return `${normalized}${importSuffix}`
 }
 
 export function fsPathFromId(id: string): string {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Discussion/info in #13957

`normalizePath` returns unexpected values when path has query parameters containing relative paths. As `normalizePath` uses `path.posix.normalize`, which also tries to resolve any relative paths in the passed string, I suppose this is because paths normally do not have query parameters. 
```bash
> path.posix.normalize('@nuxt/i18n/__config__?target=./config.ts')
'@nuxt/i18n/__config__?target=./config.ts'

> path.posix.normalize('@nuxt/i18n/__config__?target=../config.ts')
'@nuxt/i18n/__config__?target=../config.ts'

> path.posix.normalize('@nuxt/i18n/__config__?target=../../config.ts')
'@nuxt/i18n/config.ts'

> path.posix.normalize('@nuxt/i18n/__config__?target=../../../config.ts')
'@nuxt/config.ts'
```

My PR fixes this by splitting the query parameters before normalization and concatenating the parameters afterwards.

### Additional context
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
