### PR TITLE
perf: use magic-string hires boundary for sourcemaps

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-env": "^7.22.9",
     "browserslist": "^4.21.9",
     "core-js": "^3.31.1",
-    "magic-string": "^0.30.1",
+    "magic-string": "^0.30.2",
     "regenerator-runtime": "^0.13.11",
     "systemjs": "^6.14.1"
   },

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -397,7 +397,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         if (config.build.sourcemap) {
           return {
             code: ms.toString(),
-            map: ms.generateMap({ hires: true }),
+            map: ms.generateMap({ hires: 'boundary' }),
           }
         }
         return {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -86,8 +86,8 @@
     "@rollup/plugin-node-resolve": "15.1.0",
     "@rollup/plugin-typescript": "^11.1.2",
     "@rollup/pluginutils": "^5.0.2",
-    "@types/pnpapi": "^0.0.2",
     "@types/escape-html": "^1.0.2",
+    "@types/pnpapi": "^0.0.2",
     "acorn": "^8.10.0",
     "acorn-walk": "^8.2.0",
     "cac": "^6.7.14",
@@ -110,7 +110,7 @@
     "json-stable-stringify": "^1.0.2",
     "launch-editor-middleware": "^2.6.0",
     "lightningcss": "^1.21.5",
-    "magic-string": "^0.30.1",
+    "magic-string": "^0.30.2",
     "micromatch": "^4.0.5",
     "mlly": "^1.4.0",
     "mrmime": "^1.0.1",
@@ -138,10 +138,10 @@
   "peerDependencies": {
     "@types/node": ">= 14",
     "less": "*",
+    "lightningcss": "^1.21.0",
     "sass": "*",
     "stylus": "*",
     "sugarss": "*",
-    "lightningcss": "^1.21.0",
     "terser": "^5.4.0"
   },
   "peerDependenciesMeta": {

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -260,7 +260,7 @@ function shimDepsPlugin(deps: Record<string, ShimOptions>): Plugin {
 
           return {
             code: magicString.toString(),
-            map: magicString.generateMap({ hires: true }),
+            map: magicString.generateMap({ hires: 'boundary' }),
           }
         }
       }
@@ -308,7 +308,7 @@ const __require = require;
 
       return {
         code: s.toString(),
-        map: s.generateMap({ hires: true }),
+        map: s.generateMap({ hires: 'boundary' }),
       }
     },
   }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -189,7 +189,9 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       if (s) {
         return {
           code: s.toString(),
-          map: config.build.sourcemap ? s.generateMap({ hires: true }) : null,
+          map: config.build.sourcemap
+            ? s.generateMap({ hires: 'boundary' })
+            : null,
         }
       } else {
         return null

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -697,7 +697,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             // resolve public URL from CSS paths, we need to use absolute paths
             return {
               code: s.toString(),
-              map: s.generateMap({ hires: true }),
+              map: s.generateMap({ hires: 'boundary' }),
             }
           } else {
             return { code: s.toString() }
@@ -2130,7 +2130,7 @@ async function getSource(
   ms.appendLeft(0, sep)
   ms.appendLeft(0, additionalData)
 
-  const map = ms.generateMap({ hires: true })
+  const map = ms.generateMap({ hires: 'boundary' })
   map.file = filename
   map.sources = [filename]
 

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -418,7 +418,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (s) {
         return {
           code: s.toString(),
-          map: config.build.sourcemap ? s.generateMap({ hires: true }) : null,
+          map: config.build.sourcemap
+            ? s.generateMap({ hires: 'boundary' })
+            : null,
         }
       }
     },
@@ -436,7 +438,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
           return {
             code: s.toString(),
-            map: s.generateMap({ hires: true }),
+            map: s.generateMap({ hires: 'boundary' }),
           }
         } else {
           return code.replace(re, isModern)
@@ -651,7 +653,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
             if (config.build.sourcemap && chunk.map) {
               const nextMap = s.generateMap({
                 source: chunk.fileName,
-                hires: true,
+                hires: 'boundary',
               })
               const map = combineSourcemaps(chunk.fileName, [
                 nextMap as RawSourceMap,

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -365,7 +365,9 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         return (
           s && {
             code: s.toString(),
-            map: config.build.sourcemap ? s.generateMap({ hires: true }) : null,
+            map: config.build.sourcemap
+              ? s.generateMap({ hires: 'boundary' })
+              : null,
           }
         )
       }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -195,7 +195,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
           contentNode.sourceCodeLocation!.startOffset,
           contentNode.sourceCodeLocation!.endOffset,
         )
-        .generateMap({ hires: true })
+        .generateMap({ hires: 'boundary' })
       map.sources = [filename]
       map.file = filename
     }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -574,7 +574,7 @@ export async function createPluginContainer(
         return createIfNull
           ? new MagicString(this.originalCode).generateMap({
               includeContent: true,
-              hires: true,
+              hires: 'boundary',
               source: cleanUrl(this.filename),
             })
           : null

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -274,7 +274,7 @@ async function ssrTransformScript(
     },
   })
 
-  let map = s.generateMap({ hires: true })
+  let map = s.generateMap({ hires: 'boundary' })
   if (inMap && inMap.mappings && inMap.sources.length > 0) {
     map = combineSourcemaps(url, [
       {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1142,7 +1142,7 @@ export function transformStableResult(
     code: s.toString(),
     map:
       config.command === 'build' && config.build.sourcemap
-        ? s.generateMap({ hires: true, source: id })
+        ? s.generateMap({ hires: 'boundary', source: id })
         : null,
   }
 }

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -92,7 +92,7 @@ describe.runIf(isServe)('serve', () => {
     const map = extractSourcemap(css)
     expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
       {
-        "mappings": "AAAA,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACX,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC,CAAC;AACb,CAAC;",
+        "mappings": "AAAA,CAAC,QAAQ,CAAC,CAAC;AACX,CAAC,CAAC,KAAK,CAAC,CAAC,GAAG,CAAC;AACb,CAAC;",
         "sources": [
           "/root/imported.css",
         ],

--- a/playground/css-sourcemap/package.json
+++ b/playground/css-sourcemap/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "less": "^4.1.3",
-    "magic-string": "^0.30.1",
+    "magic-string": "^0.30.2",
     "sass": "^1.63.6",
     "stylus": "^0.59.0",
     "sugarss": "^4.0.1"

--- a/playground/css-sourcemap/vite.config.js
+++ b/playground/css-sourcemap/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
           const start = content.indexOf(willBeReplaced)
           ms.overwrite(start, start + willBeReplaced.length, 'purple')
 
-          const map = ms.generateMap({ hires: true })
+          const map = ms.generateMap({ hires: 'boundary' })
           map.file = filename
           map.sources = [filename]
 

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -54,7 +54,7 @@ describe.runIf(isBuild)('build tests', () => {
     const map = findAssetFile(/after-preload-dynamic.*\.js\.map/)
     expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
       {
-        "mappings": "41BAAAA,EAAA,WAAO,2BAAuB,EAAC,sEAE/B,QAAQ,IAAI,uBAAuB",
+        "mappings": "k2BAAA,OAAO,2BAAuB,EAAC,sEAE/B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: ^3.31.1
         version: 3.31.1
       magic-string:
-        specifier: ^0.30.1
-        version: 0.30.1
+        specifier: ^0.30.2
+        version: 0.30.2
       regenerator-runtime:
         specifier: ^0.13.11
         version: 0.13.11
@@ -352,8 +352,8 @@ importers:
         specifier: ^1.21.5
         version: 1.21.5
       magic-string:
-        specifier: ^0.30.1
-        version: 0.30.1
+        specifier: ^0.30.2
+        version: 0.30.2
       micromatch:
         specifier: ^4.0.5
         version: 4.0.5
@@ -560,8 +560,8 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3
       magic-string:
-        specifier: ^0.30.1
-        version: 0.30.1
+        specifier: ^0.30.2
+        version: 0.30.2
       sass:
         specifier: ^1.63.6
         version: 1.63.6
@@ -4117,7 +4117,7 @@ packages:
   /@vitest/snapshot@0.33.0:
     resolution: {integrity: sha512-tJjrl//qAHbyHajpFvr8Wsk8DIOODEebTu7pgBrP07iOepR5jYkLFiqLq2Ltxv+r0uptUb4izv1J8XBOwKkVYA==}
     dependencies:
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       pathe: 1.1.1
       pretty-format: 29.5.0
     dev: true
@@ -4160,7 +4160,7 @@ packages:
       '@vue/reactivity-transform': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       postcss: 8.4.26
       source-map-js: 1.0.2
 
@@ -4180,7 +4180,7 @@ packages:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.1
+      magic-string: 0.30.2
 
   /@vue/reactivity@3.3.4:
     resolution: {integrity: sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==}
@@ -7637,11 +7637,11 @@ packages:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
     engines: {node: '>=12'}
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /magic-string@0.30.1:
-    resolution: {integrity: sha512-mbVKXPmS0z0G4XqFDCTllmDQ6coZzn94aMlb0o/A4HEHJCKcanlDZwYJgwnkmgD3jyWhUgj9VsPrfd972yPffA==}
+  /magic-string@0.30.2:
+    resolution: {integrity: sha512-lNZdu7pewtq/ZvWUp9Wpf/x7WzMTsR26TWV03BRZrXFsv+BI6dy8RAiKgm1uM/kyR0rCfUcqvOlXKG66KhIGug==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -9088,7 +9088,7 @@ packages:
       rollup: ^3.0.0
       typescript: ^4.1 || ^5.0
     dependencies:
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       rollup: 3.25.2
       typescript: 5.0.4
     optionalDependencies:
@@ -10054,7 +10054,7 @@ packages:
       globby: 13.1.4
       hookable: 5.5.3
       jiti: 1.18.2
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       mkdist: 1.2.0(typescript@5.0.4)
       mlly: 1.4.0
       mri: 1.2.0
@@ -10278,7 +10278,7 @@ packages:
       chai: 4.3.7
       debug: 4.3.4
       local-pkg: 0.4.3
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.3.3


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Generate sourcemap segments per word boundary instead of per character. https://github.com/Rich-Harris/magic-string/pull/255

I didn't test this a lot but I think everything should stay the same. We're using magic-string to manipulate JS and CSS, which are code that are semantically separated by word boundaries.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
