### PR TITLE
fix: modulePreload false

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -344,7 +344,7 @@ export interface InlineConfig extends UserConfig {
 export type ResolvedConfig = Readonly<
   Omit<
     UserConfig,
-    'plugins' | 'css' | 'assetsInclude' | 'optimizeDeps' | 'worker'
+    'plugins' | 'css' | 'assetsInclude' | 'optimizeDeps' | 'worker' | 'build'
   > & {
     configFile: string | undefined
     configFileDependencies: string[]

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -593,8 +593,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         // inject module preload polyfill only when configured and needed
         const { modulePreload } = config.build
         if (
-          (modulePreload === true ||
-            (typeof modulePreload === 'object' && modulePreload.polyfill)) &&
+          modulePreload !== false &&
+          modulePreload.polyfill &&
           (someScriptsAreAsync || someScriptsAreDefer)
         ) {
           js = `import "${modulePreloadPolyfillId}";\n${js}`

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -154,12 +154,7 @@ function preload(
 export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
   const ssr = !!config.build.ssr
   const isWorker = config.isWorker
-  const insertPreload = !(
-    ssr ||
-    !!config.build.lib ||
-    isWorker ||
-    config.build.modulePreload === false
-  )
+  const insertPreload = !(ssr || !!config.build.lib || isWorker)
 
   const resolveModulePreloadDependencies =
     config.build.modulePreload && config.build.modulePreload.resolveDependencies
@@ -446,12 +441,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     generateBundle({ format }, bundle) {
-      if (
-        format !== 'es' ||
-        ssr ||
-        isWorker ||
-        config.build.modulePreload === false
-      ) {
+      if (format !== 'es' || ssr || isWorker) {
         return
       }
 
@@ -562,14 +552,17 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   deps.size > 1 ||
                   // main chunk is removed
                   (hasRemovedPureCssChunk && deps.size > 0)
-                    ? [...deps]
+                    ? modulePreload === false
+                      ? [...deps].filter((d) => d.endsWith('.css'))
+                      : [...deps]
                     : []
 
                 let renderedDeps: string[]
                 if (normalizedFile && customModulePreloadPaths) {
                   const { modulePreload } = config.build
-                  const resolveDependencies =
-                    modulePreload && modulePreload.resolveDependencies
+                  const resolveDependencies = modulePreload
+                    ? modulePreload.resolveDependencies
+                    : undefined
                   let resolvedDeps: string[]
                   if (resolveDependencies) {
                     // We can't let the user remove css deps as these aren't really preloads, they are just using

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -553,7 +553,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   // main chunk is removed
                   (hasRemovedPureCssChunk && deps.size > 0)
                     ? modulePreload === false
-                      ? [...deps].filter((d) => d.endsWith('.css'))
+                      ? // CSS deps use the same mechanism as module preloads, so even if disabled,
+                        // we still need to pass these deps to the preload helper in dynamic imports.
+                        [...deps].filter((d) => d.endsWith('.css'))
                       : [...deps]
                     : []
 

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -54,8 +54,7 @@ export async function resolvePlugins(
     preAliasPlugin(config),
     aliasPlugin({ entries: config.resolve.alias }),
     ...prePlugins,
-    modulePreload === true ||
-    (typeof modulePreload === 'object' && modulePreload.polyfill)
+    modulePreload !== false && modulePreload.polyfill
       ? modulePreloadPolyfillPlugin(config)
       : null,
     resolvePlugin({

--- a/playground/preload/__tests__/preload-disabled/preload-disabled.spec.ts
+++ b/playground/preload/__tests__/preload-disabled/preload-disabled.spec.ts
@@ -19,6 +19,9 @@ describe.runIf(isBuild)('build', () => {
 
     const html = await page.content()
     expect(html).not.toMatch(/link rel="modulepreload"/)
-    expect(html).not.toMatch(/link rel="stylesheet"/)
+
+    expect(html).toMatch(
+      /link rel="stylesheet".*?href=".*?\/assets\/hello-\w{8}\.css"/,
+    )
   })
 })


### PR DESCRIPTION
Fixes #10773

### Description

We currently share the same preload helper for injecting CSS stylesheets of dynamic imports. Even when `modulePreload` is set to `false`, we still need the preload import helper and preserve the CSS styles for the dynamically imported module.

We already had a test case for `modulePreload: false`, but one of the checks was wrong.

This fix isn't ideal, users that set `modulePreload` false would probably expect the import helper to be avoided. But at least the behavior is correct after this PR.

Related issue:
- https://github.com/vitejs/vite/issues/13952

#13952 one isn't easy to solve as we need `import.meta.url` in the transform hook, and populate the deps for the dynamic import in `generateBundle`. If we don't find a good way to find if the preload helper is needed at transform time, maybe we could at least reduce the helper that is quite verbose now with no deps and then replace it back in `generateBundle` (even if we leave some white space to avoid messing with sourcemaps).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other