### PR TITLE
refactor(css): use `preliminaryFileName` to detect pure CSS chunks

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -71,13 +71,6 @@ import {
 } from './asset'
 import type { ESBuildOptions } from './esbuild'
 
-declare module 'rollup' {
-  export interface RenderedChunk {
-    /** @internal */
-    viteNonFinalizedFilename: string
-  }
-}
-
 // const debug = createDebugger('vite:css')
 
 export interface CSSOptions {
@@ -534,8 +527,6 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
     },
 
     async renderChunk(code, chunk, opts) {
-      chunk.viteNonFinalizedFilename = chunk.fileName // save non finalized
-
       let chunkCSS = ''
       let isPureCssChunk = true
       const ids = Object.keys(chunk.modules)
@@ -743,16 +734,16 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       // remove empty css chunks and their imports
       if (pureCssChunks.size) {
         // map each pure css chunk (rendered chunk) to it's corresponding bundle
-        // chunk. we check that by `viteNonFinalizedFilename` as they have different
+        // chunk. we check that by `preliminaryFileName` as they have different
         // `filename`s (rendered chunk has the !~{XXX}~ placeholder)
-        const finalizedFilenamesMap = Object.fromEntries(
+        const prelimaryNameToChunkMap = Object.fromEntries(
           Object.values(bundle)
             .filter((chunk): chunk is OutputChunk => chunk.type === 'chunk')
-            .map((chunk) => [chunk.viteNonFinalizedFilename, chunk.fileName]),
+            .map((chunk) => [chunk.preliminaryFileName, chunk.fileName]),
         )
 
         const pureCssChunkNames = [...pureCssChunks].map(
-          (pureCssChunk) => finalizedFilenamesMap[pureCssChunk.fileName],
+          (pureCssChunk) => prelimaryNameToChunkMap[pureCssChunk.fileName],
         )
 
         const emptyChunkFiles = pureCssChunkNames


### PR DESCRIPTION
### Description
A better way to handle the non finalized filenames (`!~{001}~`).
I came up with this while thinking about https://github.com/vitejs/vite/pull/11671#discussion_r1274727195

related: https://github.com/rollup/rollup/issues/5080

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
