### PR TITLE
fix: avoid crawl end logic for ssr build

### DIFF
--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -96,7 +96,7 @@ export function optimizedDepsBuildPlugin(config: ResolvedConfig): Plugin {
 
       if (depsOptimizer.isOptimizedDepFile(id)) {
         return id
-      } else {
+      } else if (!options.ssr) {
         if (options?.custom?.['vite:pre-alias']) {
           // Skip registering the id if it is being resolved from the pre-alias plugin
           // When a optimized dep is aliased, we need to avoid waiting for it before optimizing


### PR DESCRIPTION
### Description

We shouldn't be doing extra resolves when we are in build SSR. I found a `Unexpected early exit. This happens when Promises returned by plugins cannot resolve.` when testing https://stackblitz.com/edit/github-vke2fz-bbe4ra?file=vite.config.ts&terminal=build locally and adding a local override to Vite. I don't know how to add a test for this one though.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other