### PR TITLE
fix(esbuild): fix static properties transpile when useDefineForClassFields false

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -383,6 +383,21 @@ describe('transformWithEsbuild', () => {
       const actual = await transformClassCode('es2022', {})
       expect(actual).toBe(defineForClassFieldsFalseTransformedCode)
     })
+
+    test('useDefineForClassFields: false and static property should not be transpile to static block', async () => {
+      const result = await transformWithEsbuild(
+        `
+          class foo {
+            static bar = 'bar'
+          }
+        `,
+        'bar.ts',
+        {
+          target: 'esnext',
+        },
+      )
+      expect(result?.code).not.toContain('static {')
+    })
   })
 })
 

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -96,6 +96,7 @@ export async function transformWithEsbuild(
   }
 
   let tsconfigRaw = options?.tsconfigRaw
+  const fallbackSupported: Record<string, boolean> = {}
 
   // if options provide tsconfigRaw in string, it takes highest precedence
   if (typeof tsconfigRaw !== 'string') {
@@ -150,6 +151,15 @@ export async function transformWithEsbuild(
       compilerOptions.experimentalDecorators = true
     }
 
+    // Compat with esbuild 0.17 where static properties are transpiled to
+    // static blocks when `useDefineForClassFields` is false. Its support
+    // is not great yet, so temporarily disable it for now.
+    // TODO: Remove this in Vite 5, don't pass hardcoded `esnext` target
+    // to `transformWithEsbuild` in the esbuild plugin.
+    if (compilerOptions.useDefineForClassFields !== true) {
+      fallbackSupported['class-static-blocks'] = false
+    }
+
     // esbuild uses tsconfig fields when both the normal options and tsconfig was set
     // but we want to prioritize the normal options
     if (options) {
@@ -172,6 +182,10 @@ export async function transformWithEsbuild(
     ...options,
     loader,
     tsconfigRaw,
+    supported: {
+      ...fallbackSupported,
+      ...options?.supported,
+    },
   }
 
   // Some projects in the ecosystem are calling this function with an ESBuildOptions


### PR DESCRIPTION
### Description

Fix https://github.com/vitejs/vite/issues/13863

In esbuild 0.18, when `target: 'esnext'` [is passed](https://github.com/vitejs/vite/blob/3aab14eb25446c0c5830a504b34d39ce434e37d6/packages/vite/src/node/plugins/esbuild.ts#L233), and `useDefineForClassFields` is `false`, it transpiles

```ts
class Foo {
  static bar = 'hello'
}
```

into

```ts
class Foo {
  static {
    bar = 'hello'
  }
}
```

Which the latter support isn't great, but it's because we specify `esnext` that it transpile it that way. In this PR, I disabled this static block transpilation so it transpiles to a syntax that's better supported:
```ts
class Foo {}
Foo.bar = 'hello'
```


### Additional context

I don't think this is a great fix. I've noted something we can improve on in the TODO to not rely on `esnext` by default.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
