### PR TITLE
feat(css): support configuring preprocessorOptions with function

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -226,7 +226,7 @@ Note if an inline config is provided, Vite will not search for other PostCSS con
 
 ## css.preprocessorOptions
 
-- **Type:** `Record<string, object|function>`
+- **Type:** `Record<string, object| (id: string) => object>`
 
 Specify options to pass to CSS pre-processors. The file extensions are used as keys for the options. The supported options for each preprocessors can be found in their respective documentation:
 
@@ -258,7 +258,7 @@ export default defineConfig({
 })
 ```
 
-You can pass a function to specific different option for different files. Note it only works for file imported from javascript, or in other word —— the entry style file.
+You can pass a function to specific different option for different files. Note it only works for file imported from javascript, or in other word —— the entry style file. If a file imports other files, for example `@import './other.css'` in `entry.css`, vite will noly generate a new preprocessorOptions for the "entry.css", but not the "other.css". The "other.css" will get them same option as the "entry.css".
 
 Example:
 

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -226,7 +226,7 @@ Note if an inline config is provided, Vite will not search for other PostCSS con
 
 ## css.preprocessorOptions
 
-- **Type:** `Record<string, object>`
+- **Type:** `Record<string, object|function>`
 
 Specify options to pass to CSS pre-processors. The file extensions are used as keys for the options. The supported options for each preprocessors can be found in their respective documentation:
 
@@ -252,6 +252,31 @@ export default defineConfig({
         define: {
           $specialColor: new stylus.nodes.RGBA(51, 197, 255, 1),
         },
+      },
+    },
+  },
+})
+```
+
+You can pass a function to specific different option for different files. Note it only works for file imported from javascript, or in other word —— the entry style file.
+
+Example:
+
+```js
+export default defineConfig({
+  css: {
+    preprocessorOptions: {
+      less: function (id) {
+        if (id.match(/some-path-regex/)) {
+          return {
+            javascriptEnabled: true,
+            additionalData: `$injectedColor: orange;`,
+          }
+        } else {
+          return {
+            additionalData: `$injectedColor: blue;`,
+          }
+        }
       },
     },
   },

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -864,17 +864,31 @@ function getCssResolversKeys(
   return Object.keys(resolvers) as unknown as Array<keyof CSSAtImportResolvers>
 }
 
+function getPreProcessorOptions(
+  id: string,
+  lang: PreprocessLang,
+  code: string,
+  config: ResolvedConfig,
+) {
+  const { preprocessorOptions } = config.css ?? {}
+  let opts = (preprocessorOptions && preprocessorOptions[lang]) || {}
+  if (typeof opts === 'function') {
+    opts = opts(id, lang, code) || {}
+  }
+  return opts
+}
+
 async function compileCSSPreprocessors(
   id: string,
   lang: PreprocessLang,
   code: string,
   config: ResolvedConfig,
 ): Promise<{ code: string; map?: ExistingRawSourceMap; deps?: Set<string> }> {
-  const { preprocessorOptions, devSourcemap } = config.css ?? {}
+  const { devSourcemap } = config.css ?? {}
   const atImportResolvers = getAtImportResolvers(config)
 
   const preProcessor = preProcessors[lang]
-  let opts = (preprocessorOptions && preprocessorOptions[lang]) || {}
+  let opts = getPreProcessorOptions(id, lang, code, config)
   // support @import from node dependencies by default
   switch (lang) {
     case PreprocessLang.scss:

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -139,6 +139,14 @@ test('less', async () => {
   await untilUpdated(() => getColor(atImport), 'blue')
 })
 
+test('less with different options', async () => {
+  const divWitOpt1 = await page.$('.div-with-less-opt1')
+  const divWitOpt2 = await page.$('.div-with-less-opt2')
+
+  expect(await getColor(divWitOpt1)).toBe('red')
+  expect(await getColor(divWitOpt2)).toBe('green')
+})
+
 test('stylus', async () => {
   const imported = await page.$('.stylus')
   const additionalData = await page.$('.stylus-additional-data')

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -51,6 +51,9 @@
   <p>Imported Less string:</p>
   <pre class="imported-less"></pre>
 
+  <div class="div-with-less-opt1">Compiled with option { color: "red"; }</div>
+  <div class="div-with-less-opt2">Compiled with option { color: "green"; }</div>
+
   <div class="form-box-data-uri">
     tests Less's `data-uri()` function with relative image paths
   </div>

--- a/playground/css/less/withOpt1.less
+++ b/playground/css/less/withOpt1.less
@@ -1,0 +1,3 @@
+.div-with-less-opt1 {
+  color: @primaryColor;
+}

--- a/playground/css/less/withOpt2.less
+++ b/playground/css/less/withOpt2.less
@@ -1,0 +1,3 @@
+.div-with-less-opt2 {
+  color: @primaryColor;
+}

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -6,6 +6,9 @@ import './sass.scss'
 import './less.less'
 import './stylus.styl'
 
+import './less/withOpt1.less'
+import './less/withOpt2.less'
+
 // eslint-disable-next-line import/no-duplicates
 import css from './imported.css'
 text('.imported-css', css) // deprecated, but leave this as-is to make sure it works

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -61,6 +61,21 @@ export default defineConfig({
           },
         ],
       },
+      less: function (id) {
+        if (id.match(/withOpt1.less/)) {
+          return {
+            additionalData: `@primaryColor: red;`,
+          }
+        } else if (id.match(/withOpt2.less/)) {
+          return {
+            additionalData: `@primaryColor: green;`,
+          }
+        } else {
+          return {
+            additionalData: `@primaryColor: gray;`,
+          }
+        }
+      },
       styl: {
         additionalData: `$injectedColor ?= orange`,
         imports: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7389,6 +7389,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -7398,6 +7399,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -7407,6 +7409,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -7416,6 +7419,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -10581,16 +10585,19 @@ packages:
   file:playground/alias/dir/module:
     resolution: {directory: playground/alias/dir/module, type: directory}
     name: '@vitejs/test-aliased-module'
+    version: 0.0.0
     dev: false
 
   file:playground/css/css-js-dep:
     resolution: {directory: playground/css/css-js-dep, type: directory}
     name: '@vitejs/test-css-js-dep'
+    version: 1.0.0
     dev: true
 
   file:playground/css/css-proxy-dep:
     resolution: {directory: playground/css/css-proxy-dep, type: directory}
     name: '@vitejs/test-css-proxy-dep'
+    version: 1.0.0
     dependencies:
       '@vitejs/test-css-proxy-dep-nested': file:playground/css/css-proxy-dep-nested
     dev: true
@@ -10598,20 +10605,24 @@ packages:
   file:playground/css/css-proxy-dep-nested:
     resolution: {directory: playground/css/css-proxy-dep-nested, type: directory}
     name: '@vitejs/test-css-proxy-dep-nested'
+    version: 1.0.0
 
   file:playground/define/commonjs-dep:
     resolution: {directory: playground/define/commonjs-dep, type: directory}
     name: '@vitejs/test-commonjs-dep'
+    version: 1.0.0
     dev: false
 
   file:playground/dynamic-import/pkg:
     resolution: {directory: playground/dynamic-import/pkg, type: directory}
     name: '@vitejs/test-pkg'
+    version: 1.0.0
     dev: false
 
   file:playground/external/dep-that-imports:
     resolution: {directory: playground/external/dep-that-imports, type: directory}
     name: '@vitejs/test-dep-that-imports'
+    version: 0.0.0
     dependencies:
       slash3: /slash@3.0.0
       slash5: /slash@5.1.0
@@ -10621,6 +10632,7 @@ packages:
   file:playground/external/dep-that-requires:
     resolution: {directory: playground/external/dep-that-requires, type: directory}
     name: '@vitejs/test-dep-that-requires'
+    version: 0.0.0
     dependencies:
       slash3: /slash@3.0.0
       slash5: /slash@5.1.0
@@ -10630,31 +10642,37 @@ packages:
   file:playground/import-assertion/import-assertion-dep:
     resolution: {directory: playground/import-assertion/import-assertion-dep, type: directory}
     name: '@vitejs/test-import-assertion-dep'
+    version: 0.0.0
     dev: false
 
   file:playground/json/json-module:
     resolution: {directory: playground/json/json-module, type: directory}
     name: '@vitejs/test-json-module'
+    version: 0.0.0
     dev: true
 
   file:playground/minify/dir/module:
     resolution: {directory: playground/minify/dir/module, type: directory}
     name: '@vitejs/test-minify'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps-no-discovery/dep-no-discovery:
     resolution: {directory: playground/optimize-deps-no-discovery/dep-no-discovery, type: directory}
     name: '@vitejs/test-dep-no-discovery'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/added-in-entries:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
     name: '@vitejs/test-added-in-entries'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-alias-using-absolute-path:
     resolution: {directory: playground/optimize-deps/dep-alias-using-absolute-path, type: directory}
     name: '@vitejs/test-dep-alias-using-absolute-path'
+    version: 1.0.0
     dependencies:
       lodash: 4.17.21
     dev: false
@@ -10662,81 +10680,97 @@ packages:
   file:playground/optimize-deps/dep-cjs-browser-field-bare:
     resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
     name: '@vitejs/test-dep-cjs-browser-field-bare'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-cjs, type: directory}
     name: '@vitejs/test-dep-cjs-compiled-from-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-esm:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-esm, type: directory}
     name: '@vitejs/test-dep-cjs-compiled-from-esm'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-with-assets:
     resolution: {directory: playground/optimize-deps/dep-cjs-with-assets, type: directory}
     name: '@vitejs/test-dep-cjs-with-assets'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-css-require:
     resolution: {directory: playground/optimize-deps/dep-css-require, type: directory}
     name: '@vitejs/test-dep-css-require'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-esbuild-plugin-transform:
     resolution: {directory: playground/optimize-deps/dep-esbuild-plugin-transform, type: directory}
     name: '@vitejs/test-dep-esbuild-plugin-transform'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-node-env:
     resolution: {directory: playground/optimize-deps/dep-node-env, type: directory}
     name: '@vitejs/test-dep-node-env'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-non-optimized:
     resolution: {directory: playground/optimize-deps/dep-non-optimized, type: directory}
     name: '@vitejs/test-dep-non-optimized'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-not-js:
     resolution: {directory: playground/optimize-deps/dep-not-js, type: directory}
     name: '@vitejs/test-dep-not-js'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-optimize-exports-with-glob:
     resolution: {directory: playground/optimize-deps/dep-optimize-exports-with-glob, type: directory}
     name: '@vitejs/test-dep-optimize-exports-with-glob'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-optimize-with-glob:
     resolution: {directory: playground/optimize-deps/dep-optimize-with-glob, type: directory}
     name: '@vitejs/test-dep-optimize-with-glob'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-relative-to-main:
     resolution: {directory: playground/optimize-deps/dep-relative-to-main, type: directory}
     name: '@vitejs/test-dep-relative-to-main'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-builtin-module-cjs:
     resolution: {directory: playground/optimize-deps/dep-with-builtin-module-cjs, type: directory}
     name: '@vitejs/test-dep-with-builtin-module-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-builtin-module-esm:
     resolution: {directory: playground/optimize-deps/dep-with-builtin-module-esm, type: directory}
     name: '@vitejs/test-dep-with-builtin-module-esm'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-dynamic-import:
     resolution: {directory: playground/optimize-deps/dep-with-dynamic-import, type: directory}
     name: '@vitejs/test-dep-with-dynamic-import'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-optional-peer-dep:
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep, type: directory}
     name: '@vitejs/test-dep-with-optional-peer-dep'
+    version: 0.0.0
     peerDependencies:
       foobar: 0.0.0
     peerDependenciesMeta:
@@ -10747,6 +10781,7 @@ packages:
   file:playground/optimize-deps/nested-exclude:
     resolution: {directory: playground/optimize-deps/nested-exclude, type: directory}
     name: '@vitejs/test-nested-exclude'
+    version: 1.0.0
     dependencies:
       '@vitejs/test-nested-include': file:playground/optimize-deps/nested-include
       nested-include: file:playground/optimize-deps/nested-include
@@ -10755,11 +10790,13 @@ packages:
   file:playground/optimize-deps/nested-include:
     resolution: {directory: playground/optimize-deps/nested-include, type: directory}
     name: '@vitejs/test-nested-include'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-missing-deps/missing-dep:
     resolution: {directory: playground/optimize-missing-deps/missing-dep, type: directory}
     name: '@vitejs/test-missing-dep'
+    version: 0.0.0
     dependencies:
       '@vitejs/test-multi-entry-dep': file:playground/optimize-missing-deps/multi-entry-dep
       multi-entry-dep: file:playground/optimize-missing-deps/multi-entry-dep
@@ -10768,15 +10805,18 @@ packages:
   file:playground/optimize-missing-deps/multi-entry-dep:
     resolution: {directory: playground/optimize-missing-deps/multi-entry-dep, type: directory}
     name: '@vitejs/test-multi-entry-dep'
+    version: 0.0.0
     dev: false
 
   file:playground/preload/dep-a:
     resolution: {directory: playground/preload/dep-a, type: directory}
     name: '@vitejs/test-dep-a'
+    version: 0.0.0
 
   file:playground/preload/dep-including-a:
     resolution: {directory: playground/preload/dep-including-a, type: directory}
     name: '@vitejs/test-dep-including-a'
+    version: 0.0.0
     dependencies:
       '@vitejs/test-dep-a': file:playground/preload/dep-a
       dep-a: file:playground/preload/dep-a
@@ -10785,26 +10825,31 @@ packages:
   file:playground/ssr-deps/css-lib:
     resolution: {directory: playground/ssr-deps/css-lib, type: directory}
     name: '@vitejs/test-css-lib'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/define-properties-exports:
     resolution: {directory: playground/ssr-deps/define-properties-exports, type: directory}
     name: '@vitejs/test-define-properties-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/define-property-exports:
     resolution: {directory: playground/ssr-deps/define-property-exports, type: directory}
     name: '@vitejs/test-define-property-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/external-entry:
     resolution: {directory: playground/ssr-deps/external-entry, type: directory}
     name: '@vitejs/test-external-entry'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/external-using-external-entry:
     resolution: {directory: playground/ssr-deps/external-using-external-entry, type: directory}
     name: '@vitejs/test-external-using-external-entry'
+    version: 0.0.0
     dependencies:
       external-entry: file:playground/ssr-deps/external-entry
     dev: false
@@ -10812,6 +10857,7 @@ packages:
   file:playground/ssr-deps/forwarded-export:
     resolution: {directory: playground/ssr-deps/forwarded-export, type: directory}
     name: '@vitejs/test-forwarded-export'
+    version: 0.0.0
     dependencies:
       object-assigned-exports: file:playground/ssr-deps/object-assigned-exports
     dev: false
@@ -10819,46 +10865,55 @@ packages:
   file:playground/ssr-deps/import-builtin-cjs:
     resolution: {directory: playground/ssr-deps/import-builtin-cjs, type: directory}
     name: '@vitejs/test-import-builtin'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/module-condition:
     resolution: {directory: playground/ssr-deps/module-condition, type: directory}
     name: '@vitejs/test-module-condition'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/nested-external:
     resolution: {directory: playground/ssr-deps/nested-external, type: directory}
     name: '@vitejs/test-nested-external'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/nested-external-cjs:
     resolution: {directory: playground/ssr-deps/nested-external-cjs, type: directory}
     name: nested-external-cjs
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/no-external-cjs:
     resolution: {directory: playground/ssr-deps/no-external-cjs, type: directory}
     name: '@vitejs/test-no-external-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/no-external-css:
     resolution: {directory: playground/ssr-deps/no-external-css, type: directory}
     name: '@vitejs/test-no-external-css'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/object-assigned-exports:
     resolution: {directory: playground/ssr-deps/object-assigned-exports, type: directory}
     name: '@vitejs/test-object-assigned-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/only-object-assigned-exports:
     resolution: {directory: playground/ssr-deps/only-object-assigned-exports, type: directory}
     name: '@vitejs/test-only-object-assigned-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/optimized-with-nested-external:
     resolution: {directory: playground/ssr-deps/optimized-with-nested-external, type: directory}
     name: '@vitejs/test-optimized-with-nested-external'
+    version: 0.0.0
     dependencies:
       nested-external: file:playground/ssr-deps/nested-external
     dev: false
@@ -10866,36 +10921,43 @@ packages:
   file:playground/ssr-deps/pkg-exports:
     resolution: {directory: playground/ssr-deps/pkg-exports, type: directory}
     name: '@vitejs/test-pkg-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/primitive-export:
     resolution: {directory: playground/ssr-deps/primitive-export, type: directory}
     name: '@vitejs/test-primitive-export'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/read-file-content:
     resolution: {directory: playground/ssr-deps/read-file-content, type: directory}
     name: '@vitejs/test-read-file-content'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/require-absolute:
     resolution: {directory: playground/ssr-deps/require-absolute, type: directory}
     name: '@vitejs/test-require-absolute'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/ts-transpiled-exports:
     resolution: {directory: playground/ssr-deps/ts-transpiled-exports, type: directory}
     name: '@vitejs/test-ts-transpiled-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-noexternal/external-cjs:
     resolution: {directory: playground/ssr-noexternal/external-cjs, type: directory}
     name: '@vitejs/test-external-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-noexternal/require-external-cjs:
     resolution: {directory: playground/ssr-noexternal/require-external-cjs, type: directory}
     name: '@vitejs/test-require-external-cjs'
+    version: 0.0.0
     dependencies:
       '@vitejs/external-cjs': file:playground/ssr-noexternal/external-cjs
       '@vitejs/test-external-cjs': file:playground/ssr-noexternal/external-cjs
@@ -10904,19 +10966,23 @@ packages:
   file:playground/ssr-resolve/deep-import:
     resolution: {directory: playground/ssr-resolve/deep-import, type: directory}
     name: '@vitejs/test-deep-import'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-resolve/entries:
     resolution: {directory: playground/ssr-resolve/entries, type: directory}
     name: '@vitejs/test-entries'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-resolve/pkg-exports:
     resolution: {directory: playground/ssr-resolve/pkg-exports, type: directory}
     name: '@vitejs/test-resolve-pkg-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/worker/dep-to-optimize:
     resolution: {directory: playground/worker/dep-to-optimize, type: directory}
     name: '@vitejs/test-dep-to-optimize'
+    version: 1.0.0
     dev: false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Suport configuring preprocessorOptions with function.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
When importing style files of different UI frameworks, like ant-design,  the global vars may lead to conflict. 

This pr support configure preprocessorOptions with function.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
