### PR TITLE
fix: dynamic import vars ignored warning

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -17,6 +17,7 @@ import {
   transformStableResult,
 } from '../utils'
 import { toAbsoluteGlob } from './importMetaGlob'
+import { hasViteIgnoreRE } from './importAnalysis'
 
 export const dynamicImportHelperId = '\0vite/dynamic-import-helper'
 
@@ -203,6 +204,10 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
         } = imports[index]
 
         if (dynamicIndex === -1 || source[start] !== '`') {
+          continue
+        }
+
+        if (hasViteIgnoreRE.test(source.slice(expStart, expEnd))) {
           continue
         }
 

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -76,7 +76,7 @@ const optimizedDepDynamicRE = /-[A-Z\d]{8}\.js/
 
 const hasImportInQueryParamsRE = /[?&]import=?\b/
 
-const hasViteIgnoreRE = /\/\*\s*@vite-ignore\s*\*\//
+export const hasViteIgnoreRE = /\/\*\s*@vite-ignore\s*\*\//
 
 const cleanUpRawUrlRE = /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm
 const urlIsStringRE = /^(?:'.*'|".*"|`.*`)$/

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -19,8 +19,7 @@ import { WORKER_FILE_ID, workerFileToUrl } from './worker'
 import { fileToUrl } from './asset'
 import type { InternalResolveOptions } from './resolve'
 import { tryFsResolve } from './resolve'
-
-const ignoreFlagRE = /\/\*\s*@vite-ignore\s*\*\//
+import { hasViteIgnoreRE } from './importAnalysis'
 
 interface WorkerOptions {
   type?: WorkerType
@@ -78,7 +77,7 @@ function getWorkerType(raw: string, clean: string, i: number): WorkerType {
     .substring(commaIndex + 1, endIndex)
     .replace(/\}[\s\S]*,/g, '}') // strip trailing comma for parsing
 
-  const hasViteIgnore = ignoreFlagRE.test(workerOptString)
+  const hasViteIgnore = hasViteIgnoreRE.test(workerOptString)
   if (hasViteIgnore) {
     return 'ignore'
   }

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -69,6 +69,20 @@ test('should load dynamic import with vars', async () => {
   )
 })
 
+test('should load dynamic import with vars ignored', async () => {
+  await untilUpdated(
+    () => page.textContent('.dynamic-import-with-vars-ignored'),
+    'hello',
+    true,
+  )
+  // No warning should be logged as we are using @vite-ignore
+  expect(
+    serverLogs.some((log) =>
+      log.includes('"https" has been externalized for browser compatibility'),
+    ),
+  ).toBe(false)
+})
+
 test('should load dynamic import with vars multiline', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-multiline'),

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -13,6 +13,9 @@
 <p>dynamic-import-with-vars</p>
 <div class="dynamic-import-with-vars">todo</div>
 
+<p>dynamic-import-with-vars-ignored</p>
+<div class="dynamic-import-with-vars-ignored">todo</div>
+
 <p>dynamic-import-with-vars-multiline</p>
 <div class="dynamic-import-with-vars-multiline">todo</div>
 

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -84,6 +84,11 @@ import(`../alias/${base}.js`).then((mod) => {
   text('.dynamic-import-with-vars', mod.hello())
 })
 
+import(/*@vite-ignore*/ `https://localhost`).catch((mod) => {
+  console.log(mod)
+  text('.dynamic-import-with-vars-ignored', 'hello')
+})
+
 // prettier-ignore
 import(
   /* this messes with */

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -18,7 +18,8 @@ export * from './vitestSetup'
 export const ports = {
   cli: 9510,
   'cli-module': 9511,
-  json: 9512,
+  'dynamic-import': 9514, // not imported but used in `dynamic-import/nested/index.js`
+  json: 9516,
   'legacy/ssr': 9520,
   lib: 9521,
   'optimize-missing-deps': 9522,

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -18,8 +18,7 @@ export * from './vitestSetup'
 export const ports = {
   cli: 9510,
   'cli-module': 9511,
-  'dynamic-import': 9514, // not imported but used in `dynamic-import/nested/index.js`
-  json: 9516,
+  json: 9512,
   'legacy/ssr': 9520,
   lib: 9521,
   'optimize-missing-deps': 9522,


### PR DESCRIPTION
### Description

When building the reproduction in https://github.com/vitejs/vite/issues/5051, we get
```
6:26:20 PM [vite] warning: Module "https" has been externalized for browser compatibility, imported by "/Users/patak/test/dynamic-vite-ignored/main.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
```

This PR respect `/*@vite-ignore*/` on the dynamic import var plugin to avoid this issue.

The PR doesn't fix, #5051

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other