### PR TITLE
perf: improve build times and memory utilization

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "prettier": "3.0.0",
     "resolve": "^1.22.2",
     "rimraf": "^5.0.1",
-    "rollup": "^3.25.2",
+    "rollup": "^3.27.1",
     "simple-git-hooks": "^2.8.1",
     "tslib": "^2.6.0",
     "tsx": "^3.12.7",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "esbuild": "^0.18.10",
     "postcss": "^8.4.26",
-    "rollup": "^3.25.2"
+    "rollup": "^3.27.1"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 7.36.2(@types/node@18.16.19)
       '@rollup/plugin-typescript':
         specifier: ^11.1.2
-        version: 11.1.2(rollup@3.25.2)(tslib@2.6.0)(typescript@5.0.2)
+        version: 11.1.2(rollup@3.27.1)(tslib@2.6.0)(typescript@5.0.2)
       '@types/babel__core':
         specifier: ^7.20.1
         version: 7.20.1
@@ -145,8 +145,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       rollup:
-        specifier: ^3.25.2
-        version: 3.25.2
+        specifier: ^3.27.1
+        version: 3.27.1
       simple-git-hooks:
         specifier: ^2.8.1
         version: 2.8.1
@@ -239,8 +239,8 @@ importers:
         specifier: ^8.4.26
         version: 8.4.26
       rollup:
-        specifier: ^3.25.2
-        version: 3.25.2
+        specifier: ^3.27.1
+        version: 3.27.1
     optionalDependencies:
       fsevents:
         specifier: ~2.3.2
@@ -260,25 +260,25 @@ importers:
         version: 0.3.18
       '@rollup/plugin-alias':
         specifier: ^4.0.4
-        version: 4.0.4(rollup@3.25.2)
+        version: 4.0.4(rollup@3.27.1)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.3
-        version: 25.0.3(rollup@3.25.2)
+        version: 25.0.3(rollup@3.27.1)
       '@rollup/plugin-dynamic-import-vars':
         specifier: ^2.0.4
-        version: 2.0.4(rollup@3.25.2)
+        version: 2.0.4(rollup@3.27.1)
       '@rollup/plugin-json':
         specifier: ^6.0.0
-        version: 6.0.0(rollup@3.25.2)
+        version: 6.0.0(rollup@3.27.1)
       '@rollup/plugin-node-resolve':
         specifier: 15.1.0
-        version: 15.1.0(rollup@3.25.2)
+        version: 15.1.0(rollup@3.27.1)
       '@rollup/plugin-typescript':
         specifier: ^11.1.2
-        version: 11.1.2(rollup@3.25.2)(tslib@2.6.0)(typescript@5.0.2)
+        version: 11.1.2(rollup@3.27.1)(tslib@2.6.0)(typescript@5.0.2)
       '@rollup/pluginutils':
         specifier: ^5.0.2
-        version: 5.0.2(rollup@3.25.2)
+        version: 5.0.2(rollup@3.27.1)
       '@types/escape-html':
         specifier: ^1.0.2
         version: 1.0.2
@@ -395,7 +395,7 @@ importers:
         version: 2.0.2
       rollup-plugin-license:
         specifier: ^3.0.1
-        version: 3.0.1(rollup@3.25.2)
+        version: 3.0.1(rollup@3.27.1)
       sirv:
         specifier: ^2.0.3
         version: 2.0.3(patch_hash=z45f224eewh2pgpijxcc3aboqm)
@@ -3528,7 +3528,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@rollup/plugin-alias@4.0.4(rollup@3.25.2):
+  /@rollup/plugin-alias@4.0.4(rollup@3.27.1):
     resolution: {integrity: sha512-0CaAY238SMtYAWEXXptWSR8iz8NYZnH7zNBKuJ14xFJSGwLtPgjvXYsoApAHfzYXXH1ejxpVw7WlHss3zhh9SQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3537,11 +3537,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.25.2
+      rollup: 3.27.1
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-alias@5.0.0(rollup@3.25.2):
+  /@rollup/plugin-alias@5.0.0(rollup@3.27.1):
     resolution: {integrity: sha512-l9hY5chSCjuFRPsnRm16twWBiSApl2uYFLsepQYwtBuAxNMQ/1dJqADld40P0Jkqm65GRTLy/AC6hnpVebtLsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3550,11 +3550,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.25.2
+      rollup: 3.27.1
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs@24.1.0(rollup@3.25.2):
+  /@rollup/plugin-commonjs@24.1.0(rollup@3.27.1):
     resolution: {integrity: sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3563,16 +3563,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.25.2
+      rollup: 3.27.1
     dev: true
 
-  /@rollup/plugin-commonjs@25.0.3(rollup@3.25.2):
+  /@rollup/plugin-commonjs@25.0.3(rollup@3.27.1):
     resolution: {integrity: sha512-uBdtWr/H3BVcgm97MUdq2oJmqBR23ny1hOrWe2PKo9FTbjsGqg32jfasJUKYAI5ouqacjRnj65mBB/S79F+GQA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3581,16 +3581,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.0.3
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.25.2
+      rollup: 3.27.1
     dev: true
 
-  /@rollup/plugin-dynamic-import-vars@2.0.4(rollup@3.25.2):
+  /@rollup/plugin-dynamic-import-vars@2.0.4(rollup@3.27.1):
     resolution: {integrity: sha512-aAD4eJ657PfQFgsIP0tvpPF6d4viSAf64BgAJQEBsxL75KrOVVr/QBlfdCnB0w7fJrVDfo9guZwz0k+xEj2FJA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3599,14 +3599,14 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
       estree-walker: 2.0.2
       fast-glob: 3.3.0
       magic-string: 0.27.0
-      rollup: 3.25.2
+      rollup: 3.27.1
     dev: true
 
-  /@rollup/plugin-json@6.0.0(rollup@3.25.2):
+  /@rollup/plugin-json@6.0.0(rollup@3.27.1):
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3615,11 +3615,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
-      rollup: 3.25.2
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
+      rollup: 3.27.1
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.25.2):
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.27.1):
     resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3628,16 +3628,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
       '@types/resolve': 1.20.2
       deepmerge: 4.2.2
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.2
-      rollup: 3.25.2
+      rollup: 3.27.1
     dev: true
 
-  /@rollup/plugin-replace@5.0.2(rollup@3.25.2):
+  /@rollup/plugin-replace@5.0.2(rollup@3.27.1):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3646,12 +3646,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
       magic-string: 0.27.0
-      rollup: 3.25.2
+      rollup: 3.27.1
     dev: true
 
-  /@rollup/plugin-typescript@11.1.2(rollup@3.25.2)(tslib@2.6.0)(typescript@5.0.2):
+  /@rollup/plugin-typescript@11.1.2(rollup@3.27.1)(tslib@2.6.0)(typescript@5.0.2):
     resolution: {integrity: sha512-0ghSOCMcA7fl1JM+0gYRf+Q/HWyg+zg7/gDSc+fRLmlJWcW5K1I+CLRzaRhXf4Y3DRyPnnDo4M2ktw+a6JcDEg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3664,14 +3664,14 @@ packages:
       tslib:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
       resolve: 1.22.2
-      rollup: 3.25.2
+      rollup: 3.27.1
       tslib: 2.6.0
       typescript: 5.0.2
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.25.2):
+  /@rollup/pluginutils@5.0.2(rollup@3.27.1):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -3683,7 +3683,7 @@ packages:
       '@types/estree': 1.0.0
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.25.2
+      rollup: 3.27.1
     dev: true
 
   /@rushstack/node-core-library@3.59.5(@types/node@18.16.19):
@@ -9083,7 +9083,7 @@ packages:
       glob: 10.2.7
     dev: true
 
-  /rollup-plugin-dts@5.3.0(rollup@3.25.2)(typescript@5.0.4):
+  /rollup-plugin-dts@5.3.0(rollup@3.27.1)(typescript@5.0.4):
     resolution: {integrity: sha512-8FXp0ZkyZj1iU5klkIJYLjIq/YZSwBoERu33QBDxm/1yw5UU4txrEtcmMkrq+ZiKu3Q4qvPCNqc3ovX6rjqzbQ==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -9091,13 +9091,13 @@ packages:
       typescript: ^4.1 || ^5.0
     dependencies:
       magic-string: 0.30.2
-      rollup: 3.25.2
+      rollup: 3.27.1
       typescript: 5.0.4
     optionalDependencies:
       '@babel/code-frame': 7.22.5
     dev: true
 
-  /rollup-plugin-license@3.0.1(rollup@3.25.2):
+  /rollup-plugin-license@3.0.1(rollup@3.27.1):
     resolution: {integrity: sha512-/lec6Y94Y3wMfTDeYTO/jSXII0GQ/XkDZCiqkMKxyU5D5nGPaxr/2JNYvAgYsoCYuOLGOanKDPjCCQiTT96p7A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -9110,13 +9110,13 @@ packages:
       mkdirp: 1.0.4
       moment: 2.29.3
       package-name-regex: 2.0.6
-      rollup: 3.25.2
+      rollup: 3.27.1
       spdx-expression-validate: 2.0.0
       spdx-satisfies: 5.0.1
     dev: true
 
-  /rollup@3.25.2:
-    resolution: {integrity: sha512-VLnkxZMDr3jpxgtmS8pQZ0UvhslmF4ADq/9w4erkctbgjCqLW9oa89fJuXEs4ZmgyoF7Dm8rMDKSS5b5u2hHUg==}
+  /rollup@3.27.1:
+    resolution: {integrity: sha512-tXNDFwOkN6C2w5Blj1g6ForKeFw6c1mDu5jxoeDO3/pmYjgt+8yvIFjKzH5FQUq70OKZBkOt0zzv0THXL7vwzQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -10043,12 +10043,12 @@ packages:
     resolution: {integrity: sha512-J4efk69Aye43tWcBPCsLK7TIRppGrEN4pAlDzRKo3HSE6MgTSTBxSEuE3ccx7ixc62JvGQ/CoFXYqqF2AHozow==}
     hasBin: true
     dependencies:
-      '@rollup/plugin-alias': 5.0.0(rollup@3.25.2)
-      '@rollup/plugin-commonjs': 24.1.0(rollup@3.25.2)
-      '@rollup/plugin-json': 6.0.0(rollup@3.25.2)
-      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.25.2)
-      '@rollup/plugin-replace': 5.0.2(rollup@3.25.2)
-      '@rollup/pluginutils': 5.0.2(rollup@3.25.2)
+      '@rollup/plugin-alias': 5.0.0(rollup@3.27.1)
+      '@rollup/plugin-commonjs': 24.1.0(rollup@3.27.1)
+      '@rollup/plugin-json': 6.0.0(rollup@3.27.1)
+      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.27.1)
+      '@rollup/plugin-replace': 5.0.2(rollup@3.27.1)
+      '@rollup/pluginutils': 5.0.2(rollup@3.27.1)
       chalk: 5.2.0
       consola: 3.1.0
       defu: 6.1.2
@@ -10063,8 +10063,8 @@ packages:
       pathe: 1.1.0
       pkg-types: 1.0.2
       pretty-bytes: 6.1.0
-      rollup: 3.25.2
-      rollup-plugin-dts: 5.3.0(rollup@3.25.2)(typescript@5.0.4)
+      rollup: 3.27.1
+      rollup-plugin-dts: 5.3.0(rollup@3.27.1)(typescript@5.0.4)
       scule: 1.0.0
       typescript: 5.0.4
       untyped: 1.3.2


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Technically this is also covered by a fresh install / lock-file maintenance, but I thought it might be good to call it out with a specific change-log notification.

On my own projects, I've seen around 28% faster builds, with a 1.3 GB (36.6%) reduction in peak memory usage. Which should hopefully help with #2433

Rollup 3.27.1 contains a change (https://github.com/rollup/rollup/pull/5075) that improves sourcemap handling for rollup builds.

These improvements seem to have the most impact where there is large amounts of treeshaking since sourcemaps are no longer being decoded in memory for files that are tree-shaken from the final bundle, but it also releases those decoded mappings arrays when they are no longer needed which frees up more memory during render chunks.

It also reduces memory usage and build times for projects that don't set `build.sourcemaps: true` in their vite config. For those projects, any sourcemaps loaded from dependencies in node_modules, etc, were being decoded proactively in the event rollup needed to trace the sourcemap to find the locations for any warnings/errors. Now that process only happens if they are needed, and a fair amount of processing and allocations can be avoided.

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
