### PR TITLE
docs(backend-integration): add react refresh url note

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -44,25 +44,15 @@ If you need a custom integration, you can follow the steps in this guide to conf
 
    This is needed for assets such as images to load properly.
 
-   Note if you are using React with `@vitejs/plugin-react`, you'll also need to add this before the above scripts, since the plugin is not able to modify the HTML you are serving:
+   Note if you are using React with `@vitejs/plugin-react`, you'll also need to add this before the above scripts, since the plugin is not able to modify the HTML you are serving (substitute `http://localhost:5173` with the local URL Vite is running at):
 
    ```html
-     <script type="module">
-       async function loadRefreshRuntime() {
-         const protocol = window.location.protocol;
-         const hostname = window.location.hostname;
-         const port = "5173"; // Default vite port
-
-         const url = `${protocol}//${hostname}:${port}/@react-refresh`;
-         const RefreshRuntime = await import(url);
-
-         RefreshRuntime.injectIntoGlobalHook(window);
-         window.$RefreshReg$ = () => {};
-         window.$RefreshSig$ = () => type => type;
-         window.__vite_plugin_react_preamble_installed__ = true;
-      }
-
-      loadRefreshRuntime();
+   <script type="module">
+     import RefreshRuntime from 'http://localhost:5173/@react-refresh'
+     RefreshRuntime.injectIntoGlobalHook(window)
+     window.$RefreshReg$ = () => {}
+     window.$RefreshSig$ = () => (type) => type
+     window.__vite_plugin_react_preamble_installed__ = true
    </script>
    ```
 

--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -47,12 +47,22 @@ If you need a custom integration, you can follow the steps in this guide to conf
    Note if you are using React with `@vitejs/plugin-react`, you'll also need to add this before the above scripts, since the plugin is not able to modify the HTML you are serving:
 
    ```html
-   <script type="module">
-     import RefreshRuntime from 'http://localhost:5173/@react-refresh'
-     RefreshRuntime.injectIntoGlobalHook(window)
-     window.$RefreshReg$ = () => {}
-     window.$RefreshSig$ = () => (type) => type
-     window.__vite_plugin_react_preamble_installed__ = true
+     <script type="module">
+       async function loadRefreshRuntime() {
+         const protocol = window.location.protocol;
+         const hostname = window.location.hostname;
+         const port = "5173"; // Default vite port
+
+         const url = `${protocol}//${hostname}:${port}/@react-refresh`;
+         const RefreshRuntime = await import(url);
+
+         RefreshRuntime.injectIntoGlobalHook(window);
+         window.$RefreshReg$ = () => {};
+         window.$RefreshSig$ = () => type => type;
+         window.__vite_plugin_react_preamble_installed__ = true;
+      }
+
+      loadRefreshRuntime();
    </script>
    ```
 


### PR DESCRIPTION
Previously, the react-refresh script was importing the module from a hard-coded 'localhost' URL. This caused issues when the Vite server was started with the '--host' option to expose t development server to the local network for mobile debugging. In such cases, the script would fail to load on mobile devices, as they were not hosting the script on 'localhost'.

This commit refactors the react-refresh script to dynamically determine the host based on `window.location.hostname`. This allows the script to correctly load the module from the appropriate host, whether it's 'localhost' or a local network IP, resolving the issue with mobile debugging.

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
