### PR TITLE
feat!: bump minimum node version to 18

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,7 @@
 // @ts-check
 const { builtinModules } = require('node:module')
 const { defineConfig } = require('eslint-define-config')
+const pkg = require('./package.json')
 
 module.exports = defineConfig({
   root: true,
@@ -16,7 +17,7 @@ module.exports = defineConfig({
   parser: '@typescript-eslint/parser',
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 2021,
+    ecmaVersion: 2022,
   },
   rules: {
     eqeqeq: ['warn', 'always', { null: 'never' }],
@@ -173,13 +174,13 @@ module.exports = defineConfig({
         'n/no-unsupported-features/es-builtins': [
           'error',
           {
-            version: '^14.18.0 || >=16.0.0',
+            version: pkg.engines.node,
           },
         ],
         'n/no-unsupported-features/node-builtins': [
           'error',
           {
-            version: '^14.18.0 || >=16.0.0',
+            version: pkg.engines.node,
           },
         ],
         '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [14, 16, 18, 20]
+        node_version: [18, 20]
         include:
           # Active LTS + other OS
           - os: macos-latest
@@ -67,14 +67,8 @@ jobs:
             packages/create-vite/template**
             **.md
 
-      - name: Install pnpm (node 14, pnpm 7)
-        if: steps.changed-files.outputs.only_changed != 'true' && matrix.node_version == 14
-        uses: pnpm/action-setup@v2.4.0
-        with:
-          version: 7
-
       - name: Install pnpm
-        if: steps.changed-files.outputs.only_changed != 'true' && matrix.node_version != 14
+        if: steps.changed-files.outputs.only_changed != 'true'
         uses: pnpm/action-setup@v2.4.0
 
       - name: Set node version to ${{ matrix.node_version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2.4.0
 
-      - name: Set node version to 16.x
+      - name: Set node version to 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18
           registry-url: https://registry.npmjs.org/
           cache: "pnpm"
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -42,7 +42,7 @@ The supported template presets are:
 ## Scaffolding Your First Vite Project
 
 ::: tip Compatibility Note
-Vite requires [Node.js](https://nodejs.org/en/) version 14.18+, 16+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
+Vite requires [Node.js](https://nodejs.org/en/) version 18+. 20+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
 :::
 
 With NPM:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "16"
+  NODE_VERSION = "18"
   # don't need playwright for docs build
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
 [build]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+    "node": "^18.0.0 || >=20.0.0"
   },
   "homepage": "https://vitejs.dev/",
   "repository": {

--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -3,7 +3,7 @@
 ## Scaffolding Your First Vite Project
 
 > **Compatibility Note:**
-> Vite requires [Node.js](https://nodejs.org/en/) version 14.18+, 16+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
+> Vite requires [Node.js](https://nodejs.org/en/) version 18+, 20+. However, some templates require a higher Node.js version to work, please upgrade if your package manager warns about it.
 
 With NPM:
 

--- a/packages/create-vite/build.config.ts
+++ b/packages/create-vite/build.config.ts
@@ -11,11 +11,12 @@ export default defineBuildConfig({
   rollup: {
     inlineDependencies: true,
     esbuild: {
+      target: 'node18',
       minify: true,
     },
   },
   alias: {
-    // we can always use non-transpiled code since we support 14.18.0+
+    // we can always use non-transpiled code since we support node 18+
     prompts: 'prompts/lib/index.js',
   },
   hooks: {

--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+    "node": "^18.0.0 || >=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/create-vite/tsconfig.json
+++ b/packages/create-vite/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["build.config.ts", "src", "__tests__"],
   "compilerOptions": {
     "outDir": "dist",
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ES2020",
     "moduleResolution": "bundler",
     "strict": true,

--- a/packages/plugin-legacy/build.config.ts
+++ b/packages/plugin-legacy/build.config.ts
@@ -7,5 +7,8 @@ export default defineBuildConfig({
   rollup: {
     emitCJS: true,
     inlineDependencies: true,
+    esbuild: {
+      target: 'node18',
+    },
   },
 })

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+    "node": "^18.0.0 || >=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -38,7 +38,7 @@
     "types"
   ],
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+    "node": "^18.0.0 || >=20.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1017,7 +1017,7 @@ async function bundleConfigFile(
     entryPoints: [fileName],
     outfile: 'out.js',
     write: false,
-    target: ['node14.18', 'node16'],
+    target: ['node18'],
     platform: 'node',
     bundle: true,
     format: isESM ? 'esm' : 'cjs',

--- a/packages/vite/tsconfig.base.json
+++ b/packages/vite/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "node",
     "strict": true,

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -3,7 +3,7 @@
   "exclude": ["**/dist/**"],
   "compilerOptions": {
     "checkJs": true,
-    "target": "ES2020",
+    "target": "ES2022",
     "module": "ESNext",
     "outDir": "dist",
     "baseUrl": ".",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "include": ["."],
   "compilerOptions": {
-    "module": "ES2020",
+    "module": "ES2022",
     "target": "ES2020",
     "moduleResolution": "Node",
     "strict": true,

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -26,6 +26,6 @@ export default defineConfig({
     },
   },
   esbuild: {
-    target: 'node14',
+    target: 'node18',
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,10 +10,8 @@ export default defineConfig({
       './playground-temp/**/*.*',
     ],
     testTimeout: 20000,
-    // node14 segfaults often with threads
-    threads: !process.versions.node.startsWith('14'),
   },
   esbuild: {
-    target: 'node14',
+    target: 'node18',
   },
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Bump the packages in this monorepo to require minimum node 18. Not sure if we need to bump to a specific minor version of 18, currently have it at 18.0.0 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
