### PR TITLE
chore: fix eslint warnings

### DIFF
--- a/packages/vite/src/types/shims.d.ts
+++ b/packages/vite/src/types/shims.d.ts
@@ -41,7 +41,7 @@ declare module 'postcss-import' {
 // so we have to shim it
 declare interface HTMLLinkElement {}
 
-// eslint-disable-next-line no-var, @typescript-eslint/consistent-type-imports
+// eslint-disable-next-line no-var
 declare var __vite_profile_session: import('node:inspector').Session | undefined
 // eslint-disable-next-line no-var
 declare var __vite_start_time: number | undefined

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -2,8 +2,6 @@
 // Thus cannot contain any top-level imports
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
-/* eslint-disable @typescript-eslint/consistent-type-imports */
-
 interface ImportMetaEnv {
   [key: string]: any
   BASE_URL: string

--- a/playground/resolve/exports-with-module-condition-required/index.cjs
+++ b/playground/resolve/exports-with-module-condition-required/index.cjs
@@ -1,3 +1,2 @@
-/* eslint-disable import/no-commonjs */
 const { msg } = require('@vitejs/test-resolve-exports-with-module-condition')
 module.exports = { msg }


### PR DESCRIPTION
lint fixes after recent deps upgrade