### PR TITLE
feat(worker): support a way to name the worker

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -229,14 +229,14 @@ declare module '*.wasm?init' {
 // web worker
 declare module '*?worker' {
   const workerConstructor: {
-    new (): Worker
+    new (options?: { name?: string }): Worker
   }
   export default workerConstructor
 }
 
 declare module '*?worker&inline' {
   const workerConstructor: {
-    new (): Worker
+    new (options?: { name?: string }): Worker
   }
   export default workerConstructor
 }
@@ -248,14 +248,14 @@ declare module '*?worker&url' {
 
 declare module '*?sharedworker' {
   const sharedWorkerConstructor: {
-    new (): SharedWorker
+    new (options?: { name?: string }): SharedWorker
   }
   export default sharedWorkerConstructor
 }
 
 declare module '*?sharedworker&inline' {
   const sharedWorkerConstructor: {
-    new (): SharedWorker
+    new (options?: { name?: string }): SharedWorker
   }
   export default sharedWorkerConstructor
 }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -296,7 +296,6 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           : 'classic'
         : 'module'
       const workerTypeOption = workerType === 'classic' ? undefined : 'module'
-      const workerName = query.name || ''
 
       if (isBuild) {
         getDepsOptimizer(config, ssr)?.registerWorkersSource(id)
@@ -316,13 +315,13 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             try {
               objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);
               if (!objURL) throw ''
-              return new ${workerConstructor}(objURL, { name: options?.name || "${workerName}" })
+              return new ${workerConstructor}(objURL, { name: options?.name })
             } catch(e) {
               return new ${workerConstructor}(
                 "data:application/javascript;base64," + encodedJs,
                 {
                   ${workerTypeOption ? `type: "${workerTypeOption}",` : ''}
-                  name: options?.name || "${workerName}"
+                  name: options?.name
                 }
               );
             } finally {
@@ -335,7 +334,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               "data:application/javascript;base64," + encodedJs,
               {
                 ${workerTypeOption ? `type: "${workerTypeOption}",` : ''}
-                name: options?.name || "${workerName}"
+                name: options?.name
               }
             );
           }
@@ -368,7 +367,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             ${JSON.stringify(url)},
             {
               ${workerTypeOption ? `type: "${workerTypeOption}",` : ''}
-              name: options?.name || "${workerName}"
+              name: options?.name
             }
           );
         }`,

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -295,7 +295,8 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           ? 'module'
           : 'classic'
         : 'module'
-      const workerOptions = workerType === 'classic' ? '' : ',{type: "module"}'
+      const workerTypeOption = workerType === 'classic' ? undefined : 'module'
+      const workerName = query.name || ''
 
       if (isBuild) {
         getDepsOptimizer(config, ssr)?.registerWorkersSource(id)
@@ -310,21 +311,33 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             workerConstructor === 'Worker'
               ? `${encodedJs}
           const blob = typeof window !== "undefined" && window.Blob && new Blob([atob(encodedJs)], { type: "text/javascript;charset=utf-8" });
-          export default function WorkerWrapper() {
+          export default function WorkerWrapper(options) {
             let objURL;
             try {
               objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);
               if (!objURL) throw ''
-              return new ${workerConstructor}(objURL)
+              return new ${workerConstructor}(objURL, { name: options?.name || "${workerName}" })
             } catch(e) {
-              return new ${workerConstructor}("data:application/javascript;base64," + encodedJs${workerOptions});
+              return new ${workerConstructor}(
+                "data:application/javascript;base64," + encodedJs,
+                {
+                  ${workerTypeOption ? `type: "${workerTypeOption}",` : ''}
+                  name: options?.name || "${workerName}"
+                }
+              );
             } finally {
               objURL && (window.URL || window.webkitURL).revokeObjectURL(objURL);
             }
           }`
               : `${encodedJs}
-          export default function WorkerWrapper() {
-            return new ${workerConstructor}("data:application/javascript;base64," + encodedJs${workerOptions});
+          export default function WorkerWrapper(options) {
+            return new ${workerConstructor}(
+              "data:application/javascript;base64," + encodedJs,
+              {
+                ${workerTypeOption ? `type: "${workerTypeOption}",` : ''}
+                name: options?.name || "${workerName}"
+              }
+            );
           }
           `
 
@@ -350,10 +363,14 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       }
 
       return {
-        code: `export default function WorkerWrapper() {
-          return new ${workerConstructor}(${JSON.stringify(
-            url,
-          )}${workerOptions})
+        code: `export default function WorkerWrapper(options) {
+          return new ${workerConstructor}(
+            ${JSON.stringify(url)},
+            {
+              ${workerTypeOption ? `type: "${workerTypeOption}",` : ''}
+              name: options?.name || "${workerName}"
+            }
+          );
         }`,
         map: { mappings: '' }, // Empty sourcemap to suppress Rollup warning
       }

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -22,6 +22,10 @@ test('normal', async () => {
   )
 })
 
+test('named', async () => {
+  await untilUpdated(() => page.textContent('.pong-named'), 'pong', true)
+})
+
 test('TS output', async () => {
   await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong', true)
 })
@@ -30,8 +34,16 @@ test('inlined', async () => {
   await untilUpdated(() => page.textContent('.pong-inline'), 'pong', true)
 })
 
+test('named inlined', async () => {
+  await untilUpdated(() => page.textContent('.pong-inline-named'), 'pong', true)
+})
+
 test('shared worker', async () => {
   await untilUpdated(() => page.textContent('.tick-count'), 'pong', true)
+})
+
+test('named shared worker', async () => {
+  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong', true)
 })
 
 test('inline shared worker', async () => {

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -17,6 +17,10 @@ test('normal', async () => {
   )
 })
 
+test('named', async () => {
+  await untilUpdated(() => page.textContent('.pong-named'), 'pong', true)
+})
+
 test('TS output', async () => {
   await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong')
 })
@@ -25,8 +29,16 @@ test('inlined', async () => {
   await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
 })
 
+test('named inlined', async () => {
+  await untilUpdated(() => page.textContent('.pong-inline-named'), 'pong', true)
+})
+
 test('shared worker', async () => {
   await untilUpdated(() => page.textContent('.tick-count'), 'pong')
+})
+
+test('named shared worker', async () => {
+  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong', true)
 })
 
 test('inline shared worker', async () => {

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -22,6 +22,10 @@ test('normal', async () => {
   )
 })
 
+test('named', async () => {
+  await untilUpdated(() => page.textContent('.pong-named'), 'pong', true)
+})
+
 test('TS output', async () => {
   await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong', true)
 })
@@ -33,6 +37,10 @@ test.skip('inlined', async () => {
 
 test('shared worker', async () => {
   await untilUpdated(() => page.textContent('.tick-count'), 'pong', true)
+})
+
+test('named shared worker', async () => {
+  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong', true)
 })
 
 test('inline shared worker', async () => {

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -21,10 +21,26 @@
 </div>
 
 <p>
+  import myWorker from '../my-worker?worker'
+  <span>new myWorker({ name: "named-worker" })</span>
+  <span class="classname">.pong-named</span>
+</p>
+<div>
+  <div>Response from worker: <span class="pong-named"></span></div>
+</div>
+
+<p>
   import InlineWorker from '../my-worker?worker&inline'
   <span class="classname">.pong-inline</span>
 </p>
 <code class="pong-inline"></code>
+
+<p>
+  import InlineWorker from '../my-worker?worker&inline'
+  <span>new InlineWorker({ name: "named-inline-worker" })</span>
+  <span class="classname">.pong-inline-named</span>
+</p>
+<code class="pong-inline-named"></code>
 
 <p>
   import TSOutputWorker from '../possible-ts-output-worker?worker'
@@ -37,6 +53,13 @@
   <span class="classname">.tick-count</span>
 </p>
 <code class="tick-count"></code>
+
+<p>
+  import mySharedWorker from '../my-shared-worker?sharedworker&name=shared'
+  <span>new mySharedWorker({ name: "namedSharedWorker" })</span>
+  <span class="classname">.tick-count-named</span>
+</p>
+<code class="tick-count-named"></code>
 
 <p>
   import InlineSharedWorker from '../my-shared-worker?sharedworker&inline'

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -21,10 +21,22 @@ worker.addEventListener('message', (e) => {
   text('.asset-url', e.data.viteSvg)
 })
 
+const namedWorker = new myWorker({ name: 'namedWorker' })
+namedWorker.postMessage('ping')
+namedWorker.addEventListener('message', (e) => {
+  text('.pong-named', e.data.msg)
+})
+
 const inlineWorker = new InlineWorker()
 inlineWorker.postMessage('ping')
 inlineWorker.addEventListener('message', (e) => {
   text('.pong-inline', e.data.msg)
+})
+
+const namedInlineWorker = new InlineWorker({ name: 'namedInlineWorker' })
+namedInlineWorker.postMessage('ping')
+namedInlineWorker.addEventListener('message', (e) => {
+  text('.pong-inline-named', e.data.msg)
 })
 
 const startSharedWorker = () => {
@@ -36,6 +48,16 @@ const startSharedWorker = () => {
 }
 startSharedWorker()
 startSharedWorker()
+
+const startNamedSharedWorker = () => {
+  const sharedWorker = new mySharedWorker({ name: 'namedSharedWorker' })
+  sharedWorker.port.addEventListener('message', (event) => {
+    text('.tick-count-named', event.data)
+  })
+  sharedWorker.port.start()
+}
+startNamedSharedWorker()
+startNamedSharedWorker()
 
 const startInlineSharedWorker = () => {
   const inlineSharedWorker = new InlineSharedWorker()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Fix https://github.com/vitejs/vite/issues/12992

I have made it possible to pass a name from the constructor in order to assign a name to the Worker.

```typescript
import MyWorker from './myworker?worker';

const namedWorker = new MyWorker({ name: 'named-worker' })
```

![image](https://github.com/vitejs/vite/assets/18340344/b436487b-8b5b-4a74-9a57-0070e3bca0ce)


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

If the test is weird or missing, I'd be glad to know.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
