### PR TITLE
feat: copyPublicDir out of experimental

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -218,7 +218,6 @@ By default, Vite will empty the `outDir` on build if it is inside project root. 
 
 ## build.copyPublicDir
 
-- **Experimental:** [Give feedback](https://github.com/vitejs/vite/discussions/13807)
 - **Type:** `boolean`
 - **Default:** `true`
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -179,7 +179,6 @@ export interface BuildOptions {
   /**
    * Copy the public directory to outDir on write.
    * @default true
-   * @experimental
    */
   copyPublicDir?: boolean
   /**

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -1,5 +1,7 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import { expect, test } from 'vitest'
-import { isBuild, isWindows, page } from '~utils'
+import { isBuild, isWindows, page, testDir } from '~utils'
 
 test('bom import', async () => {
   expect(await page.textContent('.utf8-bom')).toMatch('[success]')
@@ -198,4 +200,10 @@ test('Resolving slash with imports filed', async () => {
 
 test('Resolving from other package with imports field', async () => {
   expect(await page.textContent('.imports-pkg-slash')).toMatch('[success]')
+})
+
+test.runIf(isBuild)('public dir is not copied', async () => {
+  expect(
+    fs.existsSync(path.resolve(testDir, 'dist/should-not-be-copied')),
+  ).toBe(false)
 })

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -164,6 +164,9 @@
 <h2>resolve package that contains # in path</h2>
 <p class="path-contains-sharp-symbol"></p>
 
+<h2>No copy public dir</h2>
+<p class="no-copy-public-dir"></p>
+
 <script type="module">
   import '@generated-content-virtual-file'
   function text(selector, text) {
@@ -378,6 +381,8 @@
     '.path-contains-sharp-symbol',
     `[success] ${contains.call('#', '#')} ${last.call('#')}`,
   )
+
+  text('.mjs-extension-with-query', tsMjsExtensionWithQueryMsg)
 </script>
 
 <style>

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -164,9 +164,6 @@
 <h2>resolve package that contains # in path</h2>
 <p class="path-contains-sharp-symbol"></p>
 
-<h2>No copy public dir</h2>
-<p class="no-copy-public-dir"></p>
-
 <script type="module">
   import '@generated-content-virtual-file'
   function text(selector, text) {
@@ -381,8 +378,6 @@
     '.path-contains-sharp-symbol',
     `[success] ${contains.call('#', '#')} ${last.call('#')}`,
   )
-
-  text('.mjs-extension-with-query', tsMjsExtensionWithQueryMsg)
 </script>
 
 <style>

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -107,4 +107,7 @@ export default defineConfig({
       '@vitejs/test-resolve-sharp-dir',
     ],
   },
+  build: {
+    copyPublicDir: false,
+  },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7527,6 +7527,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     dependencies:
       detect-libc: 1.0.3
+      napi-wasm: 1.1.0
     optionalDependencies:
       lightningcss-darwin-arm64: 1.21.5
       lightningcss-darwin-x64: 1.21.5
@@ -8038,6 +8039,10 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+    dev: true
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7527,7 +7527,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     dependencies:
       detect-libc: 1.0.3
-      napi-wasm: 1.1.0
     optionalDependencies:
       lightningcss-darwin-arm64: 1.21.5
       lightningcss-darwin-x64: 1.21.5
@@ -8039,10 +8038,6 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-
-  /napi-wasm@1.1.0:
-    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
-    dev: true
 
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}


### PR DESCRIPTION
### Description

Moves `build.copyPublicDir` out of experimental. We're collecting feedback about this feature here:
- https://github.com/vitejs/vite/discussions/13807

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other