### PR TITLE
chore: use "kB" everywhere with the correct definition

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -83,7 +83,7 @@ Specify the directory to nest generated assets under (relative to `build.outDir`
 ## build.assetsInlineLimit
 
 - **Type:** `number`
-- **Default:** `4096` (4kb)
+- **Default:** `4096` (4 KiB)
 
 Imported or referenced assets that are smaller than this threshold will be inlined as base64 URLs to avoid extra http requests. Set to `0` to disable inlining altogether.
 
@@ -236,7 +236,7 @@ Enable/disable gzip-compressed size reporting. Compressing large output files ca
 - **Type:** `number`
 - **Default:** `500`
 
-Limit for chunk size warnings (in kbs). It is compared against the uncompressed chunk size as the [JavaScript size itself is related to the execution time](https://v8.dev/blog/cost-of-javascript-2019).
+Limit for chunk size warnings (in kB). It is compared against the uncompressed chunk size as the [JavaScript size itself is related to the execution time](https://v8.dev/blog/cost-of-javascript-2019).
 
 ## build.watch
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -170,8 +170,8 @@ Running `vite build` with this config uses a Rollup preset that is oriented towa
 ```
 $ vite build
 building for production...
-dist/my-lib.js      0.08 KiB / gzip: 0.07 KiB
-dist/my-lib.umd.cjs 0.30 KiB / gzip: 0.16 KiB
+dist/my-lib.js      0.08 kB / gzip: 0.07 kB
+dist/my-lib.umd.cjs 0.30 kB / gzip: 0.16 kB
 ```
 
 Recommended `package.json` for your lib:

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -317,7 +317,7 @@ const __require = require;
 /**
  * Guard the bundle size
  *
- * @param limit size in KB
+ * @param limit size in kB
  */
 function bundleSizeLimit(limit: number): Plugin {
   return {
@@ -329,10 +329,10 @@ function bundleSizeLimit(limit: number): Plugin {
           .join(''),
         'utf-8',
       )
-      const kb = size / 1024
+      const kb = size / 1000
       if (kb > limit) {
         throw new Error(
-          `Bundle size exceeded ${limit}kb, current size is ${kb.toFixed(
+          `Bundle size exceeded ${limit} kB, current size is ${kb.toFixed(
             2,
           )}kb.`,
         )

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -195,7 +195,7 @@ function createCjsConfig(isProduction: boolean) {
       ...Object.keys(pkg.dependencies),
       ...(isProduction ? [] : Object.keys(pkg.devDependencies)),
     ],
-    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(120)],
+    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(123)],
   })
 }
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -107,7 +107,7 @@ export interface BuildOptions {
   assetsDir?: string
   /**
    * Static asset files smaller than this number (in bytes) will be inlined as
-   * base64 strings. Default limit is `4096` (4kb). Set to `0` to disable.
+   * base64 strings. Default limit is `4096` (4 KiB). Set to `0` to disable.
    * @default 4096
    */
   assetsInlineLimit?: number
@@ -234,7 +234,7 @@ export interface BuildOptions {
    */
   reportCompressedSize?: boolean
   /**
-   * Adjust chunk size warning limit (in kbs).
+   * Adjust chunk size warning limit (in kB).
    * @default 500
    */
   chunkSizeWarningLimit?: number

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -285,7 +285,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       ) {
         config.logger.warn(
           colors.yellow(
-            `\n(!) Some chunks are larger than ${chunkLimit} kBs after minification. Consider:\n` +
+            `\n(!) Some chunks are larger than ${chunkLimit} kB after minification. Consider:\n` +
               `- Using dynamic import() to code-split the application\n` +
               `- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks\n` +
               `- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.`,

--- a/playground/assets/vite.config.js
+++ b/playground/assets/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig({
   assetsInclude: ['**/*.unknown'],
   build: {
     outDir: 'dist/foo',
-    assetsInlineLimit: 8192, // 8kb
+    assetsInlineLimit: 8000, // 8 kB
     manifest: true,
     watch: {},
   },


### PR DESCRIPTION
Recently I got confused with inconsistent usages across tools around ["Kilobyte"](https://en.wikipedia.org/wiki/Kilobyte).
And then I just found Vite chose to use "kB = 1000 bytes" in https://github.com/vitejs/vite/pull/10982.

This PR is just to fix small remaining inconsistencies.

I searched these using `ripgrep` by running `rg --hidden -i -w kb` and `rg --hidden -i -w kib`

Changes in this PR should not affect the behavior of Vite itself
