### PR TITLE
fix: preview --open, Multi window to find the active tab

### DIFF
--- a/packages/vite/bin/openChrome.applescript
+++ b/packages/vite/bin/openChrome.applescript
@@ -32,9 +32,9 @@ on run argv
       -- then return
       set found to my lookupTabWithUrl(theURL)
       if found then
+        tell targetWindow to activate
         set targetWindow's active tab index to targetTabIndex
         tell targetTab to reload
-        tell targetWindow to activate
         set index of targetWindow to 1
         return
       end if
@@ -44,9 +44,9 @@ on run argv
       -- We try to find an empty tab instead
       set found to my lookupTabWithUrl("chrome://newtab/")
       if found then
+        tell targetWindow to activate
         set targetWindow's active tab index to targetTabIndex
         set URL of targetTab to theURL
-        tell targetWindow to activate
         return
       end if
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When Opened multi chrome window, the last active window do not have target url,  this bin can not switch the right window.

### Additional context

compatibility
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ X] Ideally, include relevant tests that fail without this PR but pass with it.
