### PR TITLE
fix: remove regex replacement for lib mode

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -28,11 +28,6 @@ import { searchForWorkspaceRoot } from '../server/searchRoot'
 
 const debug = createDebugger('vite:esbuild')
 
-const INJECT_HELPERS_IIFE_RE =
-  /^(.*?)((?:const|var)\s+\S+\s*=\s*function\s*\([^)]*\)\s*\{\s*"use strict";)/s
-const INJECT_HELPERS_UMD_RE =
-  /^(.*?)(\(function\([^)]*\)\s*\{.+?amd.+?function\([^)]*\)\s*\{\s*"use strict";)/s
-
 const validExtensionRE = /\.\w+$/
 const jsxExtensionsRE = /\.(?:j|t)sx\b/
 
@@ -330,25 +325,6 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
 
       const res = await transformWithEsbuild(code, chunk.fileName, options)
 
-      if (config.build.lib) {
-        // #7188, esbuild adds helpers out of the UMD and IIFE wrappers, and the
-        // names are minified potentially causing collision with other globals.
-        // We use a regex to inject the helpers inside the wrappers.
-        // We don't need to create a MagicString here because both the helpers and
-        // the headers don't modify the sourcemap
-        const injectHelpers =
-          opts.format === 'umd'
-            ? INJECT_HELPERS_UMD_RE
-            : opts.format === 'iife'
-            ? INJECT_HELPERS_IIFE_RE
-            : undefined
-        if (injectHelpers) {
-          res.code = res.code.replace(
-            injectHelpers,
-            (_, helpers, header) => header + helpers,
-          )
-        }
-      }
       return res
     },
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #14065 lib mode hanging for umd build, by removing regex replacements

### Additional context

The original fix #7948 used regex for string replacement to avoid global esbuild helpers. However, it seems these can be removed now, because all the tests pass without them, probably due to updated esbuild (0.14.27 then vs 0.18.10 now).

The regex approach also doesn't completely fix the original issue, some reproductions with the latest vite (4.4.9):
- UMD build, minify: true https://stackblitz.com/edit/vitejs-vite-9frvl5?file=vite.config.ts,index.tsx&terminal=build
- UMD build, minify: false https://stackblitz.com/edit/vitejs-vite-z5wdig?file=vite.config.ts,index.ts&terminal=build

Given numerous preivous attemps [#8110](https://github.com/vitejs/vite/pull/8110/files) [#8741](https://github.com/vitejs/vite/pull/8741/files) [#10905](https://github.com/vitejs/vite/pull/10905/files#diff-6d149ac9706cd508b52db0c059a0f01d670620a9a5a73cd7b122ce62b6b69471) at fixing regex performance, I think this is an indication that regex isn't the right solution in this scenario, and we should probably remove it altogether to avoid future performance issues.

In conclusion, we need a better fix for the global esbuild helpers. Removing regex for now appears to be safe because a). all tests pass and b). the original issue is still largely unfixed (easily reproducable - probably already in many people's builds)


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
