### PR TITLE
fix: use string manipulation instead of regex to inject esbuild helpers

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -29,7 +29,8 @@ import { searchForWorkspaceRoot } from '../server/searchRoot'
 const debug = createDebugger('vite:esbuild')
 
 // IIFE content looks like `var MyLib = function() {`. Spaces are removed when minified
-const IIFE_BEGIN_RE = /(const|var)(.*)=\s*function\(\)\s*\{\s*"use strict";/
+const IIFE_BEGIN_RE =
+  /(const|var)\s+\S+\s*=\s*function\(\)\s*\{.*"use strict";/s
 
 const validExtensionRE = /\.\w+$/
 const jsxExtensionsRE = /\.(?:j|t)sx\b/

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -28,10 +28,8 @@ import { searchForWorkspaceRoot } from '../server/searchRoot'
 
 const debug = createDebugger('vite:esbuild')
 
-const INJECT_HELPERS_IIFE_RE =
-  /^(.*?)((?:const|var)\s+\S+\s*=\s*function\s*\([^)]*\)\s*\{\s*"use strict";)/s
-const INJECT_HELPERS_UMD_RE =
-  /^(.*?)(\(function\([^)]*\)\s*\{.+?amd.+?function\([^)]*\)\s*\{\s*"use strict";)/s
+// IIFE content looks like `var MyLib = function() {`. Spaces are removed when minified
+const IIFE_BEGIN_RE = /(const|var)(.*)=\s*function\(\)\s*\{\s*"use strict";/
 
 const validExtensionRE = /\.\w+$/
 const jsxExtensionsRE = /\.(?:j|t)sx\b/
@@ -333,22 +331,30 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
       if (config.build.lib) {
         // #7188, esbuild adds helpers out of the UMD and IIFE wrappers, and the
         // names are minified potentially causing collision with other globals.
-        // We use a regex to inject the helpers inside the wrappers.
+        // We inject the helpers inside the wrappers.
+        // e.g. turn:
+        //    <esbuild helpers> (function(){ /*actual content/* })()
+        // into:
+        //    (function(){ <esbuild helpers> /*actual content/* })()
+        // Not using regex because it's too hard to rule out performance issues like #8738 #8099 #10900 #14065
+        // Instead, using plain string index manipulation (indexOf, slice) which is simple and performant
         // We don't need to create a MagicString here because both the helpers and
         // the headers don't modify the sourcemap
-        const injectHelpers =
-          opts.format === 'umd'
-            ? INJECT_HELPERS_UMD_RE
-            : opts.format === 'iife'
-            ? INJECT_HELPERS_IIFE_RE
-            : undefined
-        if (injectHelpers) {
-          res.code = res.code.replace(
-            injectHelpers,
-            (_, helpers, header) => header + helpers,
-          )
+        const esbuildCode = res.code
+        const contentIndex =
+          opts.format === 'iife'
+            ? esbuildCode.match(IIFE_BEGIN_RE)?.index || 0
+            : opts.format === 'umd'
+            ? esbuildCode.indexOf(`(function(`) // same for minified or not
+            : 0
+        if (contentIndex > 0) {
+          const esbuildHelpers = esbuildCode.slice(0, contentIndex)
+          res.code = esbuildCode
+            .slice(contentIndex)
+            .replace(`"use strict";`, `"use strict";` + esbuildHelpers)
         }
       }
+
       return res
     },
   }

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -33,7 +33,9 @@ describe.runIf(isBuild)('build', () => {
       'dist/nominify/my-lib-custom-filename.iife.js',
     )
     // esbuild helpers are injected inside of the IIFE wrapper
-    expect(code).toMatch(/^var MyLib=function\(\)\{(.*?)"use strict";/)
+    // esbuild has a bug that injects some statements before `"use strict"`: https://github.com/evanw/esbuild/issues/3322
+    // remove the `.*?` part once it's fixed
+    expect(code).toMatch(/^var MyLib=function\(\)\{.*?"use strict";/)
     expect(noMinifyCode).toMatch(
       /^var MyLib\s*=\s*function\(\)\s*\{.*?"use strict";/s,
     )

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -33,7 +33,7 @@ describe.runIf(isBuild)('build', () => {
       'dist/nominify/my-lib-custom-filename.iife.js',
     )
     // esbuild helpers are injected inside of the IIFE wrapper
-    expect(code).toMatch(/^var MyLib=function\(\)\{"use strict";/)
+    expect(code).toMatch(/^var MyLib=function\(\)\{(.*?)"use strict";/)
     expect(noMinifyCode).toMatch(
       /^var MyLib\s*=\s*function\(\)\s*\{.*?"use strict";/s,
     )

--- a/playground/lib/src/main.js
+++ b/playground/lib/src/main.js
@@ -10,3 +10,6 @@ export default function myLib(sel) {
   // make sure umd helper has been moved to the right position
   console.log(`amd function(){ "use strict"; }`)
 }
+
+// For triggering unhandled global esbuild helpers in previous regex-based implementation for injection
+myLib()?.foo

--- a/playground/lib/src/main.js
+++ b/playground/lib/src/main.js
@@ -12,4 +12,4 @@ export default function myLib(sel) {
 }
 
 // For triggering unhandled global esbuild helpers in previous regex-based implementation for injection
-myLib()?.foo
+;(function () {})()?.foo

--- a/playground/lib/vite.config.js
+++ b/playground/lib/vite.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     supported: {
       // Force esbuild inject helpers to test regex
       'object-rest-spread': false,
+      'optional-chain': false,
     },
   },
   build: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #14065 lib mode hanging for umd build, by using string manipulation instead of regex

### Additional context

The original fix #7948 used regex for string replacement to avoid global esbuild helpers. 

It has since caused multiple performance issues #8738 #8099 #10900 #14065, and received numerous attempts [#8110](https://github.com/vitejs/vite/pull/8110/files) [#8741](https://github.com/vitejs/vite/pull/8741/files) [#10905](https://github.com/vitejs/vite/pull/10905/files#diff-6d149ac9706cd508b52db0c059a0f01d670620a9a5a73cd7b122ce62b6b69471) at fixing it, but there're still unhandled cases:

- UMD build, minify: true https://stackblitz.com/edit/vitejs-vite-9frvl5?file=vite.config.ts,index.tsx&terminal=build
- UMD build, minify: false https://stackblitz.com/edit/vitejs-vite-z5wdig?file=vite.config.ts,index.ts&terminal=build

I think this shows that regex isn't the right solution in this scenario. It's easier to manipulate the string directly, at the cost of a few extra lines.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
