### PR TITLE
fix!: avoid rewriting this (reverts #5312)

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -535,7 +535,6 @@ export async function build(
   }
 
   const rollupOptions: RollupOptions = {
-    context: 'globalThis',
     preserveEntrySignatures: ssr
       ? 'allow-extension'
       : libOptions


### PR DESCRIPTION
Fixes #12340

### Description

This PR reverts #5312. As it was discussed in #12340, Vite shouldn't be replacing `this` in an ESM context.

@ArnaudBarre, #5312 was intended to avoid `THIS_IS_UNDEFINED` warnings in React apps, but we're already ignoring this warning here: https://github.com/vitejs/vite/blob/63a44511133276f903e54d4dde4296d5d5963298/packages/vite/src/node/build.ts#L876
If there is a warning or error in source maps to be avoided though, we should fix it without the need for this rewrite.

As proposed by @bluwy, we can merge this in Vite 5 as it is a breaking change.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
