### PR TITLE
feat: vite config postcss support exclude option

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1003,7 +1003,7 @@ async function compileCSS(
   const atImportResolvers = getAtImportResolvers(config)
   const postcssOptions = (postcssConfig && postcssConfig.options) || {}
 
-  const isExcldue = !!postcssOptions?.exclude?.(id)
+  const isExcldue = !!postcssConfig?.exclude?.(id)
   if (isExcldue) {
     return {
       code,
@@ -1297,8 +1297,9 @@ async function finalizeCss(
 }
 
 interface PostCSSConfigResult {
-  options: PostCSS.ProcessOptions & { exclude?: (fileName: string) => boolean }
+  options: PostCSS.ProcessOptions
   plugins: PostCSS.AcceptedPlugin[]
+  exclude?: (fileName: string) => boolean
 }
 
 async function resolvePostcssConfig(
@@ -1315,13 +1316,11 @@ async function resolvePostcssConfig(
     const options = { ...inlineOptions }
 
     delete options.plugins
+    delete options.exclude
     result = {
       options,
       plugins: inlineOptions.plugins || [],
-    }
-    if (inlineOptions.exclude) {
-      Object.assign(result, { exclude: inlineOptions.exclude })
-      delete options.exclude
+      exclude: inlineOptions.exclude,
     }
   } else {
     const searchPath =

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1297,7 +1297,7 @@ async function finalizeCss(
 }
 
 interface PostCSSConfigResult {
-  options: PostCSS.ProcessOptions & { exclude?: (fileName: string)=> boolean }
+  options: PostCSS.ProcessOptions & { exclude?: (fileName: string) => boolean }
   plugins: PostCSS.AcceptedPlugin[]
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
Vite config postcss supports exclude options. 
Just like loader in webpack, developers can use the exclude option to filter the file which they don't want to process. Something like that:

```js
{
    test: SOMEREG,
    use: ['someLoader'],
    exclude: The exclude function
}
```

postcss config in vite can also be written by this pattern:

```
//vite config 
{
    ...
    css: {
        ...
        postcss: {
          plugins: ['some postcss plugins'],
          exclude: The exclude function
        },
        ...
    },
    ...
}
```
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
