### PR TITLE
feat: allow parallel worker builds when worker plugins is a function

### DIFF
--- a/docs/config/worker-options.md
+++ b/docs/config/worker-options.md
@@ -11,9 +11,13 @@ Output format for worker bundle.
 
 ## worker.plugins
 
-- **Type:** [`(Plugin | Plugin[])[]`](./shared-options#plugins)
+- **Type:** [`(() => (Plugin | Plugin[])[]) | (Plugin | Plugin[])[]`](./shared-options#plugins)
 
 Vite plugins that apply to worker bundle. Note that [config.plugins](./shared-options#plugins) only applies to workers in dev, it should be configured here instead for build.
+
+Providing a function that returns an array of plugins is preferred, so we can safely run parallel builds for workers. The function should be side effect free and return the same array of plugins every time.
+
+When providing an array of plugins, the worker builds will run sequentially and workers nested inside other workers may not build.
 
 ## worker.rollupOptions
 

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -336,7 +336,7 @@ describe('resolveConfig', () => {
   })
 })
 
-describe.only('worker config', () => {
+describe('worker config', () => {
   const userPlugin = (): PluginOption => {
     return {
       name: 'vite-plugin-worker-user-plugin',

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -335,3 +335,36 @@ describe('resolveConfig', () => {
     expect(results2.clearScreen).toBe(false)
   })
 })
+
+describe.only('worker config', () => {
+  const userPlugin = (): PluginOption => {
+    return {
+      name: 'vite-plugin-worker-user-plugin',
+    }
+  }
+
+  test('resolves to default plugins function', async () => {
+    const results = await resolveConfig({}, 'build')
+    expect(typeof results.worker.plugins).toBe('function')
+  })
+
+  test('resolves to plugins function when user defined function given', async () => {
+    const config: InlineConfig = {
+      worker: {
+        plugins: () => [userPlugin()],
+      },
+    }
+    const results = await resolveConfig(config, 'build')
+    expect(typeof results.worker.plugins).toBe('function')
+  })
+
+  test('resolves to a plugins array when user defined array given', async () => {
+    const config: InlineConfig = {
+      worker: {
+        plugins: [userPlugin()],
+      },
+    }
+    const results = await resolveConfig(config, 'build')
+    expect(Array.isArray(results.worker.plugins)).toBe(true)
+  })
+})

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -833,10 +833,10 @@ export async function resolveConfig(
     plugins: resolved.plugins.map((p) => p.name),
     worker: {
       ...resolved.worker,
-      plugins:
-        typeof resolved.worker.plugins === 'function'
-          ? await resolved.worker.plugins()
-          : resolved.worker.plugins.map((p) => p.name),
+      plugins: (typeof resolved.worker.plugins === 'function'
+        ? await resolved.worker.plugins()
+        : resolved.worker.plugins
+      ).map((p) => p.name),
     },
   })
 

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -61,7 +61,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(28)
+    expect(files.length).toBe(29)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/playground/worker/__tests__/parallel/parallel-worker-build.spec.ts
+++ b/playground/worker/__tests__/parallel/parallel-worker-build.spec.ts
@@ -1,6 +1,24 @@
 import { describe, test } from 'vitest'
 import { isBuild, page, untilUpdated } from '~utils'
 
+test('deeply nested workers', async () => {
+  await untilUpdated(
+    async () => page.textContent('.deeply-nested-worker'),
+    /Hello\sfrom\sroot.*\/parallel\/.+deeply-nested-worker\.js/,
+    true,
+  )
+  await untilUpdated(
+    async () => page.textContent('.deeply-nested-second-worker'),
+    /Hello\sfrom\ssecond.*\/parallel\/.+second-worker\.js/,
+    true,
+  )
+  await untilUpdated(
+    async () => page.textContent('.deeply-nested-third-worker'),
+    /Hello\sfrom\sthird.*\/parallel\/.+third-worker\.js/,
+    true,
+  )
+})
+
 describe.runIf(isBuild)('build', () => {
   test('expect the plugin state to be unpolluted and match across worker builds', async () => {
     await untilUpdated(

--- a/playground/worker/__tests__/parallel/parallel-worker-build.spec.ts
+++ b/playground/worker/__tests__/parallel/parallel-worker-build.spec.ts
@@ -1,0 +1,17 @@
+import { describe, test } from 'vitest'
+import { isBuild, page, untilUpdated } from '~utils'
+
+describe.runIf(isBuild)('build', () => {
+  test('expect the plugin state to be unpolluted and match across worker builds', async () => {
+    await untilUpdated(
+      () => page.textContent('.nested-worker-plugin-state'),
+      '"data":1',
+      true,
+    )
+    await untilUpdated(
+      () => page.textContent('.sub-worker-plugin-state'),
+      '"data":1',
+      true,
+    )
+  })
+})

--- a/playground/worker/__tests__/serial/serial-worker-build.spec.ts
+++ b/playground/worker/__tests__/serial/serial-worker-build.spec.ts
@@ -5,13 +5,13 @@ describe.runIf(isBuild)('build', () => {
   test('expect the plugin state to be polluted and not match across worker builds', async () => {
     await untilUpdated(
       () => page.textContent('.nested-worker-plugin-state'),
-      '"data":1',
+      '"data":2',
       true,
     )
     // The plugin state is polluted and should have a different data value from the sub worker
     await untilUpdated(
       () => page.textContent('.sub-worker-plugin-state'),
-      '"data":2',
+      '"data":1',
       true,
     )
   })

--- a/playground/worker/__tests__/serial/serial-worker-build.spec.ts
+++ b/playground/worker/__tests__/serial/serial-worker-build.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, test } from 'vitest'
 import { isBuild, page, untilUpdated } from '~utils'
 
 describe.runIf(isBuild)('build', () => {

--- a/playground/worker/__tests__/serial/serial-worker-build.spec.ts
+++ b/playground/worker/__tests__/serial/serial-worker-build.spec.ts
@@ -1,18 +1,26 @@
-import { describe, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { isBuild, page, untilUpdated } from '~utils'
 
 describe.runIf(isBuild)('build', () => {
   test('expect the plugin state to be polluted and not match across worker builds', async () => {
     await untilUpdated(
       () => page.textContent('.nested-worker-plugin-state'),
-      '"data":2',
+      '"type":"plugin-state"',
       true,
     )
-    // The plugin state is polluted and should have a different data value from the sub worker
     await untilUpdated(
       () => page.textContent('.sub-worker-plugin-state'),
-      '"data":1',
+      '"type":"plugin-state-sub"',
       true,
     )
+
+    const nestedWorkerPluginState = JSON.parse(
+      await page.textContent('.nested-worker-plugin-state'),
+    )
+    const subWorkerPluginState = JSON.parse(
+      await page.textContent('.sub-worker-plugin-state'),
+    )
+    // The plugin state is polluted and should have a different data value from the sub worker
+    expect(nestedWorkerPluginState.data).not.toEqual(subWorkerPluginState.data)
   })
 })

--- a/playground/worker/__tests__/serial/serial-worker-build.spec.ts
+++ b/playground/worker/__tests__/serial/serial-worker-build.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest'
+import { isBuild, page, untilUpdated } from '~utils'
+
+describe.runIf(isBuild)('build', () => {
+  test('expect the plugin state to be polluted and not match across worker builds', async () => {
+    await untilUpdated(
+      () => page.textContent('.nested-worker-plugin-state'),
+      '"data":1',
+      true,
+    )
+    // The plugin state is polluted and should have a different data value from the sub worker
+    await untilUpdated(
+      () => page.textContent('.sub-worker-plugin-state'),
+      '"data":2',
+      true,
+    )
+  })
+})

--- a/playground/worker/__tests__/serial/serial-worker-build.spec.ts
+++ b/playground/worker/__tests__/serial/serial-worker-build.spec.ts
@@ -5,12 +5,12 @@ describe.runIf(isBuild)('build', () => {
   test('expect the plugin state to be polluted and not match across worker builds', async () => {
     await untilUpdated(
       () => page.textContent('.nested-worker-plugin-state'),
-      '"type":"plugin-state"',
+      '"type":"workerPluginState"',
       true,
     )
     await untilUpdated(
       () => page.textContent('.sub-worker-plugin-state'),
-      '"type":"plugin-state-sub"',
+      '"type":"subWorkerPluginState"',
       true,
     )
 

--- a/playground/worker/deeply-nested-second-worker.js
+++ b/playground/worker/deeply-nested-second-worker.js
@@ -1,0 +1,19 @@
+self.postMessage({
+  type: 'deeplyNestedSecondWorker',
+  data: [
+    'Hello from second level nested worker',
+    import.meta.env.BASE_URL,
+    self.location.url,
+    import.meta.url,
+  ].join(' '),
+})
+
+const deeplyNestedThirdWorker = new Worker(
+  new URL('deeply-nested-third-worker.js', import.meta.url),
+  { type: 'module' },
+)
+deeplyNestedThirdWorker.addEventListener('message', (ev) => {
+  self.postMessage(ev.data)
+})
+
+console.log('deeply-nested-second-worker.js')

--- a/playground/worker/deeply-nested-third-worker.js
+++ b/playground/worker/deeply-nested-third-worker.js
@@ -1,0 +1,11 @@
+self.postMessage({
+  type: 'deeplyNestedThirdWorker',
+  data: [
+    'Hello from third level nested worker',
+    import.meta.env.BASE_URL,
+    self.location.url,
+    import.meta.url,
+  ].join(' '),
+})
+
+console.log('deeply-nested-third-worker.js')

--- a/playground/worker/deeply-nested-worker.js
+++ b/playground/worker/deeply-nested-worker.js
@@ -1,0 +1,19 @@
+self.postMessage({
+  type: 'deeplyNestedWorker',
+  data: [
+    'Hello from root worker',
+    import.meta.env.BASE_URL,
+    self.location.url,
+    import.meta.url,
+  ].join(' '),
+})
+
+const deeplyNestedSecondWorker = new Worker(
+  new URL('deeply-nested-second-worker.js', import.meta.url),
+  { type: 'module' },
+)
+deeplyNestedSecondWorker.addEventListener('message', (ev) => {
+  self.postMessage(ev.data)
+})
+
+console.log('deeply-nested-worker.js')

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -90,6 +90,18 @@
 <code class="nested-worker-constructor"></code>
 
 <p>
+  import NestedWorker from './worker-nested-worker?worker' - plugin-state
+  <span class="classname">.nested-worker-plugin-state</span>
+</p>
+<code class="nested-worker-plugin-state"></code>
+
+<p>
+  import SubWorker from './sub-worker?worker' - plugin-state
+  <span class="classname">.sub-worker-plugin-state</span>
+</p>
+<code class="sub-worker-plugin-state"></code>
+
+<p>
   new Worker(new URL('./classic-worker.js', import.meta.url))
   <span class="classname">.classic-worker</span>
 </p>

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -126,6 +126,27 @@
 </p>
 <code class="importMetaGlobEager-worker"></code>
 
+<p>
+  new Worker(new URL('../deeply-nested-worker.js', import.meta.url), { type:
+  'module' })
+  <span class="classname">.deeply-nested-worker</span>
+</p>
+<code class="deeply-nested-worker"></code>
+
+<p>
+  new Worker(new URL('deeply-nested-second-worker.js', import.meta.url), { type:
+  'module' })
+  <span class="classname">.deeply-nested-second-worker</span>
+</p>
+<code class="deeply-nested-second-worker"></code>
+
+<p>
+  new Worker(new URL('deeply-nested-third-worker.js', import.meta.url), { type:
+  'module' })
+  <span class="classname">.deeply-nested-third-worker</span>
+</p>
+<code class="deeply-nested-third-worker"></code>
+
 <hr />
 
 <h2 class="format-es"></h2>

--- a/playground/worker/modules/test-state.js
+++ b/playground/worker/modules/test-state.js
@@ -1,0 +1,1 @@
+export const state = 0

--- a/playground/worker/sub-worker.js
+++ b/playground/worker/sub-worker.js
@@ -1,6 +1,10 @@
+import { state } from './modules/test-state.js'
+
+self.postMessage({ type: 'plugin-state-sub', data: state })
+
 self.onmessage = (event) => {
   if (event.data === 'ping') {
-    self.postMessage(`pong ${self.location.href}`)
+    self.postMessage({ type: 'module', data: `pong ${self.location.href}` })
   }
 }
 

--- a/playground/worker/sub-worker.js
+++ b/playground/worker/sub-worker.js
@@ -1,6 +1,6 @@
 import { state } from './modules/test-state.js'
 
-self.postMessage({ type: 'plugin-state-sub', data: state })
+self.postMessage({ type: 'subWorkerPluginState', data: state })
 
 self.onmessage = (event) => {
   if (event.data === 'ping') {

--- a/playground/worker/vite.config-parallel.js
+++ b/playground/worker/vite.config-parallel.js
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite'
+import workerPluginTestPlugin from './worker-plugin-test-plugin'
+import workerPluginStatePlugin from './worker-plugin-state-plugin'
+
+export default defineConfig({
+  base: '/serial/',
+  resolve: {
+    alias: {
+      '@': __dirname,
+    },
+  },
+  worker: {
+    format: 'iife',
+    plugins: () => [workerPluginTestPlugin(), workerPluginStatePlugin()],
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/worker_asset-[name].[ext]',
+        chunkFileNames: 'assets/worker_chunk-[name].js',
+        entryFileNames: 'assets/worker_entry-[name].js',
+      },
+    },
+  },
+  build: {
+    outDir: 'dist/parallel',
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/[name].[ext]',
+        chunkFileNames: 'assets/[name].js',
+        entryFileNames: 'assets/[name].js',
+      },
+    },
+  },
+  plugins: [workerPluginTestPlugin()],
+  cacheDir: 'node_modules/.vite-es',
+})

--- a/playground/worker/vite.config-parallel.js
+++ b/playground/worker/vite.config-parallel.js
@@ -3,7 +3,7 @@ import workerPluginTestPlugin from './worker-plugin-test-plugin'
 import workerPluginStatePlugin from './worker-plugin-state-plugin'
 
 export default defineConfig({
-  base: '/serial/',
+  base: '/parallel/',
   resolve: {
     alias: {
       '@': __dirname,
@@ -31,5 +31,5 @@ export default defineConfig({
     },
   },
   plugins: [workerPluginTestPlugin()],
-  cacheDir: 'node_modules/.vite-es',
+  cacheDir: 'node_modules/.vite-parallel',
 })

--- a/playground/worker/vite.config-parallel.js
+++ b/playground/worker/vite.config-parallel.js
@@ -30,6 +30,20 @@ export default defineConfig({
       },
     },
   },
-  plugins: [workerPluginTestPlugin()],
+  plugins: [
+    workerPluginTestPlugin(),
+    {
+      name: 'resolve-deeply-nested',
+
+      transform(code, id) {
+        if (id.includes('main.js')) {
+          return code.replace(
+            `/* flag: will replace in vite config import("./main-deeply-nested") */`,
+            `import("./main-deeply-nested")`,
+          )
+        }
+      },
+    },
+  ],
   cacheDir: 'node_modules/.vite-parallel',
 })

--- a/playground/worker/vite.config-serial.js
+++ b/playground/worker/vite.config-serial.js
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite'
+import workerPluginTestPlugin from './worker-plugin-test-plugin'
+import workerPluginStatePlugin from './worker-plugin-state-plugin'
+
+export default defineConfig({
+  base: '/serial/',
+  resolve: {
+    alias: {
+      '@': __dirname,
+    },
+  },
+  worker: {
+    format: 'iife',
+    plugins: [workerPluginTestPlugin(), workerPluginStatePlugin()],
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/worker_asset-[name].[ext]',
+        chunkFileNames: 'assets/worker_chunk-[name].js',
+        entryFileNames: 'assets/worker_entry-[name].js',
+      },
+    },
+  },
+  build: {
+    outDir: 'dist/serial',
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/[name].[ext]',
+        chunkFileNames: 'assets/[name].js',
+        entryFileNames: 'assets/[name].js',
+      },
+    },
+  },
+  plugins: [workerPluginTestPlugin()],
+  cacheDir: 'node_modules/.vite-es',
+})

--- a/playground/worker/vite.config-serial.js
+++ b/playground/worker/vite.config-serial.js
@@ -31,5 +31,5 @@ export default defineConfig({
     },
   },
   plugins: [workerPluginTestPlugin()],
-  cacheDir: 'node_modules/.vite-es',
+  cacheDir: 'node_modules/.vite-serial',
 })

--- a/playground/worker/worker-nested-worker.js
+++ b/playground/worker/worker-nested-worker.js
@@ -1,5 +1,11 @@
 import ImportMetaGlobEagerWorker from './importMetaGlobEager.worker?worker'
 import SubWorker from './sub-worker?worker'
+import { state } from './modules/test-state.js'
+
+self.postMessage({
+  type: 'plugin-state',
+  data: state,
+})
 
 const subWorker = new SubWorker()
 
@@ -12,10 +18,7 @@ self.onmessage = (event) => {
 self.postMessage(self.location.href)
 
 subWorker.onmessage = (ev) => {
-  self.postMessage({
-    type: 'module',
-    data: ev.data,
-  })
+  self.postMessage(ev.data)
 }
 
 const classicWorker = new Worker(new URL('./url-worker.js', import.meta.url), {

--- a/playground/worker/worker-nested-worker.js
+++ b/playground/worker/worker-nested-worker.js
@@ -3,7 +3,7 @@ import SubWorker from './sub-worker?worker'
 import { state } from './modules/test-state.js'
 
 self.postMessage({
-  type: 'plugin-state',
+  type: 'workerPluginState',
   data: state,
 })
 

--- a/playground/worker/worker-plugin-state-plugin.js
+++ b/playground/worker/worker-plugin-state-plugin.js
@@ -1,0 +1,16 @@
+export default () => {
+  let count = 0
+  return {
+    name: 'plugin-for-plugin-state',
+    transform(code, id) {
+      count++
+      if (id.includes('worker/modules/test-state.js')) {
+        count++
+        return {
+          code: code.replace(/state = \d+/, 'state = ' + count),
+          map: null,
+        }
+      }
+    },
+  }
+}

--- a/playground/worker/worker-plugin-state-plugin.js
+++ b/playground/worker/worker-plugin-state-plugin.js
@@ -3,7 +3,6 @@ export default () => {
   return {
     name: 'plugin-for-plugin-state',
     transform(code, id) {
-      count++
       if (id.includes('worker/modules/test-state.js')) {
         count++
         return {

--- a/playground/worker/worker/main-deeply-nested.js
+++ b/playground/worker/worker/main-deeply-nested.js
@@ -1,0 +1,18 @@
+const worker = new Worker(
+  new URL('../deeply-nested-worker.js', import.meta.url),
+  { type: 'module' },
+)
+
+function text(el, text) {
+  document.querySelector(el).textContent = text
+}
+
+worker.addEventListener('message', (ev) => {
+  if (ev.data.type === 'deeplyNestedSecondWorker') {
+    text('.deeply-nested-second-worker', JSON.stringify(ev.data.data))
+  } else if (ev.data.type === 'deeplyNestedThirdWorker') {
+    text('.deeply-nested-third-worker', JSON.stringify(ev.data.data))
+  } else {
+    text('.deeply-nested-worker', JSON.stringify(ev.data.data))
+  }
+})

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -64,6 +64,12 @@ nestedWorker.addEventListener('message', (ev) => {
       text('.nested-worker-module', JSON.stringify(ev.data))
     } else if (data.type === 'constructor') {
       text('.nested-worker-constructor', JSON.stringify(ev.data))
+    } else if (data.type === 'plugin-state') {
+      console.log('got plugin state', ev.data)
+      text('.nested-worker-plugin-state', JSON.stringify(ev.data))
+    } else if (data.type === 'plugin-state-sub') {
+      console.log('got sub plugin state', ev.data)
+      text('.sub-worker-plugin-state', JSON.stringify(ev.data))
     } else if (data.type === 'importMetaGlobEager') {
       text('.importMetaGlobEager-worker', JSON.stringify(ev.data))
     }

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -64,10 +64,10 @@ nestedWorker.addEventListener('message', (ev) => {
       text('.nested-worker-module', JSON.stringify(ev.data))
     } else if (data.type === 'constructor') {
       text('.nested-worker-constructor', JSON.stringify(ev.data))
-    } else if (data.type === 'plugin-state') {
+    } else if (data.type === 'workerPluginState') {
       console.log('got plugin state', ev.data)
       text('.nested-worker-plugin-state', JSON.stringify(ev.data))
-    } else if (data.type === 'plugin-state-sub') {
+    } else if (data.type === 'subWorkerPluginState') {
       console.log('got sub plugin state', ev.data)
       text('.sub-worker-plugin-state', JSON.stringify(ev.data))
     } else if (data.type === 'importMetaGlobEager') {

--- a/playground/worker/worker/main.js
+++ b/playground/worker/worker/main.js
@@ -2,3 +2,4 @@
 import('./main-module')
 import('./main-classic')
 import('./main-url')
+/* flag: will replace in vite config import("./main-deeply-nested") */


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #13367

#### Background

Currently when there's more than 2 nested workers the Rollup build gets into a deadlock and cannot compile. This was a regression of when worker builds were made sequential (#11218). The reason for sequential building was to solve issues with plugin state pollution in parallel builds

This PR is an attempt at implementing @patak-dev's suggestion in https://github.com/vitejs/vite/pull/13394#issuecomment-157055346. By allowing users to provide plugins as a function we can ensure that each worker build gets a separate instance of plugins and hopefully minimise any state pollution problems.

#### Suggested Solution

Recommend defining `worker.plugins` in config as a function. When a function is used we run worker builds in parallel because each build can instantiate a fresh instance of the plugins to avoid pollution. 

```js
import myWorkerPlugin from 'my-worker-plugin';

export default {
   worker: {
      plugins: () => [myWorkerPlugin()]
   }
}
```

This new worker config API is backwards compatible and existing configs that have custom worker plugins as arrays will work the same as before.

Let me know if I've misunderstood the solution or whether there's more to be done. Given the complexity I understand if you want to close this PR until your own core team can work on a robust solution. 

As always, thanks for all your hard work on this amazing open source tool! 🙇 

### Additional context

I am unable to get the integration test suite running locally. I followed the contributing guidelines, but no luck. No discernible errors thrown will have to dive into the vitest setup scripts to debug. This is on a Mac M1 Pro, Ventura with Node 18 and 20. Had to debug tests via CI. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [x] Documentation update

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
