### PR TITLE
refactor(glob)!: remove `import.meta.globEager`

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -118,7 +118,6 @@ export type {
 } from 'types/customEvent'
 export type {
   ImportGlobFunction,
-  ImportGlobEagerFunction,
   ImportGlobOptions,
   GeneralImportGlobOptions,
   KnownAsTypeMap,

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -34,13 +34,11 @@ import { isCSSRequest, isModuleCSSRequest } from './css'
 const { isMatch, scan } = micromatch
 
 export interface ParsedImportGlob {
-  match: RegExpMatchArray
   index: number
   globs: string[]
   globsResolved: string[]
   isRelative: boolean
   options: GeneralImportGlobOptions
-  type: string
   start: number
   end: number
 }
@@ -109,8 +107,7 @@ export function importGlobPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
-const importGlobRE =
-  /\bimport\.meta\.(glob|globEager|globEagerDefault)(?:<\w+>)?\s*\(/g
+const importGlobRE = /\bimport\.meta\.glob(?:<\w+>)?\s*\(/g
 
 const knownOptions = {
   as: ['string'],
@@ -210,7 +207,6 @@ export async function parseImportGlob(
   const matches = Array.from(cleanCode.matchAll(importGlobRE))
 
   const tasks = matches.map(async (match, index) => {
-    const type = match[1]
     const start = match.index!
 
     const err = (msg: string) => {
@@ -317,13 +313,11 @@ export async function parseImportGlob(
     const isRelative = globs.every((i) => '.!'.includes(i[0]))
 
     return {
-      match,
       index,
       globs,
       globsResolved,
       isRelative,
       options,
-      type,
       start,
       end,
     }
@@ -382,15 +376,6 @@ export async function transformGlobImport(
     resolveId,
   )
   const matchedFiles = new Set<string>()
-
-  // TODO: backwards compatibility
-  matches.forEach((i) => {
-    if (i.type === 'globEager') i.options.eager = true
-    if (i.type === 'globEagerDefault') {
-      i.options.eager = true
-      i.options.import = 'default'
-    }
-  })
 
   if (!matches.length) return null
 

--- a/packages/vite/types/importGlob.d.ts
+++ b/packages/vite/types/importGlob.d.ts
@@ -71,27 +71,3 @@ export interface ImportGlobFunction {
     options: ImportGlobOptions<true, string>,
   ): Record<string, M>
 }
-
-export interface ImportGlobEagerFunction {
-  /**
-   * Eagerly import a list of files with a glob pattern.
-   *
-   * Overload 1: No generic provided, infer the type from `as`
-   */
-  <
-    As extends string,
-    T = As extends keyof KnownAsTypeMap ? KnownAsTypeMap[As] : unknown,
-  >(
-    glob: string | string[],
-    options?: Omit<ImportGlobOptions<boolean, As>, 'eager'>,
-  ): Record<string, T>
-  /**
-   * Eagerly import a list of files with a glob pattern.
-   *
-   * Overload 2: Module generic provided
-   */
-  <M>(
-    glob: string | string[],
-    options?: Omit<ImportGlobOptions<boolean, string>, 'eager'>,
-  ): Record<string, M>
-}

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -19,8 +19,4 @@ interface ImportMeta {
   readonly env: ImportMetaEnv
 
   glob: import('./importGlob').ImportGlobFunction
-  /**
-   * @deprecated Use `import.meta.glob('*', { eager: true })` instead
-   */
-  globEager: import('./importGlob').ImportGlobEagerFunction
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`import.meta.globEager` is deprecated since 3.0.0.
https://v3.vitejs.dev/guide/migration.html#:~:text=import.meta.globEager%20is%20now%20deprecated.%20Use%20import.meta.glob(%27*%27%2C%20%7B%20eager%3A%20true%20%7D)%20instead.

This PR removes `import.meta.globEager` (and the non-documented `import.meta.globEagerDefault`).

### Additional context
I don't remember whether we discussed about this one, but I think it's fine to remove this, because it's been deprecated for more than one year. (v3.0.0 was released on Jul 13th, 2022)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
