### PR TITLE
refactor!: merge `PreviewServerForHook` into `PreviewServer` type

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -201,15 +201,7 @@ import { preview } from 'vite'
 ## `PreviewServer`
 
 ```ts
-interface PreviewServer extends PreviewServerForHook {
-  resolvedUrls: ResolvedServerUrls
-}
-```
-
-## `PreviewServerForHook`
-
-```ts
-interface PreviewServerForHook {
+interface PreviewServer {
   /**
    * The resolved vite config object
    */
@@ -228,7 +220,8 @@ interface PreviewServerForHook {
    */
   httpServer: http.Server
   /**
-   * The resolved urls Vite prints on the CLI
+   * The resolved urls Vite prints on the CLI.
+   * null before server is listening.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -311,9 +311,9 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
 ### `configurePreviewServer`
 
-- **Type:** `(server: PreviewServerForHook) => (() => void) | void | Promise<(() => void) | void>`
+- **Type:** `(server: PreviewServer) => (() => void) | void | Promise<(() => void) | void>`
 - **Kind:** `async`, `sequential`
-- **See also:** [PreviewServerForHook](./api-javascript#previewserverforhook)
+- **See also:** [PreviewServer](./api-javascript#previewserver)
 
   Same as [`configureServer`](/guide/api-plugin.html#configureserver) but for the preview server. Similarly to `configureServer`, the `configurePreviewServer` hook is called before other middlewares are installed. If you want to inject a middleware **after** other middlewares, you can return a function from `configurePreviewServer`, which will be called after internal middlewares are installed:
 

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -34,7 +34,6 @@ export type {
 export type {
   PreviewOptions,
   PreviewServer,
-  PreviewServerForHook,
   PreviewServerHook,
   ResolvedPreviewOptions,
 } from './preview'

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -90,7 +90,7 @@ export interface Plugin extends RollupPlugin {
    */
   configureServer?: ObjectHook<ServerHook>
   /**
-   * Configure the preview server. The hook receives the {@link PreviewServerForHook}
+   * Configure the preview server. The hook receives the {@link PreviewServer}
    * instance. This can also be used to store a reference to the server
    * for use in other hooks.
    *

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -45,8 +45,7 @@ export function resolvePreviewOptions(
   }
 }
 
-// TODO: merge with PreviewServer in Vite 5
-export interface PreviewServerForHook {
+export interface PreviewServer {
   /**
    * The resolved vite config object
    */
@@ -65,7 +64,8 @@ export interface PreviewServerForHook {
    */
   httpServer: http.Server
   /**
-   * The resolved urls Vite prints on the CLI
+   * The resolved urls Vite prints on the CLI.
+   * null before server is listening.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**
@@ -74,13 +74,9 @@ export interface PreviewServerForHook {
   printUrls(): void
 }
 
-export interface PreviewServer extends PreviewServerForHook {
-  resolvedUrls: ResolvedServerUrls
-}
-
 export type PreviewServerHook = (
   this: void,
-  server: PreviewServerForHook,
+  server: PreviewServer,
 ) => (() => void) | void | Promise<(() => void) | void>
 
 /**
@@ -122,7 +118,7 @@ export async function preview(
   const options = config.preview
   const logger = config.logger
 
-  const server: PreviewServerForHook = {
+  const server: PreviewServer = {
     config,
     middlewares: app,
     httpServer,

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -147,8 +147,13 @@ const BASE_PREVIEW_SHORTCUTS: CLIShortcut<PreviewServer>[] = [
     key: 'o',
     description: 'open in browser',
     action(server) {
-      const url = server.resolvedUrls.local[0] ?? server.resolvedUrls.network[0]
-      openBrowser(url, true, server.config.logger)
+      const url =
+        server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+      if (url) {
+        openBrowser(url, true, server.config.logger)
+      } else {
+        server.config.logger.warn('No URL available to open in browser')
+      }
     },
   },
   {


### PR DESCRIPTION
### Description
Merge `PreviewServerForHook` into `PreviewServer` type. `PreviewServerForHook` was added to avoid a breaking change.
https://github.com/vitejs/vite/pull/11647#discussion_r1070955002

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
