### PR TITLE
docs: add warning about `publicDir` and `build` Javacript API

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -151,6 +151,10 @@ async function build(
 ): Promise<RollupOutput | RollupOutput[]>
 ```
 
+::: warning
+When using `build` programmatically, Vite will copy [publicDir](/config/shared-options#publicdir) to the [build.outDir](/config/build-options#build-outdir). If you're using `build` in a secondary process or inside a plugin, you should disable [publicDir](/config/shared-options#publicdir) or [build.copyPublicDir](/config/build-options#build-copypublicdir) flag to avoid copying the public directory multiple times, that can lead in unexpected side effects.
+:::
+
 **Example Usage:**
 
 ```js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
closes #14122

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This PR adds a warning about `publicDir` in the `build` JavaScript API.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
