### PR TITLE
fix(load-fallback): only read file if request has query

### DIFF
--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -9,9 +9,14 @@ export function loadFallbackPlugin(): Plugin {
   return {
     name: 'vite:load-fallback',
     async load(id) {
+      const idWithoutQuery = cleanUrl(id)
+      if (id === idWithoutQuery) {
+        return
+      }
+
       try {
         // if we don't add `await` here, we couldn't catch the error in readFile
-        return await fsp.readFile(cleanUrl(id), 'utf-8')
+        return await fsp.readFile(idWithoutQuery, 'utf-8')
       } catch (e) {
         return fsp.readFile(id, 'utf-8')
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed when using `vite-plugin-inspect` that `vite:load-fallback` appeared to be taking up a lot of time which was odd considering how little this plugin does. Ultimately, this is a false positive since `vite-plugin-inspect` can't actually measure how much cpu time is spent in a plugin for async plugins and instead it includes arbitrary wait time waiting for the promise to resolve while other tasks in the queue are being processed.

That being said, it doesn't really make sense for the `vite:load-fallback` plugin to call `readFile` for all requests as it over-inflates the time spent in this plugin. Skipping this `readFile` doesn't really provide any performance benefits as rollup just does a `readFile` of their own if the load plugin hook returns `undefined`.

### Additional context

Before:
![image](https://github.com/vitejs/vite/assets/17907922/a6bb8d2b-4626-47ef-881c-95c5fac79aeb)

After:
<img width="696" alt="image" src="https://github.com/vitejs/vite/assets/17907922/c79939f1-bd56-47fe-9563-b4b3746b5a8a">


And I also tested with readFileSync to get an idea of how much actual time is spent reading files in this project since the first number was clearly bogus and got:
<img width="460" alt="image" src="https://github.com/vitejs/vite/assets/17907922/d914480c-56eb-4c00-8ba8-58b2893dc1f9">

Since the esbuild and css plugins are also asynchronous, I'm not sure how reliable these other numbers are for vite-plugin-inspect, but that's a different problem for a different repo.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
