### PR TITLE
perf: avoid re-calculating length on every iteration of lastAcceptedHmrDeps for loop

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -381,7 +381,8 @@ export function lexAcceptedHmrDeps(
     currentDep = ''
   }
 
-  for (let i = start; i < code.length; i++) {
+  const codeLength = code.length
+  for (let i = start; i < codeLength; i++) {
     const char = code.charAt(i)
     switch (state) {
       case LexerState.inCall:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Just noticed this, since i loops many chars it should have an impact. Calling .length as I remember does cause latency.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Perf

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
