### PR TITLE
fix: initWasm options should be optional

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -221,7 +221,7 @@ declare module '*.txt' {
 // wasm?init
 declare module '*.wasm?init' {
   const initWasm: (
-    options: WebAssembly.Imports,
+    options?: WebAssembly.Imports,
   ) => Promise<WebAssembly.Instance>
   export default initWasm
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The [importObject](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/instantiate#:~:text=importObject%20Optional) parameter is optional.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
