### PR TITLE
perf(packages\vite\src\node\config.ts): modify the assignment of resolve.extensions

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -513,12 +513,17 @@ export async function resolveConfig(
   const resolvedAlias = normalizeAlias(
     mergeAlias(clientAlias, config.resolve?.alias || []),
   )
-
+  let extensions = DEFAULT_EXTENSIONS
+  if (config.resolve?.extensions) {
+    extensions = [
+      ...new Set([...DEFAULT_EXTENSIONS, ...config.resolve.extensions]),
+    ]
+  }
   const resolveOptions: ResolvedConfig['resolve'] = {
     mainFields: config.resolve?.mainFields ?? DEFAULT_MAIN_FIELDS,
     browserField: config.resolve?.browserField ?? true,
     conditions: config.resolve?.conditions ?? [],
-    extensions: config.resolve?.extensions ?? DEFAULT_EXTENSIONS,
+    extensions,
     dedupe: config.resolve?.dedupe ?? [],
     preserveSymlinks: config.resolve?.preserveSymlinks ?? false,
     alias: resolvedAlias,
@@ -856,7 +861,7 @@ assetFileNames isn't equal for every build.rollupOptions.output. A single patter
   ) {
     resolved.logger.warn(
       colors.yellow(`
-(!) Experimental legacy.buildSsrCjsExternalHeuristics and ssr.format: 'cjs' are going to be removed in Vite 5. 
+(!) Experimental legacy.buildSsrCjsExternalHeuristics and ssr.format: 'cjs' are going to be removed in Vite 5.
     Find more information and give feedback at https://github.com/vitejs/vite/discussions/13816.
 `),
     )
@@ -939,7 +944,6 @@ export async function loadConfigFromFile(
 } | null> {
   const start = performance.now()
   const getTime = () => `${(performance.now() - start).toFixed(2)}ms`
-
   let resolvedPath: string | undefined
 
   if (configFile) {


### PR DESCRIPTION
perf(packages\vite\src\node\config.ts): modify the assignment of resolve.extensions

Merge the original DEFAULT_EXTENSIONS as the default value with the extensions passed in by the user, and take their union as the packaged configuration to pass in.

<!-- Thank you for contributing! -->

### Description

My project is composed of antd+typescript+react. When I configured resolve.extensions to ['.svg'] to ignore the suffix of the svg file, I found that my project crashed. Later, I checked the source code and found resolve.extensions There is a default value, and the configuration passed in by the user will override the default value. Although there is no problem with this behavior, my original project should only need to configure ['.ts', '.tsx', '.svg'], which should be It will not crash, but the project still crashes. Many third-party libraries used in antd still fail to be referenced. I have to add ['.mjs', '.js'], and there is a third-party library that fails to reference. The common feature is that the main or module under pacakge.json does not carry the file suffix. Of course, this is also a normal phenomenon, because there are many kinds of module specifications. However, no matter the dev or prod environment uses esbuild or rollup to build the packaging project, the program will crash because of the file extension. So I think the original default configuration DEFAULT_EXTENSIONS should be necessary, and then adding new users based on the original value requires other configurations, such as '.svg', etc.

[Test project address](https://stackblitz.com/~/github.com/chovrio/antd-demo)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [[Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md)](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [[Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines)](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [[PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md)](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.