### PR TITLE
docs(library-mode): add advanced usage warning

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -214,12 +214,16 @@ Or, if exposing multiple entry points:
 }
 ```
 
-::: tip Note
+::: tip File Extensions
 If the `package.json` does not contain `"type": "module"`, Vite will generate different file extensions for Node.js compatibility. `.js` will become `.mjs` and `.cjs` will become `.js`.
 :::
 
 ::: tip Environment Variables
 In library mode, all `import.meta.env.*` usage are statically replaced when building for production. However, `process.env.*` usage are not, so that consumers of your library can dynamically change it. If this is undesirable, you can use `define: { 'process.env.NODE_ENV': '"production"' }` for example to statically replace them.
+:::
+
+::: warning Advanced Usage
+Library mode includes a simple and opinionated configuration for browser-oriented and JS framework libraries. If you are building non-browser libraries, or require advanced build flows, you can use [Rollup](https://rollupjs.org) or [esbuild](https://esbuild.github.io) directly.
 :::
 
 ## Advanced Base Options


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Supersedes and closes https://github.com/vitejs/vite/pull/13871

Add a "Advanced Usage" warning section about library mode. I initially wanted to document tsup and unbuild too, but I'm afraid this will get PRs from others who want to add _their own library packaging framework_ to the list. So I added Rollup and esbuild only as we use them internally.

(as discussed in the last team meeting)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
