### PR TITLE
chore(scan): remove redundant `scanContext` parameter

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -95,7 +95,7 @@ export function scanImports(config: ResolvedConfig): {
         .map((entry) => `\n  ${colors.dim(entry)}`)
         .join('')}`,
     )
-    return prepareEsbuildScanner(config, entries, deps, missing, scanContext)
+    return prepareEsbuildScanner(config, entries, deps, missing)
   })
 
   const result = esbuildContext
@@ -203,11 +203,8 @@ async function prepareEsbuildScanner(
   entries: string[],
   deps: Record<string, string>,
   missing: Record<string, string>,
-  scanContext?: { cancelled: boolean },
 ): Promise<BuildContext | undefined> {
   const container = await createPluginContainer(config)
-
-  if (scanContext?.cancelled) return
 
   const plugin = esbuildScanPlugin(config, container, deps, missing, entries)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Line 91 has already made a judgment, and there is no need to repeat the judgment inside `prepareEsbuildScanner`.
https://github.com/vitejs/vite/blob/0156bd2cd7d61bb288ff69436a06f5b36109ef58/packages/vite/src/node/optimizer/scan.ts#L91
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
