### PR TITLE
fix: conflicting chunk names for workers with dynamic imports (fix #10057)

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -89,7 +89,7 @@ async function serialBundleWorkerEntry(
         ? workerOutputConfig[0] || {}
         : workerOutputConfig
       : {}
-    const workerName = path.posix.basename(id)
+    const workerName = path.posix.basename(cleanUrl(id))
     const {
       output: [outputChunk, ...outputChunks],
     } = await bundle.generate({

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -89,7 +89,10 @@ async function serialBundleWorkerEntry(
         ? workerOutputConfig[0] || {}
         : workerOutputConfig
       : {}
-    const workerName = path.posix.basename(cleanUrl(id))
+    const workerName = path.posix.basename(
+      cleanUrl(id),
+      path.posix.extname(cleanUrl(id)),
+    )
     const {
       output: [outputChunk, ...outputChunks],
     } = await bundle.generate({

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -89,20 +89,21 @@ async function serialBundleWorkerEntry(
         ? workerOutputConfig[0] || {}
         : workerOutputConfig
       : {}
+    const workerName = path.posix.basename(id)
     const {
       output: [outputChunk, ...outputChunks],
     } = await bundle.generate({
       entryFileNames: path.posix.join(
         config.build.assetsDir,
-        '[name]-[hash].js',
+        `${workerName}-[name]-[hash].js`,
       ),
       chunkFileNames: path.posix.join(
         config.build.assetsDir,
-        '[name]-[hash].js',
+        `${workerName}-[name]-[hash].js`,
       ),
       assetFileNames: path.posix.join(
         config.build.assetsDir,
-        '[name]-[hash].[ext]',
+        `${workerName}-[name]-[hash].[ext]`,
       ),
       ...workerConfig,
       format,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This isn't perfect though, if the user wants to override the output
names using `worker.rollupOptions.output`, he doesn't have access to the
`workerName` as we have, as it's not a real Rollup placeholder

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
