### PR TITLE
feat: allow passing down "null" to disable server watcher

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -176,7 +176,7 @@ The error that appears in the Browser when the fallback happens can be ignored. 
 
 ## server.watch
 
-- **Type:** `object`
+- **Type:** `object | null`
 
 File system watcher options to pass on to [chokidar](https://github.com/paulmillr/chokidar#api).
 
@@ -196,6 +196,8 @@ export default defineConfig({
   },
 })
 ```
+
+If set to `null`, no files will be watched. `server.watcher` will provide a compatible event emitter, but calling `add` or `unwatch` will have no effect.
 
 ::: warning Using Vite on Windows Subsystem for Linux (WSL) 2
 

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -74,7 +74,8 @@ interface ViteDevServer {
    */
   httpServer: http.Server | null
   /**
-   * Chokidar watcher instance.
+   * Chokidar watcher instance. If watcher was disabled in the config,
+   * returns noop event emitter.
    * https://github.com/paulmillr/chokidar#api
    */
   watcher: FSWatcher

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -74,8 +74,8 @@ interface ViteDevServer {
    */
   httpServer: http.Server | null
   /**
-   * Chokidar watcher instance. If watcher was disabled in the config,
-   * returns noop event emitter.
+   * Chokidar watcher instance. If `config.server.watch` is set to `null`,
+   * returns a noop event emitter.
    * https://github.com/paulmillr/chokidar#api
    */
   watcher: FSWatcher

--- a/packages/vite/src/node/server/__tests__/fixtures/watched/index.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/watched/index.js
@@ -1,1 +1,1 @@
-export const test = 'new text'
+export const test = 'initial text'

--- a/packages/vite/src/node/server/__tests__/fixtures/watched/index.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/watched/index.js
@@ -1,0 +1,1 @@
+export const test = 'new text'

--- a/packages/vite/src/node/server/__tests__/fixtures/watched/index.js
+++ b/packages/vite/src/node/server/__tests__/fixtures/watched/index.js
@@ -1,1 +1,0 @@
-export const test = 'initial text'

--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -1,66 +1,24 @@
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { writeFileSync } from 'node:fs'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { createServer } from '../index'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
+const stubGetWatchedCode = /getWatched\(\) \{.+?return \{\};.+?\}/s
 
-afterEach(() => {
-  writeFileSync(
-    resolve(__dirname, 'fixtures/watched/index.js'),
-    "export const test = 'initial text'\n",
-  )
-})
-
-// watcher is unstable on windows
-describe.skipIf(process.platform === 'win32')('watcher configuration', () => {
-  it("when watcher is disabled, editing files doesn't trigger watcher", async () => {
+describe('watcher configuration', () => {
+  it('when watcher is disabled, return noop watcher', async () => {
     const server = await createServer({
       server: {
         watch: null,
       },
     })
-    server.watcher.on('change', () => {
-      expect.unreachable()
-    })
-
-    server.watcher.add(resolve(__dirname, 'fixtures/watched/index.js'))
-    writeFileSync(
-      resolve(__dirname, 'fixtures/watched/index.js'),
-      'export const test = "new text"',
-    )
-
-    // make sure watcher doesn't trigger
-    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(server.watcher.getWatched.toString()).toMatch(stubGetWatchedCode)
   })
 
-  it('when watcher is not disable, editing files triggers watcher', async () => {
-    expect.assertions(1)
+  it('when watcher is not disabled, return chokidar watcher', async () => {
     const server = await createServer({
       server: {
-        // "ready" event might not be triggered on macos otherwise
-        watch:
-          process.platform === 'darwin'
-            ? {
-                useFsEvents: false,
-                usePolling: false,
-              }
-            : {},
+        watch: {},
       },
     })
-    const filename = resolve(__dirname, 'fixtures/watched/index.js')
-
-    return new Promise<void>((resolve) => {
-      server.watcher.on('change', (e) => {
-        expect(e).toMatch('/fixtures/watched/index.js')
-        resolve()
-      })
-
-      server.watcher.on('ready', () => {
-        server.watcher.add(filename)
-        writeFileSync(filename, 'export const test = "new text"')
-      })
-    })
+    expect(server.watcher.getWatched.toString()).not.toMatch(stubGetWatchedCode)
   })
 })

--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -13,46 +13,54 @@ afterEach(() => {
   )
 })
 
-// watcher is unstable on macos and windows
-describe.skipIf(process.platform === 'darwin' || process.platform === 'win32')(
-  'watcher configuration',
-  () => {
-    it("when watcher is disabled, editing files doesn't trigger watcher", async () => {
-      const server = await createServer({
-        server: {
-          watch: null,
-        },
-      })
-      server.watcher.on('change', () => {
-        expect.unreachable()
-      })
-
-      server.watcher.add(resolve(__dirname, 'fixtures/watched/index.js'))
-      writeFileSync(
-        resolve(__dirname, 'fixtures/watched/index.js'),
-        'export const test = "new text"',
-      )
-
-      // make sure watcher doesn't trigger
-      await new Promise((resolve) => setTimeout(resolve, 500))
+// watcher is unstable on windows
+describe.skipIf(process.platform === 'win32')('watcher configuration', () => {
+  it("when watcher is disabled, editing files doesn't trigger watcher", async () => {
+    const server = await createServer({
+      server: {
+        watch: null,
+      },
+    })
+    server.watcher.on('change', () => {
+      expect.unreachable()
     })
 
-    it('when watcher is not disable, editing files triggers watcher', async () => {
-      expect.assertions(1)
-      const server = await createServer()
-      const filename = resolve(__dirname, 'fixtures/watched/index.js')
+    server.watcher.add(resolve(__dirname, 'fixtures/watched/index.js'))
+    writeFileSync(
+      resolve(__dirname, 'fixtures/watched/index.js'),
+      'export const test = "new text"',
+    )
 
-      return new Promise<void>((resolve) => {
-        server.watcher.on('change', (e) => {
-          expect(e).toMatch('/fixtures/watched/index.js')
-          resolve()
-        })
+    // make sure watcher doesn't trigger
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  })
 
-        server.watcher.on('ready', () => {
-          server.watcher.add(filename)
-          writeFileSync(filename, 'export const test = "new text"')
-        })
+  it('when watcher is not disable, editing files triggers watcher', async () => {
+    expect.assertions(1)
+    const server = await createServer({
+      server: {
+        // "ready" event might not be triggered on macos otherwise
+        watch:
+          process.platform === 'darwin'
+            ? {
+                useFsEvents: false,
+                usePolling: false,
+              }
+            : {},
+      },
+    })
+    const filename = resolve(__dirname, 'fixtures/watched/index.js')
+
+    return new Promise<void>((resolve) => {
+      server.watcher.on('change', (e) => {
+        expect(e).toMatch('/fixtures/watched/index.js')
+        resolve()
+      })
+
+      server.watcher.on('ready', () => {
+        server.watcher.add(filename)
+        writeFileSync(filename, 'export const test = "new text"')
       })
     })
-  },
-)
+  })
+})

--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -1,0 +1,43 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { writeFileSync } from 'node:fs'
+import { expect, it } from 'vitest'
+import { createServer } from '../index'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+it("when watcher is disabled, editing files doesn't trigger watcher", async () => {
+  const server = await createServer({
+    server: {
+      watch: null,
+    },
+  })
+  server.watcher.on('change', () => {
+    expect.unreachable()
+  })
+
+  server.watcher.add(resolve(__dirname, 'fixtures/watched/index.js'))
+  writeFileSync(
+    resolve(__dirname, 'fixtures/watched/index.js'),
+    'export const test = "new text"',
+  )
+
+  // make sure watcher doesn't trigger
+  await new Promise((resolve) => setTimeout(resolve, 500))
+})
+
+it('when watcher is not disable, editing files triggers watcher', async () => {
+  expect.assertions(1)
+  const server = await createServer()
+  const filename = resolve(__dirname, 'fixtures/watched/index.js')
+
+  server.watcher.add(filename)
+  return new Promise<void>((resolve) => {
+    server.watcher.on('change', (e) => {
+      expect(e).toMatch('/fixtures/watched/index.js')
+      resolve()
+    })
+
+    writeFileSync(filename, 'export const test = "new text"')
+  })
+})

--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -53,6 +53,6 @@ describe.skipIf(process.platform === 'darwin' || process.platform === 'win32')(
           writeFileSync(filename, 'export const test = "new text"')
         })
       })
-    }, 5_000)
+    })
   },
 )

--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -1,43 +1,58 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { writeFileSync } from 'node:fs'
-import { expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { createServer } from '../index'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-it("when watcher is disabled, editing files doesn't trigger watcher", async () => {
-  const server = await createServer({
-    server: {
-      watch: null,
-    },
-  })
-  server.watcher.on('change', () => {
-    expect.unreachable()
-  })
-
-  server.watcher.add(resolve(__dirname, 'fixtures/watched/index.js'))
+afterEach(() => {
   writeFileSync(
     resolve(__dirname, 'fixtures/watched/index.js'),
-    'export const test = "new text"',
+    "export const test = 'initial text'\n",
   )
-
-  // make sure watcher doesn't trigger
-  await new Promise((resolve) => setTimeout(resolve, 500))
 })
 
-it('when watcher is not disable, editing files triggers watcher', async () => {
-  expect.assertions(1)
-  const server = await createServer()
-  const filename = resolve(__dirname, 'fixtures/watched/index.js')
+// watcher is unstable on macos and windows
+describe.skipIf(process.platform === 'darwin' || process.platform === 'win32')(
+  'watcher configuration',
+  () => {
+    it("when watcher is disabled, editing files doesn't trigger watcher", async () => {
+      const server = await createServer({
+        server: {
+          watch: null,
+        },
+      })
+      server.watcher.on('change', () => {
+        expect.unreachable()
+      })
 
-  server.watcher.add(filename)
-  return new Promise<void>((resolve) => {
-    server.watcher.on('change', (e) => {
-      expect(e).toMatch('/fixtures/watched/index.js')
-      resolve()
+      server.watcher.add(resolve(__dirname, 'fixtures/watched/index.js'))
+      writeFileSync(
+        resolve(__dirname, 'fixtures/watched/index.js'),
+        'export const test = "new text"',
+      )
+
+      // make sure watcher doesn't trigger
+      await new Promise((resolve) => setTimeout(resolve, 500))
     })
 
-    writeFileSync(filename, 'export const test = "new text"')
-  })
-})
+    it('when watcher is not disable, editing files triggers watcher', async () => {
+      expect.assertions(1)
+      const server = await createServer()
+      const filename = resolve(__dirname, 'fixtures/watched/index.js')
+
+      return new Promise<void>((resolve) => {
+        server.watcher.on('change', (e) => {
+          expect(e).toMatch('/fixtures/watched/index.js')
+          resolve()
+        })
+
+        server.watcher.on('ready', () => {
+          server.watcher.add(filename)
+          writeFileSync(filename, 'export const test = "new text"')
+        })
+      })
+    }, 5_000)
+  },
+)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -45,7 +45,7 @@ import type { BindShortcutsOptions } from '../shortcuts'
 import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
-import { resolveChokidarOptions } from '../watch'
+import { createNoopWatcher, resolveChokidarOptions } from '../watch'
 import type { PluginContainer } from './pluginContainer'
 import { createPluginContainer } from './pluginContainer'
 import type { WebSocketServer } from './ws'
@@ -85,10 +85,10 @@ export interface ServerOptions extends CommonServerOptions {
    */
   hmr?: HmrOptions | boolean
   /**
-   * chokidar watch options
+   * chokidar watch options or null to disable FS watching
    * https://github.com/paulmillr/chokidar#api
    */
-  watch?: WatchOptions
+  watch?: WatchOptions | null
   /**
    * Create Vite dev server to be used as a middleware in an existing server
    * @default false
@@ -359,11 +359,17 @@ export async function _createServer(
     setClientErrorHandler(httpServer, config.logger)
   }
 
-  const watcher = chokidar.watch(
-    // config file dependencies and env file might be outside of root
-    [root, ...config.configFileDependencies, config.envDir],
-    resolvedWatchOptions,
-  ) as FSWatcher
+  const watchEnabled =
+    !!serverConfig.watch ||
+    serverConfig.watch === undefined ||
+    serverConfig.hmr !== false
+  const watcher = watchEnabled
+    ? (chokidar.watch(
+        // config file dependencies and env file might be outside of root
+        [root, ...config.configFileDependencies, config.envDir],
+        resolvedWatchOptions,
+      ) as FSWatcher)
+    : createNoopWatcher(resolvedWatchOptions)
 
   const moduleGraph: ModuleGraph = new ModuleGraph((url, ssr) =>
     container.resolveId(url, undefined, { ssr }),

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -359,10 +359,8 @@ export async function _createServer(
     setClientErrorHandler(httpServer, config.logger)
   }
 
-  const watchEnabled =
-    !!serverConfig.watch ||
-    serverConfig.watch === undefined ||
-    serverConfig.hmr !== false
+  // eslint-disable-next-line eqeqeq
+  const watchEnabled = serverConfig.watch !== null
   const watcher = watchEnabled
     ? (chokidar.watch(
         // config file dependencies and env file might be outside of root

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -1,5 +1,6 @@
+import { EventEmitter } from 'node:events'
 import glob from 'fast-glob'
-import type { WatchOptions } from 'dep-types/chokidar'
+import type { FSWatcher, WatchOptions } from 'dep-types/chokidar'
 import type { ResolvedConfig } from '.'
 
 export function resolveChokidarOptions(
@@ -22,4 +23,30 @@ export function resolveChokidarOptions(
   }
 
   return resolvedWatchOptions
+}
+
+class NoopWatcher extends EventEmitter implements FSWatcher {
+  constructor(public options: WatchOptions) {
+    super()
+  }
+
+  add() {
+    return this
+  }
+
+  unwatch() {
+    return this
+  }
+
+  getWatched() {
+    return {}
+  }
+
+  async close() {
+    // noop
+  }
+}
+
+export function createNoopWatcher(options: WatchOptions): FSWatcher {
+  return new NoopWatcher(options)
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #14189

Providing `null` in `server.watch` config option (similar to `build.watch`) now disables the watcher altogether. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

This helps with watch leaks in Vitest.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
