### PR TITLE
refactor: update to tsconfck3 with lazy cache

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^1.3.0",
-    "tsconfck": "^3.0.0-next.2",
+    "tsconfck": "^3.0.0-next.3",
     "tslib": "^2.6.1",
     "types": "link:./types",
     "ufo": "^1.2.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^1.3.0",
-    "tsconfck": "^2.1.2",
+    "tsconfck": "^3.0.0-next.2",
     "tslib": "^2.6.1",
     "types": "link:./types",
     "ufo": "^1.2.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -132,7 +132,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^1.3.0",
-    "tsconfck": "^3.0.0-next.7",
+    "tsconfck": "^3.0.0-next.8",
     "tslib": "^2.6.1",
     "types": "link:./types",
     "ufo": "^1.2.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^1.3.0",
-    "tsconfck": "^3.0.0-next.5",
+    "tsconfck": "^3.0.0-next.7",
     "tslib": "^2.6.1",
     "types": "link:./types",
     "ufo": "^1.2.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^1.3.0",
-    "tsconfck": "^3.0.0-next.3",
+    "tsconfck": "^3.0.0-next.4",
     "tslib": "^2.6.1",
     "types": "link:./types",
     "ufo": "^1.2.0",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^1.3.0",
-    "tsconfck": "^3.0.0-next.4",
+    "tsconfck": "^3.0.0-next.5",
     "tslib": "^2.6.1",
     "types": "link:./types",
     "ufo": "^1.2.0",

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -478,7 +478,10 @@ async function loadTsconfigJsonForFile(
     } else {
       tsconfckCache = new TSConfckCache<TSConfckParseResult>()
     }
-    const result = await parse(filename, { cache: tsconfckCache })
+    const result = await parse(filename, {
+      cache: tsconfckCache,
+      ignoreNodeModules: true,
+    })
     // tsconfig could be out of root, make sure it is watched on dev
     if (server && result.tsconfigFile) {
       ensureWatchedFile(server.watcher, result.tsconfigFile, server.config.root)

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -472,7 +472,6 @@ function initTSConfck(force?: boolean) {
   if (force || !tsconfckParseOptions)
     tsconfckParseOptions = {
       cache: new TSConfckCache(),
-      resolveWithEmptyIfConfigNotFound: true,
     }
 }
 
@@ -482,7 +481,7 @@ async function loadTsconfigJsonForFile(
   try {
     const result = await parse(filename, tsconfckParseOptions)
     // tsconfig could be out of root, make sure it is watched on dev
-    if (server && result.tsconfigFile !== 'no_tsconfig_file_found') {
+    if (server && result.tsconfigFile) {
       ensureWatchedFile(server.watcher, result.tsconfigFile, server.config.root)
     }
     return result.tsconfig

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       tsconfck:
-        specifier: ^3.0.0-next.5
-        version: 3.0.0-next.5(typescript@5.0.2)
+        specifier: ^3.0.0-next.7
+        version: 3.0.0-next.7(typescript@5.0.2)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -9919,8 +9919,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.0-next.5(typescript@5.0.2):
-    resolution: {integrity: sha512-JG2DcnGaBb3nYb7Nenvm4xOf76MduAT75um1EWPvWXB+qZkR3PM1XhMGnDqGThohMqnzUCnoU8hRab9TUg2MOw==}
+  /tsconfck@3.0.0-next.7(typescript@5.0.2):
+    resolution: {integrity: sha512-UPPXypsZ/a8Y6gfNBSCpc+eSJizU+IXHTqTI7x0rV3iWRxw2tEDFWXkX5L7+gOTjmlr6AUXfWhsQevsbOc4HwA==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,8 +397,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       tsconfck:
-        specifier: ^3.0.0-next.7
-        version: 3.0.0-next.7(typescript@5.0.2)
+        specifier: ^3.0.0-next.8
+        version: 3.0.0-next.8(typescript@5.0.2)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -10020,8 +10020,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.0-next.7(typescript@5.0.2):
-    resolution: {integrity: sha512-UPPXypsZ/a8Y6gfNBSCpc+eSJizU+IXHTqTI7x0rV3iWRxw2tEDFWXkX5L7+gOTjmlr6AUXfWhsQevsbOc4HwA==}
+  /tsconfck@3.0.0-next.8(typescript@5.0.2):
+    resolution: {integrity: sha512-lg4uK51cWF+Ciqj+1c+/LH9GVa866AsV0xEUlbtKaXuMlyr6rTMQm8t/vCOaSr8jfl1HC5oL6Jc+LTAEILNddg==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       tsconfck:
-        specifier: ^3.0.0-next.3
-        version: 3.0.0-next.3(typescript@5.0.2)
+        specifier: ^3.0.0-next.4
+        version: 3.0.0-next.4(typescript@5.0.2)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -4085,7 +4085,7 @@ packages:
     resolution: {integrity: sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.0.0
+      vite: workspace:*
       vue: ^3.2.25
     dependencies:
       vite: link:packages/vite
@@ -9919,8 +9919,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.0-next.3(typescript@5.0.2):
-    resolution: {integrity: sha512-hJYNl6vHJ6fovGXLmWhVznMAkap2Yt93h+MrVJd9sJkhAAaC/JpFTr/faI9iip9m0RAHsjN1jg+oz9uvqWGCoQ==}
+  /tsconfck@3.0.0-next.4(typescript@5.0.2):
+    resolution: {integrity: sha512-m7vs176zWv0JPh1FvkY+XsMJPfznG5/IoXSuXXvTG0VwaFzc3eN86n3tZoS4BnAFIPA995vbEmx6zc3o6XVnVw==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       tsconfck:
-        specifier: ^3.0.0-next.4
-        version: 3.0.0-next.4(typescript@5.0.2)
+        specifier: ^3.0.0-next.5
+        version: 3.0.0-next.5(typescript@5.0.2)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -9919,8 +9919,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.0-next.4(typescript@5.0.2):
-    resolution: {integrity: sha512-m7vs176zWv0JPh1FvkY+XsMJPfznG5/IoXSuXXvTG0VwaFzc3eN86n3tZoS4BnAFIPA995vbEmx6zc3o6XVnVw==}
+  /tsconfck@3.0.0-next.5(typescript@5.0.2):
+    resolution: {integrity: sha512-JG2DcnGaBb3nYb7Nenvm4xOf76MduAT75um1EWPvWXB+qZkR3PM1XhMGnDqGThohMqnzUCnoU8hRab9TUg2MOw==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       tsconfck:
-        specifier: ^2.1.2
-        version: 2.1.2(typescript@5.0.2)
+        specifier: ^3.0.0-next.2
+        version: 3.0.0-next.2(typescript@5.0.2)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -9919,12 +9919,12 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@2.1.2(typescript@5.0.2):
-    resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
-    engines: {node: ^14.13.1 || ^16 || >=18}
+  /tsconfck@3.0.0-next.2(typescript@5.0.2):
+    resolution: {integrity: sha512-FSDEF2dQMgoZcvLgAl0TB1/loIK5rQCtuZdiaZh4ib/pPtLLQPw0u1/tXh+ZolVNOTt4hzLo6LfnrQMTGIudMQ==}
+    engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
-      typescript: ^4.3.5 || ^5.0.0
+      typescript: ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       tsconfck:
-        specifier: ^3.0.0-next.2
-        version: 3.0.0-next.2(typescript@5.0.2)
+        specifier: ^3.0.0-next.3
+        version: 3.0.0-next.3(typescript@5.0.2)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -9919,8 +9919,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.0-next.2(typescript@5.0.2):
-    resolution: {integrity: sha512-FSDEF2dQMgoZcvLgAl0TB1/loIK5rQCtuZdiaZh4ib/pPtLLQPw0u1/tXh+ZolVNOTt4hzLo6LfnrQMTGIudMQ==}
+  /tsconfck@3.0.0-next.3(typescript@5.0.2):
+    resolution: {integrity: sha512-hJYNl6vHJ6fovGXLmWhVznMAkap2Yt93h+MrVJd9sJkhAAaC/JpFTr/faI9iip9m0RAHsjN1jg+oz9uvqWGCoQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

tsconfck 3 lazily caches found and parsed tsconfig files to ensure minimal use of fs without having to use the `root` or `findAll + tsconfigPaths` options.

This PR updates to a beta release to gather feedback. vite beta bundling a tsconfck beta should be fine, before releasing vite5.0 tsconfck 3.0 is going to be released and added.

### Additional context

The removal of async init and root options means we no longer have to do the song and dance to initialize it, however the way it was tied to  root/workspace root could mean it wasn't meant to be shared before. It should be safe now but extra care is needed to ensure we don't break stuff.

It should also be checked how perf is affected. cold start/ready should become slightly faster while page ready could become a little slower. hmr should be unaffected.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
