### PR TITLE
docs: remove npm@6 commands

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -66,9 +66,6 @@ Then follow the prompts!
 You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold a Vite + Vue project, run:
 
 ```bash
-# npm 6.x
-npm create vite@latest my-vue-app --template vue
-
 # npm 7+, extra double-dash is needed:
 npm create vite@latest my-vue-app -- --template vue
 

--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -28,9 +28,6 @@ Then follow the prompts!
 You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold a Vite + Vue project, run:
 
 ```bash
-# npm 6.x
-npm create vite@latest my-vue-app --template vue
-
 # npm 7+, extra double-dash is needed:
 npm create vite@latest my-vue-app -- --template vue
 


### PR DESCRIPTION
### Description
npm@6 is the default package manager for Node.js 14.x.
Node.js 16.x uses npm@8 and Node.js 18.x/20.x uses npm@9.
Given that Node.js 14.x has reached EOL, I think we can remove this part.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
