### PR TITLE
fix: disable code splitting for optimized dependencies

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -803,7 +803,6 @@ async function prepareEsbuildOptimizerRun(
     target: isBuild ? config.build.target || undefined : ESBUILD_MODULES_TARGET,
     external,
     logLevel: 'error',
-    splitting: true,
     sourcemap: true,
     outdir: processingCacheDir,
     ignoreAnnotations: !isBuild,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Disables code splitting for optimized dependencies.
Fixes #12423.
Fixes #5142.

### Additional context

The [esbuild docs](https://esbuild.github.io/api/#splitting) say that "code splitting is still a work in progress...with a known [ordering issue](https://github.com/evanw/esbuild/issues/399)" and is [not "ready for use in production yet"](https://github.com/evanw/esbuild/issues/3259#issuecomment-1644729215). The ordering issue has been around for several years with no end in sight.

It seems problematic to rely on a feature from esbuild that is known to have issues and therefore causes issues for the users of Vite.

See https://github.com/vitejs/vite/issues/12423#issuecomment-1699140622 for more context.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
