### PR TITLE
fix(create-vite): remove redundant tsconfig include configuration

### DIFF
--- a/packages/create-vite/template-svelte-ts/tsconfig.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.json
@@ -15,6 +15,6 @@
     "checkJs": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
+  "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/create-vite/template-vue-ts/tsconfig.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.json
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The `"src/**/*.d.ts"` configuration seems redundant.
Because `"src/**/*.ts"` can actually match to `.d.ts` files.
The description of include configuration on the Typescript official website is: `"e.g. .ts, .tsx, and .d.ts by default"`, but this does not mean that after you configure include in tsconfig.json, you must put `"src/**/*.ts"` and `"src/**/*.d.ts"` are configured.
I have tested that `"src/**/*.ts"` can match the `.d.ts` file in the project.
Or is this intentionally set by the vite team so that developers can directly see that the `.d.ts` file can be resolved by Typescript?
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
