### PR TITLE
chore(templates): alias react to preact/compat in tsconfig

### DIFF
--- a/packages/create-vite/template-preact-ts/tsconfig.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.json
@@ -5,6 +5,10 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
### Description

Adds TS aliases for `react` and `react-dom`, which we (the Preact team) [recommend users who wish to make use of `preact/compat` do](https://preactjs.com/guide/v10/getting-started#typescript-preactcompat-configuration) (`@preactjs/preset-vite` has the `react`, `react-dom` -> `preact/compat` aliases enabled by default).

### Additional context

I've seen a handful of users confused about type errors, assuming the preset would handle aliasing fully, including the TS portion. Obviously this isn't the case, but I'd like to provide a nicer experience out-of-the-box for these users.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
