### PR TITLE
feat: `import.meta.glob` with `as: 'path'`

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -398,7 +398,7 @@ const modules = {
 `{ as: 'path' }` gives you the relative path of the matched files.
 
 ```js
-const modules = import.meta.glob('./*.svg', { as: 'url' })
+const modules = import.meta.glob('./*.svg', { as: 'path', eager: true })
 
 /**
 const modules = {

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -382,7 +382,31 @@ const modules = {
 }
 ```
 
-`{ as: 'url' }` is also supported for loading assets as URLs.
+`{ as: 'url' }` can be used for loading assets as URLs.
+
+```js
+const modules = import.meta.glob('./*.png', { as: 'url' })
+
+/**
+const modules = {
+  './foo.png': () => import('./foo.png?url'),
+  './bar.png': () => import('./bar.png?url'),
+}
+*/
+```
+
+`{ as: 'path' }` gives you the relative path of the matched files.
+
+```js
+const modules = import.meta.glob('./*.svg', { as: 'url' })
+
+/**
+const modules = {
+  './foo.svg': './foo.svg',
+  './bar.svg': './bar.svg',
+}
+*/
+```
 
 ### Multiple Patterns
 

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
@@ -51,6 +51,8 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": (
 
 
 });
+export const importAsPathEager = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": \\"./modules/a.ts\\",\\"./modules/b.ts\\": \\"./modules/b.ts\\",\\"./modules/index.ts\\": \\"./modules/index.ts\\"});
+export const importAsPath = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": async () => \\"./modules/a.ts\\",\\"./modules/b.ts\\": async () => \\"./modules/b.ts\\",\\"./modules/index.ts\\": async () => \\"./modules/index.ts\\"});
 "
 `;
 
@@ -105,6 +107,8 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": (
 
 
 });
+export const importAsPathEager = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": \\"./modules/a.ts\\",\\"./modules/b.ts\\": \\"./modules/b.ts\\",\\"./modules/index.ts\\": \\"./modules/index.ts\\"});
+export const importAsPath = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": async () => \\"./modules/a.ts\\",\\"./modules/b.ts\\": async () => \\"./modules/b.ts\\",\\"./modules/index.ts\\": async () => \\"./modules/index.ts\\"});
 "
 `;
 

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.test.ts.snap
@@ -51,7 +51,10 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": (
 
 
 });
-export const importAsPathEager = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": \\"./modules/a.ts\\",\\"./modules/b.ts\\": \\"./modules/b.ts\\",\\"./modules/index.ts\\": \\"./modules/index.ts\\"});
+export const importAsPathEager = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": \\"./modules/a.ts\\",\\"./modules/b.ts\\": \\"./modules/b.ts\\",\\"./modules/index.ts\\": \\"./modules/index.ts\\"
+
+
+});
 export const importAsPath = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": async () => \\"./modules/a.ts\\",\\"./modules/b.ts\\": async () => \\"./modules/b.ts\\",\\"./modules/index.ts\\": async () => \\"./modules/index.ts\\"});
 "
 `;
@@ -107,7 +110,10 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": (
 
 
 });
-export const importAsPathEager = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": \\"./modules/a.ts\\",\\"./modules/b.ts\\": \\"./modules/b.ts\\",\\"./modules/index.ts\\": \\"./modules/index.ts\\"});
+export const importAsPathEager = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": \\"./modules/a.ts\\",\\"./modules/b.ts\\": \\"./modules/b.ts\\",\\"./modules/index.ts\\": \\"./modules/index.ts\\"
+
+
+});
 export const importAsPath = /* #__PURE__ */ Object.assign({\\"./modules/a.ts\\": async () => \\"./modules/a.ts\\",\\"./modules/b.ts\\": async () => \\"./modules/b.ts\\",\\"./modules/index.ts\\": async () => \\"./modules/index.ts\\"});
 "
 `;

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
@@ -66,3 +66,10 @@ export const cleverCwd2 = import.meta.glob([
   '../fixture-b/*.ts',
   '!**/index.ts',
 ])
+
+export const importAsPathEager = import.meta.glob('./modules/*.ts', {
+  as: 'path',
+  eager: true,
+})
+
+export const importAsPath = import.meta.glob('./modules/*.ts', { as: 'path' })

--- a/packages/vite/types/importGlob.d.ts
+++ b/packages/vite/types/importGlob.d.ts
@@ -34,6 +34,7 @@ export interface KnownAsTypeMap {
   raw: string
   url: string
   worker: Worker
+  path: string
 }
 
 export interface ImportGlobFunction {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['**/__tests__/**/*.spec.[tj]s'],
+    include: ['**/__tests__/**/*.{spec,test}.[tj]s'],
     exclude: [
       '**/node_modules/**',
       '**/dist/**',


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`import.meta.glob` is great for accessing folders directly from the client code. However, the current state it always implies some side effects (importing modules, or bundling assets).

In some cases, we just want to have the info of the file exists the info, and do something with them later.

For example, I might want to get a list of assets I have under the `/public` folder. Current we can use `as: url` to do:

```ts
const files = Object.values(import.meta.glob('../public/**.txt', { as: 'url', eager: true }))

// I might fetch it manually later, or do something else
const content = await fetch(files[0])
```

However, `url` will inject the imports and bundle them as assets (double assets, as they are already copied as public assets). Meanwhile, this warning will be printed at dev time:

```
Instead of /public/foo.txt?url, use /foo.txt?url.
Assets in the public directory are served at the root path.
```

So, this PR added a `as` type `path` to `import.meta.glob` for only globbing the import path without any side-effects.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
