### PR TITLE
fix(create-vite): strict checks on vite.config.ts

### DIFF
--- a/packages/create-vite/template-react-ts/tsconfig.node.json
+++ b/packages/create-vite/template-react-ts/tsconfig.node.json
@@ -4,7 +4,11 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
### Description

After creating a project using create-vite with React and TypeScript, and adding `plugin:@typescript-eslint/strict-type-checked` according to README.md, rule `@typescript-eslint/no-unnecessary-condition` throws an error on vite.config.ts when running lint.

```
/path/to/my-project/vite.config.ts
  0:1  error  This rule requires the `strictNullChecks` compiler option to be turned on to function correctly  @typescript-eslint/no-unnecessary-condition
```

Here is a small project to reproduce this error: <https://github.com/nekketsuuu/vite-config-js-strict/commit/380208d43e5348293297e454d5d94c41d9d56fee>.

That error is because TS strict mode is not enabled at tsconfig.node.json. So, this patch enables the same linting config at tsconfig.node.json as that of <https://github.com/vitejs/vite/blob/cd6bf29ca4b677ff0d6e2bf36416a65b1a6ffa21/packages/create-vite/template-react-ts/tsconfig.json>.

Also see: 4ffaeee2033531788bc6d4d2541b8b5e44352591 https://github.com/vitejs/vite/pull/12604
Follow-up: 2ad78aa205563f87b1607d0789608c13695cd9da https://github.com/vitejs/vite/pull/13749

### Additional context

Nothing.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
