### PR TITLE
refactor: ensure HTML is stripped of generated blank lines

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -588,7 +588,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           }
         }
 
-        processedHtml.set(id, s.toString())
+        processedHtml.set(id, s.toString().replace(/(^\s*\n\s*|\s*\n\s*$)/gm, ''))
 
         // inject module preload polyfill only when configured and needed
         const { modulePreload } = config.build

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -323,6 +323,20 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             config,
             publicToRelative,
           )
+        const nodeStartWithLeadingWhitespace = (
+          node: DefaultTreeAdapterMap,
+        ) => {
+          const lineStartOffset =
+            node.sourceCodeLocation!.startOffset -
+            node.sourceCodeLocation!.startCol
+          const line = s.slice(
+            lineStartOffset,
+            node.sourceCodeLocation!.startOffset,
+          )
+          return /\S/.test(line)
+            ? node.sourceCodeLocation!.startOffset
+            : lineStartOffset
+        }
 
         // pre-transform
         html = await applyHtmlTransforms(html, preHooks, {
@@ -444,7 +458,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                     const importExpression = `\nimport ${JSON.stringify(url)}`
                     styleUrls.push({
                       url,
-                      start: node.sourceCodeLocation!.startOffset,
+                      start: nodeStartWithLeadingWhitespace(node),
                       end: node.sourceCodeLocation!.endOffset,
                     })
                     js += importExpression
@@ -516,7 +530,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             // remove the script tag from the html. we are going to inject new
             // ones in the end.
             s.remove(
-              node.sourceCodeLocation!.startOffset,
+              nodeStartWithLeadingWhitespace(node),
               node.sourceCodeLocation!.endOffset,
             )
           }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -326,8 +326,10 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         const nodeStartWithLeadingWhitespace = (
           node: DefaultTreeAdapterMap['node'],
         ) => {
-          if (node.sourceCodeLocation!.startOffset == 0)
+          if (node.sourceCodeLocation!.startOffset === 0)
             return node.sourceCodeLocation!.startOffset
+
+          // Gets the offset for the start of the line that the node is on
           const lineStartOffset =
             node.sourceCodeLocation!.startOffset -
             node.sourceCodeLocation!.startCol

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -324,7 +324,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             publicToRelative,
           )
         const nodeStartWithLeadingWhitespace = (
-          node: DefaultTreeAdapterMap,
+          node: DefaultTreeAdapterMap['node'],
         ) => {
           const lineStartOffset =
             node.sourceCodeLocation!.startOffset -

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -588,7 +588,10 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           }
         }
 
-        processedHtml.set(id, s.toString().replace(/(^\s*\n\s*|\s*\n\s*$)/gm, ''))
+        processedHtml.set(
+          id,
+          s.toString().replace(/(^\s*\n\s*|\s*\n\s*$)/gm, ''),
+        )
 
         // inject module preload polyfill only when configured and needed
         const { modulePreload } = config.build

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -588,10 +588,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           }
         }
 
-        processedHtml.set(
-          id,
-          s.toString().replace(/(^\s*\n\s*|\s*\n\s*$)/gm, ''),
-        )
+        processedHtml.set(id, s.toString())
 
         // inject module preload polyfill only when configured and needed
         const { modulePreload } = config.build

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -326,6 +326,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         const nodeStartWithLeadingWhitespace = (
           node: DefaultTreeAdapterMap['node'],
         ) => {
+          if (node.sourceCodeLocation!.startOffset == 0)
+            return node.sourceCodeLocation!.startOffset
           const lineStartOffset =
             node.sourceCodeLocation!.startOffset -
             node.sourceCodeLocation!.startCol

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -323,6 +323,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             config,
             publicToRelative,
           )
+        // Determines true start position for the node, either the < character
+        // position, or the newline at the end of the previous line's node.
         const nodeStartWithLeadingWhitespace = (
           node: DefaultTreeAdapterMap['node'],
         ) => {
@@ -338,7 +340,19 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             lineStartOffset,
             node.sourceCodeLocation!.startOffset,
           )
-          return /\S/.test(line)
+
+          // <previous-line-node></previous-line-node>
+          // <target-node></target-node>
+          //
+          // Here we want to target the newline at the end of the previous line
+          // as the start position for our target.
+          //
+          // <previous-node></previous-node>
+          // <doubled-up-node></doubled-up-node><target-node></target-node>
+          //
+          // However, if there is content between our target node start and the
+          // previous newline, we cannot strip it out without risking content deletion.
+          return line.trim()
             ? node.sourceCodeLocation!.startOffset
             : lineStartOffset
         }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -329,7 +329,8 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           if (node.sourceCodeLocation!.startOffset === 0)
             return node.sourceCodeLocation!.startOffset
 
-          // Gets the offset for the start of the line that the node is on
+          // Gets the offset for the start of the line including the
+          // newline trailing the previous node
           const lineStartOffset =
             node.sourceCodeLocation!.startOffset -
             node.sourceCodeLocation!.startCol


### PR DESCRIPTION
### Description

Fixes #14273

### Additional context

Let me know if a test case is desired, and how I'm to add one. I did take a look around but found no obvious location; while `playground/html` exists, it appears to be entirely for browser/integration tests.

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [X] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
