### PR TITLE
perf: implement startsWith

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -12,6 +12,7 @@ import {
   posToNumber,
   processSrcSetSync,
   resolveHostname,
+  startsWith,
 } from '../utils'
 
 describe('bareImportRE', () => {
@@ -258,5 +259,24 @@ describe('processSrcSetSync', () => {
         ({ url }) => path.posix.join(devBase, url),
       ),
     ).toBe('/base/nested/asset.png 1x, /base/nested/asset.png 2x')
+  })
+})
+
+describe('startsWith', () => {
+  test('same with String.prototype.startsWith', () => {
+    const str = 'hello world'
+    expect(startsWith(str, 'he') === str.startsWith('he')).toBeTruthy()
+    expect(startsWith(str, 'world') === str.startsWith('world')).toBeTruthy()
+    expect(
+      startsWith(str, 'hello world!') === str.startsWith('hello world!'),
+    ).toBeTruthy()
+  })
+
+  test('string is undefined', () => {
+    let str: undefined | string
+    expect(
+      Boolean(startsWith(undefined, 'hello world!')) ===
+        Boolean(str?.startsWith('hello world!')),
+    ).toBeTruthy()
   })
 })

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -35,6 +35,7 @@ import {
   joinUrlSegments,
   normalizePath,
   requireResolveFromRootWithFallback,
+  startsWith,
   withTrailingSlash,
 } from './utils'
 import { manifestPlugin } from './plugins/manifest'
@@ -713,7 +714,7 @@ function prepareOutDir(
     for (const outDir of nonDuplicateDirs) {
       if (
         fs.existsSync(outDir) &&
-        !normalizePath(outDir).startsWith(withTrailingSlash(config.root))
+        !startsWith(normalizePath(outDir), withTrailingSlash(config.root))
       ) {
         // warn if outDir is outside of root
         config.logger.warn(
@@ -737,7 +738,7 @@ function prepareOutDir(
           const relative = path.relative(outDir, dir)
           if (
             relative &&
-            !relative.startsWith('..') &&
+            !startsWith(relative, '..') &&
             !path.isAbsolute(relative)
           ) {
             return relative
@@ -1241,7 +1242,7 @@ function areSeparateFolders(a: string, b: string) {
   const nb = normalizePath(b)
   return (
     na !== nb &&
-    !na.startsWith(withTrailingSlash(nb)) &&
-    !nb.startsWith(withTrailingSlash(na))
+    !startsWith(na, withTrailingSlash(nb)) &&
+    !startsWith(nb, withTrailingSlash(na))
   )
 }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -39,6 +39,7 @@ import {
   mergeConfig,
   normalizeAlias,
   normalizePath,
+  startsWith,
   withTrailingSlash,
 } from './utils'
 import {
@@ -1088,7 +1089,7 @@ async function bundleConfigFile(
               }
 
               // partial deno support as `npm:` does not work with esbuild
-              if (id.startsWith('npm:')) {
+              if (startsWith(id, 'npm:')) {
                 return { external: true }
               }
 

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { parse } from 'dotenv'
 import { expand } from 'dotenv-expand'
-import { arraify, tryStatSync } from './utils'
+import { arraify, startsWith, tryStatSync } from './utils'
 import type { UserConfig } from './config'
 
 export function loadEnv(
@@ -52,7 +52,7 @@ export function loadEnv(
 
   // only keys that start with prefix are exposed to client
   for (const [key, value] of Object.entries(parsed)) {
-    if (prefixes.some((prefix) => key.startsWith(prefix))) {
+    if (prefixes.some((prefix) => startsWith(key, prefix))) {
       env[key] = value
     }
   }
@@ -60,7 +60,7 @@ export function loadEnv(
   // check if there are actual env variables starting with VITE_*
   // these are typically provided inline and should be prioritized
   for (const key in process.env) {
-    if (prefixes.some((prefix) => key.startsWith(prefix))) {
+    if (prefixes.some((prefix) => startsWith(key, prefix))) {
       env[key] = process.env[key] as string
     }
   }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -10,6 +10,7 @@ import {
   isExternalUrl,
   moduleListContains,
   normalizePath,
+  startsWith,
 } from '../utils'
 import { browserExternalId, optionalPeerDepId } from '../plugins/resolve'
 import { isCSSRequest, isModuleCSSRequest } from '../plugins/css'
@@ -94,18 +95,18 @@ export function esbuildDepPlugin(
       // map importer ids to file paths for correct resolution
       _importer = importer in qualified ? qualified[importer] : importer
     }
-    const resolver = kind.startsWith('require') ? _resolveRequire : _resolve
+    const resolver = startsWith(kind, 'require') ? _resolveRequire : _resolve
     return resolver(id, _importer, undefined, ssr)
   }
 
   const resolveResult = (id: string, resolved: string) => {
-    if (resolved.startsWith(browserExternalId)) {
+    if (startsWith(resolved, browserExternalId)) {
       return {
         path: id,
         namespace: 'browser-external',
       }
     }
-    if (resolved.startsWith(optionalPeerDepId)) {
+    if (startsWith(resolved, optionalPeerDepId)) {
       return {
         path: resolved,
         namespace: 'optional-peer-dep',
@@ -144,7 +145,7 @@ export function esbuildDepPlugin(
         },
         async ({ path: id, importer, kind }) => {
           // if the prefix exist, it is already converted to `import`, so set `external: true`
-          if (id.startsWith(convertedExternalPrefix)) {
+          if (startsWith(id, convertedExternalPrefix)) {
             return {
               path: id.slice(convertedExternalPrefix.length),
               external: true,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -22,6 +22,7 @@ import {
   normalizeId,
   normalizePath,
   removeLeadingSlash,
+  startsWith,
   tryStatSync,
 } from '../utils'
 import { transformWithEsbuild } from '../plugins/esbuild'
@@ -960,7 +961,7 @@ export function createIsOptimizedDepFile(
   config: ResolvedConfig,
 ): (id: string) => boolean {
   const depsCacheDirPrefix = getDepsCacheDirPrefix(config)
-  return (id) => id.startsWith(depsCacheDirPrefix)
+  return (id) => startsWith(id, depsCacheDirPrefix)
 }
 
 export function createIsOptimizedDepUrl(
@@ -971,7 +972,7 @@ export function createIsOptimizedDepUrl(
 
   // determine the url prefix of files inside cache directory
   const depsCacheDirRelative = normalizePath(path.relative(root, depsCacheDir))
-  const depsCacheDirPrefix = depsCacheDirRelative.startsWith('../')
+  const depsCacheDirPrefix = startsWith(depsCacheDirRelative, '../')
     ? // if the cache directory is outside root, the url prefix would be something
       // like '/@fs/absolute/path/to/node_modules/.vite'
       `/@fs/${removeLeadingSlash(normalizePath(depsCacheDir))}`
@@ -980,7 +981,7 @@ export function createIsOptimizedDepUrl(
       `/${depsCacheDirRelative}`
 
   return function isOptimizedDepUrl(url: string): boolean {
-    return url.startsWith(depsCacheDirPrefix)
+    return startsWith(url, depsCacheDirPrefix)
   }
 }
 
@@ -1196,7 +1197,7 @@ const lockfileFormats = [
   { name: 'pnpm-lock.yaml', checkPatches: false, manager: 'pnpm' }, // Included in lockfile
   { name: 'bun.lockb', checkPatches: true, manager: 'bun' },
 ].sort((_, { manager }) => {
-  return process.env.npm_config_user_agent?.startsWith(manager) ? 1 : -1
+  return startsWith(process.env.npm_config_user_agent, manager) ? 1 : -1
 })
 const lockfileNames = lockfileFormats.map((l) => l.name)
 

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -66,7 +66,7 @@ export function expandGlobIds(id: string, config: ResolvedConfig): string[] {
 
     const possibleExportPaths: string[] = []
     for (const key in exports) {
-      if (key.startsWith('.')) {
+      if (key[0] === '.') {
         if (key.includes('*')) {
           // "./glob/*": {
           //   "browser": "./dist/glob/*-browser/*.js", <-- get this one

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -31,6 +31,7 @@ import {
   multilineCommentsRE,
   normalizePath,
   singlelineCommentsRE,
+  startsWith,
   virtualModulePrefix,
   virtualModuleRE,
 } from '../utils'
@@ -437,7 +438,7 @@ function esbuildScanPlugin(
               // since they may be used in the template
               const contents =
                 content +
-                (loader.startsWith('ts') ? extractImportPaths(content) : '')
+                (startsWith(loader, 'ts') ? extractImportPaths(content) : '')
 
               const key = `${path}?id=${scriptId++}`
               if (contents.includes('import.meta.glob')) {

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -23,6 +23,7 @@ import {
   joinUrlSegments,
   normalizePath,
   removeLeadingSlash,
+  startsWith,
   withTrailingSlash,
 } from '../utils'
 import { FS_PREFIX } from '../constants'
@@ -166,7 +167,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     },
 
     async load(id) {
-      if (id.startsWith(viteBuildPublicIdPrefix)) {
+      if (startsWith(id, viteBuildPublicIdPrefix)) {
         id = id.slice(viteBuildPublicIdPrefix.length)
       }
 
@@ -241,7 +242,8 @@ export function checkPublicFile(
   }
   const publicFile = path.join(publicDir, cleanUrl(url))
   if (
-    !normalizePath(publicFile).startsWith(
+    !startsWith(
+      normalizePath(publicFile),
       withTrailingSlash(normalizePath(publicDir)),
     )
   ) {
@@ -272,7 +274,7 @@ function fileToDevUrl(id: string, config: ResolvedConfig) {
   if (checkPublicFile(id, config)) {
     // in public dir during dev, keep the url as-is
     rtn = id
-  } else if (id.startsWith(withTrailingSlash(config.root))) {
+  } else if (startsWith(id, withTrailingSlash(config.root))) {
     // in project root, infer short public path
     rtn = '/' + path.posix.relative(config.root, id)
   } else {

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -9,6 +9,7 @@ import {
   isParentDirectory,
   normalizePath,
   slash,
+  startsWith,
   transformStableResult,
 } from '../utils'
 import { CLIENT_ENTRY } from '../constants'
@@ -80,7 +81,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             const templateLiteral = (ast as any).body[0].expression
             if (templateLiteral.expressions.length) {
               const pattern = buildGlobPattern(templateLiteral)
-              if (pattern.startsWith('**')) {
+              if (startsWith(pattern, '**')) {
                 // don't transform for patterns like this
                 // because users won't intend to do that in most cases
                 continue

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -54,6 +54,7 @@ import {
   processSrcSet,
   removeDirectQuery,
   requireResolveFromRootWithFallback,
+  startsWith,
   stripBase,
   stripBomTag,
 } from '../utils'
@@ -1879,11 +1880,11 @@ async function rebaseUrls(
   const rebaseFn = (url: string) => {
     if (url[0] === '/') return url
     // ignore url's starting with variable
-    if (url.startsWith(variablePrefix)) return url
+    if (startsWith(url, variablePrefix)) return url
     // match alias, no need to rewrite
     for (const { find } of alias) {
       const matches =
-        typeof find === 'string' ? url.startsWith(find) : find.test(url)
+        typeof find === 'string' ? startsWith(url, find) : find.test(url)
       if (matches) {
         return url
       }

--- a/packages/vite/src/node/plugins/dataUri.ts
+++ b/packages/vite/src/node/plugins/dataUri.ts
@@ -3,6 +3,7 @@
 // ref https://github.com/vitejs/vite/issues/1428#issuecomment-757033808
 import { URL } from 'node:url'
 import type { Plugin } from '../plugin'
+import { startsWith } from '../utils'
 
 const dataUriRE = /^([^/]+\/[^;,]+)(;base64)?,([\s\S]*)$/
 const base64RE = /base64/i
@@ -53,7 +54,7 @@ export function dataURIPlugin(): Plugin {
     },
 
     load(id) {
-      if (id.startsWith(dataUriPrefix)) {
+      if (startsWith(id, dataUriPrefix)) {
         return resolved.get(id.slice(dataUriPrefix.length))
       }
     },

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -21,6 +21,7 @@ import {
   normalizePath,
   processSrcSet,
   removeLeadingSlash,
+  startsWith,
   urlCanParse,
 } from '../utils'
 import type { ResolvedConfig } from '../config'
@@ -968,7 +969,7 @@ export function htmlEnvHook(config: ResolvedConfig): IndexHtmlTransformHook {
 
   // account for user env defines
   for (const key in config.define) {
-    if (key.startsWith(`import.meta.env.`)) {
+    if (startsWith(key, `import.meta.env.`)) {
       const val = config.define[key]
       if (typeof val === 'string') {
         try {
@@ -987,7 +988,7 @@ export function htmlEnvHook(config: ResolvedConfig): IndexHtmlTransformHook {
       if (key in env) {
         return env[key]
       } else {
-        if (envPrefix.some((prefix) => key.startsWith(prefix))) {
+        if (envPrefix.some((prefix) => startsWith(key, prefix))) {
           const relativeHtml = normalizePath(
             path.relative(config.root, ctx.filename),
           )

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -39,6 +39,7 @@ import {
   normalizePath,
   prettifyUrl,
   removeImportQuery,
+  startsWith,
   stripBase,
   stripBomTag,
   timeFrom,
@@ -185,7 +186,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       })};`
       // account for user env defines
       for (const key in config.define) {
-        if (key.startsWith(`import.meta.env.`)) {
+        if (startsWith(key, `import.meta.env.`)) {
           const val = config.define[key]
           _env += `${key} = ${
             typeof val === 'string' ? val : JSON.stringify(val)
@@ -336,7 +337,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
         // normalize all imports into resolved URLs
         // e.g. `import 'foo'` -> `import '/@fs/.../node_modules/foo/index.js'`
-        if (resolved.id.startsWith(withTrailingSlash(root))) {
+        if (startsWith(resolved.id, withTrailingSlash(root))) {
           // in root: infer short absolute path from root
           url = resolved.id.slice(root.length)
         } else if (
@@ -673,7 +674,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                 config.logger.error(e.message, { error: e })
               })
             }
-          } else if (!importer.startsWith(withTrailingSlash(clientDir))) {
+          } else if (!startsWith(importer, withTrailingSlash(clientDir))) {
             if (!isInNodeModules(importer)) {
               // check @vite-ignore which suppresses dynamic import warning
               const hasViteIgnore = hasViteIgnoreRE.test(

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -16,6 +16,7 @@ import {
   isInNodeModules,
   moduleListContains,
   numberToPos,
+  startsWith,
   withTrailingSlash,
 } from '../utils'
 import type { Plugin } from '../plugin'
@@ -272,7 +273,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
         // normalize all imports into resolved URLs
         // e.g. `import 'foo'` -> `import '/@fs/.../node_modules/foo/index.js'`
-        if (resolved.id.startsWith(withTrailingSlash(root))) {
+        if (startsWith(resolved.id, withTrailingSlash(root))) {
           // in root: infer short absolute path from root
           url = resolved.id.slice(root.length)
         } else {

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -27,6 +27,7 @@ import {
   evalValue,
   normalizePath,
   slash,
+  startsWith,
   transformStableResult,
 } from '../utils'
 import { isCSSRequest, isModuleCSSRequest } from './css'
@@ -231,7 +232,7 @@ export async function parseImportGlob(
       }) as any
     } catch (e) {
       const _e = e as any
-      if (_e.message && _e.message.startsWith('Unterminated string constant'))
+      if (_e.message && startsWith(_e.message, 'Unterminated string constant'))
         return undefined!
       if (lastTokenPos == null || lastTokenPos <= start) throw _e
 
@@ -602,9 +603,9 @@ export async function toAbsoluteGlob(
   root = globSafePath(root)
   const dir = importer ? globSafePath(dirname(importer)) : root
   if (glob[0] === '/') return pre + posix.join(root, glob.slice(1))
-  if (glob.startsWith('./')) return pre + posix.join(dir, glob.slice(2))
-  if (glob.startsWith('../')) return pre + posix.join(dir, glob)
-  if (glob.startsWith('**')) return pre + glob
+  if (startsWith(glob, './')) return pre + posix.join(dir, glob.slice(2))
+  if (startsWith(glob, '../')) return pre + posix.join(dir, glob)
+  if (startsWith(glob, '**')) return pre + glob
 
   const isSubImportsPattern = glob[0] === '#' && glob.includes('*')
 
@@ -642,7 +643,7 @@ export function getCommonBase(globsResolved: string[]): null | string {
   const dirS = bases[0].split('/')
   for (let i = 0; i < dirS.length; i++) {
     const candidate = dirS.slice(0, i + 1).join('/')
-    if (bases.every((base) => base.startsWith(candidate)))
+    if (bases.every((base) => startsWith(base, candidate)))
       commonAncestor = candidate
     else break
   }
@@ -653,5 +654,5 @@ export function getCommonBase(globsResolved: string[]): null | string {
 
 export function isVirtualModule(id: string): boolean {
   // https://vitejs.dev/guide/api-plugin.html#virtual-modules-convention
-  return id.startsWith('virtual:') || id[0] === '\0' || !id.includes('/')
+  return startsWith(id, 'virtual:') || id[0] === '\0' || !id.includes('/')
 }

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -14,6 +14,7 @@ import {
   isInNodeModules,
   isOptimizable,
   moduleListContains,
+  startsWith,
   withTrailingSlash,
 } from '../utils'
 import { getDepsOptimizer } from '../optimizer'
@@ -115,7 +116,7 @@ function matches(pattern: string | RegExp, importee: string) {
   if (importee === pattern) {
     return true
   }
-  return importee.startsWith(withTrailingSlash(pattern))
+  return startsWith(importee, withTrailingSlash(pattern))
 }
 
 function getAliasPatterns(

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -8,6 +8,7 @@ import {
   isDefined,
   isInNodeModules,
   normalizePath,
+  startsWith,
   withTrailingSlash,
 } from '../utils'
 import { LogLevels } from '../logger'
@@ -251,7 +252,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
             let log = colors.dim(withTrailingSlash(relativeOutDir))
             log +=
               !config.build.lib &&
-              entry.name.startsWith(withTrailingSlash(assetsDir))
+              startsWith(entry.name, withTrailingSlash(assetsDir))
                 ? colors.dim(assetsDir) +
                   group.color(
                     entry.name

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -2,7 +2,7 @@ import { Worker } from 'okie'
 import type { Terser } from 'dep-types/terser'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '..'
-import { requireResolveFromRootWithFallback } from '../utils'
+import { requireResolveFromRootWithFallback, startsWith } from '../utils'
 
 let terserPath: string | undefined
 const loadTerserPath = (root: string) => {
@@ -69,7 +69,7 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
         safari10: true,
         ...config.build.terserOptions,
         sourceMap: !!outputOptions.sourcemap,
-        module: outputOptions.format.startsWith('es'),
+        module: startsWith(outputOptions.format, 'es'),
         toplevel: outputOptions.format === 'cjs',
       })
       return {

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -1,13 +1,12 @@
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
-import { startsWith } from '../utils'
 import { fileToUrl } from './asset'
 
 const wasmHelperId = '\0vite/wasm-helper'
 
 const wasmHelper = async (opts = {}, url: string) => {
   let result
-  if (startsWith(url, 'data:')) {
+  if (url.startsWith('data:')) {
     const urlContent = url.replace(/^data:.*?base64,/, '')
     let bytes
     if (typeof Buffer === 'function' && typeof Buffer.from === 'function') {
@@ -34,7 +33,7 @@ const wasmHelper = async (opts = {}, url: string) => {
     const contentType = response.headers.get('Content-Type') || ''
     if (
       'instantiateStreaming' in WebAssembly &&
-      startsWith(contentType, 'application/wasm')
+      contentType.startsWith('application/wasm')
     ) {
       result = await WebAssembly.instantiateStreaming(response, opts)
     } else {

--- a/packages/vite/src/node/plugins/wasm.ts
+++ b/packages/vite/src/node/plugins/wasm.ts
@@ -1,12 +1,13 @@
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
+import { startsWith } from '../utils'
 import { fileToUrl } from './asset'
 
 const wasmHelperId = '\0vite/wasm-helper'
 
 const wasmHelper = async (opts = {}, url: string) => {
   let result
-  if (url.startsWith('data:')) {
+  if (startsWith(url, 'data:')) {
     const urlContent = url.replace(/^data:.*?base64,/, '')
     let bytes
     if (typeof Buffer === 'function' && typeof Buffer.from === 'function') {
@@ -33,7 +34,7 @@ const wasmHelper = async (opts = {}, url: string) => {
     const contentType = response.headers.get('Content-Type') || ''
     if (
       'instantiateStreaming' in WebAssembly &&
-      contentType.startsWith('application/wasm')
+      startsWith(contentType, 'application/wasm')
     ) {
       result = await WebAssembly.instantiateStreaming(response, opts)
     } else {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -16,7 +16,12 @@ import {
 import { openBrowser } from './server/openBrowser'
 import compression from './server/middlewares/compression'
 import { proxyMiddleware } from './server/middlewares/proxy'
-import { resolveHostname, resolveServerUrls, shouldServeFile } from './utils'
+import {
+  resolveHostname,
+  resolveServerUrls,
+  shouldServeFile,
+  startsWith,
+} from './utils'
 import { printServerUrls } from './logger'
 import { bindCLIShortcuts } from './shortcuts'
 import type { BindCLIShortcutsOptions } from './shortcuts'
@@ -208,7 +213,7 @@ export async function preview(
   if (options.open) {
     const path = typeof options.open === 'string' ? options.open : previewBase
     openBrowser(
-      path.startsWith('http')
+      startsWith(path, 'http')
         ? path
         : new URL(path, `${protocol}://${hostname.name}:${serverPort}`).href,
       true,

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -8,6 +8,7 @@ import { CLIENT_DIR } from '../constants'
 import {
   createDebugger,
   normalizePath,
+  startsWith,
   unique,
   withTrailingSlash,
   wrapId,
@@ -44,7 +45,7 @@ export interface HmrContext {
 }
 
 export function getShortName(file: string, root: string): string {
-  return file.startsWith(withTrailingSlash(root))
+  return startsWith(file, withTrailingSlash(root))
     ? path.posix.relative(root, file)
     : file
 }
@@ -64,7 +65,7 @@ export async function handleHMRUpdate(
   )
   const isEnv =
     config.inlineConfig.envFile !== false &&
-    (fileName === '.env' || fileName.startsWith('.env.'))
+    (fileName === '.env' || startsWith(fileName, '.env.'))
   if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
     debugHmr?.(`[config change] ${colors.dim(shortFile)}`)
@@ -89,7 +90,7 @@ export async function handleHMRUpdate(
   debugHmr?.(`[file change] ${colors.dim(shortFile)}`)
 
   // (dev only) the client itself cannot be hot updated.
-  if (file.startsWith(withTrailingSlash(normalizedClientDir))) {
+  if (startsWith(file, withTrailingSlash(normalizedClientDir))) {
     ws.send({
       type: 'full-reload',
       path: '*',

--- a/packages/vite/src/node/server/middlewares/base.ts
+++ b/packages/vite/src/node/server/middlewares/base.ts
@@ -1,6 +1,11 @@
 import type { Connect } from 'dep-types/connect'
 import type { ViteDevServer } from '..'
-import { joinUrlSegments, stripBase, withTrailingSlash } from '../../utils'
+import {
+  joinUrlSegments,
+  startsWith,
+  stripBase,
+  withTrailingSlash,
+} from '../../utils'
 
 // this middleware is only active when (base !== '/')
 
@@ -14,7 +19,7 @@ export function baseMiddleware({
     const path = parsed.pathname || '/'
     const base = config.rawBase
 
-    if (path.startsWith(base)) {
+    if (startsWith(path, base)) {
       // rewrite url to remove base. this ensures that other middleware does
       // not need to consider base being prepended or not
       req.url = stripBase(url, base)

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -32,6 +32,7 @@ import {
   joinUrlSegments,
   normalizePath,
   processSrcSetSync,
+  startsWith,
   stripBase,
   unwrapId,
   wrapId,
@@ -77,7 +78,7 @@ export function createDevHtmlTransformFn(
 }
 
 function getHtmlFilename(url: string, server: ViteDevServer) {
-  if (url.startsWith(FS_PREFIX)) {
+  if (startsWith(url, FS_PREFIX)) {
     return decodeURIComponent(fsPathFromId(url))
   } else {
     return decodeURIComponent(

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -4,7 +4,7 @@ import httpProxy from 'http-proxy'
 import type { Connect } from 'dep-types/connect'
 import type { HttpProxy } from 'dep-types/http-proxy'
 import colors from 'picocolors'
-import { createDebugger } from '../../utils'
+import { createDebugger, startsWith } from '../../utils'
 import type { CommonServerOptions, ResolvedConfig } from '../..'
 
 const debug = createDebugger('vite:proxy')
@@ -123,8 +123,8 @@ export function proxyMiddleware(
           const [proxy, opts] = proxies[context]
           if (
             opts.ws ||
-            opts.target?.toString().startsWith('ws:') ||
-            opts.target?.toString().startsWith('wss:')
+            startsWith(opts.target?.toString(), 'ws:') ||
+            startsWith(opts.target?.toString(), 'wss:')
           ) {
             if (opts.rewrite) {
               req.url = opts.rewrite(url)
@@ -173,6 +173,6 @@ export function proxyMiddleware(
 function doesProxyContextMatchUrl(context: string, url: string): boolean {
   return (
     (context[0] === '^' && new RegExp(context).test(url)) ||
-    url.startsWith(context)
+    startsWith(url, context)
   )
 }

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -19,6 +19,7 @@ import {
   removeLeadingSlash,
   shouldServeFile,
   slash,
+  startsWith,
   withTrailingSlash,
 } from '../../utils'
 
@@ -110,7 +111,7 @@ export function serveStaticMiddleware(
     for (const { find, replacement } of server.config.resolve.alias) {
       const matches =
         typeof find === 'string'
-          ? pathname.startsWith(find)
+          ? startsWith(pathname, find)
           : find.test(pathname)
       if (matches) {
         redirectedPathname = pathname.replace(find, replacement)
@@ -119,7 +120,7 @@ export function serveStaticMiddleware(
     }
     if (redirectedPathname) {
       // dir is pre-normalized to posix style
-      if (redirectedPathname.startsWith(withTrailingSlash(dir))) {
+      if (startsWith(redirectedPathname, withTrailingSlash(dir))) {
         redirectedPathname = redirectedPathname.slice(dir.length)
       }
     }
@@ -160,7 +161,7 @@ export function serveRawFsMiddleware(
     // reference assets that are also out of served root. In such cases
     // the paths are rewritten to `/@fs/` prefixed paths and must be served by
     // searching based from fs root.
-    if (url.pathname.startsWith(FS_PREFIX)) {
+    if (startsWith(url.pathname, FS_PREFIX)) {
       const pathname = decodeURI(url.pathname)
       // restrict files outside of `fs.allow`
       if (

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -15,6 +15,7 @@ import {
   prettifyUrl,
   removeImportQuery,
   removeTimestampQuery,
+  startsWith,
   unwrapId,
   withTrailingSlash,
 } from '../../utils'
@@ -78,7 +79,7 @@ export function transformMiddleware(
         if (depsOptimizer?.isOptimizedDepUrl(url)) {
           // If the browser is requesting a source map for an optimized dep, it
           // means that the dependency has already been pre-bundled and loaded
-          const sourcemapPath = url.startsWith(FS_PREFIX)
+          const sourcemapPath = startsWith(url, FS_PREFIX)
             ? fsPathFromId(url)
             : normalizePath(path.resolve(root, url.slice(1)))
           try {
@@ -130,10 +131,10 @@ export function transformMiddleware(
       // check if public dir is inside root dir
       const publicDir = normalizePath(server.config.publicDir)
       const rootDir = normalizePath(server.config.root)
-      if (publicDir.startsWith(withTrailingSlash(rootDir))) {
+      if (startsWith(publicDir, withTrailingSlash(rootDir))) {
         const publicPath = `${publicDir.slice(rootDir.length)}/`
         // warn explicit public paths
-        if (url.startsWith(withTrailingSlash(publicPath))) {
+        if (startsWith(url, withTrailingSlash(publicPath))) {
           let warning: string
 
           if (isImportRequest(url)) {

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -6,6 +6,7 @@ import {
   normalizePath,
   removeImportQuery,
   removeTimestampQuery,
+  startsWith,
 } from '../utils'
 import { FS_PREFIX } from '../constants'
 import type { TransformResult } from './transformRequest'
@@ -396,7 +397,7 @@ export class ModuleGraph {
     if (
       url !== resolvedId &&
       !url.includes('\0') &&
-      !url.startsWith(`virtual:`)
+      !startsWith(url, `virtual:`)
     ) {
       const ext = extname(cleanUrl(resolvedId))
       if (ext) {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -76,6 +76,7 @@ import {
   normalizePath,
   numberToPos,
   prettifyUrl,
+  startsWith,
   timeFrom,
   unwrapId,
 } from '../utils'
@@ -701,7 +702,7 @@ export async function createPluginContainer(
         break
       }
 
-      if (debugResolve && rawId !== id && !rawId.startsWith(FS_PREFIX)) {
+      if (debugResolve && rawId !== id && !startsWith(rawId, FS_PREFIX)) {
         const key = rawId + id
         // avoid spamming
         if (!seenResolves[key]) {

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -13,6 +13,7 @@ import {
   isInNodeModules,
   lookupFile,
   normalizePath,
+  startsWith,
   withTrailingSlash,
 } from '../utils'
 import type { Logger, ResolvedConfig } from '..'
@@ -342,7 +343,7 @@ export function cjsShouldExternalizeForSSR(
     // deep imports, check ext before externalizing - only externalize
     // extension-less imports and explicit .js imports
     if (
-      id.startsWith(withTrailingSlash(e)) &&
+      startsWith(id, withTrailingSlash(e)) &&
       (!path.extname(id) || id.endsWith('.js'))
     ) {
       return true

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -5,6 +5,7 @@ import type { ViteDevServer } from '../server'
 import {
   dynamicImport,
   isBuiltin,
+  startsWith,
   unwrapId,
   usingDynamicImport,
 } from '../utils'
@@ -268,7 +269,7 @@ async function nodeImport(
   resolveOptions: InternalResolveOptionsWithOverrideConditions,
 ) {
   let url: string
-  if (id.startsWith('node:') || id.startsWith('data:') || isBuiltin(id)) {
+  if (startsWith(id, 'node:') || startsWith(id, 'data:') || isBuiltin(id)) {
     url = id
   } else {
     const resolved = tryNodeResolve(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4085,7 +4085,7 @@ packages:
     resolution: {integrity: sha512-R6JDUfiZbJA9cMiguQ7jxALsgiprjBeHL5ikpXfJCH62pPHtI+JdJ5xWj6Ev73yXSlYl86+blXn1kZHQ7uElxw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.0.0
+      vite: workspace:*
       vue: ^3.2.25
     dependencies:
       vite: link:packages/vite


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`String.prototype.startsWith`  is too slow, so I rewrite a function with the same effect:

```ts
export function startsWith(str: string | undefined, startStr: string): boolean {
  if (str === undefined) return false
  if (startStr.length > str.length) return false
  return str?.slice(0, startStr.length) === startStr
}
```


### Additional context



[stackblitz benchmark](https://stackblitz.com/edit/vitest-dev-vitest-6gcbz4?file=test%2Fbasic.bench.ts)


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
