### PR TITLE
test(worker): correct sourcemap boundary after injecting env

### DIFF
--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -1,7 +1,15 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { isBuild, page, readManifest, testDir, untilUpdated } from '~utils'
+import {
+  isBuild,
+  isServe,
+  page,
+  readManifest,
+  testDir,
+  untilUpdated,
+  viteTestUrl,
+} from '~utils'
 
 test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong')
@@ -143,3 +151,22 @@ test('import.meta.glob eager in worker', async () => {
     '["',
   )
 })
+
+test.runIf(isServe)('sourcemap boundary', async () => {
+  const response = page.waitForResponse(/my-worker.ts\?type=module&worker_file/)
+  await page.goto(viteTestUrl)
+  const content = await (await response).text()
+  const { mappings } = decodeSourceMapUrl(content)
+  expect(mappings.startsWith(';')).toBeTruthy()
+  expect(mappings.endsWith(';')).toBeFalsy()
+})
+
+function decodeSourceMapUrl(content: string) {
+  return JSON.parse(
+    atob(
+      content.match(
+        /\/\/[#@]\ssourceMappingURL=\s*data:application\/json;base64,(\S+)/,
+      )?.[1],
+    ),
+  )
+}

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -163,10 +163,11 @@ test.runIf(isServe)('sourcemap boundary', async () => {
 
 function decodeSourceMapUrl(content: string) {
   return JSON.parse(
-    atob(
+    Buffer.from(
       content.match(
         /\/\/[#@]\ssourceMappingURL=\s*data:application\/json;base64,(\S+)/,
       )?.[1],
-    ),
+      'base64',
+    ).toString(),
   )
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

refs #14216 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
