### PR TITLE
feat!: deprecate cjs node api

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -4,6 +4,29 @@ See [Rollup's troubleshooting guide](https://rollupjs.org/troubleshooting/) for 
 
 If the suggestions here don't work, please try posting questions on [GitHub Discussions](https://github.com/vitejs/vite/discussions) or in the `#help` channel of [Vite Land Discord](https://chat.vitejs.dev).
 
+## CJS
+
+### Vite CJS Node API deprecated
+
+The CJS build of Vite's Node API is deprecated and will be removed in Vite 6. See the [GitHub discussion](https://github.com/vitejs/vite/discussions/13928) for more context. You should update your files or frameworks to import the ESM build of Vite instead.
+
+In a basic Vite project, make sure:
+
+1. The `vite.config.js` file content is using the ESM syntax.
+2. The closest `package.json` file has `"type": "module"`, or use the `.mjs` extension, e.g. `vite.config.mjs`.
+
+For other projects, there are a few general approaches:
+
+- **Configure ESM as default, opt-in to CJS if needed:** Add `"type": "module"` in the project `package.json`. All `*.js` files are now interpreted as ESM and needs to use the ESM syntax. You can rename a file with the `.cjs` extension to keep using CJS instead.
+- **Keep CJS as default, opt-in to ESM if needed:** If the project `package.json` does not have `"type": "module"`, all `*.js` files are interpreted as CJS. You can rename a file with the `.mjs` extension to use ESM instead.
+- **Dynamically import Vite:** If you need to keep using CJS, you can dynamically import Vite using `import('vite')` instead. This requires your code to be written in an `async` context, but should still be trivial as Vite's API is mostly asynchronous.
+
+If you're unsure where the warning is coming from, you can run your script with the `VITE_CJS_TRACE=true` flag to log the stack trace:
+
+```bash
+VITE_CJS_TRACE=true vite dev
+```
+
 ## CLI
 
 ### `Error: Cannot find module 'C:\foo\bar&baz\vite\bin\vite.js'`

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -27,6 +27,12 @@ If you're unsure where the warning is coming from, you can run your script with 
 VITE_CJS_TRACE=true vite dev
 ```
 
+If you'd like to temporarily ignore the warning, you can run your script with the `VITE_CJS_IGNORE_WARNING=true` flag:
+
+```bash
+VITE_CJS_IGNORE_WARNING=true vite dev
+```
+
 ## CLI
 
 ### `Error: Cannot find module 'C:\foo\bar&baz\vite\bin\vite.js'`

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -19,7 +19,7 @@ For other projects, there are a few general approaches:
 
 - **Configure ESM as default, opt-in to CJS if needed:** Add `"type": "module"` in the project `package.json`. All `*.js` files are now interpreted as ESM and needs to use the ESM syntax. You can rename a file with the `.cjs` extension to keep using CJS instead.
 - **Keep CJS as default, opt-in to ESM if needed:** If the project `package.json` does not have `"type": "module"`, all `*.js` files are interpreted as CJS. You can rename a file with the `.mjs` extension to use ESM instead.
-- **Dynamically import Vite:** If you need to keep using CJS, you can dynamically import Vite using `import('vite')` instead. This requires your code to be written in an `async` context, but should still be trivial as Vite's API is mostly asynchronous.
+- **Dynamically import Vite:** If you need to keep using CJS, you can dynamically import Vite using `import('vite')` instead. This requires your code to be written in an `async` context, but should still be manageable as Vite's API is mostly asynchronous.
 
 If you're unsure where the warning is coming from, you can run your script with the `VITE_CJS_TRACE=true` flag to log the stack trace:
 

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -37,6 +37,7 @@ unsupportedCJS.forEach((name) => {
 
 function warnCjsUsage() {
   if (process.env.VITE_CJS_IGNORE_WARNING) return
+  globalThis.__vite_cjs_skip_clear_screen = true
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
   const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
   log(

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -36,6 +36,7 @@ unsupportedCJS.forEach((name) => {
 })
 
 function warnCjsUsage() {
+  if (process.env.VITE_CJS_IGNORE_WARNING) return
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
   const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
   log(

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -1,5 +1,7 @@
 /* eslint-disable no-restricted-globals */
 
+warnCjsUsage()
+
 // type utils
 module.exports.defineConfig = (config) => config
 
@@ -32,3 +34,13 @@ unsupportedCJS.forEach((name) => {
     )
   }
 })
+
+function warnCjsUsage() {
+  const yellow = (str) => `\u001b[33m${str}\u001b[39m`
+  const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
+  log(
+    yellow(
+      `The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.`,
+    ),
+  )
+}

--- a/packages/vite/index.d.cts
+++ b/packages/vite/index.d.cts
@@ -1,3 +1,5 @@
 // Intentionally empty so the CJS exports is untyped. We can't share the ESM types
 // as it causes an incorrect error message on TypeScript side. More context:
 // https://github.com/vitejs/vite/issues/11552#issuecomment-1564789056
+
+export {}

--- a/packages/vite/index.d.cts
+++ b/packages/vite/index.d.cts
@@ -1,5 +1,6 @@
-// Intentionally empty so the CJS exports is untyped. We can't share the ESM types
-// as it causes an incorrect error message on TypeScript side. More context:
-// https://github.com/vitejs/vite/issues/11552#issuecomment-1564789056
+/**
+ * @deprecated The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
+ */
+declare const module: any
 
-export {}
+export = module

--- a/packages/vite/index.d.cts
+++ b/packages/vite/index.d.cts
@@ -1,0 +1,3 @@
+// Intentionally empty so the CJS exports is untyped. We can't share the ESM types
+// as it causes an incorrect error message on TypeScript side. More context:
+// https://github.com/vitejs/vite/issues/11552#issuecomment-1564789056

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -20,9 +20,14 @@
   "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/node/index.d.ts",
-      "import": "./dist/node/index.js",
-      "require": "./index.cjs"
+      "import": {
+        "types": "./dist/node/index.d.ts",
+        "default": "./dist/node/index.js"
+      },
+      "require": {
+        "types": "./index.d.cts",
+        "default": "./index.cjs"
+      }
     },
     "./client": {
       "types": "./client.d.ts"
@@ -35,6 +40,7 @@
     "dist",
     "client.d.ts",
     "index.cjs",
+    "index.d.cts",
     "types"
   ],
   "engines": {

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -185,7 +185,11 @@ cli
         `\n  ${colors.green(
           `${colors.bold('VITE')} v${VERSION}`,
         )}  ${startupDurationString}\n`,
-        { clear: !server.config.logger.hasWarned },
+        {
+          clear:
+            !server.config.logger.hasWarned &&
+            !(globalThis as any).__vite_cjs_skip_clear_screen,
+        },
       )
 
       server.printUrls()

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -21,7 +21,11 @@ export default defineConfig({
       moduleDirectories: ['node_modules', 'packages'],
     },
     onConsoleLog(log) {
-      if (log.match(/experimental|jit engine|emitted file|tailwind/i))
+      if (
+        log.match(
+          /experimental|jit engine|emitted file|tailwind|The CJS build of Vite/i,
+        )
+      )
         return false
     },
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

1. Add warning if CJS node api is used.
2. Support `VITE_CJS_TRACE` flag to use `console.trace` when logging the warning.
3. Fix CJS types (make empty as suggested in https://github.com/vitejs/vite/issues/11552#issuecomment-1564789056)

fix https://github.com/vitejs/vite/issues/11552

### Additional context

@andrewbranch, just confirming, is this PR making the right change to fix Vite's CJS types? I created an empty `index.d.cts` for CJS exports.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
