### PR TITLE
fix(manifest): incorrect css entry files in manifest when falsy cssCodeSplit

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -167,7 +167,7 @@ const styleAttrRE = /[?&]style-attr\b/
 const usedRE = /[?&]used\b/
 const varRE = /^var\(/i
 
-const cssBundleName = 'style.css'
+export const cssBundleName = 'style.css'
 
 const enum PreprocessLang {
   less = 'less',

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -5,6 +5,7 @@ import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
 import { normalizePath } from '../utils'
 import { generatedAssets } from './asset'
+import { cssBundleName } from './css'
 import type { GeneratedAssetMeta } from './asset'
 
 export type Manifest = Record<string, ManifestChunk>
@@ -19,6 +20,8 @@ export interface ManifestChunk {
   imports?: string[]
   dynamicImports?: string[]
 }
+
+const cssRE = /\.css$/
 
 export function manifestPlugin(config: ResolvedConfig): Plugin {
   const manifest: Manifest = {}
@@ -148,6 +151,19 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
           }
         }
       })
+
+      if (!config.build.cssCodeSplit) {
+        for (const file in manifest) {
+          const { isEntry, isDynamicEntry } = manifest[file]
+          if (
+            file !== cssBundleName &&
+            cssRE.test(file) &&
+            (isEntry || isDynamicEntry)
+          ) {
+            manifest[file].file = manifest[cssBundleName].file
+          }
+        }
+      }
 
       outputCount++
       const output = config.build.rollupOptions?.output

--- a/playground/css/__tests__/manifest/manifest.spec.ts
+++ b/playground/css/__tests__/manifest/manifest.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest'
+import { findAssetFile, isBuild } from '~utils'
+
+const baseDir = 'manifest'
+const assets = './'
+
+describe.runIf(isBuild)('manifest', () => {
+  test('manifest when cssCodeSplit is false', () => {
+    const manifest = JSON.parse(
+      findAssetFile(/manifest.json$/, baseDir, assets),
+    )
+    expect(manifest['async.css'].file).toMatch(manifest['style.css'].file)
+    expect(manifest['async/base.css'].file).toMatch(manifest['style.css'].file)
+  })
+})

--- a/playground/css/package.json
+++ b/playground/css/package.json
@@ -13,7 +13,9 @@
     "preview:relative-base": "vite --config ./vite.config-relative-base.js preview",
     "dev:no-css-minify": "vite --config ./vite.config-no-css-minify.js dev",
     "build:no-css-minify": "vite --config ./vite.config-no-css-minify.js build",
-    "preview:no-css-minify": "vite --config ./vite.config-no-css-minify.js preview"
+    "preview:no-css-minify": "vite --config ./vite.config-no-css-minify.js preview",
+    "build:manifest": "vite --config ./vite.config-manifest.js build",
+    "preview:manifest": "vite --config ./vite.config-manifest.js preview"
   },
   "devDependencies": {
     "@vitejs/test-css-dep": "link:./css-dep",

--- a/playground/css/vite.config-manifest.js
+++ b/playground/css/vite.config-manifest.js
@@ -1,0 +1,20 @@
+import path from 'node:path'
+import { defineConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default defineConfig({
+  ...baseConfig,
+  build: {
+    ...baseConfig.build,
+    manifest: true,
+    cssCodeSplit: false,
+    outDir: 'dist/manifest',
+    rollupOptions: {
+      input: {
+        base: path.resolve(__dirname, 'async/base.css'),
+        async: path.resolve(__dirname, 'async.css'),
+      },
+    },
+  },
+  cacheDir: 'node_modules/.vite-css-manifest',
+})


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

fix #14271 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
