### PR TITLE
fix: include `vite/types/*` in exports field

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -28,6 +28,9 @@
       "types": "./client.d.ts"
     },
     "./dist/client/*": "./dist/client/*",
+    "./types/*": {
+      "types": "./types/*"
+    },
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
### Description

This PR exports the files under `vite/types/*`. This makes internal type definitions available for external reference.

### Additional context

In Astro, we are referencing files within the `types` directory to provide users with type information like `ViteHotContext` and `ImportGlobFunction`.

https://github.com/withastro/astro/blob/b6066e109c5807f16dd81e07c81f300459e12897/packages/astro/import-meta.d.ts#L12-L20

However, these are not defined in `exports` field in Vite's `package.json`. As a result, when running `tsc` to check the contents of `import-meta.d.ts`, an error occurs. To resolve this, we need to extend the `exports` field in Vite's `package.json`.

ref:

https://github.com/withastro/astro/pull/8360#discussion_r1315058024

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
