### PR TITLE
fix(worker): inline es worker does not work in build mode

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -340,6 +340,8 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
                 ${workerTypeOption}
               );
             }${
+              // For module workers, we should not revoke the URL until the worker runs,
+              // otherwise the worker fails to run
               workerType === 'classic'
                 ? ` finally {
                     objURL && (window.URL || window.webkitURL).revokeObjectURL(objURL);

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -324,13 +324,16 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           export default function WorkerWrapper(options) {
             let objURL;
             try {
-
               objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);
               if (!objURL) throw ''
-              return new ${workerConstructor}(objURL, {
+              const worker = new ${workerConstructor}(objURL, {
                 ${workerTypeOption ? `type: "${workerTypeOption}",` : ''}
                 name: options?.name
-              })
+              });
+              worker.addEventListener("error", () => {
+                (window.URL || window.webkitURL).revokeObjectURL(objURL);
+              });
+              return worker;
             } catch(e) {
               return new ${workerConstructor}(
                 "data:application/javascript;base64," + encodedJs,

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -23,7 +23,7 @@ test('normal', async () => {
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'pong', true)
+  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker', true)
 })
 
 test('TS output', async () => {
@@ -35,7 +35,19 @@ test('inlined', async () => {
 })
 
 test('named inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline-named'), 'pong', true)
+  await untilUpdated(
+    () => page.textContent('.pong-inline-named'),
+    'namedInlineWorker',
+    true,
+  )
+})
+
+test('import meta url', async () => {
+  await untilUpdated(
+    () => page.textContent('.pong-inline-url'),
+    /^(blob|http):/,
+    true,
+  )
 })
 
 test('shared worker', async () => {
@@ -83,7 +95,7 @@ describe.runIf(isBuild)('build', () => {
     )
 
     // worker should have all imports resolved and no exports
-    expect(workerContent).not.toMatch(`import`)
+    expect(workerContent).not.toMatch(/import[^.]/)
     expect(workerContent).not.toMatch(`export`)
     // chunk
     expect(content).toMatch(`new Worker("/es/assets`)

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -26,7 +26,7 @@ test('normal', async () => {
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'pong', true)
+  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker', true)
 })
 
 test('TS output', async () => {
@@ -38,7 +38,11 @@ test('inlined', async () => {
 })
 
 test('named inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline-named'), 'pong', true)
+  await untilUpdated(
+    () => page.textContent('.pong-inline-named'),
+    'namedInlineWorker',
+    true,
+  )
 })
 
 test('shared worker', async () => {

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -23,7 +23,7 @@ test('normal', async () => {
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'pong', true)
+  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker', true)
 })
 
 test('TS output', async () => {

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -43,6 +43,14 @@
 <code class="pong-inline-named"></code>
 
 <p>
+  import InlineWorker from '../my-worker?worker&inline'
+  <span>new InlineWorker()</span>
+  <span>import.meta.url</span>
+  <span class="classname">.pong-inline-url</span>
+</p>
+<code class="pong-inline-url"></code>
+
+<p>
   import TSOutputWorker from '../possible-ts-output-worker?worker'
   <span class="classname">.pong-ts-output</span>
 </p>

--- a/playground/worker/my-worker.ts
+++ b/playground/worker/my-worker.ts
@@ -2,13 +2,22 @@ import { msg as msgFromDep } from '@vitejs/test-dep-to-optimize'
 import { mode, msg } from './modules/workerImport.js'
 import { bundleWithPlugin } from './modules/test-plugin'
 import viteSvg from './vite.svg'
+const metaUrl = import.meta.url
 
 self.onmessage = (e) => {
   if (e.data === 'ping') {
-    self.postMessage({ msg, mode, bundleWithPlugin, viteSvg })
+    self.postMessage({ msg, mode, bundleWithPlugin, viteSvg, metaUrl, name })
   }
 }
-self.postMessage({ msg, mode, bundleWithPlugin, msgFromDep, viteSvg })
+self.postMessage({
+  msg,
+  mode,
+  bundleWithPlugin,
+  msgFromDep,
+  viteSvg,
+  metaUrl,
+  name,
+})
 
 // for sourcemap
 console.log('my-worker.js')

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -24,7 +24,7 @@ worker.addEventListener('message', (e) => {
 const namedWorker = new myWorker({ name: 'namedWorker' })
 namedWorker.postMessage('ping')
 namedWorker.addEventListener('message', (e) => {
-  text('.pong-named', e.data.msg)
+  text('.pong-named', e.data.name)
 })
 
 const inlineWorker = new InlineWorker()
@@ -36,7 +36,13 @@ inlineWorker.addEventListener('message', (e) => {
 const namedInlineWorker = new InlineWorker({ name: 'namedInlineWorker' })
 namedInlineWorker.postMessage('ping')
 namedInlineWorker.addEventListener('message', (e) => {
-  text('.pong-inline-named', e.data.msg)
+  text('.pong-inline-named', e.data.name)
+})
+
+const inlineWorkerUrl = new InlineWorker()
+inlineWorkerUrl.postMessage('ping')
+inlineWorkerUrl.addEventListener('message', (e) => {
+  text('.pong-inline-url', e.data.metaUrl)
 })
 
 const startSharedWorker = () => {


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

1. `new Worker(blobUrl,{type:'module'/*missed*/})` It should be configured as expected (fix:#14306)
2. inline esmodule web worker should not `revokeObjectURL` immediately

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
