### PR TITLE
fix(hmr): clean importers in module graph when file is deleted

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -224,8 +224,8 @@ export async function handleFileAddUnlink(
 
   if (isUnlink) {
     for (const deletedMod of modules) {
-      server.moduleGraph.idToModuleMap.forEach((mod) => {
-        mod.importers.delete(deletedMod)
+      deletedMod.importedModules.forEach((importedMod) => {
+        importedMod.importers.delete(deletedMod)
       })
     }
   }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -218,8 +218,17 @@ export function updateModules(
 export async function handleFileAddUnlink(
   file: string,
   server: ViteDevServer,
+  isUnlink: boolean,
 ): Promise<void> {
   const modules = [...(server.moduleGraph.getModulesByFile(file) || [])]
+
+  if (isUnlink) {
+    for (const deletedMod of modules) {
+      server.moduleGraph.idToModuleMap.forEach((mod) => {
+        mod.importers.delete(deletedMod)
+      })
+    }
+  }
 
   modules.push(...getAffectedGlobModules(file, server))
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -577,9 +577,9 @@ export async function _createServer(
     }
   }
 
-  const onFileAddUnlink = async (file: string) => {
+  const onFileAddUnlink = async (file: string, isUnlink: boolean) => {
     file = normalizePath(file)
-    await handleFileAddUnlink(file, server)
+    await handleFileAddUnlink(file, server, isUnlink)
     await onHMRUpdate(file, true)
   }
 
@@ -591,8 +591,8 @@ export async function _createServer(
     await onHMRUpdate(file, false)
   })
 
-  watcher.on('add', onFileAddUnlink)
-  watcher.on('unlink', onFileAddUnlink)
+  watcher.on('add', (file) => onFileAddUnlink(file, false))
+  watcher.on('unlink', (file) => onFileAddUnlink(file, true))
 
   ws.on('vite:invalidate', async ({ path, message }: InvalidatePayload) => {
     const mod = moduleGraph.urlToModuleMap.get(path)

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -4,6 +4,7 @@ import './importing-updated'
 import './invalidation/parent'
 import './file-delete-restore'
 import './optional-chaining/parent'
+import './intermediate-file-delete'
 import logo from './logo.svg'
 
 export const foo = 1

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -33,4 +33,6 @@
 <div class="importing-reloaded"></div>
 <div class="file-delete-restore"></div>
 <div class="optional-chaining"></div>
+<button class="intermediate-file-delete-increment">1</button>
+<div class="intermediate-file-delete-display"></div>
 <image id="logo"></image>

--- a/playground/hmr/intermediate-file-delete/display.js
+++ b/playground/hmr/intermediate-file-delete/display.js
@@ -1,0 +1,1 @@
+export const displayCount = (count) => `count is ${count}`

--- a/playground/hmr/intermediate-file-delete/index.js
+++ b/playground/hmr/intermediate-file-delete/index.js
@@ -1,0 +1,17 @@
+import { displayCount } from './re-export.js'
+
+const button = document.querySelector('.intermediate-file-delete-increment')
+
+const render = () => {
+  document.querySelector('.intermediate-file-delete-display').textContent =
+    displayCount(Number(button.textContent))
+}
+
+render()
+
+button.addEventListener('click', () => {
+  button.textContent = `${Number(button.textContent) + 1}`
+  render()
+})
+
+if (import.meta.hot) import.meta.hot.accept()

--- a/playground/hmr/intermediate-file-delete/re-export.js
+++ b/playground/hmr/intermediate-file-delete/re-export.js
@@ -1,0 +1,1 @@
+export * from './display.js'


### PR DESCRIPTION
Before this PR, any update to `display.js` after `re-export.js` was deleted triggered a full page reload.

Actually because we don't (or maybe we have?) an exhaustive list of modules considered as entrypoints, the current heuristic of `no impoters` -> `entrypoint` make the hmr 'buggy' (ie unneeded page reload) in other situations:
- if the file become unused but not deleted
- when the file is deleted even if unused