### PR TITLE
fix(node): `ctrl + c` closes the server without exit code

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -58,9 +58,8 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
           server.httpServer.close()
         }
       } finally {
-        process.exit(1)
+        process.exit()
       }
-      return
     }
 
     if (actionRunning) return


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
If the shutdown process includes an exit code, it looks like something went wrong.

![image](https://github.com/vitejs/vite/assets/24516654/106bb063-5880-415e-82ce-052062450336)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
