### PR TITLE
fix(css): reset render cache on renderStart

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -405,7 +405,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:css-post',
 
-    buildStart() {
+    renderStart() {
       // Ensure new caches for every build (i.e. rebuilding in watch mode)
       pureCssChunks = new Set<RenderedChunk>()
       outputToExtractedCSSMap = new Map<NormalizedOutputOptions, string>()

--- a/playground/lib/__tests__/serve.ts
+++ b/playground/lib/__tests__/serve.ts
@@ -64,6 +64,12 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
     await build({
       root: rootDir,
       logLevel: 'warn', // output esbuild warns
+      configFile: path.resolve(__dirname, '../vite.multiple-output.config.js'),
+    })
+
+    await build({
+      root: rootDir,
+      logLevel: 'warn', // output esbuild warns
       configFile: path.resolve(__dirname, '../vite.nominify.config.js'),
     })
 

--- a/playground/lib/src/main-multiple-output.js
+++ b/playground/lib/src/main-multiple-output.js
@@ -1,0 +1,6 @@
+// import file to test css build handling
+import './index.css'
+
+export default async function message(sel) {
+  document.querySelector(sel).textContent = 'success'
+}

--- a/playground/lib/src/sub-multiple-output.js
+++ b/playground/lib/src/sub-multiple-output.js
@@ -1,0 +1,6 @@
+// import file to test css build handling
+import './index.css'
+
+export default async function message(sel) {
+  document.querySelector(sel).textContent = 'success'
+}

--- a/playground/lib/vite.multiple-output.config.js
+++ b/playground/lib/vite.multiple-output.config.js
@@ -1,0 +1,39 @@
+import path from 'node:path'
+import { defineConfig } from 'vite'
+
+const root = process.env.VITEST
+  ? path.resolve(__dirname, '../../playground-temp/lib')
+  : __dirname
+
+export default defineConfig({
+  build: {
+    lib: {
+      // set multiple entrypoint to trigger css chunking
+      entry: {
+        main: path.resolve(__dirname, 'src/main-multiple-output.js'),
+        sub: path.resolve(__dirname, 'src/sub-multiple-output.js'),
+      },
+      name: 'MyLib',
+    },
+    outDir: 'dist/multiple-output',
+    rollupOptions: {
+      // due to playground-temp, the `dir` needs to be relative to the resolvedRoot
+      output: [
+        {
+          dir: path.resolve(root, 'dist/multiple-output/es'),
+          format: 'es',
+          entryFileNames: 'index.mjs',
+          assetFileNames: 'assets/mylib.css',
+        },
+        {
+          dir: path.resolve(root, 'dist/multiple-output/cjs'),
+          format: 'cjs',
+          entryFileNames: 'index.cjs',
+          assetFileNames: 'assets/mylib.css',
+        },
+      ],
+    },
+    cssCodeSplit: true,
+  },
+  cacheDir: 'node_modules/.vite-multiple-output',
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix [unocss fail in ecosystem-ci](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6117900618/job/16605222945#step:8:1399), since #13974 that revealed a bug in our code.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
Unocss has a test in lib mode with multiple outputs, each output is rendered once. The `css-post` plugin has caches for the render hooks, e.g. `renderChunk` and `generateBundle`, the caches are scoped to each render (aka each output).

However, we reset our cache in `buildStart`, that means each render share the same cache, which is incorrect. This PR changes to `renderStart` instead.




---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
