### PR TITLE
fix(legacy): fix broken build when renderModernChunks=false & polyfills=false (fix #14324)

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -268,24 +268,26 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         )
       }
 
-      isDebug &&
-        console.log(
-          `[@vitejs/plugin-legacy] legacy polyfills:`,
-          legacyPolyfills,
-        )
+      if (legacyPolyfills.size || !options.externalSystemJS) {
+        isDebug &&
+          console.log(
+            `[@vitejs/plugin-legacy] legacy polyfills:`,
+            legacyPolyfills,
+          )
 
-      await buildPolyfillChunk(
-        config.mode,
-        legacyPolyfills,
-        bundle,
-        facadeToLegacyPolyfillMap,
-        // force using terser for legacy polyfill minification, since esbuild
-        // isn't legacy-safe
-        config.build,
-        'iife',
-        opts,
-        options.externalSystemJS,
-      )
+        await buildPolyfillChunk(
+          config.mode,
+          legacyPolyfills,
+          bundle,
+          facadeToLegacyPolyfillMap,
+          // force using terser for legacy polyfill minification, since esbuild
+          // isn't legacy-safe
+          config.build,
+          'iife',
+          opts,
+          options.externalSystemJS,
+        )
+      }
     },
   }
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -258,7 +258,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
 
       // legacy bundle
-      if (legacyPolyfills.size) {
+      if (options.polyfills !== false) {
         // check if the target needs Promise polyfill because SystemJS relies on it
         // https://github.com/systemjs/systemjs#ie11-support
         await detectPolyfills(
@@ -266,26 +266,26 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           targets,
           legacyPolyfills,
         )
-
-        isDebug &&
-          console.log(
-            `[@vitejs/plugin-legacy] legacy polyfills:`,
-            legacyPolyfills,
-          )
-
-        await buildPolyfillChunk(
-          config.mode,
-          legacyPolyfills,
-          bundle,
-          facadeToLegacyPolyfillMap,
-          // force using terser for legacy polyfill minification, since esbuild
-          // isn't legacy-safe
-          config.build,
-          'iife',
-          opts,
-          options.externalSystemJS,
-        )
       }
+
+      isDebug &&
+        console.log(
+          `[@vitejs/plugin-legacy] legacy polyfills:`,
+          legacyPolyfills,
+        )
+
+      await buildPolyfillChunk(
+        config.mode,
+        legacyPolyfills,
+        bundle,
+        facadeToLegacyPolyfillMap,
+        // force using terser for legacy polyfill minification, since esbuild
+        // isn't legacy-safe
+        config.build,
+        'iife',
+        opts,
+        options.externalSystemJS,
+      )
     },
   }
 

--- a/playground/legacy/__tests__/no-polyfills-no-systemjs/no-polyfills-no-systemjs.spec.ts
+++ b/playground/legacy/__tests__/no-polyfills-no-systemjs/no-polyfills-no-systemjs.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest'
+import { isBuild, page, untilUpdated, viteTestUrl } from '~utils'
+
+test.runIf(isBuild)('includes only a single script tag', async () => {
+  await page.goto(viteTestUrl + '/no-polyfills-no-systemjs.html')
+
+  await untilUpdated(
+    () => page.getAttribute('#vite-legacy-entry', 'data-src'),
+    /.\/assets\/index-legacy-(.+)\.js/,
+    true,
+  )
+
+  expect(await page.locator('script').count()).toBe(1)
+  expect(await page.locator('#vite-legacy-polyfill').count()).toBe(0)
+  expect(await page.locator('#vite-legacy-entry').count()).toBe(1)
+})

--- a/playground/legacy/__tests__/no-polyfills/no-polyfills.spec.ts
+++ b/playground/legacy/__tests__/no-polyfills/no-polyfills.spec.ts
@@ -1,0 +1,20 @@
+import { test } from 'vitest'
+import { isBuild, page, untilUpdated, viteTestUrl } from '~utils'
+
+test('should load and execute the JS file', async () => {
+  await page.goto(viteTestUrl + '/no-polyfills.html')
+  await untilUpdated(() => page.textContent('main'), '👋', true)
+})
+
+test.runIf(isBuild)('includes a script tag for SystemJS', async () => {
+  await untilUpdated(
+    () => page.getAttribute('#vite-legacy-polyfill', 'src'),
+    /.\/assets\/polyfills-legacy-(.+)\.js/,
+    true,
+  )
+  await untilUpdated(
+    () => page.getAttribute('#vite-legacy-entry', 'data-src'),
+    /.\/assets\/index-legacy-(.+)\.js/,
+    true,
+  )
+})

--- a/playground/legacy/no-polyfills-no-systemjs.html
+++ b/playground/legacy/no-polyfills-no-systemjs.html
@@ -1,0 +1,3 @@
+<meta charset="UTF-8" />
+<main></main>
+<script type="module" src="./no-polyfills-no-systemjs.js"></script>

--- a/playground/legacy/no-polyfills-no-systemjs.js
+++ b/playground/legacy/no-polyfills-no-systemjs.js
@@ -1,0 +1,1 @@
+document.querySelector('main').innerHTML = '👋'

--- a/playground/legacy/no-polyfills.html
+++ b/playground/legacy/no-polyfills.html
@@ -1,0 +1,3 @@
+<meta charset="UTF-8" />
+<main></main>
+<script type="module" src="./no-polyfills.js"></script>

--- a/playground/legacy/no-polyfills.js
+++ b/playground/legacy/no-polyfills.js
@@ -1,0 +1,1 @@
+document.querySelector('main').innerHTML = '👋'

--- a/playground/legacy/package.json
+++ b/playground/legacy/package.json
@@ -9,6 +9,7 @@
     "build:custom-filename": "vite --config ./vite.config-custom-filename.js build  --debug legacy",
     "build:multiple-output": "vite --config ./vite.config-multiple-output.js build",
     "build:no-polyfills": "vite --config ./vite.config-no-polyfills.js build",
+    "build:no-polyfills-no-systemjs": "vite --config ./vite.config-no-polyfills-no-systemjs.js build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
   },

--- a/playground/legacy/package.json
+++ b/playground/legacy/package.json
@@ -8,6 +8,7 @@
     "build": "vite build --debug legacy",
     "build:custom-filename": "vite --config ./vite.config-custom-filename.js build  --debug legacy",
     "build:multiple-output": "vite --config ./vite.config-multiple-output.js build",
+    "build:no-polyfills": "vite --config ./vite.config-no-polyfills.js build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"
   },

--- a/playground/legacy/vite.config-no-polyfills-no-systemjs.js
+++ b/playground/legacy/vite.config-no-polyfills-no-systemjs.js
@@ -1,0 +1,30 @@
+import path from 'node:path'
+import legacy from '@vitejs/plugin-legacy'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    legacy({
+      renderModernChunks: false,
+      polyfills: false,
+      externalSystemJS: true,
+    }),
+    {
+      name: 'remove crossorigin attribute',
+      transformIndexHtml: (html) => html.replaceAll('crossorigin', ''),
+      enforce: 'post',
+    },
+  ],
+
+  build: {
+    rollupOptions: {
+      input: {
+        index: path.resolve(__dirname, 'no-polyfills-no-systemjs.html'),
+      },
+    },
+  },
+  testConfig: {
+    baseRoute: '/no-polyfills-no-systemjs/',
+  },
+})

--- a/playground/legacy/vite.config-no-polyfills.js
+++ b/playground/legacy/vite.config-no-polyfills.js
@@ -1,0 +1,29 @@
+import path from 'node:path'
+import legacy from '@vitejs/plugin-legacy'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  base: './',
+  plugins: [
+    legacy({
+      renderModernChunks: false,
+      polyfills: false,
+    }),
+    {
+      name: 'remove crossorigin attribute',
+      transformIndexHtml: (html) => html.replaceAll('crossorigin', ''),
+      enforce: 'post',
+    },
+  ],
+
+  build: {
+    rollupOptions: {
+      input: {
+        index: path.resolve(__dirname, 'no-polyfills.html'),
+      },
+    },
+  },
+  testConfig: {
+    baseRoute: '/no-polyfills/',
+  },
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

Closes #14324

### Description



Issue #14324 has a detailed explaination of the bug. In short, if the legacy plugin is configured with `renderModernChunks=false` & `polyfills=false` then the outputted build is broken and unusable. 

This PR fixes the bug by including the ployfill chunk in this scenario, since the  ployfill chunk contains SystemJS.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I'm not sure how to add tests without creating an entirely new folder under `/playground`, since a test for this PR would require a different `vite.config.ts` file.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
