### PR TITLE
Add "bun:" escape hatch to node resolver. Resolves #14351

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -1,62 +1,62 @@
-import path from 'node:path'
-import { pathToFileURL } from 'node:url'
-import colors from 'picocolors'
-import type { ViteDevServer } from '../server'
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import colors from "picocolors";
+import type { ViteDevServer } from "../server";
 import {
   dynamicImport,
   isBuiltin,
   unwrapId,
   usingDynamicImport,
-} from '../utils'
-import { transformRequest } from '../server/transformRequest'
-import type { InternalResolveOptionsWithOverrideConditions } from '../plugins/resolve'
-import { tryNodeResolve } from '../plugins/resolve'
-import { genSourceMapUrl } from '../server/sourcemap'
+} from "../utils";
+import { transformRequest } from "../server/transformRequest";
+import type { InternalResolveOptionsWithOverrideConditions } from "../plugins/resolve";
+import { tryNodeResolve } from "../plugins/resolve";
+import { genSourceMapUrl } from "../server/sourcemap";
 import {
   ssrDynamicImportKey,
   ssrExportAllKey,
   ssrImportKey,
   ssrImportMetaKey,
   ssrModuleExportsKey,
-} from './ssrTransform'
-import { ssrFixStacktrace } from './ssrStacktrace'
+} from "./ssrTransform";
+import { ssrFixStacktrace } from "./ssrStacktrace";
 
 interface SSRContext {
-  global: typeof globalThis
+  global: typeof globalThis;
 }
 
-type SSRModule = Record<string, any>
+type SSRModule = Record<string, any>;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-const AsyncFunction = async function () {}.constructor as typeof Function
-let fnDeclarationLineCount = 0
+const AsyncFunction = async function () {}.constructor as typeof Function;
+let fnDeclarationLineCount = 0;
 {
-  const body = '/*code*/'
-  const source = new AsyncFunction('a', 'b', body).toString()
+  const body = "/*code*/";
+  const source = new AsyncFunction("a", "b", body).toString();
   fnDeclarationLineCount =
-    source.slice(0, source.indexOf(body)).split('\n').length - 1
+    source.slice(0, source.indexOf(body)).split("\n").length - 1;
 }
 
-const pendingModules = new Map<string, Promise<SSRModule>>()
-const pendingImports = new Map<string, string[]>()
-const importErrors = new WeakMap<Error, { importee: string }>()
+const pendingModules = new Map<string, Promise<SSRModule>>();
+const pendingImports = new Map<string, string[]>();
+const importErrors = new WeakMap<Error, { importee: string }>();
 
 export async function ssrLoadModule(
   url: string,
   server: ViteDevServer,
   context: SSRContext = { global },
   urlStack: string[] = [],
-  fixStacktrace?: boolean,
+  fixStacktrace?: boolean
 ): Promise<SSRModule> {
-  url = unwrapId(url)
+  url = unwrapId(url);
 
   // when we instantiate multiple dependency modules in parallel, they may
   // point to shared modules. We need to avoid duplicate instantiation attempts
   // by register every module as pending synchronously so that all subsequent
   // request to that module are simply waiting on the same promise.
-  const pending = pendingModules.get(url)
+  const pending = pendingModules.get(url);
   if (pending) {
-    return pending
+    return pending;
   }
 
   const modulePromise = instantiateModule(
@@ -64,17 +64,17 @@ export async function ssrLoadModule(
     server,
     context,
     urlStack,
-    fixStacktrace,
-  )
-  pendingModules.set(url, modulePromise)
+    fixStacktrace
+  );
+  pendingModules.set(url, modulePromise);
   modulePromise
     .catch(() => {
-      pendingImports.delete(url)
+      pendingImports.delete(url);
     })
     .finally(() => {
-      pendingModules.delete(url)
-    })
-  return modulePromise
+      pendingModules.delete(url);
+    });
+  return modulePromise;
 }
 
 async function instantiateModule(
@@ -82,134 +82,134 @@ async function instantiateModule(
   server: ViteDevServer,
   context: SSRContext = { global },
   urlStack: string[] = [],
-  fixStacktrace?: boolean,
+  fixStacktrace?: boolean
 ): Promise<SSRModule> {
-  const { moduleGraph } = server
-  const mod = await moduleGraph.ensureEntryFromUrl(url, true)
+  const { moduleGraph } = server;
+  const mod = await moduleGraph.ensureEntryFromUrl(url, true);
 
   if (mod.ssrError) {
-    throw mod.ssrError
+    throw mod.ssrError;
   }
 
   if (mod.ssrModule) {
-    return mod.ssrModule
+    return mod.ssrModule;
   }
   const result =
     mod.ssrTransformResult ||
-    (await transformRequest(url, server, { ssr: true }))
+    (await transformRequest(url, server, { ssr: true }));
   if (!result) {
     // TODO more info? is this even necessary?
-    throw new Error(`failed to load module for ssr: ${url}`)
+    throw new Error(`failed to load module for ssr: ${url}`);
   }
 
   const ssrModule = {
-    [Symbol.toStringTag]: 'Module',
-  }
-  Object.defineProperty(ssrModule, '__esModule', { value: true })
+    [Symbol.toStringTag]: "Module",
+  };
+  Object.defineProperty(ssrModule, "__esModule", { value: true });
 
   // Tolerate circular imports by ensuring the module can be
   // referenced before it's been instantiated.
-  mod.ssrModule = ssrModule
+  mod.ssrModule = ssrModule;
 
   const ssrImportMeta = {
     // The filesystem URL, matching native Node.js modules
     url: pathToFileURL(mod.file!).toString(),
-  }
+  };
 
-  urlStack = urlStack.concat(url)
-  const isCircular = (url: string) => urlStack.includes(url)
+  urlStack = urlStack.concat(url);
+  const isCircular = (url: string) => urlStack.includes(url);
 
   const {
     isProduction,
     resolve: { dedupe, preserveSymlinks },
     root,
-  } = server.config
+  } = server.config;
 
   const resolveOptions: InternalResolveOptionsWithOverrideConditions = {
-    mainFields: ['main'],
+    mainFields: ["main"],
     browserField: true,
     conditions: [],
-    overrideConditions: ['production', 'development'],
-    extensions: ['.js', '.cjs', '.json'],
+    overrideConditions: ["production", "development"],
+    extensions: [".js", ".cjs", ".json"],
     dedupe,
     preserveSymlinks,
     isBuild: false,
     isProduction,
     root,
-  }
+  };
 
   // Since dynamic imports can happen in parallel, we need to
   // account for multiple pending deps and duplicate imports.
-  const pendingDeps: string[] = []
+  const pendingDeps: string[] = [];
 
   const ssrImport = async (dep: string) => {
     try {
-      if (dep[0] !== '.' && dep[0] !== '/') {
-        return await nodeImport(dep, mod.file!, resolveOptions)
+      if (dep[0] !== "." && dep[0] !== "/") {
+        return await nodeImport(dep, mod.file!, resolveOptions);
       }
       // convert to rollup URL because `pendingImports`, `moduleGraph.urlToModuleMap` requires that
-      dep = unwrapId(dep)
+      dep = unwrapId(dep);
       if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
-        pendingDeps.push(dep)
+        pendingDeps.push(dep);
         if (pendingDeps.length === 1) {
-          pendingImports.set(url, pendingDeps)
+          pendingImports.set(url, pendingDeps);
         }
         const mod = await ssrLoadModule(
           dep,
           server,
           context,
           urlStack,
-          fixStacktrace,
-        )
+          fixStacktrace
+        );
         if (pendingDeps.length === 1) {
-          pendingImports.delete(url)
+          pendingImports.delete(url);
         } else {
-          pendingDeps.splice(pendingDeps.indexOf(dep), 1)
+          pendingDeps.splice(pendingDeps.indexOf(dep), 1);
         }
         // return local module to avoid race condition #5470
-        return mod
+        return mod;
       }
-      return moduleGraph.urlToModuleMap.get(dep)?.ssrModule
+      return moduleGraph.urlToModuleMap.get(dep)?.ssrModule;
     } catch (err) {
       // tell external error handler which mod was imported with error
-      importErrors.set(err, { importee: dep })
+      importErrors.set(err, { importee: dep });
 
-      throw err
+      throw err;
     }
-  }
+  };
 
   const ssrDynamicImport = (dep: string) => {
     // #3087 dynamic import vars is ignored at rewrite import path,
     // so here need process relative path
-    if (dep[0] === '.') {
-      dep = path.posix.resolve(path.dirname(url), dep)
+    if (dep[0] === ".") {
+      dep = path.posix.resolve(path.dirname(url), dep);
     }
-    return ssrImport(dep)
-  }
+    return ssrImport(dep);
+  };
 
   function ssrExportAll(sourceModule: any) {
     for (const key in sourceModule) {
-      if (key !== 'default' && key !== '__esModule') {
+      if (key !== "default" && key !== "__esModule") {
         Object.defineProperty(ssrModule, key, {
           enumerable: true,
           configurable: true,
           get() {
-            return sourceModule[key]
+            return sourceModule[key];
           },
-        })
+        });
       }
     }
   }
 
-  let sourceMapSuffix = ''
-  if (result.map && 'version' in result.map) {
+  let sourceMapSuffix = "";
+  if (result.map && "version" in result.map) {
     const moduleSourceMap = Object.assign({}, result.map, {
       // currently we need to offset the line
       // https://github.com/nodejs/node/issues/43047#issuecomment-1180632750
-      mappings: ';'.repeat(fnDeclarationLineCount) + result.map.mappings,
-    })
+      mappings: ";".repeat(fnDeclarationLineCount) + result.map.mappings,
+    });
     sourceMapSuffix =
-      '\n//# sourceMappingURL=' + genSourceMapUrl(moduleSourceMap)
+      "\n//# sourceMappingURL=" + genSourceMapUrl(moduleSourceMap);
   }
 
   try {
@@ -222,22 +222,22 @@ async function instantiateModule(
       ssrExportAllKey,
       '"use strict";' +
         result.code +
-        `\n//# sourceURL=${mod.id}${sourceMapSuffix}`,
-    )
+        `\n//# sourceURL=${mod.id}${sourceMapSuffix}`
+    );
     await initModule(
       context.global,
       ssrModule,
       ssrImportMeta,
       ssrImport,
       ssrDynamicImport,
-      ssrExportAll,
-    )
+      ssrExportAll
+    );
   } catch (e) {
-    mod.ssrError = e
-    const errorData = importErrors.get(e)
+    mod.ssrError = e;
+    const errorData = importErrors.get(e);
 
     if (e.stack && fixStacktrace) {
-      ssrFixStacktrace(e, moduleGraph)
+      ssrFixStacktrace(e, moduleGraph);
     }
 
     server.config.logger.error(
@@ -245,31 +245,36 @@ async function instantiateModule(
         `Error when evaluating SSR module ${url}:` +
           (errorData?.importee
             ? ` failed to import "${errorData.importee}"`
-            : '') +
-          `\n|- ${e.stack}\n`,
+            : "") +
+          `\n|- ${e.stack}\n`
       ),
       {
         timestamp: true,
         clear: server.config.clearScreen,
         error: e,
-      },
-    )
+      }
+    );
 
-    throw e
+    throw e;
   }
 
-  return Object.freeze(ssrModule)
+  return Object.freeze(ssrModule);
 }
 
 // In node@12+ we can use dynamic import to load CJS and ESM
 async function nodeImport(
   id: string,
   importer: string,
-  resolveOptions: InternalResolveOptionsWithOverrideConditions,
+  resolveOptions: InternalResolveOptionsWithOverrideConditions
 ) {
-  let url: string
-  if (id.startsWith('node:') || id.startsWith('data:') || isBuiltin(id)) {
-    url = id
+  let url: string;
+  if (
+    id.startsWith("node:") ||
+    id.startsWith("data:") ||
+    id.startsWith("bun:") ||
+    isBuiltin(id)
+  ) {
+    url = id;
   } else {
     const resolved = tryNodeResolve(
       id,
@@ -277,50 +282,50 @@ async function nodeImport(
       // Non-external modules can import ESM-only modules, but only outside
       // of test runs, because we use Node `require` in Jest to avoid segfault.
       // @ts-expect-error jest only exists when running Jest
-      typeof jest === 'undefined'
+      typeof jest === "undefined"
         ? { ...resolveOptions, tryEsmOnly: true }
         : resolveOptions,
-      false,
-    )
+      false
+    );
     if (!resolved) {
       const err: any = new Error(
-        `Cannot find module '${id}' imported from '${importer}'`,
-      )
-      err.code = 'ERR_MODULE_NOT_FOUND'
-      throw err
+        `Cannot find module '${id}' imported from '${importer}'`
+      );
+      err.code = "ERR_MODULE_NOT_FOUND";
+      throw err;
     }
-    url = resolved.id
+    url = resolved.id;
     if (usingDynamicImport) {
-      url = pathToFileURL(url).toString()
+      url = pathToFileURL(url).toString();
     }
   }
 
-  const mod = await dynamicImport(url)
-  return proxyESM(mod)
+  const mod = await dynamicImport(url);
+  return proxyESM(mod);
 }
 
 // rollup-style default import interop for cjs
 function proxyESM(mod: any) {
   // This is the only sensible option when the exports object is a primitive
-  if (isPrimitive(mod)) return { default: mod }
+  if (isPrimitive(mod)) return { default: mod };
 
-  let defaultExport = 'default' in mod ? mod.default : mod
+  let defaultExport = "default" in mod ? mod.default : mod;
 
-  if (!isPrimitive(defaultExport) && '__esModule' in defaultExport) {
-    mod = defaultExport
-    if ('default' in defaultExport) {
-      defaultExport = defaultExport.default
+  if (!isPrimitive(defaultExport) && "__esModule" in defaultExport) {
+    mod = defaultExport;
+    if ("default" in defaultExport) {
+      defaultExport = defaultExport.default;
     }
   }
 
   return new Proxy(mod, {
     get(mod, prop) {
-      if (prop === 'default') return defaultExport
-      return mod[prop] ?? defaultExport?.[prop]
+      if (prop === "default") return defaultExport;
+      return mod[prop] ?? defaultExport?.[prop];
     },
-  })
+  });
 }
 
 function isPrimitive(value: any) {
-  return !value || (typeof value !== 'object' && typeof value !== 'function')
+  return !value || (typeof value !== "object" && typeof value !== "function");
 }


### PR DESCRIPTION
### Description

Allow Vite to resolve internal `bun:` packages. Resolves https://github.com/vitejs/vite/issues/14351

### Additional context

I'd love to improve this, if needed. It's a pretty straight forward change. Maybe maintainers want to make a more robust way of excluding packages from the node resolver plugin?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
