### PR TITLE
refactor(docs): use unified outline config

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -311,5 +311,9 @@ export default defineConfig({
         },
       ],
     },
+
+    outline: {
+      level: [2, 3],
+    },
   },
 })

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Plugin API
 
 Vite plugins extends Rollup's well-designed plugin interface with a few extra Vite-specific options. As a result, you can write a Vite plugin once and have it work for both dev and build.

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Static Asset Handling
 
 - Related: [Public Base Path](./build#public-base-path)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Command Line Interface
 
 ## Dev server

--- a/docs/guide/dep-pre-bundling.md
+++ b/docs/guide/dep-pre-bundling.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Dependency Pre-Bundling
 
 When you run `vite` for the first time, Vite prebundles your project dependencies before loading your site locally. It is done automatically and transparently by default.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Features
 
 At the very basic level, developing using Vite is not that much different from using a static file server. However, Vite provides many enhancements over native ESM imports to support various features that are typically seen in bundler-based setups.

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Why Vite
 
 ## The Problems


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The same outline is configured in multiple markdown files, so I think it may be simpler and more convenient to set it directly in the theme configuration.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
