### PR TITLE
fix(sourcemap): dont inject fallback sourcemap if have existing

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -195,7 +195,7 @@ function createCjsConfig(isProduction: boolean) {
       ...Object.keys(pkg.dependencies),
       ...(isProduction ? [] : Object.keys(pkg.devDependencies)),
     ],
-    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(155)],
+    plugins: [...createNodePlugins(false, false, false), bundleSizeLimit(161)],
   })
 }
 

--- a/packages/vite/src/node/server/send.ts
+++ b/packages/vite/src/node/server/send.ts
@@ -4,11 +4,16 @@ import type {
   ServerResponse,
 } from 'node:http'
 import path from 'node:path'
+import convertSourceMap from 'convert-source-map'
 import getEtag from 'etag'
 import type { SourceMap } from 'rollup'
 import MagicString from 'magic-string'
-import { removeTimestampQuery } from '../utils'
+import { createDebugger, removeTimestampQuery } from '../utils'
 import { getCodeWithSourcemap } from './sourcemap'
+
+const debug = createDebugger('vite:send', {
+  onlyWhenFocused: true,
+})
 
 const alias: Record<string, string | undefined> = {
   js: 'application/javascript',
@@ -16,8 +21,6 @@ const alias: Record<string, string | undefined> = {
   html: 'text/html',
   json: 'application/json',
 }
-
-const sourcemapRe = /^\/\/# sourceMappingURL=.+/m
 
 export interface SendOptions {
   etag?: string
@@ -71,7 +74,9 @@ export function send(
   else if (type === 'js' && (!map || map.mappings !== '')) {
     const code = content.toString()
     // if the code has existing inline sourcemap, assume it's correct and skip
-    if (!sourcemapRe.test(code)) {
+    if (convertSourceMap.mapFileCommentRegex.test(code)) {
+      debug?.(`Skipped injecting fallback sourcemap for ${req.url}`)
+    } else {
       const urlWithoutTimestamp = removeTimestampQuery(req.url!)
       const ms = new MagicString(code)
       content = getCodeWithSourcemap(

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -1,5 +1,6 @@
 import { URL } from 'node:url'
 import { describe, expect, test } from 'vitest'
+import { mapFileCommentRegex } from 'convert-source-map'
 import {
   extractSourcemap,
   findAssetFile,
@@ -35,7 +36,7 @@ if (!isBuild) {
     )
     const js = await res.text()
 
-    const sourcemapComments = js.match(/\/\/# sourceMappingURL=.+/g).length
+    const sourcemapComments = js.match(mapFileCommentRegex).length
     expect(sourcemapComments).toBe(1)
 
     const map = extractSourcemap(js)

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -29,6 +29,30 @@ if (!isBuild) {
     `)
   })
 
+  test('js with existing inline sourcemap', async () => {
+    const res = await page.request.get(
+      new URL('./foo-with-sourcemap.js', page.url()).href,
+    )
+    const js = await res.text()
+
+    const sourcemapComments = js.match(/\/\/# sourceMappingURL=.+/g).length
+    expect(sourcemapComments).toBe(1)
+
+    const map = extractSourcemap(js)
+    expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
+      {
+        "mappings": "AAAA,MAAM,CAAC,KAAK,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG",
+        "sources": [
+          "",
+        ],
+        "sourcesContent": [
+          null,
+        ],
+        "version": 3,
+      }
+    `)
+  })
+
   test('ts', async () => {
     const res = await page.request.get(new URL('./bar.ts', page.url()).href)
     const js = await res.text()

--- a/playground/js-sourcemap/foo-with-sourcemap.js
+++ b/playground/js-sourcemap/foo-with-sourcemap.js
@@ -1,0 +1,5 @@
+export const foo = 'foo'
+
+// default boundary sourcemap with magic-string
+
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHIn0=


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Found in vite-plugin-svelte's ecosystem-ci, if the transformed code already has an inline sourcemap (for some reason) and has no returned `map`, we don't inject a fallback sourcemap.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
