### PR TITLE
feat: allow loadEnv to not contain process.env

### DIFF
--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -32,7 +32,7 @@ export function loadEnv(
       if (!tryStatSync(filePath)?.isFile()) return []
 
       return Object.entries(parse(fs.readFileSync(filePath)))
-    })
+    }),
   )
 
   // test NODE_ENV override before expand as otherwise process.env.NODE_ENV would override this

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -9,11 +9,12 @@ export function loadEnv(
   mode: string,
   envDir: string,
   prefixes: string | string[] = 'VITE_',
+  includeProcessEnv = true
 ): Record<string, string> {
   if (mode === 'local') {
     throw new Error(
       `"local" cannot be used as a mode name because it conflicts with ` +
-        `the .local postfix for .env files.`,
+        `the .local postfix for .env files.`
     )
   }
   prefixes = arraify(prefixes)
@@ -26,12 +27,12 @@ export function loadEnv(
   ]
 
   const parsed = Object.fromEntries(
-    envFiles.flatMap((file) => {
+    envFiles.flatMap(file => {
       const filePath = path.join(envDir, file)
       if (!tryStatSync(filePath)?.isFile()) return []
 
       return Object.entries(parse(fs.readFileSync(filePath)))
-    }),
+    })
   )
 
   // test NODE_ENV override before expand as otherwise process.env.NODE_ENV would override this
@@ -52,15 +53,19 @@ export function loadEnv(
 
   // only keys that start with prefix are exposed to client
   for (const [key, value] of Object.entries(parsed)) {
-    if (prefixes.some((prefix) => key.startsWith(prefix))) {
+    if (prefixes.some(prefix => key.startsWith(prefix))) {
       env[key] = value
     }
+  }
+
+  if (!includeProcessEnv) {
+    return env
   }
 
   // check if there are actual env variables starting with VITE_*
   // these are typically provided inline and should be prioritized
   for (const key in process.env) {
-    if (prefixes.some((prefix) => key.startsWith(prefix))) {
+    if (prefixes.some(prefix => key.startsWith(prefix))) {
       env[key] = process.env[key] as string
     }
   }

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -70,8 +70,8 @@ export function loadEnv(
     const parsedKeys = Object.keys(parsed)
     
     Object.keys(process.env)
-      .filter(key => !parseKeys.includes(key) && key in env)
-      .forEach(unwantedKey => delete env[key])
+      .filter(processEnvKey => processEnvKey in env && !parseKeys.includes(processEnvKey))
+      .forEach(unwantedKey => delete env[unwantedKey])
   }
 
   return env

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -14,7 +14,7 @@ export function loadEnv(
   if (mode === 'local') {
     throw new Error(
       `"local" cannot be used as a mode name because it conflicts with ` +
-        `the .local postfix for .env files.`
+        `the .local postfix for .env files.`,
     )
   }
   prefixes = arraify(prefixes)
@@ -27,7 +27,7 @@ export function loadEnv(
   ]
 
   const parsed = Object.fromEntries(
-    envFiles.flatMap(file => {
+    envFiles.flatMap((file) => {
       const filePath = path.join(envDir, file)
       if (!tryStatSync(filePath)?.isFile()) return []
 
@@ -53,21 +53,25 @@ export function loadEnv(
 
   // only keys that start with prefix are exposed to client
   for (const [key, value] of Object.entries(parsed)) {
-    if (prefixes.some(prefix => key.startsWith(prefix))) {
+    if (prefixes.some((prefix) => key.startsWith(prefix))) {
       env[key] = value
     }
-  }
-
-  if (!includeProcessEnv) {
-    return env
   }
 
   // check if there are actual env variables starting with VITE_*
   // these are typically provided inline and should be prioritized
   for (const key in process.env) {
-    if (prefixes.some(prefix => key.startsWith(prefix))) {
+    if (prefixes.some((prefix) => key.startsWith(prefix))) {
       env[key] = process.env[key] as string
     }
+  }
+
+  if (!includeProcessEnv) {
+    const parsedKeys = Object.keys(parsed)
+    
+    Object.keys(process.env)
+      .filter(key => !parseKeys.includes(key) && key in env)
+      .forEach(unwantedKey => delete env[key])
   }
 
   return env


### PR DESCRIPTION
### Description

This is a new non-breaking option to `loadEnv` which allows return environment variables _without_ having `process.env` spilled into the returned value.

### Additional context

I'd like to use this in the context of building a lambda@edge function. As you may know it does not allow `process.env` configuration, so i'll need to dump configured env with an esbuild `banner.js` line containing something along the lines of:

```ts
{
  banner: {
    js: `Object.assign(process.env, ${loadEnv(process.env.NODE_ENV!, process.cwd(), '')});`
  }
}
``` 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
