### PR TITLE
fix: case sensitivity issues when using fs module under unix system

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -585,7 +585,9 @@ function tryCleanFsResolve(
   const { tryPrefix, extensions, preserveSymlinks } = options
 
   let fileStat = tryStatSync(file)
-  if (!isWindows && fileStat === void 0 && (file = findRealPath(file))) {
+  if (!isWindows && fileStat === void 0) {
+    const newPath = findRealPath(file)
+    if (newPath) file = newPath
     fileStat = tryStatSync(file)
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

 case sensitivity issues when using fs module under unix system.
Vite internally operates files through the fs module. On win and macos systems, there is no case sensitivity issue in fs operating files. For example, if I have a file 'xxx/Test/1.png', I can pass 'xxx/test/1. png' can be read, but it does not work on some unix systems, such as centos. This PR solves this problem.

### Additional context

#14374 

https://stackblitz.com/~/github.com/chovrio/vite

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ x ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ x ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ x ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ x ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ x ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ x ] Ideally, include relevant tests that fail without this PR but pass with it.
