### PR TITLE
docs: update wrangler command

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -220,7 +220,7 @@ Learn more about Vercel’s [Git Integration](https://vercel.com/docs/concepts/g
 1. Install [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/).
 2. Authenticate Wrangler with your Cloudflare account using `wrangler login`.
 3. Run your build command.
-4. Deploy using `npx wrangler pages publish dist`.
+4. Deploy using `npx wrangler pages deploy dist`.
 
 ```bash
 # Install Wrangler CLI


### PR DESCRIPTION
`wrangler pages publish` is now `wranger pages deploy`
