### PR TITLE
docs: use extends instead of spreading default theme

### DIFF
--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,14 +1,15 @@
 import { h } from 'vue'
-import Theme from 'vitepress/theme'
+import type { Theme } from 'vitepress'
+import DefaultTheme from 'vitepress/theme'
 import './styles/vars.css'
 import HomeSponsors from './components/HomeSponsors.vue'
 import AsideSponsors from './components/AsideSponsors.vue'
 import SvgImage from './components/SvgImage.vue'
 
 export default {
-  ...Theme,
+  extends: DefaultTheme,
   Layout() {
-    return h(Theme.Layout, null, {
+    return h(DefaultTheme.Layout, null, {
       'home-features-after': () => h(HomeSponsors),
       'aside-ads-before': () => h(AsideSponsors),
     })
@@ -16,4 +17,4 @@ export default {
   enhanceApp({ app }) {
     app.component('SvgImage', SvgImage)
   },
-}
+} satisfies Theme


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Same with https://github.com/sapphi-red/vitepress-plugins/pull/34
> Spreading the default theme when `enhanceApp` is specified prevents registering some of the vitepress components like badges that other people might be using.

We don't use vitepress components yet, but it'd be better not to break them.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
