### PR TITLE
fix: respect `resolve.conditions` during `nodeResolve`

### DIFF
--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -121,7 +121,7 @@ async function instantiateModule(
 
   const {
     isProduction,
-    resolve: { dedupe, preserveSymlinks },
+    resolve: { dedupe, preserveSymlinks, conditions },
     root,
   } = server.config
 
@@ -129,7 +129,7 @@ async function instantiateModule(
     mainFields: ['main'],
     browserField: true,
     conditions: [],
-    overrideConditions: ['production', 'development'],
+    overrideConditions: [...conditions, 'production', 'development'],
     extensions: ['.js', '.cjs', '.json'],
     dedupe,
     preserveSymlinks,

--- a/playground/ssr-deps/__tests__/ssr-deps.spec.ts
+++ b/playground/ssr-deps/__tests__/ssr-deps.spec.ts
@@ -122,6 +122,13 @@ test('import css library', async () => {
   expect(await page.textContent('.module-condition')).toMatch('[success]')
 })
 
+test('import react/server/server.node.unbundled.js', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.react-server')).toMatch(
+    'server.node.unbundled.js',
+  )
+})
+
 describe.runIf(isServe)('hmr', () => {
   test('handle isomorphic module updates', async () => {
     await page.goto(url)

--- a/playground/ssr-deps/package.json
+++ b/playground/ssr-deps/package.json
@@ -17,6 +17,7 @@
     "@vitejs/test-object-assigned-exports": "file:./object-assigned-exports",
     "@vitejs/test-only-object-assigned-exports": "file:./only-object-assigned-exports",
     "@vitejs/test-primitive-export": "file:./primitive-export",
+    "@vitejs/test-react-server": "file:./react-server",
     "@vitejs/test-read-file-content": "file:./read-file-content",
     "@vitejs/test-require-absolute": "file:./require-absolute",
     "@vitejs/test-ts-transpiled-exports": "file:./ts-transpiled-exports",

--- a/playground/ssr-deps/react-server/package.json
+++ b/playground/ssr-deps/react-server/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@vitejs/test-react-server",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "exports": {
+    "./server": {
+      "react-server": {
+        "workerd": "./server.edge.js",
+        "deno": "./server.browser.js",
+        "node": {
+          "webpack": "./server.node.js",
+          "default": "./server.node.unbundled.js"
+        },
+        "edge-light": "./server.edge.js",
+        "browser": "./server.browser.js"
+      },
+      "default": "./server.js"
+    }
+  }
+}

--- a/playground/ssr-deps/react-server/server.browser.js
+++ b/playground/ssr-deps/react-server/server.browser.js
@@ -1,0 +1,1 @@
+export default 'server.browser.js'

--- a/playground/ssr-deps/react-server/server.edge.js
+++ b/playground/ssr-deps/react-server/server.edge.js
@@ -1,0 +1,1 @@
+export default 'server.edge.js'

--- a/playground/ssr-deps/react-server/server.js
+++ b/playground/ssr-deps/react-server/server.js
@@ -1,0 +1,1 @@
+export default 'server.js'

--- a/playground/ssr-deps/react-server/server.node.js
+++ b/playground/ssr-deps/react-server/server.node.js
@@ -1,0 +1,1 @@
+export default 'server.node.js'

--- a/playground/ssr-deps/react-server/server.node.unbundled.js
+++ b/playground/ssr-deps/react-server/server.node.unbundled.js
@@ -1,0 +1,1 @@
+export default 'server.node.unbundled.js'

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -21,6 +21,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
   ).createServer({
     root,
     logLevel: isTest ? 'error' : 'info',
+    resolve: {
+      conditions: ['react-server'],
+    },
     server: {
       middlewareMode: true,
       watch: {

--- a/playground/ssr-deps/src/app.js
+++ b/playground/ssr-deps/src/app.js
@@ -16,6 +16,7 @@ import importBuiltinCjs from '@vitejs/test-import-builtin-cjs'
 import { hello as linkedNoExternal } from '@vitejs/test-linked-no-external'
 import virtualMessage from '@vitejs/test-pkg-exports/virtual'
 import moduleConditionMessage from '@vitejs/test-module-condition'
+import reactServerMessage from '@vitejs/test-react-server/server'
 import '@vitejs/test-css-lib'
 
 // This import will set a 'Hello World!" message in the nested-external non-entry dependency
@@ -90,6 +91,8 @@ export async function render(url, rootDir) {
   html += `\n<p class="css-lib">I should be blue</p>`
 
   html += `\n<p class="module-condition">${moduleConditionMessage}</p>`
+
+  html += `\n<p class="react-server">${reactServerMessage}</p>`
 
   html += `\n<p class="isomorphic-module-server">${isomorphicModuleMessage}</p>`
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1222,6 +1222,9 @@ importers:
       '@vitejs/test-primitive-export':
         specifier: file:./primitive-export
         version: file:playground/ssr-deps/primitive-export
+      '@vitejs/test-react-server':
+        specifier: file:./react-server
+        version: file:playground/ssr-deps/react-server
       '@vitejs/test-read-file-content':
         specifier: file:./read-file-content
         version: file:playground/ssr-deps/read-file-content
@@ -1301,6 +1304,8 @@ importers:
   playground/ssr-deps/pkg-exports: {}
 
   playground/ssr-deps/primitive-export: {}
+
+  playground/ssr-deps/react-server: {}
 
   playground/ssr-deps/read-file-content: {}
 
@@ -10915,6 +10920,11 @@ packages:
   file:playground/ssr-deps/primitive-export:
     resolution: {directory: playground/ssr-deps/primitive-export, type: directory}
     name: '@vitejs/test-primitive-export'
+    dev: false
+
+  file:playground/ssr-deps/react-server:
+    resolution: {directory: playground/ssr-deps/react-server, type: directory}
+    name: '@vitejs/test-react-server'
     dev: false
 
   file:playground/ssr-deps/read-file-content:


### PR DESCRIPTION
Based on upstream: #13487, but add e2e test coverage