### PR TITLE
chore: ensure create-vite has unbuild dev dep

### DIFF
--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -38,6 +38,7 @@
     "cross-spawn": "^7.0.3",
     "kolorist": "^1.8.0",
     "minimist": "^1.2.8",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "unbuild": "^2.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      unbuild:
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.0.2)
 
   packages/plugin-legacy:
     dependencies:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The `create-vite` package doesn't have an explicit `unbuild` dev dep, even though it's using it. It was likely using the hoisted `unbuild` instance from `plugin-legacy`.

