### PR TITLE
fix: make injectQuery idempotent

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -629,7 +629,10 @@ export function injectQuery(url: string, queryToInject: string): string {
 
   // clean up existing query to avoid ?import&import etc.
   searchParams.delete(queryToInject)
-  const search = searchParams.toString()
+  const search = searchParams
+    .toString()
+    // clean up blank string values (e.g. ?vue= becomes ?vue)
+    .replace(/=(&|$)/g, '$1')
 
   return `${pathname}?${queryToInject}${search ? `&` + search : ''}${
     hash || ''

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -625,13 +625,15 @@ export function injectQuery(url: string, queryToInject: string): string {
 
   // can't use pathname from URL since it may be relative like ../
   const pathname = url.replace(/#.*$/, '').replace(/\?.*$/, '')
-  const { search, searchParams, hash } = new URL(url, 'http://vitejs.dev')
+  const { searchParams, hash } = new URL(url, 'http://vitejs.dev')
 
-  return searchParams.get(queryToInject) === ''
-    ? `${pathname}${search}${hash || ''}`
-    : `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
-        hash || ''
-      }`
+  // clean up existing query to avoid ?import&import etc.
+  searchParams.delete(queryToInject)
+  const search = searchParams.toString()
+
+  return `${pathname}?${queryToInject}${search ? `&` + search : ''}${
+    hash || ''
+  }`
 }
 
 export { ErrorOverlay }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -625,11 +625,13 @@ export function injectQuery(url: string, queryToInject: string): string {
 
   // can't use pathname from URL since it may be relative like ../
   const pathname = url.replace(/#.*$/, '').replace(/\?.*$/, '')
-  const { search, hash } = new URL(url, 'http://vitejs.dev')
+  const { search, searchParams, hash } = new URL(url, 'http://vitejs.dev')
 
-  return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
-    hash || ''
-  }`
+  return searchParams.get(queryToInject) === ''
+    ? `${pathname}${search}${hash || ''}`
+    : `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
+        hash || ''
+      }`
 }
 
 export { ErrorOverlay }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -628,7 +628,7 @@ export function injectQuery(url: string, queryToInject: string): string {
   const { searchParams, hash } = new URL(url, 'http://vitejs.dev')
 
   // clean up existing query to avoid ?import&import etc.
-  searchParams.delete(queryToInject)
+  searchParams.delete(queryToInject.split('=')[0])
   const search = searchParams
     .toString()
     // clean up blank string values (e.g. ?vue= becomes ?vue)

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -124,9 +124,21 @@ describe('injectQuery', () => {
     )
   })
 
+  test('path with injected query already present when providing a key-vale pair for the injected query', () => {
+    expect(injectQuery('/usr/vite/query?foo', 'foo=bar')).toEqual(
+      '/usr/vite/query?foo=bar',
+    )
+  })
+
   test('path with injected query already present with a value', () => {
     expect(injectQuery('/usr/vite/query?direct=value', 'direct')).toEqual(
       '/usr/vite/query?direct',
+    )
+  })
+
+  test('path with injected query already present with a value when providing a key-vale pair for the injected query', () => {
+    expect(injectQuery('/usr/vite/query?foo=oldValue', 'foo=newValue')).toEqual(
+      '/usr/vite/query?foo=newValue',
     )
   })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -111,6 +111,48 @@ describe('injectQuery', () => {
       '/usr/vite/東京 %20 hello?direct',
     )
   })
+
+  test('path with injected query already present', () => {
+    expect(injectQuery('/usr/vite/query?direct', 'direct')).toEqual(
+      '/usr/vite/query?direct',
+    )
+  })
+
+  test('path with injected query already present multiple times', () => {
+    expect(injectQuery('/usr/vite/query?direct&direct', 'direct')).toEqual(
+      '/usr/vite/query?direct',
+    )
+  })
+
+  test('path with injected query already present, along with other query params at the start', () => {
+    expect(
+      injectQuery('/usr/vite/query?something=else&direct', 'direct'),
+    ).toEqual('/usr/vite/query?direct&something=else')
+  })
+
+  test('path with injected query already present, along with other query params at the end', () => {
+    expect(
+      injectQuery('/usr/vite/query?direct&something=else', 'direct'),
+    ).toEqual('/usr/vite/query?direct&something=else')
+  })
+
+  test('path with injected query already present with a value', () => {
+    expect(injectQuery('/usr/vite/query?direct=value', 'direct')).toEqual(
+      '/usr/vite/query?direct',
+    )
+  })
+
+  test('path with injected query already present with a value defined, along with other query params at the start', () => {
+    expect(
+      injectQuery('/usr/vite/query?something=else&direct=value', 'direct'),
+    ).toEqual('/usr/vite/query?direct&something=else')
+  })
+
+  test('path with injected query already present with a value defined, along with other query params at the end', () => {
+    expect(
+      injectQuery('/usr/vite/query?direct=value&something=else', 'direct'),
+    ).toEqual('/usr/vite/query?direct&something=else')
+  })
 })
 
 describe('resolveHostname', () => {

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -124,34 +124,46 @@ describe('injectQuery', () => {
     )
   })
 
-  test('path with injected query already present, along with other query params at the start', () => {
-    expect(
-      injectQuery('/usr/vite/query?something=else&direct', 'direct'),
-    ).toEqual('/usr/vite/query?direct&something=else')
-  })
-
-  test('path with injected query already present, along with other query params at the end', () => {
-    expect(
-      injectQuery('/usr/vite/query?direct&something=else', 'direct'),
-    ).toEqual('/usr/vite/query?direct&something=else')
-  })
-
   test('path with injected query already present with a value', () => {
     expect(injectQuery('/usr/vite/query?direct=value', 'direct')).toEqual(
       '/usr/vite/query?direct',
     )
   })
 
+  test('path with injected query already present, along with other query params at the start', () => {
+    expect(
+      injectQuery(
+        '/usr/vite/file.vue?vue&type=template&lang.js&direct',
+        'direct',
+      ),
+    ).toEqual('/usr/vite/file.vue?direct&vue&type=template&lang.js')
+  })
+
+  test('path with injected query already present, along with other query params at the end', () => {
+    expect(
+      injectQuery(
+        '/usr/vite/file.vue?direct&vue&type=template&lang.js',
+        'direct',
+      ),
+    ).toEqual('/usr/vite/file.vue?direct&vue&type=template&lang.js')
+  })
+
   test('path with injected query already present with a value defined, along with other query params at the start', () => {
     expect(
-      injectQuery('/usr/vite/query?something=else&direct=value', 'direct'),
-    ).toEqual('/usr/vite/query?direct&something=else')
+      injectQuery(
+        '/usr/vite/file.vue?vue&type=template&lang.js&direct=value',
+        'direct',
+      ),
+    ).toEqual('/usr/vite/file.vue?direct&vue&type=template&lang.js')
   })
 
   test('path with injected query already present with a value defined, along with other query params at the end', () => {
     expect(
-      injectQuery('/usr/vite/query?direct=value&something=else', 'direct'),
-    ).toEqual('/usr/vite/query?direct&something=else')
+      injectQuery(
+        '/usr/vite/file.vue?direct=value&vue&type=template&lang.js',
+        'direct',
+      ),
+    ).toEqual('/usr/vite/file.vue?direct&vue&type=template&lang.js')
   })
 })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -124,7 +124,7 @@ describe('injectQuery', () => {
     )
   })
 
-  test('path with injected query already present when providing a key-vale pair for the injected query', () => {
+  test('path with injected query already present when providing a key-value pair for the injected query', () => {
     expect(injectQuery('/usr/vite/query?foo', 'foo=bar')).toEqual(
       '/usr/vite/query?foo=bar',
     )
@@ -136,7 +136,7 @@ describe('injectQuery', () => {
     )
   })
 
-  test('path with injected query already present with a value when providing a key-vale pair for the injected query', () => {
+  test('path with injected query already present with a value when providing a key-value pair for the injected query', () => {
     expect(injectQuery('/usr/vite/query?foo=oldValue', 'foo=newValue')).toEqual(
       '/usr/vite/query?foo=newValue',
     )

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -320,12 +320,15 @@ export function injectQuery(url: string, queryToInject: string): string {
     url.replace(replacePercentageRE, '%25'),
     'relative:///',
   )
-  const { search, hash } = resolvedUrl
+  const { search, searchParams, hash } = resolvedUrl
   let pathname = cleanUrl(url)
   pathname = isWindows ? slash(pathname) : pathname
-  return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
-    hash ?? ''
-  }`
+
+  return searchParams.get(queryToInject) === ''
+    ? `${pathname}${search}${hash ?? ''}`
+    : `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
+        hash ?? ''
+      }`
 }
 
 const timestampRE = /\bt=\d{13}&?\b/

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -320,15 +320,17 @@ export function injectQuery(url: string, queryToInject: string): string {
     url.replace(replacePercentageRE, '%25'),
     'relative:///',
   )
-  const { search, searchParams, hash } = resolvedUrl
+  const { searchParams, hash } = resolvedUrl
   let pathname = cleanUrl(url)
   pathname = isWindows ? slash(pathname) : pathname
 
-  return searchParams.get(queryToInject) === ''
-    ? `${pathname}${search}${hash ?? ''}`
-    : `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${
-        hash ?? ''
-      }`
+  // clean up existing query to avoid ?import&import etc.
+  searchParams.delete(queryToInject)
+  const search = searchParams.toString()
+
+  return `${pathname}?${queryToInject}${search ? `&` + search : ''}${
+    hash ?? ''
+  }`
 }
 
 const timestampRE = /\bt=\d{13}&?\b/

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -326,7 +326,10 @@ export function injectQuery(url: string, queryToInject: string): string {
 
   // clean up existing query to avoid ?import&import etc.
   searchParams.delete(queryToInject)
-  const search = searchParams.toString()
+  const search = searchParams
+    .toString()
+    // clean up blank string values (e.g. ?vue= becomes ?vue)
+    .replace(/=(&|$)/g, '$1')
 
   return `${pathname}?${queryToInject}${search ? `&` + search : ''}${
     hash ?? ''

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -325,7 +325,7 @@ export function injectQuery(url: string, queryToInject: string): string {
   pathname = isWindows ? slash(pathname) : pathname
 
   // clean up existing query to avoid ?import&import etc.
-  searchParams.delete(queryToInject)
+  searchParams.delete(queryToInject.split('=')[0])
   const search = searchParams
     .toString()
     // clean up blank string values (e.g. ?vue= becomes ?vue)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This fixes the following issue with the `injectQuery` util:

```js
injectQuery('/foo?import', 'import');
// -> '/foo?import&import'
```

I ran into this because we're experimenting with using Vite for Remix. Remix injects a script tag in the HTML from the server to load all the JS modules for the current route before running the app, e.g.:

```html
<script type="module" async="">
import * as route0 from "/@fs/path/to/app/root.tsx";
import * as route1 from "/@fs/path/to/app/routes/_index.tsx";
window.__remixRouteModules = {"root":route0,"routes/_index":route1};

import("/@fs/path/to/app/entry.client.tsx");
</script>
```

However, this fails in Vite when using MDX routes since the Vite dev server responds with the raw MDX content.

```html
<script type="module" async="">
import * as route0 from "/@fs/path/to/app/root.tsx";
import * as route1 from "/@fs/path/to/app/routes/mdx/route.mdx"; // <-- THIS IS AN ERROR 😭
window.__remixRouteModules = {"root":route0,"routes/mdx":route1};

import("/@fs/path/to/app/entry.client.tsx");
</script>
```

To fix this, I appended `?import` to the route module URLs in the Remix manifest in dev mode so that the Vite dev server responds with the compiled JS. This ensures that module URLs in the Remix manifest are valid JS modules, even when using other file formats. This means the injected script tag is now correct:

```html
<script type="module" async="">
import * as route0 from "/@fs/path/to/app/root.tsx";
import * as route1 from "/@fs/path/to/app/routes/mdx/route.mdx?import"; // <-- THIS WORKS! 🎉
window.__remixRouteModules = {"root":route0,"routes/mdx":route1};

import("/@fs/path/to/app/entry.client.tsx");
</script>
```

However this causes issues when these URLs are imported within Remix library code because Vite transforms the import statement to use `injectQuery` which turns the query string into `?import&import`.

To fix this, I've updated `injectQuery` to <strike>detect whether the `queryToInject` argument is already present in the search params and that it has a blank value, and if so,</strike> first delete any values for `queryToInject` from the search params to avoid adding it again.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
