### PR TITLE
fix(legacy): suppress babel warning during polyfill scan

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -630,6 +630,7 @@ export async function detectPolyfills(
     ast: true,
     babelrc: false,
     configFile: false,
+    compact: false,
     presets: [
       [
         (await import('@babel/preset-env')).default,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Babel throws the following warning during building which is quite annoying:
```
[BABEL] Note: The code generator has deoptimised the styling of undefined as it exceeds the max of 500KB.
```
I think we can simply turn on `compact` option when detecting polyfills. Just like what Evan previous did in https://github.com/vitejs/vite/commit/045e519d51fbce94bddb60793e9e99311acc5aa2

fixes #7907

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
