### PR TITLE
fix(hmr): dev mode reduce unnecessary restart

### DIFF
--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -5,6 +5,15 @@ import { expand } from 'dotenv-expand'
 import { arraify, tryStatSync } from './utils'
 import type { UserConfig } from './config'
 
+export function getEnvFilesForMode(mode: string): string[] {
+  return [
+    /** default file */ `.env`,
+    /** local file */ `.env.local`,
+    /** mode file */ `.env.${mode}`,
+    /** mode local file */ `.env.${mode}.local`,
+  ]
+}
+
 export function loadEnv(
   mode: string,
   envDir: string,
@@ -18,12 +27,7 @@ export function loadEnv(
   }
   prefixes = arraify(prefixes)
   const env: Record<string, string> = {}
-  const envFiles = [
-    /** default file */ `.env`,
-    /** local file */ `.env.local`,
-    /** mode file */ `.env.${mode}`,
-    /** mode local file */ `.env.${mode}.local`,
-  ]
+  const envFiles = getEnvFilesForMode(mode)
 
   const parsed = Object.fromEntries(
     envFiles.flatMap((file) => {

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -62,9 +62,14 @@ export async function handleHMRUpdate(
   const isConfigDependency = config.configFileDependencies.some(
     (name) => file === name,
   )
+  const isDev = config.mode === 'development'
+  const isChangedProductionEnv =
+    isDev &&
+    (fileName === '.env.production' || fileName === '.env.production.local')
   const isEnv =
     config.inlineConfig.envFile !== false &&
-    (fileName === '.env' || fileName.startsWith('.env.'))
+    (fileName === '.env' ||
+      (fileName.startsWith('.env.') && !isChangedProductionEnv))
   if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
     debugHmr?.(`[config change] ${colors.dim(shortFile)}`)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -16,6 +16,7 @@ import type { ViteDevServer } from '..'
 import { isCSSRequest } from '../plugins/css'
 import { getAffectedGlobModules } from '../plugins/importMetaGlob'
 import { isExplicitImportRequired } from '../plugins/importAnalysis'
+import { getEnvFilesForMode } from '../env'
 import type { ModuleNode } from './moduleGraph'
 
 export const debugHmr = createDebugger('vite:hmr')
@@ -49,13 +50,6 @@ export function getShortName(file: string, root: string): string {
     : file
 }
 
-function changeEnvShouldRestart(mode: string, fileName: string) {
-  if (fileName === '.env' || fileName === '.env.local') {
-    return true
-  }
-  return fileName === `.env.${mode}` || fileName === `.env.${mode}.local`
-}
-
 export async function handleHMRUpdate(
   file: string,
   server: ViteDevServer,
@@ -72,7 +66,7 @@ export async function handleHMRUpdate(
 
   const isEnv =
     config.inlineConfig.envFile !== false &&
-    changeEnvShouldRestart(config.mode, fileName)
+    getEnvFilesForMode(config.mode).includes(fileName)
   if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
     debugHmr?.(`[config change] ${colors.dim(shortFile)}`)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -49,6 +49,13 @@ export function getShortName(file: string, root: string): string {
     : file
 }
 
+function changeEnvShouldRestart(mode: string, fileName: string) {
+  if (fileName === '.env' || fileName === '.env.local') {
+    return true
+  }
+  return fileName === `.env.${mode}` || fileName === `.env.${mode}.local`
+}
+
 export async function handleHMRUpdate(
   file: string,
   server: ViteDevServer,
@@ -62,14 +69,10 @@ export async function handleHMRUpdate(
   const isConfigDependency = config.configFileDependencies.some(
     (name) => file === name,
   )
-  const isDev = config.mode === 'development'
-  const isChangedProductionEnv =
-    isDev &&
-    (fileName === '.env.production' || fileName === '.env.production.local')
+
   const isEnv =
     config.inlineConfig.envFile !== false &&
-    (fileName === '.env' ||
-      (fileName.startsWith('.env.') && !isChangedProductionEnv))
+    changeEnvShouldRestart(config.mode, fileName)
   if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
     debugHmr?.(`[config change] ${colors.dim(shortFile)}`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I don't think it's necessary to restart the server to modify the production environment related env in development mode.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
