### PR TITLE
fix(legacy): modern polyfill autodetection was injecting more polyfills than needed

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -123,6 +123,20 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   let config: ResolvedConfig
   let targets: Options['targets']
 
+  // browsers supporting ESM + dynamic import + import.meta + async generator
+  const modernTargetsEsbuild = [
+    'es2020',
+    'edge79',
+    'firefox67',
+    'chrome64',
+    'safari12',
+  ]
+  // same with above but by browserslist syntax
+  // es2020 = chrome 80+, safari 13.1+, firefox 72+, edge 80+
+  // https://github.com/evanw/esbuild/issues/121#issuecomment-646956379
+  const modernTargetsBabel =
+    'edge>=80, firefox>=72, chrome>=80, safari>=13.1, chromeAndroid>=80, iOS>=13.1'
+
   const genLegacy = options.renderLegacyChunks !== false
   const genModern = options.renderModernChunks !== false
   if (!genLegacy && !genModern) {
@@ -188,14 +202,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           // Vite's default target browsers are **not** the same.
           // See https://github.com/vitejs/vite/pull/10052#issuecomment-1242076461
           overriddenBuildTarget = config.build.target !== undefined
-          // browsers supporting ESM + dynamic import + import.meta + async generator
-          config.build.target = [
-            'es2020',
-            'edge79',
-            'firefox67',
-            'chrome64',
-            'safari12',
-          ]
+          config.build.target = modernTargetsEsbuild
         }
       }
 
@@ -375,7 +382,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           genModern
         ) {
           // analyze and record modern polyfills
-          await detectPolyfills(raw, { esmodules: true }, modernPolyfills)
+          await detectPolyfills(raw, modernTargetsBabel, modernPolyfills)
         }
 
         const ms = new MagicString(raw)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Modern chunks are targeting "ESM + dynamic import + import.meta + async generator" but the polyfill detection was using `{ esmodules: true }` as the target.

#### injected modern polyfills in legacy playground
<details>

**before**
```js
 {
  'core-js/modules/es.symbol.description.js',
  'core-js/modules/es.symbol.async-iterator.js',
  'core-js/modules/es.array.iterator.js',
  'core-js/modules/web.dom-collections.iterator.js',
  'core-js/modules/es.error.cause.js',
  'core-js/modules/es.promise.js',
  'core-js/modules/web.url.js',
  'core-js/modules/web.url-search-params.js',
  'core-js/modules/web.url-search-params.delete.js',
  'core-js/modules/web.url-search-params.has.js',
  'core-js/modules/web.url-search-params.size.js',
  'core-js/modules/es.string.ends-with.js',
  'core-js/modules/esnext.set.difference.v2.js',
  'core-js/modules/esnext.set.intersection.v2.js',
  'core-js/modules/esnext.set.is-disjoint-from.v2.js',
  'core-js/modules/esnext.set.is-subset-of.v2.js',
  'core-js/modules/esnext.set.is-superset-of.v2.js',
  'core-js/modules/esnext.set.symmetric-difference.v2.js',
  'core-js/modules/esnext.set.union.v2.js',
  'core-js/modules/es.json.stringify.js',
  'core-js/modules/web.dom-exception.constructor.js',
  'core-js/modules/web.dom-exception.stack.js',
  'core-js/modules/web.dom-exception.to-string-tag.js',
  'core-js/modules/web.structured-clone.js',
  'core-js/modules/es.array.push.js'
}
```
**after**
```js
{
  'core-js/modules/web.dom-collections.iterator.js',
  'core-js/modules/web.url.js',
  'core-js/modules/web.url-search-params.js',
  'core-js/modules/web.url-search-params.delete.js',
  'core-js/modules/web.url-search-params.has.js',
  'core-js/modules/web.url-search-params.size.js',
  'core-js/modules/es.error.cause.js',
  'core-js/modules/esnext.set.difference.v2.js',
  'core-js/modules/esnext.set.intersection.v2.js',
  'core-js/modules/esnext.set.is-disjoint-from.v2.js',
  'core-js/modules/esnext.set.is-subset-of.v2.js',
  'core-js/modules/esnext.set.is-superset-of.v2.js',
  'core-js/modules/esnext.set.symmetric-difference.v2.js',
  'core-js/modules/esnext.set.union.v2.js',
  'core-js/modules/web.dom-exception.stack.js',
  'core-js/modules/web.structured-clone.js',
  'core-js/modules/es.array.push.js'
}
```
</details>

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
