### PR TITLE
refactor(legacy)!: remove `ignoreBrowserslistConfig` option

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -44,6 +44,8 @@ npm add -D terser
 
   The query is also [Browserslist compatible](https://github.com/browserslist/browserslist). See [Browserslist Best Practices](https://github.com/browserslist/browserslist#best-practices) for more details.
 
+  If it's not set, plugin-legacy will load [the browserslit config sources](https://github.com/browserslist/browserslist#queries) and then fallback to the default value.
+
 ### `polyfills`
 
 - **Type:** `boolean | string[]`
@@ -62,18 +64,6 @@ npm add -D terser
   Add custom imports to the legacy polyfills chunk. Since the usage-based polyfill detection only covers ES language features, it may be necessary to manually specify additional DOM API polyfills using this option.
 
   Note: if additional polyfills are needed for both the modern and legacy chunks, they can simply be imported in the application source code.
-
-### `ignoreBrowserslistConfig`
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-  `@babel/preset-env` automatically detects [`browserslist` config sources](https://github.com/browserslist/browserslist#browserslist-):
-
-  - `browserslist` field in `package.json`
-  - `.browserslistrc` file in cwd.
-
-  Set to `true` to ignore these sources.
 
 ### `modernPolyfills`
 

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -44,7 +44,7 @@ npm add -D terser
 
   The query is also [Browserslist compatible](https://github.com/browserslist/browserslist). See [Browserslist Best Practices](https://github.com/browserslist/browserslist#best-practices) for more details.
 
-  If it's not set, plugin-legacy will load [the browserslit config sources](https://github.com/browserslist/browserslist#queries) and then fallback to the default value.
+  If it's not set, plugin-legacy will load [the browserslist config sources](https://github.com/browserslist/browserslist#queries) and then fallback to the default value.
 
 ### `polyfills`
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -454,10 +454,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           ],
           [
             (await import('@babel/preset-env')).default,
-            createBabelPresetEnvOptions(targets, {
-              needPolyfills,
-              ignoreBrowserslistConfig: options.ignoreBrowserslistConfig,
-            }),
+            createBabelPresetEnvOptions(targets, { needPolyfills }),
           ],
         ],
       })
@@ -633,9 +630,7 @@ export async function detectPolyfills(
     presets: [
       [
         (await import('@babel/preset-env')).default,
-        createBabelPresetEnvOptions(targets, {
-          ignoreBrowserslistConfig: true,
-        }),
+        createBabelPresetEnvOptions(targets, {}),
       ],
     ],
   })
@@ -654,10 +649,7 @@ export async function detectPolyfills(
 
 function createBabelPresetEnvOptions(
   targets: any,
-  {
-    needPolyfills = true,
-    ignoreBrowserslistConfig,
-  }: { needPolyfills?: boolean; ignoreBrowserslistConfig?: boolean },
+  { needPolyfills = true }: { needPolyfills?: boolean },
 ) {
   return {
     targets,
@@ -672,7 +664,7 @@ function createBabelPresetEnvOptions(
         }
       : undefined,
     shippedProposals: true,
-    ignoreBrowserslistConfig,
+    ignoreBrowserslistConfig: true,
   }
 }
 

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -4,10 +4,6 @@ export interface Options {
    */
   targets?: string | string[] | { [key: string]: string }
   /**
-   * default: false
-   */
-  ignoreBrowserslistConfig?: boolean
-  /**
    * default: true
    */
   polyfills?: boolean | string[]


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Given that we started always passing `target` option to babel in #11318, `ignoreBrowserslistConfig` option did nothing.
This PR removes that option.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
