### PR TITLE
feat(css): bundle css as part of optimizeDeps

### DIFF
--- a/docs/config/dep-optimization-options.md
+++ b/docs/config/dep-optimization-options.md
@@ -82,3 +82,12 @@ If you want to try this build strategy, you can use `optimizeDeps.disabled: fals
 - **Type:** `string[]`
 
 Forces ESM interop when importing these dependencies. Vite is able to properly detect when a dependency needs interop, so this option isn't generally needed. However, different combinations of dependencies could cause some of them to be prebundled differently. Adding these packages to `needsInterop` can speed up cold start by avoiding full-page reloads. You'll receive a warning if this is the case for one of your dependencies, suggesting to add the package name to this array in your config.
+
+## optimizeDeps.cssBundle
+
+- **Type:** `boolean`
+- **Default:** `false` for 'build', `true` otherwise
+
+When set to `true`, optimized dependencies that contain .css imports will have the css extracted and bundled in a separate file. This is useful for reducingthe number of small css requests coming from component-libraries, etc, replacing it instead with a single large css bundle request per dependency.
+
+Since the css bundle produced is not able to be tree-shaken for production builds, this default behavior if this option is not overrided is enabled for 'dev', and disabled for 'build'. That way, an optimized 'build' will externalize the css requests from dependencies so that the individual css imports may be tree-shaken away during the build.

--- a/packages/vite/src/node/optimizer/esbuildCssBundlePlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildCssBundlePlugin.ts
@@ -1,0 +1,31 @@
+import { basename } from 'node:path'
+import { readFile, writeFile } from 'node:fs/promises'
+import { type Plugin } from 'esbuild'
+
+export function esbuildCssBundlePlugin(): Plugin {
+  return {
+    name: 'vite:dep-pre-bundle-css',
+    setup(build) {
+      if (!build.initialOptions.metafile) {
+        throw new Error(
+          'The `metafile` option must be enabled for prebundling css imports to work.',
+        )
+      }
+
+      // clear package cache when esbuild is finished
+      build.onEnd(async (result) => {
+        await Promise.all(
+          Object.keys(result.metafile!.outputs).map(async (path) => {
+            const meta = result.metafile?.outputs[path]
+            if (!meta || !meta.cssBundle) {
+              return
+            }
+            const contents = await readFile(path, 'utf-8')
+            const cssBundle = basename(meta.cssBundle)
+            await writeFile(path, `${contents}\nimport "./${cssBundle}";\n`)
+          }),
+        )
+      })
+    },
+  }
+}

--- a/packages/vite/src/node/optimizer/esbuildCssBundlePlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildCssBundlePlugin.ts
@@ -12,7 +12,10 @@ export function esbuildCssBundlePlugin(): Plugin {
         )
       }
 
-      // clear package cache when esbuild is finished
+      // append a css import to the end of any js file that has an associated cssBundle
+      // esbuild strips the css imports as part of extracting and bundling css, but to
+      // maintain compatibility we need to ensure that if the js file gets imported, the
+      // css bundle will also get imported.
       build.onEnd(async (result) => {
         await Promise.all(
           Object.keys(result.metafile!.outputs).map(async (path) => {

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -50,6 +50,7 @@ export function esbuildDepPlugin(
   external: string[],
   config: ResolvedConfig,
   ssr: boolean,
+  cssBundle: boolean,
 ): Plugin {
   const { extensions } = getDepOptimizationConfig(config, ssr)
 
@@ -57,6 +58,10 @@ export function esbuildDepPlugin(
   const allExternalTypes = extensions
     ? externalTypes.filter((type) => !extensions?.includes('.' + type))
     : externalTypes
+
+  if (!cssBundle) {
+    allExternalTypes.unshift('css')
+  }
 
   // use separate package cache for optimizer as it caches paths around node_modules
   // and it's unlikely for the core Vite process to traverse into node_modules again

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -22,7 +22,6 @@ const cjsExternalFacadeNamespace = 'vite:cjs-external-facade'
 const nonFacadePrefix = 'vite-cjs-external-facade:'
 
 const externalTypes = [
-  'css',
   // supported pre-processor types
   'less',
   'sass',

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -210,7 +210,7 @@ test('pre bundle css require', async () => {
     await page.goto(viteTestUrl)
     const content = await (await response).text()
     expect(content).toMatch(
-      /import\s"\/@fs.+@vitejs\/test-dep-css-require\/style\.css"/,
+      /import\s"\/node_modules\/.vite\/deps\/@vitejs_test-dep-css-require.css\?v=[\da-fA-F]{8}"/,
     )
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This feature is intended to support component libraries that ship tree-shakable modules that include css imports.

When building with Vite, if the js files within your dependencies, contain css, then at build time, the css will get pulled into the app's css bundles and will be tree-shaken as part of the build (if `sideEffects: false` in the dependency and the module which imported the css is also dropped). For dev builds, treeshaking
doesn't happen, and instead, all of the css will wind up getting imported. The current behavior with optimizeDeps is that the css imports are externalized and preserved in the resulting .js deps bundles. This can result in a lot of css request being made on page load to the dev server. While css imports are faster to process than js imports, it still isn't ideal.

This feature extends the default preoptimized dependency bundling to support css imports from within the dependency's .js files. Esbuild already supports this feature, but it does so by bundling the css to a single .css bundle that sits alongside the js bundle, and it removes all imports to the css files from the resulting js bundle. The implied use- case is that consumers of a library built with esbuild would need to use a style tag, or import the css file directly.

Since we can't really change the semantics of how the library is consumed as a result of optimizeDeps, we need to inject a single import statement into the .js bundle if it has a corresponding cssBundle file in the esbuild metadata file. We are just appending this import statement to the bottom of the file so that the sourcemaps are still functional.

The end result is that the css for these dependencies will now be bundled into a single .css request for each dep / chunk that contains imports to a css file.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

I work on a component library that has around 350 vue files, 260 of which have `<style>` blocks.
When this library is built, the resulting artifacts are individual .js files for each of the .vue components,
and 1 or more .css files depending on how many `<style>` blocks there are. These .css files are then
imported with a static import along the lines of:
```js
// file: "./dist/component1.js"
import './component1.css'
```

This approach seems to be pretty portable across different application build tools, but produces sub-
optimal results when using vite dev mode. While the requests still complete pretty quickly, the
connection does wind up stalled because of the number of requests being made and it slows the
initial page load and refreshes down a bit.

The following screenshot is all css requests:
![image](https://github.com/vitejs/vite/assets/17907922/9be7de82-cf4d-4ea7-8aa4-5ee8b693be68)

With this PR, there is a single 410 kB .css request made instead with a minimal amount of stalling at the start
of the request:
<img width="290" alt="image" src="https://github.com/vitejs/vite/assets/17907922/36283720-9bd3-4a9a-bda7-a5d82af63346">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
