### PR TITLE
feat: show warning to discourage putting process/global to `define` option

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -489,6 +489,21 @@ export async function resolveConfig(
     customLogger: config.customLogger,
   })
 
+  let foundDiscouragedVariableName
+  if (
+    (foundDiscouragedVariableName = Object.keys(config.define ?? {}).find((k) =>
+      ['process', 'global'].includes(k),
+    ))
+  ) {
+    logger.warn(
+      colors.yellow(
+        `Putting ${colors.bold(
+          foundDiscouragedVariableName,
+        )} to define option is discoraged. See https://vitejs.dev/config/shared-options.html#define for more details.`,
+      ),
+    )
+  }
+
   // resolve root
   const resolvedRoot = normalizePath(
     config.root ? path.resolve(config.root) : process.cwd(),

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -497,9 +497,9 @@ export async function resolveConfig(
   ) {
     logger.warn(
       colors.yellow(
-        `Putting ${colors.bold(
+        `Replacing ${colors.bold(
           foundDiscouragedVariableName,
-        )} to define option is discoraged. See https://vitejs.dev/config/shared-options.html#define for more details.`,
+        )} using the define option is discouraged. See https://vitejs.dev/config/shared-options.html#define for more details.`,
       ),
     )
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I've been seen many people doing `define: { global: 'window' }` and breaking their apps.
Ideally it'd be better to improve how `define` works, but I think having a warning until that's implemented is nice.

- https://github.com/vitejs/vite/discussions/14445
- https://github.com/vitejs/vite/issues/14191#issuecomment-1693575525
- https://github.com/vitejs/vite/issues/13237#issuecomment-1552310827
- https://github.com/vitejs/vite/issues/12814
- https://github.com/vitejs/vite/issues/9720
- https://github.com/vitejs/vite/issues/4796
- https://github.com/vitejs/vite/issues/2700

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
