### PR TITLE
test(ssr): proper test coverage of SSR shebang import hoisting

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -747,11 +747,13 @@ test('import hoisted after hashbang', async () => {
   expect(
     await ssrTransformSimpleCode(
       `#!/usr/bin/env node
-import "foo"`,
+console.log(foo);
+import foo from "foo"`,
     ),
   ).toMatchInlineSnapshot(`
     "#!/usr/bin/env node
     const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"foo\\");
+    console.log(__vite_ssr_import_0__.default);
     "
   `)
 })


### PR DESCRIPTION
### Description

The current test for import hoisting with shebang doesn't actually test the actual hoisting logic because the import is not referenced. This means there is no coverage of actual hoisting. This test still passes even if hoisting is broken by a change such as: https://github.com/vitejs/vite/pull/14441.

By including usage of the import that needs hoisting, this ensures proper test coverage of the hoisting logic with shebangs.

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
