### PR TITLE
fix(create-vite): remove non-standard style

### DIFF
--- a/packages/create-vite/template-lit-ts/src/index.css
+++ b/packages/create-vite/template-lit-ts/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-lit/src/index.css
+++ b/packages/create-vite/template-lit/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 body {

--- a/packages/create-vite/template-preact-ts/src/index.css
+++ b/packages/create-vite/template-preact-ts/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-preact/src/index.css
+++ b/packages/create-vite/template-preact/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-qwik-ts/src/index.css
+++ b/packages/create-vite/template-qwik-ts/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-qwik/src/index.css
+++ b/packages/create-vite/template-qwik/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-react-ts/src/index.css
+++ b/packages/create-vite/template-react-ts/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-react/src/index.css
+++ b/packages/create-vite/template-react/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-solid-ts/src/index.css
+++ b/packages/create-vite/template-solid-ts/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-solid/src/index.css
+++ b/packages/create-vite/template-solid/src/index.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-svelte-ts/src/app.css
+++ b/packages/create-vite/template-svelte-ts/src/app.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-svelte/src/app.css
+++ b/packages/create-vite/template-svelte/src/app.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-vanilla-ts/src/style.css
+++ b/packages/create-vite/template-vanilla-ts/src/style.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-vanilla/style.css
+++ b/packages/create-vite/template-vanilla/style.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-vue-ts/src/style.css
+++ b/packages/create-vite/template-vue-ts/src/style.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {

--- a/packages/create-vite/template-vue/src/style.css
+++ b/packages/create-vite/template-vue/src/style.css
@@ -11,7 +11,6 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 a {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`-webkit-text-size-adjust` is a non-standard style, after the initialization project runs, a warning message appears. 
So I think it should be removed and let users add to specific environments on their own.

![image](https://github.com/vitejs/vite/assets/24516654/4148ea84-44ca-40b1-99d0-67f2913c6695)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
