### PR TITLE
fix(analysis): warnings for dynamic imports that use static template literals

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -470,7 +470,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
             return
           } else if (templateLiteralRE.test(rawUrl)) {
-            if (!rawUrl.includes('${') && !rawUrl.includes('}')) {
+            if (!(rawUrl.includes('${') && rawUrl.includes('}'))) {
               specifier = rawUrl.replace(templateLiteralRE, '$1')
             }
           }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -470,6 +470,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
             return
           } else if (templateLiteralRE.test(rawUrl)) {
+            // If the import has backticks but isn't transformed as a glob import
+            // (as there's nothing to glob), check if it's simply a plain string.
+            // If so, we can replace the specifier as a plain string to prevent
+            // an incorrect "cannot be analyzed" warning.
             if (!(rawUrl.includes('${') && rawUrl.includes('}'))) {
               specifier = rawUrl.replace(templateLiteralRE, '$1')
             }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -470,9 +470,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
             return
           } else if (templateLiteralRE.test(rawUrl)) {
-            // Only static template literal will into this branch.
-            // It has variables will processed in importMetaGlob.ts
-            specifier = rawUrl.replace(templateLiteralRE, '$1')
+            if (!rawUrl.includes('${') && !rawUrl.includes('}')) {
+              specifier = rawUrl.replace(templateLiteralRE, '$1')
+            }
           }
 
           const isDynamicImport = dynamicIndex > -1

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -79,6 +79,8 @@ export const hasViteIgnoreRE = /\/\*\s*@vite-ignore\s*\*\//
 const cleanUpRawUrlRE = /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm
 const urlIsStringRE = /^(?:'.*'|".*"|`.*`)$/
 
+const templateLiteralRE = /^\s*`(.*)`\s*$/
+
 interface UrlPosition {
   url: string
   start: number
@@ -425,9 +427,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             d: dynamicIndex,
             // #2083 User may use escape path,
             // so use imports[index].n to get the unescaped string
-            n: specifier,
             a: assertIndex,
           } = importSpecifier
+          let specifier = importSpecifier.n
 
           const rawUrl = source.slice(start, end)
 
@@ -466,6 +468,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               hasEnv = true
             }
             return
+          } else if (templateLiteralRE.test(rawUrl)) {
+            specifier = rawUrl.replace(templateLiteralRE, '$1')
           }
 
           const isDynamicImport = dynamicIndex > -1

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -425,10 +425,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             ss: expStart,
             se: expEnd,
             d: dynamicIndex,
-            // #2083 User may use escape path,
-            // so use imports[index].n to get the unescaped string
             a: assertIndex,
           } = importSpecifier
+
+          // #2083 User may use escape path,
+          // so use imports[index].n to get the unescaped string
           let specifier = importSpecifier.n
 
           const rawUrl = source.slice(start, end)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -469,6 +469,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
             return
           } else if (templateLiteralRE.test(rawUrl)) {
+            // Only static template literal will into this branch.
+            // It has variables will processed in importMetaGlob.ts
             specifier = rawUrl.replace(templateLiteralRE, '$1')
           }
 

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -35,6 +35,8 @@
 
 <div class="dynamic-import-self"></div>
 
+<div class="dynamic-import-static"></div>
+
 <div class="dynamic-import-nested-self"></div>
 
 <script type="module" src="./nested/index.js"></script>

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -131,4 +131,8 @@ import(`../nested/nested/${base}.js`).then((mod) => {
   text('.dynamic-import-nested-self', mod.self)
 })
 
+import(`../nested/static.js`).then((mod) => {
+  text('.dynamic-import-static', mod.self)
+})
+
 console.log('index.js')

--- a/playground/dynamic-import/nested/static.js
+++ b/playground/dynamic-import/nested/static.js
@@ -1,0 +1,1 @@
+export const self = 'dynamic-import-static'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When I finished this PR, I noticed that there was another one #14103 being processed. But I think we shouldn't hide warnings.

Fixes: #14101
Closes: #14103


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
