### PR TITLE
fix(import-analysis): preserve importedUrls import order

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -275,7 +275,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       let needQueryInjectHelper = false
       let s: MagicString | undefined
       const str = () => s || (s = new MagicString(source))
-      const importedUrls = new Set<string>()
       let isPartiallySelfAccepting = false
       const importedBindings = enablePartialAccept
         ? new Map<string, Set<string>>()
@@ -408,6 +407,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         return [url, resolved.id]
       }
 
+      const orderedImportedUrls = new Array<string | undefined>(imports.length)
       const orderedAcceptedUrls = new Array<Set<UrlPosition> | undefined>(
         imports.length,
       )
@@ -602,7 +602,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             const hmrUrl = unwrapId(stripBase(url, base))
             const isLocalImport = !isExternalUrl(hmrUrl) && !isDataUrl(hmrUrl)
             if (isLocalImport) {
-              importedUrls.add(hmrUrl)
+              orderedImportedUrls[index] = hmrUrl
             }
 
             if (enablePartialAccept && importedBindings) {
@@ -680,6 +680,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }),
       )
 
+      const importedUrls = new Set(
+        orderedImportedUrls.filter(Boolean) as string[],
+      )
       const acceptedUrls = mergeAcceptedUrls(orderedAcceptedUrls)
       const acceptedExports = mergeAcceptedUrls(orderedAcceptedExports)
 

--- a/playground/module-graph/__tests__/module-graph.spec.ts
+++ b/playground/module-graph/__tests__/module-graph.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from 'vitest'
+import { isServe, page, viteServer } from '~utils'
+
+test.runIf(isServe)('importedUrls order is preserved', async () => {
+  const el = page.locator('.imported-urls-order')
+  expect(await el.textContent()).toBe('[success]')
+  const mod = await viteServer.moduleGraph.getModuleByUrl(
+    '/imported-urls-order.js',
+  )
+  const importedModuleIds = [...mod.importedModules].map((m) => m.url)
+  expect(importedModuleIds).toEqual(['\x00virtual:slow-module', '/empty.js'])
+})

--- a/playground/module-graph/imported-urls-order.js
+++ b/playground/module-graph/imported-urls-order.js
@@ -1,0 +1,7 @@
+import { msg } from 'virtual:slow-module'
+import './empty.js'
+
+export default msg
+
+// This module tests that the import order is preserved in this module's `importedUrls` property
+// as the imports can be processed in parallel

--- a/playground/module-graph/index.html
+++ b/playground/module-graph/index.html
@@ -1,0 +1,10 @@
+<div class="imported-urls-order"></div>
+
+<script type="module">
+  import importedUrlsOrderSuccess from './imported-urls-order'
+  text('.imported-urls-order', importedUrlsOrderSuccess)
+
+  function text(el, text) {
+    document.querySelector(el).textContent = text
+  }
+</script>

--- a/playground/module-graph/package.json
+++ b/playground/module-graph/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitejs/test-hmr",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "preview": "vite preview"
+  }
+}

--- a/playground/module-graph/vite.config.ts
+++ b/playground/module-graph/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vite'
+import type { Plugin } from 'vite'
+
+export default defineConfig({
+  plugins: [slowModulePlugin()],
+})
+
+function slowModulePlugin(): Plugin {
+  return {
+    name: 'slow-module',
+    resolveId(id) {
+      if (id === 'virtual:slow-module') {
+        return '\0virtual:slow-module'
+      }
+    },
+    async load(id) {
+      if (id === '\0virtual:slow-module') {
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        return `export const msg = '[success]'`
+      }
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,8 @@ importers:
 
   playground/minify/dir/module: {}
 
+  playground/module-graph: {}
+
   playground/multiple-entrypoints:
     devDependencies:
       sass:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix https://github.com/withastro/astro/issues/8044

In import analysis, we're transforming the imports populate `importedUrls` in parallel, causing it to be non-deterministic. This affects frameworks that crawl the module graph for CSS to populate the HTML to prevent FOUC, e.g. SvelteKit and Astro (afaia), causing the CSS order to be incorrect.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
