### PR TITLE
test: cleanup `testConfig.baseRoute` and use `testConfig.previewBase`

### DIFF
--- a/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
+++ b/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
@@ -6,10 +6,7 @@ import {
   getColor,
   isBuild,
   page,
-  viteConfig,
 } from '~utils'
-
-const getBase = () => (viteConfig ? viteConfig?.testConfig?.baseRoute : '')
 
 const absoluteAssetMatch = isBuild
   ? /http.*\/other-assets\/asset-\w{8}\.png/
@@ -140,8 +137,7 @@ describe('css url() references', () => {
 describe.runIf(isBuild)('index.css URLs', () => {
   let css: string
   beforeAll(() => {
-    const base = getBase()
-    css = findAssetFile(/index.*\.css$/, base, 'other-assets')
+    css = findAssetFile(/index.*\.css$/, 'relative-base', 'other-assets')
   })
 
   test('relative asset URL', () => {
@@ -203,7 +199,7 @@ test('?url import on css', async () => {
     isBuild ? /http.*\/other-assets\/icons-\w{8}\.css/ : '/css/icons.css',
   )
   isBuild &&
-    expect(findAssetFile(/index.*\.js$/, getBase(), 'entries')).toMatch(
+    expect(findAssetFile(/index.*\.js$/, 'relative-base', 'entries')).toMatch(
       /icons-.+\.css(?!\?used)/,
     )
 })

--- a/playground/assets/__tests__/url-base/url-base-assets.spec.ts
+++ b/playground/assets/__tests__/url-base/url-base-assets.spec.ts
@@ -6,7 +6,6 @@ import {
   getColor,
   isBuild,
   page,
-  viteConfig,
 } from '~utils'
 
 const urlAssetMatch = isBuild
@@ -132,8 +131,7 @@ describe('css url() references', () => {
 describe.runIf(isBuild)('index.css URLs', () => {
   let css: string
   beforeAll(() => {
-    const base = viteConfig ? viteConfig?.testConfig?.baseRoute : ''
-    css = findAssetFile(/index.*\.css$/, base, 'other-assets')
+    css = findAssetFile(/index.*\.css$/, 'url-base', 'other-assets')
   })
 
   test('use base URL for asset URL', () => {

--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -18,8 +18,5 @@ export default defineConfig({
       },
     },
   },
-  testConfig: {
-    baseRoute: '/relative-base/',
-  },
   cacheDir: 'node_modules/.vite-relative-base',
 })

--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -1,8 +1,6 @@
 import { defineConfig } from 'vite'
 import baseConfig from './vite.config.js'
 
-let isTestHookCalled = false
-
 export default defineConfig({
   ...baseConfig,
   base: './', // relative base to make dist portable
@@ -21,23 +19,7 @@ export default defineConfig({
     },
   },
   cacheDir: 'node_modules/.vite-relative-base',
-  __test__() {
-    // process.argv is different when running tests
-    // so use this hook instead
-    isTestHookCalled = true
+  testConfig: {
+    previewBase: '/relative-base/',
   },
-  plugins: [
-    {
-      name: 'set-base-if-preview',
-      config() {
-        // TODO: use something like ConfigEnv['cmd'] https://github.com/vitejs/vite/pull/12298
-        const isPreview = isTestHookCalled || process.argv.includes('preview')
-        if (isPreview) {
-          return {
-            base: '/relative-base/',
-          }
-        }
-      },
-    },
-  ],
 })

--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import baseConfig from './vite.config.js'
 
+let isTestHookCalled = false
+
 export default defineConfig({
   ...baseConfig,
   base: './', // relative base to make dist portable
@@ -19,4 +21,23 @@ export default defineConfig({
     },
   },
   cacheDir: 'node_modules/.vite-relative-base',
+  __test__() {
+    // process.argv is different when running tests
+    // so use this hook instead
+    isTestHookCalled = true
+  },
+  plugins: [
+    {
+      name: 'set-base-if-preview',
+      config() {
+        // TODO: use something like ConfigEnv['cmd'] https://github.com/vitejs/vite/pull/12298
+        const isPreview = isTestHookCalled || process.argv.includes('preview')
+        if (isPreview) {
+          return {
+            base: '/relative-base/',
+          }
+        }
+      },
+    },
+  ],
 })

--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -18,8 +18,8 @@ export default defineConfig({
       },
     },
   },
-  cacheDir: 'node_modules/.vite-relative-base',
   testConfig: {
     previewBase: '/relative-base/',
   },
+  cacheDir: 'node_modules/.vite-relative-base',
 })

--- a/playground/assets/vite.config-url-base.js
+++ b/playground/assets/vite.config-url-base.js
@@ -29,8 +29,5 @@ export default defineConfig({
     port,
     strictPort: true,
   },
-  testConfig: {
-    baseRoute: '/url-base/',
-  },
   cacheDir: 'node_modules/.vite-url-base',
 })

--- a/playground/css/vite.config-relative-base.js
+++ b/playground/css/vite.config-relative-base.js
@@ -19,4 +19,7 @@ export default defineConfig({
     },
   },
   cacheDir: 'node_modules/.vite-relative-base',
+  testConfig: {
+    previewBase: '/relative-base/',
+  },
 })

--- a/playground/css/vite.config-relative-base.js
+++ b/playground/css/vite.config-relative-base.js
@@ -18,8 +18,5 @@ export default defineConfig({
       },
     },
   },
-  testConfig: {
-    baseRoute: '/relative-base/',
-  },
   cacheDir: 'node_modules/.vite-relative-base',
 })

--- a/playground/css/vite.config-relative-base.js
+++ b/playground/css/vite.config-relative-base.js
@@ -18,8 +18,8 @@ export default defineConfig({
       },
     },
   },
-  cacheDir: 'node_modules/.vite-relative-base',
   testConfig: {
     previewBase: '/relative-base/',
   },
+  cacheDir: 'node_modules/.vite-relative-base',
 })

--- a/playground/legacy/vite.config-no-polyfills-no-systemjs.js
+++ b/playground/legacy/vite.config-no-polyfills-no-systemjs.js
@@ -24,7 +24,4 @@ export default defineConfig({
       },
     },
   },
-  testConfig: {
-    baseRoute: '/no-polyfills-no-systemjs/',
-  },
 })

--- a/playground/legacy/vite.config-no-polyfills-no-systemjs.js
+++ b/playground/legacy/vite.config-no-polyfills-no-systemjs.js
@@ -24,4 +24,7 @@ export default defineConfig({
       },
     },
   },
+  testConfig: {
+    previewBase: '/no-polyfills-no-systemjs/',
+  },
 })

--- a/playground/legacy/vite.config-no-polyfills.js
+++ b/playground/legacy/vite.config-no-polyfills.js
@@ -23,4 +23,7 @@ export default defineConfig({
       },
     },
   },
+  testConfig: {
+    previewBase: '/no-polyfills/',
+  },
 })

--- a/playground/legacy/vite.config-no-polyfills.js
+++ b/playground/legacy/vite.config-no-polyfills.js
@@ -23,7 +23,4 @@ export default defineConfig({
       },
     },
   },
-  testConfig: {
-    baseRoute: '/no-polyfills/',
-  },
 })

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -266,6 +266,10 @@ export async function startDefaultServe(): Promise<void> {
     if (config && config.__test__) {
       config.__test__()
     }
+    // TODO: use something like ConfigEnv['cmd'] https://github.com/vitejs/vite/pull/12298
+    if (config?.testConfig?.previewBase) {
+      testConfig.base = config.testConfig.previewBase
+    }
     const _nodeEnv = process.env.NODE_ENV
     const previewServer = await preview(testConfig)
     // prevent preview change NODE_ENV
@@ -346,5 +350,16 @@ declare module 'vite' {
      * runs after build and before preview
      */
     __test__?: () => void
+    /**
+     * special test only configs
+     */
+    testConfig?: {
+      /**
+       * a base used for preview
+       *
+       * useful for relative base tests
+       */
+      previewBase?: string
+    }
   }
 }

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -62,11 +62,6 @@ export let testDir: string
  * Test folder name
  */
 export let testName: string
-/**
- * current test using vite inline config
- * when using serve.[jt]s is not possible to get the config
- */
-export let viteConfig: InlineConfig | undefined
 
 export const serverLogs: string[] = []
 export const browserLogs: string[] = []
@@ -78,22 +73,6 @@ export let page: Page = undefined!
 export let browser: Browser = undefined!
 export let viteTestUrl: string = ''
 export let watcher: RollupWatcher | undefined = undefined
-
-declare module 'vite' {
-  interface InlineConfig {
-    testConfig?: {
-      // relative base output use relative path
-      // rewrite the url to truth file path
-      baseRoute: string
-    }
-  }
-
-  interface UserConfig {
-    testConfig?: {
-      baseRoute: string
-    }
-  }
-}
 
 export function setViteUrl(url: string): void {
   viteTestUrl = url
@@ -259,7 +238,6 @@ export async function startDefaultServe(): Promise<void> {
   if (!isBuild) {
     process.env.VITE_INLINE = 'inline-serve'
     const testConfig = mergeConfig(options, config || {})
-    viteConfig = testConfig
     viteServer = server = await (await createServer(testConfig)).listen()
     // use resolved port/base from server
     const devBase = server.config.base
@@ -278,7 +256,6 @@ export async function startDefaultServe(): Promise<void> {
     })
     options.plugins = [resolvedPlugin()]
     const testConfig = mergeConfig(options, config || {})
-    viteConfig = testConfig
     const rollupOutput = await build(testConfig)
     const isWatch = !!resolvedConfig!.build.watch
     // in build watch,call startStaticServer after the build is complete

--- a/playground/worker/vite.config-relative-base-iife.js
+++ b/playground/worker/vite.config-relative-base-iife.js
@@ -29,9 +29,6 @@ export default defineConfig({
       },
     },
   },
-  testConfig: {
-    baseRoute: '/relative-base-iife/',
-  },
   plugins: [workerPluginTestPlugin()],
   cacheDir: 'node_modules/.vite-relative-base-iife',
 })

--- a/playground/worker/vite.config-relative-base-iife.js
+++ b/playground/worker/vite.config-relative-base-iife.js
@@ -1,8 +1,6 @@
 import { defineConfig } from 'vite'
 import workerPluginTestPlugin from './worker-plugin-test-plugin'
 
-let isTestHookCalled = false
-
 export default defineConfig({
   base: './',
   resolve: {
@@ -31,25 +29,9 @@ export default defineConfig({
       },
     },
   },
-  plugins: [
-    {
-      name: 'set-base-if-preview',
-      config() {
-        // TODO: use something like ConfigEnv['cmd'] https://github.com/vitejs/vite/pull/12298
-        const isPreview = isTestHookCalled || process.argv.includes('preview')
-        if (isPreview) {
-          return {
-            base: '/relative-base/',
-          }
-        }
-      },
-    },
-    workerPluginTestPlugin(),
-  ],
+  plugins: [workerPluginTestPlugin()],
   cacheDir: 'node_modules/.vite-relative-base-iife',
-  __test__() {
-    // process.argv is different when running tests
-    // so use this hook instead
-    isTestHookCalled = true
+  testConfig: {
+    previewBase: '/relative-base-iife/',
   },
 })

--- a/playground/worker/vite.config-relative-base-iife.js
+++ b/playground/worker/vite.config-relative-base-iife.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import workerPluginTestPlugin from './worker-plugin-test-plugin'
 
+let isTestHookCalled = false
+
 export default defineConfig({
   base: './',
   resolve: {
@@ -29,6 +31,25 @@ export default defineConfig({
       },
     },
   },
-  plugins: [workerPluginTestPlugin()],
+  plugins: [
+    {
+      name: 'set-base-if-preview',
+      config() {
+        // TODO: use something like ConfigEnv['cmd'] https://github.com/vitejs/vite/pull/12298
+        const isPreview = isTestHookCalled || process.argv.includes('preview')
+        if (isPreview) {
+          return {
+            base: '/relative-base/',
+          }
+        }
+      },
+    },
+    workerPluginTestPlugin(),
+  ],
   cacheDir: 'node_modules/.vite-relative-base-iife',
+  __test__() {
+    // process.argv is different when running tests
+    // so use this hook instead
+    isTestHookCalled = true
+  },
 })

--- a/playground/worker/vite.config-relative-base-iife.js
+++ b/playground/worker/vite.config-relative-base-iife.js
@@ -29,9 +29,9 @@ export default defineConfig({
       },
     },
   },
-  plugins: [workerPluginTestPlugin()],
-  cacheDir: 'node_modules/.vite-relative-base-iife',
   testConfig: {
     previewBase: '/relative-base-iife/',
   },
+  plugins: [workerPluginTestPlugin()],
+  cacheDir: 'node_modules/.vite-relative-base-iife',
 })

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -1,8 +1,6 @@
 import { defineConfig } from 'vite'
 import workerPluginTestPlugin from './worker-plugin-test-plugin'
 
-let isTestHookCalled = false
-
 export default defineConfig({
   base: './',
   resolve: {
@@ -32,18 +30,6 @@ export default defineConfig({
     },
   },
   plugins: [
-    {
-      name: 'set-base-if-preview',
-      config() {
-        // TODO: use something like ConfigEnv['cmd'] https://github.com/vitejs/vite/pull/12298
-        const isPreview = isTestHookCalled || process.argv.includes('preview')
-        if (isPreview) {
-          return {
-            base: '/relative-base/',
-          }
-        }
-      },
-    },
     workerPluginTestPlugin(),
     {
       name: 'resolve-format-es',
@@ -58,9 +44,7 @@ export default defineConfig({
     },
   ],
   cacheDir: 'node_modules/.vite-relative-base',
-  __test__() {
-    // process.argv is different when running tests
-    // so use this hook instead
-    isTestHookCalled = true
+  testConfig: {
+    previewBase: '/relative-base/',
   },
 })

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import workerPluginTestPlugin from './worker-plugin-test-plugin'
 
+let isTestHookCalled = false
+
 export default defineConfig({
   base: './',
   resolve: {
@@ -30,6 +32,18 @@ export default defineConfig({
     },
   },
   plugins: [
+    {
+      name: 'set-base-if-preview',
+      config() {
+        // TODO: use something like ConfigEnv['cmd'] https://github.com/vitejs/vite/pull/12298
+        const isPreview = isTestHookCalled || process.argv.includes('preview')
+        if (isPreview) {
+          return {
+            base: '/relative-base/',
+          }
+        }
+      },
+    },
     workerPluginTestPlugin(),
     {
       name: 'resolve-format-es',
@@ -44,4 +58,9 @@ export default defineConfig({
     },
   ],
   cacheDir: 'node_modules/.vite-relative-base',
+  __test__() {
+    // process.argv is different when running tests
+    // so use this hook instead
+    isTestHookCalled = true
+  },
 })

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -29,6 +29,9 @@ export default defineConfig({
       },
     },
   },
+  testConfig: {
+    previewBase: '/relative-base/',
+  },
   plugins: [
     workerPluginTestPlugin(),
     {
@@ -44,7 +47,4 @@ export default defineConfig({
     },
   ],
   cacheDir: 'node_modules/.vite-relative-base',
-  testConfig: {
-    previewBase: '/relative-base/',
-  },
 })

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -29,9 +29,6 @@ export default defineConfig({
       },
     },
   },
-  testConfig: {
-    baseRoute: '/relative-base/',
-  },
   plugins: [
     workerPluginTestPlugin(),
     {


### PR DESCRIPTION
### Description
1. Remove `testConfig.baseRoute` as it was not used
    - it was introduced by https://github.com/vitejs/vite/pull/8541 and then removed by https://github.com/vitejs/vite/pull/9992
3. Fix relative-base test to run the preview server with a different base
    - `testConfig.baseRoute` was introduced to do this. So I restored that by changing the base when running preview.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
