### PR TITLE
test: fix "WebSocket server error: Port is already in use" happening in json playground

### DIFF
--- a/playground/json/__tests__/ssr/serve.ts
+++ b/playground/json/__tests__/ssr/serve.ts
@@ -3,7 +3,7 @@
 
 import path from 'node:path'
 import kill from 'kill-port'
-import { ports, rootDir } from '~utils'
+import { hmrPorts, ports, rootDir } from '~utils'
 
 export const port = ports.json
 
@@ -11,7 +11,7 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
   await kill(port)
 
   const { createServer } = await import(path.resolve(rootDir, 'server.js'))
-  const { app, vite } = await createServer(rootDir)
+  const { app, vite } = await createServer(rootDir, hmrPorts.json)
 
   return new Promise((resolve, reject) => {
     try {

--- a/playground/json/server.js
+++ b/playground/json/server.js
@@ -7,7 +7,7 @@ import express from 'express'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const isTest = process.env.VITEST
 
-export async function createServer(root = process.cwd()) {
+export async function createServer(root = process.cwd(), hmrPort) {
   const resolve = (p) => path.resolve(__dirname, p)
   const app = express()
 
@@ -26,6 +26,9 @@ export async function createServer(root = process.cwd()) {
         // misses change events, so enforce polling for consistency
         usePolling: true,
         interval: 100,
+      },
+      hmr: {
+        port: hmrPort,
       },
     },
     appType: 'custom',

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -49,6 +49,7 @@ export const hmrPorts = {
   'ssr-noexternal': 24684,
   'ssr-pug': 24685,
   'css/lightningcss-proxy': 24686,
+  json: 24687,
 }
 
 const hexToNameMap: Record<string, string> = {}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fixes https://github.com/vitejs/vite/actions/runs/6309962812/job/17130947724#step:13:79

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
