### PR TITLE
fix(resolve): support submodules of optional peer deps

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -732,9 +732,11 @@ export function tryNodeResolve(
     ) {
       const mainPkg = findNearestMainPackageData(basedir, packageCache)?.data
       if (mainPkg) {
+        const pkgName = getNpmPackageName(id)
         if (
-          mainPkg.peerDependencies?.[id] &&
-          mainPkg.peerDependenciesMeta?.[id]?.optional
+          pkgName != null &&
+          mainPkg.peerDependencies?.[pkgName] &&
+          mainPkg.peerDependenciesMeta?.[pkgName]?.optional
         ) {
           return {
             id: `${optionalPeerDepId}:${id}:${mainPkg.name}`,

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -108,6 +108,19 @@ test('dep with optional peer dep', async () => {
   }
 })
 
+test('dep with optional peer dep submodule', async () => {
+  expect(
+    await page.textContent('.dep-with-optional-peer-dep-submodule'),
+  ).toMatch(`[success]`)
+  if (isServe) {
+    expect(browserErrors.map((error) => error.message)).toEqual(
+      expect.arrayContaining([
+        'Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule". Is it installed?',
+      ]),
+    )
+  }
+})
+
 test('dep with css import', async () => {
   expect(await getColor('.dep-linked-include')).toBe('red')
 })

--- a/playground/optimize-deps/dep-with-optional-peer-dep-submodule/index.js
+++ b/playground/optimize-deps/dep-with-optional-peer-dep-submodule/index.js
@@ -1,0 +1,7 @@
+export function callItself() {
+  return '[success]'
+}
+
+export async function callPeerDepSubmodule() {
+  return await import('foobar/baz')
+}

--- a/playground/optimize-deps/dep-with-optional-peer-dep-submodule/package.json
+++ b/playground/optimize-deps/dep-with-optional-peer-dep-submodule/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vitejs/test-dep-with-optional-peer-dep-submodule",
+  "private": true,
+  "version": "0.0.0",
+  "main": "index.js",
+  "type": "module",
+  "peerDependencies": {
+    "foobar": "0.0.0"
+  },
+  "peerDependenciesMeta": {
+    "foobar": {
+      "optional": true
+    }
+  }
+}

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -65,6 +65,9 @@
 <h2>Import from dependency with optional peer dep</h2>
 <div class="dep-with-optional-peer-dep"></div>
 
+<h2>Import from dependency with optional peer dep submodule</h2>
+<div class="dep-with-optional-peer-dep-submodule"></div>
+
 <h2>Externalize known non-js files in optimize included dep</h2>
 <div class="externalize-known-non-js"></div>
 
@@ -203,6 +206,16 @@
   text('.dep-with-optional-peer-dep', callItself())
   // expect error as optional peer dep not installed
   callPeerDep()
+</script>
+
+<script type="module">
+  import {
+    callItself,
+    callPeerDepSubmodule,
+  } from '@vitejs/test-dep-with-optional-peer-dep-submodule'
+  text('.dep-with-optional-peer-dep-submodule', callItself())
+  // expect error as optional peer dep not installed
+  callPeerDepSubmodule()
 </script>
 
 <script type="module">

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -30,6 +30,7 @@
     "@vitejs/test-dep-with-builtin-module-esm": "file:./dep-with-builtin-module-esm",
     "@vitejs/test-dep-with-dynamic-import": "file:./dep-with-dynamic-import",
     "@vitejs/test-dep-with-optional-peer-dep": "file:./dep-with-optional-peer-dep",
+    "@vitejs/test-dep-with-optional-peer-dep-submodule": "file:./dep-with-optional-peer-dep-submodule",
     "@vitejs/test-dep-non-optimized": "file:./dep-non-optimized",
     "@vitejs/test-added-in-entries": "file:./added-in-entries",
     "lodash-es": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,6 +864,9 @@ importers:
       '@vitejs/test-dep-with-optional-peer-dep':
         specifier: file:./dep-with-optional-peer-dep
         version: file:playground/optimize-deps/dep-with-optional-peer-dep
+      '@vitejs/test-dep-with-optional-peer-dep-submodule':
+        specifier: file:./dep-with-optional-peer-dep-submodule
+        version: file:playground/optimize-deps/dep-with-optional-peer-dep-submodule
       '@vitejs/test-nested-exclude':
         specifier: file:./nested-exclude
         version: file:playground/optimize-deps/nested-exclude
@@ -969,6 +972,8 @@ importers:
   playground/optimize-deps/dep-with-dynamic-import: {}
 
   playground/optimize-deps/dep-with-optional-peer-dep: {}
+
+  playground/optimize-deps/dep-with-optional-peer-dep-submodule: {}
 
   playground/optimize-deps/nested-exclude:
     dependencies:
@@ -10323,6 +10328,16 @@ packages:
   file:playground/optimize-deps/dep-with-optional-peer-dep:
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep, type: directory}
     name: '@vitejs/test-dep-with-optional-peer-dep'
+    peerDependencies:
+      foobar: 0.0.0
+    peerDependenciesMeta:
+      foobar:
+        optional: true
+    dev: false
+
+  file:playground/optimize-deps/dep-with-optional-peer-dep-submodule:
+    resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep-submodule, type: directory}
+    name: '@vitejs/test-dep-with-optional-peer-dep-submodule'
     peerDependencies:
       foobar: 0.0.0
     peerDependenciesMeta:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

#9321 added support for resolving optional peer deps. But I hit a corner case where that wasn't resolving properly when developing [TypeSchema](https://github.com/decs/typeschema).

`@sinclair/typebox` is one of the optional peer deps, but we actually import it as `@sinclair/typebox/compiler`. Vite's logic can't detect that `@sinclair/typebox/compiler` is handled by the `@sinclair/typebox` because it looks for the exact name on `peerDependencies`. So if I try to build with Vite, I get this error:

```
[vite]: Rollup failed to resolve import "@sinclair/typebox/compiler" from "/Users/deco/sample/node_modules/@decs/typeschema/dist/index.mjs".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
error during build:
Error: [vite]: Rollup failed to resolve import "@sinclair/typebox/compiler" from "/Users/deco/sample/node_modules/@decs/typeschema/dist/index.mjs".
This is most likely unintended because it can break your application at runtime.
If you do want to externalize this module explicitly add it to
`build.rollupOptions.external`
    at viteWarn (file:///Users/deco/sample/node_modules/vite/dist/node/chunks/dep-df561101.js:48142:27)
    at onRollupWarning (file:///Users/deco/sample/node_modules/vite/dist/node/chunks/dep-df561101.js:48174:9)
    at onwarn (file:///Users/deco/sample/node_modules/vite/dist/node/chunks/dep-df561101.js:47902:13)
    at file:///Users/deco/sample/node_modules/rollup/dist/es/shared/node-entry.js:24271:13
    at Object.logger [as onLog] (file:///Users/deco/sample/node_modules/rollup/dist/es/shared/node-entry.js:25945:9)
    at ModuleLoader.handleInvalidResolvedId (file:///Users/deco/sample/node_modules/rollup/dist/es/shared/node-entry.js:24857:26)
    at ModuleLoader.resolveDynamicImport (file:///Users/deco/sample/node_modules/rollup/dist/es/shared/node-entry.js:24915:58)
    at async file:///Users/deco/sample/node_modules/rollup/dist/es/shared/node-entry.js:24802:32
```

My proposal is to fix this error by checking for the NPM package name on `peerDependencies`, instead of the full module name.

### Additional context

I also added a test case to avoid regressions.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
