### PR TITLE
fix(css): ensure code is valid after empty css chunk imports are removed (fix #14515)

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -272,7 +272,8 @@ import "other-module";`
     expect(replaced.length).toBe(code.length)
     expect(replaced).toMatchInlineSnapshot(`
       "import \\"some-module\\";
-      /* empty css              */import \\"other-module\\";"
+      /* empty css             */
+      import \\"other-module\\";"
     `)
   })
 
@@ -298,7 +299,8 @@ require("other-module");`
     expect(replaced.length).toBe(code.length)
     expect(replaced).toMatchInlineSnapshot(`
       "require(\\"some-module\\");
-      /* empty css                */require(\\"other-module\\");"
+      ;/* empty css              */
+      require(\\"other-module\\");"
     `)
   })
 
@@ -309,7 +311,30 @@ require("other-module");`
     const replaced = replacer(code)
     expect(replaced.length).toBe(code.length)
     expect(replaced).toMatchInlineSnapshot(
-      '"require(\\"some-module\\");/* empty css               */require(\\"other-module\\");"',
+      '"require(\\"some-module\\");;/* empty css              */require(\\"other-module\\");"',
+    )
+  })
+
+  test('replaces require call in minified code that uses comma operator', () => {
+    const code =
+      'require("some-module"),require("pure_css_chunk.js"),require("other-module");'
+
+    const replacer = getEmptyChunkReplacer(['pure_css_chunk.js'], 'cjs')
+    const newCode = replacer(code)
+    expect(newCode).toMatchInlineSnapshot(
+      '"require(\\"some-module\\"),/* empty css               */require(\\"other-module\\");"',
+    )
+    // So there should be no pure css chunk anymore
+    expect(newCode.match(/pure_css_chunk\.js/)).toBeNull()
+  })
+
+  test('replaces require call in minified code that uses comma operator followed by assignment', () => {
+    const code =
+      'require("some-module"),require("pure_css_chunk.js");const v=require("other-module");'
+
+    const replacer = getEmptyChunkReplacer(['pure_css_chunk.js'], 'cjs')
+    expect(replacer(code)).toMatchInlineSnapshot(
+      '"require(\\"some-module\\");/* empty css               */const v=require(\\"other-module\\");"',
     )
   })
 })

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -841,9 +841,10 @@ export function getEmptyChunkReplacer(
     code.replace(
       emptyChunkRE,
       // remove css import while preserving source map location
-      (m) => outputFormat === 'es'
-        ? `/* empty css ${''.padEnd(m.length - 15)}*/`
-        : `${m.at(-1)}/* empty css ${''.padEnd(m.length - 16)}*/`,
+      (m) =>
+        outputFormat === 'es'
+          ? `/* empty css ${''.padEnd(m.length - 15)}*/`
+          : `${m.at(-1)}/* empty css ${''.padEnd(m.length - 16)}*/`,
     )
 }
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -827,9 +827,9 @@ export function getEmptyChunkReplacer(
     .join('|')
     .replace(/\./g, '\\.')
 
-  // require and import calls might be chained by minifier using the comma operator
-  // in this case we have to keep one comma
-  // if a next require is chained or add a semicolon to terminate the chain.
+  // for cjs, require calls might be chained by minifier using the comma operator.
+  // in this case we have to keep one comma if a next require is chained
+  // or add a semicolon to terminate the chain.
   const emptyChunkRE = new RegExp(
     outputFormat === 'es'
       ? `\\bimport\\s*["'][^"']*(?:${emptyChunkFiles})["'];`

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -827,10 +827,13 @@ export function getEmptyChunkReplacer(
     .join('|')
     .replace(/\./g, '\\.')
 
+  // require and import calls might be chained by minifier using the comma operator
+  // in this case we have to keep one comma
+  // if a next require is chained or add a semicolon to terminate the chain.
   const emptyChunkRE = new RegExp(
     outputFormat === 'es'
-      ? `\\bimport\\s*["'][^"']*(?:${emptyChunkFiles})["'];\n?`
-      : `\\brequire\\(\\s*["'][^"']*(?:${emptyChunkFiles})["']\\);\n?`,
+      ? `\\bimport\\s*["'][^"']*(?:${emptyChunkFiles})["'];`
+      : `(\\b|,\\s*)require\\(\\s*["'][^"']*(?:${emptyChunkFiles})["']\\)(;|,)`,
     'g',
   )
 
@@ -838,7 +841,9 @@ export function getEmptyChunkReplacer(
     code.replace(
       emptyChunkRE,
       // remove css import while preserving source map location
-      (m) => `/* empty css ${''.padEnd(m.length - 15)}*/`,
+      (m) => outputFormat === 'es'
+        ? `/* empty css ${''.padEnd(m.length - 15)}*/`
+        : `${m.at(-1)}/* empty css ${''.padEnd(m.length - 16)}*/`,
     )
 }
 


### PR DESCRIPTION
### Description

* Resolves #14515 

Make sure that minified code that chains `require` calls with the `,` operator will not result in invalid code when removing one of the chained requires. Previously the last require that terminates with a semicolon was removed with the semicolon. This produced invalid code like `require(), /* empty css */const foo =`

Now we append either a comma if a next require call was chained, like `require(...), require(css), other` --> `require(...)/* empty css */, other`

Or terminate with a semicolon
`require(...), require(css); const foo = ...` --> `require(...)/* empty css */; const foo = ...`

### Additional context

This also fixes a problem where empty chunks were not removed if chained in the middle with `,`.
E.g. this like this: `require(...), require(empty chunk), require(...);`

*(I really would like to add test cases, but it seems pretty hard to mock the plugin state for only testing the output hook)*
---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
