### PR TITLE
test: fix flaky legacy structuredClone fail

### DIFF
--- a/playground/legacy/vite.config-no-polyfills-no-systemjs.js
+++ b/playground/legacy/vite.config-no-polyfills-no-systemjs.js
@@ -18,6 +18,7 @@ export default defineConfig({
   ],
 
   build: {
+    outDir: 'dist/no-polyfills-no-systemjs',
     rollupOptions: {
       input: {
         index: path.resolve(__dirname, 'no-polyfills-no-systemjs.html'),

--- a/playground/legacy/vite.config-no-polyfills.js
+++ b/playground/legacy/vite.config-no-polyfills.js
@@ -17,6 +17,7 @@ export default defineConfig({
   ],
 
   build: {
+    outDir: 'dist/no-polyfills',
     rollupOptions: {
       input: {
         index: path.resolve(__dirname, 'no-polyfills.html'),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This test was flaky because the other build (`vite.config-no-polyfills.js`) overwrote the build (`vite.config.js`).
https://github.com/vitejs/vite/blob/ad9718d5d251094470cb7b1eaa3540e3595300a0/playground/legacy/__tests__/legacy.spec.ts#L129

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
