### PR TITLE
fix: esbuild glob resolve error

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -7,6 +7,7 @@ import type {
   BuildContext,
   BuildOptions,
   Loader,
+  OnLoadArgs,
   OnLoadResult,
   Plugin,
 } from 'esbuild'
@@ -380,116 +381,127 @@ function esbuildScanPlugin(
         }
       })
 
+      const htmlTypeOnLoadCallback: (
+        args: OnLoadArgs,
+      ) => Promise<OnLoadResult | null | undefined> = async ({ path: p }) => {
+        let raw = await fsp.readFile(p, 'utf-8')
+        // Avoid matching the content of the comment
+        raw = raw.replace(commentRE, '<!---->')
+        const isHtml = p.endsWith('.html')
+        scriptRE.lastIndex = 0
+        let js = ''
+        let scriptId = 0
+        let match: RegExpExecArray | null
+        while ((match = scriptRE.exec(raw))) {
+          const [, openTag, content] = match
+          const typeMatch = openTag.match(typeRE)
+          const type =
+            typeMatch && (typeMatch[1] || typeMatch[2] || typeMatch[3])
+          const langMatch = openTag.match(langRE)
+          const lang =
+            langMatch && (langMatch[1] || langMatch[2] || langMatch[3])
+          // skip non type module script
+          if (isHtml && type !== 'module') {
+            continue
+          }
+          // skip type="application/ld+json" and other non-JS types
+          if (
+            type &&
+            !(
+              type.includes('javascript') ||
+              type.includes('ecmascript') ||
+              type === 'module'
+            )
+          ) {
+            continue
+          }
+          let loader: Loader = 'js'
+          if (lang === 'ts' || lang === 'tsx' || lang === 'jsx') {
+            loader = lang
+          } else if (p.endsWith('.astro')) {
+            loader = 'ts'
+          }
+          const srcMatch = openTag.match(srcRE)
+          if (srcMatch) {
+            const src = srcMatch[1] || srcMatch[2] || srcMatch[3]
+            js += `import ${JSON.stringify(src)}\n`
+          } else if (content.trim()) {
+            // The reason why virtual modules are needed:
+            // 1. There can be module scripts (`<script context="module">` in Svelte and `<script>` in Vue)
+            // or local scripts (`<script>` in Svelte and `<script setup>` in Vue)
+            // 2. There can be multiple module scripts in html
+            // We need to handle these separately in case variable names are reused between them
+
+            // append imports in TS to prevent esbuild from removing them
+            // since they may be used in the template
+            const contents =
+              content +
+              (loader.startsWith('ts') ? extractImportPaths(content) : '')
+
+            const key = `${p}?id=${scriptId++}`
+            if (contents.includes('import.meta.glob')) {
+              scripts[key] = {
+                loader: 'js', // since it is transpiled
+                contents: await doTransformGlobImport(contents, p, loader),
+                resolveDir: normalizePath(path.dirname(p)),
+                pluginData: {
+                  htmlType: { loader },
+                },
+              }
+            } else {
+              scripts[key] = {
+                loader,
+                contents,
+                resolveDir: normalizePath(path.dirname(p)),
+                pluginData: {
+                  htmlType: { loader },
+                },
+              }
+            }
+
+            const virtualModulePath = JSON.stringify(virtualModulePrefix + key)
+
+            const contextMatch = openTag.match(contextRE)
+            const context =
+              contextMatch &&
+              (contextMatch[1] || contextMatch[2] || contextMatch[3])
+
+            // Especially for Svelte files, exports in <script context="module"> means module exports,
+            // exports in <script> means component props. To avoid having two same export name from the
+            // star exports, we need to ignore exports in <script>
+            if (p.endsWith('.svelte') && context !== 'module') {
+              js += `import ${virtualModulePath}\n`
+            } else {
+              js += `export * from ${virtualModulePath}\n`
+            }
+          }
+        }
+
+        // This will trigger incorrectly if `export default` is contained
+        // anywhere in a string. Svelte and Astro files can't have
+        // `export default` as code so we know if it's encountered it's a
+        // false positive (e.g. contained in a string)
+        if (!p.endsWith('.vue') || !js.includes('export default')) {
+          js += '\nexport default {}'
+        }
+
+        return {
+          loader: 'js',
+          contents: js,
+        }
+      }
+
       // extract scripts inside HTML-like files and treat it as a js module
       build.onLoad(
         { filter: htmlTypesRE, namespace: 'html' },
-        async ({ path }) => {
-          let raw = await fsp.readFile(path, 'utf-8')
-          // Avoid matching the content of the comment
-          raw = raw.replace(commentRE, '<!---->')
-          const isHtml = path.endsWith('.html')
-          scriptRE.lastIndex = 0
-          let js = ''
-          let scriptId = 0
-          let match: RegExpExecArray | null
-          while ((match = scriptRE.exec(raw))) {
-            const [, openTag, content] = match
-            const typeMatch = openTag.match(typeRE)
-            const type =
-              typeMatch && (typeMatch[1] || typeMatch[2] || typeMatch[3])
-            const langMatch = openTag.match(langRE)
-            const lang =
-              langMatch && (langMatch[1] || langMatch[2] || langMatch[3])
-            // skip non type module script
-            if (isHtml && type !== 'module') {
-              continue
-            }
-            // skip type="application/ld+json" and other non-JS types
-            if (
-              type &&
-              !(
-                type.includes('javascript') ||
-                type.includes('ecmascript') ||
-                type === 'module'
-              )
-            ) {
-              continue
-            }
-            let loader: Loader = 'js'
-            if (lang === 'ts' || lang === 'tsx' || lang === 'jsx') {
-              loader = lang
-            } else if (path.endsWith('.astro')) {
-              loader = 'ts'
-            }
-            const srcMatch = openTag.match(srcRE)
-            if (srcMatch) {
-              const src = srcMatch[1] || srcMatch[2] || srcMatch[3]
-              js += `import ${JSON.stringify(src)}\n`
-            } else if (content.trim()) {
-              // The reason why virtual modules are needed:
-              // 1. There can be module scripts (`<script context="module">` in Svelte and `<script>` in Vue)
-              // or local scripts (`<script>` in Svelte and `<script setup>` in Vue)
-              // 2. There can be multiple module scripts in html
-              // We need to handle these separately in case variable names are reused between them
-
-              // append imports in TS to prevent esbuild from removing them
-              // since they may be used in the template
-              const contents =
-                content +
-                (loader.startsWith('ts') ? extractImportPaths(content) : '')
-
-              const key = `${path}?id=${scriptId++}`
-              if (contents.includes('import.meta.glob')) {
-                scripts[key] = {
-                  loader: 'js', // since it is transpiled
-                  contents: await doTransformGlobImport(contents, path, loader),
-                  pluginData: {
-                    htmlType: { loader },
-                  },
-                }
-              } else {
-                scripts[key] = {
-                  loader,
-                  contents,
-                  pluginData: {
-                    htmlType: { loader },
-                  },
-                }
-              }
-
-              const virtualModulePath = JSON.stringify(
-                virtualModulePrefix + key,
-              )
-
-              const contextMatch = openTag.match(contextRE)
-              const context =
-                contextMatch &&
-                (contextMatch[1] || contextMatch[2] || contextMatch[3])
-
-              // Especially for Svelte files, exports in <script context="module"> means module exports,
-              // exports in <script> means component props. To avoid having two same export name from the
-              // star exports, we need to ignore exports in <script>
-              if (path.endsWith('.svelte') && context !== 'module') {
-                js += `import ${virtualModulePath}\n`
-              } else {
-                js += `export * from ${virtualModulePath}\n`
-              }
-            }
-          }
-
-          // This will trigger incorrectly if `export default` is contained
-          // anywhere in a string. Svelte and Astro files can't have
-          // `export default` as code so we know if it's encountered it's a
-          // false positive (e.g. contained in a string)
-          if (!path.endsWith('.vue') || !js.includes('export default')) {
-            js += '\nexport default {}'
-          }
-
-          return {
-            loader: 'js',
-            contents: js,
-          }
-        },
+        htmlTypeOnLoadCallback,
+      )
+      // the onResolve above will use namespace=html but esbuild doesn't
+      // call onResolve for glob imports and those will use namespace=file
+      // https://github.com/evanw/esbuild/issues/3317
+      build.onLoad(
+        { filter: htmlTypesRE, namespace: 'file' },
+        htmlTypeOnLoadCallback,
       )
 
       // bare imports: record and externalize ----------------------------------


### PR DESCRIPTION
### Description
This PR tries to fix the scanner error in https://github.com/vitejs/vite-ecosystem-ci/actions/runs/6401781367/job/17379560146#step:8:460 (plugin-vue).
> Could not resolve import("../components/**/*.vue")

This error was happening because `resolveDir` was not specified when resolving the script tag in Vue SFC.
https://github.com/vitejs/vite/blob/673f5295b7acf8103d7547fdcdfb6bc92596e74e/packages/vite/src/node/optimizer/scan.ts#L446
https://github.com/vitejs/vite/blob/673f5295b7acf8103d7547fdcdfb6bc92596e74e/packages/vite/src/node/optimizer/scan.ts#L362-L364
So I added them.

> No loader is configured for ".vue" files: src/components/ImportType.vue

But then this new error happened. This was happening because `onResolve` is not called for glob imports (https://github.com/evanw/esbuild/issues/3317).
https://github.com/vitejs/vite-plugin-vue/blob/e8503055b0ed29aa102b1f5b9a27f6b27a1f9713/playground/ssr-vue/src/pages/Home.vue#L31-L33
So I added a `onLoad` hook for `namespace: 'file'`.
https://github.com/vitejs/vite/blob/673f5295b7acf8103d7547fdcdfb6bc92596e74e/packages/vite/src/node/optimizer/scan.ts#L494-L505
~~(TODO: check if this solves https://github.com/vitejs/vite-plugin-vue/issues/253)~~

> Error: The following dependencies are imported but could not be resolved:
>   @vitejs/test-dep-import-type/deep (imported by C:/Users/green/Documents/GitHub/vite-plugin-vue/playground/ssr-vue/src/components/ImportType.vue?id=0)
> Are they installed?

And but then, this new error happend. This was happening because `extractImportPaths` was appending `import '@vitejs/test-dep-import-type/deep'` to the content of script tag. (related PR: https://github.com/vitejs/vite/pull/5850)
https://github.com/vitejs/vite/blob/673f5295b7acf8103d7547fdcdfb6bc92596e74e/packages/vite/src/node/optimizer/scan.ts#L640-L660
https://github.com/vitejs/vite/blob/673f5295b7acf8103d7547fdcdfb6bc92596e74e/packages/vite/src/node/optimizer/scan.ts#L435-L439
`@vitejs/test-dep-import-type/deep` is a type only file and Vite fails to resolve that.
I guess this is the same error with https://github.com/vitejs/vite-plugin-vue/issues/24.
We can change the test in plugin-vue to use `import type` for now as it wasn't working from before.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
