### PR TITLE
fix: include marko extensions when scanning dependencies

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -42,7 +42,7 @@ type ResolveIdOptions = Parameters<PluginContainer['resolveId']>[2]
 
 const debug = createDebugger('vite:deps')
 
-const htmlTypesRE = /\.(html|vue|svelte|astro|imba)$/
+const htmlTypesRE = /\.(html|vue|svelte|astro|imba|marko)$/
 
 // A simple regex to detect import sources. This is only used on
 // <script lang="ts"> blocks in vue (setup only) or svelte files, since


### PR DESCRIPTION
### Description

Adds `.marko` as one of the file extensions to consider when performing the dependency optimization scan.

### Additional context

Currently due to the way `@marko/vite` is setup it relied exclusively on `optimizeDeps.include` and not the dependency scanning so adding this change does break existing Marko apps.

However @marko/vite is being updated to use `optimizeDeps.entries` instead since the include method we were using needlessly bundles more than necessary.

The actual processing of Marko files is done by an esbuild hook added by `@marko/vite` so no further change is needed here other than allowing `.marko` files to pass through the `isScannable` checks.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
