### PR TITLE
fix(lib): esbuild helper functions injection not working with named exports

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -25,9 +25,10 @@ import type { Plugin } from '../plugin'
 
 const debug = createDebugger('vite:esbuild')
 
-// IIFE content looks like `var MyLib = function() {`. Spaces are removed when minified
+// IIFE content looks like `var MyLib = function() {`.
+// Spaces are removed and parameters are mangled when minified
 const IIFE_BEGIN_RE =
-  /(const|var)\s+\S+\s*=\s*function\(\)\s*\{.*"use strict";/s
+  /(const|var)\s+\S+\s*=\s*function\([^()]*\)\s*\{\s*"use strict";/
 
 const validExtensionRE = /\.\w+$/
 const jsxExtensionsRE = /\.(?:j|t)sx\b/

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -19,11 +19,13 @@ describe.runIf(isBuild)('build', () => {
     const noMinifyCode = readFile(
       'dist/nominify/my-lib-custom-filename.umd.cjs',
     )
+    const namedCode = readFile('dist/named/my-lib-named.umd.cjs')
     // esbuild helpers are injected inside of the UMD wrapper
     expect(code).toMatch(/^\(function\(/)
     expect(noMinifyCode).toMatch(
       /^\(function\(global.+?"use strict";var.+?function\smyLib\(/s,
     )
+    expect(namedCode).toMatch(/^\(function\(/)
   })
 
   test('iife', async () => {
@@ -32,10 +34,14 @@ describe.runIf(isBuild)('build', () => {
     const noMinifyCode = readFile(
       'dist/nominify/my-lib-custom-filename.iife.js',
     )
+    const namedCode = readFile('dist/named/my-lib-named.iife.js')
     // esbuild helpers are injected inside of the IIFE wrapper
     expect(code).toMatch(/^var MyLib=function\(\)\{\s*"use strict";/)
     expect(noMinifyCode).toMatch(
       /^var MyLib\s*=\s*function\(\)\s*\{\s*"use strict";/,
+    )
+    expect(namedCode).toMatch(
+      /^var MyLibNamed=function\([^()]+\)\{\s*"use strict";/,
     )
   })
 

--- a/playground/lib/__tests__/serve.ts
+++ b/playground/lib/__tests__/serve.ts
@@ -82,6 +82,12 @@ export async function serve(): Promise<{ close(): Promise<void> }> {
       ),
     })
 
+    await build({
+      root: rootDir,
+      logLevel: 'warn', // output esbuild warns
+      configFile: path.resolve(__dirname, '../vite.named-exports.config.js'),
+    })
+
     // start static file server
     const serve = sirv(path.resolve(rootDir, 'dist'))
     const httpServer = http.createServer((req, res) => {

--- a/playground/lib/src/main-named.js
+++ b/playground/lib/src/main-named.js
@@ -1,0 +1,4 @@
+export const foo = 'foo'
+
+// Force esbuild spread helpers
+console.log({ ...foo })

--- a/playground/lib/vite.named-exports.config.js
+++ b/playground/lib/vite.named-exports.config.js
@@ -1,0 +1,20 @@
+import path from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    supported: {
+      // Force esbuild inject helpers to test regex
+      'object-rest-spread': false,
+    },
+  },
+  build: {
+    lib: {
+      entry: path.resolve(__dirname, 'src/main-named.js'),
+      name: 'MyLibNamed',
+      formats: ['umd', 'iife'],
+      fileName: 'my-lib-named',
+    },
+    outDir: 'dist/named',
+  },
+})


### PR DESCRIPTION
### Description
This is a regression caused by #14094

fixes #14537

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
