### PR TITLE
docs: fix resolveDependencies signature

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -43,7 +43,7 @@ type ResolveModulePreloadDependenciesFn = (
   context: {
     importer: string
   },
-) => (string | { runtime?: string })[]
+) => string[]
 ```
 
 The `resolveDependencies` function will be called for each dynamic import with a list of the chunks it depends on, and it will also be called for each chunk imported in entry HTML files. A new dependencies array can be returned with these filtered or more dependencies injected, and their paths modified. The `deps` paths are relative to the `build.outDir`. Returning a relative path to the `hostId` for `hostType === 'js'` is allowed, in which case `new URL(dep, import.meta.url)` is used to get an absolute path when injecting this module preload in the HTML head.


### PR DESCRIPTION
### Description

Thanks @bluwy for spotting this. `resolveDependencies` only supports returning a list of strings.
It was a leftover from this refactoring https://github.com/vitejs/vite/pull/9938/commits/9f1eaa5f7539eb7588506419465aa8c7251b2efd in the PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other