### PR TITLE
fix(dev): bind plugin context functions

### DIFF
--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -21,11 +21,16 @@ describe('plugin container', () => {
         expect(this.load.prototype).equals(undefined)
         expect(this.parse.prototype).equals(undefined)
         expect(this.resolve.prototype).equals(undefined)
+        expect(this.getModuleInfo.prototype).equals(undefined)
+        expect(this.getModuleIds.prototype).equals(undefined)
         expect(this.addWatchFile.prototype).equals(undefined)
+        expect(this.getWatchFiles.prototype).equals(undefined)
         expect(this.setAssetSource.prototype).equals(undefined)
         expect(this.getFileName.prototype).equals(undefined)
         expect(this.warn.prototype).equals(undefined)
         expect(this.error.prototype).equals(undefined)
+        expect(this.debug.prototype).equals(undefined)
+        expect(this.info.prototype).equals(undefined)
       },
     }
 

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -10,6 +10,32 @@ let resolveId: (id: string) => any
 let moduleGraph: ModuleGraph
 
 describe('plugin container', () => {
+  it('has bound methods', async () => {
+    expect.assertions(8)
+    const entryUrl = '/x.js'
+
+    const plugin: Plugin = {
+      name: 'p1',
+      load(id) {
+        // bound functions and bound arrow functions do not have prototype
+        expect(this.load.prototype).equals(undefined)
+        expect(this.parse.prototype).equals(undefined)
+        expect(this.resolve.prototype).equals(undefined)
+        expect(this.addWatchFile.prototype).equals(undefined)
+        expect(this.setAssetSource.prototype).equals(undefined)
+        expect(this.getFileName.prototype).equals(undefined)
+        expect(this.warn.prototype).equals(undefined)
+        expect(this.error.prototype).equals(undefined)
+      },
+    }
+
+    const container = await getPluginContainer({
+      plugins: [plugin],
+    })
+
+    await container.load(entryUrl)
+  })
+
   describe('getModuleInfo', () => {
     beforeEach(() => {
       moduleGraph = new ModuleGraph((id) => resolveId(id))

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -18,9 +18,9 @@ describe('plugin container', () => {
       name: 'p1',
       load(id) {
         // bound functions and bound arrow functions do not have prototype
-        expect(this.load.prototype).equals(undefined)
         expect(this.parse.prototype).equals(undefined)
         expect(this.resolve.prototype).equals(undefined)
+        expect(this.load.prototype).equals(undefined)
         expect(this.getModuleInfo.prototype).equals(undefined)
         expect(this.getModuleIds.prototype).equals(undefined)
         expect(this.addWatchFile.prototype).equals(undefined)

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -11,7 +11,7 @@ let moduleGraph: ModuleGraph
 
 describe('plugin container', () => {
   it('has bound methods', async () => {
-    expect.assertions(13)
+    expect.assertions(14)
     const entryUrl = '/x.js'
 
     const plugin: Plugin = {
@@ -25,6 +25,7 @@ describe('plugin container', () => {
         expect(this.getModuleIds.prototype).equals(undefined)
         expect(this.addWatchFile.prototype).equals(undefined)
         expect(this.getWatchFiles.prototype).equals(undefined)
+        expect(this.emitFile.prototype).equals(undefined)
         expect(this.setAssetSource.prototype).equals(undefined)
         expect(this.getFileName.prototype).equals(undefined)
         expect(this.warn.prototype).equals(undefined)

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -11,7 +11,7 @@ let moduleGraph: ModuleGraph
 
 describe('plugin container', () => {
   it('has bound methods', async () => {
-    expect.assertions(8)
+    expect.assertions(13)
     const entryUrl = '/x.js'
 
     const plugin: Plugin = {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -292,13 +292,14 @@ export async function createPluginContainer(
 
     constructor(initialPlugin?: Plugin) {
       this._activePlugin = initialPlugin || null
-      this.load = this.load.bind(this)
       this.parse = this.parse.bind(this)
       this.resolve = this.resolve.bind(this)
+      this.load = this.load.bind(this)
       this.getModuleInfo = this.getModuleInfo.bind(this)
       this.getModuleIds = this.getModuleIds.bind(this)
       this.addWatchFile = this.addWatchFile.bind(this)
       this.getWatchFiles = this.getWatchFiles.bind(this)
+      this.emitFile = this.emitFile.bind(this)
       this.setAssetSource = this.setAssetSource.bind(this)
       this.getFileName = this.getFileName.bind(this)
       this.warn = this.warn.bind(this)

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -292,6 +292,14 @@ export async function createPluginContainer(
 
     constructor(initialPlugin?: Plugin) {
       this._activePlugin = initialPlugin || null
+      this.load = this.load.bind(this)
+      this.parse = this.parse.bind(this)
+      this.resolve = this.resolve.bind(this)
+      this.addWatchFile = this.addWatchFile.bind(this)
+      this.setAssetSource = this.setAssetSource.bind(this)
+      this.getFileName = this.getFileName.bind(this)
+      this.warn = this.warn.bind(this)
+      this.error = this.error.bind(this)
     }
 
     parse(code: string, opts: any = {}) {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -295,11 +295,16 @@ export async function createPluginContainer(
       this.load = this.load.bind(this)
       this.parse = this.parse.bind(this)
       this.resolve = this.resolve.bind(this)
+      this.getModuleInfo = this.getModuleInfo.bind(this)
+      this.getModuleIds = this.getModuleIds.bind(this)
       this.addWatchFile = this.addWatchFile.bind(this)
+      this.getWatchFiles = this.getWatchFiles.bind(this)
       this.setAssetSource = this.setAssetSource.bind(this)
       this.getFileName = this.getFileName.bind(this)
       this.warn = this.warn.bind(this)
       this.error = this.error.bind(this)
+      this.debug = this.debug.bind(this)
+      this.info = this.info.bind(this)
     }
 
     parse(code: string, opts: any = {}) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

rollup binds the plugin context functions to itself and plugins use that.
e.g. commonjs. 

closes https://github.com/rollup/plugins/pull/1603


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
