### PR TITLE
build: clean generated type file

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -29,16 +29,13 @@ const singlelineCommentsRE = /\/\/[^/].*/g
 const licenseCommentsRE = /MIT License|MIT license|BSD license/
 const consecutiveNewlinesRE = /\n{2,}/g
 const identifierWithTrailingDollarRE = /\b(\w+)\$\d+\b/g
-const importStatementWithoutTypeRE = /^import (?!type|\{ type)/gm
-const exportStatementWithoutTypeRE = /^export (?!type|\{ type)/gm
 
 /**
  * Patch the types files before passing to dts plugin
  * 1. Resolve `dep-types/*` and `types/*` imports
  * 2. Validate unallowed dependency imports
  * 3. Replace confusing type names
- * 4. Ensure import/export statements use `import type` and `export type`
- * 5. Clean unnecessary comments
+ * 4. Clean unnecessary comments
  */
 function patchTypes(): Plugin {
   return {
@@ -107,11 +104,6 @@ function patchTypes(): Plugin {
           betterName,
         )
       }
-
-      // Make sure all import and exports uses `import type` and `export type`
-      code = code
-        .replace(importStatementWithoutTypeRE, 'import type ')
-        .replace(exportStatementWithoutTypeRE, 'export type ')
 
       // Clean unnecessary comments
       code = code

--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -134,7 +134,7 @@ function patchTypes(): Plugin {
             )
           }
           code = code.replace(
-            new RegExp(`\\b${escapeRegex(id)}\\b`, 'g'),
+            new RegExp(`\\b${regexEscapedId}\\b`, 'g'),
             betterId,
           )
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Following up from https://github.com/vitejs/vite/pull/14571

The generated types file is improved a little.
- Names like `Plugin$1` are renamed to something better (previously happen in api-extractor too). The type names can sometimes show up in TypeScript messages which is confusing.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Also wonder if we should export the esbuild type, but I left it out for now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
