### PR TITLE
refactor!: remove `resolvePackageEntry` and `resolvePackageData` APIs

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -52,14 +52,14 @@ import { resolve } from 'import-meta-env'
 import { findDepPkgJsonPath } from 'vitefu'
 import fs from 'node:fs'
 
-const package = 'my-lib'
+const pkg = 'my-lib'
 const basedir = process.cwd()
 
 // `resolvePackageEntry`:
-const packageEntry = resolve(package, basedir)
+const packageEntry = resolve(pkg, basedir)
 
 // `resolvePackageData`:
-const packageJsonPath = findDepPkgJsonPath(package, basedir)
+const packageJsonPath = findDepPkgJsonPath(pkg, basedir)
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
 ```
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -40,6 +40,29 @@ CLI shortcuts, like `r` to restart the dev server, now require an additional `En
 
 This change prevents Vite from swallowing and controlling OS-specific shortcuts, allowing better compatibility when combining the Vite dev server with other processes, and avoids the [previous caveats](https://github.com/vitejs/vite/pull/14342).
 
+### Remove `resolvePackageEntry` and `resolvePackageData` APIs
+
+The `resolvePackageEntry` and `resolvePackageData` APIs are removed as they exposed Vite's internals and blocked potential Vite 4.3 optimizations in the past. These APIs can be replaced with third-party packages, for example:
+
+- `resolvePackageEntry`: [`import.meta.resolve`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta/resolve) or the [`import-meta-resolve`](https://github.com/wooorm/import-meta-resolve) package.
+- `resolvePackageData`: Same as above, and crawl up the package directory to get the root `package.json`. Or use the community [`vitefu`](https://github.com/svitejs/vitefu) package.
+
+```js
+import { resolve } from 'import-meta-env'
+import { findDepPkgJsonPath } from 'vitefu'
+import fs from 'node:fs'
+
+const package = 'my-lib'
+const basedir = process.cwd()
+
+// `resolvePackageEntry`:
+const packageEntry = resolve(package, basedir)
+
+// `resolvePackageData`:
+const packageJsonPath = findDepPkgJsonPath(package, basedir)
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+```
+
 ## Removed Deprecated APIs
 
 - Default exports of CSS files (e.g `import style from './foo.css'`): Use the `?inline` query instead

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -25,16 +25,6 @@ asyncFunctions.forEach((name) => {
     import('./dist/node/index.js').then((i) => i[name](...args))
 })
 
-// some sync functions are marked not supported due to their complexity and uncommon usage
-const unsupportedCJS = ['resolvePackageEntry', 'resolvePackageData']
-unsupportedCJS.forEach((name) => {
-  module.exports[name] = () => {
-    throw new Error(
-      `"${name}" is not supported in CJS build of Vite 4.\nPlease use ESM or dynamic imports \`const { ${name} } = await import('vite')\`.`,
-    )
-  }
-})
-
 function warnCjsUsage() {
   if (process.env.VITE_CJS_IGNORE_WARNING) return
   globalThis.__vite_cjs_skip_clear_screen = true

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -8,8 +8,6 @@ export { build } from './build'
 export { optimizeDeps } from './optimizer'
 export { formatPostcssSourceMap, preprocessCSS } from './plugins/css'
 export { transformWithEsbuild } from './plugins/esbuild'
-export { resolvePackageEntry } from './plugins/resolve'
-export { resolvePackageData } from './packages'
 export { buildErrorMessage } from './server/middlewares/error'
 export * from './publicUtils'
 
@@ -54,7 +52,6 @@ export type {
   SSRTarget,
 } from './ssr'
 export type { Plugin, HookHandler } from './plugin'
-export type { PackageCache, PackageData } from './packages'
 export type {
   Logger,
   LogOptions,

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -1,8 +1,9 @@
 import path from 'node:path'
 import type { ImportKind, Plugin } from 'esbuild'
 import { KNOWN_ASSET_TYPES } from '../constants'
+import type { PackageCache } from '../packages'
 import { getDepOptimizationConfig } from '..'
-import type { PackageCache, ResolvedConfig } from '..'
+import type { ResolvedConfig } from '..'
 import {
   escapeRegex,
   flattenId,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
They are preventing caching optimizations that we can do. IIRC the `setResolvedCache` API isn't correct too and is causing bugs. (~~have to find the issue~~ https://github.com/vitejs/vite/issues/12957#issuecomment-1546664484)



### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
After a lot of yak shaving, I finally got to what I wanted to do!

---

Admittedly I didn't plan this ahead since it would be better with a deprecation phase, but I think it's fine as these APIs are rather internal.

GitHub search for [resolvePackageEntry](https://github.com/search?q=%22resolvePackageEntry%28%22+%28path%3A*.js+OR+path%3A*.ts%29+-repo%3Avitejs%2Fvite+NOT+is%3Afork&type=code) and [resolvePackageData](https://github.com/search?q=%22resolvePackageData%28%22+%28path%3A*.js+OR+path%3A*.ts%29+-repo%3Avitejs%2Fvite+NOT+is%3Afork&type=code&p=1) usage

Unfortunately `resolvePackageEntry` affects some Vite plugins, and `resolvePackageData` affects two big projects: `qwik` and `slidev`. But their usage are simple enough that the migration guide should work.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
