### PR TITLE
fix: off-by-one bug in HTML whitespace removal

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -337,7 +337,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             node.sourceCodeLocation!.startOffset -
             node.sourceCodeLocation!.startCol
           const line = s.slice(
-            lineStartOffset,
+            Math.max(0, lineStartOffset),
             node.sourceCodeLocation!.startOffset,
           )
 


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/pull/14274#issuecomment-1758742149

`startCol` is 1-indexed, while `startOffset` is 0 indexed. This fix ensures `magic-string` isn't given a negative start position when checking a specific line.

### Additional context

Same thing I mentioned on #14274 in that there doesn't seem to be any existing tests for the HTML output, just browser/integration tests, but I'd be happy to add a few if someone could direct me towards what's needed.

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
