### PR TITLE
fix(html): relative paths without leading dot wasn't rewritten

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -92,6 +92,8 @@ function shouldPreTransform(url: string, config: ResolvedConfig) {
   )
 }
 
+const startsWithWordCharRE = /^\w/
+
 const processNodeUrl = (
   attr: Token.Attribute,
   sourceCodeLocation: Token.Location,
@@ -118,7 +120,7 @@ const processNodeUrl = (
       preTransformRequest(server, fullUrl, devBase)
     }
   } else if (
-    url[0] === '.' &&
+    (url[0] === '.' || startsWithWordCharRE.test(url)) &&
     originalUrl &&
     originalUrl !== '/' &&
     htmlPath === '/index.html'

--- a/playground/assets/vite.config.js
+++ b/playground/assets/vite.config.js
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
-  base: '/foo',
+  base: '/foo/bar',
   publicDir: 'static',
   resolve: {
     alias: {


### PR DESCRIPTION
### Description
When the base is without trailing slash, relative path without leading dot wasn't working.
https://github.com/vitejs/vite/blob/31333bbb77ce3bf4a34380a2f07f926330993cac/playground/assets/index.html#L364

The first commit simply changes the base (this will make the test fail even with the paths in the test is updated).
The second commit is the actual fix.

This bug was found in https://github.com/vitejs/vite/pull/5657.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
