### PR TITLE
fix(html): import expression in classic script for dev

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -10,6 +10,7 @@ import {
   addToHTMLProxyCache,
   applyHtmlTransforms,
   assetAttrsConfig,
+  extractImportExpressionFromClassicScript,
   findNeedTransformStyleAttribute,
   getAttrKey,
   getScriptInfo,
@@ -103,17 +104,16 @@ function shouldPreTransform(url: string, config: ResolvedConfig) {
 
 const startsWithWordCharRE = /^\w/
 
+const isSrcSet = (attr: Token.Attribute) =>
+  attr.name === 'srcset' && attr.prefix === undefined
 const processNodeUrl = (
-  attr: Token.Attribute,
-  sourceCodeLocation: Token.Location,
-  s: MagicString,
+  url: string,
+  useSrcSetReplacer: boolean,
   config: ResolvedConfig,
   htmlPath: string,
   originalUrl?: string,
   server?: ViteDevServer,
-) => {
-  let url = attr.value || ''
-
+): string | undefined => {
   if (server?.moduleGraph) {
     const mod = server.moduleGraph.urlToModuleMap.get(url)
     if (mod && mod.lastHMRTimestamp > 0) {
@@ -124,10 +124,10 @@ const processNodeUrl = (
   if (url[0] === '/' && url[1] !== '/') {
     // prefix with base (dev only, base is never relative)
     const fullUrl = path.posix.join(devBase, url)
-    overwriteAttrValue(s, sourceCodeLocation, fullUrl)
     if (server && shouldPreTransform(url, config)) {
       preTransformRequest(server, fullUrl, devBase)
     }
+    return fullUrl
   } else if (
     (url[0] === '.' || startsWithWordCharRE.test(url)) &&
     originalUrl &&
@@ -148,11 +148,10 @@ const processNodeUrl = (
     // rewrite before `./index.js` -> `localhost:5173/a/index.js`.
     // rewrite after `../index.js` -> `localhost:5173/index.js`.
 
-    const processedUrl =
-      attr.name === 'srcset' && attr.prefix === undefined
-        ? processSrcSetSync(url, ({ url }) => replacer(url))
-        : replacer(url)
-    overwriteAttrValue(s, sourceCodeLocation, processedUrl)
+    const processedUrl = useSrcSetReplacer
+      ? processSrcSetSync(url, ({ url }) => replacer(url))
+      : replacer(url)
+    return processedUrl
   }
 }
 const devHtmlHook: IndexHtmlTransformHook = async (
@@ -241,17 +240,39 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       const { src, sourceCodeLocation, isModule } = getScriptInfo(node)
 
       if (src) {
-        processNodeUrl(
-          src,
-          sourceCodeLocation!,
-          s,
+        const processedUrl = processNodeUrl(
+          src.value,
+          isSrcSet(src),
           config,
           htmlPath,
           originalUrl,
           server,
         )
+        if (processedUrl) {
+          overwriteAttrValue(s, sourceCodeLocation!, processedUrl)
+        }
       } else if (isModule && node.childNodes.length) {
         addInlineModule(node, 'js')
+      } else if (node.childNodes.length) {
+        const scriptNode = node.childNodes[
+          node.childNodes.length - 1
+        ] as DefaultTreeAdapterMap['textNode']
+        for (const {
+          url,
+          start,
+          end,
+        } of extractImportExpressionFromClassicScript(scriptNode)) {
+          const processedUrl = processNodeUrl(
+            url,
+            false,
+            config,
+            htmlPath,
+            originalUrl,
+          )
+          if (processedUrl) {
+            s.update(start, end, processedUrl)
+          }
+        }
       }
     }
 
@@ -280,14 +301,20 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       for (const p of node.attrs) {
         const attrKey = getAttrKey(p)
         if (p.value && assetAttrs.includes(attrKey)) {
-          processNodeUrl(
-            p,
-            node.sourceCodeLocation!.attrs![attrKey],
-            s,
+          const processedUrl = processNodeUrl(
+            p.value,
+            isSrcSet(p),
             config,
             htmlPath,
             originalUrl,
           )
+          if (processedUrl) {
+            overwriteAttrValue(
+              s,
+              node.sourceCodeLocation!.attrs![attrKey],
+              processedUrl,
+            )
+          }
         }
       }
     }

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -239,11 +239,10 @@ export async function startDefaultServe(): Promise<void> {
     process.env.VITE_INLINE = 'inline-serve'
     const testConfig = mergeConfig(options, config || {})
     viteServer = server = await (await createServer(testConfig)).listen()
-    // use resolved port/base from server
-    const devBase = server.config.base
-    viteTestUrl = `http://localhost:${server.config.server.port}${
-      devBase === '/' ? '' : devBase
-    }`
+    viteTestUrl = server.resolvedUrls.local[0]
+    if (server.config.base === '/') {
+      viteTestUrl = viteTestUrl.replace(/\/$/, '')
+    }
     await page.goto(viteTestUrl)
   } else {
     process.env.VITE_INLINE = 'inline-build'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
~~**This PR includes changes from #14592** (otherwise, the tests fail)~~

Support for `import` expressions in classic script (added by #6525) was not working for dev.
This PR fixes that.

This bug was found at https://github.com/vitejs/vite/pull/5657#discussion_r1327973252.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
