### PR TITLE
test: update test for inline sourcemap

### DIFF
--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -31,7 +31,7 @@ if (!isBuild) {
     `)
   })
 
-  test('js with existing inline sourcemap', async () => {
+  test('js with inline sourcemap injected by a plugin', async () => {
     const res = await page.request.get(
       new URL('./foo-with-sourcemap.js', page.url()).href,
     )

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -1,6 +1,7 @@
 import { URL } from 'node:url'
 import { describe, expect, test } from 'vitest'
 import { mapFileCommentRegex } from 'convert-source-map'
+import { commentSourceMap } from '../foo-with-sourcemap-plugin'
 import {
   extractSourcemap,
   findAssetFile,
@@ -36,6 +37,7 @@ if (!isBuild) {
     )
     const js = await res.text()
 
+    expect(js).toContain(commentSourceMap)
     const sourcemapComments = js.match(mapFileCommentRegex).length
     expect(sourcemapComments).toBe(1)
 
@@ -45,9 +47,6 @@ if (!isBuild) {
         "mappings": "AAAA,MAAM,CAAC,KAAK,CAAC,GAAG,CAAC,CAAC,CAAC,CAAC,GAAG",
         "sources": [
           "",
-        ],
-        "sourcesContent": [
-          null,
         ],
         "version": 3,
       }

--- a/playground/js-sourcemap/foo-with-sourcemap-plugin.ts
+++ b/playground/js-sourcemap/foo-with-sourcemap-plugin.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'vite'
+import type { Plugin } from 'vite'
 
 export const commentSourceMap =
   '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHIn0='

--- a/playground/js-sourcemap/foo-with-sourcemap-plugin.ts
+++ b/playground/js-sourcemap/foo-with-sourcemap-plugin.ts
@@ -1,14 +1,16 @@
 import type { Plugin } from 'vite'
 
-export const commentSourceMap =
-  '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHIn0='
+export const commentSourceMap = [
+  '// default boundary sourcemap with magic-string',
+  '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHIn0=',
+].join('\n')
 
 export default function transformFooWithInlineSourceMap(): Plugin {
   return {
     name: 'transform-foo-with-inline-sourcemap',
     transform(code, id) {
       if (id.includes('foo-with-sourcemap.js')) {
-        return `${code}\n${commentSourceMap}`
+        return `${code}${commentSourceMap}`
       }
     },
   }

--- a/playground/js-sourcemap/foo-with-sourcemap-plugin.ts
+++ b/playground/js-sourcemap/foo-with-sourcemap-plugin.ts
@@ -1,0 +1,15 @@
+import { Plugin } from 'vite'
+
+export const commentSourceMap =
+  '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHIn0='
+
+export default function transformFooWithInlineSourceMap(): Plugin {
+  return {
+    name: 'transform-foo-with-inline-sourcemap',
+    transform(code, id) {
+      if (id.includes('foo-with-sourcemap.js')) {
+        return `${code}\n${commentSourceMap}`
+      }
+    },
+  }
+}

--- a/playground/js-sourcemap/foo-with-sourcemap.js
+++ b/playground/js-sourcemap/foo-with-sourcemap.js
@@ -1,3 +1,1 @@
 export const foo = 'foo'
-
-// default boundary sourcemap with magic-string

--- a/playground/js-sourcemap/foo-with-sourcemap.js
+++ b/playground/js-sourcemap/foo-with-sourcemap.js
@@ -1,5 +1,3 @@
 export const foo = 'foo'
 
 // default boundary sourcemap with magic-string
-
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxNQUFNLENBQUMsS0FBSyxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQyxHQUFHIn0=

--- a/playground/js-sourcemap/vite.config.js
+++ b/playground/js-sourcemap/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
+import transformFooWithInlineSourceMap from './foo-with-sourcemap-plugin'
 
 export default defineConfig({
+  plugins: [transformFooWithInlineSourceMap()],
   build: {
     sourcemap: true,
     rollupOptions: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

I noticed that the processing of #14370 is not related to the test.

According to the description of #14370's description, the inline-sourcemap should have been added in the transform, not hard code in the original file. 

Also, this test blocked #14588


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
