### PR TITLE
feat: add image type awebp

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -94,6 +94,10 @@ declare module '*.webp' {
   const src: string
   export default src
 }
+declare module '*.awebp' {
+  const src: string
+  export default src
+}
 declare module '*.avif' {
   const src: string
   export default src

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -106,6 +106,7 @@ export const KNOWN_ASSET_TYPES = [
   'svg',
   'ico',
   'webp',
+  'awebp',
   'avif',
 
   // media

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -105,8 +105,7 @@ export const KNOWN_ASSET_TYPES = [
   'gif',
   'svg',
   'ico',
-  'webp',
-  'awebp',
+  'a?webp',
   'avif',
 
   // media

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -52,6 +52,7 @@ export const generatedAssets = new WeakMap<
 export function registerCustomMime(): void {
   // https://github.com/lukeed/mrmime/issues/3
   mrmime.mimes['ico'] = 'image/x-icon'
+  mrmime.mimes['awebp'] = 'image/webp'
   // https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Containers#flac
   mrmime.mimes['flac'] = 'audio/flac'
   // mrmime and mime-db is not released yet: https://github.com/jshttp/mime-db/commit/c9242a9b7d4bb25d7a0c9244adec74aeef08d8a1


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Support importing images with suffix `awebp`.

The awebp's mime type is `undefined` looked up by `mrmime`.

Related issue: https://github.com/vuejs/vitepress/issues/3076

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
