### PR TITLE
chore: remove `server.host` option for e2e test

### DIFF
--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -239,7 +239,7 @@ export async function startDefaultServe(): Promise<void> {
     process.env.VITE_INLINE = 'inline-serve'
     const testConfig = mergeConfig(options, config || {})
     viteServer = server = await (await createServer(testConfig)).listen()
-    viteTestUrl = server.resolvedUrls.local[0]
+    viteTestUrl = server.resolvedUrls.network[0]
     if (server.config.base === '/') {
       viteTestUrl = viteTestUrl.replace(/\/$/, '')
     }

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -218,7 +218,6 @@ export async function startDefaultServe(): Promise<void> {
         usePolling: true,
         interval: 100,
       },
-      host: true,
       fs: {
         strict: !isBuild,
       },
@@ -239,7 +238,7 @@ export async function startDefaultServe(): Promise<void> {
     process.env.VITE_INLINE = 'inline-serve'
     const testConfig = mergeConfig(options, config || {})
     viteServer = server = await (await createServer(testConfig)).listen()
-    viteTestUrl = server.resolvedUrls.network[0]
+    viteTestUrl = server.resolvedUrls.local[0]
     if (server.config.base === '/') {
       viteTestUrl = viteTestUrl.replace(/\/$/, '')
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->



An edge case I encountered. Ports 5173 are occupied by another `vite` server that uses the `server.host` option by default. When I run `pnpm test-serve`, the test server will `listen()` successfully. Normally it should fail and then start port 5174 but it doesn't. 

I noticed `server.host = true` in e2e test, so the host is `undefined`. According to the documentation described as follows

> If host is omitted, the server will accept connections on the [unspecified IPv6 address](https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address) (::) when IPv6 is available, or the [unspecified IPv4 address](https://en.wikipedia.org/wiki/0.0.0.0) (0.0.0.0) otherwise. 

> [Learn more about node documentation](https://nodejs.org/dist/latest-v18.x/docs/api/net.html#serverlistenport-host-backlog-callback)


So the http server may not listen to `localhost`.  maybe `192.168.xx.xx` or else.

The solution to this issue is easy, just use `network[0]` instead of `local[0]` will work

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
