### PR TITLE
fix: worker build

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -44,9 +44,9 @@ function saveEmitWorkerAsset(
 // Ensure that only one rollup build is called at the same time to avoid
 // leaking state in plugins between worker builds.
 // TODO: Review if we can parallelize the bundling of workers.
-const workerKey = { key: 'vite:worker' }
+const workerKey: { key: string } = { key: 'vite:worker' }
 const workerConfigSemaphore = new WeakMap<
-  ResolvedConfig,
+  typeof workerKey,
   Promise<OutputChunk>
 >()
 export async function bundleWorkerEntry(


### PR DESCRIPTION
When we have multiple workers, the config cannot be used as weak map key since the config can mutate.

Since we're not in a multi-thread environment we can use a fixed key to store the promise of the current worker build.

You can use the reproduction provided in https://github.com/vitejs/vite/issues/13367 , when building the third worker, there is a pending promise since the config changes and there is no way to delete it and then the error.

closes #13367

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

check #13367

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
