### PR TITLE
revert: fix: disable keepNames in vite:esbuild (fixes #9164)

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -248,11 +248,7 @@ export function esbuildPlugin(config: ResolvedConfig): Plugin {
     minifyIdentifiers: false,
     minifySyntax: false,
     minifyWhitespace: false,
-    treeShaking: false,
-    // keepNames is not needed when minify is disabled.
-    // Also transforming multiple times with keepNames enabled breaks
-    // tree-shaking. (#9164)
-    keepNames: false,
+    treeShaking: false
   }
 
   return {

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -248,7 +248,7 @@ export function esbuildPlugin(config: ResolvedConfig): Plugin {
     minifyIdentifiers: false,
     minifySyntax: false,
     minifyWhitespace: false,
-    treeShaking: false
+    treeShaking: false,
   }
 
   return {


### PR DESCRIPTION
This reverts commit e6f3b026bd1e281cfad6b19386195b6c2dc94165 to fix #13727.

<!-- Thank you for contributing! -->

### Description

It is possible for esbuild [to rename symbols even if it is not minifying](https://esbuild.github.io/api/#keep-names:~:text=and%20bundling%20sometimes%20need%20to%20rename%20symbols).
But in order for tree-shaking to properly work, we disabled `keepNames` in `vite:esbuild` phase, which let renaming. One [proof of concept](https://github.com/spence-novata/vitest-keep-name-poc) shows it actually renames and causes a problem like in #13727.
Therefore we should let `keepNames` be respected again in `vite:esbuild` phase.

### Additional context

Tree-shaking is about file size while `keepNames` is about the real logic that matters. I think it's an enough reason to revert a commit.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
