### PR TITLE
fix(server): merge https prefer object

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -185,6 +185,37 @@ describe('mergeConfig', () => {
     expect(mergeConfig(newConfig, baseConfig)).toEqual(mergedConfig)
   })
 
+  test('handles server.https and preview.https', () => {
+    const baseConfig = {
+      server: {
+        https: { cert: '' },
+      },
+      preview: {
+        https: { cert: '' },
+      },
+    }
+
+    const newConfig = {
+      server: {
+        https: true,
+      },
+      preview: {
+        https: true,
+      },
+    }
+
+    const mergedConfig = {
+      server: {
+        https: { cert: '' },
+      },
+      preview: {
+        https: { cert: '' },
+      },
+    }
+
+    expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
+  })
+
   test('throws error with functions', () => {
     const baseConfig = defineConfig(() => ({ base: 'base' }))
     const newConfig = defineConfig(() => ({ base: 'new' }))

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1055,6 +1055,14 @@ function mergeConfigRecursively(
     ) {
       merged[key] = true
       continue
+    } else if (
+      key === 'https' &&
+      (rootPath === 'server' || rootPath === 'preview') &&
+      typeof existing === 'object' &&
+      value === true
+    ) {
+      // if `--https` and `https: { ... }` are both present, prefer the object form
+      continue
     }
 
     if (Array.isArray(existing) || Array.isArray(value)) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
fix #10058

If `--https` and `https: { ... }` are both present, prefer the object form

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
maybe this could be done more generically, since object-form is implicitly `true` and more "in-depth". but only applying for `server.https` and `preview.https` for now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
