### PR TITLE
refactor: use the native JSON.stringify method to replace json-stable-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/estree": "^1.0.2",
     "@types/etag": "^1.8.1",
     "@types/fs-extra": "^11.0.2",
-    "@types/json-stable-stringify": "^1.0.34",
     "@types/less": "^3.0.4",
     "@types/micromatch": "^4.0.3",
     "@types/node": "^18.18.4",

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -1867,32 +1867,6 @@ Repository: git+https://github.com/isaacs/isexe.git
 
 ---------------------------------------
 
-## json-stable-stringify
-License: MIT
-By: James Halliday
-Repository: git://github.com/ljharb/json-stable-stringify.git
-
-> This software is released under the MIT license:
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy of
-> this software and associated documentation files (the "Software"), to deal in
-> the Software without restriction, including without limitation the rights to
-> use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-> the Software, and to permit persons to whom the Software is furnished to do so,
-> subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-> FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-> COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-> IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-> CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
 ## launch-editor
 License: MIT
 By: Evan You

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -113,7 +113,6 @@
     "etag": "^1.8.1",
     "fast-glob": "^3.3.1",
     "http-proxy": "^1.18.1",
-    "json-stable-stringify": "^1.0.2",
     "launch-editor-middleware": "^2.6.1",
     "lightningcss": "^1.22.0",
     "magic-string": "^0.30.4",

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -116,10 +116,6 @@ function createNodePlugins(
           pattern: /require(?=\((configFile|'ts-node')\))/g,
           replacement: `__require`,
         },
-        'json-stable-stringify/index.js': {
-          pattern: /^var json = typeof JSON.+require\('jsonify'\);$/gm,
-          replacement: 'var json = JSON',
-        },
         // postcss-import uses the `resolve` dep if the `resolve` option is not passed.
         // However, we always pass the `resolve` option. Remove this import to avoid
         // bundling the `resolve` dep.

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -1,6 +1,5 @@
 import path from 'node:path'
 import type { OutputAsset, OutputChunk } from 'rollup'
-import jsonStableStringify from 'json-stable-stringify'
 import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
 import { normalizePath } from '../utils'
@@ -159,7 +158,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
               ? config.build.manifest
               : '.vite/manifest.json',
           type: 'asset',
-          source: jsonStableStringify(manifest, { space: 2 }),
+          source: JSON.stringify(manifest, undefined, 2),
         })
       }
     },

--- a/packages/vite/src/node/ssr/ssrManifestPlugin.ts
+++ b/packages/vite/src/node/ssr/ssrManifestPlugin.ts
@@ -2,7 +2,6 @@ import { basename, dirname, join, relative } from 'node:path'
 import { parse as parseImports } from 'es-module-lexer'
 import type { ImportSpecifier } from 'es-module-lexer'
 import type { OutputChunk } from 'rollup'
-import jsonStableStringify from 'json-stable-stringify'
 import type { ResolvedConfig } from '..'
 import type { Plugin } from '../plugin'
 import { preloadMethod } from '../plugins/importAnalysisBuild'
@@ -96,7 +95,7 @@ export function ssrManifestPlugin(config: ResolvedConfig): Plugin {
             ? config.build.ssrManifest
             : '.vite/ssr-manifest.json',
         type: 'asset',
-        source: jsonStableStringify(ssrManifest, { space: 2 }),
+        source: JSON.stringify(ssrManifest, undefined, 2),
       })
     },
   }

--- a/playground/nested-deps/test-package-b/node_modules/test-package-a/index.js
+++ b/playground/nested-deps/test-package-b/node_modules/test-package-a/index.js
@@ -1,1 +1,0 @@
-export default 'A@1.0.0'

--- a/playground/nested-deps/test-package-b/node_modules/test-package-a/package.json
+++ b/playground/nested-deps/test-package-b/node_modules/test-package-a/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "test-package-a",
-  "version": "1.0.0",
-  "main": "index.js"
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.2
         version: 11.0.2
-      '@types/json-stable-stringify':
-        specifier: ^1.0.34
-        version: 1.0.34
       '@types/less':
         specifier: ^3.0.4
         version: 3.0.4
@@ -327,9 +324,6 @@ importers:
       http-proxy:
         specifier: ^1.18.1
         version: 1.18.1(debug@4.3.4)
-      json-stable-stringify:
-        specifier: ^1.0.2
-        version: 1.0.2
       launch-editor-middleware:
         specifier: ^2.6.1
         version: 2.6.1
@@ -3905,10 +3899,6 @@ packages:
     resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
     dev: true
 
-  /@types/json-stable-stringify@1.0.34:
-    resolution: {integrity: sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==}
-    dev: true
-
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
@@ -6978,12 +6968,6 @@ packages:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
 
-  /json-stable-stringify@1.0.2:
-    resolution: {integrity: sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==}
-    dependencies:
-      jsonify: 0.0.1
-    dev: true
-
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     dev: true
@@ -7010,10 +6994,6 @@ packages:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.11
-    dev: true
-
-  /jsonify@0.0.1:
-    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
     dev: true
 
   /jsonparse@1.3.1:
@@ -7132,6 +7112,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -7141,6 +7122,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -7150,6 +7132,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -7159,6 +7142,7 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

`json-stable-stringify` is used for pretty-printing in `vite`, it could be replaced with `JSON.stringify`

### Additional context

By deault, `json-stable-stringify` will sort on the object key names, is this feature necessary?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
