### PR TITLE
feat: implement AsyncDisposable

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -151,3 +151,6 @@ export const wildcardHosts = new Set([
 export const DEFAULT_DEV_PORT = 5173
 
 export const DEFAULT_PREVIEW_PORT = 4173
+
+export const ASYNC_DISPOSE: typeof Symbol.asyncDispose =
+  Symbol.asyncDispose || Symbol.for('Symbol.asyncDispose')

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -48,7 +48,7 @@ export type ExportsData = {
   jsxLoader?: boolean
 }
 
-export interface DepsOptimizer {
+export interface DepsOptimizer extends AsyncDisposable {
   metadata: DepOptimizationMetadata
   scanProcessing?: Promise<void>
   registerMissingImport: (id: string, resolved: string) => OptimizedDepInfo

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -2,6 +2,7 @@ import colors from 'picocolors'
 import { createDebugger, getHash } from '../utils'
 import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig, ViteDevServer } from '..'
+import { ASYNC_DISPOSE } from '../constants'
 import {
   addManuallyIncludedOptimizeDeps,
   addOptimizedDepInfo,
@@ -119,6 +120,9 @@ async function createDepsOptimizer(
     resetRegisteredIds,
     ensureFirstRun,
     close,
+    [ASYNC_DISPOSE]() {
+      return this.close()
+    },
     options: getDepOptimizationConfig(config, ssr),
   }
 
@@ -832,6 +836,7 @@ async function createDevSsrDepsOptimizer(
     ensureFirstRun: () => {},
 
     close: async () => {},
+    [ASYNC_DISPOSE]: async () => {},
     options: config.ssr.optimizeDeps,
   }
   devSsrDepsOptimizerMap.set(config, depsOptimizer)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -14,6 +14,7 @@ import type { SourceMap } from 'rollup'
 import picomatch from 'picomatch'
 import type { Matcher } from 'picomatch'
 import type { InvalidatePayload } from 'types/customEvent'
+import { ASYNC_DISPOSE, CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,
@@ -42,7 +43,6 @@ import {
 } from '../optimizer'
 import { bindCLIShortcuts } from '../shortcuts'
 import type { BindCLIShortcutsOptions } from '../shortcuts'
-import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
 import { createNoopWatcher, resolveChokidarOptions } from '../watch'
@@ -180,7 +180,7 @@ export type ServerHook = (
   server: ViteDevServer,
 ) => (() => void) | void | Promise<(() => void) | void>
 
-export interface ViteDevServer {
+export interface ViteDevServer extends AsyncDisposable {
   /**
    * The resolved vite config object
    */
@@ -510,6 +510,9 @@ export async function _createServer(
         )
       }
       server.resolvedUrls = null
+    },
+    [ASYNC_DISPOSE]() {
+      return this.close()
     },
     printUrls() {
       if (server.resolvedUrls) {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -64,6 +64,7 @@ import type { FSWatcher } from 'chokidar'
 import colors from 'picocolors'
 import type * as postcss from 'postcss'
 import type { Plugin } from '../plugin'
+import { ASYNC_DISPOSE, FS_PREFIX } from '../constants'
 import {
   cleanUrl,
   combineSourcemaps,
@@ -78,7 +79,6 @@ import {
   timeFrom,
   unwrapId,
 } from '../utils'
-import { FS_PREFIX } from '../constants'
 import type { ResolvedConfig } from '../config'
 import { createPluginHookUtils } from '../plugins'
 import { buildErrorMessage } from './middlewares/error'
@@ -105,7 +105,7 @@ export interface PluginContainerOptions {
   writeFile?: (name: string, source: string | Uint8Array) => void
 }
 
-export interface PluginContainer {
+export interface PluginContainer extends AsyncDisposable {
   options: InputOptions
   getModuleInfo(id: string): ModuleInfo | null
   buildStart(options: InputOptions): Promise<void>
@@ -793,6 +793,9 @@ export async function createPluginContainer(
         () => ctx,
         () => [],
       )
+    },
+    [ASYNC_DISPOSE]() {
+      return this.close()
     },
   }
 

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -11,6 +11,7 @@ import { WebSocketServer as WebSocketServerRaw_ } from 'ws'
 import type { WebSocket as WebSocketTypes } from 'dep-types/ws'
 import type { CustomPayload, ErrorPayload, HMRPayload } from 'types/hmrPayload'
 import type { InferCustomEventPayload } from 'types/customEvent'
+import { ASYNC_DISPOSE } from '../constants'
 import type { ResolvedConfig } from '..'
 import { isObject } from '../utils'
 
@@ -29,7 +30,7 @@ export type WebSocketCustomListener<T> = (
   client: WebSocketClient,
 ) => void
 
-export interface WebSocketServer {
+export interface WebSocketServer extends AsyncDisposable {
   /**
    * Listen on port and host
    */
@@ -307,6 +308,9 @@ export function createWebSocketServer(
           }
         })
       })
+    },
+    [ASYNC_DISPOSE]() {
+      return this.close()
     },
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

implement `AsyncDisposable` interface for supporting `using` syntax

Extracted `Symbol.asyncDispose` to a constant for support of Babel downgrading [Example](https://babeljs.io/repl#?browsers=chrome%20100&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=K4Zwlgdg5gBAhjAvDARgCgJRA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env&prettier=false&targets=&version=7.23.2&externalPlugins=%40babel%2Fplugin-proposal-explicit-resource-management%407.23.0&assumptions=%7B%7D)

#### Example

```ts
import { createServer } from 'vite'
await using server = await createServer()
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

[TS docs](https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/#using-declarations-and-explicit-resource-management)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
