### PR TITLE
fix(esbuild): handle tsconfck cache undefined

### DIFF
--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -463,7 +463,7 @@ function prettifyMessage(m: Message, code: string): string {
   return res + `\n`
 }
 
-let tsconfckCache: TSConfckCache<TSConfckParseResult>
+let tsconfckCache: TSConfckCache<TSConfckParseResult> | undefined
 
 async function loadTsconfigJsonForFile(
   filename: string,
@@ -518,7 +518,7 @@ async function reloadOnTsconfigChange(changedFile: string) {
     server.moduleGraph.invalidateAll()
 
     // reset tsconfck so that recompile works with up2date configs
-    tsconfckCache.clear()
+    tsconfckCache?.clear()
 
     // server may not be available if vite config is updated at the same time
     if (server) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description


Found this from https://github.com/vitejs/vite/actions/runs/6533903497/job/17740475948?pr=12809#step:13:107

The `tsconfckCache` can technically be undefined if `transformWithEsbuild` was never called first.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
