### PR TITLE
feat: csp nonce support

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -392,16 +392,22 @@ if ('document' in globalThis) {
     })
 }
 
-function getNonceFromElements(selectors: 'style' | 'script') {
-  return [...document.querySelectorAll(selectors)].find(
-    (element) => !!element.nonce,
-  )?.nonce
+function getNonceFromElements(
+  selectors: 'style' | 'link[rel="stylesheet"]' | 'script',
+) {
+  return [
+    ...document.querySelectorAll<
+      HTMLStyleElement | HTMLLinkElement | HTMLScriptElement
+    >(selectors),
+  ].find((element) => !!element.nonce)?.nonce
 }
 
 const nonceValue =
   'document' in globalThis
-    ? // prioritize style tag's nonce as that will work with style-src
-      getNonceFromElements('style') ?? getNonceFromElements('script')
+    ? // prioritize style/link[rel="stylesheet"] tag's nonce as that will work with style-src
+      getNonceFromElements('style') ??
+      getNonceFromElements('link[rel="stylesheet"]') ??
+      getNonceFromElements('script')
     : undefined
 
 // all css imports should be inserted at the same position

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -392,6 +392,18 @@ if ('document' in globalThis) {
     })
 }
 
+function getNonceFromElements(selectors: 'style' | 'script') {
+  return [...document.querySelectorAll(selectors)].find(
+    (element) => !!element.nonce,
+  )?.nonce
+}
+
+const nonceValue =
+  'document' in globalThis
+    ? // prioritize style tag's nonce as that will work with style-src
+      getNonceFromElements('style') ?? getNonceFromElements('script')
+    : undefined
+
 // all css imports should be inserted at the same position
 // because after build it will be a single css file
 let lastInsertedStyle: HTMLStyleElement | undefined
@@ -402,6 +414,9 @@ export function updateStyle(id: string, content: string): void {
     style = document.createElement('style')
     style.setAttribute('type', 'text/css')
     style.setAttribute('data-vite-dev-id', id)
+    if (nonceValue) {
+      style.setAttribute('nonce', nonceValue)
+    }
     style.textContent = content
 
     if (!lastInsertedStyle) {

--- a/packages/vite/src/client/tsconfig.json
+++ b/packages/vite/src/client/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "types": [],
     "target": "ES2019",
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "declaration": false
   }
 }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -930,6 +930,8 @@ export interface IndexHtmlTransformContext {
   bundle?: OutputBundle
   chunk?: OutputChunk
   originalUrl?: string
+  /** nonce value extracted from script tag only available in normal/post hooks during dev */
+  nonce?: string
 }
 
 export type IndexHtmlTransformHook = (

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -930,8 +930,11 @@ export interface IndexHtmlTransformContext {
   bundle?: OutputBundle
   chunk?: OutputChunk
   originalUrl?: string
-  /** nonce value extracted from script tag only available in normal/post hooks during dev */
-  nonce?: string
+  /** nonce value extracted from script/style tag only available in normal/post hooks during dev */
+  nonce: {
+    script?: string
+    style?: string
+  }
 }
 
 export type IndexHtmlTransformHook = (

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -85,8 +85,12 @@ function detectScriptRel() {
 declare const scriptRel: string
 declare const seen: Record<string, boolean>
 function createPreload() {
-  function getCspNonce(tagName: 'script' | 'style'): string | undefined {
-    const elements = document.getElementsByTagName(tagName)
+  function getCspNonce(
+    selectors: 'script' | 'style' | 'link[rel="stylesheet"]',
+  ): string | undefined {
+    const elements = document.querySelectorAll<
+      HTMLScriptElement | HTMLStyleElement | HTMLLinkElement
+    >(selectors)
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i]
       if (element.nonce) {

--- a/playground/csp/direct.css
+++ b/playground/csp/direct.css
@@ -1,0 +1,3 @@
+.direct {
+  color: blue;
+}

--- a/playground/csp/from-js.css
+++ b/playground/csp/from-js.css
@@ -1,0 +1,3 @@
+.from-js {
+  color: blue;
+}

--- a/playground/csp/index.html
+++ b/playground/csp/index.html
@@ -1,0 +1,4 @@
+<script type="module" src="./index.js"></script>
+<link rel="stylesheet" href="./direct.css" />
+<p class="direct">direct</p>
+<p class="from-js">from-js</p>

--- a/playground/csp/index.html
+++ b/playground/csp/index.html
@@ -1,4 +1,4 @@
-<script type="module" src="./index.js"></script>
-<link rel="stylesheet" href="./direct.css" />
+<script type="module" src="./index.js" nonce="$@NONCE_SCRIPT@$"></script>
+<link rel="stylesheet" href="./direct.css" nonce="$@NONCE_STYLE@$" />
 <p class="direct">direct</p>
 <p class="from-js">from-js</p>

--- a/playground/csp/index.js
+++ b/playground/csp/index.js
@@ -1,0 +1,2 @@
+import './from-js.css'
+console.log('foo')

--- a/playground/csp/package.json
+++ b/playground/csp/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitejs/test-assets",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "debug": "node --inspect-brk ../../packages/vite/bin/vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  }
+}

--- a/playground/csp/vite.config.js
+++ b/playground/csp/vite.config.js
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite'
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
-const createNonce = () => crypto.randomUUID().replaceAll('-', '')
+const createNonce = () => crypto.randomBytes(16).toString('base64')
 
 /**
  * @param {import('node:http').ServerResponse} res

--- a/playground/csp/vite.config.js
+++ b/playground/csp/vite.config.js
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises'
+import url from 'node:url'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { defineConfig } from 'vite'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+const createNonce = () => crypto.randomUUID().replaceAll('-', '')
+
+/**
+ * @param {import('node:http').ServerResponse} res
+ * @param {string} nonce
+ */
+const setNonceHeader = (res, nonce) => {
+  res.setHeader(
+    'Content-Security-Policy',
+    `default-src 'nonce-${nonce}'; connect-src 'self'`,
+  )
+}
+
+/**
+ * @param {string} htmlFile
+ * @param {string} nonce
+ */
+const getNonceInjectedHtml = async (htmlFile, nonce) => {
+  const content = await fs.readFile(htmlFile, 'utf8')
+  const tranformedContent = content
+    .replace(/<script\s*/g, `$&nonce="${nonce}" `)
+    .replace(/<link\s*/g, `$&nonce="${nonce}" `)
+  return tranformedContent
+}
+
+export default defineConfig({
+  plugins: [
+    {
+      name: 'nonce-inject',
+      config() {
+        return { appType: 'custom' }
+      },
+      configureServer({ transformIndexHtml, middlewares }) {
+        return () => {
+          middlewares.use(async (req, res) => {
+            const nonce = createNonce()
+            setNonceHeader(res, nonce)
+            const content = await getNonceInjectedHtml(
+              path.join(__dirname, './index.html'),
+              nonce,
+            )
+            res.end(await transformIndexHtml(req.originalUrl, content))
+          })
+        }
+      },
+      configurePreviewServer({ middlewares }) {
+        middlewares.use(async (req, res, next) => {
+          const { pathname } = new URL(req.url, 'http://example.com')
+          const assetPath = path.join(__dirname, 'dist', `.${pathname}`)
+          try {
+            if ((await fs.stat(assetPath)).isFile()) {
+              next()
+              return
+            }
+          } catch {}
+
+          const nonce = createNonce()
+          setNonceHeader(res, nonce)
+          const content = await getNonceInjectedHtml(
+            path.join(__dirname, './dist/index.html'),
+            nonce,
+          )
+          res.end(content)
+        })
+      },
+    },
+  ],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -488,6 +488,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
 
+  playground/csp: {}
+
   playground/css:
     devDependencies:
       '@vitejs/test-css-dep':


### PR DESCRIPTION
### Description
This PR adds CSP nonce support for dev and build.

- In dev
  - CSS imports in JS: If any script tag or `style`/`link[rel=stylesheet]` tag has a `nonce` attribute, `@vite/client` will inject the style tag with that `nonce` value.
  - Injected `script`/`style`/`link[rel=stylesheet]` tags by `transformIndexHtml`: normal/post hook now can have access to `ctx.nonce` that contains a `nonce` attribute extracted from the HTML. Each plugins has the responsibility to inject the nonce tag if needed.
- In build
  - preload function: If any script tag or `style`/`link[rel=stylesheet]` tag has a `nonce` attribute, it will add the link tag with that nonce value.
  - nonce values in HTML: the value would be preserved for usecases like replacing the value in the middleware (e.g. nginx)

close #9719
close #11862

- Difference from
  - #11864: read the value from `meta[property=csp-nonce]` and use that when injecting style tag generated by CSS imports in JS
    - Requires a custom tag for declaring the nonce value. In my PR, Vite uses the nonce value that is already declared.
    - Works with different nonce value for `script-src` and `style-src`. In my PR, that is not supported unless there's a style tag in the HTML. If we add a fallback to obtain the value from `meta[property=csp-nonce-style]`, we can support this case as well.
    - Doesn't handle injected tags by `transformIndexHtml`. My PR handles that.
    - Doesn't handle preload function. My PR handles that.
    - Works with backend integration. My PR also works.
  - #11958: adds a new option `noncePlaceholder` and inject that value in HTML when bundling
    - Adds a new option. In my PR, Vite uses the nonce value that is already declared.
- Things to consider
  - [nonce should be generated for each request](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce#:~:text=Nonces%20should%20be%20generated%20differently%20each%20time%20the%20page%20loads%20(nonce%20only%20once!).). Preserving the nonce value of the input HTML might provoke a misusage of using a static value for nonce.

TODO
- [ ] Add a test case
- [ ] Warn if there's multiple nonce values
- [ ] Add docs

### Additional context

This table (https://github.com/vitejs/vite/pull/11864#issuecomment-1716852907) was really helpful to think about the way to support CSP nonce. Thank you @justin-tay.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
