### PR TITLE
fix(ssr): add missing `.map.toUrl()` method for transformRequest

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -18,7 +18,7 @@ import {
 } from '../utils'
 import { checkPublicFile } from '../plugins/asset'
 import { getDepsOptimizer } from '../optimizer'
-import { applySourcemapIgnoreList, injectSourcesContent } from './sourcemap'
+import { applySourcemapIgnoreList, genSourceMapUrl, injectSourcesContent } from './sourcemap'
 import { isFileServingAllowed } from './middlewares/static'
 import { throwClosedServerError } from './pluginContainer'
 
@@ -346,6 +346,10 @@ async function loadAndTransform(
   if (timestamp > mod.lastInvalidationTimestamp) {
     if (ssr) mod.ssrTransformResult = result
     else mod.transformResult = result
+  }
+
+  if (result && result.map) {
+    result.map.toUrl = genSourceMapUrl.bind(null, result.map);
   }
 
   return result


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The TS types for `TransformResult` indicate that the `.map` property is a `SourceMap`, which should include a `.toUrl()` method that returns a base64-encoded Data URL to be used in `//# sourceMappingURL=` comments. That method is missing (at least some of the time?), this PR adds it. I borrowed the implementation from [the importAnalysis plugin](https://github.com/vitejs/vite/blob/96a4ce37d9fe17818b683c68455b9228f7307217/packages/vite/src/node/plugins/importAnalysisBuild.ts#L686).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
