### PR TITLE
feat: postcss config `.cts` support

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -33,6 +33,8 @@ If you'd like to temporarily ignore the warning, you can run your script with th
 VITE_CJS_IGNORE_WARNING=true vite dev
 ```
 
+Note that postcss config files does not support ESM + TypeScript (`.mts` or `.ts` in `"type": "module"`) yet. If you have postcss configs with `.ts` and added `"type": "module"` to package.json, you'll also need to rename the postcss config to use `.cts`.
+
 ## CLI
 
 ### `Error: Cannot find module 'C:\foo\bar&baz\vite\bin\vite.js'`

--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "patchedDependencies": {
       "chokidar@3.5.3": "patches/chokidar@3.5.3.patch",
       "sirv@2.0.3": "patches/sirv@2.0.3.patch",
-      "dotenv-expand@10.0.0": "patches/dotenv-expand@10.0.0.patch"
+      "dotenv-expand@10.0.0": "patches/dotenv-expand@10.0.0.patch",
+      "postcss-load-config@4.0.1": "patches/postcss-load-config@4.0.1.patch"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/patches/postcss-load-config@4.0.1.patch
+++ b/patches/postcss-load-config@4.0.1.patch
@@ -1,0 +1,38 @@
+diff --git a/src/index.js b/src/index.js
+index a7d16703a96a1229381beef905287192db332332..53a29ba20c7826caefc18bc0e786493a6ffcf978 100644
+--- a/src/index.js
++++ b/src/index.js
+@@ -85,10 +85,12 @@ const addTypeScriptLoader = (options = {}, loader) => {
+       `.${moduleName}rc.yaml`,
+       `.${moduleName}rc.yml`,
+       `.${moduleName}rc.ts`,
++      `.${moduleName}rc.cts`,
+       `.${moduleName}rc.js`,
+       `.${moduleName}rc.cjs`,
+       `.${moduleName}rc.mjs`,
+       `${moduleName}.config.ts`,
++      `${moduleName}.config.cts`,
+       `${moduleName}.config.js`,
+       `${moduleName}.config.cjs`,
+       `${moduleName}.config.mjs`
+@@ -100,7 +102,8 @@ const addTypeScriptLoader = (options = {}, loader) => {
+       '.js': importDefault,
+       '.cjs': importDefault,
+       '.mjs': importDefault,
+-      '.ts': loader
++      '.ts': loader,
++      '.cts': loader
+     }
+   }
+ }
+@@ -112,7 +115,9 @@ const withTypeScriptLoader = (rcFunc) => {
+ 
+       try {
+         // Register TypeScript compiler instance
+-        registerer = require('ts-node').register()
++        registerer = require('ts-node').register({
++          moduleTypes: { '**/*.cts': 'cjs' }
++        })
+ 
+         return require(configFile)
+       } catch (err) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ patchedDependencies:
   dotenv-expand@10.0.0:
     hash: weuqf2vlv5b5g6cikeo4slurbm
     path: patches/dotenv-expand@10.0.0.patch
+  postcss-load-config@4.0.1:
+    hash: 5knejszxzvonoprcgageucoem4
+    path: patches/postcss-load-config@4.0.1.patch
   sirv@2.0.3:
     hash: z45f224eewh2pgpijxcc3aboqm
     path: patches/sirv@2.0.3.patch
@@ -371,7 +374,7 @@ importers:
         version: 15.1.0(postcss@8.4.31)
       postcss-load-config:
         specifier: ^4.0.1
-        version: 4.0.1(postcss@8.4.31)(ts-node@10.9.1)
+        version: 4.0.1(patch_hash=5knejszxzvonoprcgageucoem4)(postcss@8.4.31)(ts-node@10.9.1)
       postcss-modules:
         specifier: ^6.0.0
         version: 6.0.0(postcss@8.4.31)
@@ -8040,7 +8043,7 @@ packages:
       camelcase-css: 2.0.1
       postcss: 8.4.31
 
-  /postcss-load-config@4.0.1(postcss@8.4.31)(ts-node@10.9.1):
+  /postcss-load-config@4.0.1(patch_hash=5knejszxzvonoprcgageucoem4)(postcss@8.4.31)(ts-node@10.9.1):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -8056,6 +8059,7 @@ packages:
       postcss: 8.4.31
       ts-node: 10.9.1(@types/node@18.18.5)(typescript@5.2.2)
       yaml: 2.1.1
+    patched: true
 
   /postcss-modules-extract-imports@3.0.0(postcss@8.4.31):
     resolution: {integrity: sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==}
@@ -9198,7 +9202,7 @@ packages:
       postcss: 8.4.31
       postcss-import: 15.1.0(postcss@8.4.31)
       postcss-js: 4.0.1(postcss@8.4.31)
-      postcss-load-config: 4.0.1(postcss@8.4.31)(ts-node@10.9.1)
+      postcss-load-config: 4.0.1(patch_hash=5knejszxzvonoprcgageucoem4)(postcss@8.4.31)(ts-node@10.9.1)
       postcss-nested: 6.0.1(postcss@8.4.31)
       postcss-selector-parser: 6.0.11
       resolve: 1.22.2


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
postcss-load-config doesn't support `.cts` and that makes a bit harder to migrate to `"type": "module"`.
This PR adds a patch to support `.cts` as a short term solution. For a long term solution, I guess https://github.com/postcss/postcss-load-config/pull/249 would work.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
