### PR TITLE
refactor: use dynamic import directly

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -30,7 +30,6 @@ import {
   asyncFlatten,
   createDebugger,
   createFilter,
-  dynamicImport,
   isBuiltin,
   isExternalUrl,
   isNodeBuiltin,
@@ -1180,7 +1179,7 @@ async function loadConfigFromBundledFile(
     const fileUrl = `${pathToFileURL(fileBase)}.mjs`
     await fsp.writeFile(fileNameTmp, bundledCode)
     try {
-      return (await dynamicImport(fileUrl)).default
+      return (await import(fileUrl)).default
     } finally {
       fs.unlink(fileNameTmp, () => {}) // Ignore errors
     }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import colors from 'picocolors'
 import type { ViteDevServer } from '../server'
-import { dynamicImport, isBuiltin, unwrapId } from '../utils'
+import { isBuiltin, unwrapId } from '../utils'
 import { transformRequest } from '../server/transformRequest'
 import type { InternalResolveOptionsWithOverrideConditions } from '../plugins/resolve'
 import { tryNodeResolve } from '../plugins/resolve'
@@ -288,7 +288,7 @@ async function nodeImport(
     url = pathToFileURL(resolved.id).toString()
   }
 
-  const mod = await dynamicImport(url)
+  const mod = await import(url)
   return proxyESM(mod)
 }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -973,13 +973,6 @@ export const multilineCommentsRE = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g
 export const singlelineCommentsRE = /\/\/.*/g
 export const requestQuerySplitRE = /\?(?!.*[/|}])/
 
-/**
- * Dynamically import files. It will make sure it's not being compiled away by TS/Rollup.
- *
- * @param file File path to import.
- */
-export const dynamicImport = new Function('file', 'return import(file)')
-
 export function parseRequest(id: string): Record<string, string> | null {
   const [_, search] = id.split(requestQuerySplitRE, 2)
   if (!search) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Seems like we can use dynamic imports directly. I don't see Rollup or TypeScript interfering 🤔 

This fixes plugin-vue ecosystem-ci locally for me.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
