### PR TITLE
fix(assets): make timestamp invalidation lazy

### DIFF
--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -293,9 +293,7 @@ describe('svg fragments', () => {
 
   test('from js import', async () => {
     const img = await page.$('.svg-frag-import')
-    expect(await img.getAttribute('src')).toMatch(
-      isBuild ? /svg#icon-heart-view$/ : /svg\?t=\d+#icon-heart-view$/,
-    )
+    expect(await img.getAttribute('src')).toMatch(/svg#icon-heart-view$/)
   })
 })
 
@@ -323,11 +321,11 @@ test('?url import', async () => {
 test('?url import on css', async () => {
   const src = readFile('css/icons.css')
   const txt = await page.textContent('.url-css')
-  isBuild
-    ? expect(txt).toEqual(
-        `data:text/css;base64,${Buffer.from(src).toString('base64')}`,
-      )
-    : expect(txt).toMatch(/^\/foo\/bar\/css\/icons.css\?t=\d+$/)
+  expect(txt).toEqual(
+    isBuild
+      ? `data:text/css;base64,${Buffer.from(src).toString('base64')}`
+      : '/foo/bar/css/icons.css',
+  )
 })
 
 describe('unicode url', () => {

--- a/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
+++ b/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
@@ -179,9 +179,7 @@ describe('svg fragments', () => {
 
   test('from js import', async () => {
     const img = await page.$('.svg-frag-import')
-    expect(await img.getAttribute('src')).toMatch(
-      isBuild ? /svg#icon-heart-view$/ : /svg\?t=\d+#icon-heart-view$/,
-    )
+    expect(await img.getAttribute('src')).toMatch(/svg#icon-heart-view$/)
   })
 })
 

--- a/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
+++ b/playground/assets/__tests__/runtime-base/runtime-base-assets.spec.ts
@@ -179,9 +179,7 @@ describe('svg fragments', () => {
 
   test('from js import', async () => {
     const img = await page.$('.svg-frag-import')
-    expect(await img.getAttribute('src')).toMatch(
-      isBuild ? /svg#icon-heart-view$/ : /svg\?t=\d+#icon-heart-view$/,
-    )
+    expect(await img.getAttribute('src')).toMatch(/svg#icon-heart-view$/)
   })
 })
 

--- a/playground/assets/__tests__/url-base/url-base-assets.spec.ts
+++ b/playground/assets/__tests__/url-base/url-base-assets.spec.ts
@@ -173,9 +173,7 @@ describe('svg fragments', () => {
 
   test('from js import', async () => {
     const img = await page.$('.svg-frag-import')
-    expect(await img.getAttribute('src')).toMatch(
-      isBuild ? /svg#icon-heart-view$/ : /svg\?t=\d+#icon-heart-view$/,
-    )
+    expect(await img.getAttribute('src')).toMatch(/svg#icon-heart-view$/)
   })
 })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Followup from https://github.com/vitejs/vite/pull/13371

It just hit me that we can inject the timestamp lazily similar to `importAnalysis` today. This should break ecosystem-ci less.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
