### PR TITLE
chore(create-vite): update dependencies

### DIFF
--- a/packages/create-vite/template-lit-ts/package.json
+++ b/packages/create-vite/template-lit-ts/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-lit/package.json
+++ b/packages/create-vite/template-lit/package.json
@@ -12,6 +12,6 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-preact-ts/package.json
+++ b/packages/create-vite/template-preact-ts/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.6.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-preact/package.json
+++ b/packages/create-vite/template-preact/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.6.0",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.2.13"

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.2.13"

--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -23,6 +23,6 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-react/package.json
+++ b/packages/create-vite/template-react/package.json
@@ -21,6 +21,6 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-solid-ts/package.json
+++ b/packages/create-vite/template-solid-ts/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7",
+    "vite": "^5.0.0-beta.11",
     "vite-plugin-solid": "^2.7.1"
   }
 }

--- a/packages/create-vite/template-solid/package.json
+++ b/packages/create-vite/template-solid/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.8.1"
   },
   "devDependencies": {
-    "vite": "^5.0.0-beta.7",
+    "vite": "^5.0.0-beta.11",
     "vite-plugin-solid": "^2.7.1"
   }
 }

--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -10,12 +10,12 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.0.0-next.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0-next.1",
     "@tsconfig/svelte": "^5.0.2",
     "svelte": "^4.2.1",
     "svelte-check": "^3.5.2",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-svelte/package.json
+++ b/packages/create-vite/template-svelte/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.0.0-next.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0-next.1",
     "svelte": "^4.2.1",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-vanilla-ts/package.json
+++ b/packages/create-vite/template-vanilla-ts/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-vanilla/package.json
+++ b/packages/create-vite/template-vanilla/package.json
@@ -9,6 +9,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }

--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.7",
+    "vite": "^5.0.0-beta.11",
     "vue-tsc": "^1.8.19"
   }
 }

--- a/packages/create-vite/template-vue/package.json
+++ b/packages/create-vite/template-vue/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.4.0",
-    "vite": "^5.0.0-beta.7"
+    "vite": "^5.0.0-beta.11"
   }
 }


### PR DESCRIPTION
Update to vite 5.0.0-beta.11 and `@sveltejs/vite-plugin-svelte` to `next.1` as its the only plugin that has a beta. Similar PR: https://github.com/vitejs/vite/pull/14534