### PR TITLE
refactor(ssr): remove unused metadata code

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -102,9 +102,9 @@ test('export * from', async () => {
       `export * from 'vue'\n` + `export * from 'react'`,
     ),
   ).toMatchInlineSnapshot(`
-    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\", {\\"isExportAll\\":true});
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
     __vite_ssr_exportAll__(__vite_ssr_import_0__);
-    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"react\\", {\\"isExportAll\\":true});
+    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"react\\");
     __vite_ssr_exportAll__(__vite_ssr_import_1__);
 
     "
@@ -114,7 +114,7 @@ test('export * from', async () => {
 test('export * as from', async () => {
   expect(await ssrTransformSimpleCode(`export * as foo from 'vue'`))
     .toMatchInlineSnapshot(`
-      "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\", {\\"isExportAll\\":true});
+      "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\");
 
       Object.defineProperty(__vite_ssr_exports__, \\"foo\\", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_0__ }});"
     `)
@@ -133,7 +133,7 @@ test('export then import minified', async () => {
     ),
   ).toMatchInlineSnapshot(`
     "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"vue\\", {\\"namedImportSpecifiers\\":[\\"createApp\\"]});
-    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"vue\\", {\\"isExportAll\\":true});
+    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"vue\\");
     __vite_ssr_exportAll__(__vite_ssr_import_1__);
     "
   `)
@@ -964,9 +964,9 @@ console.log(foo + 2)
   `),
   ).toMatchInlineSnapshot(`
     "const __vite_ssr_import_0__ = await __vite_ssr_import__(\\"./foo\\", {\\"namedImportSpecifiers\\":[\\"foo\\"]});
-    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"./a\\", {\\"isExportAll\\":true});
+    const __vite_ssr_import_1__ = await __vite_ssr_import__(\\"./a\\");
     __vite_ssr_exportAll__(__vite_ssr_import_1__);
-    const __vite_ssr_import_2__ = await __vite_ssr_import__(\\"./b\\", {\\"isExportAll\\":true});
+    const __vite_ssr_import_2__ = await __vite_ssr_import__(\\"./b\\");
     __vite_ssr_exportAll__(__vite_ssr_import_2__);
 
     console.log(__vite_ssr_import_0__.foo + 1)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -31,7 +31,6 @@ interface NodeImportResolveOptions
 
 interface SSRImportMetadata {
   isDynamicImport?: boolean
-  isExportAll?: boolean
   namedImportSpecifiers?: string[]
 }
 

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -29,7 +29,6 @@ interface TransformOptions {
 }
 
 interface DefineImportMetadata {
-  isExportAll?: boolean
   namedImportSpecifiers?: string[]
 }
 
@@ -105,7 +104,6 @@ async function ssrTransformScript(
     // Reduce metadata to undefined if it's all default values
     if (
       metadata &&
-      metadata.isExportAll !== true &&
       (metadata.namedImportSpecifiers == null ||
         metadata.namedImportSpecifiers.length === 0)
     ) {
@@ -237,9 +235,7 @@ async function ssrTransformScript(
     // export * from './foo'
     if (node.type === 'ExportAllDeclaration') {
       s.remove(node.start, node.end)
-      const importId = defineImport(node.source.value as string, {
-        isExportAll: true,
-      })
+      const importId = defineImport(node.source.value as string)
       // hoist re-exports near the defined import so they are immediately exported
       if (node.exported) {
         defineExport(hoistIndex, node.exported.name, `${importId}`)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Found here https://github.com/vitejs/vite/pull/14456/files#r1366605315

We're actually not using the `isExportAll` metadata added in SSR since the ssr proxy PR (#14521). I added it while prototyping things and forgot to clean it up.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
