### PR TITLE
fix(worker): force rollup to build workerImportMetaUrl under watch mode

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -218,7 +218,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
     },
 
     shouldTransformCachedModule({ id }) {
-      if (isBuild && isWorkerQueryId(id) && config.build.watch) {
+      if (isBuild && config.build.watch && isWorkerQueryId(id)) {
         return true
       }
     },

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -96,6 +96,17 @@ function getWorkerType(raw: string, clean: string, i: number): WorkerType {
   return 'classic'
 }
 
+function isIncludeWorkerImportMetaUrl(code: string): boolean {
+  if (
+    (code.includes('new Worker') || code.includes('new SharedWorker')) &&
+    code.includes('new URL') &&
+    code.includes(`import.meta.url`)
+  ) {
+    return true
+  }
+  return false
+}
+
 export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
   let workerResolver: ResolveFn
@@ -108,17 +119,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     packageCache: config.packageCache,
     ssrConfig: config.ssr,
     asSrc: true,
-  }
-
-  const isIncludeWorkerImportMetaUrl = (code: string): boolean => {
-    if (
-      (code.includes('new Worker') || code.includes('new SharedWorker')) &&
-      code.includes('new URL') &&
-      code.includes(`import.meta.url`)
-    ) {
-      return true
-    }
-    return false
   }
 
   return {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix: #14435

In the same way as #11919, change to use `shouldTransformCachedModule` to re-transform `workerImportMetaUrl` when in build watch mode.

> In build watch mode, the transform hook will not be called after the load hook of vite:worker plugin except in the very first build. So use shouldtransformcachedmodule hook to indicate re-call transform hook in watch build mode.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
