### PR TITLE
fix(assets): fix svg inline in css url

### DIFF
--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -253,6 +253,18 @@ describe('css url() references', () => {
     // generate non-relative base for public path in CSS
     expect(css).not.toMatch(`../icon.png`)
   })
+
+  test('url() with svg', async () => {
+    expect(await getBg('.css-url-svg')).toMatch(
+      isBuild ? /data:image\/svg\+xml,.+/ : '/foo/bar/nested/fragment-bg.svg',
+    )
+  })
+
+  test('image-set() with svg', async () => {
+    expect(await getBg('.css-image-set-svg')).toMatch(
+      isBuild ? /data:image\/svg\+xml,.+/ : '/foo/bar/nested/fragment-bg.svg',
+    )
+  })
 })
 
 describe('image', () => {

--- a/playground/assets/css/css-url.css
+++ b/playground/assets/css/css-url.css
@@ -107,3 +107,16 @@ urls inside comments should be ignored
   background-size: 10px;
 }
 */
+
+.css-url-svg {
+  background: url(../nested/fragment-bg.svg);
+  background-size: 10px;
+}
+
+.css-image-set-svg {
+  background: -webkit-image-set(
+    url('../nested/fragment-bg.svg') 1x,
+    url('../nested/fragment-bg.svg') 2x
+  );
+  background-size: 10px;
+}

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -115,6 +115,14 @@
   <span style="background: #fff">CSS background (aliased)</span>
 </div>
 
+<div class="css-url-svg">
+  <span style="background: #fff">CSS SVG background</span>
+</div>
+
+<div class="css-image-set-svg">
+  <span style="background: #fff">CSS SVG background with image-set</span>
+</div>
+
 <h2>Unicode URL</h2>
 <div>
   <code class="unicode-url"></code>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Follow-up from https://github.com/vitejs/vite/pull/14643

SVG quotes are not properly escaped currently. Found this from https://github.com/unocss/unocss/pull/3252

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
