### PR TITLE
fix: normalize default html path

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -492,7 +492,7 @@ export async function build(
             ))
     : typeof options.ssr === 'string'
       ? resolve(options.ssr)
-      : options.rollupOptions?.input || resolve('index.html')
+      : options.rollupOptions?.input || normalizePath(resolve('index.html'))
 
   if (ssr && typeof input === 'string' && input.endsWith('.html')) {
     throw new Error(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

For the following example, executing the build command on windows results in an error:

```ts
export default {
  plugins: [
    {
      name: 'my-virtual-html',
      resolveId(source, _, options) {
        if (source.endsWith('index.html') && options.isEntry) {
          return source;
        }
      },
      async load(id) {
        if (id.endsWith('index.html')) {
          return `<script type="module">
          import './src/main.ts'
          </script>`;
        }
      },
    },
  ],
};
```

---

### What is the purpose of this pull request?
- [x] Bug fix

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
