### PR TITLE
docs(static-deploy): bump gh-pages action to v2

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -115,7 +115,7 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
              path: './dist'
          - name: Deploy to GitHub Pages
            id: deployment
-           uses: actions/deploy-pages@v1
+           uses: actions/deploy-pages@v2
    ```
 
 ## GitLab Pages and GitLab CI


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

On the [Deploying a Static Site](https://vitejs.dev/guide/static-deploy.html) in the [GitHub Pages](https://vitejs.dev/guide/static-deploy.html#github-pages) section, I've updated the `yml` example to use the latest GitHub Pages version (v2):
```diff
-  uses: actions/deploy-pages@v1
+ uses: actions/deploy-pages@v2
```

### Additional context

I've tested if everything, it works fine. You can check it [here](https://github.com/semantichtml/semantichtml.github.io/actions/runs/6615063067/job/17966406291#step:8:1)

---

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
