### PR TITLE
fix: external URLs normalized to absolute path

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -16,7 +16,7 @@ import {
   cleanUrl,
   generateCodeFrame,
   getHash,
-  isDataUrl,
+  isExcludedUrl,
   isExternalUrl,
   normalizePath,
   processSrcSet,
@@ -292,11 +292,6 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   preHooks.push(htmlEnvHook(config))
   postHooks.push(postImportMapHook())
   const processedHtml = new Map<string, string>()
-  const isExcludedUrl = (url: string) =>
-    url[0] === '#' ||
-    isExternalUrl(url) ||
-    isDataUrl(url) ||
-    checkPublicFile(url, config)
   // Same reason with `htmlInlineProxyPlugin`
   isAsyncScriptMap.set(config, new Map())
 
@@ -402,7 +397,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
             if (isModule) {
               inlineModuleIndex++
-              if (url && !isExcludedUrl(url)) {
+              if (url && !isExcludedUrl(url, config)) {
                 // <script type="module" src="..."/>
                 // add it as an import
                 js += `\nimport ${JSON.stringify(url)}`
@@ -424,7 +419,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               someScriptsAreAsync ||= isAsync
               someScriptsAreDefer ||= !isAsync
             } else if (url && !isPublicFile) {
-              if (!isExcludedUrl(url)) {
+              if (!isExcludedUrl(url, config)) {
                 config.logger.warn(
                   `<script src="${url}"> in "${publicPath}" can't be bundled without type="module" attribute`,
                 )
@@ -449,7 +444,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                   node.sourceCodeLocation!.attrs![attrKey]
                 // assetsUrl may be encodeURI
                 const url = decodeURI(p.value)
-                if (!isExcludedUrl(url)) {
+                if (!isExcludedUrl(url, config)) {
                   if (
                     node.nodeName === 'link' &&
                     isCSSRequest(url) &&
@@ -573,7 +568,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         }
         // emit <script>import("./aaa")</script> asset
         for (const { start, end, url } of scriptUrls) {
-          if (!isExcludedUrl(url)) {
+          if (!isExcludedUrl(url, config)) {
             s.update(start, end, await urlToBuiltUrl(url, id, config, this))
           } else if (checkPublicFile(url, config)) {
             s.update(start, end, toOutputPublicFilePath(url))

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -36,6 +36,7 @@ import {
   joinUrlSegments,
   normalizePath,
   processSrcSetSync,
+  safeURL,
   stripBase,
   unwrapId,
   wrapId,
@@ -135,7 +136,7 @@ const processNodeUrl = (
     // prefix with base (dev only, base is never relative)
     const replacer = (url: string) => {
       const devBase = config.base
-      const fullUrl = path.posix.join(devBase, url)
+      const fullUrl = safeURL(url)?.href ?? path.posix.join(devBase, url)
       if (server && shouldPreTransform(url, config)) {
         preTransformRequest(server, fullUrl, devBase)
       }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -32,11 +32,11 @@ import {
   fsPathFromId,
   getHash,
   injectQuery,
+  isExternalUrl,
   isJSRequest,
   joinUrlSegments,
   normalizePath,
   processSrcSetSync,
-  safeURL,
   stripBase,
   unwrapId,
   wrapId,
@@ -136,7 +136,7 @@ const processNodeUrl = (
     // prefix with base (dev only, base is never relative)
     const replacer = (url: string) => {
       const devBase = config.base
-      const fullUrl = safeURL(url)?.href ?? path.posix.join(devBase, url)
+      const fullUrl = isExternalUrl(url) ? url : path.posix.join(devBase, url)
       if (server && shouldPreTransform(url, config)) {
         preTransformRequest(server, fullUrl, devBase)
       }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -32,7 +32,7 @@ import {
   fsPathFromId,
   getHash,
   injectQuery,
-  isExternalUrl,
+  isExcludedUrl,
   isJSRequest,
   joinUrlSegments,
   normalizePath,
@@ -136,7 +136,9 @@ const processNodeUrl = (
     // prefix with base (dev only, base is never relative)
     const replacer = (url: string) => {
       const devBase = config.base
-      const fullUrl = isExternalUrl(url) ? url : path.posix.join(devBase, url)
+      const fullUrl = isExcludedUrl(url, config)
+        ? url
+        : path.posix.join(devBase, url)
       if (server && shouldPreTransform(url, config)) {
         preTransformRequest(server, fullUrl, devBase)
       }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1320,3 +1320,14 @@ export function getPackageManagerCommand(
       throw new TypeError(`Unknown command type: ${type}`)
   }
 }
+
+export function safeURL(
+  input: string,
+  base?: string | URL | undefined,
+): URL | null {
+  try {
+    return new URL(input, base)
+  } catch {
+    return null
+  }
+}

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -37,6 +37,7 @@ import {
   findNearestPackageData,
   resolvePackageData,
 } from './packages'
+import { checkPublicFile } from './plugins/asset'
 import type { CommonServerOptions } from '.'
 
 /**
@@ -1321,13 +1322,11 @@ export function getPackageManagerCommand(
   }
 }
 
-export function safeURL(
-  input: string,
-  base?: string | URL | undefined,
-): URL | null {
-  try {
-    return new URL(input, base)
-  } catch {
-    return null
-  }
+export function isExcludedUrl(url: string, config: ResolvedConfig): boolean {
+  return (
+    url[0] === '#' ||
+    isExternalUrl(url) ||
+    isDataUrl(url) ||
+    !!checkPublicFile(url, config)
+  )
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR addresses the issue of incorrectly handling external URLs within the index.html file. When external URLs are included using the <script> tag, they get merged with the base path, resulting in malformations like /https:// (or prepended with whatever the BASE_URL is).

The changes introduced in this PR ensure that the strings are checked to determine if they are valid URLs before merging, preventing such issues.

### Additional context

The problem arose when external script URLs were getting prefixed with the base path, which should not happen. This fix aims to streamline the handling of URLs and prevent potential errors caused by this incorrect merging.


---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
