### PR TITLE
fix: suppress addWatchFile invalid phase error

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -893,6 +893,15 @@ export function onRollupWarning(
         return
       }
 
+      // Rollup tracks the build phase slightly earlier before `buildEnd` is called,
+      // so there's a chance we can call `this.addWatchFile` in the invalid phase. Skip for now.
+      if (
+        warning.plugin === 'vite:worker-import-meta-url' &&
+        warning.pluginCode === 'INVALID_ROLLUP_PHASE'
+      ) {
+        return
+      }
+
       if (warningIgnoreList.includes(warning.code!)) {
         return
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fix https://github.com/vitejs/vite/actions/runs/6624843925/job/17994626864?pr=11151

The error happens at `watchFile` https://github.com/vitejs/vite/blob/14966a9f48ee9d83b29a3c165af0e03e244a6c9a/packages/vite/src/node/packages.ts#L233-L236

While we do swap to a stub after the build ends at https://github.com/vitejs/vite/blob/14966a9f48ee9d83b29a3c165af0e03e244a6c9a/packages/vite/src/node/packages.ts#L248-L250

Rollup only calls `buildEnd` here https://github.com/rollup/rollup/blob/de1c7b6b30f44047026922c168d3a876fdd5514f/src/rollup/rollup.ts#L83, but the "generate phase" (that's used to track and trigger the error) is set at https://github.com/rollup/rollup/blob/de1c7b6b30f44047026922c168d3a876fdd5514f/src/Graph.ts#L120 (inside `graph.build()`, which is called in the code above the first Rollup link. Additionally, here's `addWatchFIle`'s error guard https://github.com/rollup/rollup/blob/de1c7b6b30f44047026922c168d3a876fdd5514f/src/utils/PluginContext.ts#L56-L61

So there's a short in-between phase where Rollup declares the start of "generate phase" but haven't ended the build with `buildEnd` yet. This PR suppresses the error for now as there's no way to detect the phase.


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
