### PR TITLE
docs: replace `serve` command with `dev` to start a dev server

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -115,7 +115,7 @@ Vite also supports [multi-page apps](./build#multi-page-app) with multiple `.htm
 
 #### Specifying Alternative Root
 
-Running `vite` starts the dev server using the current working directory as root. You can specify an alternative root with `vite serve some/sub/dir`.
+Running `vite` starts the dev server using the current working directory as root. You can specify an alternative root with `vite dev some/sub/dir`.
 Note that Vite will also resolve [its config file (i.e. `vite.config.js`)](/config/#configuring-vite) inside the project root, so you'll need to move it if the root is changed.
 
 ## Command Line Interface


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Is there a typo? Should it say `dev` here instead of `serve` ?

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
