### PR TITLE
fix(build): make build error message clearer

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -36,6 +36,7 @@ import {
   withTrailingSlash,
 } from './utils'
 import { manifestPlugin } from './plugins/manifest'
+import { buildBreakInfo } from './logger'
 import type { Logger } from './logger'
 import { dataURIPlugin } from './plugins/dataUri'
 import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
@@ -537,6 +538,8 @@ export async function build(
     if (e.frame) {
       msg += `\n` + colors.yellow(e.frame)
     }
+    buildBreakInfo.break = true
+    clearLine()
     config.logger.error(msg, { error: e })
   }
 
@@ -854,6 +857,14 @@ const dynamicImportWarningIgnoreList = [
   `statically analyzed`,
 ]
 
+function clearLine() {
+  const tty = process.stdout.isTTY && !process.env.CI
+  if (tty) {
+    process.stdout.clearLine(0)
+    process.stdout.cursorTo(0)
+  }
+}
+
 export function onRollupWarning(
   warning: RollupLog,
   warn: LoggingFunction,
@@ -919,11 +930,7 @@ export function onRollupWarning(
     warn(warnLog)
   }
 
-  const tty = process.stdout.isTTY && !process.env.CI
-  if (tty) {
-    process.stdout.clearLine(0)
-    process.stdout.cursorTo(0)
-  }
+  clearLine()
   const userOnWarn = config.build.rollupOptions?.onwarn
   if (userOnWarn) {
     userOnWarn(warning, viteWarn)

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -36,7 +36,6 @@ import {
   withTrailingSlash,
 } from './utils'
 import { manifestPlugin } from './plugins/manifest'
-import { buildBreakInfo } from './logger'
 import type { Logger } from './logger'
 import { dataURIPlugin } from './plugins/dataUri'
 import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
@@ -538,7 +537,6 @@ export async function build(
     if (e.frame) {
       msg += `\n` + colors.yellow(e.frame)
     }
-    buildBreakInfo.break = true
     clearLine()
     config.logger.error(msg, { error: e })
   }

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -33,10 +33,6 @@ export const LogLevels: Record<LogLevel, number> = {
   info: 3,
 }
 
-export const buildBreakInfo: Record<string, boolean> = {
-  break: false,
-}
-
 let lastType: LogType | undefined
 let lastMsg: string | undefined
 let sameCount = 0

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -33,6 +33,10 @@ export const LogLevels: Record<LogLevel, number> = {
   info: 3,
 }
 
+export const buildBreakInfo: Record<string, boolean> = {
+  break: false,
+}
+
 let lastType: LogType | undefined
 let lastMsg: string | undefined
 let sameCount = 0

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -10,7 +10,7 @@ import {
   normalizePath,
   withTrailingSlash,
 } from '../utils'
-import { LogLevels, buildBreakInfo } from '../logger'
+import { LogLevels } from '../logger'
 
 const groups = [
   { name: 'Assets', color: colors.green },
@@ -48,6 +48,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
   let chunkCount = 0
   let compressedCount = 0
   let startTime = Date.now()
+  let buildFailed = false
 
   async function getCompressedSize(
     code: string | Uint8Array,
@@ -108,7 +109,8 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       transformedCount = 0
     },
 
-    buildEnd() {
+    buildEnd(error?: Error) {
+      buildFailed = !!error
       if (shouldLogInfo) {
         if (tty) {
           clearLine()
@@ -301,7 +303,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
     },
 
     closeBundle() {
-      if (shouldLogInfo && !config.build.watch && !buildBreakInfo.break) {
+      if (shouldLogInfo && !config.build.watch && !buildFailed) {
         config.logger.info(
           `${colors.green(
             `✓ built in ${displayTime(Date.now() - startTime)}`,

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -10,7 +10,7 @@ import {
   normalizePath,
   withTrailingSlash,
 } from '../utils'
-import { LogLevels } from '../logger'
+import { LogLevels, buildBreakInfo } from '../logger'
 
 const groups = [
   { name: 'Assets', color: colors.green },
@@ -301,7 +301,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
     },
 
     closeBundle() {
-      if (shouldLogInfo && !config.build.watch) {
+      if (shouldLogInfo && !config.build.watch && !buildBreakInfo.break) {
         config.logger.info(
           `${colors.green(
             `✓ built in ${displayTime(Date.now() - startTime)}`,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The error message is output at the beginning of the line to make it look clearer. And, I think there should be no need to output the build time if the build terminates with an error.

![image](https://github.com/vitejs/vite/assets/24516654/32c22f3c-41b0-4b90-97b7-76a678bd1283)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
