### PR TITLE
fix: skip watchPackageDataPlugin for worker builds

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -893,15 +893,6 @@ export function onRollupWarning(
         return
       }
 
-      // Rollup tracks the build phase slightly earlier before `buildEnd` is called,
-      // so there's a chance we can call `this.addWatchFile` in the invalid phase. Skip for now.
-      if (
-        warning.plugin === 'vite:worker-import-meta-url' &&
-        warning.pluginCode === 'INVALID_ROLLUP_PHASE'
-      ) {
-        return
-      }
-
       if (warningIgnoreList.includes(warning.code!)) {
         return
       }

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -241,7 +241,16 @@ export function watchPackageDataPlugin(packageCache: PackageCache): Plugin {
   return {
     name: 'vite:watch-package-data',
     buildStart() {
-      watchFile = this.addWatchFile.bind(this)
+      watchFile = (id) => {
+        try {
+          this.addWatchFile(id)
+        } catch (e) {
+          // Rollup tracks the build phase slightly earlier before `buildEnd` is called,
+          // so there's a chance we can call `this.addWatchFile` in the invalid phase. Skip for now.
+          if (e.pluginCode === 'INVALID_ROLLUP_PHASE') return
+          throw e
+        }
+      }
       watchQueue.forEach(watchFile)
       watchQueue.clear()
     },

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -241,16 +241,7 @@ export function watchPackageDataPlugin(packageCache: PackageCache): Plugin {
   return {
     name: 'vite:watch-package-data',
     buildStart() {
-      watchFile = (id) => {
-        try {
-          this.addWatchFile(id)
-        } catch (e) {
-          // Rollup tracks the build phase slightly earlier before `buildEnd` is called,
-          // so there's a chance we can call `this.addWatchFile` in the invalid phase. Skip for now.
-          if (e.pluginCode === 'INVALID_ROLLUP_PHASE') return
-          throw e
-        }
-      }
+      watchFile = this.addWatchFile.bind(this)
       watchQueue.forEach(watchFile)
       watchQueue.clear()
     },

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -32,6 +32,7 @@ export async function resolvePlugins(
   postPlugins: Plugin[],
 ): Promise<Plugin[]> {
   const isBuild = config.command === 'build'
+  const isWorker = config.isWorker
   const buildPlugins = isBuild
     ? await (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
@@ -47,7 +48,7 @@ export async function resolvePlugins(
         ]
       : []),
     isBuild ? metadataPlugin() : null,
-    watchPackageDataPlugin(config.packageCache),
+    !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     preAliasPlugin(config),
     aliasPlugin({ entries: config.resolve.alias }),
     ...prePlugins,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The actual fix instead of https://github.com/vitejs/vite/pull/14751 (the PR did nothing)

The issue was that `this.addWatchFile` was brought outside the scope of `buildStart` by the plugin:

https://github.com/vitejs/vite/blob/521ca58d5d7cf9fbd554169a449282c8163c81ac/packages/vite/src/node/packages.ts#L243-L247

So Rollup wasn't able to catch the error and pass it to `onwarn` for filtering (and I also think it should be `onLog` now). The error is invoked outside the scope:

https://github.com/vitejs/vite/blob/521ca58d5d7cf9fbd554169a449282c8163c81ac/packages/vite/src/node/packages.ts#L233-L239

### Additional context

It's a bit hard to reproduce this so I thought the other PR fixed it. But I think this PR should fix it for real now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
