### PR TITLE
fix(html): ignore rewrite external urls

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -102,7 +102,7 @@ function shouldPreTransform(url: string, config: ResolvedConfig) {
   )
 }
 
-const startsWithWordCharRE = /^\w/
+const wordCharRE = /\w/
 
 const isSrcSet = (attr: Token.Attribute) =>
   attr.name === 'srcset' && attr.prefix === undefined
@@ -125,9 +125,10 @@ const processNodeUrl = (
     (url[0] === '/' && url[1] !== '/') ||
     // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets
     // path will add `/a/` prefix, it will caused 404.
-    // rewrite before `./index.js` -> `localhost:5173/a/index.js`.
-    // rewrite after `../index.js` -> `localhost:5173/index.js`.
-    ((url[0] === '.' || startsWithWordCharRE.test(url)) &&
+    // rewrite `./index.js` -> `localhost:5173/a/index.js`.
+    // rewrite `../index.js` -> `localhost:5173/index.js`.
+    // rewrite `relative/index.js` -> `localhost:5173/a/relative/index.js`.
+    ((url[0] === '.' || (wordCharRE.test(url[0]) && !url.includes(':'))) &&
       originalUrl &&
       originalUrl !== '/' &&
       htmlPath === '/index.html')

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -125,6 +125,9 @@ const processNodeUrl = (
     (url[0] === '/' && url[1] !== '/') ||
     // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets
     // path will add `/a/` prefix, it will caused 404.
+    //
+    // skip if url contains `:` as it implies a url protocol or Windows path that we don't want to replace.
+    //
     // rewrite `./index.js` -> `localhost:5173/a/index.js`.
     // rewrite `../index.js` -> `localhost:5173/index.js`.
     // rewrite `relative/index.js` -> `localhost:5173/a/relative/index.js`.

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -513,6 +513,11 @@ test('url() contains file in publicDir, as inline style', async () => {
   expect(await getBg('.inline-style-public')).toContain(iconMatch)
 })
 
+test('should not rewrite non-relative urls in html', async () => {
+  const link = page.locator('.data-href')
+  expect(await link.getAttribute('href')).toBe('data:,')
+})
+
 test.runIf(isBuild)('assets inside <noscript> is rewrote', async () => {
   const indexHtml = readFile('./dist/foo/index.html')
   expect(indexHtml).toMatch(

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -5,7 +5,7 @@
   <link class="ico" rel="icon" type="image/svg+xml" href="favicon.ico" />
 </head>
 
-<link rel="icon" href="data:," />
+<link class="data-href" rel="icon" href="data:," />
 <link rel="stylesheet" href="/raw.css" />
 
 <h1>Assets</h1>


### PR DESCRIPTION


### Description

Fix https://github.com/vitejs/vite/issues/14770

Make sure relative urls that don't start with a `.` are not external urls by checking `:`. I think that should be good enough 🤔 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other