### PR TITLE
feat: experimental preTransformDynamicRequests

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -626,8 +626,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               // pre-transform known direct imports
               // These requests will also be registered in transformRequest to be awaited
               // by the deps optimizer
-              const url = removeImportQuery(requestUrl)
-              server.transformRequest(url, { ssr }).catch((e) => {
+              server.transformRequest(requestUrl, { ssr }).catch((e) => {
                 if (
                   e?.code === ERR_OUTDATED_OPTIMIZED_DEP ||
                   e?.code === ERR_CLOSED_SERVER

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -616,15 +616,17 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               )
             }
 
+            const requestUrl = removeImportQuery(hmrUrl)
             if (
-              !isDynamicImport &&
+              (!isDynamicImport ||
+                config.server.preTransformDynamicRequests?.(requestUrl)) &&
               isLocalImport &&
               config.server.preTransformRequests
             ) {
               // pre-transform known direct imports
               // These requests will also be registered in transformRequest to be awaited
               // by the deps optimizer
-              const url = removeImportQuery(hmrUrl)
+              const url = removeImportQuery(requestUrl)
               server.transformRequest(url, { ssr }).catch((e) => {
                 if (
                   e?.code === ERR_OUTDATED_OPTIMIZED_DEP ||

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -619,7 +619,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             const requestUrl = removeImportQuery(hmrUrl)
             if (
               (!isDynamicImport ||
-                config.server.preTransformDynamicRequests?.(requestUrl)) &&
+                config.server.preTransformDynamicRequests?.(
+                  requestUrl,
+                  importer,
+                )) &&
               isLocalImport &&
               config.server.preTransformRequests
             ) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -125,6 +125,12 @@ export interface ServerOptions extends CommonServerOptions {
    */
   preTransformRequests?: boolean
   /**
+   * Pre-transform a set of dynamic imports
+   * @experimental
+   * @default true
+   */
+  preTransformDynamicRequests?: (url: string) => boolean
+  /**
    * Whether or not to ignore-list source files in the dev server sourcemap, used to populate
    * the [`x_google_ignoreList` source map extension](https://developer.chrome.com/blog/devtools-better-angular-debugging/#the-x_google_ignorelist-source-map-extension).
    *

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -129,7 +129,7 @@ export interface ServerOptions extends CommonServerOptions {
    * @experimental
    * @default true
    */
-  preTransformDynamicRequests?: (url: string) => boolean
+  preTransformDynamicRequests?: (url: string, importer: string) => boolean
   /**
    * Whether or not to ignore-list source files in the dev server sourcemap, used to populate
    * the [`x_google_ignoreList` source map extension](https://developer.chrome.com/blog/devtools-better-angular-debugging/#the-x_google_ignorelist-source-map-extension).

--- a/playground/dynamic-import/vite.config.js
+++ b/playground/dynamic-import/vite.config.js
@@ -3,6 +3,11 @@ import path from 'node:path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  server: {
+    preTransformDynamicRequests(url) {
+      return url.startsWith('/views/')
+    },
+  },
   plugins: [
     {
       name: 'copy',


### PR DESCRIPTION
### Description

@danielroe has been working to adopt the new `warmup` functionality from Vite 5 and review their warmup implementation.

This PR implements an idea we discussed. The current `warmup`, `--open`, and `preTransformRequests` will only crawl static imports. There are some dynamic imports in routes that frameworks know should be crawled but if all of them are added to `warmup`, there could be a lot of unneeded modules processed depending on the route the user is visiting. Interested in hearing your opinion on this one @bluwy.

`preTransformDynamicRequests` will let frameworks decide if a request that would be started by a dynamic import should be crawled or not.

I named the function `preTransformDynamicRequests` instead of `preTransformDynamicImports` because we are giving a URL to it, we can change the name.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other