### PR TITLE
perf: use loop to replace Object.fromEntries

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -5,6 +5,7 @@ import {
   asyncFlatten,
   bareImportRE,
   flattenId,
+  fromEntries,
   getHash,
   getLocalhostAddressIfDiffersFromDNS,
   injectQuery,
@@ -278,5 +279,25 @@ describe('flattenId', () => {
     id += tenChars
     const result2 = flattenId(id)
     expect(result2).toHaveLength(170)
+  })
+})
+
+describe('fromEntries', () => {
+  test('same with Object.fromObject', () => {
+    const arr = [
+      ['foo', 'bar'],
+      ['1', 1],
+      ['2', 2],
+      ['3', 3],
+      [
+        '4',
+        {
+          '4': 4,
+        },
+      ],
+      ['5', [5, 6, 7]],
+    ] as [string, string | number | any][]
+
+    expect(fromEntries(arr)).toEqual(Object.fromEntries(arr))
   })
 })

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { parse } from 'dotenv'
 import { expand } from 'dotenv-expand'
-import { arraify, tryStatSync } from './utils'
+import { arraify, fromEntries, tryStatSync } from './utils'
 import type { UserConfig } from './config'
 
 export function getEnvFilesForMode(mode: string): string[] {
@@ -29,7 +29,7 @@ export function loadEnv(
   const env: Record<string, string> = {}
   const envFiles = getEnvFilesForMode(mode)
 
-  const parsed = Object.fromEntries(
+  const parsed = fromEntries(
     envFiles.flatMap((file) => {
       const filePath = path.join(envDir, file)
       if (!tryStatSync(filePath)?.isFile()) return []

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -15,6 +15,7 @@ import {
   arraify,
   createDebugger,
   flattenId,
+  fromEntries,
   getHash,
   isOptimizable,
   isWindows,
@@ -1054,7 +1055,7 @@ function stringifyDepsOptimizerMetadata(
     {
       hash,
       browserHash,
-      optimized: Object.fromEntries(
+      optimized: fromEntries(
         Object.values(optimized).map(
           ({ id, src, file, fileHash, needsInterop }) => [
             id,
@@ -1067,7 +1068,7 @@ function stringifyDepsOptimizerMetadata(
           ],
         ),
       ),
-      chunks: Object.fromEntries(
+      chunks: fromEntries(
         Object.values(chunks).map(({ id, file }) => [id, { file }]),
       ),
     },

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -25,6 +25,7 @@ import {
   createDebugger,
   dataUrlRE,
   externalRE,
+  fromEntries,
   isInNodeModules,
   isObject,
   isOptimizable,
@@ -242,7 +243,7 @@ function orderedDependencies(deps: Record<string, string>) {
   const depsList = Object.entries(deps)
   // Ensure the same browserHash for the same set of dependencies
   depsList.sort((a, b) => a[0].localeCompare(b[0]))
-  return Object.fromEntries(depsList)
+  return fromEntries(depsList)
 }
 
 function globEntries(pattern: string | string[], config: ResolvedConfig) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -42,6 +42,7 @@ import {
   cleanUrl,
   combineSourcemaps,
   emptyCssComments,
+  fromEntries,
   generateCodeFrame,
   getHash,
   getPackageManagerCommand,
@@ -729,7 +730,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         // map each pure css chunk (rendered chunk) to it's corresponding bundle
         // chunk. we check that by `preliminaryFileName` as they have different
         // `filename`s (rendered chunk has the !~{XXX}~ placeholder)
-        const prelimaryNameToChunkMap = Object.fromEntries(
+        const prelimaryNameToChunkMap = fromEntries(
           Object.values(bundle)
             .filter((chunk): chunk is OutputChunk => chunk.type === 'chunk')
             .map((chunk) => [chunk.preliminaryFileName, chunk.fileName]),

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1322,3 +1322,13 @@ export function getPackageManagerCommand(
       throw new TypeError(`Unknown command type: ${type}`)
   }
 }
+
+export function fromEntries<T extends string | number | any>(
+  value: [string, T][],
+): Record<string, T> {
+  const result: Record<string, T> = {}
+  for (const [key, val] of value) {
+    result[key] = val
+  }
+  return result
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Use a for loop to  replace `Object.formEntries`:

Simple benchmark: [benchmark](https://stackblitz.com/edit/vitest-dev-vitest-n3tqnb?file=index.bench.ts)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
