### PR TITLE
fix(define): correctly replace same define values

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -50,7 +50,16 @@ describe('definePlugin', () => {
       'import.meta.hot': 'import.meta.hot',
     })
     expect(await overrideTransform('const hot = import.meta.hot;')).toBe(
-      undefined,
+      'const hot = import.meta.hot;\n',
+    )
+  })
+
+  test('preserve import.meta.env.UNKNOWN with override', async () => {
+    const transform = await createDefinePluginTransform({
+      'import.meta.env.UNKNOWN': 'import.meta.env.UNKNOWN',
+    })
+    expect(await transform('const foo = import.meta.env.UNKNOWN;')).toBe(
+      'const foo = import.meta.env.UNKNOWN;\n',
     )
   })
 })

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -49,16 +49,6 @@ export function definePlugin(config: ResolvedConfig): Plugin {
   const userDefine: Record<string, string> = {}
   const userDefineEnv: Record<string, any> = {}
   for (const key in config.define) {
-    // user can define keys with the same values to declare that some keys
-    // should not be replaced. in this case, we delete references of the key
-    // so they aren't replaced in the first place.
-    const val = config.define[key]
-    if (key === val) {
-      delete processNodeEnv[key]
-      delete importMetaKeys[key]
-      continue
-    }
-
     userDefine[key] = handleDefineValue(config.define[key])
 
     // make sure `import.meta.env` object has user define properties


### PR DESCRIPTION

### Description

fix https://github.com/vitejs/vite/issues/14783

This PR deletes a code that was causing issues for patterns like:

```js
define: {
  'import.meta.env.FOO': 'import.meta.env.FOO' // preserve during build
}
```

As esbuild detects the `import.meta.env` part and replaces away with an object. 

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
