### PR TITLE
feat: add a runtime warning for the old object type transformIndexHtml hook

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -63,6 +63,7 @@ export function createDevHtmlTransformFn(
 ): (url: string, html: string, originalUrl: string) => Promise<string> {
   const [preHooks, normalHooks, postHooks] = resolveHtmlTransforms(
     server.config.plugins,
+    server.config.logger,
   )
   return (url: string, html: string, originalUrl: string): Promise<string> => {
     return applyHtmlTransforms(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The old object type `transformIndexHtml` hook was deprecated in Vite 4. But didn't have a runtime warning.

I considered removing this in Vite 5, but it was still [used in many places](https://github.com/search?q=transformIndexHtml+NOT+is%3Afork+enforce+language%3ATypeScript+OR+language%3AJavaScript&type=code&p=1).

<details>

- https://github.com/vbenjs/vite-plugin-html/blob/ac54a6e6c5334ce24454a3b68542114514f632e6/packages/core/src/htmlPlugin.ts#L96-L98
- https://github.com/unocss/unocss/blob/84ad6255bb988946da5555b6dc600dd192bc33fc/packages/vite/src/modes/global/build.ts#L83-L85
- https://github.com/vaadin/flow/blob/76f5fcdeca4c77bf7a74ec6cfbc6882698e98823/flow-server/src/main/resources/vite.generated.ts#L750-L752
- https://github.com/vaadin/flow/blob/76f5fcdeca4c77bf7a74ec6cfbc6882698e98823/flow-server/src/main/resources/vite.generated.ts#L765-L767
- https://github.com/stauren/vise-ssr/blob/87b99834b1711876c89e21472a75979090f2e150/packages/shared/src/vise-scaffold-plugin.ts#L84-L86
- https://github.com/youzan/vant/blob/5accade26567d6b8824a31cce1680f05ae7d37ba/packages/vant-cli/src/config/vite.site.ts#L89-L91
- https://github.com/Borrus-sudo/tinypages/blob/ee6981bdf5dbc049379041e72b0ff0b3a8319db0/packages/vite/src/node/plugins/build/rebuild.ts#L11-L13
- https://github.com/Borrus-sudo/tinypages/blob/ee6981bdf5dbc049379041e72b0ff0b3a8319db0/packages/vite/src/node/plugins/build/rebuild.ts#L34-L36

</details>

refs https://github.com/vitejs/vite/pull/9669

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
