### PR TITLE
refactor!: remove non boolean middleware mode

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -150,6 +150,7 @@ const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
 - Default exports of CSS files (e.g `import style from './foo.css'`): Use the `?inline` query instead
 - `import.meta.globEager`: Use `import.meta.glob('*', { eager: true })` instead
 - `ssr.format: 'cjs'` and `legacy.buildSsrCjsExternalHeuristics` ([#13816](https://github.com/vitejs/vite/discussions/13816))
+- `server.middlewareMode: 'ssr'` and `server.middlewareMode: 'html'`: Use [`appType`](/config/shared-options.md#apptype) + [`server.middlewareMode: true`](/config/server-options.md#server-middlewaremode) instead ([#8452](https://github.com/vitejs/vite/pull/8452))
 
 ## Advanced
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -670,8 +670,6 @@ export async function resolveConfig(
   const server = resolveServerOptions(resolvedRoot, config.server, logger)
   const ssr = resolveSSROptions(config.ssr, resolveOptions.preserveSymlinks)
 
-  const middlewareMode = config?.server?.middlewareMode
-
   const optimizeDeps = config.optimizeDeps || {}
 
   const BASE_URL = resolvedBase
@@ -796,7 +794,7 @@ export async function resolveConfig(
       },
     },
     worker: resolvedWorkerOptions,
-    appType: config.appType ?? (middlewareMode === 'ssr' ? 'custom' : 'spa'),
+    appType: config.appType ?? 'spa',
     experimental: {
       importGlobRestoreExtension: false,
       hmrPartialAccept: false,
@@ -824,24 +822,6 @@ export async function resolveConfig(
       .map((hook) => hook(resolved)),
   )
 
-  // validate config
-
-  if (middlewareMode === 'ssr') {
-    logger.warn(
-      colors.yellow(
-        `Setting server.middlewareMode to 'ssr' is deprecated, set server.middlewareMode to \`true\`${
-          config.appType === 'custom' ? '' : ` and appType to 'custom'`
-        } instead`,
-      ),
-    )
-  } else if (middlewareMode === 'html') {
-    logger.warn(
-      colors.yellow(
-        `Setting server.middlewareMode to 'html' is deprecated, set server.middlewareMode to \`true\` instead`,
-      ),
-    )
-  }
-
   debug?.(`using resolved config: %O`, {
     ...resolved,
     plugins: resolved.plugins.map((p) => p.name),
@@ -850,6 +830,8 @@ export async function resolveConfig(
       plugins: `() => plugins`,
     },
   })
+
+  // validate config
 
   if (config.build?.terserOptions && config.build.minify !== 'terser') {
     logger.warn(

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -108,7 +108,7 @@ export interface ServerOptions extends CommonServerOptions {
    * Create Vite dev server to be used as a middleware in an existing server
    * @default false
    */
-  middlewareMode?: boolean | 'html' | 'ssr'
+  middlewareMode?: boolean
   /**
    * Options for files served via '/\@fs/'.
    */


### PR DESCRIPTION
### Description
This PR removes the non boolean middleware mode option which is deprecated by https://github.com/vitejs/vite/pull/8452 since Vite 3.

[github search result](https://github.com/search?q=%2FmiddlewareMode%3A%5Cs*%5B%27%22%5Dhtml%5B%27%22%5D%2F+NOT+is%3Afork&type=code&p=1)

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
