### PR TITLE
feat(html): pass `req` + `res` to `transformIndexHtml`

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -374,6 +374,9 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
       server?: ViteDevServer
       bundle?: import('rollup').OutputBundle
       chunk?: import('rollup').OutputChunk
+      originalUrl?: string
+      req?: import('connect').IncomingMessage
+      res?: http.ServerResponse
     },
   ) =>
     | IndexHtmlTransformResult

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1,3 +1,4 @@
+import type * as http from 'node:http'
 import path from 'node:path'
 import type {
   OutputAsset,
@@ -6,6 +7,7 @@ import type {
   RollupError,
   SourceMapInput,
 } from 'rollup'
+import type { Connect } from 'dep-types/connect'
 import MagicString from 'magic-string'
 import colors from 'picocolors'
 import type { DefaultTreeAdapterMap, ParserError, Token } from 'parse5'
@@ -938,6 +940,8 @@ export interface IndexHtmlTransformContext {
   bundle?: OutputBundle
   chunk?: OutputChunk
   originalUrl?: string
+  req?: Connect.IncomingMessage
+  res?: http.ServerResponse
 }
 
 export type IndexHtmlTransformHook = (

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -180,6 +180,11 @@ export type ServerHook = (
   server: ViteDevServer,
 ) => (() => void) | void | Promise<(() => void) | void>
 
+export interface ConnectContext {
+  req: Connect.IncomingMessage
+  res: http.ServerResponse
+}
+
 export interface ViteDevServer {
   /**
    * The resolved vite config object
@@ -237,6 +242,7 @@ export interface ViteDevServer {
     url: string,
     html: string,
     originalUrl?: string,
+    connectCtx?: ConnectContext,
   ): Promise<string>
   /**
    * Transform module code into SSR format.


### PR DESCRIPTION
Fixes #14431.

### Description

As discussed in https://github.com/vitejs/vite/issues/14431#issuecomment-1782419293, it may be useful to pass `req` and `res` to `transformIndexHtml` during `vite dev`. This has no effect on `vite preview` or `vite build`.

### Additional context

Original discussion: https://github.com/vitejs/vite/issues/14431#issuecomment-1782419293

<!-- e.g. is there anything you'd like reviewers to focus on? -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
