### PR TITLE
chore(shortcuts): resolve generic type error

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -46,9 +46,11 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
     )
   }
 
-  const shortcuts = (opts?.customShortcuts ?? [])
-    // @ts-expect-error passing the right types, but typescript can't detect it
-    .concat(isDev ? BASE_DEV_SHORTCUTS : BASE_PREVIEW_SHORTCUTS)
+  const shortcuts = (opts?.customShortcuts ?? []).concat(
+    (isDev
+      ? BASE_DEV_SHORTCUTS
+      : BASE_PREVIEW_SHORTCUTS) as CLIShortcut<Server>[],
+  )
 
   let actionRunning = false
 


### PR DESCRIPTION
### Description

Fix type incompatibility when binding CLI shortcuts caused by concatenating typed arrays with generic type mismatch.

This PR removes the need for the `@ts-expect-error` comment that was previously suppressing the type error.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
