### PR TITLE
refactor(esbuild)!: remove esbuild 0.17 -> 0.18 compat

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -57,6 +57,8 @@ Some configuration fields under `compilerOptions` in `tsconfig.json` require spe
 
 #### `isolatedModules`
 
+- [TypeScript documentation](https://www.typescriptlang.org/tsconfig#isolatedModules)
+
 Should be set to `true`.
 
 It is because `esbuild` only performs transpilation without type information, it doesn't support certain features like const enum and implicit type-only imports.
@@ -67,7 +69,11 @@ However, some libraries (e.g. [`vue`](https://github.com/vuejs/core/issues/1228)
 
 #### `useDefineForClassFields`
 
+- [TypeScript documentation](https://www.typescriptlang.org/tsconfig#useDefineForClassFields)
+
 Starting from Vite 2.5.0, the default value will be `true` if the TypeScript target is `ESNext` or `ES2022` or newer. It is consistent with the [behavior of `tsc` 4.3.2 and later](https://github.com/microsoft/TypeScript/pull/42663). It is also the standard ECMAScript runtime behavior.
+
+Other TypeScript targets will default to `false`.
 
 But it may be counter-intuitive for those coming from other programming languages or older versions of TypeScript.
 You can read more about the transition in the [TypeScript 3.7 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier).
@@ -78,13 +84,32 @@ Most libraries expect `"useDefineForClassFields": true`, such as [MobX](https://
 
 But a few libraries haven't transitioned to this new default yet, including [`lit-element`](https://github.com/lit/lit-element/issues/1030). Please explicitly set `useDefineForClassFields` to `false` in these cases.
 
+#### `target`
+
+- [TypeScript documentation](https://www.typescriptlang.org/tsconfig#target)
+
+Vite does not transpile TypeScript with the configured `target` value by default, following the same behaviour as `esbuild`.
+
+The [`esbuild.target`](/config/shared-options.html#esbuild) option can be used instead, which defaults to `esnext` for minimal transpilation. In builds, the [`build.target`](/config/build-options.html#build-target) option takes higher priority and can also be set if needed.
+
+::: warning `useDefineForClassFields`
+If `target` is not `ESNext` or `ES2022` or newer, or if there's no `tsconfig.json` file, `useDefineForClassFields` will default to `false` which can be problematic with the default `esbuild.target` value of `esnext`. It may transpile to [static initialization blocks](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks#browser_compatibility) which may not be supported in your browser.
+
+As such, it is recommended to set `target` to `ESNext` or `ES2022` or newer, or set `useDefineForClassFields` to `true` explicitly when configuring `tsconfig.json`.
+:::
+
 #### Other Compiler Options Affecting the Build Result
 
 - [`extends`](https://www.typescriptlang.org/tsconfig#extends)
 - [`importsNotUsedAsValues`](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues)
 - [`preserveValueImports`](https://www.typescriptlang.org/tsconfig#preserveValueImports)
+- [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax)
+- [`jsx`](https://www.typescriptlang.org/tsconfig#jsx)
 - [`jsxFactory`](https://www.typescriptlang.org/tsconfig#jsxFactory)
 - [`jsxFragmentFactory`](https://www.typescriptlang.org/tsconfig#jsxFragmentFactory)
+- [`jsxImportSource`](https://www.typescriptlang.org/tsconfig#jsxImportSource)
+- [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig#experimentalDecorators)
+- [`alwaysStrict`](https://www.typescriptlang.org/tsconfig#alwaysStrict)
 
 If migrating your codebase to `"isolatedModules": true` is an insurmountable effort, you may be able to get around it with a third-party plugin such as [rollup-plugin-friendly-type-imports](https://www.npmjs.com/package/rollup-plugin-friendly-type-imports). However, this approach is not officially supported by Vite.
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -117,6 +117,31 @@ CLI shortcuts, like `r` to restart the dev server, now require an additional `En
 
 This change prevents Vite from swallowing and controlling OS-specific shortcuts, allowing better compatibility when combining the Vite dev server with other processes, and avoids the [previous caveats](https://github.com/vitejs/vite/pull/14342).
 
+### Update `experimentalDecorators` and `useDefineForClassFields` TypeScript behaviour
+
+Vite 5 uses esbuild 0.18, which changes how `experimentalDecorators` and `useDefineForClassFields` are handled.
+
+- **`experimentalDecorators` is not enabled by default**
+
+  You need to set `compilerOptions.experimentalDecorators` to `true` in `tsconfig.json` to use decorators.
+
+- **`useDefineForClassFields` defaults depend on the TypeScript `target` value**
+
+  If `target` is not `ESNext` or `ES2022` or newer, or if there's no `tsconfig.json` file, `useDefineForClassFields` will default to `false` which can be problematic with the default `esbuild.target` value of `esnext`. It may transpile to [static initialization blocks](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks#browser_compatibility) which may not be supported in your browser.
+
+  As such, it is recommended to set `target` to `ESNext` or `ES2022` or newer, or set `useDefineForClassFields` to `true` explicitly when configuring `tsconfig.json`.
+
+```jsonc
+{
+  "compilerOptions": {
+    // Set true if you use decorators
+    "experimentalDecorators": true,
+    // Set true if you see parsing errors in your browser
+    "useDefineForClassFields": true
+  }
+}
+```
+
 ### Remove `--https` flag and `https: true`
 
 `--https` flag sets `https: true`. This config was meant to be used together with the automatic https certification generation feature which [was dropped in Vite 3](https://v3.vitejs.dev/guide/migration.html#automatic-https-certificate-generation). This config no longer makes sense as it will make Vite start a HTTPS server without a certificate.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -119,7 +119,7 @@ This change prevents Vite from swallowing and controlling OS-specific shortcuts,
 
 ### Update `experimentalDecorators` and `useDefineForClassFields` TypeScript behaviour
 
-Vite 5 uses esbuild 0.18, which changes how `experimentalDecorators` and `useDefineForClassFields` are handled.
+Vite 5 uses esbuild 0.19 and removes the compatibility layer for esbuild 0.18, which changes how `experimentalDecorators` and `useDefineForClassFields` are handled.
 
 - **`experimentalDecorators` is not enabled by default**
 

--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -383,21 +383,6 @@ describe('transformWithEsbuild', () => {
       const actual = await transformClassCode('es2022', {})
       expect(actual).toBe(defineForClassFieldsFalseTransformedCode)
     })
-
-    test('useDefineForClassFields: false and static property should not be transpile to static block', async () => {
-      const result = await transformWithEsbuild(
-        `
-          class foo {
-            static bar = 'bar'
-          }
-        `,
-        'bar.ts',
-        {
-          target: 'esnext',
-        },
-      )
-      expect(result?.code).not.toContain('static {')
-    })
   })
 })
 

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -27,7 +27,7 @@ import {
 import { transformWithEsbuild } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET } from '../constants'
 import { esbuildCjsExternalPlugin, esbuildDepPlugin } from './esbuildDepPlugin'
-import { resolveTsconfigRaw, scanImports } from './scan'
+import { scanImports } from './scan'
 import { createOptimizeDepsIncludeResolver, expandGlobIds } from './resolve'
 export {
   initDepsOptimizer,
@@ -730,12 +730,8 @@ async function prepareEsbuildOptimizerRun(
 
   const optimizeDeps = getDepOptimizationConfig(config, ssr)
 
-  const {
-    plugins: pluginsFromConfig = [],
-    tsconfig,
-    tsconfigRaw,
-    ...esbuildOptions
-  } = optimizeDeps?.esbuildOptions ?? {}
+  const { plugins: pluginsFromConfig = [], ...esbuildOptions } =
+    optimizeDeps?.esbuildOptions ?? {}
 
   await Promise.all(
     Object.keys(depsInfo).map(async (id) => {
@@ -826,8 +822,6 @@ async function prepareEsbuildOptimizerRun(
     metafile: true,
     plugins,
     charset: 'utf8',
-    tsconfig,
-    tsconfigRaw: resolveTsconfigRaw(tsconfig, tsconfigRaw),
     ...esbuildOptions,
     supported: {
       'dynamic-import': true,

--- a/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
+++ b/playground/tsconfig-json/__tests__/tsconfig-json.spec.ts
@@ -71,9 +71,8 @@ describe('transformWithEsbuild', () => {
   test('experimentalDecorators', async () => {
     const main = path.resolve(__dirname, '../src/decorator.ts')
     const mainContent = fs.readFileSync(main, 'utf-8')
-    // Should not error when transpiling decorators
-    // TODO: In Vite 5, this should require setting `tsconfigRaw.experimentalDecorators`
-    // or via the closest `tsconfig.json`
+    // Should not error when transpiling decorators as nearest tsconfig.json
+    // has "experimentalDecorators": true
     const result = await transformWithEsbuild(mainContent, main, {
       target: 'es2020',
     })

--- a/playground/tsconfig-json/tsconfig.json
+++ b/playground/tsconfig-json/tsconfig.json
@@ -14,7 +14,8 @@
     "noImplicitReturns": true,
 
     "useDefineForClassFields": true,
-    "importsNotUsedAsValues": "preserve"
+    "importsNotUsedAsValues": "preserve",
+    "experimentalDecorators": true
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Removed esbuild 0.17 to 0.18 compat code we added in Vite 4. I only saw this comment that we should remove this in Vite 5 just now 😬 

1. `experimentalDecorators` needs to be enabled if used
   - https://github.com/vitejs/vite/pull/13981
   - https://github.com/vitejs/vite/pull/13805
   - https://github.com/vitejs/vite/pull/13525
 2. Removed special `supported` handling for `useDefineForClassFields`. I figured it's better to document what's happening and how they can fix it. I initially thought we could respect `esbuild.compilerOptions.target` and override `esbuild.target` if set, but I don't think it's worth breaking that now, nor a good default. This is also esbuild's behaviour.
    - https://github.com/vitejs/vite/pull/13992

I added some documentation to explain what's going on.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
