### PR TITLE
feat(assets): improve inlining svg

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -446,6 +446,7 @@ function svgToDataURL(content: Buffer): string {
         .replaceAll('"', "'")
         .replaceAll('%', '%25')
         .replaceAll('#', '%23')
+        .replaceAll('<style', '%3сstyle')
         // Spaces are not valid in srcset it has some use cases
         // it can make the uncompressed URI slightly higher than base64, but will compress way better
         // https://github.com/vitejs/vite/pull/14643#issuecomment-1766288673

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -446,8 +446,6 @@ function svgToDataURL(content: Buffer): string {
         .replaceAll('"', "'")
         .replaceAll('%', '%25')
         .replaceAll('#', '%23')
-        .replaceAll('<', '%3c')
-        .replaceAll('>', '%3e')
         // Spaces are not valid in srcset it has some use cases
         // it can make the uncompressed URI slightly higher than base64, but will compress way better
         // https://github.com/vitejs/vite/pull/14643#issuecomment-1766288673

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -333,7 +333,7 @@ describe('svg fragments', () => {
     expect(await img.getAttribute('src')).toMatch(
       isBuild
         ? // Assert trimmed (data URI starts with < and ends with >)
-          /^data:image\/svg\+xml,%3c.*%3e#icon-heart-view$/
+          /^data:image\/svg\+xml,<.*>#icon-heart-view$/
         : /svg#icon-heart-view$/,
     )
   })


### PR DESCRIPTION
### Description

All major browser engines do not need to encode `>` and `<` characters.

It's also easy to remove all whitespaces between tags before encoding whitespaces.

Both changes allow you to slightly reduce the amount of data in the output.

### Additional context

Based on [discussion](https://github.com/vitejs/vite/pull/14643#discussion_r1376247460)

---

### What is the purpose of this pull request?

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [X] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
