### PR TITLE
feat(pluginContainer): implement watchChange hook

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -580,12 +580,14 @@ export async function _createServer(
 
   const onFileAddUnlink = async (file: string, isUnlink: boolean) => {
     file = normalizePath(file)
+    await container.watchChange(file, {event: isUnlink ? 'delete' : 'create'})
     await handleFileAddUnlink(file, server, isUnlink)
     await onHMRUpdate(file, true)
   }
 
   watcher.on('change', async (file) => {
     file = normalizePath(file)
+    await container.watchChange(file, {event: 'update'})
     // invalidate module graph cache on file change
     moduleGraph.onFileChange(file)
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -580,14 +580,14 @@ export async function _createServer(
 
   const onFileAddUnlink = async (file: string, isUnlink: boolean) => {
     file = normalizePath(file)
-    await container.watchChange(file, {event: isUnlink ? 'delete' : 'create'})
+    await container.watchChange(file, { event: isUnlink ? 'delete' : 'create' })
     await handleFileAddUnlink(file, server, isUnlink)
     await onHMRUpdate(file, true)
   }
 
   watcher.on('change', async (file) => {
     file = normalizePath(file)
-    await container.watchChange(file, {event: 'update'})
+    await container.watchChange(file, { event: 'update' })
     // invalidate module graph cache on file change
     moduleGraph.onFileChange(file)
 

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -138,7 +138,10 @@ export interface PluginContainer {
       ssr?: boolean
     },
   ): Promise<LoadResult | null>
-  watchChange(id: string, change: {event: 'create' | 'update' | 'delete'}): Promise<void>
+  watchChange(
+    id: string,
+    change: { event: 'create' | 'update' | 'delete' },
+  ): Promise<void>
   close(): Promise<void>
 }
 

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -138,6 +138,7 @@ export interface PluginContainer {
       ssr?: boolean
     },
   ): Promise<LoadResult | null>
+  watchChange(id: string, change: {event: 'create' | 'update' | 'delete'}): Promise<void>
   close(): Promise<void>
 }
 
@@ -776,6 +777,15 @@ export async function createPluginContainer(
         code,
         map: ctx._getCombinedSourcemap(),
       }
+    },
+
+    async watchChange(id, change) {
+      const ctx = new Context()
+      await hookParallel(
+        'watchChange',
+        () => ctx,
+        () => [id, change],
+      )
     },
 
     async close() {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR implements the [watchChange plugin hook](https://rollupjs.org/plugin-development/#watchchange).

### Additional context

Currently, observing file changes can only be done via `server.watcher.on("change", ...)`, or somewhat lossily via the `handleHotUpdate()` plugin hook (operates on Modules rather than Files though, and doesn't run for deletions). 

Since the Plugin TS definition and container implementation indicate `watchChange()` hook is available (it doesn't throw like `emitFile`), I figured it would make sense to add support for it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
