### PR TITLE
chore: revert "feat: show warning to discourage putting process/global to `define` option (#14447)"

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -483,21 +483,6 @@ export async function resolveConfig(
     customLogger: config.customLogger,
   })
 
-  let foundDiscouragedVariableName
-  if (
-    (foundDiscouragedVariableName = Object.keys(config.define ?? {}).find((k) =>
-      ['process', 'global'].includes(k),
-    ))
-  ) {
-    logger.warn(
-      colors.yellow(
-        `Replacing ${colors.bold(
-          foundDiscouragedVariableName,
-        )} using the define option is discouraged. See https://vitejs.dev/config/shared-options.html#define for more details.`,
-      ),
-    )
-  }
-
   // resolve root
   const resolvedRoot = normalizePath(
     config.root ? path.resolve(config.root) : process.cwd(),


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description
This reverts commit 83a56f7b46538d485a204a4b9309f3f10c94ee51, PR #14447.

This is no longer needed as #11151 is merged.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
