### PR TITLE
refactor: simplify build optimizer node_env handling

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -755,13 +755,12 @@ async function prepareEsbuildOptimizerRun(
   if (optimizerContext.cancelled) return { context: undefined, idToExports }
 
   // esbuild automatically replaces process.env.NODE_ENV for platform 'browser'
-  // In lib mode, we need to keep process.env.NODE_ENV untouched, so to at build
-  // time we replace it by __vite_process_env_NODE_ENV. This placeholder will be
-  // later replaced by the define plugin
+  // But in lib mode, we need to keep process.env.NODE_ENV untouched
   const define = {
-    'process.env.NODE_ENV': isBuild
-      ? '__vite_process_env_NODE_ENV'
-      : JSON.stringify(process.env.NODE_ENV || config.mode),
+    'process.env.NODE_ENV':
+      isBuild && config.build.lib
+        ? 'process.env.NODE_ENV'
+        : JSON.stringify(process.env.NODE_ENV || config.mode),
   }
 
   const platform =

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -26,7 +26,6 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       'process.env.NODE_ENV': JSON.stringify(nodeEnv),
       'global.process.env.NODE_ENV': JSON.stringify(nodeEnv),
       'globalThis.process.env.NODE_ENV': JSON.stringify(nodeEnv),
-      __vite_process_env_NODE_ENV: JSON.stringify(nodeEnv),
     })
   }
 
@@ -69,9 +68,6 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     }
 
     // Additional define fixes based on `ssr` value
-    if (isBuild && !replaceProcessEnv) {
-      define['__vite_process_env_NODE_ENV'] = 'process.env.NODE_ENV'
-    }
     if ('import.meta.env.SSR' in define) {
       define['import.meta.env.SSR'] = ssr + ''
     }
@@ -86,7 +82,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     // Create regex pattern as a fast check before running esbuild
     const patternKeys = Object.keys(userDefine)
     if (replaceProcessEnv && Object.keys(processEnv).length) {
-      patternKeys.push('process.env', '__vite_process_env_NODE_ENV')
+      patternKeys.push('process.env')
     }
     if (Object.keys(importMetaKeys).length) {
       patternKeys.push('import.meta.env', 'import.meta.hot')

--- a/playground/define/__tests__/define.spec.ts
+++ b/playground/define/__tests__/define.spec.ts
@@ -73,11 +73,6 @@ test('ignores constants in string literals', async () => {
     ),
   ).toBe('globalThis.process.env.NODE_ENV')
   expect(
-    await page.textContent(
-      '.ignores-string-literals .__vite_process_env_NODE_ENV',
-    ),
-  ).toBe('__vite_process_env_NODE_ENV')
-  expect(
     await page.textContent('.ignores-string-literals .import-meta-hot'),
   ).toBe('import' + '.meta.hot')
 })

--- a/playground/define/index.html
+++ b/playground/define/index.html
@@ -37,10 +37,6 @@
     globalThis.process.env.NODE_ENV
     <code class="globalThis-process-env-NODE_ENV"></code>
   </p>
-  <p>
-    __vite_process_env_NODE_ENV
-    <code class="__vite_process_env_NODE_ENV"></code>
-  </p>
   <p>import.meta.hot <code class="import-meta-hot"></code></p>
 </section>
 
@@ -59,10 +55,6 @@
   <p>
     globalThis.process.env.NODE_ENV
     <code class="globalThis-process-env-NODE_ENV"></code>
-  </p>
-  <p>
-    __vite_process_env_NODE_ENV
-    <code class="__vite_process_env_NODE_ENV"></code>
   </p>
   <p>import.meta.hot <code class="import-meta-hot"></code></p>
 </section>
@@ -122,10 +114,6 @@
   text(
     '.ignores-string-literals .globalThis-process-env-NODE_ENV',
     'globalThis.process.env.NODE_ENV',
-  )
-  text(
-    '.ignores-string-literals .__vite_process_env_NODE_ENV',
-    '__vite_process_env_NODE_ENV',
   )
   text('.ignores-string-literals .import-meta-hot', 'import.meta.hot')
 


### PR DESCRIPTION

### Description

We can workaround the change in `optimizer/index.ts` with `define: { 'process.env.NODE_ENV': 'process.env.NODE_ENV' }` instead. ([esbuild example](https://esbuild.github.io/try/#YgAwLjE5LjUAewogIHBsYXRmb3JtOiAnYnJvd3NlcicsCiAgZGVmaW5lOiB7CiAgICAncHJvY2Vzcy5lbnYuTk9ERV9FTlYnOiAncHJvY2Vzcy5lbnYuTk9ERV9FTlYnLAogIH0sCn0AZQBlbnRyeS5qcwBjb25zb2xlLmxvZyhwcm9jZXNzLmVudi5OT0RFX0VOVik))

Also I'm not sure if the check was wrong. The comment mentioned lib builds but we were checking generic builds. I changed the condition to check lib builds instead (same as `define.ts`)

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
