### PR TITLE
feat: expose parseAst and parseAstAsync from rollup

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   },
   external: [
     /^node:*/,
+    'rollup/parseAst',
     ...Object.keys(pkg.dependencies),
     // lightningcss types are bundled
     ...Object.keys(pkg.devDependencies).filter((d) => d !== 'lightningcss'),
@@ -80,13 +81,14 @@ function patchTypes(): Plugin {
     },
     renderChunk(code, chunk) {
       // Validate that chunk imports do not import dev deps
-      const deps = new Set(Object.keys(pkg.dependencies))
+      const deps = Object.keys(pkg.dependencies)
       for (const id of chunk.imports) {
         if (
           !id.startsWith('./') &&
           !id.startsWith('../') &&
           !id.startsWith('node:') &&
-          !deps.has(id)
+          !deps.includes(id) &&
+          !deps.some((name) => id.startsWith(name + '/'))
         ) {
           // If validation failed, only warn and set exit code 1 so that files
           // are written to disk for inspection, but the build will fail

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -1,6 +1,7 @@
 import type * as Rollup from 'rollup'
 
 export type { Rollup }
+export { parseAst, parseAstAsync } from 'rollup/parseAst'
 export {
   defineConfig,
   loadConfigFromFile,

--- a/packages/vite/tsconfig.check.json
+++ b/packages/vite/tsconfig.check.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
+    "module": "node16",
     "noEmit": true,
     "strict": true,
     "exactOptionalPropertyTypes": true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR exposes `parseAst` and `parseAstAsync` methods from rollup for an easy access to AST-parsing APIs.

To allow export of `rollup/parseAst`, we would have to require `"moduleResolution"` to be `node16` or higher (because this type is specified in `exports` field, which is not supported in `node` module resolution - https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution-is-host-defined if `skipLibCheck` is disabled (although as far as I know, Vite already fails with esbuild's `WebAssembly` global usage). But this goes in line with node versions that Vite supports.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
