### PR TITLE
fix: preview pre-rendered pages

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -190,16 +190,15 @@ export async function preview(
   app.use(previewBase, viteAssetMiddleware)
 
   // html fallback
-  if (config.appType === 'spa' || config.appType === 'mpa') {
-    app.use(
-      previewBase,
-      htmlFallbackMiddleware(
-        distDir,
-        config.appType === 'spa',
-        previewBase !== '/',
-      ),
-    )
-  }
+  // we serve `.html` files for all app types (`appType)`, including SSR apps/frameworks (`appType: 'custom'`) in order to serve pre-rendered pages
+  app.use(
+    previewBase,
+    htmlFallbackMiddleware(
+      distDir,
+      config.appType === 'spa',
+      previewBase !== '/',
+    ),
+  )
 
   // apply post server hooks from plugins
   postHooks.forEach((fn) => fn && fn())


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The HTML of [pre-rendered pages](https://vike.dev/pre-rendering) lives in `dist/`, therefore it makes sense to serve `.html` files also for `appType: 'custom'`.

### Additional context

This fixes a regression introduced by https://github.com/vitejs/vite/pull/14756.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
