### PR TITLE
chore: bump pnpm to 8.10.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ To develop and test the core `vite` package:
 
 You can alternatively use [Vite.js Docker Dev](https://github.com/nystudio107/vitejs-docker-dev) for a containerized Docker setup for Vite.js development.
 
-> Vite uses pnpm v7. If you are working on multiple projects with different versions of pnpm, it's recommended to enable [Corepack](https://github.com/nodejs/corepack) by running `corepack enable`.
+> Vite uses pnpm v8. If you are working on multiple projects with different versions of pnpm, it's recommended to enable [Corepack](https://github.com/nodejs/corepack) by running `corepack enable`.
 
 ### Ignoring commits when running `git blame`
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
       "eslint --cache --fix"
     ]
   },
-  "packageManager": "pnpm@8.10.0",
+  "packageManager": "pnpm@8.10.1",
   "pnpm": {
     "overrides": {
       "vite": "workspace:*"


### PR DESCRIPTION
Bump to [8.10.1](https://github.com/pnpm/pnpm/releases/tag/v8.10.1) to workaround a npm bug preventing us from publishing Vite in CI. (pnpm release notes have info on the bug)