### PR TITLE
fix: use correct publicDir in ERR_LOAD_PUBLIC_URL

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -249,10 +249,8 @@ async function loadAndTransform(
   }
   if (code == null) {
     const isPublicFile = checkPublicFile(url, config)
-    const publicDirName =
-      config.publicDir && config.root
-        ? path.relative(config.root, config.publicDir)
-        : '/public'
+    let publicDirName = path.relative(config.root, config.publicDir)
+    if (publicDirName[0] !== '.') publicDirName = '/' + publicDirName
     const msg = isPublicFile
       ? `This file is in ${publicDirName} and will be copied as-is during ` +
         `build without going through the plugin transforms, and therefore ` +

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -249,10 +249,15 @@ async function loadAndTransform(
   }
   if (code == null) {
     const isPublicFile = checkPublicFile(url, config)
+    const publicDirName =
+      config.publicDir && config.root
+        ? path.relative(config.root, config.publicDir)
+        : '/public'
     const msg = isPublicFile
-      ? `This file is in /public and will be copied as-is during build without ` +
-        `going through the plugin transforms, and therefore should not be ` +
-        `imported from source code. It can only be referenced via HTML tags.`
+      ? `This file is in ${publicDirName} and will be copied as-is during ` +
+        `build without going through the plugin transforms, and therefore ` +
+        `should not be imported from source code. It can only be referenced ` +
+        `via HTML tags.`
       : `Does the file exist?`
     const importerMod: ModuleNode | undefined = server.moduleGraph.idToModuleMap
       .get(id)


### PR DESCRIPTION
### Description

```
Failed to load url /config.js (resolved id: /config.js). This file is in /public and will be copied 
as-is during build without going through the plugin transforms, and therefore should not be 
imported from source code. It can only be referenced via HTML tags.
```

had a hardcoded value for `/public`.  This introspects the correct value from `config` to improve the error message.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
  - There don't seem to be any tests for the error message, and I don't know the repo well enough to make one.