### PR TITLE
feat!: add isPreview to ConfigEnv and resolveConfig

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -48,10 +48,10 @@ Vite also directly supports TS config files. You can use `vite.config.ts` with t
 
 ## Conditional Config
 
-If the config needs to conditionally determine options based on the command (`dev`/`serve` or `build`), the [mode](/guide/env-and-mode) being used, or if it is an SSR build (`ssrBuild`), it can export a function instead:
+If the config needs to conditionally determine options based on the command (`serve` or `build`), the [mode](/guide/env-and-mode) being used, if it's an SSR build (`isSsrBuild`), or is previewing the build (`isPreview`), it can export a function instead:
 
 ```js
-export default defineConfig(({ command, mode, ssrBuild }) => {
+export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
   if (command === 'serve') {
     return {
       // dev specific config
@@ -66,8 +66,6 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
 ```
 
 It is important to note that in Vite's API the `command` value is `serve` during dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases), and `build` when building for production (`vite build`).
-
-`ssrBuild` is experimental. It is only available during build instead of a more general `ssr` flag because, during dev, the config is shared by the single server handling SSR and non-SSR requests. The value could be `undefined` for tools that don't have separate commands for the browser and SSR build, so use explicit comparison against `true` and `false`.
 
 ## Async Config
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -67,6 +67,8 @@ export default defineConfig(({ command, mode, isSsrBuild, isPreview }) => {
 
 It is important to note that in Vite's API the `command` value is `serve` during dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases), and `build` when building for production (`vite build`).
 
+`isSsrBuild` and `isPreview` are additional optional flags to differentiate the kind of `build` and `serve` commands respectively. Some tools that load the Vite config may not support these flags and will pass `undefined` instead. Hence, it's recommended to use explicit comparison against `true` and `false`.
+
 ## Async Config
 
 If the config needs to call async functions, it can export an async function instead. And this async function can also be passed through `defineConfig` for improved intellisense support:

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -251,10 +251,12 @@ async function resolveConfig(
   inlineConfig: InlineConfig,
   command: 'build' | 'serve',
   defaultMode = 'development',
+  defaultNodeEnv = 'development',
+  isPreview = false,
 ): Promise<ResolvedConfig>
 ```
 
-The `command` value is `serve` in dev (in the cli `vite`, `vite dev`, and `vite serve` are aliases).
+The `command` value is `serve` in dev and preview, and `build` in build.
 
 ## `mergeConfig`
 

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -218,6 +218,8 @@ Also there are other breaking changes which only affect few users.
   - In the past, when a library `"exports"` field maps to an `.mjs` file, Vite will still try to match the `"browser"` and `"module"` fields to fix compatibility with certain libraries. This behavior is now removed to align with the exports resolution algorithm.
 - [[#14733] feat(resolve)!: remove `resolve.browserField`](https://github.com/vitejs/vite/pull/14733)
   - `resolve.browserField` has been deprecated since Vite 3 in favour of an updated default of `['browser', 'module', 'jsnext:main', 'jsnext']` for [`resolve.mainFields`](/config/shared-options.md#resolve-mainfields).
+- [[#14855] feat!: add isPreview to ConfigEnv and resolveConfig](https://github.com/vitejs/vite/pull/14855)
+  - Renamed `ssrBuild` to `isSsrBuild` in the `ConfigEnv` object.
 
 ## Migration from v3
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -77,8 +77,8 @@ const promisifiedRealpath = promisify(fs.realpath)
 export interface ConfigEnv {
   command: 'build' | 'serve'
   mode: string
-  isSsrBuild: boolean
-  isPreview: boolean
+  isSsrBuild?: boolean
+  isPreview?: boolean
 }
 
 /**

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -77,10 +77,8 @@ const promisifiedRealpath = promisify(fs.realpath)
 export interface ConfigEnv {
   command: 'build' | 'serve'
   mode: string
-  /**
-   * @experimental
-   */
-  ssrBuild?: boolean
+  isSsrBuild: boolean
+  isPreview: boolean
 }
 
 /**
@@ -404,6 +402,7 @@ export async function resolveConfig(
   command: 'build' | 'serve',
   defaultMode = 'development',
   defaultNodeEnv = 'development',
+  isPreview = false,
 ): Promise<ResolvedConfig> {
   let config = inlineConfig
   let configFileDependencies: string[] = []
@@ -417,10 +416,11 @@ export async function resolveConfig(
     process.env.NODE_ENV = defaultNodeEnv
   }
 
-  const configEnv = {
+  const configEnv: ConfigEnv = {
     mode,
     command,
-    ssrBuild: !!config.build?.ssr,
+    isSsrBuild: !!config.build?.ssr,
+    isPreview,
   }
 
   let { configFile } = config

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -183,9 +183,6 @@ export async function startDefaultServe(): Promise<void> {
   const configEnv: ConfigEnv = {
     command: isBuild ? 'build' : 'serve',
     mode: isBuild ? 'production' : 'development',
-    // we're unable to differentiate these properties so just set false
-    isSsrBuild: false,
-    isPreview: false,
   }
 
   // config file named by convention as the *.spec.ts folder

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -183,6 +183,9 @@ export async function startDefaultServe(): Promise<void> {
   const configEnv: ConfigEnv = {
     command: isBuild ? 'build' : 'serve',
     mode: isBuild ? 'production' : 'development',
+    // we're unable to differentiate these properties so just set false
+    isSsrBuild: false,
+    isPreview: false,
   }
 
   // config file named by convention as the *.spec.ts folder


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Add `isPreview` to `ConfigEnv`. Supersedes https://github.com/vitejs/vite/pull/12298

I made a very direct breaking change to `ssrBuild` (renamed to `isSsrBuild`) and we could decide if it's a good idea or not 😬 

This will break `loadConfigForFile` mostly and its first parameter accepts a `ConfigEnv`. However, I don't think it's hard to fix it.

### Additional context

- Discussion to stabilize `ssrBuild`: https://github.com/vitejs/vite/discussions/13809
   As the discussion mentioned, `ssrBuild` is not widely used.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other
