### PR TITLE
feat(assets): add early access to generatedAssets with content

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -13,6 +13,7 @@ export { preview } from './preview'
 export { build } from './build'
 export { optimizeDeps } from './optimizer'
 export { formatPostcssSourceMap, preprocessCSS } from './plugins/css'
+export { getAssets, assetUrlRE } from './plugins/asset'
 export { transformWithEsbuild } from './plugins/esbuild'
 export { buildErrorMessage } from './server/middlewares/error'
 export * from './publicUtils'
@@ -118,6 +119,7 @@ export type {
   TransformResult,
 } from './server/transformRequest'
 export type { HmrOptions, HmrContext } from './server/hmr'
+export type { AssetPluginApi, GeneratedAssetMeta } from './plugins/asset'
 
 export type { BindCLIShortcutsOptions, CLIShortcut } from './shortcuts'
 

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -642,9 +642,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             type: 'asset',
             source: chunkCSS,
           })
-          generatedAssets
-            .get(config)!
-            .set(referenceId, { originalName: originalFilename, isEntry })
+          generatedAssets.get(config)!.set(referenceId, {
+            originalName: originalFilename,
+            isEntry,
+            source: chunkCSS,
+          })
           chunk.viteMetadata!.importedCss.add(this.getFileName(referenceId))
 
           if (emitTasksLength === emitTasks.length) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Rollup doesn't provide a possibility to read files that emitted to bundle from transform hook, so I added early access to vite-generated assets to make it possible to define resource by it's reference id.

### Additional context

I wrote a plugin that collects information about fonts and performs code transformations in the transform hook according to collected information.
When fonts are injected into the project from some external place in CSS files by import - the rollup transform hook is not triggered by id (file id - second argument in transform hook) because all CSS files are processed by `vite:css` plugin\postcss processor\urlReplacer function.
I don't want to do additional oversteps and process CSS files bypassing vite process, but after the vite transform only asset aliases with reference ID (a.k.a. __VITE_ASSET_referenceId__)  can be seen, which isn't helpful in understanding what a resource it was.

```scss
// css file before vite
@import 'node_modules/some-css-with-fonts.css'
```

```scss
// css after vite
@font-face {
  font-family: "Trickster";
  src:
    local("Trickster"),
    url(__VITE_ASSET_referenceId__) format("opentype") tech(color-COLRv1),
    url(__VITE_ASSET_referenceId__) format("opentype"),
    url(__VITE_ASSET_referenceId__) format("woff");
}
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
