### PR TITLE
chore: fix git tag log

### DIFF
--- a/scripts/releaseUtils.ts
+++ b/scripts/releaseUtils.ts
@@ -20,7 +20,7 @@ export async function getLatestTag(pkgName: string): Promise<string> {
   const prefix = pkgName === 'vite' ? 'v' : `${pkgName}@`
   return tags
     .filter((tag) => tag.startsWith(prefix))
-    .sort()
+    .sort((a, b) => a.localeCompare(b, 'en', { numeric: true }))
     .reverse()[0]
 }
 


### PR DESCRIPTION
When releasing the Vite betas, the versions aren't sorted right, e.g. `beta.0`, `beta.1`, `beta.10`, `beta.2`. This fixes it using `localeCompare`.

It's only used to show what commits in between will be released.