### PR TITLE
fix(css): initialize lightningCSS targets when not using options

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -363,7 +363,7 @@ export type ResolvedConfig = Readonly<
       alias: Alias[]
     }
     plugins: readonly Plugin[]
-    css: ResolvedCSSOptions | undefined
+    css: ResolvedCSSOptions
     esbuild: ESBuildOptions | false
     server: ResolvedServerOptions
     build: ResolvedBuildOptions

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -141,7 +141,7 @@ export type ResolvedCSSOptions = Omit<CSSOptions, 'lightningcss'> & {
 
 export function resolveCSSOptions(
   options: CSSOptions | undefined,
-): ResolvedCSSOptions | undefined {
+): ResolvedCSSOptions {
   if (options?.transformer === 'lightningcss') {
     return {
       ...options,
@@ -153,8 +153,7 @@ export function resolveCSSOptions(
       },
     }
   }
-  // TS doesn't narrow the type with the previous if :/
-  return options as Omit<CSSOptions, 'lightningcss'> | undefined
+  return { ...options, lightningcss: undefined }
 }
 
 const cssModuleRE = new RegExp(`\\.module${CSS_LANGS_RE.source}`)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -142,19 +142,19 @@ export type ResolvedCSSOptions = Omit<CSSOptions, 'lightningcss'> & {
 export function resolveCSSOptions(
   options: CSSOptions | undefined,
 ): ResolvedCSSOptions | undefined {
-  if (options?.lightningcss) {
+  if (options?.transformer === 'lightningcss') {
     return {
       ...options,
       lightningcss: {
         ...options.lightningcss,
         targets:
-          options.lightningcss.targets ??
+          options.lightningcss?.targets ??
           convertTargets(ESBUILD_MODULES_TARGET),
       },
     }
   }
   // TS doesn't narrow the type with the previous if :/
-  return options as Omit<CSSOptions, 'lightningcss'>
+  return options as Omit<CSSOptions, 'lightningcss'> | undefined
 }
 
 const cssModuleRE = new RegExp(`\\.module${CSS_LANGS_RE.source}`)


### PR DESCRIPTION
This was a weird behaviour where:

```js
css: {
  transformer: "lightningcss",
},
```
was not the same as 
```js
css: {
   transformer: "lightningcss",
   lightningcss: {},
},
```

Because without any targets LightningCSS will default to latest specs and do a lot of syntax shortening and vendor-prefixing cleanup, this should always be set to avoid sending non supported CSS to the browser.