### PR TITLE
fix(assets): use base64 when inlining SVG with foreignObject tag

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -437,15 +437,19 @@ export async function urlToBuiltUrl(
 // Inspired by https://github.com/iconify/iconify/blob/main/packages/utils/src/svg/url.ts
 function svgToDataURL(content: Buffer): string {
   const stringContent = content.toString()
-  // If the SVG contains some text, any transformation is unsafe, and given that double quotes would then
+  // If the SVG contains some text or HTML, any transformation is unsafe, and given that double quotes would then
   // need to be escaped, the gain to use a data URI would be ridiculous if not negative
-  if (stringContent.includes('<text')) {
+  if (
+    stringContent.includes('<text') ||
+    stringContent.includes('<foreignObject')
+  ) {
     return `data:image/svg+xml;base64,${content.toString('base64')}`
   } else {
     return (
       'data:image/svg+xml,' +
       stringContent
         .trim()
+        .replaceAll(/>\s+</g, '><')
         .replaceAll('"', "'")
         .replaceAll('%', '%25')
         .replaceAll('#', '%23')


### PR DESCRIPTION
Followup: #14643 & #14815

I introduce the `><` optimization from @firefoxic because I think this one is safe and we can keep the other PR about `<` encoding