### PR TITLE
build: strip internal function parameters

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -83,6 +83,7 @@
   },
   "devDependencies": {
     "@ampproject/remapping": "^2.2.1",
+    "@babel/parser": "^7.23.0",
     "@jridgewell/trace-mapping": "^0.3.20",
     "@rollup/plugin-alias": "^5.0.1",
     "@rollup/plugin-commonjs": "^25.0.7",

--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { findStaticImports } from 'mlly'
-import { type Plugin, defineConfig } from 'rollup'
+import { defineConfig } from 'rollup'
+import type { Plugin, PluginContext, RenderedChunk } from 'rollup'
 import dts from 'rollup-plugin-dts'
 
 const depTypesDir = new URL('./src/types/', import.meta.url)
@@ -80,89 +81,106 @@ function patchTypes(): Plugin {
       }
     },
     renderChunk(code, chunk) {
-      // Validate that chunk imports do not import dev deps
-      const deps = Object.keys(pkg.dependencies)
-      for (const id of chunk.imports) {
-        if (
-          !id.startsWith('./') &&
-          !id.startsWith('../') &&
-          !id.startsWith('node:') &&
-          !deps.includes(id) &&
-          !deps.some((name) => id.startsWith(name + '/'))
-        ) {
-          // If validation failed, only warn and set exit code 1 so that files
-          // are written to disk for inspection, but the build will fail
-          this.warn(`${chunk.fileName} imports "${id}" which is not allowed`)
-          process.exitCode = 1
-        }
-      }
-
-      // Rollup deduplicate type names with a trailing `$1` or `$2`, which can be
-      // confusing when showed in autocompletions. Try to replace with a better name
-      const imports = findStaticImports(code)
-      for (const modName in identifierReplacements) {
-        const imp = imports.find(
-          (imp) => imp.specifier === modName && imp.imports.includes('{'),
-        )
-        // Validate that `identifierReplacements` is not outdated if there's no match
-        if (!imp) {
-          this.warn(
-            `${chunk.fileName} does not import "${modName}" for replacement`,
-          )
-          process.exitCode = 1
-          continue
-        }
-
-        const replacements = identifierReplacements[modName]
-        for (const id in replacements) {
-          // Validate that `identifierReplacements` is not outdated if there's no match
-          if (!imp.imports.includes(id)) {
-            this.warn(
-              `${chunk.fileName} does not import "${id}" from "${modName}" for replacement`,
-            )
-            process.exitCode = 1
-            continue
-          }
-
-          const betterId = replacements[id]
-          const regexEscapedId = escapeRegex(id)
-          // If the better id accesses a namespace, the existing `Foo as Foo$1`
-          // named import cannot be replaced with `Foo as Namespace.Foo`, so we
-          // pre-emptively remove the whole named import
-          if (betterId.includes('.')) {
-            code = code.replace(
-              new RegExp(`\\b\\w+\\b as ${regexEscapedId},?\\s?`),
-              '',
-            )
-          }
-          code = code.replace(
-            new RegExp(`\\b${regexEscapedId}\\b`, 'g'),
-            betterId,
-          )
-        }
-      }
-      const unreplacedIds = unique(
-        Array.from(code.matchAll(identifierWithTrailingDollarRE), (m) => m[0]),
-      )
-      if (unreplacedIds.length) {
-        const unreplacedStr = unreplacedIds.map((id) => `\n- ${id}`).join('')
-        this.warn(
-          `${chunk.fileName} contains confusing identifier names${unreplacedStr}`,
-        )
-        process.exitCode = 1
-      }
-
-      // Clean unnecessary comments
-      code = code
-        .replace(singlelineCommentsRE, '')
-        .replace(multilineCommentsRE, (m) => {
-          return licenseCommentsRE.test(m) ? '' : m
-        })
-        .replace(consecutiveNewlinesRE, '\n\n')
-
+      validateChunkImports.call(this, chunk)
+      code = replaceConfusingTypeNames.call(this, code, chunk)
+      code = cleanUnnecessaryComments(code)
       return code
     },
   }
+}
+
+/**
+ * Validate that chunk imports do not import dev deps
+ */
+function validateChunkImports(this: PluginContext, chunk: RenderedChunk) {
+  const deps = Object.keys(pkg.dependencies)
+  for (const id of chunk.imports) {
+    if (
+      !id.startsWith('./') &&
+      !id.startsWith('../') &&
+      !id.startsWith('node:') &&
+      !deps.includes(id) &&
+      !deps.some((name) => id.startsWith(name + '/'))
+    ) {
+      // If validation failed, only warn and set exit code 1 so that files
+      // are written to disk for inspection, but the build will fail
+      this.warn(`${chunk.fileName} imports "${id}" which is not allowed`)
+      process.exitCode = 1
+    }
+  }
+}
+
+/**
+ * Rollup deduplicate type names with a trailing `$1` or `$2`, which can be
+ * confusing when showed in autocompletions. Try to replace with a better name
+ */
+function replaceConfusingTypeNames(
+  this: PluginContext,
+  code: string,
+  chunk: RenderedChunk,
+) {
+  const imports = findStaticImports(code)
+
+  for (const modName in identifierReplacements) {
+    const imp = imports.find(
+      (imp) => imp.specifier === modName && imp.imports.includes('{'),
+    )
+    // Validate that `identifierReplacements` is not outdated if there's no match
+    if (!imp) {
+      this.warn(
+        `${chunk.fileName} does not import "${modName}" for replacement`,
+      )
+      process.exitCode = 1
+      continue
+    }
+
+    const replacements = identifierReplacements[modName]
+    for (const id in replacements) {
+      // Validate that `identifierReplacements` is not outdated if there's no match
+      if (!imp.imports.includes(id)) {
+        this.warn(
+          `${chunk.fileName} does not import "${id}" from "${modName}" for replacement`,
+        )
+        process.exitCode = 1
+        continue
+      }
+
+      const betterId = replacements[id]
+      const regexEscapedId = escapeRegex(id)
+      // If the better id accesses a namespace, the existing `Foo as Foo$1`
+      // named import cannot be replaced with `Foo as Namespace.Foo`, so we
+      // pre-emptively remove the whole named import
+      if (betterId.includes('.')) {
+        code = code.replace(
+          new RegExp(`\\b\\w+\\b as ${regexEscapedId},?\\s?`),
+          '',
+        )
+      }
+      code = code.replace(new RegExp(`\\b${regexEscapedId}\\b`, 'g'), betterId)
+    }
+  }
+
+  const unreplacedIds = unique(
+    Array.from(code.matchAll(identifierWithTrailingDollarRE), (m) => m[0]),
+  )
+  if (unreplacedIds.length) {
+    const unreplacedStr = unreplacedIds.map((id) => `\n- ${id}`).join('')
+    this.warn(
+      `${chunk.fileName} contains confusing identifier names${unreplacedStr}`,
+    )
+    process.exitCode = 1
+  }
+
+  return code
+}
+
+function cleanUnnecessaryComments(code: string) {
+  return code
+    .replace(singlelineCommentsRE, '')
+    .replace(multilineCommentsRE, (m) => {
+      return licenseCommentsRE.test(m) ? '' : m
+    })
+    .replace(consecutiveNewlinesRE, '\n\n')
 }
 
 const escapeRegexRE = /[-/\\^$*+?.()|[\]{}]/g

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -152,7 +152,9 @@ export class ModuleGraph {
     seen: Set<ModuleNode> = new Set(),
     timestamp: number = Date.now(),
     isHmr: boolean = false,
+    /** @internal */
     hmrBoundaries: ModuleNode[] = [],
+    /** @internal */
     softInvalidate = false,
   ): void {
     const prevInvalidationState = mod.invalidationState
@@ -249,6 +251,7 @@ export class ModuleGraph {
     acceptedExports: Set<string> | null,
     isSelfAccepting: boolean,
     ssr?: boolean,
+    /** @internal */
     staticImportedUrls?: Set<string>,
   ): Promise<Set<ModuleNode> | undefined> {
     mod.isSelfAccepting = isSelfAccepting

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@ampproject/remapping':
         specifier: ^2.2.1
         version: 2.2.1
+      '@babel/parser':
+        specifier: ^7.23.0
+        version: 7.23.0
       '@jridgewell/trace-mapping':
         specifier: ^0.3.20
         version: 0.3.20


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

There's some function parameters in `moduleGraph` currently that's bugging me that it's exposed. I updated `rollup.dts.config.ts` to handle `@internal` again.

I made two commits:

1. Split each dts `renderChunk` step as its own function.
2. Create new strip internal flow/function.

It's easier to review if you ignore the whitespace changes.

### Additional context

The added `@internal`s are related to soft-invalidation which I don't expect users to manually handle. I also feel like we could handle soft invalidations differently in the future.

The `hmrBoundaries` was marked internal as it's only used to fix an edgecase (https://github.com/vitejs/vite/issues/3033). It's not expected for users to pass this in general. And I also feel like it can be fixed in a different way in the future.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

