### PR TITLE
fix: file link in overlay with custom backend

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -221,7 +221,12 @@ export class ErrorOverlay extends HTMLElement {
           link.textContent = file
           link.className = 'file-link'
           link.onclick = () => {
-            fetch(`${base}__open-in-editor?file=` + encodeURIComponent(file))
+            fetch(
+              new URL(
+                `${base}__open-in-editor?file=${encodeURIComponent(file)}`,
+                import.meta.url,
+              ),
+            )
           }
           el.appendChild(link)
           curIndex += frag.length + file.length


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Vite server listens on the same host with the client script. `import` uses `import.meta.url` as the base, but `fetch` uses `location.href` as the base. So in this case, we need to explicitly resolve the URL on `import.meta.url`.

fixes #13770

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
