### PR TITLE
test: avoid read check when running as root

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -243,8 +243,10 @@ describe('isFileReadable', () => {
       expect(isFileReadable(testFile)).toBe(true)
     })
     test('file without read permission', async () => {
-      fs.chmodSync(testFile, '044')
-      expect(isFileReadable(testFile)).toBe(false)
+      if (process.getuid && process.getuid() !== 0) {
+        fs.chmodSync(testFile, '044')
+        expect(isFileReadable(testFile)).toBe(false)
+      }
       fs.chmodSync(testFile, '644')
     })
   }

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -242,13 +242,14 @@ describe('isFileReadable', () => {
       fs.chmodSync(testFile, '400')
       expect(isFileReadable(testFile)).toBe(true)
     })
-    test('file without read permission', async () => {
-      if (process.getuid && process.getuid() !== 0) {
+    test.runIf(process.getuid && process.getuid() !== 0)(
+      'file without read permission',
+      async () => {
         fs.chmodSync(testFile, '044')
         expect(isFileReadable(testFile)).toBe(false)
-      }
-      fs.chmodSync(testFile, '644')
-    })
+        fs.chmodSync(testFile, '644')
+      },
+    )
   }
 })
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When I clone the repository with `root` and `run test`, I find that I get an error

![Snipaste_2023-11-06_10-23-19](https://github.com/vitejs/vite/assets/57977288/5fe56ba9-c60e-4042-952f-b89211bf1016)

I learned that root always has permission to read a file, so I thought I'd add an `if statement` before this test



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
