### PR TITLE
perf: simple regex

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -70,8 +70,8 @@ function parseDynamicImportPattern(
     return null
   }
 
-  const [userPattern] = userPatternQuery.split(requestQuerySplitRE, 2)
-  const [rawPattern] = filename.split(requestQuerySplitRE, 2)
+  const userPattern = userPatternQuery.replace(requestQuerySplitRE, '')
+  const rawPattern = filename.replace(requestQuerySplitRE, '')
 
   const as = (['worker', 'url', 'raw'] as const).find(
     (key) => rawQuery && key in rawQuery,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -155,7 +155,7 @@ export function isOptimizable(
   )
 }
 
-export const bareImportRE = /^(?![a-zA-Z]:)[\w@](?!.*:\/\/)/
+export const bareImportRE = /^[\w@][^:]/
 export const deepImportRE = /^([^@][^/]*)\/|^(@[^/]+\/[^/]+)\//
 
 // TODO: use import()
@@ -991,10 +991,10 @@ export function arraify<T>(target: T | T[]): T[] {
 // Taken from https://stackoverflow.com/a/36328890
 export const multilineCommentsRE = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g
 export const singlelineCommentsRE = /\/\/.*/g
-export const requestQuerySplitRE = /\?(?!.*[/|}])/
+export const requestQuerySplitRE = /\?[^/|}]*$/
 
 export function parseRequest(id: string): Record<string, string> | null {
-  const [_, search] = id.split(requestQuerySplitRE, 2)
+  const search = requestQuerySplitRE.exec(id)?.[0]
   if (!search) {
     return null
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Some regex can be replaced with simpler forms.

For `requestQuerySplitRe`:

- query doesn't include `/`, `|` and `}` after `?`.

For `bareImportRE`:

- package name starts with `@` or `\w`
- relative path doesn't start with `\w`
- absolute will start with `\w:`

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/vitejs/vite/blob/main/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
