### PR TITLE
fix(build): mixed external and transpiled srcset 

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -388,7 +388,13 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             !namedOutput.includes(url) && // Direct reference to named output
             !namedOutput.includes(removeLeadingSlash(url)) // Allow for absolute references as named output can't be an absolute path
           ) {
-            return await urlToBuiltUrl(url, id, config, this)
+            try {
+              return await urlToBuiltUrl(url, id, config, this)
+            } catch (e) {
+              if (e.code !== 'ENOENT') {
+                throw e
+              }
+            }
           }
           return url
         }
@@ -587,13 +593,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           )
         }
 
-        try {
-          await Promise.all(assetUrlsPromises)
-        } catch (e) {
-          if (e.code !== 'ENOENT') {
-            throw e
-          }
-        }
+        await Promise.all(assetUrlsPromises)
 
         // emit <script>import("./aaa")</script> asset
         for (const { start, end, url } of scriptUrls) {

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -284,8 +284,7 @@ describe('image', () => {
     })
   })
 
-  // TODO: fix build
-  test.runIf(!isBuild)('srcset (mixed)', async () => {
+  test('srcset (mixed)', async () => {
     const img = await page.$('.img-src-set-mixed')
     const srcset = await img.getAttribute('srcset')
     const srcs = srcset.split(', ')


### PR DESCRIPTION
### Description

The two commits could be merged separately.

Follow up to https://github.com/vitejs/vite/pull/14870, fixing the commented-out test during build added in the PR.

The first commit is a refactor to avoid some "is public" checks and avoid confusion with `isExcluded`, as public urls are transpiled.

The second commit is the fix. The URLs are overwritten in parallel after these changes, and they are only replaced if the decoded URL is different from the processed URL. Before it was always replaced, so we were changing encoded URLs to decoded ones even if no transpilation is needed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other