### PR TITLE
fix: resovedUrls is null after server restart

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -408,9 +408,6 @@ export async function _createServer(
     ws,
     moduleGraph,
     resolvedUrls: null, // will be set on listen
-    _setInternalServer(_server: ViteDevServer) {
-      server = _server
-    },
     ssrTransform(
       code: string,
       inMap: SourceMap | { mappings: '' } | null,
@@ -581,6 +578,11 @@ export async function _createServer(
       return server._restartPromise
     },
 
+    _setInternalServer(_server: ViteDevServer) {
+      // Rebind internal the server variable so functions reference the user
+      // server instance after a restart
+      server = _server
+    },
     _restartPromise: null,
     _importGlobMap: new Map(),
     _forceOptimizeOnRestart: false,

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -58,19 +58,29 @@ interface InlineStyleAttribute {
 }
 
 export function createDevHtmlTransformFn(
+  config: ResolvedConfig,
+): (
   server: ViteDevServer,
-): (url: string, html: string, originalUrl: string) => Promise<string> {
+  url: string,
+  html: string,
+  originalUrl?: string,
+) => Promise<string> {
   const [preHooks, normalHooks, postHooks] = resolveHtmlTransforms(
-    server.config.plugins,
-    server.config.logger,
+    config.plugins,
+    config.logger,
   )
-  return (url: string, html: string, originalUrl: string): Promise<string> => {
+  return (
+    server: ViteDevServer,
+    url: string,
+    html: string,
+    originalUrl?: string,
+  ): Promise<string> => {
     return applyHtmlTransforms(
       html,
       [
-        preImportMapHook(server.config),
+        preImportMapHook(config),
         ...preHooks,
-        htmlEnvHook(server.config),
+        htmlEnvHook(config),
         devHtmlHook,
         ...normalHooks,
         ...postHooks,

--- a/playground/cli/__tests__/cli.spec.ts
+++ b/playground/cli/__tests__/cli.spec.ts
@@ -23,10 +23,15 @@ test('cli should work', async () => {
 test('should restart', async () => {
   editFile('./vite.config.js', (content) => content)
   await withRetry(async () => {
-    expect(streams.server.out).toEqual(
+    const logs = streams.server.out.slice(2)
+    expect(logs).toEqual(
       expect.arrayContaining([expect.stringMatching('server restarted')]),
     )
-    expect(streams.server.out).not.toEqual(
+    // Don't reprint the server URLs as they are the same
+    expect(logs).not.toEqual(
+      expect.arrayContaining([expect.stringMatching('http://localhost')]),
+    )
+    expect(logs).not.toEqual(
       expect.arrayContaining([expect.stringMatching('error')]),
     )
   })


### PR DESCRIPTION
### Description

Fixes a regression introduced by:
- https://github.com/vitejs/vite/pull/8746

To reproduce, start a dev server, change the config, and see that server URLs are re-printed even if they haven't changed. This was reported at https://github.com/vitejs/vite/pull/14418#discussion_r1383397916

`newServer.resolvedUrls` was used [here](https://github.com/vitejs/vite/pull/8746/files#diff-abb3345b6e3b2ec6d297c2ebc54cca85ae4487a31bac3cc9e78457f5114adb26L906), but after the PR it was changed to `server.resolvedUrls` [here](https://github.com/vitejs/vite/pull/8746/files#diff-abb3345b6e3b2ec6d297c2ebc54cca85ae4487a31bac3cc9e78457f5114adb26R934).

The problem is that when restarting, we keep the prev server instance and replace its guts with the new server [here](https://github.com/vitejs/vite/blob/fc24b07ac181a7728df006a1a6c8f6598961dc37/packages/vite/src/node/server/index.ts#L920
)
```js
  // Assign new server props to existing server instance
  Object.assign(server, newServer)
```
The `newServer` functions still refer internally to the new instance. In [the `listen` function](https://github.com/vitejs/vite/blob/fc24b07ac181a7728df006a1a6c8f6598961dc37/packages/vite/src/node/server/index.ts#L459C8-L459C8), we do
```js
server.resolvedUrls = ...
```
This happens after the `Object.assign` so it only gets set in `newServer`.

This PR fixes the issue with a new internal function to swap the internal `server` variable in the new server so functions start to refer to it.

An alternative could be to use `this` on functions. It will mean that server functions are no longer binded. I think this could be ok as we don't document this anywhere, but it is a big change.

This PR may fix other issues, for example, at `close` we were setting `resolvedUrls` to `null`, this never affected the proper server after a restart. There could be other similar cases for other server properties.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other