### PR TITLE
fix: serve static and public middlewares after restart

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -711,9 +711,7 @@ export async function _createServer(
   // this applies before the transform middleware so that these files are served
   // as-is without transforms.
   if (config.publicDir) {
-    middlewares.use(
-      servePublicMiddleware(config.publicDir, config.server.headers),
-    )
+    middlewares.use(servePublicMiddleware(server))
   }
 
   // main transform middleware
@@ -721,7 +719,7 @@ export async function _createServer(
 
   // serve static files
   middlewares.use(serveRawFsMiddleware(server))
-  middlewares.use(serveStaticMiddleware(root, server))
+  middlewares.use(serveStaticMiddleware(server))
 
   // html fallback
   if (config.appType === 'spa' || config.appType === 'mpa') {


### PR DESCRIPTION
### Description

Follow up to https://github.com/vitejs/vite/pull/14892, for the serve static and public middlewares. In middleware mode, after a restart, `headers`, `root`, and `publicDir` were not respected. It seems we need to create all the middlewares passing the server instance instead.

I see other middlewares with the same issue, we can tackle that in a separate PR.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other