### PR TITLE
docs: clarify origin part of `base` is not used in dev

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -13,11 +13,12 @@ See [Project Root](/guide/#index-html-and-project-root) for more details.
 
 - **Type:** `string`
 - **Default:** `/`
+- **Related:** [`server.origin`](/config/server-options.md#server-origin)
 
 Base public path when served in development or production. Valid values include:
 
 - Absolute URL pathname, e.g. `/foo/`
-- Full URL, e.g. `https://foo.com/`
+- Full URL, e.g. `https://foo.com/` (The origin part won't be used in development)
 - Empty string or `./` (for embedded deployment)
 
 See [Public Base Path](/guide/build#public-base-path) for more details.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Clarify that origin part of the `base` option is not used in dev. Also add a link to `server.origin` for those that want to change the origin part.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
