### PR TITLE
revert: remove AsyncDisposable

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -152,6 +152,3 @@ export const wildcardHosts = new Set([
 export const DEFAULT_DEV_PORT = 5173
 
 export const DEFAULT_PREVIEW_PORT = 4173
-
-export const ASYNC_DISPOSE: typeof Symbol.asyncDispose =
-  Symbol.asyncDispose || Symbol.for('Symbol.asyncDispose')

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -48,7 +48,7 @@ export type ExportsData = {
   jsxLoader?: boolean
 }
 
-export interface DepsOptimizer extends AsyncDisposable {
+export interface DepsOptimizer {
   metadata: DepOptimizationMetadata
   scanProcessing?: Promise<void>
   registerMissingImport: (id: string, resolved: string) => OptimizedDepInfo

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -2,7 +2,6 @@ import colors from 'picocolors'
 import { createDebugger, getHash } from '../utils'
 import { getDepOptimizationConfig } from '../config'
 import type { ResolvedConfig, ViteDevServer } from '..'
-import { ASYNC_DISPOSE } from '../constants'
 import {
   addManuallyIncludedOptimizeDeps,
   addOptimizedDepInfo,
@@ -120,9 +119,6 @@ async function createDepsOptimizer(
     resetRegisteredIds,
     ensureFirstRun,
     close,
-    [ASYNC_DISPOSE]() {
-      return this.close()
-    },
     options: getDepOptimizationConfig(config, ssr),
   }
 
@@ -836,7 +832,6 @@ async function createDevSsrDepsOptimizer(
     ensureFirstRun: () => {},
 
     close: async () => {},
-    [ASYNC_DISPOSE]: async () => {},
     options: config.ssr.optimizeDeps,
   }
   devSsrDepsOptimizerMap.set(config, depsOptimizer)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -15,7 +15,6 @@ import type { SourceMap } from 'rollup'
 import picomatch from 'picomatch'
 import type { Matcher } from 'picomatch'
 import type { InvalidatePayload } from 'types/customEvent'
-import { ASYNC_DISPOSE, CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,
@@ -45,6 +44,7 @@ import {
 } from '../optimizer'
 import { bindCLIShortcuts } from '../shortcuts'
 import type { BindCLIShortcutsOptions } from '../shortcuts'
+import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
 import { createNoopWatcher, resolveChokidarOptions } from '../watch'
@@ -185,7 +185,7 @@ export type ServerHook = (
 
 export type HttpServer = http.Server | Http2SecureServer
 
-export interface ViteDevServer extends AsyncDisposable {
+export interface ViteDevServer {
   /**
    * The resolved vite config object
    */
@@ -553,9 +553,6 @@ export async function _createServer(
         )
       }
       server.resolvedUrls = null
-    },
-    [ASYNC_DISPOSE]() {
-      return this.close()
     },
     printUrls() {
       if (server.resolvedUrls) {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -64,7 +64,6 @@ import type { FSWatcher } from 'chokidar'
 import colors from 'picocolors'
 import type * as postcss from 'postcss'
 import type { Plugin } from '../plugin'
-import { ASYNC_DISPOSE, FS_PREFIX } from '../constants'
 import {
   cleanUrl,
   combineSourcemaps,
@@ -79,6 +78,7 @@ import {
   timeFrom,
   unwrapId,
 } from '../utils'
+import { FS_PREFIX } from '../constants'
 import type { ResolvedConfig } from '../config'
 import { createPluginHookUtils, getHookHandler } from '../plugins'
 import { buildErrorMessage } from './middlewares/error'
@@ -105,7 +105,7 @@ export interface PluginContainerOptions {
   writeFile?: (name: string, source: string | Uint8Array) => void
 }
 
-export interface PluginContainer extends AsyncDisposable {
+export interface PluginContainer {
   options: InputOptions
   getModuleInfo(id: string): ModuleInfo | null
   buildStart(options: InputOptions): Promise<void>
@@ -798,9 +798,6 @@ export async function createPluginContainer(
         () => ctx,
         () => [],
       )
-    },
-    [ASYNC_DISPOSE]() {
-      return this.close()
     },
   }
 

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -11,7 +11,6 @@ import { WebSocketServer as WebSocketServerRaw_ } from 'ws'
 import type { WebSocket as WebSocketTypes } from 'dep-types/ws'
 import type { CustomPayload, ErrorPayload, HMRPayload } from 'types/hmrPayload'
 import type { InferCustomEventPayload } from 'types/customEvent'
-import { ASYNC_DISPOSE } from '../constants'
 import type { ResolvedConfig } from '..'
 import { isObject } from '../utils'
 import type { HttpServer } from '.'
@@ -31,7 +30,7 @@ export type WebSocketCustomListener<T> = (
   client: WebSocketClient,
 ) => void
 
-export interface WebSocketServer extends AsyncDisposable {
+export interface WebSocketServer {
   /**
    * Listen on port and host
    */
@@ -309,9 +308,6 @@ export function createWebSocketServer(
           }
         })
       })
-    },
-    [ASYNC_DISPOSE]() {
-      return this.close()
     },
   }
 }


### PR DESCRIPTION
This reverts commit 385d580a7df67570b8014318a607f62fe15eaef9. #14648

<!-- Thank you for contributing! -->

### Description

I've been fixing the SvelteKit ecosystem ci issue, the AsyncDisposable type only exists in `compilerOptions.target: "ESNext"` or `@types/node@18.18.x`.

The issue is that not all libraries are using `esnext` and `node18` types (e.g. dual vite 4 and 5 support). Plus our types declare the `@types/node` range to be `^18.0.0`.

Reverts the commit for now.