### PR TITLE
fix: injectQuery check with double slash in the url

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -75,7 +75,13 @@ const hasImportInQueryParamsRE = /[?&]import=?\b/
 
 export const hasViteIgnoreRE = /\/\*\s*@vite-ignore\s*\*\//
 
-const cleanedUpRawUrlRE = /^(\s*)(\S|\S[\s\S]*\S)\s*$/
+const trimWhitespaceRE = /^(\s*)(\S|\S[\s\S]*\S)\s*$/
+const trimWhitespaceAndComments = (code: string) => {
+  const cleanedCode = stripLiteral(code)
+  const match = trimWhitespaceRE.exec(cleanedCode)
+  return match ? code.slice(match[1].length, match[2].length) : code
+}
+
 const urlIsStringRE = /^(?:'.*'|".*"|`.*`)$/
 
 const templateLiteralRE = /^\s*`(.*)`\s*$/
@@ -651,12 +657,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
 
             if (!ssr) {
-              // Remove comments and trim whitespace
-              const cleanedUrl = stripLiteral(rawUrl)
-              const match = cleanedUpRawUrlRE.exec(cleanedUrl)
-              const url = match
-                ? rawUrl.slice(match[1].length, match[2].length)
-                : rawUrl
+              const url = trimWhitespaceAndComments(rawUrl)
               if (
                 !urlIsStringRE.test(url) ||
                 isExplicitImportRequired(url.slice(1, -1))

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -83,6 +83,14 @@ test('should load dynamic import with vars ignored', async () => {
   ).toBe(false)
 })
 
+test('should load dynamic import with double slash ignored', async () => {
+  await untilUpdated(
+    () => page.textContent('.dynamic-import-with-double-slash-ignored'),
+    'hello',
+    true,
+  )
+})
+
 test('should load dynamic import with vars multiline', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-multiline'),

--- a/playground/dynamic-import/index.html
+++ b/playground/dynamic-import/index.html
@@ -16,6 +16,9 @@
 <p>dynamic-import-with-vars-ignored</p>
 <div class="dynamic-import-with-vars-ignored">todo</div>
 
+<p>dynamic-import-with-double-slash-ignored</p>
+<div class="dynamic-import-with-double-slash-ignored">todo</div>
+
 <p>dynamic-import-with-vars-multiline</p>
 <div class="dynamic-import-with-vars-multiline">todo</div>
 

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -89,6 +89,11 @@ import(/*@vite-ignore*/ `https://localhost`).catch((mod) => {
   text('.dynamic-import-with-vars-ignored', 'hello')
 })
 
+import(/*@vite-ignore*/ `https://localhost//${'test'}`).catch((mod) => {
+  console.log(mod)
+  text('.dynamic-import-with-double-slash-ignored', 'hello')
+})
+
 // prettier-ignore
 import(
   /* this messes with */


### PR DESCRIPTION
Fixes #5051

### Description

The currently used regex will fail if there is a double slash in the URL

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other