### PR TITLE
docs(ssr): properly handle vite.middlewares after restart

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -249,7 +249,9 @@ async function createServer() {
     appType: 'custom', // don't include Vite's default HTML handling middlewares
   })
   // Use vite's connect instance as middleware
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res) => {
     // Since `appType` is `'custom'`, should serve response here.

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -90,10 +90,10 @@ async function createServer() {
   // Use vite's connect instance as middleware. If you use your own
   // express router (express.Router()), you should use router.use
   app.use((req, res, next) => {
-    // Once the server restarts (for example after the user modifies
-    // vite.config.js), vite.middlewares is reasigned. Using vite's
-    // connect instance inside a wrapper handlers ensures the updated
-    // version of Vite middlewares are always used.
+    // When the server restarts (for example after the user modifies
+    // vite.config.js), `vite.middlewares` will be reassigned. Calling
+    // `vite.middlewares` inside a wrapper handler ensures that the
+    // latest Vite middlewares are always used.
     vite.middlewares.handle(req, res, next)
   })
 

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -89,7 +89,13 @@ async function createServer() {
 
   // Use vite's connect instance as middleware. If you use your own
   // express router (express.Router()), you should use router.use
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    // Once the server restarts (for example after the user modifies
+    // vite.config.js), vite.middlewares is reasigned. Using vite's
+    // connect instance inside a wrapper handlers ensures the updated
+    // version of Vite middlewares are always used.
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res) => {
     // serve index.html - we will tackle this next

--- a/playground/css-lightningcss-proxy/server.js
+++ b/playground/css-lightningcss-proxy/server.js
@@ -45,7 +45,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
     appType: 'custom',
   })
   // use vite's connect instance as middleware
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res, next) => {
     try {

--- a/playground/json/server.js
+++ b/playground/json/server.js
@@ -37,7 +37,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
     },
   })
   // use vite's connect instance as middleware
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res) => {
     try {

--- a/playground/optimize-missing-deps/server.js
+++ b/playground/optimize-missing-deps/server.js
@@ -26,7 +26,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
     },
     appType: 'custom',
   })
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res) => {
     try {

--- a/playground/ssr-conditions/server.js
+++ b/playground/ssr-conditions/server.js
@@ -35,7 +35,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
     appType: 'custom',
   })
 
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res) => {
     try {

--- a/playground/ssr-deps/server.js
+++ b/playground/ssr-deps/server.js
@@ -84,7 +84,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
     ],
   })
   // use vite's connect instance as middleware
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res) => {
     try {

--- a/playground/ssr-html/server.js
+++ b/playground/ssr-html/server.js
@@ -66,7 +66,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
     ],
   })
   // use vite's connect instance as middleware
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res, next) => {
     try {

--- a/playground/ssr-noexternal/server.js
+++ b/playground/ssr-noexternal/server.js
@@ -44,7 +44,9 @@ export async function createServer(
       },
       appType: 'custom',
     })
-    app.use(vite.middlewares)
+    app.use((req, res, next) => {
+      vite.middlewares.handle(req, res, next)
+    })
   }
 
   app.use('*', async (req, res) => {

--- a/playground/ssr-pug/server.js
+++ b/playground/ssr-pug/server.js
@@ -45,7 +45,9 @@ export async function createServer(root = process.cwd(), hmrPort) {
     appType: 'custom',
   })
   // use vite's connect instance as middleware
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res) => {
     try {

--- a/playground/ssr/server.js
+++ b/playground/ssr/server.js
@@ -39,7 +39,9 @@ export async function createServer(
     customLogger,
   })
   // use vite's connect instance as middleware
-  app.use(vite.middlewares)
+  app.use((req, res, next) => {
+    vite.middlewares.handle(req, res, next)
+  })
 
   app.use('*', async (req, res, next) => {
     try {


### PR DESCRIPTION
### Description

See:
- https://github.com/vitejs/vite/pull/14892
- https://github.com/vitejs/vite/pull/14905

`vite.middlewares` is updated after a restart in `middlewareMode: true`. We need to recommend an indirection so users always get the latest middlewares, as proposed by @bluwy [here](https://discord.com/channels/804011606160703521/804439875226173480/1171848899821043722)

We could try to make `vite.middlewares` more magical and avoid reassigning in the future, but it isn't bad either that users know the middlewares change after a restart explicitly.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
