### PR TITLE
fix(worker): prevent inject esm in classic workers

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,5 +8,4 @@ pnpm-workspace.yaml
 playground/tsconfig-json-load-error/has-error/tsconfig.json
 playground/html/invalid.html
 playground/html/valid.html
-playground/worker/classic-worker.js
 playground/external/public/slash@3.0.0.js

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -642,7 +642,7 @@ export function injectQuery(url: string, queryToInject: string): string {
   }
 
   // can't use pathname from URL since it may be relative like ../
-  const pathname = url.replace(/#.*$/, '').replace(/\?.*$/, '')
+  const pathname = url.replace(/[?#].*$/s, '')
   const { search, hash } = new URL(url, 'http://vitejs.dev')
 
   return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${

--- a/playground/worker/__tests__/es/es-worker.spec.ts
+++ b/playground/worker/__tests__/es/es-worker.spec.ts
@@ -174,6 +174,10 @@ test('classic worker', async () => {
     true,
   )
   await untilUpdated(
+    () => page.textContent('.classic-worker-import'),
+    '[success] classic-esm',
+  )
+  await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',
     true,

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -137,6 +137,10 @@ test('module worker', async () => {
 test('classic worker', async () => {
   await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
   await untilUpdated(
+    () => page.textContent('.classic-worker-import'),
+    '[success] classic-esm',
+  )
+  await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',
   )

--- a/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
+++ b/playground/worker/__tests__/relative-base/relative-base-worker.spec.ts
@@ -123,6 +123,10 @@ test.runIf(isBuild)('classic worker', async () => {
     true,
   )
   await untilUpdated(
+    () => page.textContent('.classic-worker-import'),
+    '[success] classic-esm',
+  )
+  await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',
     true,

--- a/playground/worker/classic-esm.js
+++ b/playground/worker/classic-esm.js
@@ -1,0 +1,1 @@
+export const msg = '[success] classic-esm'

--- a/playground/worker/classic-worker.js
+++ b/playground/worker/classic-worker.js
@@ -3,9 +3,29 @@ if (base.endsWith('.js') || base === `/worker-entries`) base = '' // for dev
 
 importScripts(`${base}/classic.js`)
 
-self.addEventListener('message', () => {
-  self.postMessage(self.constant)
+self.addEventListener('message', async (e) => {
+  switch (e.data) {
+    case 'ping': {
+      self.postMessage({
+        message: e.data,
+        result: self.constant,
+      })
+      break
+    }
+    case 'test-import': {
+      // Vite may inject imports to handle this dynamic import, make sure
+      // it still works in classic workers.
+      // NOTE: this test only works in dev.
+      const importPath = `${base}/classic-esm.js`
+      const { msg } = await import(/* @vite-ignore */ importPath)
+      self.postMessage({
+        message: e.data,
+        result: msg,
+      })
+      break
+    }
+  }
 })
 
 // for sourcemap
-console.log("classic-worker.js")
+console.log('classic-worker.js')

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -125,6 +125,7 @@
   <span class="classname">.classic-worker</span>
 </p>
 <code class="classic-worker"></code>
+<code class="classic-worker-import"></code>
 
 <p>
   new SharedWorker(new URL('./classic-shared-worker.js', import.meta.url), {

--- a/playground/worker/worker/main-classic.js
+++ b/playground/worker/worker/main-classic.js
@@ -12,9 +12,19 @@ let classicWorker = new Worker(
 classicWorker = new Worker(new URL('../classic-worker.js', import.meta.url))
 
 classicWorker.addEventListener('message', ({ data }) => {
-  text('.classic-worker', JSON.stringify(data))
+  switch (data.message) {
+    case 'ping': {
+      text('.classic-worker', data.result)
+      break
+    }
+    case 'test-import': {
+      text('.classic-worker-import', data.result)
+      break
+    }
+  }
 })
 classicWorker.postMessage('ping')
+classicWorker.postMessage('test-import')
 
 // prettier-ignore
 // test trailing comma


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/11266
supersedes https://github.com/vitejs/vite/pull/12995

`importAnalysis` could run on classic worker code, which I think is the only non-ESM code we allow to be processed (?). This PR checks for classic workers and avoid adding top-level imports.

This should also fix the confusing errors from https://github.com/vitejs/vite/issues/5396 (does not fix the issue)

### Additional context

The fix isn't really clean. I can't think of a way to inline `__vite__injectQuery` without a significant refactoring.

The test is also subpar but it somewhat works 😬 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
