### PR TITLE
feat: skip initial clear screen if has logs

### DIFF
--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -27,7 +27,6 @@ asyncFunctions.forEach((name) => {
 
 function warnCjsUsage() {
   if (process.env.VITE_CJS_IGNORE_WARNING) return
-  globalThis.__vite_cjs_skip_clear_screen = true
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
   const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
   log(

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -180,15 +180,15 @@ cli
             )} ms`,
           )
         : ''
+      const hasExistingLogs =
+        process.stdout.bytesWritten > 0 || process.stderr.bytesWritten > 0
 
       info(
         `\n  ${colors.green(
           `${colors.bold('VITE')} v${VERSION}`,
         )}  ${startupDurationString}\n`,
         {
-          clear:
-            !server.config.logger.hasWarned &&
-            !(globalThis as any).__vite_cjs_skip_clear_screen,
+          clear: !hasExistingLogs,
         },
       )
 


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/9378

Don't clear the initial startup if have existing logs. This makes `logger.hasWarned` no longer used, but we could probably remove that in the next major if it's no longer useful.



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
