### PR TITLE
refactor: update es-module-lexer to 1.4.0

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -106,7 +106,7 @@
     "dep-types": "link:./src/types",
     "dotenv": "^16.3.1",
     "dotenv-expand": "^10.0.0",
-    "es-module-lexer": "^1.3.1",
+    "es-module-lexer": "^1.4.0",
     "escape-html": "^1.0.3",
     "estree-walker": "^3.0.3",
     "etag": "^1.8.1",

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -12,7 +12,6 @@ import {
   createFilter,
   normalizePath,
   parseRequest,
-  removeComments,
   requestQuerySplitRE,
   transformStableResult,
 } from '../utils'
@@ -218,14 +217,8 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
         s ||= new MagicString(source)
         let result
         try {
-          // When import string is using backticks, es-module-lexer `end` captures
-          // until the closing parenthesis, instead of the closing backtick.
-          // There may be inline comments between the backtick and the closing
-          // parenthesis, so we manually remove them for now.
-          // See https://github.com/guybedford/es-module-lexer/issues/118
-          const importSource = removeComments(source.slice(start, end)).trim()
           result = await transformDynamicImport(
-            importSource,
+            source.slice(start, end),
             importer,
             resolve,
             config.root,

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -3,7 +3,11 @@ import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import colors from 'picocolors'
 import MagicString from 'magic-string'
-import type { ExportSpecifier, ImportSpecifier } from 'es-module-lexer'
+import type {
+  ParseError as EsModuleLexerParseError,
+  ExportSpecifier,
+  ImportSpecifier,
+} from 'es-module-lexer'
 import { init, parse as parseImports } from 'es-module-lexer'
 import { parse as parseJS } from 'acorn'
 import { stripLiteral } from 'strip-literal'
@@ -236,7 +240,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       source = stripBomTag(source)
       try {
         ;[imports, exports] = parseImports(source)
-      } catch (e: any) {
+      } catch (_e: unknown) {
+        const e = _e as EsModuleLexerParseError
         const { message, showCodeFrame } = createParseErrorInfo(
           importer,
           source,

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -10,7 +10,6 @@ import type {
 } from 'es-module-lexer'
 import { init, parse as parseImports } from 'es-module-lexer'
 import { parse as parseJS } from 'acorn'
-import { stripLiteral } from 'strip-literal'
 import type { Node } from 'estree'
 import { findStaticImports, parseStaticImport } from 'mlly'
 import { makeLegalIdentifier } from '@rollup/pluginutils'
@@ -79,13 +78,6 @@ const optimizedDepDynamicRE = /-[A-Z\d]{8}\.js/
 const hasImportInQueryParamsRE = /[?&]import=?\b/
 
 export const hasViteIgnoreRE = /\/\*\s*@vite-ignore\s*\*\//
-
-const trimWhitespaceRE = /^(\s*)(\S|\S[\s\S]*\S)\s*$/
-const trimWhitespaceAndComments = (code: string) => {
-  const cleanedCode = stripLiteral(code)
-  const match = trimWhitespaceRE.exec(cleanedCode)
-  return match ? code.slice(match[1].length, match[2].length) : code
-}
 
 const urlIsStringRE = /^(?:'.*'|".*"|`.*`)$/
 
@@ -663,13 +655,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
 
             if (!ssr) {
-              const url = trimWhitespaceAndComments(rawUrl)
               if (
-                !urlIsStringRE.test(url) ||
-                isExplicitImportRequired(url.slice(1, -1))
+                !urlIsStringRE.test(rawUrl) ||
+                isExplicitImportRequired(rawUrl.slice(1, -1))
               ) {
                 needQueryInjectHelper = true
-                // Use rawUrl to avoid removing comments like @vite-ignore
                 str().overwrite(
                   start,
                   end,

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -1,6 +1,9 @@
 import path from 'node:path'
 import MagicString from 'magic-string'
-import type { ImportSpecifier } from 'es-module-lexer'
+import type {
+  ParseError as EsModuleLexerParseError,
+  ImportSpecifier,
+} from 'es-module-lexer'
 import { init, parse as parseImports } from 'es-module-lexer'
 import type { OutputChunk, SourceMap } from 'rollup'
 import colors from 'picocolors'
@@ -222,7 +225,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       let imports: readonly ImportSpecifier[] = []
       try {
         imports = parseImports(source)[0]
-      } catch (e: any) {
+      } catch (_e: unknown) {
+        const e = _e as EsModuleLexerParseError
         const { message, showCodeFrame } = createParseErrorInfo(
           importer,
           source,

--- a/packages/vite/src/node/ssr/ssrManifestPlugin.ts
+++ b/packages/vite/src/node/ssr/ssrManifestPlugin.ts
@@ -1,6 +1,9 @@
 import { basename, dirname, join, relative } from 'node:path'
 import { parse as parseImports } from 'es-module-lexer'
-import type { ImportSpecifier } from 'es-module-lexer'
+import type {
+  ParseError as EsModuleLexerParseError,
+  ImportSpecifier,
+} from 'es-module-lexer'
 import type { OutputChunk } from 'rollup'
 import jsonStableStringify from 'json-stable-stringify'
 import type { ResolvedConfig } from '..'
@@ -46,7 +49,8 @@ export function ssrManifestPlugin(config: ResolvedConfig): Plugin {
             let imports: ImportSpecifier[] = []
             try {
               imports = parseImports(code)[0].filter((i) => i.n && i.d > -1)
-            } catch (e: any) {
+            } catch (_e: unknown) {
+              const e = _e as EsModuleLexerParseError
               const loc = numberToPos(code, e.idx)
               this.error({
                 name: e.name,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1034,10 +1034,6 @@ export function emptyCssComments(raw: string): string {
   return raw.replace(multilineCommentsRE, (s) => ' '.repeat(s.length))
 }
 
-export function removeComments(raw: string): string {
-  return raw.replace(multilineCommentsRE, '').replace(singlelineCommentsRE, '')
-}
-
 function backwardCompatibleWorkerPlugins(plugins: any) {
   if (Array.isArray(plugins)) {
     return plugins

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,8 +310,8 @@ importers:
         specifier: ^10.0.0
         version: 10.0.0(patch_hash=weuqf2vlv5b5g6cikeo4slurbm)
       es-module-lexer:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.4.0
+        version: 1.4.0
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -5532,8 +5532,8 @@ packages:
       which-typed-array: 1.1.11
     dev: true
 
-  /es-module-lexer@1.3.1:
-    resolution: {integrity: sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==}
+  /es-module-lexer@1.4.0:
+    resolution: {integrity: sha512-lcCr3v3OLezdfFyx9r5NRYHOUTQNnFEQ9E87Mx8Kc+iqyJNkO7MJoB4GQRTlIMw9kLLTwGw0OAkm4BQQud/d9g==}
     dev: true
 
   /es-set-tostringtag@2.0.1:


### PR DESCRIPTION
### Description
This PR updates es-module-lexer to 1.4.0 and removes a workaround introduced in #9314.
Also uses the newly introduced `ParseError` type instead of any.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
