### PR TITLE
fix: add watch in fallback file load

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -722,6 +722,9 @@ export async function createPluginContainer(
           return result
         }
       }
+
+      watchFiles.add(id)
+      if (watcher) ensureWatchedFile(watcher, id, root)
       return null
     },
 

--- a/playground/hmr-root/__tests__/hmr-root.spec.ts
+++ b/playground/hmr-root/__tests__/hmr-root.spec.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+
+import { editFile, isServe, page, untilUpdated } from '~utils'
+
+test.runIf(isServe)('should watch files outside root', async () => {
+  expect(await page.textContent('#foo')).toBe('foo')
+  editFile('foo.js', (code) => code.replace("'foo'", "'foobar'"))
+  await page.waitForEvent('load')
+  await untilUpdated(async () => await page.textContent('#foo'), 'foobar')
+})

--- a/playground/hmr-root/foo.js
+++ b/playground/hmr-root/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/playground/hmr-root/root/index.html
+++ b/playground/hmr-root/root/index.html
@@ -1,0 +1,7 @@
+<div id="foo"></div>
+
+<script type="module">
+  import { foo } from '../foo.js'
+
+  document.querySelector('#foo').textContent = foo
+</script>

--- a/playground/hmr-root/vite.config.ts
+++ b/playground/hmr-root/vite.config.ts
@@ -1,0 +1,9 @@
+import path from 'node:path'
+import url from 'node:url'
+import { defineConfig } from 'vite'
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  root: path.join(__dirname, './root'),
+})


### PR DESCRIPTION
### Description
Files that were loaded by the fallback file load were not added to watcher.

fixes #14927
refs #14508

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
