### PR TITLE
revert: build assets with the entry name when it is an entry point (#11578)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -609,12 +609,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           pureCssChunks.add(chunk)
         }
         if (opts.format === 'es' || opts.format === 'cjs') {
-          const isEntry = chunk.isEntry && isPureCssChunk
-          const cssAssetName = normalizePath(
-            !isEntry && chunk.facadeModuleId
-              ? path.relative(config.root, chunk.facadeModuleId)
-              : chunk.name,
-          )
+          const cssAssetName = chunk.facadeModuleId
+            ? normalizePath(path.relative(config.root, chunk.facadeModuleId))
+            : chunk.name
 
           const lang = path.extname(cssAssetName).slice(1)
           const cssFileName = ensureFileExt(cssAssetName, '.css')
@@ -644,6 +641,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             source: chunkCSS,
           })
           const originalName = isPreProcessor(lang) ? cssAssetName : cssFileName
+          const isEntry = chunk.isEntry && isPureCssChunk
           generatedAssets
             .get(config)!
             .set(referenceId, { originalName, isEntry })

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -37,7 +37,7 @@ describe.runIf(isBuild)('build', () => {
     const cssAssetEntry = manifest['global.css']
     const scssAssetEntry = manifest['nested/blue.scss']
     const imgAssetEntry = manifest['../images/logo.png']
-    const dirFooAssetEntry = manifest['../dynamic/foo.css'] // '\\' should not be used even on windows
+    const dirFooAssetEntry = manifest['../../dir/foo.css'] // '\\' should not be used even on windows
     expect(htmlEntry.css.length).toEqual(1)
     expect(htmlEntry.assets.length).toEqual(1)
     expect(cssAssetEntry?.file).not.toBeUndefined()
@@ -48,9 +48,6 @@ describe.runIf(isBuild)('build', () => {
     expect(imgAssetEntry?.file).not.toBeUndefined()
     expect(imgAssetEntry?.isEntry).toBeUndefined()
     expect(dirFooAssetEntry).not.toBeUndefined()
-    // use the entry name
-    expect(manifest['bar.css']).not.toBeUndefined()
-    expect(manifest['foo.css']).toBeUndefined()
   })
 })
 

--- a/playground/backend-integration/dir/foo.css
+++ b/playground/backend-integration/dir/foo.css
@@ -1,3 +1,3 @@
-.entry-name-foo {
+.windows-path-foo {
   color: blue;
 }

--- a/playground/backend-integration/frontend/dynamic/foo.css
+++ b/playground/backend-integration/frontend/dynamic/foo.css
@@ -1,3 +1,0 @@
-.windows-path-foo {
-  color: blue;
-}

--- a/playground/backend-integration/frontend/dynamic/foo.ts
+++ b/playground/backend-integration/frontend/dynamic/foo.ts
@@ -1,1 +1,0 @@
-import './foo.css'

--- a/playground/backend-integration/frontend/entrypoints/main.ts
+++ b/playground/backend-integration/frontend/entrypoints/main.ts
@@ -1,5 +1,4 @@
 import 'vite/modulepreload-polyfill'
-import('../dynamic/foo') // should be dynamic import to split chunks
 
 export const colorClass = 'text-black'
 

--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -19,7 +19,7 @@ function BackendIntegrationExample() {
         .map((filename) => [path.relative(root, filename), filename])
 
       entrypoints.push(['tailwindcss-colors', 'tailwindcss/colors.js'])
-      entrypoints.push(['bar.css', path.resolve(__dirname, './dir/foo.css')])
+      entrypoints.push(['foo.css', path.resolve(__dirname, './dir/foo.css')])
 
       return {
         build: {


### PR DESCRIPTION
Fixes #14943

This reverts commit fd9a2ccdf2e78616ff3c937538111dbe1586f537.

### Description

Given that we are close to the release and the PR will break several integrations, I think it is better to revert #11578 at this point and work with downstream projects with more time if we intend to change this.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other