### PR TITLE
fix: don't watch SPA fallback paths

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -722,9 +722,6 @@ export async function createPluginContainer(
           return result
         }
       }
-
-      watchFiles.add(id)
-      if (watcher) ensureWatchedFile(watcher, id, root)
       return null
     },
 

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -12,6 +12,7 @@ import {
   blankReplacer,
   cleanUrl,
   createDebugger,
+  ensureWatchedFile,
   injectQuery,
   isObject,
   prettifyUrl,
@@ -220,6 +221,7 @@ async function loadAndTransform(
           throw e
         }
       }
+      ensureWatchedFile(server.watcher, file, config.root)
     }
     if (code) {
       try {


### PR DESCRIPTION
### Description
This PR fixes the CI fail in https://github.com/vuejs/vitepress/pull/3200.
https://discord.com/channels/804011606160703521/831456449632534538/1172931790554546368

The reason why it was failing with `ELOOP: too many symbolic links encountered, stat '/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/gems/mechanize-2.9.1/mechanize-2.9.1'` since beta.17 is because

- #14938 added `ensureWatchedFile(watcher, id, root)` after no plugin's `load` hook handled that id
- `/home` was passed to that because accessing `/home` goes through the plugin pipeline (https://github.com/vitejs/vite/blob/b42a2282bc561cf3cfb34e2235446666e95e229c/packages/vite/src/node/server/transformRequest.ts#L201-L205)
- `ensureWatchedFile` has `fs.existsSync(file)`, but `/home` is `true` even though that is not a file

I moved the `ensureWatchedFile` after `if (options.html && !id.endsWith('.html'))`. Instead, I can move some code from `loadAndTransform` to the plugin container, but I think it's safer to avoid that.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
