### PR TITLE
fix(pluginContainer): run transform in this.load

### DIFF
--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -32,7 +32,7 @@ describe('plugin container', () => {
         },
         load(id) {
           if (id === entryUrl) {
-            const { meta } = this.getModuleInfo(entryUrl)
+            const { meta } = this.getModuleInfo(entryUrl) ?? {}
             metaArray.push(meta)
 
             return { code: 'export {}', meta: { x: 2 } }
@@ -40,14 +40,14 @@ describe('plugin container', () => {
         },
         transform(code, id) {
           if (id === entryUrl) {
-            const { meta } = this.getModuleInfo(entryUrl)
+            const { meta } = this.getModuleInfo(entryUrl) ?? {}
             metaArray.push(meta)
 
             return { meta: { x: 3 } }
           }
         },
         buildEnd() {
-          const { meta } = this.getModuleInfo(entryUrl)
+          const { meta } = this.getModuleInfo(entryUrl) ?? {}
           metaArray.push(meta)
         },
       }
@@ -84,7 +84,7 @@ describe('plugin container', () => {
         name: 'p2',
         load(id) {
           if (id === entryUrl) {
-            const { meta } = this.getModuleInfo(entryUrl)
+            const { meta } = this.getModuleInfo(entryUrl) ?? {}
             expect(meta).toEqual({ x: 1 })
             return null
           }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -333,7 +333,13 @@ export async function createPluginContainer(
       // but we can at least update the module info properties we support
       updateModuleInfo(options.id, options)
 
-      await container.load(options.id, { ssr: this.ssr })
+      const loadResult = await container.load(options.id, { ssr: this.ssr })
+      const code =
+        typeof loadResult === 'object' ? loadResult?.code : loadResult
+      if (code != null) {
+        await container.transform(code, options.id, { ssr: this.ssr })
+      }
+
       const moduleInfo = this.getModuleInfo(options.id)
       // This shouldn't happen due to calling ensureEntryFromUrl, but 1) our types can't ensure that
       // and 2) moduleGraph may not have been provided (though in the situations where that happens,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Rollup docs: https://rollupjs.org/plugin-development/#this-load

Follow-up from https://github.com/vitejs/vite/pull/11469

> * Further, `this.load` is supposed to trigger `transform` and `moduleParsed` - this does not (in accordance with vite's on-demand nature)

I think it still make sense to run the `transform` part. Vite's on-demand nature shouldn't affect plugin container's compatibility with Rollup as long as it makes sense in dev. We do `transform` in dev, but we don't do `moduleParsed`, but we should have the code to also support that if we want.

### Additional context

I spotted this while working with the Remix folks. It doesn't blocked them or me now, so this would be a nice to have.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
