### PR TITLE
fix: handle addWatchFile in load hooks

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -82,7 +82,7 @@ import { FS_PREFIX } from '../constants'
 import type { ResolvedConfig } from '../config'
 import { createPluginHookUtils, getHookHandler } from '../plugins'
 import { buildErrorMessage } from './middlewares/error'
-import type { ModuleGraph } from './moduleGraph'
+import type { ModuleGraph, ModuleNode } from './moduleGraph'
 
 const noop = () => {}
 
@@ -182,6 +182,11 @@ export async function createPluginContainer(
   // ---------------------------------------------------------------------------
 
   const watchFiles = new Set<string>()
+  // _addedFiles from the `load()` hook gets saved here so it can be reused in the `transform()` hook
+  const moduleNodeToLoadAddedImports = new WeakMap<
+    ModuleNode,
+    Set<string> | null
+  >()
 
   const minimalContext: MinimalPluginContext = {
     meta: {
@@ -270,6 +275,13 @@ export async function createPluginContainer(
       if (moduleInfo) {
         moduleInfo.meta = { ...moduleInfo.meta, ...meta }
       }
+    }
+  }
+
+  function updateModuleLoadAddedImports(id: string, ctx: Context) {
+    const module = moduleGraph?.getModuleById(id)
+    if (module) {
+      moduleNodeToLoadAddedImports.set(module, ctx._addedImports)
     }
   }
 
@@ -520,9 +532,9 @@ export async function createPluginContainer(
     sourcemapChain: NonNullable<SourceDescription['map']>[] = []
     combinedMap: SourceMap | { mappings: '' } | null = null
 
-    constructor(filename: string, code: string, inMap?: SourceMap | string) {
+    constructor(id: string, code: string, inMap?: SourceMap | string) {
       super()
-      this.filename = filename
+      this.filename = id
       this.originalCode = code
       if (inMap) {
         if (debugSourcemapCombine) {
@@ -530,6 +542,11 @@ export async function createPluginContainer(
           inMap.name = '$inMap'
         }
         this.sourcemapChain.push(inMap)
+      }
+      // Inherit `_addedImports` from the `load()` hook
+      const node = moduleGraph?.getModuleById(id)
+      if (node) {
+        this._addedImports = moduleNodeToLoadAddedImports.get(node) ?? null
       }
     }
 
@@ -719,9 +736,11 @@ export async function createPluginContainer(
           if (isObject(result)) {
             updateModuleInfo(id, result)
           }
+          updateModuleLoadAddedImports(id, ctx)
           return result
         }
       }
+      updateModuleLoadAddedImports(id, ctx)
       return null
     },
 

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -82,7 +82,7 @@ import { FS_PREFIX } from '../constants'
 import type { ResolvedConfig } from '../config'
 import { createPluginHookUtils, getHookHandler } from '../plugins'
 import { buildErrorMessage } from './middlewares/error'
-import type { ModuleGraph } from './moduleGraph'
+import type { ModuleGraph, ModuleNode } from './moduleGraph'
 
 const noop = () => {}
 
@@ -183,7 +183,10 @@ export async function createPluginContainer(
 
   const watchFiles = new Set<string>()
   // _addedFiles from the `load()` hook gets saved here so it can be reused in the `transform()` hook
-  const idToAddedImports = new Map<string, Set<string> | null>()
+  const moduleNodeToLoadAddedImports = new WeakMap<
+    ModuleNode,
+    Set<string> | null
+  >()
 
   const minimalContext: MinimalPluginContext = {
     meta: {
@@ -272,6 +275,13 @@ export async function createPluginContainer(
       if (moduleInfo) {
         moduleInfo.meta = { ...moduleInfo.meta, ...meta }
       }
+    }
+  }
+
+  function updateModuleLoadAddedImports(id: string, ctx: Context) {
+    const module = moduleGraph?.getModuleById(id)
+    if (module) {
+      moduleNodeToLoadAddedImports.set(module, ctx._addedImports)
     }
   }
 
@@ -533,6 +543,11 @@ export async function createPluginContainer(
         }
         this.sourcemapChain.push(inMap)
       }
+      // Inherit `_addedImports` from the `load()` hook
+      const node = moduleGraph?.getModuleById(id)
+      if (node) {
+        this._addedImports = moduleNodeToLoadAddedImports.get(node) ?? null
+      }
     }
 
     _getCombinedSourcemap() {
@@ -699,7 +714,6 @@ export async function createPluginContainer(
 
       if (id) {
         partial.id = isExternalUrl(id) ? id : normalizePath(id)
-        idToAddedImports.set(partial.id, ctx._addedImports)
         return partial as PartialResolvedId
       } else {
         return null
@@ -710,8 +724,6 @@ export async function createPluginContainer(
       const ssr = options?.ssr
       const ctx = new Context()
       ctx.ssr = !!ssr
-      // Inherit `_addedImports` from `resolveId()` hook
-      ctx._addedImports = idToAddedImports.get(id) ?? null
       for (const plugin of getSortedPlugins('load')) {
         if (closed && !ssr) throwClosedServerError()
         if (!plugin.load) continue
@@ -724,11 +736,11 @@ export async function createPluginContainer(
           if (isObject(result)) {
             updateModuleInfo(id, result)
           }
-          idToAddedImports.set(id, ctx._addedImports)
+          updateModuleLoadAddedImports(id, ctx)
           return result
         }
       }
-      idToAddedImports.set(id, ctx._addedImports)
+      updateModuleLoadAddedImports(id, ctx)
       return null
     },
 
@@ -737,8 +749,6 @@ export async function createPluginContainer(
       const ssr = options?.ssr
       const ctx = new TransformContext(id, code, inMap as SourceMap)
       ctx.ssr = !!ssr
-      // Inherit `_addedImports` from `load()` hook
-      ctx._addedImports = idToAddedImports.get(id) ?? null
       for (const plugin of getSortedPlugins('transform')) {
         if (closed && !ssr) throwClosedServerError()
         if (!plugin.transform) continue

--- a/playground/transform-plugin/__tests__/transform-plugin.spec.ts
+++ b/playground/transform-plugin/__tests__/transform-plugin.spec.ts
@@ -1,9 +1,12 @@
 import { expect, test } from 'vitest'
 import { editFile, page, untilUpdated } from '~utils'
 
-test('should re-run transform when plugin-dep file is edited', async () => {
+test('should re-run transform when dependencies are edited', async () => {
   expect(await page.textContent('#transform-count')).toBe('1')
 
-  await editFile('plugin-dep.js', (str) => str)
+  editFile('plugin-dep.js', (str) => str)
   await untilUpdated(() => page.textContent('#transform-count'), '2')
+
+  editFile('plugin-dep-load.js', (str) => str)
+  await untilUpdated(() => page.textContent('#transform-count'), '3')
 })

--- a/playground/transform-plugin/__tests__/transform-plugin.spec.ts
+++ b/playground/transform-plugin/__tests__/transform-plugin.spec.ts
@@ -9,7 +9,4 @@ test('should re-run transform when dependencies are edited', async () => {
 
   editFile('plugin-dep-load.js', (str) => str)
   await untilUpdated(() => page.textContent('#transform-count'), '3')
-
-  editFile('plugin-dep-resolve-id.js', (str) => str)
-  await untilUpdated(() => page.textContent('#transform-count'), '3')
 })

--- a/playground/transform-plugin/__tests__/transform-plugin.spec.ts
+++ b/playground/transform-plugin/__tests__/transform-plugin.spec.ts
@@ -9,4 +9,7 @@ test('should re-run transform when dependencies are edited', async () => {
 
   editFile('plugin-dep-load.js', (str) => str)
   await untilUpdated(() => page.textContent('#transform-count'), '3')
+
+  editFile('plugin-dep-resolve-id.js', (str) => str)
+  await untilUpdated(() => page.textContent('#transform-count'), '3')
 })

--- a/playground/transform-plugin/plugin-dep-load.js
+++ b/playground/transform-plugin/plugin-dep-load.js
@@ -1,0 +1,1 @@
+// Empty file for detecting changes in tests

--- a/playground/transform-plugin/plugin-dep-resolve-id.js
+++ b/playground/transform-plugin/plugin-dep-resolve-id.js
@@ -1,0 +1,1 @@
+// Empty file for detecting changes in tests

--- a/playground/transform-plugin/plugin-dep-resolve-id.js
+++ b/playground/transform-plugin/plugin-dep-resolve-id.js
@@ -1,1 +1,0 @@
-// Empty file for detecting changes in tests

--- a/playground/transform-plugin/vite.config.js
+++ b/playground/transform-plugin/vite.config.js
@@ -1,12 +1,19 @@
 import { resolve } from 'node:path'
 import { defineConfig, normalizePath } from 'vite'
 
+const file = normalizePath(resolve(__dirname, 'index.js'))
 let transformCount = 1
 
 const transformPlugin = {
   name: 'transform',
+  load(id) {
+    if (id === file) {
+      // Ensure `index.js` is reloaded if 'plugin-dep-load.js' is changed
+      this.addWatchFile('./plugin-dep-load.js')
+    }
+  },
   transform(code, id) {
-    if (id === normalizePath(resolve(__dirname, 'index.js'))) {
+    if (id === file) {
       // Ensure `index.js` is reevaluated if 'plugin-dep.js' is changed
       this.addWatchFile('./plugin-dep.js')
 

--- a/playground/transform-plugin/vite.config.js
+++ b/playground/transform-plugin/vite.config.js
@@ -6,16 +6,6 @@ let transformCount = 1
 
 const transformPlugin = {
   name: 'transform',
-  resolveId: {
-    order: 'pre',
-    handler(id) {
-      if (id === './index.js') {
-        // Ensure `index.js` is reloaded if 'plugin-dep-resolve-id.js' is changed
-        this.addWatchFile('./plugin-dep-resolve-id.js')
-        return file
-      }
-    },
-  },
   load(id) {
     if (id === file) {
       // Ensure `index.js` is reloaded if 'plugin-dep-load.js' is changed

--- a/playground/transform-plugin/vite.config.js
+++ b/playground/transform-plugin/vite.config.js
@@ -6,6 +6,16 @@ let transformCount = 1
 
 const transformPlugin = {
   name: 'transform',
+  resolveId: {
+    order: 'pre',
+    handler(id) {
+      if (id === './index.js') {
+        // Ensure `index.js` is reloaded if 'plugin-dep-resolve-id.js' is changed
+        this.addWatchFile('./plugin-dep-resolve-id.js')
+        return file
+      }
+    },
+  },
   load(id) {
     if (id === file) {
       // Ensure `index.js` is reloaded if 'plugin-dep-load.js' is changed


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/3474

The `_addedImports` of the plugin context only exists for each hook in isolation, e.g. `load()` and `transform()`. In `importAnalysis.ts`, we handle `_addedImports` in the `transform()` hook, so only `addWatchFile` in `transform()` hook works. `load()` was always being ignored.

This PR saves the `_addedImports` from `load()` (cached via `ModuleNode` weak map), and re-instates in the `transform()` hook later.

NOTE: this is not supported for CSS, looks like we hardcode dependency handling for our CSS plugin only.

### Additional context

https://rollupjs.org/plugin-development/#this-addwatchfile

I also tried supporting this in `resolveId()` as the Rollup docs mention that it supports it, however I reverted it (see 3rd commit) as it doesn't seem to work in Rollup (`vite build --watch`). Plus the implementation to support in `resolveId()` has a few downsides:

- Since `resolveId` doesn't guarantee a `ModuleNode` yet, we have to cache by the `id` string (unable to GC)
- `resolveId` can be called but we don't necessarily want to load it. Saving the `_addedImports` could pollute subsequent `load` + `transform`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
