### PR TITLE
fix(plugin-legacy): add invoke to modern detector to avoid terser treeshaking

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -156,7 +156,7 @@ The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https
 
 - `sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=`
 - `sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=`
-- `sha256-4y/gEB2/KIwZFTfNqwXJq4olzvmQ0S214m9jwKgNXoc=`
+- `sha256-8uUkKieevHiD3yYtzjkRvyDZWt+uZkBLuGEQWNiV3+c=`
 - `sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc=`
 
 <!--

--- a/packages/plugin-legacy/src/snippets.ts
+++ b/packages/plugin-legacy/src/snippets.ts
@@ -8,7 +8,7 @@ export const systemJSInlineCode = `System.import(document.getElementById('${lega
 
 const detectModernBrowserVarName = '__vite_is_modern_browser'
 export const detectModernBrowserDetector =
-  'import.meta.url;import("_").catch(()=>1);async function* g(){};'
+  'import.meta.url;import("_").catch(()=>1);(async function* g(){})();'
 export const detectModernBrowserCode = `${detectModernBrowserDetector}if(location.protocol!="file:"){window.${detectModernBrowserVarName}=true}`
 export const dynamicFallbackInlineCode = `!function(){if(window.${detectModernBrowserVarName})return;console.warn("vite: loading legacy chunks, syntax error above and the same error below should be ignored");var e=document.getElementById("${legacyPolyfillId}"),n=document.createElement("script");n.src=e.src,n.onload=function(){${systemJSInlineCode}},document.body.appendChild(n)}();`
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix`detectModernBrowserDetector` in `@vite/plugin-legacy`.Because terser will remove empty functions that are not being called which will cause detector different between html and entry file.For example:

<img width="1129" alt="image" src="https://github.com/vitejs/vite/assets/14540385/e6568b27-1749-4962-b00f-ff47d135a2d3">
<img width="490" alt="image" src="https://github.com/vitejs/vite/assets/14540385/cd6df092-b669-459d-9350-ed16a980c6ff">


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
