### PR TITLE
build: dont strip single line comments

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -31,7 +31,6 @@ export default defineConfig({
 
 // Taken from https://stackoverflow.com/a/36328890
 const multilineCommentsRE = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g
-const singlelineCommentsRE = /\/\/[^/].*/g
 const licenseCommentsRE = /MIT License|MIT license|BSD license/
 const consecutiveNewlinesRE = /\n{2,}/g
 const identifierWithTrailingDollarRE = /\b(\w+)\$\d+\b/g
@@ -239,7 +238,6 @@ function removeInternal(s: MagicString, node: any): boolean {
 
 function cleanUnnecessaryComments(code: string) {
   return code
-    .replace(singlelineCommentsRE, '')
     .replace(multilineCommentsRE, (m) => {
       return licenseCommentsRE.test(m) ? '' : m
     })


### PR DESCRIPTION
### Description

In our built `.dts` files, some links are incorrectly stripped, e.g. `https://example.com/...` gets stripped as `http:` as the single-line comment regex was a bit too naive. It broke quite a few jsdoc comments too.

I figured it's better to remove stripping single line comments altogether since they aren't a lot, and sometimes contain useful information, e.g. `// Inlined to avoid extra dependency (chokidar is bundled in the published build)`
