### PR TITLE
fix: relax overlay frame regex

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -151,7 +151,7 @@ kbd {
 `
 
 const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
-const codeframeRE = /^(?:>?\s+\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
+const codeframeRE = /^(?:>?\s*\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
 // Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
 // `HTMLElement` was not originally defined.


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/10746

Vite's generated code frame (`generateCodeFrame`) when assigned to `err.frame` may sometimes look like this:

```html
1  |  tag vite-imba
2  |          <self>
3  |                  <h2> item.
   |             ^
```

Note that the leading 1, 2, 3 does not have a leading space. The current `codeframeRE` requires a leading space which would've failed to match here.

Using the issue's repo, relaxing the `\s+` to `\s*` fixes this:

<img width="908" alt="image" src="https://github.com/vitejs/vite/assets/34116392/9a673d82-b11e-496e-b11b-62a4ccf1398a">


### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
