### PR TITLE
fix(esbuild): set js loader for build transpile

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -21,6 +21,7 @@ describe('resolveEsbuildTranspileOptions', () => {
     )
     expect(options).toEqual({
       charset: 'utf8',
+      loader: 'js',
       target: 'es2020',
       format: 'esm',
       keepNames: true,
@@ -64,6 +65,7 @@ describe('resolveEsbuildTranspileOptions', () => {
     )
     expect(options).toEqual({
       charset: 'utf8',
+      loader: 'js',
       target: undefined,
       format: 'esm',
       keepNames: true,
@@ -94,6 +96,7 @@ describe('resolveEsbuildTranspileOptions', () => {
     )
     expect(options).toEqual({
       charset: 'utf8',
+      loader: 'js',
       target: 'es2020',
       format: 'esm',
       keepNames: true,
@@ -126,6 +129,7 @@ describe('resolveEsbuildTranspileOptions', () => {
     )
     expect(options).toEqual({
       charset: 'utf8',
+      loader: 'js',
       target: undefined,
       format: 'esm',
       keepNames: true,
@@ -158,6 +162,7 @@ describe('resolveEsbuildTranspileOptions', () => {
     )
     expect(options).toEqual({
       charset: 'utf8',
+      loader: 'js',
       target: undefined,
       format: 'cjs',
       keepNames: true,
@@ -189,6 +194,7 @@ describe('resolveEsbuildTranspileOptions', () => {
     )
     expect(options).toEqual({
       charset: 'utf8',
+      loader: 'js',
       target: undefined,
       format: 'esm',
       keepNames: true,
@@ -224,6 +230,7 @@ describe('resolveEsbuildTranspileOptions', () => {
     )
     expect(options).toEqual({
       charset: 'utf8',
+      loader: 'js',
       target: undefined,
       format: 'cjs',
       keepNames: true,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -357,6 +357,7 @@ export function resolveEsbuildTranspileOptions(
   const options: TransformOptions = {
     charset: 'utf8',
     ...esbuildOptions,
+    loader: 'js',
     target: target || undefined,
     format: rollupToEsbuildFormatMap[format],
     // the final build should always support dynamic import and import.meta.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/10147

Since `renderChunk` should always only deal with JS files, we can set `loader: 'js'` as an optimization, and also fix #10147 so it doesn't have to detect the extension manually.

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
