### PR TITLE
ci(publish): workaround provenance bug

### DIFF
--- a/scripts/publishCI.ts
+++ b/scripts/publishCI.ts
@@ -1,3 +1,8 @@
 import { publish } from '@vitejs/release-scripts'
 
-publish({ defaultPackage: 'vite', provenance: true, packageManager: 'pnpm' })
+// Check the tag passed in CI, and skip provenance if tag has `@` due to
+// https://github.com/slsa-framework/slsa-github-generator/pull/2758 not released
+const tag = process.argv.slice(2)[0] ?? ''
+const provenance = tag.includes('@') ? false : true
+
+publish({ defaultPackage: 'vite', provenance, packageManager: 'pnpm' })

--- a/scripts/publishCI.ts
+++ b/scripts/publishCI.ts
@@ -3,6 +3,6 @@ import { publish } from '@vitejs/release-scripts'
 // Check the tag passed in CI, and skip provenance if tag has `@` due to
 // https://github.com/slsa-framework/slsa-github-generator/pull/2758 not released
 const tag = process.argv.slice(2)[0] ?? ''
-const provenance = tag.includes('@') ? false : true
+const provenance = !tag.includes('@')
 
 publish({ defaultPackage: 'vite', provenance, packageManager: 'pnpm' })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Workaround until https://github.com/slsa-framework/slsa-github-generator/pull/2758 is released.

Disable provenance if tag passed has `@`. This means that publishing `vite` will still have provenance.

NOTES:

The publish script is called here:

https://github.com/vitejs/vite/blob/123751dd801cce359c9d07bbb58cebbc81a65915/.github/workflows/publish.yml#L39

Release script parses the package name and tag like so, which we emulate:

https://github.com/vitejs/release-scripts/blob/e5a8ab0b45838c3cb43efec6594d2cda3039c74c/src/publish.ts#L23-L24