### PR TITLE
fix(css): @import with .css in node_modules importing a different package failed to resolve

### DIFF
--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -292,6 +292,10 @@ test('@import dependency that @import another dependency', async () => {
   expect(await getColor('.css-proxy-dep')).toBe('purple')
 })
 
+test('@import scss dependency that @import another dependency', async () => {
+  expect(await getColor('.scss-proxy-dep')).toBe('purple')
+})
+
 test('@import dependency w/out package scss', async () => {
   expect(await getColor('.sass-dep')).toBe('lavender')
 })

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -292,7 +292,7 @@ test('@import dependency that @import another dependency', async () => {
   expect(await getColor('.css-proxy-dep')).toBe('purple')
 })
 
-test('@import scss dependency that @import another dependency', async () => {
+test('@import scss dependency that has @import with a css extension pointing to another dependency', async () => {
   expect(await getColor('.scss-proxy-dep')).toBe('purple')
 })
 

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -143,6 +143,10 @@
   <p class="css-proxy-dep">
     @import dependency that @import another dependency: this should be purple
   </p>
+  <p class="scss-proxy-dep">
+    @import dependency that @import another dependency: this should be purple
+    too
+  </p>
 
   <p class="dir-dep">PostCSS dir-dependency: this should be grey</p>
   <p class="dir-dep-2">

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -144,8 +144,7 @@
     @import dependency that @import another dependency: this should be purple
   </p>
   <p class="scss-proxy-dep">
-    @import dependency that @import another dependency: this should be purple
-    too
+    @import dependency that has @import with a css extension pointing to another dependency: this should be purple
   </p>
 
   <p class="dir-dep">PostCSS dir-dependency: this should be grey</p>

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -144,7 +144,8 @@
     @import dependency that @import another dependency: this should be purple
   </p>
   <p class="scss-proxy-dep">
-    @import dependency that has @import with a css extension pointing to another dependency: this should be purple
+    @import dependency that has @import with a css extension pointing to another
+    dependency: this should be purple
   </p>
 
   <p class="dir-dep">PostCSS dir-dependency: this should be grey</p>

--- a/playground/css/package.json
+++ b/playground/css/package.json
@@ -20,6 +20,7 @@
     "@vitejs/test-css-dep-exports": "link:./css-dep-exports",
     "@vitejs/test-css-js-dep": "file:./css-js-dep",
     "@vitejs/test-css-proxy-dep": "file:./css-proxy-dep",
+    "@vitejs/test-scss-proxy-dep": "file:./scss-proxy-dep",
     "fast-glob": "^3.3.2",
     "less": "^4.2.0",
     "postcss-nested": "^6.0.1",

--- a/playground/css/sass.scss
+++ b/playground/css/sass.scss
@@ -2,6 +2,7 @@
 @import '=/nested/partial'; // sass convention: omitting leading _ for partials
 @import '@vitejs/test-css-dep'; // package w/ sass entry points
 @import '@vitejs/test-css-dep-exports'; // package with a sass export mapping
+@import '@vitejs/test-scss-proxy-dep'; // package with a sass proxy import
 @import 'virtual-dep'; // virtual file added through importer
 @import '=/pkg-dep'; // package w/out sass field
 @import '=/weapp.wxss'; // wxss file

--- a/playground/css/scss-proxy-dep-nested/index.css
+++ b/playground/css/scss-proxy-dep-nested/index.css
@@ -1,0 +1,3 @@
+.scss-proxy-dep {
+  color: purple;
+}

--- a/playground/css/scss-proxy-dep-nested/package.json
+++ b/playground/css/scss-proxy-dep-nested/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@vitejs/test-scss-proxy-dep-nested",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/playground/css/scss-proxy-dep/index.scss
+++ b/playground/css/scss-proxy-dep/index.scss
@@ -1,0 +1,1 @@
+@import '@vitejs/test-scss-proxy-dep-nested/index.css';

--- a/playground/css/scss-proxy-dep/package.json
+++ b/playground/css/scss-proxy-dep/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-scss-proxy-dep",
+  "private": true,
+  "version": "1.0.0",
+  "sass": "index.scss",
+  "dependencies": {
+    "@vitejs/test-scss-proxy-dep-nested": "file:../scss-proxy-dep-nested"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -514,6 +514,9 @@ importers:
       '@vitejs/test-css-proxy-dep':
         specifier: file:./css-proxy-dep
         version: file:playground/css/css-proxy-dep
+      '@vitejs/test-scss-proxy-dep':
+        specifier: file:./scss-proxy-dep
+        version: file:playground/css/scss-proxy-dep
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -591,6 +594,14 @@ importers:
   playground/css/postcss-caching/blue-app: {}
 
   playground/css/postcss-caching/green-app: {}
+
+  playground/css/scss-proxy-dep:
+    dependencies:
+      '@vitejs/test-scss-proxy-dep-nested':
+        specifier: file:../scss-proxy-dep-nested
+        version: file:playground/css/scss-proxy-dep-nested
+
+  playground/css/scss-proxy-dep-nested: {}
 
   playground/data-uri: {}
 
@@ -10108,6 +10119,17 @@ packages:
   file:playground/css/css-proxy-dep-nested:
     resolution: {directory: playground/css/css-proxy-dep-nested, type: directory}
     name: '@vitejs/test-css-proxy-dep-nested'
+
+  file:playground/css/scss-proxy-dep:
+    resolution: {directory: playground/css/scss-proxy-dep, type: directory}
+    name: '@vitejs/test-scss-proxy-dep'
+    dependencies:
+      '@vitejs/test-scss-proxy-dep-nested': file:playground/css/scss-proxy-dep-nested
+    dev: true
+
+  file:playground/css/scss-proxy-dep-nested:
+    resolution: {directory: playground/css/scss-proxy-dep-nested, type: directory}
+    name: '@vitejs/test-scss-proxy-dep-nested'
 
   file:playground/define/commonjs-dep:
     resolution: {directory: playground/define/commonjs-dep, type: directory}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes https://github.com/vitejs/vite/issues/12227
refs https://github.com/vitejs/vite/issues/9681

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

The cause of the bug is when performing sass style preprocessing, it's trying to rewrite the @import lines in the code using sass render with internalImporter.

The internalImporter resolve the url and then tries to perform a rebase of the url. The rebaseUrls is not correctly performing rebase if we try to perform another import from a different package.

So instead of calling path.resolve, we have to try the corresponding resolver first with id and importer.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
