### PR TITLE
feat(plugin-legacy)!: bump vite peer dep

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "terser": "^5.4.0",
-    "vite": "^4.0.0"
+    "vite": "^5.0.0"
   },
   "devDependencies": {
     "acorn": "^8.11.2",


### PR DESCRIPTION
Vite `^4.0.0` to `^5.0.0` required before we cut a stable for plugin-legacy