### PR TITLE
feat(create-vite): update templates for vite 5

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -524,7 +524,7 @@ function setupReactSwc(root: string, isTs: boolean) {
   editFile(path.resolve(root, 'package.json'), (content) => {
     return content.replace(
       /"@vitejs\/plugin-react": ".+?"/,
-      `"@vitejs/plugin-react-swc": "^3.3.2"`,
+      `"@vitejs/plugin-react-swc": "^3.5.0"`,
     )
   })
   editFile(

--- a/packages/create-vite/template-lit-ts/package.json
+++ b/packages/create-vite/template-lit-ts/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-lit/package.json
+++ b/packages/create-vite/template-lit/package.json
@@ -12,6 +12,6 @@
     "lit": "^3.0.2"
   },
   "devDependencies": {
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-preact-ts/package.json
+++ b/packages/create-vite/template-preact-ts/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@preact/preset-vite": "^2.6.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-preact/package.json
+++ b/packages/create-vite/template-preact/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.6.0",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.2.17"

--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^4.5.0"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.2.17"

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.2.17"

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0"
+    "vite": "^4.5.0"
   },
   "dependencies": {
     "@builder.io/qwik": "^1.2.17"

--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -18,11 +18,11 @@
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
-    "@vitejs/plugin-react": "^4.1.1",
+    "@vitejs/plugin-react": "^4.2.0",
     "eslint": "^8.53.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-react/package.json
+++ b/packages/create-vite/template-react/package.json
@@ -16,11 +16,11 @@
   "devDependencies": {
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
-    "@vitejs/plugin-react": "^4.1.1",
+    "@vitejs/plugin-react": "^4.2.0",
     "eslint": "^8.53.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.4",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-solid-ts/package.json
+++ b/packages/create-vite/template-solid-ts/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18",
+    "vite": "^5.0.0",
     "vite-plugin-solid": "^2.7.2"
   }
 }

--- a/packages/create-vite/template-solid/package.json
+++ b/packages/create-vite/template-solid/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.8.5"
   },
   "devDependencies": {
-    "vite": "^5.0.0-beta.18",
+    "vite": "^5.0.0",
     "vite-plugin-solid": "^2.7.2"
   }
 }

--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -10,12 +10,12 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.0.0-next.2",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "@tsconfig/svelte": "^5.0.2",
     "svelte": "^4.2.3",
     "svelte-check": "^3.6.0",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-svelte/package.json
+++ b/packages/create-vite/template-svelte/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.0.0-next.2",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.2.3",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-vanilla-ts/package.json
+++ b/packages/create-vite/template-vanilla-ts/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-vanilla/package.json
+++ b/packages/create-vite/template-vanilla/package.json
@@ -9,6 +9,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^5.0.0-beta.18"
+    "vite": "^5.0.0"
   }
 }

--- a/packages/create-vite/template-vue-ts/package.json
+++ b/packages/create-vite/template-vue-ts/package.json
@@ -12,9 +12,9 @@
     "vue": "^3.3.8"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.4.1",
+    "@vitejs/plugin-vue": "^4.5.0",
     "typescript": "^5.2.2",
-    "vite": "^5.0.0-beta.18",
+    "vite": "^5.0.0",
     "vue-tsc": "^1.8.22"
   }
 }

--- a/packages/create-vite/template-vue/package.json
+++ b/packages/create-vite/template-vue/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.3.8"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.4.1",
-    "vite": "^5.0.0-beta.18"
+    "@vitejs/plugin-vue": "^4.5.0",
+    "vite": "^5.0.0"
   }
 }


### PR DESCRIPTION
Update:

- `vite` to `^5.0.0` (except qwik - CI still fails for Vite 5, pinned to `^4.5.0` instead)
- `@vitejs/plugin-react` to `^4.2.0`
- `@vitejs/plugin-vue` to `^4.5.0`
- `@sveltejs/vite-plugin-svelte` to `^3.0.0`

We still need to update for preact, qwik, and react-swc for the templates. 