### PR TITLE
fix(legacy): preserve async generator function invocation

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -156,8 +156,8 @@ The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https
 
 - `sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=`
 - `sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=`
-- `sha256-BoFUHKsYhJ9tbsHugtNQCmnkBbZ11pcW6kZguu+T+EU=`
-- `sha256-A18HC3jLpyEc9B8oyxq/NBFCyFBJFSsRLt0gmT9kft8=`
+- `sha256-6gxDO54HJkJNWi7H6ipFpWWSkWSRpyuZYMGDyG6bcNE=`
+- `sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc=`
 
 <!--
 Run `node --input-type=module -e "import {cspHashes} from '@vitejs/plugin-legacy'; console.log(cspHashes.map(h => 'sha256-'+h))"` to retrieve the value.

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -156,8 +156,8 @@ The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https
 
 - `sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=`
 - `sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=`
-- `sha256-8uUkKieevHiD3yYtzjkRvyDZWt+uZkBLuGEQWNiV3+c=`
-- `sha256-+5XkZFazzJo8n0iOP4ti/cLCMUudTf//Mzkb7xNPXIc=`
+- `sha256-BoFUHKsYhJ9tbsHugtNQCmnkBbZ11pcW6kZguu+T+EU=`
+- `sha256-A18HC3jLpyEc9B8oyxq/NBFCyFBJFSsRLt0gmT9kft8=`
 
 <!--
 Run `node --input-type=module -e "import {cspHashes} from '@vitejs/plugin-legacy'; console.log(cspHashes.map(h => 'sha256-'+h))"` to retrieve the value.

--- a/packages/plugin-legacy/src/snippets.ts
+++ b/packages/plugin-legacy/src/snippets.ts
@@ -7,8 +7,7 @@ export const legacyEntryId = 'vite-legacy-entry'
 export const systemJSInlineCode = `System.import(document.getElementById('${legacyEntryId}').getAttribute('data-src'))`
 
 const detectModernBrowserVarName = '__vite_is_modern_browser'
-export const detectModernBrowserDetector =
-  'import.meta.url;import("_").catch(()=>1);(async function* g(){})();'
+export const detectModernBrowserDetector = `import.meta.url;import("_").catch(()=>1);(async function*(){})().next()`
 export const detectModernBrowserCode = `${detectModernBrowserDetector}if(location.protocol!="file:"){window.${detectModernBrowserVarName}=true}`
 export const dynamicFallbackInlineCode = `!function(){if(window.${detectModernBrowserVarName})return;console.warn("vite: loading legacy chunks, syntax error above and the same error below should be ignored");var e=document.getElementById("${legacyPolyfillId}"),n=document.createElement("script");n.src=e.src,n.onload=function(){${systemJSInlineCode}},document.body.appendChild(n)}();`
 

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -152,10 +152,12 @@ describe.runIf(isBuild)('build', () => {
     ).toBeFalsy()
   })
 
-  test('should have only entry files guarded', async () => {
+  test('should have only modern entry files guarded', async () => {
     const guard = /(import\s*\()|(import.meta)|(async\s*function\*)/
     expect(findAssetFile(/index(?!-legacy)/)).toMatch(guard)
     expect(findAssetFile(/polyfills(?!-legacy)/)).toMatch(guard)
+
+    expect(findAssetFile(/chunk-async(?!-legacy)/)).not.toMatch(guard)
     expect(findAssetFile(/index-legacy/)).not.toMatch(guard)
   })
 })

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -120,11 +120,13 @@ describe.runIf(isBuild)('build', () => {
     const terserPattern = /^(?:!function|System.register)/
 
     expect(findAssetFile(/chunk-async-legacy/)).toMatch(terserPattern)
-    expect(findAssetFile(/chunk-async\./)).not.toMatch(terserPattern)
+    expect(findAssetFile(/chunk-async(?!-legacy)/)).not.toMatch(terserPattern)
     expect(findAssetFile(/immutable-chunk-legacy/)).toMatch(terserPattern)
-    expect(findAssetFile(/immutable-chunk\./)).not.toMatch(terserPattern)
+    expect(findAssetFile(/immutable-chunk(?!-legacy)/)).not.toMatch(
+      terserPattern,
+    )
     expect(findAssetFile(/index-legacy/)).toMatch(terserPattern)
-    expect(findAssetFile(/index\./)).not.toMatch(terserPattern)
+    expect(findAssetFile(/index(?!-legacy)/)).not.toMatch(terserPattern)
     expect(findAssetFile(/polyfills-legacy/)).toMatch(terserPattern)
   })
 
@@ -148,5 +150,12 @@ describe.runIf(isBuild)('build', () => {
         /polyfills-legacy.+\.map$/.test(filename),
       ),
     ).toBeFalsy()
+  })
+
+  test('should have only entry files guarded', async () => {
+    const guard = /(import\s*\()|(import.meta)|(async\s*function\*)/
+    expect(findAssetFile(/index(?!-legacy)/)).toMatch(guard)
+    expect(findAssetFile(/polyfills(?!-legacy)/)).toMatch(guard)
+    expect(findAssetFile(/index-legacy/)).not.toMatch(guard)
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR is a continuation of #14968, whose trick works perfectly fine on older versions of vite but fails on vite@>4.4.0 because of the version bump of `esbuild` to 0.18.2. `esbuild@0.18.2` introduces [pure annotations for iife expressions](https://github.com/evanw/esbuild/commit/a1a1e449da7c2447f56232fb14ad8b5564579220), so the annotated async generator function will be dropped (by minifiers I think).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
A shorter way to preserve the generator function here is:
```js
(async function* g(){import.meta.url;import("_").catch(()=>1)})();
```
I don't know if that is enough for syntax detecting since the body won't be executed until `.next()` is called.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
