### PR TITLE
fix: run htmlFallbackMiddleware for no accept header requests

### DIFF
--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -14,13 +14,11 @@ export function htmlFallbackMiddleware(
     if (
       // Only accept GET or HEAD
       (req.method !== 'GET' && req.method !== 'HEAD') ||
-      // Require Accept header
-      !req.headers ||
-      typeof req.headers.accept !== 'string' ||
       // Ignore JSON requests
-      req.headers.accept.includes('application/json') ||
+      req.headers.accept?.includes('application/json') ||
       // Require Accept: text/html or */*
       !(
+        req.headers.accept === undefined || // equivalent to `Accept: */*`
         req.headers.accept.includes('text/html') ||
         req.headers.accept.includes('*/*')
       )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fixes #9520
fixes #15022

### Additional context
https://github.com/bripkens/connect-history-api-fallback does this check.
https://github.com/bripkens/connect-history-api-fallback/blob/74564d61c2db06e302923a23bd459bb5dd91712b/lib/index.js#L11-L43

I also think this middleware should not check `Accept: application/json`. But I didn't change that because this part also comes from `connect-history-api-fallback` and didn't want to change the behavior much.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
