### PR TITLE
docs: add blog rss feed on docs build

### DIFF
--- a/docs/.vitepress/buildEnd.config.ts
+++ b/docs/.vitepress/buildEnd.config.ts
@@ -1,0 +1,50 @@
+import path from 'path'
+import { writeFileSync } from 'fs'
+import { Feed } from 'feed'
+import { createContentLoader, type SiteConfig } from 'vitepress'
+
+const siteUrl = 'https://vitejs.dev'
+const blogUrl = `${siteUrl}/blog`
+
+export const onBuildEnd = () => async (config: SiteConfig) => {
+  const feed = new Feed({
+    title: 'Vite',
+    description: 'Next Generation Frontend Tooling',
+    id: blogUrl,
+    link: blogUrl,
+    language: 'en',
+    image: 'https://vitejs.dev/og-image.png',
+    favicon: 'https://vitejs.dev/logo.svg',
+    copyright: 'Copyright © 2019-present Evan You & Vite Contributors',
+  })
+
+  const posts = await createContentLoader('blog/*.md', {
+    excerpt: true,
+    render: true,
+  }).load()
+
+  posts.sort(
+    (a, b) =>
+      +new Date(b.frontmatter.date as string) -
+      +new Date(a.frontmatter.date as string),
+  )
+
+  for (const { url, excerpt, frontmatter, html } of posts) {
+    console.log({ url, excerpt, frontmatter, html })
+    feed.addItem({
+      title: frontmatter.title,
+      id: `${siteUrl}${url}`,
+      link: `${siteUrl}${url}`,
+      description: excerpt,
+      content: html,
+      author: [
+        {
+          name: frontmatter.author.name,
+        },
+      ],
+      date: frontmatter.date,
+    })
+  }
+
+  writeFileSync(path.join(config.outDir, 'blog.rss'), feed.rss2())
+}

--- a/docs/.vitepress/buildEnd.config.ts
+++ b/docs/.vitepress/buildEnd.config.ts
@@ -30,7 +30,6 @@ export const onBuildEnd = () => async (config: SiteConfig) => {
   )
 
   for (const { url, excerpt, frontmatter, html } of posts) {
-    console.log({ url, excerpt, frontmatter, html })
     feed.addItem({
       title: frontmatter.title,
       id: `${siteUrl}${url}`,

--- a/docs/.vitepress/buildEnd.config.ts
+++ b/docs/.vitepress/buildEnd.config.ts
@@ -6,7 +6,7 @@ import { createContentLoader, type SiteConfig } from 'vitepress'
 const siteUrl = 'https://vitejs.dev'
 const blogUrl = `${siteUrl}/blog`
 
-export const onBuildEnd = () => async (config: SiteConfig) => {
+export const buildEnd = async (config: SiteConfig) => {
   const feed = new Feed({
     title: 'Vite',
     description: 'Next Generation Frontend Tooling',

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, DefaultTheme } from 'vitepress'
-import { onBuildEnd } from './buildEnd.config'
+import { buildEnd } from './buildEnd.config'
 
 const ogDescription = 'Next Generation Frontend Tooling'
 const ogImage = 'https://vitejs.dev/og-image.png'
@@ -330,5 +330,5 @@ export default defineConfig({
       level: [2, 3],
     },
   },
-  buildEnd: onBuildEnd(),
+  buildEnd,
 })

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, DefaultTheme } from 'vitepress'
+import { onBuildEnd } from './buildEnd.config'
 
 const ogDescription = 'Next Generation Frontend Tooling'
 const ogImage = 'https://vitejs.dev/og-image.png'
@@ -66,6 +67,10 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/logo.svg' }],
+    [
+      'link',
+      { rel: 'alternate', type: 'application/rss+xml', href: '/blog.rss' },
+    ],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: ogTitle }],
     ['meta', { property: 'og:image', content: ogImage }],
@@ -325,4 +330,5 @@ export default defineConfig({
       level: [2, 3],
     },
   },
+  buildEnd: onBuildEnd(),
 })

--- a/docs/blog/announcing-vite2.md
+++ b/docs/blog/announcing-vite2.md
@@ -1,4 +1,7 @@
 ---
+title: Announcing Vite 2.0
+author:
+  - name: Evan You
 sidebar: false
 date: 2021-02-16
 head:

--- a/docs/blog/announcing-vite2.md
+++ b/docs/blog/announcing-vite2.md
@@ -1,7 +1,7 @@
 ---
 title: Announcing Vite 2.0
 author:
-  - name: Evan You
+  - name: The Vite Team
 sidebar: false
 date: 2021-02-16
 head:

--- a/docs/blog/announcing-vite3.md
+++ b/docs/blog/announcing-vite3.md
@@ -1,7 +1,7 @@
 ---
 title: Vite 3.0 is out!
 author:
-  name: patak
+  name: The Vite Team
 date: 2022-07-23
 sidebar: false
 head:

--- a/docs/blog/announcing-vite3.md
+++ b/docs/blog/announcing-vite3.md
@@ -1,6 +1,9 @@
 ---
-sidebar: false
+title: Vite 3.0 is out!
+author:
+  name: patak
 date: 2022-07-23
+sidebar: false
 head:
   - - meta
     - property: og:type

--- a/docs/blog/announcing-vite4-3.md
+++ b/docs/blog/announcing-vite4-3.md
@@ -1,7 +1,7 @@
 ---
 title: Vite 4.3 is out!
 author:
-  name: patak
+  name: The Vite Team
 date: 2023-04-20
 sidebar: false
 head:

--- a/docs/blog/announcing-vite4-3.md
+++ b/docs/blog/announcing-vite4-3.md
@@ -1,6 +1,9 @@
 ---
-sidebar: false
+title: Vite 4.3 is out!
+author:
+  name: patak
 date: 2023-04-20
+sidebar: false
 head:
   - - meta
     - property: og:type

--- a/docs/blog/announcing-vite4.md
+++ b/docs/blog/announcing-vite4.md
@@ -1,6 +1,9 @@
 ---
-sidebar: false
+title: Vite 4.0 is out!
+author:
+  name: patak
 date: 2022-12-09
+sidebar: false
 head:
   - - meta
     - property: og:type

--- a/docs/blog/announcing-vite4.md
+++ b/docs/blog/announcing-vite4.md
@@ -1,7 +1,7 @@
 ---
 title: Vite 4.0 is out!
 author:
-  name: patak
+  name: The Vite Team
 date: 2022-12-09
 sidebar: false
 head:

--- a/docs/blog/announcing-vite5.md
+++ b/docs/blog/announcing-vite5.md
@@ -1,7 +1,7 @@
 ---
 title: Vite 5.0 is out!
 author:
-  name: patak
+  name: The Vite Team
 date: 2023-11-16
 sidebar: false
 head:

--- a/docs/blog/announcing-vite5.md
+++ b/docs/blog/announcing-vite5.md
@@ -1,6 +1,9 @@
 ---
-sidebar: false
+title: Vite 5.0 is out!
+author:
+  name: patak
 date: 2023-11-16
+sidebar: false
 head:
   - - meta
     - property: og:type

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-n": "^16.3.1",
     "eslint-plugin-regexp": "^2.1.1",
     "execa": "^8.0.1",
+    "feed": "^4.2.2",
     "fs-extra": "^11.1.1",
     "lint-staged": "^15.1.0",
     "npm-run-all2": "^6.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 overrides:
   vite: workspace:*
 
@@ -111,6 +107,9 @@ importers:
       execa:
         specifier: ^8.0.1
         version: 8.0.1
+      feed:
+        specifier: ^4.2.2
+        version: 4.2.2
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
@@ -6001,6 +6000,13 @@ packages:
     dependencies:
       reusify: 1.0.4
 
+  /feed@4.2.2:
+    resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      xml-js: 1.6.11
+    dev: true
+
   /fetch-blob@3.1.5:
     resolution: {integrity: sha512-N64ZpKqoLejlrwkIAnb9iLSA3Vx/kjgzpcDhygcqJ2KKjky8nCgUQ+dzXtbrLaWZGZNmNfQTsiQ0weZ1svglHg==}
     engines: {node: ^12.20 || >= 14.13}
@@ -10120,6 +10126,13 @@ packages:
         optional: true
     dev: true
 
+  /xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+    dependencies:
+      sax: 1.3.0
+    dev: true
+
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -10196,16 +10209,19 @@ packages:
   file:playground/alias/dir/module:
     resolution: {directory: playground/alias/dir/module, type: directory}
     name: '@vitejs/test-aliased-module'
+    version: 0.0.0
     dev: false
 
   file:playground/css/css-js-dep:
     resolution: {directory: playground/css/css-js-dep, type: directory}
     name: '@vitejs/test-css-js-dep'
+    version: 1.0.0
     dev: true
 
   file:playground/css/css-proxy-dep:
     resolution: {directory: playground/css/css-proxy-dep, type: directory}
     name: '@vitejs/test-css-proxy-dep'
+    version: 1.0.0
     dependencies:
       '@vitejs/test-css-proxy-dep-nested': file:playground/css/css-proxy-dep-nested
     dev: true
@@ -10213,21 +10229,25 @@ packages:
   file:playground/css/css-proxy-dep-nested:
     resolution: {directory: playground/css/css-proxy-dep-nested, type: directory}
     name: '@vitejs/test-css-proxy-dep-nested'
+    version: 1.0.0
 
   file:playground/define/commonjs-dep:
     resolution: {directory: playground/define/commonjs-dep, type: directory}
     name: '@vitejs/test-commonjs-dep'
+    version: 1.0.0
     dev: false
 
   file:playground/dynamic-import/pkg:
     resolution: {directory: playground/dynamic-import/pkg, type: directory}
     name: '@vitejs/test-pkg'
+    version: 1.0.0
     dev: false
 
   file:playground/external/dep-that-imports(typescript@5.2.2):
     resolution: {directory: playground/external/dep-that-imports, type: directory}
     id: file:playground/external/dep-that-imports
     name: '@vitejs/test-dep-that-imports'
+    version: 0.0.0
     dependencies:
       slash3: /slash@3.0.0
       slash5: /slash@5.1.0
@@ -10240,6 +10260,7 @@ packages:
     resolution: {directory: playground/external/dep-that-requires, type: directory}
     id: file:playground/external/dep-that-requires
     name: '@vitejs/test-dep-that-requires'
+    version: 0.0.0
     dependencies:
       slash3: /slash@3.0.0
       slash5: /slash@5.1.0
@@ -10256,36 +10277,43 @@ packages:
   file:playground/import-assertion/import-assertion-dep:
     resolution: {directory: playground/import-assertion/import-assertion-dep, type: directory}
     name: '@vitejs/test-import-assertion-dep'
+    version: 0.0.0
     dev: false
 
   file:playground/js-sourcemap/importee-pkg:
     resolution: {directory: playground/js-sourcemap/importee-pkg, type: directory}
     name: '@vitejs/test-importee-pkg'
+    version: 0.0.0
     dev: false
 
   file:playground/json/json-module:
     resolution: {directory: playground/json/json-module, type: directory}
     name: '@vitejs/test-json-module'
+    version: 0.0.0
     dev: true
 
   file:playground/minify/dir/module:
     resolution: {directory: playground/minify/dir/module, type: directory}
     name: '@vitejs/test-minify'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps-no-discovery/dep-no-discovery:
     resolution: {directory: playground/optimize-deps-no-discovery/dep-no-discovery, type: directory}
     name: '@vitejs/test-dep-no-discovery'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/added-in-entries:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
     name: '@vitejs/test-added-in-entries'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-alias-using-absolute-path:
     resolution: {directory: playground/optimize-deps/dep-alias-using-absolute-path, type: directory}
     name: '@vitejs/test-dep-alias-using-absolute-path'
+    version: 1.0.0
     dependencies:
       lodash: 4.17.21
     dev: false
@@ -10293,81 +10321,97 @@ packages:
   file:playground/optimize-deps/dep-cjs-browser-field-bare:
     resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
     name: '@vitejs/test-dep-cjs-browser-field-bare'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-cjs, type: directory}
     name: '@vitejs/test-dep-cjs-compiled-from-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-esm:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-esm, type: directory}
     name: '@vitejs/test-dep-cjs-compiled-from-esm'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-with-assets:
     resolution: {directory: playground/optimize-deps/dep-cjs-with-assets, type: directory}
     name: '@vitejs/test-dep-cjs-with-assets'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-css-require:
     resolution: {directory: playground/optimize-deps/dep-css-require, type: directory}
     name: '@vitejs/test-dep-css-require'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-esbuild-plugin-transform:
     resolution: {directory: playground/optimize-deps/dep-esbuild-plugin-transform, type: directory}
     name: '@vitejs/test-dep-esbuild-plugin-transform'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-node-env:
     resolution: {directory: playground/optimize-deps/dep-node-env, type: directory}
     name: '@vitejs/test-dep-node-env'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-non-optimized:
     resolution: {directory: playground/optimize-deps/dep-non-optimized, type: directory}
     name: '@vitejs/test-dep-non-optimized'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-not-js:
     resolution: {directory: playground/optimize-deps/dep-not-js, type: directory}
     name: '@vitejs/test-dep-not-js'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-optimize-exports-with-glob:
     resolution: {directory: playground/optimize-deps/dep-optimize-exports-with-glob, type: directory}
     name: '@vitejs/test-dep-optimize-exports-with-glob'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-optimize-with-glob:
     resolution: {directory: playground/optimize-deps/dep-optimize-with-glob, type: directory}
     name: '@vitejs/test-dep-optimize-with-glob'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-relative-to-main:
     resolution: {directory: playground/optimize-deps/dep-relative-to-main, type: directory}
     name: '@vitejs/test-dep-relative-to-main'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-builtin-module-cjs:
     resolution: {directory: playground/optimize-deps/dep-with-builtin-module-cjs, type: directory}
     name: '@vitejs/test-dep-with-builtin-module-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-builtin-module-esm:
     resolution: {directory: playground/optimize-deps/dep-with-builtin-module-esm, type: directory}
     name: '@vitejs/test-dep-with-builtin-module-esm'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-dynamic-import:
     resolution: {directory: playground/optimize-deps/dep-with-dynamic-import, type: directory}
     name: '@vitejs/test-dep-with-dynamic-import'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-optional-peer-dep:
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep, type: directory}
     name: '@vitejs/test-dep-with-optional-peer-dep'
+    version: 0.0.0
     peerDependencies:
       foobar: 0.0.0
     peerDependenciesMeta:
@@ -10378,6 +10422,7 @@ packages:
   file:playground/optimize-deps/dep-with-optional-peer-dep-submodule:
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep-submodule, type: directory}
     name: '@vitejs/test-dep-with-optional-peer-dep-submodule'
+    version: 0.0.0
     peerDependencies:
       foobar: 0.0.0
     peerDependenciesMeta:
@@ -10388,11 +10433,13 @@ packages:
   file:playground/optimize-deps/longfilename:
     resolution: {directory: playground/optimize-deps/longfilename, type: directory}
     name: '@vitejs/longfilename-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/nested-exclude:
     resolution: {directory: playground/optimize-deps/nested-exclude, type: directory}
     name: '@vitejs/test-nested-exclude'
+    version: 1.0.0
     dependencies:
       '@vitejs/test-nested-include': file:playground/optimize-deps/nested-include
       nested-include: file:playground/optimize-deps/nested-include
@@ -10401,11 +10448,13 @@ packages:
   file:playground/optimize-deps/nested-include:
     resolution: {directory: playground/optimize-deps/nested-include, type: directory}
     name: '@vitejs/test-nested-include'
+    version: 1.0.0
     dev: false
 
   file:playground/optimize-missing-deps/missing-dep:
     resolution: {directory: playground/optimize-missing-deps/missing-dep, type: directory}
     name: '@vitejs/test-missing-dep'
+    version: 0.0.0
     dependencies:
       '@vitejs/test-multi-entry-dep': file:playground/optimize-missing-deps/multi-entry-dep
       multi-entry-dep: file:playground/optimize-missing-deps/multi-entry-dep
@@ -10414,15 +10463,18 @@ packages:
   file:playground/optimize-missing-deps/multi-entry-dep:
     resolution: {directory: playground/optimize-missing-deps/multi-entry-dep, type: directory}
     name: '@vitejs/test-multi-entry-dep'
+    version: 0.0.0
     dev: false
 
   file:playground/preload/dep-a:
     resolution: {directory: playground/preload/dep-a, type: directory}
     name: '@vitejs/test-dep-a'
+    version: 0.0.0
 
   file:playground/preload/dep-including-a:
     resolution: {directory: playground/preload/dep-including-a, type: directory}
     name: '@vitejs/test-dep-including-a'
+    version: 0.0.0
     dependencies:
       '@vitejs/test-dep-a': file:playground/preload/dep-a
       dep-a: file:playground/preload/dep-a
@@ -10431,36 +10483,43 @@ packages:
   file:playground/ssr-conditions/external:
     resolution: {directory: playground/ssr-conditions/external, type: directory}
     name: '@vitejs/test-ssr-conditions-external'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-conditions/no-external:
     resolution: {directory: playground/ssr-conditions/no-external, type: directory}
     name: '@vitejs/test-ssr-conditions-no-external'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/css-lib:
     resolution: {directory: playground/ssr-deps/css-lib, type: directory}
     name: '@vitejs/test-css-lib'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/define-properties-exports:
     resolution: {directory: playground/ssr-deps/define-properties-exports, type: directory}
     name: '@vitejs/test-define-properties-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/define-property-exports:
     resolution: {directory: playground/ssr-deps/define-property-exports, type: directory}
     name: '@vitejs/test-define-property-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/external-entry:
     resolution: {directory: playground/ssr-deps/external-entry, type: directory}
     name: '@vitejs/test-external-entry'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/external-using-external-entry:
     resolution: {directory: playground/ssr-deps/external-using-external-entry, type: directory}
     name: '@vitejs/test-external-using-external-entry'
+    version: 0.0.0
     dependencies:
       external-entry: file:playground/ssr-deps/external-entry
     dev: false
@@ -10468,6 +10527,7 @@ packages:
   file:playground/ssr-deps/forwarded-export:
     resolution: {directory: playground/ssr-deps/forwarded-export, type: directory}
     name: '@vitejs/test-forwarded-export'
+    version: 0.0.0
     dependencies:
       object-assigned-exports: file:playground/ssr-deps/object-assigned-exports
     dev: false
@@ -10475,46 +10535,55 @@ packages:
   file:playground/ssr-deps/import-builtin-cjs:
     resolution: {directory: playground/ssr-deps/import-builtin-cjs, type: directory}
     name: '@vitejs/test-import-builtin'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/module-condition:
     resolution: {directory: playground/ssr-deps/module-condition, type: directory}
     name: '@vitejs/test-module-condition'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/nested-external:
     resolution: {directory: playground/ssr-deps/nested-external, type: directory}
     name: '@vitejs/test-nested-external'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/nested-external-cjs:
     resolution: {directory: playground/ssr-deps/nested-external-cjs, type: directory}
     name: nested-external-cjs
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/no-external-cjs:
     resolution: {directory: playground/ssr-deps/no-external-cjs, type: directory}
     name: '@vitejs/test-no-external-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/no-external-css:
     resolution: {directory: playground/ssr-deps/no-external-css, type: directory}
     name: '@vitejs/test-no-external-css'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/object-assigned-exports:
     resolution: {directory: playground/ssr-deps/object-assigned-exports, type: directory}
     name: '@vitejs/test-object-assigned-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/only-object-assigned-exports:
     resolution: {directory: playground/ssr-deps/only-object-assigned-exports, type: directory}
     name: '@vitejs/test-only-object-assigned-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/optimized-with-nested-external:
     resolution: {directory: playground/ssr-deps/optimized-with-nested-external, type: directory}
     name: '@vitejs/test-optimized-with-nested-external'
+    version: 0.0.0
     dependencies:
       nested-external: file:playground/ssr-deps/nested-external
     dev: false
@@ -10522,36 +10591,43 @@ packages:
   file:playground/ssr-deps/pkg-exports:
     resolution: {directory: playground/ssr-deps/pkg-exports, type: directory}
     name: '@vitejs/test-pkg-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/primitive-export:
     resolution: {directory: playground/ssr-deps/primitive-export, type: directory}
     name: '@vitejs/test-primitive-export'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/read-file-content:
     resolution: {directory: playground/ssr-deps/read-file-content, type: directory}
     name: '@vitejs/test-read-file-content'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/require-absolute:
     resolution: {directory: playground/ssr-deps/require-absolute, type: directory}
     name: '@vitejs/test-require-absolute'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/ts-transpiled-exports:
     resolution: {directory: playground/ssr-deps/ts-transpiled-exports, type: directory}
     name: '@vitejs/test-ts-transpiled-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-noexternal/external-cjs:
     resolution: {directory: playground/ssr-noexternal/external-cjs, type: directory}
     name: '@vitejs/test-external-cjs'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-noexternal/require-external-cjs:
     resolution: {directory: playground/ssr-noexternal/require-external-cjs, type: directory}
     name: '@vitejs/test-require-external-cjs'
+    version: 0.0.0
     dependencies:
       '@vitejs/external-cjs': file:playground/ssr-noexternal/external-cjs
       '@vitejs/test-external-cjs': file:playground/ssr-noexternal/external-cjs
@@ -10560,29 +10636,39 @@ packages:
   file:playground/ssr-resolve/deep-import:
     resolution: {directory: playground/ssr-resolve/deep-import, type: directory}
     name: '@vitejs/test-deep-import'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-resolve/entries:
     resolution: {directory: playground/ssr-resolve/entries, type: directory}
     name: '@vitejs/test-entries'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-resolve/pkg-exports:
     resolution: {directory: playground/ssr-resolve/pkg-exports, type: directory}
     name: '@vitejs/test-resolve-pkg-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-webworker/browser-exports:
     resolution: {directory: playground/ssr-webworker/browser-exports, type: directory}
     name: '@vitejs/test-browser-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/ssr-webworker/worker-exports:
     resolution: {directory: playground/ssr-webworker/worker-exports, type: directory}
     name: '@vitejs/test-worker-exports'
+    version: 0.0.0
     dev: false
 
   file:playground/worker/dep-to-optimize:
     resolution: {directory: playground/worker/dep-to-optimize, type: directory}
     name: '@vitejs/test-dep-to-optimize'
+    version: 1.0.0
     dev: false
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
 overrides:
   vite: workspace:*
 
@@ -10209,19 +10213,16 @@ packages:
   file:playground/alias/dir/module:
     resolution: {directory: playground/alias/dir/module, type: directory}
     name: '@vitejs/test-aliased-module'
-    version: 0.0.0
     dev: false
 
   file:playground/css/css-js-dep:
     resolution: {directory: playground/css/css-js-dep, type: directory}
     name: '@vitejs/test-css-js-dep'
-    version: 1.0.0
     dev: true
 
   file:playground/css/css-proxy-dep:
     resolution: {directory: playground/css/css-proxy-dep, type: directory}
     name: '@vitejs/test-css-proxy-dep'
-    version: 1.0.0
     dependencies:
       '@vitejs/test-css-proxy-dep-nested': file:playground/css/css-proxy-dep-nested
     dev: true
@@ -10229,25 +10230,21 @@ packages:
   file:playground/css/css-proxy-dep-nested:
     resolution: {directory: playground/css/css-proxy-dep-nested, type: directory}
     name: '@vitejs/test-css-proxy-dep-nested'
-    version: 1.0.0
 
   file:playground/define/commonjs-dep:
     resolution: {directory: playground/define/commonjs-dep, type: directory}
     name: '@vitejs/test-commonjs-dep'
-    version: 1.0.0
     dev: false
 
   file:playground/dynamic-import/pkg:
     resolution: {directory: playground/dynamic-import/pkg, type: directory}
     name: '@vitejs/test-pkg'
-    version: 1.0.0
     dev: false
 
   file:playground/external/dep-that-imports(typescript@5.2.2):
     resolution: {directory: playground/external/dep-that-imports, type: directory}
     id: file:playground/external/dep-that-imports
     name: '@vitejs/test-dep-that-imports'
-    version: 0.0.0
     dependencies:
       slash3: /slash@3.0.0
       slash5: /slash@5.1.0
@@ -10260,7 +10257,6 @@ packages:
     resolution: {directory: playground/external/dep-that-requires, type: directory}
     id: file:playground/external/dep-that-requires
     name: '@vitejs/test-dep-that-requires'
-    version: 0.0.0
     dependencies:
       slash3: /slash@3.0.0
       slash5: /slash@5.1.0
@@ -10277,43 +10273,36 @@ packages:
   file:playground/import-assertion/import-assertion-dep:
     resolution: {directory: playground/import-assertion/import-assertion-dep, type: directory}
     name: '@vitejs/test-import-assertion-dep'
-    version: 0.0.0
     dev: false
 
   file:playground/js-sourcemap/importee-pkg:
     resolution: {directory: playground/js-sourcemap/importee-pkg, type: directory}
     name: '@vitejs/test-importee-pkg'
-    version: 0.0.0
     dev: false
 
   file:playground/json/json-module:
     resolution: {directory: playground/json/json-module, type: directory}
     name: '@vitejs/test-json-module'
-    version: 0.0.0
     dev: true
 
   file:playground/minify/dir/module:
     resolution: {directory: playground/minify/dir/module, type: directory}
     name: '@vitejs/test-minify'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps-no-discovery/dep-no-discovery:
     resolution: {directory: playground/optimize-deps-no-discovery/dep-no-discovery, type: directory}
     name: '@vitejs/test-dep-no-discovery'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/added-in-entries:
     resolution: {directory: playground/optimize-deps/added-in-entries, type: directory}
     name: '@vitejs/test-added-in-entries'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-alias-using-absolute-path:
     resolution: {directory: playground/optimize-deps/dep-alias-using-absolute-path, type: directory}
     name: '@vitejs/test-dep-alias-using-absolute-path'
-    version: 1.0.0
     dependencies:
       lodash: 4.17.21
     dev: false
@@ -10321,97 +10310,81 @@ packages:
   file:playground/optimize-deps/dep-cjs-browser-field-bare:
     resolution: {directory: playground/optimize-deps/dep-cjs-browser-field-bare, type: directory}
     name: '@vitejs/test-dep-cjs-browser-field-bare'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-cjs:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-cjs, type: directory}
     name: '@vitejs/test-dep-cjs-compiled-from-cjs'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-compiled-from-esm:
     resolution: {directory: playground/optimize-deps/dep-cjs-compiled-from-esm, type: directory}
     name: '@vitejs/test-dep-cjs-compiled-from-esm'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-cjs-with-assets:
     resolution: {directory: playground/optimize-deps/dep-cjs-with-assets, type: directory}
     name: '@vitejs/test-dep-cjs-with-assets'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-css-require:
     resolution: {directory: playground/optimize-deps/dep-css-require, type: directory}
     name: '@vitejs/test-dep-css-require'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-esbuild-plugin-transform:
     resolution: {directory: playground/optimize-deps/dep-esbuild-plugin-transform, type: directory}
     name: '@vitejs/test-dep-esbuild-plugin-transform'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-node-env:
     resolution: {directory: playground/optimize-deps/dep-node-env, type: directory}
     name: '@vitejs/test-dep-node-env'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-non-optimized:
     resolution: {directory: playground/optimize-deps/dep-non-optimized, type: directory}
     name: '@vitejs/test-dep-non-optimized'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-not-js:
     resolution: {directory: playground/optimize-deps/dep-not-js, type: directory}
     name: '@vitejs/test-dep-not-js'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-optimize-exports-with-glob:
     resolution: {directory: playground/optimize-deps/dep-optimize-exports-with-glob, type: directory}
     name: '@vitejs/test-dep-optimize-exports-with-glob'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-optimize-with-glob:
     resolution: {directory: playground/optimize-deps/dep-optimize-with-glob, type: directory}
     name: '@vitejs/test-dep-optimize-with-glob'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-relative-to-main:
     resolution: {directory: playground/optimize-deps/dep-relative-to-main, type: directory}
     name: '@vitejs/test-dep-relative-to-main'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-builtin-module-cjs:
     resolution: {directory: playground/optimize-deps/dep-with-builtin-module-cjs, type: directory}
     name: '@vitejs/test-dep-with-builtin-module-cjs'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-builtin-module-esm:
     resolution: {directory: playground/optimize-deps/dep-with-builtin-module-esm, type: directory}
     name: '@vitejs/test-dep-with-builtin-module-esm'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-dynamic-import:
     resolution: {directory: playground/optimize-deps/dep-with-dynamic-import, type: directory}
     name: '@vitejs/test-dep-with-dynamic-import'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/dep-with-optional-peer-dep:
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep, type: directory}
     name: '@vitejs/test-dep-with-optional-peer-dep'
-    version: 0.0.0
     peerDependencies:
       foobar: 0.0.0
     peerDependenciesMeta:
@@ -10422,7 +10395,6 @@ packages:
   file:playground/optimize-deps/dep-with-optional-peer-dep-submodule:
     resolution: {directory: playground/optimize-deps/dep-with-optional-peer-dep-submodule, type: directory}
     name: '@vitejs/test-dep-with-optional-peer-dep-submodule'
-    version: 0.0.0
     peerDependencies:
       foobar: 0.0.0
     peerDependenciesMeta:
@@ -10433,13 +10405,11 @@ packages:
   file:playground/optimize-deps/longfilename:
     resolution: {directory: playground/optimize-deps/longfilename, type: directory}
     name: '@vitejs/longfilename-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    version: 0.0.0
     dev: false
 
   file:playground/optimize-deps/nested-exclude:
     resolution: {directory: playground/optimize-deps/nested-exclude, type: directory}
     name: '@vitejs/test-nested-exclude'
-    version: 1.0.0
     dependencies:
       '@vitejs/test-nested-include': file:playground/optimize-deps/nested-include
       nested-include: file:playground/optimize-deps/nested-include
@@ -10448,13 +10418,11 @@ packages:
   file:playground/optimize-deps/nested-include:
     resolution: {directory: playground/optimize-deps/nested-include, type: directory}
     name: '@vitejs/test-nested-include'
-    version: 1.0.0
     dev: false
 
   file:playground/optimize-missing-deps/missing-dep:
     resolution: {directory: playground/optimize-missing-deps/missing-dep, type: directory}
     name: '@vitejs/test-missing-dep'
-    version: 0.0.0
     dependencies:
       '@vitejs/test-multi-entry-dep': file:playground/optimize-missing-deps/multi-entry-dep
       multi-entry-dep: file:playground/optimize-missing-deps/multi-entry-dep
@@ -10463,18 +10431,15 @@ packages:
   file:playground/optimize-missing-deps/multi-entry-dep:
     resolution: {directory: playground/optimize-missing-deps/multi-entry-dep, type: directory}
     name: '@vitejs/test-multi-entry-dep'
-    version: 0.0.0
     dev: false
 
   file:playground/preload/dep-a:
     resolution: {directory: playground/preload/dep-a, type: directory}
     name: '@vitejs/test-dep-a'
-    version: 0.0.0
 
   file:playground/preload/dep-including-a:
     resolution: {directory: playground/preload/dep-including-a, type: directory}
     name: '@vitejs/test-dep-including-a'
-    version: 0.0.0
     dependencies:
       '@vitejs/test-dep-a': file:playground/preload/dep-a
       dep-a: file:playground/preload/dep-a
@@ -10483,43 +10448,36 @@ packages:
   file:playground/ssr-conditions/external:
     resolution: {directory: playground/ssr-conditions/external, type: directory}
     name: '@vitejs/test-ssr-conditions-external'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-conditions/no-external:
     resolution: {directory: playground/ssr-conditions/no-external, type: directory}
     name: '@vitejs/test-ssr-conditions-no-external'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/css-lib:
     resolution: {directory: playground/ssr-deps/css-lib, type: directory}
     name: '@vitejs/test-css-lib'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/define-properties-exports:
     resolution: {directory: playground/ssr-deps/define-properties-exports, type: directory}
     name: '@vitejs/test-define-properties-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/define-property-exports:
     resolution: {directory: playground/ssr-deps/define-property-exports, type: directory}
     name: '@vitejs/test-define-property-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/external-entry:
     resolution: {directory: playground/ssr-deps/external-entry, type: directory}
     name: '@vitejs/test-external-entry'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/external-using-external-entry:
     resolution: {directory: playground/ssr-deps/external-using-external-entry, type: directory}
     name: '@vitejs/test-external-using-external-entry'
-    version: 0.0.0
     dependencies:
       external-entry: file:playground/ssr-deps/external-entry
     dev: false
@@ -10527,7 +10485,6 @@ packages:
   file:playground/ssr-deps/forwarded-export:
     resolution: {directory: playground/ssr-deps/forwarded-export, type: directory}
     name: '@vitejs/test-forwarded-export'
-    version: 0.0.0
     dependencies:
       object-assigned-exports: file:playground/ssr-deps/object-assigned-exports
     dev: false
@@ -10535,55 +10492,46 @@ packages:
   file:playground/ssr-deps/import-builtin-cjs:
     resolution: {directory: playground/ssr-deps/import-builtin-cjs, type: directory}
     name: '@vitejs/test-import-builtin'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/module-condition:
     resolution: {directory: playground/ssr-deps/module-condition, type: directory}
     name: '@vitejs/test-module-condition'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/nested-external:
     resolution: {directory: playground/ssr-deps/nested-external, type: directory}
     name: '@vitejs/test-nested-external'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/nested-external-cjs:
     resolution: {directory: playground/ssr-deps/nested-external-cjs, type: directory}
     name: nested-external-cjs
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/no-external-cjs:
     resolution: {directory: playground/ssr-deps/no-external-cjs, type: directory}
     name: '@vitejs/test-no-external-cjs'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/no-external-css:
     resolution: {directory: playground/ssr-deps/no-external-css, type: directory}
     name: '@vitejs/test-no-external-css'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/object-assigned-exports:
     resolution: {directory: playground/ssr-deps/object-assigned-exports, type: directory}
     name: '@vitejs/test-object-assigned-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/only-object-assigned-exports:
     resolution: {directory: playground/ssr-deps/only-object-assigned-exports, type: directory}
     name: '@vitejs/test-only-object-assigned-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/optimized-with-nested-external:
     resolution: {directory: playground/ssr-deps/optimized-with-nested-external, type: directory}
     name: '@vitejs/test-optimized-with-nested-external'
-    version: 0.0.0
     dependencies:
       nested-external: file:playground/ssr-deps/nested-external
     dev: false
@@ -10591,43 +10539,36 @@ packages:
   file:playground/ssr-deps/pkg-exports:
     resolution: {directory: playground/ssr-deps/pkg-exports, type: directory}
     name: '@vitejs/test-pkg-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/primitive-export:
     resolution: {directory: playground/ssr-deps/primitive-export, type: directory}
     name: '@vitejs/test-primitive-export'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/read-file-content:
     resolution: {directory: playground/ssr-deps/read-file-content, type: directory}
     name: '@vitejs/test-read-file-content'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/require-absolute:
     resolution: {directory: playground/ssr-deps/require-absolute, type: directory}
     name: '@vitejs/test-require-absolute'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-deps/ts-transpiled-exports:
     resolution: {directory: playground/ssr-deps/ts-transpiled-exports, type: directory}
     name: '@vitejs/test-ts-transpiled-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-noexternal/external-cjs:
     resolution: {directory: playground/ssr-noexternal/external-cjs, type: directory}
     name: '@vitejs/test-external-cjs'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-noexternal/require-external-cjs:
     resolution: {directory: playground/ssr-noexternal/require-external-cjs, type: directory}
     name: '@vitejs/test-require-external-cjs'
-    version: 0.0.0
     dependencies:
       '@vitejs/external-cjs': file:playground/ssr-noexternal/external-cjs
       '@vitejs/test-external-cjs': file:playground/ssr-noexternal/external-cjs
@@ -10636,39 +10577,29 @@ packages:
   file:playground/ssr-resolve/deep-import:
     resolution: {directory: playground/ssr-resolve/deep-import, type: directory}
     name: '@vitejs/test-deep-import'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-resolve/entries:
     resolution: {directory: playground/ssr-resolve/entries, type: directory}
     name: '@vitejs/test-entries'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-resolve/pkg-exports:
     resolution: {directory: playground/ssr-resolve/pkg-exports, type: directory}
     name: '@vitejs/test-resolve-pkg-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-webworker/browser-exports:
     resolution: {directory: playground/ssr-webworker/browser-exports, type: directory}
     name: '@vitejs/test-browser-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/ssr-webworker/worker-exports:
     resolution: {directory: playground/ssr-webworker/worker-exports, type: directory}
     name: '@vitejs/test-worker-exports'
-    version: 0.0.0
     dev: false
 
   file:playground/worker/dep-to-optimize:
     resolution: {directory: playground/worker/dep-to-optimize, type: directory}
     name: '@vitejs/test-dep-to-optimize'
-    version: 1.0.0
     dev: false
-
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Add RSS feed for Vite blog.

* Add `<link rel="alternate" type="application/rss+xml" href="/blog.rss">` in homepage
* Generate rss on docs build `pnpm run docs-build`, then `pnpm run docs-serve`, visit `http://localhost:{port}/blog.rss`
* A preview of the rss generated

```
<?xml version="1.0" encoding="utf-8"?>
<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/">
    <channel>
        <title>Vite</title>
        <link>https://vitejs.dev/blog</link>
        <description>Next Generation Frontend Tooling</description>
        <lastBuildDate>Mon, 20 Nov 2023 09:55:24 GMT</lastBuildDate>
        <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
        <generator>https://github.com/jpmonette/feed</generator>
        <language>en</language>
        <image>
            <title>Vite</title>
            <url>https://vitejs.dev/og-image.png</url>
            <link>https://vitejs.dev/blog</link>
        </image>
        <copyright>Copyright Â© 2019-present Evan You &amp; Vite Contributors</copyright>
        <item>
            <title><![CDATA[Vite 5.0 is out!]]></title>
            <link>https://vitejs.dev/blog/announcing-vite5.html</link>
            <guid>https://vitejs.dev/blog/announcing-vite5.html</guid>
            <pubDate>Thu, 16 Nov 2023 00:00:00 GMT</pubDate>
            <content:encoded><![CDATA[<h1 id="vite-5-0-is-out" tabindex="-1">Vite 5.0 is out! <a class="header-anchor" href="#vite-5-0-is-out" aria-label="Permalink to &quot;Vite 5.0 is out!&quot;">&ZeroWidthSpace;</a></h1>
<p><em>November 16, 2023</em></p>
<p><img src="/og-image-announcing-vite5.png" alt="Vite 5 Announcement Cover Image"></p>
<p>Vite 4 <a href="./announcing-vite4.html">was released</a> almost a year ago, and it served as a solid base for the ecosystem. npm downloads per week jumped from 2.5 million to 7.5 million, as projects keep building on a shared infrastructure. Frameworks continued to innovate, and on top of <a href="https://astro.build/" target="_blank" rel="noreferrer">Astro</a>, <a href="https://nuxt.com/" target="_blank" rel="noreferrer">Nuxt</a>, <a href="https://kit.svelte.dev/" target="_blank" rel="noreferrer">SvelteKit</a>, <a href="https://www.solidjs.com/blog/introducing-solidstart" target="_blank" rel="noreferrer">Solid Start</a>, <a href="https://qwik.builder.io/qwikcity/overview/" target="_blank" rel="noreferrer">Qwik City</a>, between others, we saw new frameworks joining and making the ecosystem stronger. <a href="https://redwoodjs.com/" target="_blank" rel="noreferrer">RedwoodJS</a> and <a href="https://remix.run/" target="_blank" rel="noreferrer">Remix</a> switching to Vite paves the way for further adoption in the React ecosystem. <a href="https://vitest.dev" target="_blank" rel="noreferrer">Vitest</a> kept growing at an even faster pace than Vite. Its team has been hard at work and will soon <a href="https://github.com/vitest-dev/vitest/issues/3596" target="_blank" rel="noreferrer">release Vitest 1.0</a>. The story of Vite when used with other tools such as <a href="https://storybook.js.org" target="_blank" rel="noreferrer">Storybook</a>, <a href="https://nx.dev" target="_blank" rel="noreferrer">Nx</a>, and <a href="https://playwright.dev" target="_blank" rel="noreferrer">Playwright</a> kept improving, and the same goes for environments, with Vite dev working both in <a href="https://deno.com" target="_blank" rel="noreferrer">Deno</a> and <a href="https://bun.sh" target="_blank" rel="noreferrer">Bun</a>.</p>
....
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
An issue has recently been raised regarding rss feed.
close https://github.com/vitejs/vite/issues/15024

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
