### PR TITLE
perf(hmr): skip traversed modules when checking circular imports

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -361,11 +361,13 @@ function propagateUpdate(
  * @param nodeChain The chain of nodes/imports that lead to the node.
  *   (The last node in the chain imports the `node` parameter)
  * @param currentChain The current chain tracked from the `node` parameter
+ * @param traversedModules The set of modules that have been traversed
  */
 function isNodeWithinCircularImports(
   node: ModuleNode,
   nodeChain: ModuleNode[],
   currentChain: ModuleNode[] = [node],
+  traversedModules = new Set<ModuleNode>(),
 ): HasDeadEnd {
   // To help visualize how each parameters work, imagine this import graph:
   //
@@ -382,6 +384,12 @@ function isNodeWithinCircularImports(
   //
   // It works by checking if any `node` importers are within `nodeChain`, which
   // means there's an import loop with a HMR-accepted module in it.
+
+  if (traversedModules.has(node)) {
+    // To avoid infinite recursion, we only check each module once.
+    return false
+  }
+  traversedModules.add(node)
 
   for (const importer of node.importers) {
     // Node may import itself which is safe
@@ -416,6 +424,7 @@ function isNodeWithinCircularImports(
         importer,
         nodeChain,
         currentChain.concat(importer),
+        traversedModules,
       )
       if (result) return result
     }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -361,7 +361,7 @@ function propagateUpdate(
  * @param nodeChain The chain of nodes/imports that lead to the node.
  *   (The last node in the chain imports the `node` parameter)
  * @param currentChain The current chain tracked from the `node` parameter
- * @param traversedModules The set of modules that have been traversed
+ * @param traversedModules The set of modules that have traversed
  */
 function isNodeWithinCircularImports(
   node: ModuleNode,
@@ -386,7 +386,6 @@ function isNodeWithinCircularImports(
   // means there's an import loop with a HMR-accepted module in it.
 
   if (traversedModules.has(node)) {
-    // To avoid infinite recursion, we only check each module once.
     return false
   }
   traversedModules.add(node)


### PR DESCRIPTION
### Description

This PR is fixing graph traversal issue where long module graph seems to be explored repetitively, at least the HMR reloading is super slow and can sometimes result in the server becoming irresponsive. It is likely related to the codebase having a lot of barrel files and circular imports. 

### Additional context

I just tried 5.0 out an a large codebase with a lot of circular imports and barrel files. Unfortunately we often end up on cases where Vite becomes irresponsive when changing certain files. 

The regression is related to https://github.com/vitejs/vite/pull/14867.

I could come up with a test case that reproduces this. @ArnaudBarre do you have an idea on how to do that?

The solution was suggested by @ArnaudBarre [here](https://github.com/vitejs/vite/pull/14867#issuecomment-1817642549).

Performance improvement: most importantly the server is now responsive again, but for some files that took 14 seconds to determine a circular import (vite 5.0.0), it now takes ~10 ms. 

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
