### PR TITLE
build: handle latest json-stable-stringify replacement

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -117,8 +117,8 @@ function createNodePlugins(
           replacement: `__require`,
         },
         'json-stable-stringify/index.js': {
-          pattern: /^var json = typeof JSON.+require\('jsonify'\);$/gm,
-          replacement: 'var json = JSON',
+          src: "require('jsonify')",
+          replacement: 'JSON',
         },
         // postcss-import uses the `resolve` dep if the `resolve` option is not passed.
         // However, we always pass the `resolve` option. Remove this import to avoid


### PR DESCRIPTION
### Description

In the recent version (`v1.1.0`) of the `json-stable-stringify` module, caching of `JSON.stringify` was implemented. 

The syntax changed from:
```js
var json = typeof JSON !== 'undefined' ? JSON : require('jsonify');
```
to:
```js
var jsonStringify = (typeof JSON !== 'undefined' ? JSON : require('jsonify')).stringify;
```
Vite optimized the `json-stable-stringify` module and in its transform phase it matched a regular expression for the `jsonify` module, which caused build failures due to changes in syntax.

The original regex pattern was:
```js
/^var json = typeof JSON.+require\('jsonify'\);$/gm
```
I personally think that there is no need to consider how the submodule of itself is dependent on by the `json-stable-stringfy` module, just replacing its own submodule with `JSON` can achieve expectations.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.