### PR TITLE
docs(legacy): clarify that csp hashes could change between minors

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -163,6 +163,8 @@ The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https
 Run `node --input-type=module -e "import {cspHashes} from '@vitejs/plugin-legacy'; console.log(cspHashes.map(h => 'sha256-'+h))"` to retrieve the value.
 -->
 
+Note that these values could change between minor versions. If you rely on these values, we recommend pinning the minor version using `~`.
+
 These values (without the `sha256-` prefix) can also be retrieved via
 
 ```js

--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -152,7 +152,15 @@ export default {
 
 ## Content Security Policy
 
-The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc), SystemJS initialization, and dynamic import fallback. If you have a strict CSP policy requirement, you will need to [add the corresponding hashes to your `script-src` list](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script):
+The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https://gist.github.com/samthor/64b114e4a4f539915a95b91ffd340acc), SystemJS initialization, and dynamic import fallback. If you have a strict CSP policy requirement, you will need to [add the corresponding hashes to your `script-src` list](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script).
+
+The hash values (without the `sha256-` prefix) can be retrieved via:
+
+```js
+import { cspHashes } from '@vitejs/plugin-legacy'
+```
+
+The current values are:
 
 - `sha256-MS6/3FCg4WjP9gwgaBGwLpRCY6fZBgwmhVCdrPrNf3E=`
 - `sha256-tQjf8gvb2ROOMapIxFvFAYBeUJ0v1HCbOcSmDNXGtDo=`
@@ -163,13 +171,7 @@ The legacy plugin requires inline scripts for [Safari 10.1 `nomodule` fix](https
 Run `node --input-type=module -e "import {cspHashes} from '@vitejs/plugin-legacy'; console.log(cspHashes.map(h => 'sha256-'+h))"` to retrieve the value.
 -->
 
-Note that these values could change between minor versions. If you rely on these values, we recommend pinning the minor version using `~`.
-
-These values (without the `sha256-` prefix) can also be retrieved via
-
-```js
-import { cspHashes } from '@vitejs/plugin-legacy'
-```
+Note that these values could change between minor versions. Thus, we recommend generating the CSP header from the exported `cspHashes` variable. If you copy the values manually, then you should pin the minor version using `~`.
 
 When using the `regenerator-runtime` polyfill, it will attempt to use the `globalThis` object to register itself. If `globalThis` is not available (it is [fairly new](https://caniuse.com/?search=globalThis) and not widely supported, including IE 11), it attempts to perform dynamic `Function(...)` call which violates the CSP. To avoid dynamic `eval` in the absence of `globalThis` consider adding `core-js/proposals/global-this` to `additionalLegacyPolyfills` to define it.
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
https://github.com/vitejs/vite/pull/15021#issuecomment-1820741801

### Additional context
Should we mention that pinning the version isn't needed if you are getting the value from `import { cspHashes } from '@vitejs/plugin-legacy'`?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
