### PR TITLE
fix: make htmlFallback more permissive

### DIFF
--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -14,11 +14,10 @@ export function htmlFallbackMiddleware(
     if (
       // Only accept GET or HEAD
       (req.method !== 'GET' && req.method !== 'HEAD') ||
-      // Ignore JSON requests
-      req.headers.accept?.includes('application/json') ||
       // Require Accept: text/html or */*
       !(
         req.headers.accept === undefined || // equivalent to `Accept: */*`
+        req.headers.accept === '' || // equivalent to `Accept: */*`
         req.headers.accept.includes('text/html') ||
         req.headers.accept.includes('*/*')
       )

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -414,3 +414,17 @@ test('html serve behavior', async () => {
   expect(bothSlashIndexHtml.status).toBe(200)
   expect(await bothSlashIndexHtml.text()).toContain('both/index.html')
 })
+
+test('html fallback works non browser accept header', async () => {
+  expect((await fetch('/', { headers: { Accept: '' } })).status).toBe(200)
+  // defaults to "Accept: */*"
+  expect((await fetch('/')).status).toBe(200)
+  // wait-on uses axios and axios sends this accept header
+  expect(
+    (
+      await fetch('/', {
+        headers: { Accept: 'application/json, text/plain, */*' },
+      })
+    ).status,
+  ).toBe(200)
+})

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -416,13 +416,15 @@ test('html serve behavior', async () => {
 })
 
 test('html fallback works non browser accept header', async () => {
-  expect((await fetch('/', { headers: { Accept: '' } })).status).toBe(200)
+  expect(
+    (await fetch(viteTestUrl + '/', { headers: { Accept: '' } })).status,
+  ).toBe(200)
   // defaults to "Accept: */*"
-  expect((await fetch('/')).status).toBe(200)
+  expect((await fetch(viteTestUrl + '/')).status).toBe(200)
   // wait-on uses axios and axios sends this accept header
   expect(
     (
-      await fetch('/', {
+      await fetch(viteTestUrl + '/', {
         headers: { Accept: 'application/json, text/plain, */*' },
       })
     ).status,

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -416,15 +416,15 @@ test('html serve behavior', async () => {
 })
 
 test('html fallback works non browser accept header', async () => {
-  expect(
-    (await fetch(viteTestUrl + '/', { headers: { Accept: '' } })).status,
-  ).toBe(200)
+  expect((await fetch(viteTestUrl, { headers: { Accept: '' } })).status).toBe(
+    200,
+  )
   // defaults to "Accept: */*"
-  expect((await fetch(viteTestUrl + '/')).status).toBe(200)
+  expect((await fetch(viteTestUrl)).status).toBe(200)
   // wait-on uses axios and axios sends this accept header
   expect(
     (
-      await fetch(viteTestUrl + '/', {
+      await fetch(viteTestUrl, {
         headers: { Accept: 'application/json, text/plain, */*' },
       })
     ).status,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I only tested the fix in #15025 by `fetch('/')`. But `fetch('/')` was sending `Accept: */*`. 🤦

Also it turns out that wait-on sends `Accept: application/json, text/plain, */*`. We need to remove the json part.

fixes #15022

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
