### PR TITLE
chore: update release process to include pnpm build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ If you have publish access, the steps below explain how to cut a release for a p
 "Release" is done locally to generate the changelogs and git tags:
 
 1. Make sure the git remote for https://github.com/vitejs/vite is set as `origin`.
-2. In the `vite` project root `main` branch, run `git pull` and `pnpm i` to get it up-to-date.
+2. In the `vite` project root `main` branch, run `git pull` and `pnpm i` to get it up-to-date. Then run `pnpm build`.
 3. Run `pnpm release` and follow the prompts to cut a release for a package. It will generate the changelog, a git release tag, and push them to `origin`. You can run with the `--dry` flag to test it out.
 4. When the command finishes, it will provide a link to https://github.com/vitejs/vite/actions/workflows/publish.yml.
 5. Click the link to visit the page, and follow the next steps below.


### PR DESCRIPTION
### Description

@sapphi-red reported that there is a publint error if there is no build done before calling `pnpm release`. We aren't triggering a build in vite-release-scripts because it is too time-consuming, for now, let's add it as part of the process.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other