### PR TITLE
test: skip unicode test on windows instead of lowering the Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - os: macos-latest
             node_version: 20
           - os: windows-latest
-            node_version: 20.3.1 # https://github.com/nodejs/node/issues/48673
+            node_version: 20
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"

--- a/playground/hasWindowsUnicodeFsBug.js
+++ b/playground/hasWindowsUnicodeFsBug.js
@@ -1,0 +1,10 @@
+import os from 'node:os'
+
+const isWindows = os.platform() === 'win32'
+const nodeVersionArray = process.versions.node.split('.')
+// ignore some files due to https://github.com/nodejs/node/issues/48673
+// node <=21.0.0 and ^20.4.0 has the bug
+export const hasWindowsUnicodeFsBug =
+  isWindows &&
+  (+nodeVersionArray[0] > 20 ||
+    (+nodeVersionArray[0] === 20 && +nodeVersionArray[1] >= 4))

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it, test } from 'vitest'
+import { hasWindowsUnicodeFsBug } from '../../hasWindowsUnicodeFsBug'
 import {
   addFile,
   browserLogs,
@@ -205,21 +206,24 @@ if (!isBuild) {
     await untilUpdated(() => el.textContent(), '3')
   })
 
-  test('full-reload encodeURI path', async () => {
-    await page.goto(
-      viteTestUrl + '/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
-    )
-    const el = await page.$('#app')
-    expect(await el.textContent()).toBe('title')
-    editFile('unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html', (code) =>
-      code.replace('title', 'title2'),
-    )
-    await page.waitForEvent('load')
-    await untilUpdated(
-      async () => (await page.$('#app')).textContent(),
-      'title2',
-    )
-  })
+  test.skipIf(hasWindowsUnicodeFsBug)(
+    'full-reload encodeURI path',
+    async () => {
+      await page.goto(
+        viteTestUrl + '/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
+      )
+      const el = await page.$('#app')
+      expect(await el.textContent()).toBe('title')
+      editFile('unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html', (code) =>
+        code.replace('title', 'title2'),
+      )
+      await page.waitForEvent('load')
+      await untilUpdated(
+        async () => (await page.$('#app')).textContent(),
+        'title2',
+      )
+    },
+  )
 
   test('CSS update preserves query params', async () => {
     await page.goto(viteTestUrl)

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, test } from 'vitest'
+import { hasWindowsUnicodeFsBug } from '../../hasWindowsUnicodeFsBug'
 import {
   browserLogs,
   editFile,
@@ -218,7 +219,7 @@ describe('noBody', () => {
   })
 })
 
-describe('Unicode path', () => {
+describe.skipIf(hasWindowsUnicodeFsBug)('Unicode path', () => {
   test('direct access', async () => {
     await page.goto(
       viteTestUrl + '/unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -1,5 +1,6 @@
 import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
+import { hasWindowsUnicodeFsBug } from '../hasWindowsUnicodeFsBug'
 
 export default defineConfig({
   base: './',
@@ -20,10 +21,14 @@ export default defineConfig({
         inline1: resolve(__dirname, 'inline/shared-1.html'),
         inline2: resolve(__dirname, 'inline/shared-2.html'),
         inline3: resolve(__dirname, 'inline/unique.html'),
-        unicodePath: resolve(
-          __dirname,
-          'unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
-        ),
+        ...(hasWindowsUnicodeFsBug
+          ? {}
+          : {
+              unicodePath: resolve(
+                __dirname,
+                'unicode-path/中文-にほんご-한글-🌕🌖🌗/index.html',
+              ),
+            }),
         linkProps: resolve(__dirname, 'link-props/index.html'),
         valid: resolve(__dirname, 'valid.html'),
         importmapOrder: resolve(__dirname, 'importmapOrder.html'),

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import fs from 'fs-extra'
 import type { BrowserServer } from 'playwright-chromium'
 import { chromium } from 'playwright-chromium'
+import { hasWindowsUnicodeFsBug } from './hasWindowsUnicodeFsBug'
 
 const DIR = path.join(os.tmpdir(), 'vitest_playwright_global_setup')
 
@@ -30,6 +31,9 @@ export async function setup(): Promise<void> {
     .copy(path.resolve(__dirname, '../playground'), tempDir, {
       dereference: false,
       filter(file) {
+        if (file.includes('中文-にほんご-한글-🌕🌖🌗')) {
+          return !hasWindowsUnicodeFsBug
+        }
         file = file.replace(/\\/g, '/')
         return !file.includes('__tests__') && !file.match(/dist(\/|$)/)
       },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The fix (https://github.com/nodejs/node/pull/50650) for the Windows unicode fs bug (https://github.com/nodejs/node/issues/48673) seems to be not included in the next LTS release (https://github.com/nodejs/node/pull/50682).
This means we'll need to pin the version for at least 2 week more.

I think it's better to skip this (edge case) test rather than running in the older version.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
