### PR TITLE
docs: improve community templates section

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -91,7 +91,7 @@ See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite)
 
 create-vite is a tool to quickly start a project from a basic template for popular frameworks. Check out Awesome Vite for [community maintained templates](https://github.com/vitejs/awesome-vite#templates) that include other tools or target different frameworks.
 
-For a template at `https://github/user/project`, you can try it out online using `https://stackblitz.com/github/user/project`.
+For a template at `https://github.com/user/project`, you can try it out online using `https://stackblitz.com/github/user/project`.
 
 You can also use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates. Assuming the project is in GitHub and uses `main` as the default branch, you can create a local copy using:
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -91,7 +91,7 @@ See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite)
 
 create-vite is a tool to quickly start a project from a basic template for popular frameworks. Check out Awesome Vite for [community maintained templates](https://github.com/vitejs/awesome-vite#templates) that include other tools or target different frameworks.
 
-For a template at `https://github.com/user/project`, you can try it out online using `https://stackblitz.com/github/user/project`.
+For a template at `https://github.com/user/project`, you can try it out online using `https://github.stackblitz.com/user/project` (adding `.stackblitz` after `github` to the URL of the project).
 
 You can also use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates. Assuming the project is on GitHub and uses `main` as the default branch, you can create a local copy using:
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -89,20 +89,18 @@ See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite)
 
 ## Community Templates
 
-create-vite is a tool to quickly start a project from a basic template for popular frameworks. Check out Awesome Vite for [community maintained templates](https://github.com/vitejs/awesome-vite#templates) that include other tools or target different frameworks. You can use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates.
+create-vite is a tool to quickly start a project from a basic template for popular frameworks. Check out Awesome Vite for [community maintained templates](https://github.com/vitejs/awesome-vite#templates) that include other tools or target different frameworks.
+
+For a template at `https://github/user/project`, you can try it out online using `https://stackblitz.com/github/user/project`.
+
+You can also use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates. Assuming the project is in GitHub and uses `main` as the default branch, you can create a local copy using:
 
 ```bash
-npx degit user/project my-project
+npx degit user/project#main my-project
 cd my-project
 
 npm install
 npm run dev
-```
-
-If the project uses `main` as the default branch, suffix the project repo with `#main`
-
-```bash
-npx degit user/project#main my-project
 ```
 
 ## `index.html` and Project Root

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -93,7 +93,7 @@ create-vite is a tool to quickly start a project from a basic template for popul
 
 For a template at `https://github.com/user/project`, you can try it out online using `https://stackblitz.com/github/user/project`.
 
-You can also use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates. Assuming the project is in GitHub and uses `main` as the default branch, you can create a local copy using:
+You can also use a tool like [degit](https://github.com/Rich-Harris/degit) to scaffold your project with one of the templates. Assuming the project is on GitHub and uses `main` as the default branch, you can create a local copy using:
 
 ```bash
 npx degit user/project#main my-project


### PR DESCRIPTION
### Description

Simplify degit section to include a single code block. I think that `main` now is the most used default branch name in templates, so it is better to directly guide users to the right snippet using it.

The PR also adds a line about how to try out the templates online, in the same way we do for create-vite (first online -> scaffold offline)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other