### PR TITLE
fix(css): render correct asset url when CSS chunk name is nested

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -54,6 +54,7 @@ import {
   processSrcSet,
   removeDirectQuery,
   requireResolveFromRootWithFallback,
+  slash,
   stripBase,
   stripBomTag,
 } from '../utils'
@@ -388,10 +389,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       : rollupOptionsOutput
   )?.assetFileNames
   const getCssAssetDirname = (cssAssetName: string) => {
+    const cssAssetNameDir = path.dirname(cssAssetName)
     if (!assetFileNames) {
-      return config.build.assetsDir
+      return path.join(config.build.assetsDir, cssAssetNameDir)
     } else if (typeof assetFileNames === 'string') {
-      return path.dirname(assetFileNames)
+      return path.join(path.dirname(assetFileNames), cssAssetNameDir)
     } else {
       return path.dirname(
         assetFileNames({
@@ -556,7 +558,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         const relative = config.base === './' || config.base === ''
         const cssAssetDirname =
           encodedPublicUrls || relative
-            ? getCssAssetDirname(cssAssetName)
+            ? slash(getCssAssetDirname(cssAssetName))
             : undefined
 
         const toRelative = (filename: string) => {

--- a/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
+++ b/playground/assets/__tests__/relative-base/relative-base-assets.spec.ts
@@ -132,6 +132,11 @@ describe('css url() references', () => {
     const bg = await getBg('.css-url-aliased')
     expect(bg).toMatch(cssBgAssetMatch)
   })
+
+  test('nested manual chunks', async () => {
+    const bg = await getBg('.css-manual-chunks-relative')
+    expect(bg).toMatch(cssBgAssetMatch)
+  })
 })
 
 describe.runIf(isBuild)('index.css URLs', () => {

--- a/playground/assets/css/manual-chunks.css
+++ b/playground/assets/css/manual-chunks.css
@@ -1,0 +1,4 @@
+.css-manual-chunks-relative {
+  background: url(../nested/asset.png);
+  background-size: 10px;
+}

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -114,6 +114,11 @@
 <div class="css-url-aliased">
   <span style="background: #fff">CSS background (aliased)</span>
 </div>
+<div class="css-manual-chunks-relative">
+  <span style="background: #fff"
+    >CSS nested manual chunks relative base background</span
+  >
+</div>
 
 <div class="css-url-svg">
   <span style="background: #fff">CSS SVG background</span>
@@ -395,6 +400,7 @@
   import './css/fonts.css'
   import './css/css-url.css'
   import './css/icons.css'
+  import './css/manual-chunks.css'
 
   text('.base', `import.meta.${``}env.BASE_URL: ${import.meta.env.BASE_URL}`)
 

--- a/playground/assets/vite.config-relative-base.js
+++ b/playground/assets/vite.config-relative-base.js
@@ -15,6 +15,11 @@ export default defineConfig(({ isPreview }) => ({
         entryFileNames: 'entries/[name].js',
         chunkFileNames: 'chunks/[name]-[hash].js',
         assetFileNames: 'other-assets/[name]-[hash][extname]',
+        manualChunks(id) {
+          if (id.includes('css/manual-chunks.css')) {
+            return 'css/manual-chunks'
+          }
+        },
       },
     },
   },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When the CSS chunk is generated in a nested directory, the rendered asset URL was wrong when using relative base.

refs #14945
fixes #15141

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
