### PR TITLE
fix(css): use non-nested chunk name if facadeModule is not CSS file

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -613,7 +613,11 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           }
 
           const isEntry = chunk.isEntry && isPureCssChunk
-          const cssAssetName = ensureFileExt(chunk.name, '.css')
+          const cssFullAssetName = ensureFileExt(chunk.name, '.css')
+          const cssAssetName =
+            chunk.facadeModuleId && isCSSRequest(chunk.facadeModuleId)
+              ? cssFullAssetName
+              : path.basename(cssFullAssetName)
           const originalFilename = getChunkOriginalFileName(
             chunk,
             config.root,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -614,10 +614,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
           const isEntry = chunk.isEntry && isPureCssChunk
           const cssFullAssetName = ensureFileExt(chunk.name, '.css')
+          // if facadeModuleId doesn't exist or doesn't have a CSS extension,
+          // that means a JS entry file imports a CSS file.
+          // in this case, only use the filename for the CSS chunk name like JS chunks.
           const cssAssetName =
-            chunk.facadeModuleId && isCSSRequest(chunk.facadeModuleId)
-              ? cssFullAssetName
-              : path.basename(cssFullAssetName)
+            chunk.isEntry &&
+            (!chunk.facadeModuleId || !isCSSRequest(chunk.facadeModuleId))
+              ? path.basename(cssFullAssetName)
+              : cssFullAssetName
           const originalFilename = getChunkOriginalFileName(
             chunk,
             config.root,

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -54,6 +54,13 @@ describe.runIf(isBuild)('build', () => {
     // use the entry name
     expect(dirFooAssetEntry.file).toMatch('assets/bar-')
   })
+
+  test('CSS imported from JS entry should be have a non-nested chunk name', () => {
+    const manifest = readManifest('dev')
+    const mainTsEntryCss = manifest['nested/sub.ts'].css
+    expect(mainTsEntryCss.length).toBe(1)
+    expect(mainTsEntryCss[0].replace('assets/', '')).not.toContain('/')
+  })
 })
 
 describe.runIf(isServe)('serve', () => {

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -55,7 +55,7 @@ describe.runIf(isBuild)('build', () => {
     expect(dirFooAssetEntry.file).toMatch('assets/bar-')
   })
 
-  test('CSS imported from JS entry should be have a non-nested chunk name', () => {
+  test('CSS imported from JS entry should have a non-nested chunk name', () => {
     const manifest = readManifest('dev')
     const mainTsEntryCss = manifest['nested/sub.ts'].css
     expect(mainTsEntryCss.length).toBe(1)

--- a/playground/backend-integration/frontend/entrypoints/index.html
+++ b/playground/backend-integration/frontend/entrypoints/index.html
@@ -27,7 +27,12 @@
   </li>
 </ul>
 
+<h2>CSS imported from JS</h2>
+
+<p class="imported">text</p>
+
 <script type="module" src="./main.ts"></script>
+<script type="module" src="./nested/sub.ts"></script>
 <script type="module">
   import './global.css'
 

--- a/playground/backend-integration/frontend/entrypoints/nested/sub.ts
+++ b/playground/backend-integration/frontend/entrypoints/nested/sub.ts
@@ -1,0 +1,1 @@
+import '../../styles/imported.css'

--- a/playground/backend-integration/frontend/styles/imported.css
+++ b/playground/backend-integration/frontend/styles/imported.css
@@ -1,0 +1,3 @@
+.imported {
+  color: green;
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
#14945 changed the CSS chunk names to respect chunk name correctly.
That fixed the following cases:

- A CSS file is specified in `build.rollupOptions.input` (e.g. `build.rollupOptions.input: { 'css/foo.css': 'css/foo.css' }`) (https://github.com/vitejs/vite/issues/4863#issuecomment-1367775712)
- `build.rollupOptions.output.preserveModules: true` is set (#8057, #12072)

But this also changed the CSS chunk name when a nested JS entry chunk imports a CSS chunk. For example,
```js
build: {
  rollupOptions: {
    input: {
      'nested/foo.js': 'nested/foo.js' // nested/foo.js imports a CSS file
    }
  }
}
```
In this case, some people would want the CSS file to be output under `nested` directory, while others would want the CSS file to be output without `nested` directory.
The current behavior is the latter one, and this PR changes to the former one. But I'm not sure which is better. 🤔 

refs #14945
refs #15141

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
