### PR TITLE
fix: bindCLIShortcuts to proper server

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -942,26 +942,33 @@ async function restartServer(server: ViteDevServer) {
     })
   }
 
-  let newServer = null
-  try {
-    // delay ws server listen
-    newServer = await _createServer(inlineConfig, { ws: false })
-  } catch (err: any) {
-    server.config.logger.error(err.message, {
-      timestamp: true,
-    })
-    server.config.logger.error('server restart failed', { timestamp: true })
-    return
+  // Reinit the server by creating a new instance using the same inlineConfig
+  // This will triger a reload of the config file and re-create the plugins and
+  // middlewares. We then assign all properties of the new server to the existing
+  // server instance and set the user instance to be used in the new server.
+  // This allows us to keep the same server instance for the user.
+  {
+    let newServer = null
+    try {
+      // delay ws server listen
+      newServer = await _createServer(inlineConfig, { ws: false })
+    } catch (err: any) {
+      server.config.logger.error(err.message, {
+        timestamp: true,
+      })
+      server.config.logger.error('server restart failed', { timestamp: true })
+      return
+    }
+
+    await server.close()
+
+    // Assign new server props to existing server instance
+    newServer._configServerPort = server._configServerPort
+    newServer._currentServerPort = server._currentServerPort
+    Object.assign(server, newServer)
+    // Rebind internal server variable so functions reference the user server
+    newServer._setInternalServer(server)
   }
-
-  await server.close()
-
-  // Assign new server props to existing server instance
-  newServer._configServerPort = server._configServerPort
-  newServer._currentServerPort = server._currentServerPort
-  Object.assign(server, newServer)
-  // Rebind internal server variable so functions reference the user server
-  newServer._setInternalServer(server)
 
   const {
     logger,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -933,33 +933,6 @@ async function restartServer(server: ViteDevServer) {
   global.__vite_start_time = performance.now()
   const shortcutsOptions = server._shortcutsOptions
 
-  await closeAndReinitServer(server)
-
-  const {
-    logger,
-    server: { port, middlewareMode },
-  } = server.config
-  if (!middlewareMode) {
-    await server.listen(port, true)
-  } else {
-    server.ws.listen()
-  }
-  logger.info('server restarted.', { timestamp: true })
-
-  if (shortcutsOptions) {
-    shortcutsOptions.print = false
-    bindCLIShortcuts(server, shortcutsOptions)
-  }
-}
-
-/**
- * Reinit the server by creating a new instance using the same inlineConfig
- * This will triger a reload of the config file and re-create the plugins and
- * middlewares. We then assign all properties of the new server to the existing
- * server instance and set the user instance to be used in the new server.
- * This allows us to keep the same server instance for the user.
- */
-async function closeAndReinitServer(server: ViteDevServer) {
   let inlineConfig = server.config.inlineConfig
   if (server._forceOptimizeOnRestart) {
     inlineConfig = mergeConfig(inlineConfig, {
@@ -989,6 +962,22 @@ async function closeAndReinitServer(server: ViteDevServer) {
   Object.assign(server, newServer)
   // Rebind internal server variable so functions reference the user server
   newServer._setInternalServer(server)
+
+  const {
+    logger,
+    server: { port, middlewareMode },
+  } = server.config
+  if (!middlewareMode) {
+    await server.listen(port, true)
+  } else {
+    server.ws.listen()
+  }
+  logger.info('server restarted.', { timestamp: true })
+
+  if (shortcutsOptions) {
+    shortcutsOptions.print = false
+    bindCLIShortcuts(server, shortcutsOptions)
+  }
 }
 
 /**

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -976,7 +976,7 @@ async function restartServer(server: ViteDevServer) {
 
   if (shortcutsOptions) {
     shortcutsOptions.print = false
-    bindCLIShortcuts(newServer, shortcutsOptions)
+    bindCLIShortcuts(server, shortcutsOptions)
   }
 }
 


### PR DESCRIPTION
Fixes #15159

### Description

https://github.com/vitejs/vite/commit/1ab9596f639f5fadbf327e83d1882504b3a07c92 is the fix, we should use the `server` instance after the reinit process is done

https://github.com/vitejs/vite/pull/15162/commits/b4d0cd4b2ac4324c3d2dfbb4ebb5ba7809f716c6 scopes the `newServer -> server` logic to avoid `newServer` being used in the future after the reinit and close process is done.

Ref #14890

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other