### PR TITLE
feat(legacy): support any separator before hash in fileNames

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -120,7 +120,7 @@ const legacyEnvVarMarker = `__VITE_IS_LEGACY__`
 const _require = createRequire(import.meta.url)
 
 const nonLeadingHashInFileNameRE = /[^/]+\[hash(?::\d+)?\]/
-const prefixedHashInFileNameRE = /[.-]?\[hash(:\d+)?\]/
+const prefixedHashInFileNameRE = /\W?\[hash(:\d+)?\]/
 
 function viteLegacyPlugin(options: Options = {}): Plugin[] {
   let config: ResolvedConfig


### PR DESCRIPTION
### Description

Small followup to:
- https://github.com/vitejs/vite/pull/15115

See comment: https://github.com/vitejs/vite/pull/15115#issuecomment-1824073000

Before this PR:
```
custom_[hash].[ext] -> custom_-template[hash].[ext]
```
Afterwards
```
custom_[hash].[ext] -> custom-template_[hash].[ext]
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other