### PR TITLE
refactor: align with Promise.withResolvers()

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -166,11 +166,6 @@ export interface DepOptimizationResult {
   cancel: () => void
 }
 
-export interface DepOptimizationProcessing {
-  promise: Promise<void>
-  resolve: () => void
-}
-
 export interface OptimizedDepInfo {
   id: string
   file: string
@@ -883,14 +878,6 @@ export async function addManuallyIncludedOptimizeDeps(
       }
     }
   }
-}
-
-export function newDepOptimizationProcessing(): DepOptimizationProcessing {
-  let resolve: () => void
-  const promise = new Promise((_resolve) => {
-    resolve = _resolve
-  }) as Promise<void>
-  return { promise, resolve: resolve! }
 }
 
 // Convert to { id: src }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1331,3 +1331,18 @@ export function isDevServer(
 ): server is ViteDevServer {
   return 'pluginContainer' in server
 }
+
+export interface PromiseWithResolvers<T> {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: any) => void
+}
+export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
+  let resolve: any
+  let reject: any
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
+}

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -267,12 +267,7 @@ async function untilBrowserLog(
   target?: string | RegExp | Array<string | RegExp>,
   expectOrder = true,
 ): Promise<string[]> {
-  let resolve: () => void
-  let reject: (reason: any) => void
-  const promise = new Promise<void>((_resolve, _reject) => {
-    resolve = _resolve
-    reject = _reject
-  })
+  const { promise, resolve, reject } = promiseWithResolvers<void>()
 
   const logs = []
 
@@ -362,4 +357,19 @@ export async function killProcess(
   } else {
     serverProcess.kill('SIGTERM', { forceKillAfterTimeout: 2000 })
   }
+}
+
+export interface PromiseWithResolvers<T> {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: any) => void
+}
+export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
+  let resolve: any
+  let reject: any
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve
+    reject = _reject
+  })
+  return { promise, resolve, reject }
 }


### PR DESCRIPTION
### Description

[`Promise.withResolvers()`](https://github.com/tc39/proposal-promise-with-resolvers) reached stage 4 yesterday.

This PR implements a `promiseWithResolvers<T>()` util to align the codebase with the standard, while we await for node to support the proposal. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other