### PR TITLE
fix(define): allow define process.env

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -14,15 +14,12 @@ export function definePlugin(config: ResolvedConfig): Plugin {
 
   // ignore replace process.env in lib build
   const processEnv: Record<string, string> = {}
-  const processNodeEnv: Record<string, string> = {}
   if (!isBuildLib) {
     const nodeEnv = process.env.NODE_ENV || config.mode
     Object.assign(processEnv, {
       'process.env': `{}`,
       'global.process.env': `{}`,
       'globalThis.process.env': `{}`,
-    })
-    Object.assign(processNodeEnv, {
       'process.env.NODE_ENV': JSON.stringify(nodeEnv),
       'global.process.env.NODE_ENV': JSON.stringify(nodeEnv),
       'globalThis.process.env.NODE_ENV': JSON.stringify(nodeEnv),
@@ -60,11 +57,10 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     const replaceProcessEnv = !ssr || config.ssr?.target === 'webworker'
 
     const define: Record<string, string> = {
-      ...(replaceProcessEnv ? processNodeEnv : {}),
+      ...(replaceProcessEnv ? processEnv : {}),
       ...importMetaKeys,
       ...userDefine,
       ...importMetaFallbackKeys,
-      ...(replaceProcessEnv ? processEnv : {}),
     }
 
     // Additional define fixes based on `ssr` value

--- a/playground/define/__tests__/define.spec.ts
+++ b/playground/define/__tests__/define.spec.ts
@@ -19,6 +19,9 @@ test('string', async () => {
   expect(await page.textContent('.process-node-env')).toBe(
     JSON.parse(defines['process.env.NODE_ENV']),
   )
+  expect(await page.textContent('.process-env')).toBe(
+    JSON.stringify(defines['process.env'], null, 2),
+  )
   expect(await page.textContent('.env-var')).toBe(
     JSON.parse(defines['process.env.SOMEVAR']),
   )

--- a/playground/define/index.html
+++ b/playground/define/index.html
@@ -10,6 +10,7 @@
 <p>Object <span class="pre object"></span></p>
 <p>Env Var <code class="env-var"></code></p>
 <p>process node env: <code class="process-node-env"></code></p>
+<p>process env: <code class="process-env"></code></p>
 <p>process as property: <code class="process-as-property"></code></p>
 <p>spread object: <code class="spread-object"></code></p>
 <p>spread array: <code class="spread-array"></code></p>
@@ -68,6 +69,7 @@
   text('.undefined', __UNDEFINED__)
   text('.object', JSON.stringify(__OBJ__, null, 2))
   text('.process-node-env', process.env.NODE_ENV)
+  text('.process-env', JSON.stringify(process.env, null, 2))
   text('.env-var', process.env.SOMEVAR)
   text('.process-as-property', __OBJ__.process.env.SOMEVAR)
   text(

--- a/playground/define/vite.config.js
+++ b/playground/define/vite.config.js
@@ -20,6 +20,11 @@ export default defineConfig({
     },
     'process.env.NODE_ENV': '"dev"',
     'process.env.SOMEVAR': '"SOMEVAR"',
+    'process.env': {
+      NODE_ENV: 'dev',
+      SOMEVAR: 'SOMEVAR',
+      OTHER: 'works',
+    },
     $DOLLAR: 456,
     ÖUNICODE_LETTERɵ: 789,
     __VAR_NAME__: false,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/15164

Allow `define` to override what `process.env` replaces, same as Vite 4. It works before because we replace things like this instead: https://github.com/vitejs/vite/pull/11151/files#diff-d90a7c21c9fb9222e557704bd906ea5671d5fe384c8fb105459eea8c36fdb4f0L22-R23

### Additional context

Personally I don't think this is a good pattern in general, but I suppose it doesn't hurt to support it for now.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
