### PR TITLE
fix: revert "fix: js fallback sourcemap content should be using original content (#15135)"

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -20,7 +20,7 @@ import {
 } from '../../utils'
 import { send } from '../send'
 import { ERR_LOAD_URL, transformRequest } from '../transformRequest'
-import { applySourcemapIgnoreList, getOriginalContent } from '../sourcemap'
+import { applySourcemapIgnoreList } from '../sourcemap'
 import { isHTMLProxy } from '../../plugins/html'
 import {
   DEP_VERSION_RE,
@@ -205,21 +205,12 @@ export function transformMiddleware(
           const type = isDirectCSSRequest(url) ? 'css' : 'js'
           const isDep =
             DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
-          let originalContent: string | undefined
-          if (type === 'js' && result.map == null) {
-            const filepath = (
-              await server.moduleGraph.getModuleByUrl(url, false)
-            )?.file
-            originalContent =
-              filepath != null ? await getOriginalContent(filepath) : undefined
-          }
           return send(req, res, result.code, type, {
             etag: result.etag,
             // allow browser to cache npm deps!
             cacheControl: isDep ? 'max-age=31536000,immutable' : 'no-cache',
             headers: server.config.server.headers,
             map: result.map,
-            originalContent,
           })
         }
       }

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -65,13 +65,6 @@ export async function injectSourcesContent(
   }
 }
 
-export async function getOriginalContent(
-  filepath: string,
-): Promise<string | undefined> {
-  if (virtualSourceRE.test(filepath)) return undefined
-  return await fsp.readFile(filepath, 'utf-8').catch(() => undefined)
-}
-
 export function genSourceMapUrl(map: SourceMap | string): string {
   if (typeof map !== 'string') {
     map = JSON.stringify(map)


### PR DESCRIPTION
This reverts commit 227d56d37fbfcd1af4b5d93182770b4e650511ee.

<!-- Thank you for contributing! -->

### Description

Fixes #15177

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
