### PR TITLE
refactor: make HMR agnostic to environment

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -1,6 +1,7 @@
-import type { ErrorPayload, HMRPayload, Update } from 'types/hmrPayload'
-import type { ModuleNamespace, ViteHotContext } from 'types/hot'
+import type { ErrorPayload, HMRPayload } from 'types/hmrPayload'
+import type { ViteHotContext } from 'types/hot'
 import type { InferCustomEventPayload } from 'types/customEvent'
+import { ClientHMR, ClientHMRContext } from '../shared/hmr'
 import { ErrorOverlay, overlayId } from './overlay'
 import '@vite/env'
 
@@ -110,17 +111,6 @@ function setupWebSocket(
   return socket
 }
 
-function warnFailedFetch(err: Error, path: string | string[]) {
-  if (!err.message.match('fetch')) {
-    console.error(err)
-  }
-  console.error(
-    `[hmr] Failed to reload ${path}. ` +
-      `This could be due to syntax errors or importing non-existent ` +
-      `modules. (see errors above)`,
-  )
-}
-
 function cleanUrl(pathname: string): string {
   const url = new URL(pathname, location.toString())
   url.searchParams.delete('direct')
@@ -143,6 +133,22 @@ const debounceReload = (time: number) => {
   }
 }
 const pageReload = debounceReload(50)
+
+const hmr = new ClientHMR(console, async function importUpdatedModule({
+  acceptedPath,
+  timestamp,
+  explicitImportRequired,
+}) {
+  const [acceptedPathWithoutQuery, query] = acceptedPath.split(`?`)
+  return await import(
+    /* @vite-ignore */
+    base +
+      acceptedPathWithoutQuery.slice(1) +
+      `?${explicitImportRequired ? 'import&' : ''}t=${timestamp}${
+        query ? `&${query}` : ''
+      }`
+  )
+})
 
 async function handleMessage(payload: HMRPayload) {
   switch (payload.type) {
@@ -173,7 +179,7 @@ async function handleMessage(payload: HMRPayload) {
       await Promise.all(
         payload.updates.map(async (update): Promise<void> => {
           if (update.type === 'js-update') {
-            return queueUpdate(fetchUpdate(update))
+            return queueUpdate(hmr.fetchUpdate(update))
           }
 
           // css-update
@@ -250,9 +256,9 @@ async function handleMessage(payload: HMRPayload) {
       // (.e.g style injections)
       // TODO Trigger their dispose callbacks.
       payload.paths.forEach((path) => {
-        const fn = pruneMap.get(path)
+        const fn = hmr.pruneMap.get(path)
         if (fn) {
-          fn(dataMap.get(path))
+          fn(hmr.dataMap.get(path))
         }
       })
       break
@@ -280,10 +286,7 @@ function notifyListeners<T extends string>(
   data: InferCustomEventPayload<T>,
 ): void
 function notifyListeners(event: string, data: any): void {
-  const cbs = customListenersMap.get(event)
-  if (cbs) {
-    cbs.forEach((cb) => cb(data))
-  }
+  hmr.notifyListeners(event, data)
 }
 
 const enableOverlay = __HMR_ENABLE_OVERLAY__
@@ -430,55 +433,6 @@ export function removeStyle(id: string): void {
   }
 }
 
-async function fetchUpdate({
-  path,
-  acceptedPath,
-  timestamp,
-  explicitImportRequired,
-}: Update) {
-  const mod = hotModulesMap.get(path)
-  if (!mod) {
-    // In a code-splitting project,
-    // it is common that the hot-updating module is not loaded yet.
-    // https://github.com/vitejs/vite/issues/721
-    return
-  }
-
-  let fetchedModule: ModuleNamespace | undefined
-  const isSelfUpdate = path === acceptedPath
-
-  // determine the qualified callbacks before we re-import the modules
-  const qualifiedCallbacks = mod.callbacks.filter(({ deps }) =>
-    deps.includes(acceptedPath),
-  )
-
-  if (isSelfUpdate || qualifiedCallbacks.length > 0) {
-    const disposer = disposeMap.get(acceptedPath)
-    if (disposer) await disposer(dataMap.get(acceptedPath))
-    const [acceptedPathWithoutQuery, query] = acceptedPath.split(`?`)
-    try {
-      fetchedModule = await import(
-        /* @vite-ignore */
-        base +
-          acceptedPathWithoutQuery.slice(1) +
-          `?${explicitImportRequired ? 'import&' : ''}t=${timestamp}${
-            query ? `&${query}` : ''
-          }`
-      )
-    } catch (e) {
-      warnFailedFetch(e, acceptedPath)
-    }
-  }
-
-  return () => {
-    for (const { deps, fn } of qualifiedCallbacks) {
-      fn(deps.map((dep) => (dep === acceptedPath ? fetchedModule : undefined)))
-    }
-    const loggedPath = isSelfUpdate ? path : `${acceptedPath} via ${path}`
-    console.debug(`[vite] hot updated: ${loggedPath}`)
-  }
-}
-
 function sendMessageBuffer() {
   if (socket.readyState === 1) {
     messageBuffer.forEach((msg) => socket.send(msg))
@@ -486,150 +440,15 @@ function sendMessageBuffer() {
   }
 }
 
-interface HotModule {
-  id: string
-  callbacks: HotCallback[]
-}
-
-interface HotCallback {
-  // the dependencies must be fetchable paths
-  deps: string[]
-  fn: (modules: Array<ModuleNamespace | undefined>) => void
-}
-
-type CustomListenersMap = Map<string, ((data: any) => void)[]>
-
-const hotModulesMap = new Map<string, HotModule>()
-const disposeMap = new Map<string, (data: any) => void | Promise<void>>()
-const pruneMap = new Map<string, (data: any) => void | Promise<void>>()
-const dataMap = new Map<string, any>()
-const customListenersMap: CustomListenersMap = new Map()
-const ctxToListenersMap = new Map<string, CustomListenersMap>()
-
 export function createHotContext(ownerPath: string): ViteHotContext {
-  if (!dataMap.has(ownerPath)) {
-    dataMap.set(ownerPath, {})
-  }
-
-  // when a file is hot updated, a new context is created
-  // clear its stale callbacks
-  const mod = hotModulesMap.get(ownerPath)
-  if (mod) {
-    mod.callbacks = []
-  }
-
-  // clear stale custom event listeners
-  const staleListeners = ctxToListenersMap.get(ownerPath)
-  if (staleListeners) {
-    for (const [event, staleFns] of staleListeners) {
-      const listeners = customListenersMap.get(event)
-      if (listeners) {
-        customListenersMap.set(
-          event,
-          listeners.filter((l) => !staleFns.includes(l)),
-        )
-      }
-    }
-  }
-
-  const newListeners: CustomListenersMap = new Map()
-  ctxToListenersMap.set(ownerPath, newListeners)
-
-  function acceptDeps(deps: string[], callback: HotCallback['fn'] = () => {}) {
-    const mod: HotModule = hotModulesMap.get(ownerPath) || {
-      id: ownerPath,
-      callbacks: [],
-    }
-    mod.callbacks.push({
-      deps,
-      fn: callback,
-    })
-    hotModulesMap.set(ownerPath, mod)
-  }
-
-  const hot: ViteHotContext = {
-    get data() {
-      return dataMap.get(ownerPath)
+  return new ClientHMRContext(ownerPath, hmr, {
+    addBuffer(message) {
+      messageBuffer.push(message)
     },
-
-    accept(deps?: any, callback?: any) {
-      if (typeof deps === 'function' || !deps) {
-        // self-accept: hot.accept(() => {})
-        acceptDeps([ownerPath], ([mod]) => deps?.(mod))
-      } else if (typeof deps === 'string') {
-        // explicit deps
-        acceptDeps([deps], ([mod]) => callback?.(mod))
-      } else if (Array.isArray(deps)) {
-        acceptDeps(deps, callback)
-      } else {
-        throw new Error(`invalid hot.accept() usage.`)
-      }
-    },
-
-    // export names (first arg) are irrelevant on the client side, they're
-    // extracted in the server for propagation
-    acceptExports(_, callback) {
-      acceptDeps([ownerPath], ([mod]) => callback?.(mod))
-    },
-
-    dispose(cb) {
-      disposeMap.set(ownerPath, cb)
-    },
-
-    prune(cb) {
-      pruneMap.set(ownerPath, cb)
-    },
-
-    // Kept for backward compatibility (#11036)
-    // @ts-expect-error untyped
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    decline() {},
-
-    // tell the server to re-perform hmr propagation from this module as root
-    invalidate(message) {
-      notifyListeners('vite:invalidate', { path: ownerPath, message })
-      this.send('vite:invalidate', { path: ownerPath, message })
-      console.debug(
-        `[vite] invalidate ${ownerPath}${message ? `: ${message}` : ''}`,
-      )
-    },
-
-    // custom events
-    on(event, cb) {
-      const addToMap = (map: Map<string, any[]>) => {
-        const existing = map.get(event) || []
-        existing.push(cb)
-        map.set(event, existing)
-      }
-      addToMap(customListenersMap)
-      addToMap(newListeners)
-    },
-
-    // remove a custom event
-    off(event, cb) {
-      const removeFromMap = (map: Map<string, any[]>) => {
-        const existing = map.get(event)
-        if (existing === undefined) {
-          return
-        }
-        const pruned = existing.filter((l) => l !== cb)
-        if (pruned.length === 0) {
-          map.delete(event)
-          return
-        }
-        map.set(event, pruned)
-      }
-      removeFromMap(customListenersMap)
-      removeFromMap(newListeners)
-    },
-
-    send(event, data) {
-      messageBuffer.push(JSON.stringify({ type: 'custom', event, data }))
+    send() {
       sendMessageBuffer()
     },
-  }
-
-  return hot
+  })
 }
 
 /**

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -251,16 +251,7 @@ async function handleMessage(payload: HMRPayload) {
       break
     case 'prune':
       notifyListeners('vite:beforePrune', payload)
-      // After an HMR update, some modules are no longer imported on the page
-      // but they may have left behind side effects that need to be cleaned up
-      // (.e.g style injections)
-      // TODO Trigger their dispose callbacks.
-      payload.paths.forEach((path) => {
-        const fn = hmrClient.pruneMap.get(path)
-        if (fn) {
-          fn(hmrClient.dataMap.get(path))
-        }
-      })
+      hmrClient.prunePaths(payload.paths)
       break
     case 'error': {
       notifyListeners('vite:error', payload)

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -186,6 +186,19 @@ export class HMRClient {
     }
   }
 
+  // After an HMR update, some modules are no longer imported on the page
+  // but they may have left behind side effects that need to be cleaned up
+  // (.e.g style injections)
+  // TODO Trigger their dispose callbacks.
+  public prunePaths(paths: string[]): void {
+    paths.forEach((path) => {
+      const fn = this.pruneMap.get(path)
+      if (fn) {
+        fn(this.dataMap.get(path))
+      }
+    })
+  }
+
   protected warnFailedUpdate(err: Error, path: string | string[]): void {
     if (!err.message.match('fetch')) {
       this.logger.error(err)

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -1,0 +1,237 @@
+import type { Update } from 'types/hmrPayload'
+import type { ModuleNamespace, ViteHotContext } from 'types/hot'
+import type { InferCustomEventPayload } from 'types/customEvent'
+
+type CustomListenersMap = Map<string, ((data: any) => void)[]>
+
+interface HotModule {
+  id: string
+  callbacks: HotCallback[]
+}
+
+interface HotCallback {
+  // the dependencies must be fetchable paths
+  deps: string[]
+  fn: (modules: Array<ModuleNamespace | undefined>) => void
+}
+
+interface Connection {
+  addBuffer(message: string): void
+  send(): unknown
+}
+
+export class ClientHMRContext implements ViteHotContext {
+  private newListeners: CustomListenersMap
+
+  constructor(
+    private ownerPath: string,
+    private hmr: ClientHMR,
+    private connection: Connection,
+  ) {
+    if (!hmr.dataMap.has(ownerPath)) {
+      hmr.dataMap.set(ownerPath, {})
+    }
+
+    // when a file is hot updated, a new context is created
+    // clear its stale callbacks
+    const mod = hmr.hotModulesMap.get(ownerPath)
+    if (mod) {
+      mod.callbacks = []
+    }
+
+    // clear stale custom event listeners
+    const staleListeners = hmr.ctxToListenersMap.get(ownerPath)
+    if (staleListeners) {
+      for (const [event, staleFns] of staleListeners) {
+        const listeners = hmr.customListenersMap.get(event)
+        if (listeners) {
+          hmr.customListenersMap.set(
+            event,
+            listeners.filter((l) => !staleFns.includes(l)),
+          )
+        }
+      }
+    }
+
+    this.newListeners = new Map()
+    hmr.ctxToListenersMap.set(ownerPath, this.newListeners)
+  }
+
+  get data(): any {
+    return this.hmr.dataMap.get(this.ownerPath)
+  }
+
+  accept(deps?: any, callback?: any): void {
+    if (typeof deps === 'function' || !deps) {
+      // self-accept: hot.accept(() => {})
+      this.acceptDeps([this.ownerPath], ([mod]) => deps?.(mod))
+    } else if (typeof deps === 'string') {
+      // explicit deps
+      this.acceptDeps([deps], ([mod]) => callback?.(mod))
+    } else if (Array.isArray(deps)) {
+      this.acceptDeps(deps, callback)
+    } else {
+      throw new Error(`invalid hot.accept() usage.`)
+    }
+  }
+
+  // export names (first arg) are irrelevant on the client side, they're
+  // extracted in the server for propagation
+  acceptExports(
+    _: string | readonly string[],
+    callback: (data: any) => void,
+  ): void {
+    this.acceptDeps([this.ownerPath], ([mod]) => callback?.(mod))
+  }
+
+  dispose(cb: (data: any) => void): void {
+    this.hmr.disposeMap.set(this.ownerPath, cb)
+  }
+
+  prune(cb: (data: any) => void): void {
+    this.hmr.pruneMap.set(this.ownerPath, cb)
+  }
+
+  // Kept for backward compatibility (#11036)
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  decline(): void {}
+
+  invalidate(message: string): void {
+    this.hmr.notifyListeners('vite:invalidate', {
+      path: this.ownerPath,
+      message,
+    })
+    this.send('vite:invalidate', { path: this.ownerPath, message })
+    this.hmr.logger.debug(
+      `[vite] invalidate ${this.ownerPath}${message ? `: ${message}` : ''}`,
+    )
+  }
+
+  on<T extends string>(
+    event: T,
+    cb: (payload: InferCustomEventPayload<T>) => void,
+  ): void {
+    const addToMap = (map: Map<string, any[]>) => {
+      const existing = map.get(event) || []
+      existing.push(cb)
+      map.set(event, existing)
+    }
+    addToMap(this.hmr.customListenersMap)
+    addToMap(this.newListeners)
+  }
+
+  off<T extends string>(
+    event: T,
+    cb: (payload: InferCustomEventPayload<T>) => void,
+  ): void {
+    const removeFromMap = (map: Map<string, any[]>) => {
+      const existing = map.get(event)
+      if (existing === undefined) {
+        return
+      }
+      const pruned = existing.filter((l) => l !== cb)
+      if (pruned.length === 0) {
+        map.delete(event)
+        return
+      }
+      map.set(event, pruned)
+    }
+    removeFromMap(this.hmr.customListenersMap)
+    removeFromMap(this.newListeners)
+  }
+
+  send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void {
+    this.connection.addBuffer(JSON.stringify({ type: 'custom', event, data }))
+    this.connection.send()
+  }
+
+  private acceptDeps(
+    deps: string[],
+    callback: HotCallback['fn'] = () => {},
+  ): void {
+    const mod: HotModule = this.hmr.hotModulesMap.get(this.ownerPath) || {
+      id: this.ownerPath,
+      callbacks: [],
+    }
+    mod.callbacks.push({
+      deps,
+      fn: callback,
+    })
+    this.hmr.hotModulesMap.set(this.ownerPath, mod)
+  }
+}
+
+export class ClientHMR {
+  public hotModulesMap = new Map<string, HotModule>()
+  public disposeMap = new Map<string, (data: any) => void | Promise<void>>()
+  public pruneMap = new Map<string, (data: any) => void | Promise<void>>()
+  public dataMap = new Map<string, any>()
+  public customListenersMap: CustomListenersMap = new Map()
+  public ctxToListenersMap = new Map<string, CustomListenersMap>()
+
+  constructor(
+    public logger: Console,
+    private importUpdatedModule: (update: Update) => Promise<ModuleNamespace>,
+  ) {}
+
+  public notifyListeners<T extends string>(
+    event: T,
+    data: InferCustomEventPayload<T>,
+  ): void
+  public notifyListeners(event: string, data: any): void {
+    const cbs = this.customListenersMap.get(event)
+    if (cbs) {
+      cbs.forEach((cb) => cb(data))
+    }
+  }
+
+  protected warnFailedUpdate(err: Error, path: string | string[]): void {
+    if (!err.message.match('fetch')) {
+      this.logger.error(err)
+    }
+    this.logger.error(
+      `[hmr] Failed to reload ${path}. ` +
+        `This could be due to syntax errors or importing non-existent ` +
+        `modules. (see errors above)`,
+    )
+  }
+
+  public async fetchUpdate(update: Update): Promise<(() => void) | undefined> {
+    const { path, acceptedPath } = update
+    const mod = this.hotModulesMap.get(path)
+    if (!mod) {
+      // In a code-splitting project,
+      // it is common that the hot-updating module is not loaded yet.
+      // https://github.com/vitejs/vite/issues/721
+      return
+    }
+
+    let fetchedModule: ModuleNamespace | undefined
+    const isSelfUpdate = path === acceptedPath
+
+    // determine the qualified callbacks before we re-import the modules
+    const qualifiedCallbacks = mod.callbacks.filter(({ deps }) =>
+      deps.includes(acceptedPath),
+    )
+
+    if (isSelfUpdate || qualifiedCallbacks.length > 0) {
+      const disposer = this.disposeMap.get(acceptedPath)
+      if (disposer) await disposer(this.dataMap.get(acceptedPath))
+      try {
+        fetchedModule = await this.importUpdatedModule(update)
+      } catch (e) {
+        this.warnFailedUpdate(e, acceptedPath)
+      }
+    }
+
+    return () => {
+      for (const { deps, fn } of qualifiedCallbacks) {
+        fn(
+          deps.map((dep) => (dep === acceptedPath ? fetchedModule : undefined)),
+        )
+      }
+      const loggedPath = isSelfUpdate ? path : `${acceptedPath} via ${path}`
+      this.logger.debug(`[vite] hot updated: ${loggedPath}`)
+    }
+  }
+}

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -175,14 +175,14 @@ export class HMRClient {
     private importUpdatedModule: (update: Update) => Promise<ModuleNamespace>,
   ) {}
 
-  public notifyListeners<T extends string>(
+  public async notifyListeners<T extends string>(
     event: T,
     data: InferCustomEventPayload<T>,
-  ): unknown
-  public notifyListeners(event: string, data: any): unknown {
+  ): Promise<void>
+  public async notifyListeners(event: string, data: any): Promise<void> {
     const cbs = this.customListenersMap.get(event)
     if (cbs) {
-      return cbs.map((cb) => cb(data))
+      await Promise.allSettled(cbs.map((cb) => cb(data)))
     }
   }
 

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -178,11 +178,11 @@ export class HMRClient {
   public notifyListeners<T extends string>(
     event: T,
     data: InferCustomEventPayload<T>,
-  ): void
-  public notifyListeners(event: string, data: any): void {
+  ): unknown
+  public notifyListeners(event: string, data: any): unknown {
     const cbs = this.customListenersMap.get(event)
     if (cbs) {
-      cbs.forEach((cb) => cb(data))
+      return cbs.map((cb) => cb(data))
     }
   }
 

--- a/packages/vite/src/shared/tsconfig.json
+++ b/packages/vite/src/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["./", "../dep-types", "../types"],
+  "exclude": ["**/__tests__"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "stripInternal": true
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR makes core HMR implementation agnostic to the environment so it can be reused (and enhanced if needed) in other runtimes (Node/Deno/Bun) like in #12165. No logic is changed.

Unfortunately, I had to move it into another file which breaks git history for client file a bit :(

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
