### PR TITLE
docs: verify Mastodon account

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -71,6 +71,7 @@ export default defineConfig({
       'link',
       { rel: 'alternate', type: 'application/rss+xml', href: '/blog.rss' },
     ],
+    ['link', { rel: 'me', href: 'https://m.webtoo.ls/@vite' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:title', content: ogTitle }],
     ['meta', { property: 'og:image', content: ogImage }],


### PR DESCRIPTION
### Description

Add a header in the docs so the Website meta at https://m.webtoo.ls/@vite will show as verified. See https://fedi.tips/how-do-i-verify-my-account/

Example of a verified Website meta in an account https://m.webtoo.ls/@patak

Requested by https://elk.zone/m.webtoo.ls/@frozencanuck@mas.to/111490340424033092

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other