### PR TITLE
fix: emit `vite:preloadError` for chunks without deps

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -92,57 +92,60 @@ function preload(
   deps?: string[],
   importerUrl?: string,
 ) {
+  let promise: Promise<unknown> = Promise.resolve()
   // @ts-expect-error __VITE_IS_MODERN__ will be replaced with boolean later
-  if (!__VITE_IS_MODERN__ || !deps || deps.length === 0) {
-    return baseModule()
+  if (__VITE_IS_MODERN__ && deps && deps.length > 0) {
+    const links = document.getElementsByTagName('link')
+
+    promise = Promise.all(
+      deps.map((dep) => {
+        // @ts-expect-error assetsURL is declared before preload.toString()
+        dep = assetsURL(dep, importerUrl)
+        if (dep in seen) return
+        seen[dep] = true
+        const isCss = dep.endsWith('.css')
+        const cssSelector = isCss ? '[rel="stylesheet"]' : ''
+        const isBaseRelative = !!importerUrl
+
+        // check if the file is already preloaded by SSR markup
+        if (isBaseRelative) {
+          // When isBaseRelative is true then we have `importerUrl` and `dep` is
+          // already converted to an absolute URL by the `assetsURL` function
+          for (let i = links.length - 1; i >= 0; i--) {
+            const link = links[i]
+            // The `links[i].href` is an absolute URL thanks to browser doing the work
+            // for us. See https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes:idl-domstring-5
+            if (link.href === dep && (!isCss || link.rel === 'stylesheet')) {
+              return
+            }
+          }
+        } else if (
+          document.querySelector(`link[href="${dep}"]${cssSelector}`)
+        ) {
+          return
+        }
+
+        const link = document.createElement('link')
+        link.rel = isCss ? 'stylesheet' : scriptRel
+        if (!isCss) {
+          link.as = 'script'
+          link.crossOrigin = ''
+        }
+        link.href = dep
+        document.head.appendChild(link)
+        if (isCss) {
+          return new Promise((res, rej) => {
+            link.addEventListener('load', res)
+            link.addEventListener('error', () =>
+              rej(new Error(`Unable to preload CSS for ${dep}`)),
+            )
+          })
+        }
+      }),
+    )
   }
 
-  const links = document.getElementsByTagName('link')
-
-  return Promise.all(
-    deps.map((dep) => {
-      // @ts-expect-error assetsURL is declared before preload.toString()
-      dep = assetsURL(dep, importerUrl)
-      if (dep in seen) return
-      seen[dep] = true
-      const isCss = dep.endsWith('.css')
-      const cssSelector = isCss ? '[rel="stylesheet"]' : ''
-      const isBaseRelative = !!importerUrl
-
-      // check if the file is already preloaded by SSR markup
-      if (isBaseRelative) {
-        // When isBaseRelative is true then we have `importerUrl` and `dep` is
-        // already converted to an absolute URL by the `assetsURL` function
-        for (let i = links.length - 1; i >= 0; i--) {
-          const link = links[i]
-          // The `links[i].href` is an absolute URL thanks to browser doing the work
-          // for us. See https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes:idl-domstring-5
-          if (link.href === dep && (!isCss || link.rel === 'stylesheet')) {
-            return
-          }
-        }
-      } else if (document.querySelector(`link[href="${dep}"]${cssSelector}`)) {
-        return
-      }
-
-      const link = document.createElement('link')
-      link.rel = isCss ? 'stylesheet' : scriptRel
-      if (!isCss) {
-        link.as = 'script'
-        link.crossOrigin = ''
-      }
-      link.href = dep
-      document.head.appendChild(link)
-      if (isCss) {
-        return new Promise((res, rej) => {
-          link.addEventListener('load', res)
-          link.addEventListener('error', () =>
-            rej(new Error(`Unable to preload CSS for ${dep}`)),
-          )
-        })
-      }
-    }),
-  )
+  return promise
     .then(() => baseModule())
     .catch((err) => {
       const e = new Event('vite:preloadError', { cancelable: true })

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -116,7 +116,7 @@ describe.runIf(isBuild)('build tests', () => {
     const map = findAssetFile(/after-preload-dynamic.*\.js\.map/)
     expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
       {
-        "mappings": "k2BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
+        "mappings": "i3BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
If the loaded chunk didn't have any deps, `vite:preloadError` was not emitted.

For example, the event is not emitted for https://stackblitz.com/edit/vitejs-vite-ho9n9z?file=main.js,counter.js and is emitted for https://stackblitz.com/edit/vitejs-vite-eubg1i?file=main.js,counter.js
The difference between them is that `counter.js` imports `counter.css` in the latter one.

refs #12084

/cc @danielroe 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
