### PR TITLE
test: reduce optimize-deps playground flaky fail

### DIFF
--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   browserErrors,
   browserLogs,
+  expectWithRetry,
   getColor,
   isBuild,
   isServe,
@@ -12,93 +13,123 @@ import {
 } from '~utils'
 
 test('default + named imports from cjs dep (react)', async () => {
-  expect(await page.textContent('.cjs button')).toBe('count is 0')
+  await expectWithRetry(() => page.textContent('.cjs button')).toBe(
+    'count is 0',
+  )
   await page.click('.cjs button')
-  expect(await page.textContent('.cjs button')).toBe('count is 1')
+  await expectWithRetry(() => page.textContent('.cjs button')).toBe(
+    'count is 1',
+  )
 })
 
 test('named imports from webpacked cjs (phoenix)', async () => {
-  expect(await page.textContent('.cjs-phoenix')).toBe('ok')
+  await expectWithRetry(() => page.textContent('.cjs-phoenix')).toBe('ok')
 })
 
 test('default import from webpacked cjs (clipboard)', async () => {
-  expect(await page.textContent('.cjs-clipboard')).toBe('ok')
+  await expectWithRetry(() => page.textContent('.cjs-clipboard')).toBe('ok')
 })
 
 test('dynamic imports from cjs dep (react)', async () => {
-  expect(await page.textContent('.cjs-dynamic button')).toBe('count is 0')
+  await expectWithRetry(() => page.textContent('.cjs-dynamic button')).toBe(
+    'count is 0',
+  )
   await page.click('.cjs-dynamic button')
-  expect(await page.textContent('.cjs-dynamic button')).toBe('count is 1')
+  await expectWithRetry(() => page.textContent('.cjs-dynamic button')).toBe(
+    'count is 1',
+  )
 })
 
 test('dynamic named imports from webpacked cjs (phoenix)', async () => {
-  expect(await page.textContent('.cjs-dynamic-phoenix')).toBe('ok')
+  await expectWithRetry(() => page.textContent('.cjs-dynamic-phoenix')).toBe(
+    'ok',
+  )
 })
 
 test('dynamic default import from webpacked cjs (clipboard)', async () => {
-  expect(await page.textContent('.cjs-dynamic-clipboard')).toBe('ok')
+  await expectWithRetry(() => page.textContent('.cjs-dynamic-clipboard')).toBe(
+    'ok',
+  )
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-esm)', async () => {
-  expect(await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm')).toBe(
-    'ok',
-  )
+  await expectWithRetry(() =>
+    page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm'),
+  ).toBe('ok')
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-cjs)', async () => {
-  expect(await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs')).toBe(
-    'ok',
-  )
+  await expectWithRetry(() =>
+    page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs'),
+  ).toBe('ok')
 })
 
 test('dedupe', async () => {
-  expect(await page.textContent('.dedupe button')).toBe('count is 0')
+  await expectWithRetry(() => page.textContent('.dedupe button')).toBe(
+    'count is 0',
+  )
   await page.click('.dedupe button')
-  expect(await page.textContent('.dedupe button')).toBe('count is 1')
+  await expectWithRetry(() => page.textContent('.dedupe button')).toBe(
+    'count is 1',
+  )
 })
 
 test('cjs browser field (axios)', async () => {
-  expect(await page.textContent('.cjs-browser-field')).toBe('pong')
+  await expectWithRetry(() => page.textContent('.cjs-browser-field')).toBe(
+    'pong',
+  )
 })
 
 test('cjs browser field bare', async () => {
-  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
+  await expectWithRetry(() => page.textContent('.cjs-browser-field-bare')).toBe(
+    'pong',
+  )
 })
 
 test('dep from linked dep (lodash-es)', async () => {
-  expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
+  await expectWithRetry(() => page.textContent('.deps-linked')).toBe(
+    'fooBarBaz',
+  )
 })
 
 test('forced include', async () => {
-  expect(await page.textContent('.force-include')).toMatch(`[success]`)
+  await expectWithRetry(() => page.textContent('.force-include')).toMatch(
+    `[success]`,
+  )
 })
 
 test('import * from optimized dep', async () => {
-  expect(await page.textContent('.import-star')).toMatch(`[success]`)
+  await expectWithRetry(() => page.textContent('.import-star')).toMatch(
+    `[success]`,
+  )
 })
 
 test('import from dep with process.env.NODE_ENV', async () => {
-  expect(await page.textContent('.node-env')).toMatch(isBuild ? 'prod' : 'dev')
+  await expectWithRetry(() => page.textContent('.node-env')).toMatch(
+    isBuild ? 'prod' : 'dev',
+  )
 })
 
 test('import from dep with .notjs files', async () => {
-  expect(await page.textContent('.not-js')).toMatch(`[success]`)
+  await expectWithRetry(() => page.textContent('.not-js')).toMatch(`[success]`)
 })
 
 test('Import from dependency which uses relative path which needs to be resolved by main field', async () => {
-  expect(await page.textContent('.relative-to-main')).toMatch(`[success]`)
+  await expectWithRetry(() => page.textContent('.relative-to-main')).toMatch(
+    `[success]`,
+  )
 })
 
 test('dep with dynamic import', async () => {
-  expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
-    `[success]`,
-  )
+  await expectWithRetry(() =>
+    page.textContent('.dep-with-dynamic-import'),
+  ).toMatch(`[success]`)
 })
 
 test('dep with optional peer dep', async () => {
-  expect(await page.textContent('.dep-with-optional-peer-dep')).toMatch(
-    `[success]`,
-  )
+  await expectWithRetry(() =>
+    page.textContent('.dep-with-optional-peer-dep'),
+  ).toMatch(`[success]`)
   if (isServe) {
     expect(browserErrors.map((error) => error.message)).toEqual(
       expect.arrayContaining([
@@ -109,8 +140,8 @@ test('dep with optional peer dep', async () => {
 })
 
 test('dep with optional peer dep submodule', async () => {
-  expect(
-    await page.textContent('.dep-with-optional-peer-dep-submodule'),
+  expectWithRetry(() =>
+    page.textContent('.dep-with-optional-peer-dep-submodule'),
   ).toMatch(`[success]`)
   if (isServe) {
     expect(browserErrors.map((error) => error.message)).toEqual(
@@ -122,61 +153,69 @@ test('dep with optional peer dep submodule', async () => {
 })
 
 test('dep with css import', async () => {
-  expect(await getColor('.dep-linked-include')).toBe('red')
+  await expectWithRetry(() => getColor('.dep-linked-include')).toBe('red')
 })
 
 test('CJS dep with css import', async () => {
-  expect(await getColor('.cjs-with-assets')).toBe('blue')
+  await expectWithRetry(() => getColor('.cjs-with-assets')).toBe('blue')
 })
 
 test('externalize known non-js files in optimize included dep', async () => {
-  expect(await page.textContent('.externalize-known-non-js')).toMatch(
-    `[success]`,
-  )
+  await expectWithRetry(() =>
+    page.textContent('.externalize-known-non-js'),
+  ).toMatch(`[success]`)
 })
 
 test('vue + vuex', async () => {
-  expect(await page.textContent('.vue')).toMatch(`[success]`)
+  await expectWithRetry(() => page.textContent('.vue')).toMatch(`[success]`)
 })
 
 // When we use the Rollup CommonJS plugin instead of esbuild prebundling,
 // the esbuild plugins won't apply to dependencies
 test('esbuild-plugin', async () => {
-  expect(await page.textContent('.esbuild-plugin')).toMatch(
+  await expectWithRetry(() => page.textContent('.esbuild-plugin')).toMatch(
     `Hello from an esbuild plugin`,
   )
 })
 
 test('import from hidden dir', async () => {
-  expect(await page.textContent('.hidden-dir')).toBe('hello!')
+  await expectWithRetry(() => page.textContent('.hidden-dir')).toBe('hello!')
 })
 
 test('import optimize-excluded package that imports optimized-included package', async () => {
-  expect(await page.textContent('.nested-include')).toBe('nested-include')
-})
-
-test('import aliased package with colon', async () => {
-  expect(await page.textContent('.url')).toBe('vitejs.dev')
-})
-
-test('import aliased package using absolute path', async () => {
-  expect(await page.textContent('.alias-using-absolute-path')).toBe(
-    'From dep-alias-using-absolute-path',
+  await expectWithRetry(() => page.textContent('.nested-include')).toBe(
+    'nested-include',
   )
 })
 
+test('import aliased package with colon', async () => {
+  await expectWithRetry(() => page.textContent('.url')).toBe('vitejs.dev')
+})
+
+test('import aliased package using absolute path', async () => {
+  await expectWithRetry(() =>
+    page.textContent('.alias-using-absolute-path'),
+  ).toBe('From dep-alias-using-absolute-path')
+})
+
 test('variable names are reused in different scripts', async () => {
-  expect(await page.textContent('.reused-variable-names')).toBe('reused')
+  await expectWithRetry(() => page.textContent('.reused-variable-names')).toBe(
+    'reused',
+  )
 })
 
 test('flatten id should generate correctly', async () => {
-  expect(await page.textContent('.clonedeep-slash')).toBe('clonedeep-slash')
-  expect(await page.textContent('.clonedeep-dot')).toBe('clonedeep-dot')
+  await expectWithRetry(() => page.textContent('.clonedeep-slash')).toBe(
+    'clonedeep-slash',
+  )
+  await expectWithRetry(() => page.textContent('.clonedeep-dot')).toBe(
+    'clonedeep-dot',
+  )
 })
 
 test('non optimized module is not duplicated', async () => {
-  expect(
-    await page.textContent('.non-optimized-module-is-not-duplicated'),
+  await expectWithRetry(() =>
+    page.textContent('.non-optimized-module-is-not-duplicated'),
   ).toBe('from-absolute-path, from-relative-path')
 })
 
@@ -227,8 +266,8 @@ test('pre bundle css require', async () => {
     )
   }
 
-  expect(await getColor('.css-require')).toBe('red')
-  expect(await getColor('.css-module-require')).toBe('red')
+  await expectWithRetry(() => getColor('.css-require')).toBe('red')
+  await expectWithRetry(() => getColor('.css-module-require')).toBe('red')
 })
 
 test.runIf(isBuild)('no missing deps during build', async () => {
@@ -276,5 +315,7 @@ describe.runIf(isServe)('optimizeDeps config', () => {
 })
 
 test('long file name should work', async () => {
-  expect(await page.textContent('.long-file-name')).toMatch(`hello world`)
+  await expectWithRetry(() => page.textContent('.long-file-name')).toMatch(
+    `hello world`,
+  )
 })

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -9,254 +9,175 @@ import {
   readDepOptimizationMetadata,
   serverLogs,
   viteTestUrl,
-  withRetry,
 } from '~utils'
 
 test('default + named imports from cjs dep (react)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs button')).toBe('count is 0'),
-  )
+  expect(await page.textContent('.cjs button')).toBe('count is 0')
   await page.click('.cjs button')
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs button')).toBe('count is 1'),
-  )
+  expect(await page.textContent('.cjs button')).toBe('count is 1')
 })
 
 test('named imports from webpacked cjs (phoenix)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-phoenix')).toBe('ok'),
-  )
+  expect(await page.textContent('.cjs-phoenix')).toBe('ok')
 })
 
 test('default import from webpacked cjs (clipboard)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-clipboard')).toBe('ok'),
-  )
+  expect(await page.textContent('.cjs-clipboard')).toBe('ok')
 })
 
 test('dynamic imports from cjs dep (react)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-dynamic button')).toBe('count is 0'),
-  )
+  expect(await page.textContent('.cjs-dynamic button')).toBe('count is 0')
   await page.click('.cjs-dynamic button')
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-dynamic button')).toBe('count is 1'),
-  )
+  expect(await page.textContent('.cjs-dynamic button')).toBe('count is 1')
 })
 
 test('dynamic named imports from webpacked cjs (phoenix)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-dynamic-phoenix')).toBe('ok'),
-  )
+  expect(await page.textContent('.cjs-dynamic-phoenix')).toBe('ok')
 })
 
 test('dynamic default import from webpacked cjs (clipboard)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-dynamic-clipboard')).toBe('ok'),
-  )
+  expect(await page.textContent('.cjs-dynamic-clipboard')).toBe('ok')
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-esm)', async () => {
-  await withRetry(async () =>
-    expect(
-      await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm'),
-    ).toBe('ok'),
+  expect(await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm')).toBe(
+    'ok',
   )
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-cjs)', async () => {
-  await withRetry(async () =>
-    expect(
-      await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs'),
-    ).toBe('ok'),
+  expect(await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs')).toBe(
+    'ok',
   )
 })
 
 test('dedupe', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.dedupe button')).toBe('count is 0'),
-  )
+  expect(await page.textContent('.dedupe button')).toBe('count is 0')
   await page.click('.dedupe button')
-  await withRetry(async () =>
-    expect(await page.textContent('.dedupe button')).toBe('count is 1'),
-  )
+  expect(await page.textContent('.dedupe button')).toBe('count is 1')
 })
 
 test('cjs browser field (axios)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-browser-field')).toBe('pong'),
-  )
+  expect(await page.textContent('.cjs-browser-field')).toBe('pong')
 })
 
 test('cjs browser field bare', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong'),
-  )
+  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
 })
 
 test('dep from linked dep (lodash-es)', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.deps-linked')).toBe('fooBarBaz'),
-  )
+  expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
 })
 
 test('forced include', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.force-include')).toMatch(`[success]`),
-  )
+  expect(await page.textContent('.force-include')).toMatch(`[success]`)
 })
 
 test('import * from optimized dep', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.import-star')).toMatch(`[success]`),
-  )
+  expect(await page.textContent('.import-star')).toMatch(`[success]`)
 })
 
 test('import from dep with process.env.NODE_ENV', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.node-env')).toMatch(
-      isBuild ? 'prod' : 'dev',
-    ),
-  )
+  expect(await page.textContent('.node-env')).toMatch(isBuild ? 'prod' : 'dev')
 })
 
 test('import from dep with .notjs files', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.not-js')).toMatch(`[success]`),
-  )
+  expect(await page.textContent('.not-js')).toMatch(`[success]`)
 })
 
 test('Import from dependency which uses relative path which needs to be resolved by main field', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.relative-to-main')).toMatch(`[success]`),
-  )
+  expect(await page.textContent('.relative-to-main')).toMatch(`[success]`)
 })
 
 test('dep with dynamic import', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
-      `[success]`,
-    ),
+  expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
+    `[success]`,
   )
 })
 
 test('dep with optional peer dep', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.dep-with-optional-peer-dep')).toMatch(
-      `[success]`,
-    ),
+  expect(await page.textContent('.dep-with-optional-peer-dep')).toMatch(
+    `[success]`,
   )
   if (isServe) {
-    await withRetry(async () =>
-      expect(browserErrors.map((error) => error.message)).toEqual(
-        expect.arrayContaining([
-          'Could not resolve "foobar" imported by "@vitejs/test-dep-with-optional-peer-dep". Is it installed?',
-        ]),
-      ),
+    expect(browserErrors.map((error) => error.message)).toEqual(
+      expect.arrayContaining([
+        'Could not resolve "foobar" imported by "@vitejs/test-dep-with-optional-peer-dep". Is it installed?',
+      ]),
     )
   }
 })
 
 test('dep with optional peer dep submodule', async () => {
-  await withRetry(async () =>
-    expect(
-      await page.textContent('.dep-with-optional-peer-dep-submodule'),
-    ).toMatch(`[success]`),
-  )
+  expect(
+    await page.textContent('.dep-with-optional-peer-dep-submodule'),
+  ).toMatch(`[success]`)
   if (isServe) {
-    await withRetry(async () =>
-      expect(browserErrors.map((error) => error.message)).toEqual(
-        expect.arrayContaining([
-          'Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule". Is it installed?',
-        ]),
-      ),
+    expect(browserErrors.map((error) => error.message)).toEqual(
+      expect.arrayContaining([
+        'Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule". Is it installed?',
+      ]),
     )
   }
 })
 
 test('dep with css import', async () => {
-  await withRetry(async () =>
-    expect(await getColor('.dep-linked-include')).toBe('red'),
-  )
+  expect(await getColor('.dep-linked-include')).toBe('red')
 })
 
 test('CJS dep with css import', async () => {
-  await withRetry(async () =>
-    expect(await getColor('.cjs-with-assets')).toBe('blue'),
-  )
+  expect(await getColor('.cjs-with-assets')).toBe('blue')
 })
 
 test('externalize known non-js files in optimize included dep', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.externalize-known-non-js')).toMatch(
-      `[success]`,
-    ),
+  expect(await page.textContent('.externalize-known-non-js')).toMatch(
+    `[success]`,
   )
 })
 
 test('vue + vuex', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.vue')).toMatch(`[success]`),
-  )
+  expect(await page.textContent('.vue')).toMatch(`[success]`)
 })
 
 // When we use the Rollup CommonJS plugin instead of esbuild prebundling,
 // the esbuild plugins won't apply to dependencies
 test('esbuild-plugin', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.esbuild-plugin')).toMatch(
-      `Hello from an esbuild plugin`,
-    ),
+  expect(await page.textContent('.esbuild-plugin')).toMatch(
+    `Hello from an esbuild plugin`,
   )
 })
 
 test('import from hidden dir', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.hidden-dir')).toBe('hello!'),
-  )
+  expect(await page.textContent('.hidden-dir')).toBe('hello!')
 })
 
 test('import optimize-excluded package that imports optimized-included package', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.nested-include')).toBe('nested-include'),
-  )
+  expect(await page.textContent('.nested-include')).toBe('nested-include')
 })
 
 test('import aliased package with colon', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.url')).toBe('vitejs.dev'),
-  )
+  expect(await page.textContent('.url')).toBe('vitejs.dev')
 })
 
 test('import aliased package using absolute path', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.alias-using-absolute-path')).toBe(
-      'From dep-alias-using-absolute-path',
-    ),
+  expect(await page.textContent('.alias-using-absolute-path')).toBe(
+    'From dep-alias-using-absolute-path',
   )
 })
 
 test('variable names are reused in different scripts', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.reused-variable-names')).toBe('reused'),
-  )
+  expect(await page.textContent('.reused-variable-names')).toBe('reused')
 })
 
 test('flatten id should generate correctly', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.clonedeep-slash')).toBe('clonedeep-slash'),
-  )
-  await withRetry(async () =>
-    expect(await page.textContent('.clonedeep-dot')).toBe('clonedeep-dot'),
-  )
+  expect(await page.textContent('.clonedeep-slash')).toBe('clonedeep-slash')
+  expect(await page.textContent('.clonedeep-dot')).toBe('clonedeep-dot')
 })
 
 test('non optimized module is not duplicated', async () => {
-  await withRetry(async () =>
-    expect(
-      await page.textContent('.non-optimized-module-is-not-duplicated'),
-    ).toBe('from-absolute-path, from-relative-path'),
-  )
+  expect(
+    await page.textContent('.non-optimized-module-is-not-duplicated'),
+  ).toBe('from-absolute-path, from-relative-path')
 })
 
 test.runIf(isServe)('error on builtin modules usage', () => {
@@ -306,12 +227,8 @@ test('pre bundle css require', async () => {
     )
   }
 
-  await withRetry(async () =>
-    expect(await getColor('.css-require')).toBe('red'),
-  )
-  await withRetry(async () =>
-    expect(await getColor('.css-module-require')).toBe('red'),
-  )
+  expect(await getColor('.css-require')).toBe('red')
+  expect(await getColor('.css-module-require')).toBe('red')
 })
 
 test.runIf(isBuild)('no missing deps during build', async () => {
@@ -359,7 +276,5 @@ describe.runIf(isServe)('optimizeDeps config', () => {
 })
 
 test('long file name should work', async () => {
-  await withRetry(async () =>
-    expect(await page.textContent('.long-file-name')).toMatch(`hello world`),
-  )
+  expect(await page.textContent('.long-file-name')).toMatch(`hello world`)
 })

--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -9,175 +9,254 @@ import {
   readDepOptimizationMetadata,
   serverLogs,
   viteTestUrl,
+  withRetry,
 } from '~utils'
 
 test('default + named imports from cjs dep (react)', async () => {
-  expect(await page.textContent('.cjs button')).toBe('count is 0')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs button')).toBe('count is 0'),
+  )
   await page.click('.cjs button')
-  expect(await page.textContent('.cjs button')).toBe('count is 1')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs button')).toBe('count is 1'),
+  )
 })
 
 test('named imports from webpacked cjs (phoenix)', async () => {
-  expect(await page.textContent('.cjs-phoenix')).toBe('ok')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-phoenix')).toBe('ok'),
+  )
 })
 
 test('default import from webpacked cjs (clipboard)', async () => {
-  expect(await page.textContent('.cjs-clipboard')).toBe('ok')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-clipboard')).toBe('ok'),
+  )
 })
 
 test('dynamic imports from cjs dep (react)', async () => {
-  expect(await page.textContent('.cjs-dynamic button')).toBe('count is 0')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-dynamic button')).toBe('count is 0'),
+  )
   await page.click('.cjs-dynamic button')
-  expect(await page.textContent('.cjs-dynamic button')).toBe('count is 1')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-dynamic button')).toBe('count is 1'),
+  )
 })
 
 test('dynamic named imports from webpacked cjs (phoenix)', async () => {
-  expect(await page.textContent('.cjs-dynamic-phoenix')).toBe('ok')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-dynamic-phoenix')).toBe('ok'),
+  )
 })
 
 test('dynamic default import from webpacked cjs (clipboard)', async () => {
-  expect(await page.textContent('.cjs-dynamic-clipboard')).toBe('ok')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-dynamic-clipboard')).toBe('ok'),
+  )
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-esm)', async () => {
-  expect(await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm')).toBe(
-    'ok',
+  await withRetry(async () =>
+    expect(
+      await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-esm'),
+    ).toBe('ok'),
   )
 })
 
 test('dynamic default import from cjs (cjs-dynamic-dep-cjs-compiled-from-cjs)', async () => {
-  expect(await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs')).toBe(
-    'ok',
+  await withRetry(async () =>
+    expect(
+      await page.textContent('.cjs-dynamic-dep-cjs-compiled-from-cjs'),
+    ).toBe('ok'),
   )
 })
 
 test('dedupe', async () => {
-  expect(await page.textContent('.dedupe button')).toBe('count is 0')
+  await withRetry(async () =>
+    expect(await page.textContent('.dedupe button')).toBe('count is 0'),
+  )
   await page.click('.dedupe button')
-  expect(await page.textContent('.dedupe button')).toBe('count is 1')
+  await withRetry(async () =>
+    expect(await page.textContent('.dedupe button')).toBe('count is 1'),
+  )
 })
 
 test('cjs browser field (axios)', async () => {
-  expect(await page.textContent('.cjs-browser-field')).toBe('pong')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-browser-field')).toBe('pong'),
+  )
 })
 
 test('cjs browser field bare', async () => {
-  expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong')
+  await withRetry(async () =>
+    expect(await page.textContent('.cjs-browser-field-bare')).toBe('pong'),
+  )
 })
 
 test('dep from linked dep (lodash-es)', async () => {
-  expect(await page.textContent('.deps-linked')).toBe('fooBarBaz')
+  await withRetry(async () =>
+    expect(await page.textContent('.deps-linked')).toBe('fooBarBaz'),
+  )
 })
 
 test('forced include', async () => {
-  expect(await page.textContent('.force-include')).toMatch(`[success]`)
+  await withRetry(async () =>
+    expect(await page.textContent('.force-include')).toMatch(`[success]`),
+  )
 })
 
 test('import * from optimized dep', async () => {
-  expect(await page.textContent('.import-star')).toMatch(`[success]`)
+  await withRetry(async () =>
+    expect(await page.textContent('.import-star')).toMatch(`[success]`),
+  )
 })
 
 test('import from dep with process.env.NODE_ENV', async () => {
-  expect(await page.textContent('.node-env')).toMatch(isBuild ? 'prod' : 'dev')
+  await withRetry(async () =>
+    expect(await page.textContent('.node-env')).toMatch(
+      isBuild ? 'prod' : 'dev',
+    ),
+  )
 })
 
 test('import from dep with .notjs files', async () => {
-  expect(await page.textContent('.not-js')).toMatch(`[success]`)
+  await withRetry(async () =>
+    expect(await page.textContent('.not-js')).toMatch(`[success]`),
+  )
 })
 
 test('Import from dependency which uses relative path which needs to be resolved by main field', async () => {
-  expect(await page.textContent('.relative-to-main')).toMatch(`[success]`)
+  await withRetry(async () =>
+    expect(await page.textContent('.relative-to-main')).toMatch(`[success]`),
+  )
 })
 
 test('dep with dynamic import', async () => {
-  expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
-    `[success]`,
+  await withRetry(async () =>
+    expect(await page.textContent('.dep-with-dynamic-import')).toMatch(
+      `[success]`,
+    ),
   )
 })
 
 test('dep with optional peer dep', async () => {
-  expect(await page.textContent('.dep-with-optional-peer-dep')).toMatch(
-    `[success]`,
+  await withRetry(async () =>
+    expect(await page.textContent('.dep-with-optional-peer-dep')).toMatch(
+      `[success]`,
+    ),
   )
   if (isServe) {
-    expect(browserErrors.map((error) => error.message)).toEqual(
-      expect.arrayContaining([
-        'Could not resolve "foobar" imported by "@vitejs/test-dep-with-optional-peer-dep". Is it installed?',
-      ]),
+    await withRetry(async () =>
+      expect(browserErrors.map((error) => error.message)).toEqual(
+        expect.arrayContaining([
+          'Could not resolve "foobar" imported by "@vitejs/test-dep-with-optional-peer-dep". Is it installed?',
+        ]),
+      ),
     )
   }
 })
 
 test('dep with optional peer dep submodule', async () => {
-  expect(
-    await page.textContent('.dep-with-optional-peer-dep-submodule'),
-  ).toMatch(`[success]`)
+  await withRetry(async () =>
+    expect(
+      await page.textContent('.dep-with-optional-peer-dep-submodule'),
+    ).toMatch(`[success]`),
+  )
   if (isServe) {
-    expect(browserErrors.map((error) => error.message)).toEqual(
-      expect.arrayContaining([
-        'Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule". Is it installed?',
-      ]),
+    await withRetry(async () =>
+      expect(browserErrors.map((error) => error.message)).toEqual(
+        expect.arrayContaining([
+          'Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule". Is it installed?',
+        ]),
+      ),
     )
   }
 })
 
 test('dep with css import', async () => {
-  expect(await getColor('.dep-linked-include')).toBe('red')
+  await withRetry(async () =>
+    expect(await getColor('.dep-linked-include')).toBe('red'),
+  )
 })
 
 test('CJS dep with css import', async () => {
-  expect(await getColor('.cjs-with-assets')).toBe('blue')
+  await withRetry(async () =>
+    expect(await getColor('.cjs-with-assets')).toBe('blue'),
+  )
 })
 
 test('externalize known non-js files in optimize included dep', async () => {
-  expect(await page.textContent('.externalize-known-non-js')).toMatch(
-    `[success]`,
+  await withRetry(async () =>
+    expect(await page.textContent('.externalize-known-non-js')).toMatch(
+      `[success]`,
+    ),
   )
 })
 
 test('vue + vuex', async () => {
-  expect(await page.textContent('.vue')).toMatch(`[success]`)
+  await withRetry(async () =>
+    expect(await page.textContent('.vue')).toMatch(`[success]`),
+  )
 })
 
 // When we use the Rollup CommonJS plugin instead of esbuild prebundling,
 // the esbuild plugins won't apply to dependencies
 test('esbuild-plugin', async () => {
-  expect(await page.textContent('.esbuild-plugin')).toMatch(
-    `Hello from an esbuild plugin`,
+  await withRetry(async () =>
+    expect(await page.textContent('.esbuild-plugin')).toMatch(
+      `Hello from an esbuild plugin`,
+    ),
   )
 })
 
 test('import from hidden dir', async () => {
-  expect(await page.textContent('.hidden-dir')).toBe('hello!')
+  await withRetry(async () =>
+    expect(await page.textContent('.hidden-dir')).toBe('hello!'),
+  )
 })
 
 test('import optimize-excluded package that imports optimized-included package', async () => {
-  expect(await page.textContent('.nested-include')).toBe('nested-include')
+  await withRetry(async () =>
+    expect(await page.textContent('.nested-include')).toBe('nested-include'),
+  )
 })
 
 test('import aliased package with colon', async () => {
-  expect(await page.textContent('.url')).toBe('vitejs.dev')
+  await withRetry(async () =>
+    expect(await page.textContent('.url')).toBe('vitejs.dev'),
+  )
 })
 
 test('import aliased package using absolute path', async () => {
-  expect(await page.textContent('.alias-using-absolute-path')).toBe(
-    'From dep-alias-using-absolute-path',
+  await withRetry(async () =>
+    expect(await page.textContent('.alias-using-absolute-path')).toBe(
+      'From dep-alias-using-absolute-path',
+    ),
   )
 })
 
 test('variable names are reused in different scripts', async () => {
-  expect(await page.textContent('.reused-variable-names')).toBe('reused')
+  await withRetry(async () =>
+    expect(await page.textContent('.reused-variable-names')).toBe('reused'),
+  )
 })
 
 test('flatten id should generate correctly', async () => {
-  expect(await page.textContent('.clonedeep-slash')).toBe('clonedeep-slash')
-  expect(await page.textContent('.clonedeep-dot')).toBe('clonedeep-dot')
+  await withRetry(async () =>
+    expect(await page.textContent('.clonedeep-slash')).toBe('clonedeep-slash'),
+  )
+  await withRetry(async () =>
+    expect(await page.textContent('.clonedeep-dot')).toBe('clonedeep-dot'),
+  )
 })
 
 test('non optimized module is not duplicated', async () => {
-  expect(
-    await page.textContent('.non-optimized-module-is-not-duplicated'),
-  ).toBe('from-absolute-path, from-relative-path')
+  await withRetry(async () =>
+    expect(
+      await page.textContent('.non-optimized-module-is-not-duplicated'),
+    ).toBe('from-absolute-path, from-relative-path'),
+  )
 })
 
 test.runIf(isServe)('error on builtin modules usage', () => {
@@ -227,8 +306,12 @@ test('pre bundle css require', async () => {
     )
   }
 
-  expect(await getColor('.css-require')).toBe('red')
-  expect(await getColor('.css-module-require')).toBe('red')
+  await withRetry(async () =>
+    expect(await getColor('.css-require')).toBe('red'),
+  )
+  await withRetry(async () =>
+    expect(await getColor('.css-module-require')).toBe('red'),
+  )
 })
 
 test.runIf(isBuild)('no missing deps during build', async () => {
@@ -276,5 +359,7 @@ describe.runIf(isServe)('optimizeDeps config', () => {
 })
 
 test('long file name should work', async () => {
-  expect(await page.textContent('.long-file-name')).toMatch(`hello world`)
+  await withRetry(async () =>
+    expect(await page.textContent('.long-file-name')).toMatch(`hello world`),
+  )
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

It was flaky on my machine. This PR simply wraps most expect with `withRetry`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
