### PR TITLE
perf: async fs calls in resolve and package handling

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -579,6 +579,28 @@ License: MIT
 By: Rich Harris
 Repository: rollup/plugins
 
+> The MIT License (MIT)
+> 
+> Copyright (c) 2019 RollupJS Plugin Contributors (https://github.com/rollup/plugins/graphs/contributors)
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
 ---------------------------------------
 
 ## acorn

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -851,7 +851,7 @@ export async function addManuallyIncludedOptimizeDeps(
     for (let i = 0; i < includes.length; i++) {
       const id = includes[i]
       if (glob.isDynamicPattern(id)) {
-        const globIds = expandGlobIds(id, config)
+        const globIds = await expandGlobIds(id, config)
         includes.splice(i, 1, ...globIds)
         i += globIds.length - 1
       }

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -25,7 +25,7 @@ export function createOptimizeDepsIncludeResolver(
     // 'foo > bar > baz' => 'foo > bar' & 'baz'
     const nestedRoot = id.substring(0, lastArrowIndex).trim()
     const nestedPath = id.substring(lastArrowIndex + 1).trim()
-    const basedir = nestedResolveBasedir(
+    const basedir = await nestedResolveBasedir(
       nestedRoot,
       config.root,
       config.resolve.preserveSymlinks,
@@ -42,11 +42,14 @@ export function createOptimizeDepsIncludeResolver(
 /**
  * Expand the glob syntax in `optimizeDeps.include` to proper import paths
  */
-export function expandGlobIds(id: string, config: ResolvedConfig): string[] {
+export async function expandGlobIds(
+  id: string,
+  config: ResolvedConfig,
+): Promise<string[]> {
   const pkgName = getNpmPackageName(id)
   if (!pkgName) return []
 
-  const pkgData = resolvePackageData(
+  const pkgData = await resolvePackageData(
     pkgName,
     config.root,
     config.resolve.preserveSymlinks,
@@ -160,14 +163,15 @@ function getFirstExportStringValue(
 /**
  * Continuously resolve the basedir of packages separated by '>'
  */
-function nestedResolveBasedir(
+async function nestedResolveBasedir(
   id: string,
   basedir: string,
   preserveSymlinks = false,
 ) {
   const pkgs = id.split('>').map((pkg) => pkg.trim())
   for (const pkg of pkgs) {
-    basedir = resolvePackageData(pkg, basedir, preserveSymlinks)?.dir || basedir
+    basedir =
+      (await resolvePackageData(pkg, basedir, preserveSymlinks))?.dir || basedir
   }
   return basedir
 }

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -109,7 +109,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           let file: string | undefined
           if (url[0] === '.') {
             file = slash(path.resolve(path.dirname(id), url))
-            file = tryFsResolve(file, fsResolveOptions) ?? file
+            file = (await tryFsResolve(file, fsResolveOptions)) ?? file
           } else {
             assetResolver ??= config.createResolver({
               extensions: [],

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -488,7 +488,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
             // skip ssr external
             if (ssr) {
-              if (shouldExternalizeForSSR(specifier, importer, config)) {
+              if (await shouldExternalizeForSSR(specifier, importer, config)) {
                 return
               }
               if (isBuiltin(specifier)) {

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -166,7 +166,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           let file: string | undefined
           if (url[0] === '.') {
             file = path.resolve(path.dirname(id), url)
-            file = tryFsResolve(file, fsResolveOptions) ?? file
+            file = (await tryFsResolve(file, fsResolveOptions)) ?? file
           } else {
             workerResolver ??= config.createResolver({
               extensions: [],

--- a/packages/vite/src/node/ssr/ssrExternal.ts
+++ b/packages/vite/src/node/ssr/ssrExternal.ts
@@ -121,9 +121,7 @@ export function createIsConfiguredAsSsrExternal(
   }
 }
 
-function createIsSsrExternal(
-  config: ResolvedConfig,
-): (id: string, importer?: string) => Promise<boolean | undefined> {
+function createIsSsrExternal(config: ResolvedConfig): IsSsrExternalFunction {
   const processedIds = new Map<string, boolean | undefined>()
 
   const isConfiguredAsExternal = createIsConfiguredAsSsrExternal(config)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -295,7 +295,7 @@ async function nodeImport(
   if (isRuntimeHandled) {
     url = id
   } else {
-    const resolved = tryNodeResolve(
+    const resolved = await tryNodeResolve(
       id,
       importer,
       { ...resolveOptions, tryEsmOnly: true },
@@ -320,7 +320,7 @@ async function nodeImport(
   } else if (isRuntimeHandled) {
     return mod
   } else {
-    analyzeImportedModDifference(
+    await analyzeImportedModDifference(
       mod,
       url,
       id,
@@ -362,7 +362,7 @@ function isPrimitive(value: any) {
  * Top-level imports and dynamic imports work slightly differently in Node.js.
  * This function normalizes the differences so it matches prod behaviour.
  */
-function analyzeImportedModDifference(
+async function analyzeImportedModDifference(
   mod: any,
   filePath: string,
   rawId: string,
@@ -372,7 +372,7 @@ function analyzeImportedModDifference(
   // No normalization needed if the user already dynamic imports this module
   if (metadata?.isDynamicImport) return
   // If file path is ESM, everything should be fine
-  if (isFilePathESM(filePath, packageCache)) return
+  if (await isFilePathESM(filePath, packageCache)) return
 
   // For non-ESM, named imports is done via static analysis with cjs-module-lexer in Node.js.
   // If the user named imports a specifier that can't be analyzed, error.

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { exec } from 'node:child_process'
+// import { exec } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { URL, URLSearchParams, fileURLToPath } from 'node:url'
 import { builtinModules, createRequire } from 'node:module'
@@ -629,12 +629,13 @@ export function copyDir(srcDir: string, destDir: string): void {
 // `fs.realpathSync.native` resolves differently in Windows network drive,
 // causing file read errors. skip for now.
 // https://github.com/nodejs/node/issues/37737
-export let safeRealpath = isWindows ? windowsSafeRealPath : fsp.realpath
+export const safeRealpath = isWindows ? realpathFallback : fsp.realpath
 
 async function realpathFallback(path: string) {
   return fs.realpathSync(path)
 }
 
+/*
 // Based on https://github.com/larrybahr/windows-network-drive
 // MIT License, Copyright (c) 2017 Larry Bahr
 const windowsNetworkMap = new Map()
@@ -692,6 +693,7 @@ async function optimizeSafeRealPath() {
     }
   })
 }
+*/
 
 export function ensureWatchedFile(
   watcher: FSWatcher,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -652,7 +652,7 @@ let firstSafeRealPathRun = false
 
 async function windowsSafeRealPath(path: string): Promise<string> {
   if (!firstSafeRealPathRun) {
-    await optimizeSafeRealPath()
+    optimizeSafeRealPath()
     firstSafeRealPathRun = true
   }
   return fs.realpathSync(path)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-// import { exec } from 'node:child_process'
+import { exec } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { URL, URLSearchParams, fileURLToPath } from 'node:url'
 import { builtinModules, createRequire } from 'node:module'
@@ -629,13 +629,12 @@ export function copyDir(srcDir: string, destDir: string): void {
 // `fs.realpathSync.native` resolves differently in Windows network drive,
 // causing file read errors. skip for now.
 // https://github.com/nodejs/node/issues/37737
-export const safeRealpath = isWindows ? realpathFallback : fsp.realpath
+export let safeRealpath = isWindows ? windowsSafeRealPath : fsp.realpath
 
 async function realpathFallback(path: string) {
   return fs.realpathSync(path)
 }
 
-/*
 // Based on https://github.com/larrybahr/windows-network-drive
 // MIT License, Copyright (c) 2017 Larry Bahr
 const windowsNetworkMap = new Map()
@@ -693,7 +692,6 @@ async function optimizeSafeRealPath() {
     }
   })
 }
-*/
 
 export function ensureWatchedFile(
   watcher: FSWatcher,


### PR DESCRIPTION
### Description

`getRealPath` in resolve is taking ~8% of the workload in https://github.com/yyx990803/vite-dev-server-perf, and it is calling `fs.realPathSync.native`. After this PR, it takes ~2% by using `fsp.realPath` (equivalent to the `.native` sync version).

I tested the speed improvement using the test in the repo instead of the cpuprofile, but it isn't stable on my machine. I think that even if we now have a ton of promises being generated, the non-blocking `fs` calls should still make this change worth it. We need to test in some other benchmarks.

The PR also changes a `fs.readFileSync` in `package.ts` to be async, and that triggered a whole bunch of async/await changes in the codebase too.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other