### PR TITLE
feat(server): allow disabling built-in shortcuts

### DIFF
--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -14,6 +14,7 @@ export type BindCLIShortcutsOptions<Server = ViteDevServer | PreviewServer> = {
   /**
    * Custom shortcuts to run when a key is pressed. These shortcuts take priority
    * over the default shortcuts if they have the same keys (except the `h` key).
+   * To disable a default shortcut, define the same key but with `action: undefined`.
    */
   customShortcuts?: CLIShortcut<Server>[]
 }
@@ -21,7 +22,7 @@ export type BindCLIShortcutsOptions<Server = ViteDevServer | PreviewServer> = {
 export type CLIShortcut<Server = ViteDevServer | PreviewServer> = {
   key: string
   description: string
-  action(server: Server): void | Promise<void>
+  action?(server: Server): void | Promise<void>
 }
 
 export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
@@ -66,6 +67,8 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
         if (loggedKeys.has(shortcut.key)) continue
         loggedKeys.add(shortcut.key)
 
+        if (shortcut.action == null) continue
+
         server.config.logger.info(
           colors.dim('  press ') +
             colors.bold(`${shortcut.key} + enter`) +
@@ -77,7 +80,7 @@ export function bindCLIShortcuts<Server extends ViteDevServer | PreviewServer>(
     }
 
     const shortcut = shortcuts.find((shortcut) => shortcut.key === input)
-    if (!shortcut) return
+    if (!shortcut || shortcut.action == null) return
 
     actionRunning = true
     await shortcut.action(server)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Allow disabling builtin shortcuts by defining custom shortcuts with `action: undefined`. Currently trying to use this for Astro, and there's some shortcuts like `c + enter` to clear screen that they don't need.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
