### PR TITLE
chore: replace 'some' with 'includes' in resolveEnvPrefix

### DIFF
--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -76,7 +76,7 @@ export function resolveEnvPrefix({
   envPrefix = 'VITE_',
 }: UserConfig): string[] {
   envPrefix = arraify(envPrefix)
-  if (envPrefix.some((prefix) => prefix === '')) {
+  if (envPrefix.includes('')) {
     throw new Error(
       `envPrefix option contains value '', which could lead unexpected exposure of sensitive information.`,
     )


### PR DESCRIPTION
The functionality of includes and some is equivalent in this context, but I think using includes here is more concise and readable...