### PR TITLE
fix: proxy html path should be encoded

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -98,10 +98,7 @@ export function htmlInlineProxyPlugin(config: ResolvedConfig): Plugin {
         const index = Number(proxyMatch[1])
         const file = cleanUrl(id)
         const url = file.replace(normalizePath(config.root), '')
-        const encodedUrl = url.startsWith('\0')
-          ? '\0' + encodeURI(url.slice(1))
-          : encodeURI(url)
-        const result = htmlProxyMap.get(config)!.get(encodedUrl)?.[index]
+        const result = htmlProxyMap.get(config)!.get(url)?.[index]
         if (result) {
           return result
         } else {

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -98,7 +98,10 @@ export function htmlInlineProxyPlugin(config: ResolvedConfig): Plugin {
         const index = Number(proxyMatch[1])
         const file = cleanUrl(id)
         const url = file.replace(normalizePath(config.root), '')
-        const result = htmlProxyMap.get(config)!.get(url)?.[index]
+        const encodedUrl = url.startsWith('\0')
+          ? '\0' + encodeURI(url.slice(1))
+          : encodeURI(url)
+        const result = htmlProxyMap.get(config)!.get(encodedUrl)?.[index]
         if (result) {
           return result
         } else {

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -191,9 +191,10 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
   const s = new MagicString(html)
   let inlineModuleIndex = -1
-  const proxyCacheUrl = cleanUrl(proxyModulePath).replace(
-    normalizePath(config.root),
-    '',
+  // The key to the proxyHtml cache is decoded, as it will be compared
+  // against decoded URLs by the HTML plugins.
+  const proxyCacheUrl = decodeURI(
+    cleanUrl(proxyModulePath).replace(normalizePath(config.root), ''),
   )
   const styleUrl: AssetNode[] = []
   const inlineStyles: InlineStyleAttribute[] = []

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -170,7 +170,6 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 ) => {
   const { config, moduleGraph, watcher } = server!
   const base = config.base || '/'
-  htmlPath = decodeURI(htmlPath)
 
   let proxyModulePath: string
   let proxyModuleUrl: string
@@ -434,6 +433,11 @@ function preTransformRequest(server: ViteDevServer, url: string, base: string) {
   if (!server.config.server.preTransformRequests) return
 
   // transform all url as non-ssr as html includes client-side assets only
-  url = unwrapId(stripBase(url, base))
+  try {
+    url = unwrapId(stripBase(decodeURI(url), base))
+  } catch {
+    // ignore
+    return
+  }
   server.warmupRequest(url)
 }

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port, serverLogs } from './serve'
-import { editFile, page, withRetry } from '~utils'
+import { browserLogs, editFile, isServe, page, withRetry } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -28,4 +28,12 @@ test('should restart ssr', async () => {
       expect.arrayContaining([expect.stringMatching('error')]),
     )
   })
+})
+
+test.runIf(isServe)('html proxy is encoded', async () => {
+  await page.goto(
+    `${url}?%22%3E%3C/script%3E%3Cscript%3Econsole.log(%27html proxy is not encoded%27)%3C/script%3E`,
+  )
+
+  expect(browserLogs).not.toContain('html proxy is not encoded')
 })

--- a/playground/ssr/index.html
+++ b/playground/ssr/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SSR</title>
+    <script type="module">
+      // Inline script for testing html-proxy encoding
+      console.log('from inline script')
+    </script>
   </head>
   <body>
     <h1>SSR</h1>


### PR DESCRIPTION
### Description

After #13581, the htmlProxy URLs were unencoded. This PR reverts this change, still fixing the linked bugs (there was a test added in that PR).

I tried two approaches, the second commit has the keys in the proxy HTML cache decoded. I think this is the simpler of the two.

There was also an issue when pre-transforming requests in index HTML middleware, the URLs sent to `warmupRequest` should be decoded. Once I did the fix, the ssr-deps playground started to fail for this reason. I added the decoding logic there too.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other