### PR TITLE
fix: json error with position

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -39,7 +39,7 @@ export const customQueryObject = /* #__PURE__ */ Object.assign({"./sibling.ts": 
 export const parent = /* #__PURE__ */ Object.assign({
 
 });
-export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/css.spec.ts": () => import("../../css.spec.ts?url").then(m => m["default"]),"/define.spec.ts": () => import("../../define.spec.ts?url").then(m => m["default"]),"/esbuild.spec.ts": () => import("../../esbuild.spec.ts?url").then(m => m["default"]),"/import.spec.ts": () => import("../../import.spec.ts?url").then(m => m["default"]),"/importGlob/fixture-b/a.ts": () => import("../fixture-b/a.ts?url").then(m => m["default"]),"/importGlob/fixture-b/b.ts": () => import("../fixture-b/b.ts?url").then(m => m["default"]),"/importGlob/fixture-b/index.ts": () => import("../fixture-b/index.ts?url").then(m => m["default"])
+export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/css.spec.ts": () => import("../../css.spec.ts?url").then(m => m["default"]),"/define.spec.ts": () => import("../../define.spec.ts?url").then(m => m["default"]),"/esbuild.spec.ts": () => import("../../esbuild.spec.ts?url").then(m => m["default"]),"/import.spec.ts": () => import("../../import.spec.ts?url").then(m => m["default"]),"/importGlob/fixture-b/a.ts": () => import("../fixture-b/a.ts?url").then(m => m["default"]),"/importGlob/fixture-b/b.ts": () => import("../fixture-b/b.ts?url").then(m => m["default"]),"/importGlob/fixture-b/index.ts": () => import("../fixture-b/index.ts?url").then(m => m["default"]),"/json.spec.ts": () => import("../../json.spec.ts?url").then(m => m["default"])
 
 
 });
@@ -93,7 +93,7 @@ export const customQueryObject = /* #__PURE__ */ Object.assign({"./sibling.ts": 
 export const parent = /* #__PURE__ */ Object.assign({
 
 });
-export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/css.spec.ts": () => import("../../css.spec.ts?url&lang.ts").then(m => m["default"]),"/define.spec.ts": () => import("../../define.spec.ts?url&lang.ts").then(m => m["default"]),"/esbuild.spec.ts": () => import("../../esbuild.spec.ts?url&lang.ts").then(m => m["default"]),"/import.spec.ts": () => import("../../import.spec.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/a.ts": () => import("../fixture-b/a.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/b.ts": () => import("../fixture-b/b.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/index.ts": () => import("../fixture-b/index.ts?url&lang.ts").then(m => m["default"])
+export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/css.spec.ts": () => import("../../css.spec.ts?url&lang.ts").then(m => m["default"]),"/define.spec.ts": () => import("../../define.spec.ts?url&lang.ts").then(m => m["default"]),"/esbuild.spec.ts": () => import("../../esbuild.spec.ts?url&lang.ts").then(m => m["default"]),"/import.spec.ts": () => import("../../import.spec.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/a.ts": () => import("../fixture-b/a.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/b.ts": () => import("../fixture-b/b.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/index.ts": () => import("../fixture-b/index.ts?url&lang.ts").then(m => m["default"]),"/json.spec.ts": () => import("../../json.spec.ts?url&lang.ts").then(m => m["default"])
 
 
 });

--- a/packages/vite/src/node/__tests__/plugins/json.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/json.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+import { extractJsonErrorPosition } from '../../plugins/json'
+
+const getErrorMessage = (input: string) => {
+  try {
+    JSON.parse(input)
+    throw new Error('No error happened')
+  } catch (e) {
+    return e.message
+  }
+}
+
+test('can extract json error position', () => {
+  const cases = [
+    { input: '{', expectedPosition: 0 },
+    { input: '{},', expectedPosition: 1 },
+    { input: '"f', expectedPosition: 1 },
+    { input: '[', expectedPosition: 0 },
+  ]
+
+  for (const { input, expectedPosition } of cases) {
+    expect(extractJsonErrorPosition(getErrorMessage(input), input.length)).toBe(
+      expectedPosition,
+    )
+  }
+})

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -71,13 +71,26 @@ export function jsonPlugin(
           map: { mappings: '' },
         }
       } catch (e) {
-        const errorMessageList = /\d+/.exec(e.message)
-        const position = errorMessageList && parseInt(errorMessageList[0], 10)
+        const position = extractJsonErrorPosition(e.message, json.length)
         const msg = position
-          ? `, invalid JSON syntax found at line ${position}`
+          ? `, invalid JSON syntax found at position ${position}`
           : `.`
-        this.error(`Failed to parse JSON file` + msg, e.idx)
+        this.error(`Failed to parse JSON file` + msg, position)
       }
     },
   }
+}
+
+export function extractJsonErrorPosition(
+  errorMessage: string,
+  inputLength: number,
+): number | undefined {
+  if (errorMessage.startsWith('Unexpected end of JSON input')) {
+    return inputLength - 1
+  }
+
+  const errorMessageList = /at position (\d+)/.exec(errorMessage)
+  return errorMessageList
+    ? Math.max(parseInt(errorMessageList[1], 10) - 1, 0)
+    : undefined
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
A code to show better JSON parse error existed but was not working. This PR fixes that code and adds a code to handle "Unexpected end of JSON input" error as well.

**Before**
```
[plugin:vite:json] Failed to parse JSON file, invalid JSON syntax found at line 19
D:/documents/GitHub/vite/playground/define/data.json
```
**After**
```
[plugin:vite:json] Failed to parse JSON file, invalid JSON syntax found at position 18
D:/documents/GitHub/vite/playground/define/data.json:2:17
1  |  {
2  |    "foo": "__EXP__
   |                  ^
3  |  }
4  |
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
