### PR TITLE
fix: backport #15223, proxy html path should be encoded

### DIFF
--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port, serverLogs } from './serve'
-import { editFile, page, withRetry } from '~utils'
+import { browserLogs, editFile, isServe, page, withRetry } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -28,4 +28,12 @@ test('should restart ssr', async () => {
       expect.arrayContaining([expect.stringMatching('error')]),
     )
   })
+})
+
+test.runIf(isServe)('html proxy is encoded', async () => {
+  await page.goto(
+    `${url}?%22%3E%3C/script%3E%3Cscript%3Econsole.log(%27html proxy is not encoded%27)%3C/script%3E`,
+  )
+
+  expect(browserLogs).not.toContain('html proxy is not encoded')
 })

--- a/playground/ssr/index.html
+++ b/playground/ssr/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SSR</title>
+    <script type="module">
+      // Inline script for testing html-proxy encoding
+      console.log('from inline script')
+    </script>
   </head>
   <body>
     <h1>SSR</h1>


### PR DESCRIPTION
### Description

Backport
- #15223 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other