### PR TITLE
fix(hmr): don't consider CSS dep as a circular dep

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -394,6 +394,11 @@ function isNodeWithinCircularImports(
     // Node may import itself which is safe
     if (importer === node) continue
 
+    // a PostCSS plugin like Tailwind JIT may register
+    // any file as a dependency to a CSS file.
+    // But in that case, the actual dependency chain is separate.
+    if (isCSSRequest(importer.url)) continue
+
     // Check circular imports
     const importerIndex = nodeChain.indexOf(importer)
     if (importerIndex > -1) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
In future, maybe we should add `cssImporters` field to `ModuleNode` type which will resolve these tailwind related issues together including #9512. But that will be a big change, so instead I made a small change that would fix the case that was working in past.

fixes #15221
refs #14867
refs 6eaec3ab74d126310d93f8a93f8577bed1c3f474

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
