### PR TITLE
docs(env): add .env parsing note and vite-env.d.ts augmentation

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -102,9 +102,9 @@ If your code relies on types from browser environments such as [DOM](https://git
 }
 ```
 
-:::warning Imports will break augumentation in `vite-env.d.ts`
+:::warning Imports will break type augmentation
 
-If `ImportMetaEnv` augumentation does not work, make sure you do not have any `import` statements in `vite-env.d.ts`
+If the `ImportMetaEnv` augmentation does not work, make sure you do not have any `import` statements in `vite-env.d.ts`. See the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/2/modules.html#how-javascript-modules-are-defined) for more information.
 :::
 
 ## HTML Env Replacement

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -52,10 +52,7 @@ console.log(import.meta.env.DB_PASSWORD) // undefined
 
 :::tip Env parsing
 
-As seen in example above `VITE_SOME_KEY` is a number.  
-But when parsed, Env properties are strings even if they are numbers or booleans in the Env file.  
-User has to convert them to desired types in the code.
-A recommandation is to wrap all the Env properties in quotes to make that explicit.
+As shown above, `VITE_SOME_KEY` is a number but returns a string when parsed. The same would also happen for boolean env variables. Make sure to convert to the desired type when using it in your code.
 :::
 
 Also, Vite uses [dotenv-expand](https://github.com/motdotla/dotenv-expand) to expand variables out of the box. To learn more about the syntax, check out [their docs](https://github.com/motdotla/dotenv-expand#what-rules-does-the-expansion-engine-follow).

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -46,9 +46,17 @@ DB_PASSWORD=foobar
 Only `VITE_SOME_KEY` will be exposed as `import.meta.env.VITE_SOME_KEY` to your client source code, but `DB_PASSWORD` will not.
 
 ```js
-console.log(import.meta.env.VITE_SOME_KEY) // 123
+console.log(import.meta.env.VITE_SOME_KEY) // "123"
 console.log(import.meta.env.DB_PASSWORD) // undefined
 ```
+
+:::tip Env parsing
+
+As seen in example above `VITE_SOME_KEY` is a number.  
+But when parsed, Env properties are strings even if they are numbers or booleans in the Env file.  
+User has to convert them to desired types in the code.
+A recommandation is to wrap all the Env properties in quotes to make that explicit.
+:::
 
 Also, Vite uses [dotenv-expand](https://github.com/motdotla/dotenv-expand) to expand variables out of the box. To learn more about the syntax, check out [their docs](https://github.com/motdotla/dotenv-expand#what-rules-does-the-expansion-engine-follow).
 
@@ -74,7 +82,7 @@ If you want to customize the env variables prefix, see the [envPrefix](/config/s
 
 By default, Vite provides type definitions for `import.meta.env` in [`vite/client.d.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/client.d.ts). While you can define more custom env variables in `.env.[mode]` files, you may want to get TypeScript IntelliSense for user-defined env variables that are prefixed with `VITE_`.
 
-To achieve this, you can create an `env.d.ts` in `src` directory, then augment `ImportMetaEnv` like this:
+To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augment `ImportMetaEnv` like this:
 
 ```typescript
 /// <reference types="vite/client" />
@@ -96,6 +104,11 @@ If your code relies on types from browser environments such as [DOM](https://git
   "lib": ["WebWorker"]
 }
 ```
+
+:::warning Imports will break augumentation in `vite-env.d.ts`
+
+If `ImportMetaEnv` augumentation does not work, make sure you do not have any `import` statements in `vite-env.d.ts`
+:::
 
 ## HTML Env Replacement
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Add a note about how `.env` file is parsed
- Add a warning that using `import` statements in `vite-env.d.ts` breaks global augmentation

### Additional context

fix #15231

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
