### PR TITLE
test: missing __dirname in playground

### DIFF
--- a/playground/optimize-missing-deps/server.js
+++ b/playground/optimize-missing-deps/server.js
@@ -1,8 +1,10 @@
 // @ts-check
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import express from 'express'
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const isTest = process.env.VITEST
 
 export async function createServer(root = process.cwd(), hmrPort) {


### PR DESCRIPTION
### Description

Fixes `pnpm run dev` isn't working in the `optimize-missing-deps` playground. We missed this `__dirname` when it was converted to esm.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other