### PR TITLE
fix: check the existence of "document" before using it

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -300,6 +300,8 @@ function hasErrorOverlay() {
   if (hasDocument) {
     return document.querySelectorAll(overlayId).length
   }
+  
+  return false
 }
 
 let pending = false

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -281,18 +281,25 @@ function notifyListeners(event: string, data: any): void {
 }
 
 const enableOverlay = __HMR_ENABLE_OVERLAY__
+const hasDocument = typeof document !== 'undefined'
 
 function createErrorOverlay(err: ErrorPayload['err']) {
   clearErrorOverlay()
-  document.body.appendChild(new ErrorOverlay(err))
+  if (hasDocument) {
+    document.body.appendChild(new ErrorOverlay(err))
+  }
 }
 
 function clearErrorOverlay() {
-  document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close())
+  if (hasDocument) {
+    document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close())
+  }
 }
 
 function hasErrorOverlay() {
-  return document.querySelectorAll(overlayId).length
+  if (hasDocument) {
+    return document.querySelectorAll(overlayId).length
+  }
 }
 
 let pending = false
@@ -378,7 +385,7 @@ const sheetsMap = new Map<string, HTMLStyleElement>()
 
 // collect existing style elements that may have been inserted during SSR
 // to avoid FOUC or duplicate styles
-if ('document' in globalThis) {
+if (hasDocument) {
   document
     .querySelectorAll<HTMLStyleElement>('style[data-vite-dev-id]')
     .forEach((el) => {


### PR DESCRIPTION
### Description

When loading the client in a worker "document" is not available and should not be used.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
