### PR TITLE
fix: symbolic links in public dir

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -645,7 +645,7 @@ export async function _createServer(
     file = normalizePath(file)
     await container.watchChange(file, { event: isUnlink ? 'delete' : 'create' })
 
-    if (config.publicDir && file.startsWith(config.publicDir)) {
+    if (publicFiles && config.publicDir && file.startsWith(config.publicDir)) {
       publicFiles[isUnlink ? 'delete' : 'add'](
         file.slice(config.publicDir.length),
       )

--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -54,7 +54,7 @@ const sirvOptions = ({
 
 export function servePublicMiddleware(
   server: ViteDevServer,
-  publicFiles: Set<string>,
+  publicFiles?: Set<string>,
 ): Connect.NextHandleFunction {
   const dir = server.config.publicDir
   const serve = sirv(
@@ -82,7 +82,7 @@ export function servePublicMiddleware(
     // in-memory set of known public files. This set is updated on restarts.
     // also skip import request and internal requests `/@fs/ /@vite-client` etc...
     if (
-      !publicFiles.has(toFilePath(req.url!)) ||
+      (publicFiles && !publicFiles.has(toFilePath(req.url!))) ||
       isImportRequest(req.url!) ||
       isInternalRequest(req.url!)
     ) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -623,6 +623,8 @@ export function copyDir(srcDir: string, destDir: string): void {
   }
 }
 
+export const ERR_SYMLINK_IN_RECURSIVE_READDIR =
+  'ERR_SYMLINK_IN_RECURSIVE_READDIR'
 export async function recursiveReaddir(dir: string): Promise<string[]> {
   if (!fs.existsSync(dir)) {
     return []
@@ -636,6 +638,13 @@ export async function recursiveReaddir(dir: string): Promise<string[]> {
       return []
     }
     throw e
+  }
+  if (dirents.some((dirent) => dirent.isSymbolicLink())) {
+    const err: any = new Error(
+      'Symbolic links are not supported in recursiveReaddir',
+    )
+    err.code = ERR_SYMLINK_IN_RECURSIVE_READDIR
+    throw err
   }
   const files = await Promise.all(
     dirents.map((dirent) => {


### PR DESCRIPTION
Fixes #15261

### Description

https://github.com/vitejs/vite/pull/15195 introduced a regression for symbolic links in the public directory. For now, we revert back to the regular check if there are symbolic links to fix it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other