### PR TITLE
chore: remove unneeded condition in getRealPath

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1299,7 +1299,7 @@ function equalWithoutSuffix(path: string, key: string, suffix: string) {
 }
 
 function getRealPath(resolved: string, preserveSymlinks?: boolean): string {
-  if (!preserveSymlinks && browserExternalId !== resolved) {
+  if (!preserveSymlinks) {
     resolved = safeRealpathSync(resolved)
   }
   return normalizePath(resolved)


### PR DESCRIPTION
### Description

The function is only called if the path is from a file

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other