### PR TITLE
fix: suppress terser warning if minify disabled

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -821,7 +821,11 @@ export async function resolveConfig(
 
   // validate config
 
-  if (config.build?.terserOptions && config.build.minify !== 'terser') {
+  if (
+    config.build?.terserOptions &&
+    config.build.minify &&
+    config.build.minify !== 'terser'
+  ) {
     logger.warn(
       colors.yellow(
         `build.terserOptions is specified but build.minify is not set to use Terser. ` +


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/withastro/astro/issues/9341

Astro disables minification is SSR explicitly, but the user could still pass `build.terserOptions` as they configure it for the client build. This PR only warns about the terser options if minify is enabled.

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
