### PR TITLE
docs: Improve Clarity of Environment Variables Documentation

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -36,7 +36,7 @@ In addition, environment variables that already exist when Vite is executed have
 
 Loaded env variables are also exposed to your client source code via `import.meta.env` as strings.
 
-To prevent accidentally leaking env variables to the client, only variables prefixed with `VITE_` are exposed to your Vite-processed code. e.g. for the following env variables:
+To ensure security and clarity, **only environment variables prefixed with VITE_ are accessible** in your Vite-processed code. Variables without the VITE_ prefix will not be exposed to the client, nor will they be accessible in your client-side code. This prevents an accidental leaking of env variables to the client.e.g. for the following env variables:
 
 ```
 VITE_SOME_KEY=123


### PR DESCRIPTION
Improve Clarity of Environment Variables Documentation

### Description

The current wording in the Vite documentation regarding environment variables might lead to confusion for readers who are new to Vite or unfamiliar with how environment variables are handled in a client-side context.

The statement "only variables prefixed with VITE_ are exposed to your Vite-processed code" could be misinterpreted to mean that non-prefixed variables are still usable but not exposed, which is not the case. In reality, any environment variables not prefixed with VITE_ are neither exposed to the client nor accessible in Vite-processed code.


### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before su