### PR TITLE
fix: add `md`/`mdx` into `KNOWN_ASSET_TYPES` for `@mdx-js/rollup`

### DIFF
--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -130,6 +130,8 @@ export const KNOWN_ASSET_TYPES = [
   'webmanifest',
   'pdf',
   'txt',
+  'md',
+  'mdx',
 ]
 
 export const DEFAULT_ASSETS_RE = new RegExp(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

close #15281

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.

---

I didn't include `declare module` for `*.md` and `*.mdx` because it is bundled to use [`@types/mdx`](https://unpkg.com/browse/@types/mdx@2.0.10/index.d.ts) in `@mdx-js/rollup`.
