### PR TITLE
fix(scanner): catch all external files for glob imports

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -550,7 +550,6 @@ function esbuildScanPlugin(
       // should be faster than doing it in the catch-all via js
       // they are done after the bare import resolve because a package name
       // may end with these extensions
-
       const setupExternalize = (
         filter: RegExp,
         doExternalize: (path: string) => boolean,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -561,16 +561,6 @@ function esbuildScanPlugin(
             external: doExternalize(path),
           }
         })
-        // onResolve is not called for glob imports.
-        // we need to add that here as well until esbuild calls onResolve for glob imports.
-        // https://github.com/evanw/esbuild/issues/3317
-        build.onLoad({ filter, namespace: 'file' }, () => {
-          const externalOnLoadResult: OnLoadResult = {
-            loader: 'js',
-            contents: 'export default {}',
-          }
-          return externalOnLoadResult
-        })
       }
 
       // css
@@ -645,6 +635,16 @@ function esbuildScanPlugin(
         return {
           loader,
           contents,
+        }
+      })
+
+      // onResolve is not called for glob imports.
+      // we need to add that here as well until esbuild calls onResolve for glob imports.
+      // https://github.com/evanw/esbuild/issues/3317
+      build.onLoad({ filter: /.*/, namespace: 'file' }, () => {
+        return {
+          loader: 'js',
+          contents: 'export default {}',
         }
       })
     },


### PR DESCRIPTION
### Description
fixes https://github.com/vitejs/vite/issues/15281 
fixes https://github.com/vitejs/vite/issues/15284
refs #15140

Starting from [esbuild@0.19.0](https://github.com/evanw/esbuild/releases/tag/v0.19.0), it will attempt to bundle `glob imports` modules, and the special point in handling `glob import` modules is to skip calling the `onResolve` hook and directly call the `onLoad` hook. If the module cannot be captured by the existing `onLoad` hook, then it will prompt "No loader is configured for ".xxx” files:", which is a common issue encountered in `vite@5.0.0` and later versions.

Due to the inability of `esbuild` to call `onResolve` plugin when parsing `glob imports`, `vite` relies on `esbuild` during the initial pre-build phase to quickly scan the pre-built dependencies. The modification of #15140 only supports the suffixes supported by Vite. There is no additional processing for suffixes not supported by Vite, so import unsupported suffix types during the pre-build phase will result in an error when scanning dependencies. This change will handle all unconsidered suffixes as a fallback, preventing `vite` from throwing errors when scanning new suffixes during the pre-build phase. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
