### PR TITLE
fix: missing warmupRequest in transformIndexHtml

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -148,15 +148,12 @@ const processNodeUrl = (
         originalUrl !== '/' &&
         htmlPath === '/index.html')
     ) {
-      const devBase = config.base
-      const fullUrl = path.posix.join(devBase, url)
-      if (server && shouldPreTransform(url, config)) {
-        preTransformRequest(server, fullUrl, devBase)
-      }
-      return fullUrl
-    } else {
-      return url
+      url = path.posix.join(config.base, url)
     }
+    if (server && shouldPreTransform(url, config)) {
+      preTransformRequest(server, url, config.base)
+    }
+    return url
   }
 
   const processedUrl = useSrcSetReplacer

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -133,6 +133,7 @@ const processNodeUrl = (
       }
     }
 
+    let preTransformUrl: string | undefined
     if (
       (url[0] === '/' && url[1] !== '/') ||
       // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets
@@ -149,9 +150,20 @@ const processNodeUrl = (
         htmlPath === '/index.html')
     ) {
       url = path.posix.join(config.base, url)
+
+      preTransformUrl = url
+    } else if (url[0] === '/') {
+      preTransformUrl = url
+    } else if (url[0] === '.') {
+      preTransformUrl = path.posix.join(
+        config.base,
+        path.posix.dirname(htmlPath),
+        url,
+      )
     }
-    if (server && shouldPreTransform(url, config)) {
-      preTransformRequest(server, url, config.base)
+
+    if (preTransformUrl && server && shouldPreTransform(url, config)) {
+      preTransformRequest(server, preTransformUrl, config.base)
     }
     return url
   }


### PR DESCRIPTION
### Description

We missed a branch to warmup when processing the HTML files. `--open` didn't trigger the static imports pre-warmup in https://github.com/sapphi-red/performance-compare

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other