### PR TITLE
fix: public files map will be updated on add/unlink in windows

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -645,10 +645,11 @@ export async function _createServer(
     file = normalizePath(file)
     await container.watchChange(file, { event: isUnlink ? 'delete' : 'create' })
 
-    if (publicFiles && config.publicDir && file.startsWith(config.publicDir)) {
-      publicFiles[isUnlink ? 'delete' : 'add'](
-        file.slice(config.publicDir.length),
-      )
+    if (config.publicDir && publicFiles) {
+      const publicDir = normalizePath(config.publicDir)
+      if (file.startsWith(publicDir)) {
+        publicFiles[isUnlink ? 'delete' : 'add'](file.slice(publicDir.length))
+      }
     }
     await handleFileAddUnlink(file, server, isUnlink)
     await onHMRUpdate(file, true)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -641,14 +641,17 @@ export async function _createServer(
     }
   }
 
+  const normalizedPublicDir = normalizePath(config.publicDir)
+
   const onFileAddUnlink = async (file: string, isUnlink: boolean) => {
     file = normalizePath(file)
     await container.watchChange(file, { event: isUnlink ? 'delete' : 'create' })
 
     if (config.publicDir && publicFiles) {
-      const publicDir = normalizePath(config.publicDir)
-      if (file.startsWith(publicDir)) {
-        publicFiles[isUnlink ? 'delete' : 'add'](file.slice(publicDir.length))
+      if (file.startsWith(normalizedPublicDir)) {
+        publicFiles[isUnlink ? 'delete' : 'add'](
+          file.slice(normalizedPublicDir.length),
+        )
       }
     }
     await handleFileAddUnlink(file, server, isUnlink)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR will correctly update the public files map when files are added or removed in windows.

Fixes #15316.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
