### PR TITLE
perf: avoid computing paths on each request

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -48,6 +48,13 @@ export function transformMiddleware(
   server: ViteDevServer,
 ): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
+
+  // check if public dir is inside root dir
+  const publicDir = normalizePath(server.config.publicDir)
+  const rootDir = normalizePath(server.config.root)
+  const publicDirInRootDir = publicDir.startsWith(withTrailingSlash(rootDir))
+  const publicPath = `${publicDir.slice(rootDir.length)}/`
+
   return async function viteTransformMiddleware(req, res, next) {
     if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
       return next()
@@ -123,43 +130,8 @@ export function transformMiddleware(
         }
       }
 
-      // check if public dir is inside root dir
-      const publicDir = normalizePath(server.config.publicDir)
-      const rootDir = normalizePath(server.config.root)
-      if (publicDir.startsWith(withTrailingSlash(rootDir))) {
-        const publicPath = `${publicDir.slice(rootDir.length)}/`
-        // warn explicit public paths
-        if (url.startsWith(withTrailingSlash(publicPath))) {
-          let warning: string
-
-          if (isImportRequest(url)) {
-            const rawUrl = removeImportQuery(url)
-            if (urlRE.test(url)) {
-              warning =
-                `Assets in the public directory are served at the root path.\n` +
-                `Instead of ${colors.cyan(rawUrl)}, use ${colors.cyan(
-                  rawUrl.replace(publicPath, '/'),
-                )}.`
-            } else {
-              warning =
-                'Assets in public directory cannot be imported from JavaScript.\n' +
-                `If you intend to import that asset, put the file in the src directory, and use ${colors.cyan(
-                  rawUrl.replace(publicPath, '/src/'),
-                )} instead of ${colors.cyan(rawUrl)}.\n` +
-                `If you intend to use the URL of that asset, use ${colors.cyan(
-                  injectQuery(rawUrl.replace(publicPath, '/'), 'url'),
-                )}.`
-            }
-          } else {
-            warning =
-              `Files in the public directory are served at the root path.\n` +
-              `Instead of ${colors.cyan(url)}, use ${colors.cyan(
-                url.replace(publicPath, '/'),
-              )}.`
-          }
-
-          server.config.logger.warn(colors.yellow(warning))
-        }
+      if (publicDirInRootDir && url.startsWith(publicPath)) {
+        warnAboutExplicitPublicPathInUrl(url)
       }
 
       if (
@@ -264,5 +236,37 @@ export function transformMiddleware(
     }
 
     next()
+  }
+
+  function warnAboutExplicitPublicPathInUrl(url: string) {
+    let warning: string
+
+    if (isImportRequest(url)) {
+      const rawUrl = removeImportQuery(url)
+      if (urlRE.test(url)) {
+        warning =
+          `Assets in the public directory are served at the root path.\n` +
+          `Instead of ${colors.cyan(rawUrl)}, use ${colors.cyan(
+            rawUrl.replace(publicPath, '/'),
+          )}.`
+      } else {
+        warning =
+          'Assets in public directory cannot be imported from JavaScript.\n' +
+          `If you intend to import that asset, put the file in the src directory, and use ${colors.cyan(
+            rawUrl.replace(publicPath, '/src/'),
+          )} instead of ${colors.cyan(rawUrl)}.\n` +
+          `If you intend to use the URL of that asset, use ${colors.cyan(
+            injectQuery(rawUrl.replace(publicPath, '/'), 'url'),
+          )}.`
+      }
+    } else {
+      warning =
+        `Files in the public directory are served at the root path.\n` +
+        `Instead of ${colors.cyan(url)}, use ${colors.cyan(
+          url.replace(publicPath, '/'),
+        )}.`
+    }
+
+    server.config.logger.warn(colors.yellow(warning))
   }
 }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -50,10 +50,10 @@ export function transformMiddleware(
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
 
   // check if public dir is inside root dir
+  const { root } = server.config
   const publicDir = normalizePath(server.config.publicDir)
-  const rootDir = normalizePath(server.config.root)
-  const publicDirInRootDir = publicDir.startsWith(withTrailingSlash(rootDir))
-  const publicPath = `${publicDir.slice(rootDir.length)}/`
+  const publicDirInRoot = publicDir.startsWith(withTrailingSlash(root))
+  const publicPath = `${publicDir.slice(root.length)}/`
 
   return async function viteTransformMiddleware(req, res, next) {
     if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
@@ -130,7 +130,7 @@ export function transformMiddleware(
         }
       }
 
-      if (publicDirInRootDir && url.startsWith(publicPath)) {
+      if (publicDirInRoot && url.startsWith(publicPath)) {
         warnAboutExplicitPublicPathInUrl(url)
       }
 


### PR DESCRIPTION
### Description

We should optimize responding from the server as much as possible. For large projects, the time it takes the server to serve already transformed requests will greatly affect reloading time.

This PR avoids normalize paths and path checks that were done on each request. It is safe to cache this in the middleware constructor after https://github.com/vitejs/vite/pull/15166

I also moved the warning to another function because it isn't important for the main logic of the handler.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other