### PR TITLE
fix(worker): replace `import.meta` correctly for IIFE worker

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -171,7 +171,7 @@ export function webWorkerPostPlugin(): Plugin {
         // compiling import.meta
         if (!property) {
           // rollup only supports `url` property. we only support `url` property as well.
-          // https://github.com/rollup/rollup/blob/62b648e1cc6a1f00260bb85aa2050097bb4afd2b/src/ast/nodes/MetaProperty.ts#L164-L173 
+          // https://github.com/rollup/rollup/blob/62b648e1cc6a1f00260bb85aa2050097bb4afd2b/src/ast/nodes/MetaProperty.ts#L164-L173
           return `{
             url: self.location.href
           }`

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -165,10 +165,19 @@ export async function workerFileToUrl(
 export function webWorkerPostPlugin(): Plugin {
   return {
     name: 'vite:worker-post',
-    resolveImportMeta(property, { chunkId, format }) {
+    resolveImportMeta(property, { format }) {
       // document is undefined in the worker, so we need to avoid it in iife
-      if (property === 'url' && format === 'iife') {
-        return 'self.location.href'
+      if (format === 'iife') {
+        // compiling import.meta
+        if (!property) {
+          return `{
+            url: self.location.href
+          }`
+        }
+        // compiling import.meta.url
+        if (property === 'url') {
+          return 'self.location.href'
+        }
       }
 
       return null

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -170,6 +170,8 @@ export function webWorkerPostPlugin(): Plugin {
       if (format === 'iife') {
         // compiling import.meta
         if (!property) {
+          // rollup only supports `url` property. we only support `url` property as well.
+          // https://github.com/rollup/rollup/blob/62b648e1cc6a1f00260bb85aa2050097bb4afd2b/src/ast/nodes/MetaProperty.ts#L164-L173 
           return `{
             url: self.location.href
           }`

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -114,17 +114,17 @@ describe.runIf(isBuild)('build', () => {
 test('module worker', async () => {
   await untilUpdated(
     async () => page.textContent('.worker-import-meta-url'),
-    /A\sstring.*\/iife\/.+url-worker\.js/,
+    /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
     true,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-resolve'),
-    /A\sstring.*\/iife\/.+url-worker\.js/,
+    /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
     true,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-without-extension'),
-    'A string',
+    /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
     true,
   )
   await untilUpdated(

--- a/playground/worker/url-worker.js
+++ b/playground/worker/url-worker.js
@@ -3,6 +3,7 @@ self.postMessage(
     'A string',
     import.meta.env.BASE_URL,
     self.location.url,
+    import.meta && import.meta.url,
     import.meta.url,
   ].join(' '),
 )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/15310
fix https://github.com/vitejs/vite/issues/15305
refs #12629

### Additional context

We may also need to compile `import.meta` to avoid errors when using it directly in `worker`. this modification is consistent with the development environment, and `import.meta` only exposes the `url` property.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
