### PR TITLE
fix: more stable hash calculation for depsOptimize

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1216,8 +1216,8 @@ export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
       assetsInclude: config.assetsInclude,
       plugins: config.plugins.map((p) => p.name),
       optimizeDeps: {
-        include: optimizeDeps?.include,
-        exclude: optimizeDeps?.exclude,
+        include: Array.from(new Set(optimizeDeps?.include)).sort(),
+        exclude: Array.from(new Set(optimizeDeps?.exclude)).sort(),
         esbuildOptions: {
           ...optimizeDeps?.esbuildOptions,
           plugins: optimizeDeps?.esbuildOptions?.plugins?.map((p) => p.name),
@@ -1289,7 +1289,6 @@ export async function optimizedDepNeedsInterop(
   return depInfo?.needsInterop
 }
 
-const MAX_TEMP_DIR_AGE_MS = 24 * 60 * 60 * 1000
 export async function cleanupDepsCacheStaleDirs(
   config: ResolvedConfig,
 ): Promise<void> {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1216,8 +1216,12 @@ export function getDepHash(config: ResolvedConfig, ssr: boolean): string {
       assetsInclude: config.assetsInclude,
       plugins: config.plugins.map((p) => p.name),
       optimizeDeps: {
-        include: Array.from(new Set(optimizeDeps?.include)).sort(),
-        exclude: Array.from(new Set(optimizeDeps?.exclude)).sort(),
+        include: optimizeDeps?.include
+          ? Array.from(new Set(optimizeDeps.include)).sort()
+          : undefined,
+        exclude: optimizeDeps?.exclude
+          ? Array.from(new Set(optimizeDeps.exclude)).sort()
+          : undefined,
         esbuildOptions: {
           ...optimizeDeps?.esbuildOptions,
           plugins: optimizeDeps?.esbuildOptions?.plugins?.map((p) => p.name),
@@ -1289,6 +1293,7 @@ export async function optimizedDepNeedsInterop(
   return depInfo?.needsInterop
 }
 
+const MAX_TEMP_DIR_AGE_MS = 24 * 60 * 60 * 1000
 export async function cleanupDepsCacheStaleDirs(
   config: ResolvedConfig,
 ): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Plugins could contribute to that list by simply pushing new items. While the order of them and duplicated items do not affect how deps works. We do a unique and sort, to make the hash calculation more stable.

### Additional context

related: https://github.com/nuxt/nuxt/issues/24196#issuecomment-1853505843
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
