### PR TITLE
feat: support multiple HMR clients on the server

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -423,7 +423,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
   - Filter and narrow down the affected module list so that the HMR is more accurate.
 
-  - Return an empty array and perform complete custom HMR handling by sending custom events to the client (example uses `server.hot` which was introduced in Vite #, it is recommended to also use `server.ws` if you support lower versions):
+  - Return an empty array and perform complete custom HMR handling by sending custom events to the client (example uses `server.hot` which was introduced in Vite 5.1, it is recommended to also use `server.ws` if you support lower versions):
 
     ```js
     handleHotUpdate({ server }) {
@@ -534,7 +534,7 @@ Since Vite 2.9, we provide some utilities for plugins to help handle the communi
 
 ### Server to Client
 
-On the plugin side, we could use `server.hot.send` (since Vite #) or `server.ws.send` to broadcast events to all the clients:
+On the plugin side, we could use `server.hot.send` (since Vite 5.1) or `server.ws.send` to broadcast events to all the clients:
 
 ```js
 // vite.config.js
@@ -579,7 +579,7 @@ if (import.meta.hot) {
 }
 ```
 
-Then use `server.hot.on` (since Vite #) or `server.ws.on` and listen to the events on the server side:
+Then use `server.hot.on` (since Vite 5.1) or `server.ws.on` and listen to the events on the server side:
 
 ```js
 // vite.config.js

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -423,11 +423,11 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
   - Filter and narrow down the affected module list so that the HMR is more accurate.
 
-  - Return an empty array and perform complete custom HMR handling by sending custom events to the client:
+  - Return an empty array and perform complete custom HMR handling by sending custom events to the client (example uses `server.hot` which was introduced in Vite #, it is recommended to also use `server.ws` if you support lower versions):
 
     ```js
     handleHotUpdate({ server }) {
-      server.ws.send({
+      server.hot.send({
         type: 'custom',
         event: 'special-update',
         data: {}
@@ -534,9 +534,7 @@ Since Vite 2.9, we provide some utilities for plugins to help handle the communi
 
 ### Server to Client
 
-<!-- TODO: add server.hot.on docs -->
-
-On the plugin side, we could use `server.ws.send` to broadcast events to all the clients:
+On the plugin side, we could use `server.hot.send` (since Vite #) or `server.ws.send` to broadcast events to all the clients:
 
 ```js
 // vite.config.js
@@ -546,8 +544,8 @@ export default defineConfig({
       // ...
       configureServer(server) {
         // Example: wait for a client to connect before sending a message
-        server.ws.on('connection', () => {
-          server.ws.send('my:greetings', { msg: 'hello' })
+        server.hot.on('connection', () => {
+          server.hot.send('my:greetings', { msg: 'hello' })
         })
       },
     },
@@ -581,7 +579,7 @@ if (import.meta.hot) {
 }
 ```
 
-Then use `server.ws.on` and listen to the events on the server side:
+Then use `server.hot.on` (since Vite #) or `server.ws.on` and listen to the events on the server side:
 
 ```js
 // vite.config.js
@@ -590,7 +588,7 @@ export default defineConfig({
     {
       // ...
       configureServer(server) {
-        server.ws.on('my:from-client', (data, client) => {
+        server.hot.on('my:from-client', (data, client) => {
           console.log('Message from client:', data.msg) // Hey!
           // reply only to the client (if needed)
           client.send('my:ack', { msg: 'Hi! I got your message!' })

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -534,6 +534,8 @@ Since Vite 2.9, we provide some utilities for plugins to help handle the communi
 
 ### Server to Client
 
+<!-- TODO: add server.hot.on docs -->
+
 On the plugin side, we could use `server.ws.send` to broadcast events to all the clients:
 
 ```js

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -487,7 +487,7 @@ async function createDepsOptimizer(
       // reloaded.
       server.moduleGraph.invalidateAll()
 
-      server.ws.send({
+      server.hot.send({
         type: 'full-reload',
         path: '*',
       })

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -129,7 +129,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
    *   the descriptors.
    *
    * - The hook can also return an empty array and then perform custom updates
-   *   by sending a custom hmr payload via server.ws.send().
+   *   by sending a custom hmr payload via server.hot.send().
    *
    * - If the hook doesn't return a value, the hmr update will be performed as
    *   normal.

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -491,7 +491,7 @@ async function reloadOnTsconfigChange(changedFile: string) {
     // server may not be available if vite config is updated at the same time
     if (server) {
       // force full reload
-      server.ws.send({
+      server.hot.send({
         type: 'full-reload',
         path: '*',
       })

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -82,6 +82,7 @@ export interface HMRChannel {
       ...args: any[]
     ) => void,
   ): void
+  on(event: 'connection', listener: () => void): void
   /**
    * Unregister event listener.
    */
@@ -706,7 +707,7 @@ export function createHMRBroadcaster(): HMRBroadcaster {
     addChannel(channel) {
       channels.push(channel)
     },
-    on(event, listener) {
+    on(event: string, listener: (...args: any[]) => any) {
       channels.forEach((channel) => channel.on(event, listener))
       return broadcaster
     },

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -64,6 +64,10 @@ export interface HMRBroadcasterClient {
 
 export interface HMRChannel {
   /**
+   * Unique channel name
+   */
+  name: string
+  /**
    * Broadcast events to all clients
    */
   send(payload: HMRPayload): void
@@ -93,7 +97,7 @@ export interface HMRChannel {
   close(): void | Promise<void>
 }
 
-export interface HMRBroadcaster extends Omit<HMRChannel, 'close'> {
+export interface HMRBroadcaster extends Omit<HMRChannel, 'close' | 'name'> {
   /**
    * All registered channels. Always has websocket channel.
    */
@@ -706,6 +710,9 @@ export function createHMRBroadcaster(): HMRBroadcaster {
       return [...channels]
     },
     addChannel(channel) {
+      if (channels.some((c) => c.name === channel.name)) {
+        throw new Error(`HMR channel "${channel.name}" is already defined.`)
+      }
       channels.push(channel)
       return broadcaster
     },

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -90,10 +90,10 @@ export interface HMRChannel {
   /**
    * Disconnect all clients, called when server is closed or restarted.
    */
-  close(): void
+  close(): void | Promise<void>
 }
 
-export interface HMRBroadcaster extends HMRChannel {
+export interface HMRBroadcaster extends Omit<HMRChannel, 'close'> {
   /**
    * All registered channels. Always has websocket channel.
    */
@@ -102,6 +102,7 @@ export interface HMRBroadcaster extends HMRChannel {
    * Add a new third-party channel.
    */
   addChannel(connection: HMRChannel): HMRBroadcaster
+  close(): Promise<unknown[]>
 }
 
 export function getShortName(file: string, root: string): string {
@@ -720,7 +721,7 @@ export function createHMRBroadcaster(): HMRBroadcaster {
       channels.forEach((channel) => channel.send(...(args as [any])))
     },
     close() {
-      return channels.map((channel) => channel.close())
+      return Promise.all(channels.map((channel) => channel.close()))
     },
   }
   return broadcaster

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -84,11 +84,11 @@ export interface HMRChannel {
   ): void
   on(event: 'connection', listener: () => void): void
   /**
-   * Unregister event listener.
+   * Unregister event listener
    */
   off(event: string, listener: Function): void
   /**
-   * Called when server is closed.
+   * Disconnect all clients, called when server is closed or restarted.
    */
   close(): void
 }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -101,7 +101,7 @@ export interface HMRBroadcaster extends HMRChannel {
   /**
    * Add a new third-party channel.
    */
-  addChannel(connection: HMRChannel): void
+  addChannel(connection: HMRChannel): HMRBroadcaster
 }
 
 export function getShortName(file: string, root: string): string {
@@ -115,7 +115,7 @@ export async function handleHMRUpdate(
   server: ViteDevServer,
   configOnly: boolean,
 ): Promise<void> {
-  const { config, hot, moduleGraph } = server
+  const { hot, config, moduleGraph } = server
   const shortFile = getShortName(file, config.root)
   const fileName = path.basename(file)
 
@@ -706,6 +706,7 @@ export function createHMRBroadcaster(): HMRBroadcaster {
     },
     addChannel(channel) {
       channels.push(channel)
+      return broadcaster
     },
     on(event: string, listener: (...args: any[]) => any) {
       channels.forEach((channel) => channel.on(event, listener))

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -233,8 +233,16 @@ export interface ViteDevServer {
   watcher: FSWatcher
   /**
    * web socket server with `send(payload)` method
+   * @deprecated use `hot` instead
    */
   ws: WebSocketServer
+  /**
+   * HMR broadcaster that can be used to send custom HMR messages to the client
+   *
+   * Always sends a message to at least a WebSocket client. Any third party can
+   * add a channel to the broadcaster to process messages so be aware of that
+   */
+  hot: HMRBroadcaster
   /**
    * Rollup plugin container that can run plugin hooks on a given file
    */
@@ -322,12 +330,6 @@ export interface ViteDevServer {
    * @param forceOptimize - force the optimizer to re-bundle, same as --force cli flag
    */
   restart(forceOptimize?: boolean): Promise<void>
-
-  /**
-   * TODO: docs
-   */
-  hot: HMRBroadcaster
-
   /**
    * Open browser
    */

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -329,6 +329,7 @@ export interface ViteDevServer {
    * @param forceOptimize - force the optimizer to re-bundle, same as --force cli flag
    */
   restart(forceOptimize?: boolean): Promise<void>
+
   /**
    * Open browser
    */
@@ -411,9 +412,8 @@ export async function _createServer(
     ? null
     : await resolveHttpServer(serverConfig, middlewares, httpsOptions)
 
-  const hot = createHMRBroadcaster()
   const ws = createWebSocketServer(httpServer, config, httpsOptions)
-  hot.addChannel(ws)
+  const hot = createHMRBroadcaster().addChannel(ws)
 
   if (httpServer) {
     setClientErrorHandler(httpServer, config.logger)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -15,7 +15,6 @@ import launchEditorMiddleware from 'launch-editor-middleware'
 import type { SourceMap } from 'rollup'
 import picomatch from 'picomatch'
 import type { Matcher } from 'picomatch'
-import type { InvalidatePayload } from 'types/customEvent'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,
@@ -694,7 +693,7 @@ export async function _createServer(
     onFileAddUnlink(file, true)
   })
 
-  ws.on('vite:invalidate', async ({ path, message }: InvalidatePayload) => {
+  hot.on('vite:invalidate', async ({ path, message }) => {
     const mod = moduleGraph.urlToModuleMap.get(path)
     if (mod && mod.isSelfAccepting && mod.lastHMRTimestamp > 0) {
       config.logger.info(

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -51,7 +51,7 @@ export function logError(server: ViteDevServer, err: RollupError): void {
     error: err,
   })
 
-  server.ws.send({
+  server.hot.send({
     type: 'error',
     err: prepareError(err),
   })

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -223,6 +223,7 @@ export function createWebSocketServer(
   let bufferedError: ErrorPayload | null = null
 
   return {
+    name: 'ws',
     listen: () => {
       wsHttpServer?.listen(port, host)
     },

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -13,6 +13,7 @@ import type { CustomPayload, ErrorPayload, HMRPayload } from 'types/hmrPayload'
 import type { InferCustomEventPayload } from 'types/customEvent'
 import type { ResolvedConfig } from '..'
 import { isObject } from '../utils'
+import type { HMRChannel } from './hmr'
 import type { HttpServer } from '.'
 
 /* In Bun, the `ws` module is overridden to hook into the native code. Using the bundled `js` version
@@ -30,7 +31,7 @@ export type WebSocketCustomListener<T> = (
   client: WebSocketClient,
 ) => void
 
-export interface WebSocketServer {
+export interface WebSocketServer extends HMRChannel {
   /**
    * Listen on port and host
    */
@@ -39,14 +40,6 @@ export interface WebSocketServer {
    * Get all connected clients.
    */
   clients: Set<WebSocketClient>
-  /**
-   * Broadcast events to all clients
-   */
-  send(payload: HMRPayload): void
-  /**
-   * Send custom event
-   */
-  send<T extends string>(event: T, payload?: InferCustomEventPayload<T>): void
   /**
    * Disconnect all clients and terminate the server.
    */

--- a/playground/hmr/vite.config.ts
+++ b/playground/hmr/vite.config.ts
@@ -12,12 +12,12 @@ export default defineConfig({
         if (file.endsWith('customFile.js')) {
           const content = await read()
           const msg = content.match(/export const msg = '(\w+)'/)[1]
-          server.ws.send('custom:foo', { msg })
-          server.ws.send('custom:remove', { msg })
+          server.hot.send('custom:foo', { msg })
+          server.hot.send('custom:remove', { msg })
         }
       },
       configureServer(server) {
-        server.ws.on('custom:remote-add', ({ a, b }, client) => {
+        server.hot.on('custom:remote-add', ({ a, b }, client) => {
           client.send('custom:remote-add-result', { result: a + b })
         })
       },
@@ -44,7 +44,7 @@ export const virtual = _virtual + '${num}';`
       }
     },
     configureServer(server) {
-      server.ws.on('virtual:increment', async () => {
+      server.hot.on('virtual:increment', async () => {
         const mod = await server.moduleGraph.getModuleByUrl('\0virtual:file')
         if (mod) {
           num++

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -1,15 +1,14 @@
 import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
+import type { GlobalSetupContext } from 'vitest/node'
 import type { BrowserServer } from 'playwright-chromium'
 import { chromium } from 'playwright-chromium'
 import { hasWindowsUnicodeFsBug } from './hasWindowsUnicodeFsBug'
 
-const DIR = path.join(os.tmpdir(), 'vitest_playwright_global_setup')
-
 let browserServer: BrowserServer | undefined
 
-export async function setup(): Promise<void> {
+export async function setup({ provide }: GlobalSetupContext): Promise<void> {
   process.env.NODE_ENV = process.env.VITE_TEST_BUILD
     ? 'production'
     : 'development'
@@ -21,8 +20,7 @@ export async function setup(): Promise<void> {
       : undefined,
   })
 
-  await fs.mkdirp(DIR)
-  await fs.writeFile(path.join(DIR, 'wsEndpoint'), browserServer.wsEndpoint())
+  provide('wsEndpoint', browserServer.wsEndpoint())
 
   const tempDir = path.resolve(__dirname, '../playground-temp')
   await fs.ensureDir(tempDir)

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -1,4 +1,3 @@
-import os from 'node:os'
 import path from 'node:path'
 import fs from 'fs-extra'
 import type { GlobalSetupContext } from 'vitest/node'

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -1,6 +1,5 @@
 import type * as http from 'node:http'
-import path, { dirname, join, resolve } from 'node:path'
-import os from 'node:os'
+import path, { dirname, resolve } from 'node:path'
 import fs from 'fs-extra'
 import { chromium } from 'playwright-chromium'
 import type {
@@ -22,7 +21,7 @@ import {
 import type { Browser, Page } from 'playwright-chromium'
 import type { RollupError, RollupWatcher, RollupWatcherEvent } from 'rollup'
 import type { File } from 'vitest'
-import { beforeAll } from 'vitest'
+import { beforeAll, inject } from 'vitest'
 
 // #region env
 
@@ -80,8 +79,6 @@ export function setViteUrl(url: string): void {
 
 // #endregion
 
-const DIR = join(os.tmpdir(), 'vitest_playwright_global_setup')
-
 beforeAll(async (s) => {
   const suite = s as File
   // skip browser setup for non-playground tests
@@ -89,7 +86,7 @@ beforeAll(async (s) => {
     return
   }
 
-  const wsEndpoint = fs.readFileSync(join(DIR, 'wsEndpoint'), 'utf-8')
+  const wsEndpoint = inject('wsEndpoint')
   if (!wsEndpoint) {
     throw new Error('wsEndpoint not found')
   }
@@ -352,5 +349,11 @@ declare module 'vite' {
      * runs after build and before preview
      */
     __test__?: () => void
+  }
+}
+
+declare module 'vitest' {
+  export interface ProvidedContext {
+    wsEndpoint: string
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR introduces `hot` property on the `server` that allows extending HMR logic by providing your own HMR channel. This is required to support HMR on the server in the future.

This is not a breaking change since it doesn't replace `ws` usage (all plugins should still work as they did before). In the future, it is recommended to use `hot` property instead of `ws` when supporting SSR:
```diff
configureServer(server) {
-  server.ws.on('connection', () => server.ws.send('custom'))
+  server.hot.on('connection', () => server.hot.send('custom'))
}
```

Type interface also requires passing down a channel to the `on` handler to send messages back (this is how `ws.on` already works).

HMR channel is also required to send `connection` event before being able to send messages. 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
