### PR TITLE
fix: prevent double base in assets on dev mode when assets plugin is applied before html transformation

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -138,19 +138,21 @@ const processNodeUrl = (
     }
 
     if (
-      (url[0] === '/' && url[1] !== '/') ||
-      // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets
-      // path will add `/a/` prefix, it will caused 404.
-      //
-      // skip if url contains `:` as it implies a url protocol or Windows path that we don't want to replace.
-      //
-      // rewrite `./index.js` -> `localhost:5173/a/index.js`.
-      // rewrite `../index.js` -> `localhost:5173/index.js`.
-      // rewrite `relative/index.js` -> `localhost:5173/a/relative/index.js`.
-      ((url[0] === '.' || isBareRelative(url)) &&
-        originalUrl &&
-        originalUrl !== '/' &&
-        htmlPath === '/index.html')
+      // avoid duplicate base prefix when applying html transforms after assets plugin
+      !url.startsWith(config.base) &&
+      ((url[0] === '/' && url[1] !== '/') ||
+        // #3230 if some request url (localhost:3000/a/b) return to fallback html, the relative assets
+        // path will add `/a/` prefix, it will caused 404.
+        //
+        // skip if url contains `:` as it implies a url protocol or Windows path that we don't want to replace.
+        //
+        // rewrite `./index.js` -> `localhost:5173/a/index.js`.
+        // rewrite `../index.js` -> `localhost:5173/index.js`.
+        // rewrite `relative/index.js` -> `localhost:5173/a/relative/index.js`.
+        ((url[0] === '.' || isBareRelative(url)) &&
+          originalUrl &&
+          originalUrl !== '/' &&
+          htmlPath === '/index.html'))
     ) {
       url = path.posix.join(config.base, url)
     }


### PR DESCRIPTION
### Description
On dev mode, for absolute asset URLs in monorepos, the assets plugin resolves the asset including the `base` and `origin` from the vite config when calling [fileToDevUrl](https://github.com/vitejs/vite/blob/73e971f27a63b2d4ecb5acf44f8726cdd3d2082b/packages/vite/src/node/plugins/asset.ts#L302), then when `transformIndexHtml` is applied, the `indexHtml` plugin appends `base` again when resolving the asset path in [processNodeUrl](https://github.com/vitejs/vite/blob/73e971f27a63b2d4ecb5acf44f8726cdd3d2082b/packages/vite/src/node/server/middlewares/indexHtml.ts#L152C5-L152C5) the `base` is appended again.

Fixes https://github.com/vitejs/vite/issues/15214

**Before**
<img width="299" alt="Screenshot 2023-12-13 at 4 22 31 PM" src="https://github.com/vitejs/vite/assets/3106549/1c0ac19e-2784-4a89-bdba-ba512ea5d19d">
<img width="690" alt="Screenshot 2023-12-13 at 4 22 24 PM" src="https://github.com/vitejs/vite/assets/3106549/63315ff2-e8d2-472e-87ec-0d3ea9ee97a4">

**After**
<img width="299" alt="Screenshot 2023-12-13 at 4 22 31 PM" src="https://github.com/vitejs/vite/assets/3106549/cc217b3c-d73f-446e-b285-f9a2e1d79285">
<img width="524" alt="Screenshot 2023-12-13 at 4 24 13 PM" src="https://github.com/vitejs/vite/assets/3106549/b9c43a17-6afc-4138-9db0-791bc2981421">

### Additional context

Setup
**vite config**
```
{
  base: '/my-path/'
}
```
**directory structure**
```
/
  /lib
  /app
```
**example snippet**
`library-file.tsx`
```
 import myicon from './myicon.svg'

 export const LibComponent = () =>  <img src={myicon} />;
```

`app-file.tsx`
```
import { LibComponent } '@namespace/lib';

export const appComponent = () => <LibComponent/>;
```

The resolved asset URL in dev mode results as `/my-path/my-path/@fs/Users/myuser/example/lib/library-assets/myicon.svg`

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
