### PR TITLE
fix: omit protocol does not require pre-transform

### DIFF
--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -157,7 +157,7 @@ const processNodeUrl = (
 
     if (server && shouldPreTransform(url, config)) {
       let preTransformUrl: string | undefined
-      if (url[0] === '/') {
+      if (url[0] === '/' && url[1] !== '/') {
         preTransformUrl = url
       } else if (url[0] === '.' || isBareRelative(url)) {
         preTransformUrl = path.posix.join(


### PR DESCRIPTION
### Description

fix: https://github.com/vitejs/vite/issues/15335

### Additional context

From a logical standpoint, it appears that at this stage, only `JS` requests or `CSS` requests are invoked with `preTransformRequest`, which is generally expected. However, when calling `preTransformRequest` from `processNodeUrl`, we may need to prevent the parsing of external `JS` or `CSS` request links. Therefore, this modification filters potential external links starting with `//`.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
