### PR TITLE
fix: do not mark already resolved ids as external (optimize deps)

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -677,6 +677,10 @@ function shouldExternalizeDep(resolvedId: string, rawId: string): boolean {
   if (!path.isAbsolute(resolvedId)) {
     return true
   }
+  // was already resolved to a file
+  if (resolvedId === rawId && fs.existsSync(resolvedId)) {
+    return false
+  }
   // virtual id
   if (resolvedId === rawId || resolvedId.includes('\0')) {
     return true


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description

our custom esbuild resolver sometimes resolves an id to a full path and calls build.resolve with it. this causes those paths to be marked as external.

### Additional context

i'm not sure if there is a better solution. Ideally i would like to skip all plugins on build.resolve in esbuild, but that option is not available.
Is there any alternative?

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
