### PR TITLE
fix(assets): avoid splitting `,` inside base64 value of `srcset` attribute

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -332,6 +332,14 @@ describe('processSrcSetSync', () => {
       ),
     ).toBe('/base/nested/asset.png 1x, /base/nested/asset.png 2x')
   })
+
+  test('should not split the comma inside base64 value', async () => {
+    const base64 =
+      'data:image/avif;base64,AAAA 400w, data:image/avif;base64,BBBB 800w'
+    expect(processSrcSetSync(base64, ({ url }) => url)).toBe(base64)
+  })
+
+  test('should not split ')
 })
 
 describe('flattenId', () => {

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -338,8 +338,6 @@ describe('processSrcSetSync', () => {
       'data:image/avif;base64,AAAA 400w, data:image/avif;base64,BBBB 800w'
     expect(processSrcSetSync(base64, ({ url }) => url)).toBe(base64)
   })
-
-  test('should not split ')
 })
 
 describe('flattenId', () => {

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -335,7 +335,7 @@ describe('processSrcSetSync', () => {
 
   test('should not split the comma inside base64 value', async () => {
     const base64 =
-      'data:image/avif;base64,AAAA 400w, data:image/avif;base64,BBBB 800w'
+      'data:image/avif;base64,aA+/0= 400w, data:image/avif;base64,bB+/9= 800w'
     expect(processSrcSetSync(base64, ({ url }) => url)).toBe(base64)
   })
 })

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -790,7 +790,7 @@ const cleanSrcSetRE =
   /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:[/;,\w]+/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
-  // There could be a ',' inside of url(data:...), linear-gradient(...) or "data:..."
+  // There could be a ',' inside of url(data:...), linear-gradient(...), "data:..." or data:...
   const cleanedSrcs = srcs.replace(cleanSrcSetRE, blankReplacer)
   let startIndex = 0
   let splitIndex: number

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -787,7 +787,7 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:image\/[\w.+\-]+;base64,[\w+/=]+/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
   // There could be a ',' inside of url(data:...), linear-gradient(...), "data:..." or data:...

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -787,7 +787,7 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:[/;,\w]+/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:image\/[\w.+\-]+;base64,[\w+/=]+/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
   // There could be a ',' inside of url(data:...), linear-gradient(...), "data:..." or data:...

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -787,7 +787,7 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:[/;,\w]+/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
   // There could be a ',' inside of url(data:...), linear-gradient(...) or "data:..."


### PR DESCRIPTION
<!-- Thank you for contributing! -->
fixes #15419

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

As mentioned in the issue, when parsing `srcset`, the `,` inside base64 value was getting split and joined again, breaking the base64 encoding.

The comment of `splitSrcSet` says that it is handling `"data:..."` case. But RE itself is only catching single or double quotes. I added additional RE logic to capture the whole base64 values.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
