### PR TITLE
fix(html): handle offset magic-string slice error

### DIFF
--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -39,6 +39,7 @@ export default defineConfig({
         serveFolder: resolve(__dirname, 'serve/folder/index.html'),
         serveBothFile: resolve(__dirname, 'serve/both.html'),
         serveBothFolder: resolve(__dirname, 'serve/both/index.html'),
+        write: resolve(__dirname, 'write.html'),
       },
     },
   },

--- a/playground/html/write.html
+++ b/playground/html/write.html
@@ -1,0 +1,3 @@
+<!-- prettier-ignore -->
+<html><head><style>div {}
+</style></head><body><script type="module" src="./shared.js"></script></body></html>


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/15327

magic-string `.slice()` may throw an error if the sliced string has removed content. I added a try-catch to fix it.

I was thinking if we could check against the plain string instead, but seems risky if there's added content later in magic-string.

I also refactored the code a bit.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
