### PR TITLE
docs: add warning on Worker import with constructor limitations

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -637,7 +637,7 @@ const worker = new Worker(workerUrl, {
 ))
 ```
 
-Here is how to make it should be:
+Here is how it should be:
 
 ```javascript
 const worker = new Worker(new URL('./worker.js', import.meta.url), {

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -636,7 +636,9 @@ const worker = new Worker(workerUrl, {
     name: WORKER_NAME
 ))
 ```
+
 Here is how to make it should be:
+
 ```javascript
 const worker = new Worker(new URL('./worker.js', import.meta.url), {
     type: 'module',

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -636,7 +636,7 @@ const worker = new Worker(workerUrl, {
     name: WORKER_NAME
 ))
 ```
-and here is how it should be:
+Here is how to make it should be:
 ```javascript
 const worker = new Worker(new URL('./worker.js', import.meta.url), {
     type: 'module',

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -617,36 +617,7 @@ const worker = new Worker(new URL('./worker.js', import.meta.url), {
 })
 ```
 
-:::warning
-
-Make sure to declare the `new URL()` constructor directly inside the `new Worker()` declaration, as done in the above example;
-declaring the URL in a separate variable will cause Vite to ignore the constructor, and the Worker may end up not being included in the built bundle.
-
-Additionaly, all options parameters must be static values (i.e. string literals). Using variables or constants will trigger a build error.
-
-The following example won't work:
-
-```javascript
-const WORKER_NAME = 'MyWorkerName'
-const workerUrl = new URL('./worker.js', import.meta.url)
-// the declaration of the worker will be ignored by Vite due to the URL being declared in a separate variable
-const worker = new Worker(workerUrl, {
-  type: 'module',
-  // the non-static name option will trigger an error
-  name: WORKER_NAME,
-})
-```
-
-Here is how it should be:
-
-```javascript
-const worker = new Worker(new URL('./worker.js', import.meta.url), {
-  type: 'module',
-  name: 'MyWorkerName',
-})
-```
-
-:::
+The worker detection will only work if the `new URL()` constructor is used directly inside the `new Worker()` declaration. Additionally, all options parameters must be static values (i.e. string literals).
 
 ### Import with Query Suffixes
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -631,18 +631,18 @@ const WORKER_NAME = 'MyWorkerName'
 const workerUrl = new URL('./worker.js', import.meta.url)
 // the declaration of the worker will be ignored by Vite due to the URL being declared in a separate variable
 const worker = new Worker(workerUrl, {
-    type: 'module',
-    // the non-static name option will trigger an error
-    name: WORKER_NAME
-))
+  type: 'module',
+  // the non-static name option will trigger an error
+  name: WORKER_NAME,
+})
 ```
 
 Here is how it should be:
 
 ```javascript
 const worker = new Worker(new URL('./worker.js', import.meta.url), {
-    type: 'module',
-    name: 'MyWorkerName'
+  type: 'module',
+  name: 'MyWorkerName',
 })
 ```
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -622,7 +622,7 @@ const worker = new Worker(new URL('./worker.js', import.meta.url), {
 Make sure to declare the `new URL()` constructor directly inside the `new Worker()` declaration, as done in the above example;
 declaring the URL in a separate variable will cause Vite to ignore the constructor, and the Worker may end up not being included in the built bundle.
 
-Additionaly, all options parameter must be static values, i.e. string literals. Using variables or constants will trigger a build error.
+Additionaly, all options parameters must be static values (i.e. string literals). Using variables or constants will trigger a build error.
 
 The following example won't work:
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -617,6 +617,35 @@ const worker = new Worker(new URL('./worker.js', import.meta.url), {
 })
 ```
 
+:::warning
+
+Make sure to declare the `new URL()` constructor directly inside the `new Worker()` declaration, as done in the above example;
+declaring the URL in a separate variable will cause Vite to ignore the constructor, and the Worker may end up not being included in the built bundle.
+
+Additionaly, all options parameter must be static values, i.e. string literals. Using variables or constants will trigger a build error.
+
+The following example won't work:
+
+```javascript
+const WORKER_NAME = 'MyWorkerName'
+const workerUrl = new URL('./worker.js', import.meta.url)
+// the declaration of the worker will be ignored by Vite due to the URL being declared in a separate variable
+const worker = new Worker(workerUrl, {
+    type: 'module',
+    // the non-static name option will trigger an error
+    name: WORKER_NAME
+))
+```
+and here is how it should be:
+```javascript
+const worker = new Worker(new URL('./worker.js', import.meta.url), {
+    type: 'module',
+    name: 'MyWorkerName'
+))
+```
+
+:::
+
 ### Import with Query Suffixes
 
 A web worker script can be directly imported by appending `?worker` or `?sharedworker` to the import request. The default export will be a custom worker constructor:

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -643,7 +643,7 @@ Here is how it should be:
 const worker = new Worker(new URL('./worker.js', import.meta.url), {
     type: 'module',
     name: 'MyWorkerName'
-))
+})
 ```
 
 :::


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The explanation on [how to import Workers with Constructor](https://vitejs.dev/guide/features#import-with-constructors) is not explaining how Vite actually parses the user code at build time.

I tried to import a `SharedWorker` like this:
```javascript
const WORKER_NAME = 'MyWorkerName'
const workerUrl = new URL('./worker.js', import.meta.url)
const worker = new SharedWorker(workerUrl, {
    type: 'module',
    name: WORKER_NAME
))
```

This isn't working for two reasons:
- the `name` option isn't a static value, and it triggers a build error
- `workerUrl` is declared in a separated variable, and this is not recognized by Vite

The latter does not even trigger an error, but just a warning. This ends up in a potentially broken build, without the Worker being bundled correctly.

Reference to the relevant code: https://github.com/vitejs/vite/blob/56ae92c33cba6c86ab5819877c19b9ea39f7121b/packages/vite/src/node/plugins/workerImportMetaUrl.ts

I added a warning that explains this behavior.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
