### PR TITLE
fix: resolvedUrls is null in plugin's configureServer after server restart

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -621,6 +621,7 @@ export async function _createServer(
     _shortcutsOptions: undefined,
   }
 
+  // maintain consistency with the server instance after restarting.
   const reflexServer = new Proxy(server, {
     get: (_, property: keyof ViteDevServer) => {
       return server[property]

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -621,6 +621,16 @@ export async function _createServer(
     _shortcutsOptions: undefined,
   }
 
+  const reflexServer = new Proxy(server, {
+    get: (_, property: keyof ViteDevServer) => {
+      return server[property]
+    },
+    set: (_, property: keyof ViteDevServer, value: never) => {
+      server[property] = value
+      return true
+    },
+  })
+
   if (!middlewareMode) {
     exitProcess = async () => {
       try {
@@ -714,7 +724,7 @@ export async function _createServer(
   // apply server configuration hooks from plugins
   const postHooks: ((() => void) | void)[] = []
   for (const hook of config.getSortedPluginHooks('configureServer')) {
-    postHooks.push(await hook(server))
+    postHooks.push(await hook(reflexServer))
   }
 
   // Internal middlewares ------------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fixes https://github.com/vitejs/vite/issues/15438
refs https://github.com/vitejs/vite/pull/14890

### Additional context

#14890 PR fixed the issue of indirectly referencing the dev `server` instance (e.g. referencing it In the delayed execution function), which was not effective when directly referencing the dev `server` instance after restarting the server (e.g. partial `middlewares` and `configureServer` hook in the plugin). `vite` will expose the dev `server` instance to the `configureServer` hook in the plugin, which also means that the dev `server` instance may be used by other hooks in the plugin. Therefore, I think it is necessary to maintain consistency of the dev `server` instance after server restart. as for the `middlewares`, I don't think any additional processing is necessary at the moment, as it may result in performance loss and inconsistent behavior before and after configuration. This fix adds a layer of proxy to the dev `server` reference in the `configureServer` hook of the plugin. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
