### PR TITLE
refactor: reuse existing node utils

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -27,6 +27,7 @@ import { buildReporterPlugin } from './plugins/reporter'
 import { buildEsbuildPlugin } from './plugins/esbuild'
 import { type TerserOptions, terserPlugin } from './plugins/terser'
 import {
+  arraify,
   asyncFlatten,
   copyDir,
   emptyDir,
@@ -427,13 +428,9 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
       completeSystemWrapPlugin(),
       ...(usePluginCommonjs ? [commonjsPlugin(options.commonjsOptions)] : []),
       dataURIPlugin(),
-      ...((
-        await asyncFlatten(
-          Array.isArray(rollupOptionsPlugins)
-            ? rollupOptionsPlugins
-            : [rollupOptionsPlugins],
-        )
-      ).filter(Boolean) as Plugin[]),
+      ...((await asyncFlatten(arraify(rollupOptionsPlugins))).filter(
+        Boolean,
+      ) as Plugin[]),
       ...(config.isWorker ? [webWorkerPostPlugin()] : []),
     ],
     post: [

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -23,6 +23,7 @@ import {
   normalizePath,
   removeLeadingSlash,
   tryStatSync,
+  unique,
 } from '../utils'
 import { transformWithEsbuild } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET } from '../constants'
@@ -1226,10 +1227,10 @@ function getConfigHash(config: ResolvedConfig, ssr: boolean): string {
       plugins: config.plugins.map((p) => p.name),
       optimizeDeps: {
         include: optimizeDeps?.include
-          ? Array.from(new Set(optimizeDeps.include)).sort()
+          ? unique(optimizeDeps.include).sort()
           : undefined,
         exclude: optimizeDeps?.exclude
-          ? Array.from(new Set(optimizeDeps.exclude)).sort()
+          ? unique(optimizeDeps.exclude).sort()
           : undefined,
         esbuildOptions: {
           ...optimizeDeps?.esbuildOptions,

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -4,7 +4,7 @@ import type {
   ManualChunkMeta,
   OutputOptions,
 } from 'rollup'
-import { isInNodeModules } from '../utils'
+import { arraify, isInNodeModules } from '../utils'
 import type { UserConfig } from '../../node'
 import type { Plugin } from '../plugin'
 
@@ -103,7 +103,7 @@ export function splitVendorChunkPlugin(): Plugin {
     config(config) {
       let outputs = config?.build?.rollupOptions?.output
       if (outputs) {
-        outputs = Array.isArray(outputs) ? outputs : [outputs]
+        outputs = arraify(outputs)
         for (const output of outputs) {
           const viteManualChunks = createSplitVendorChunk(output, config)
           if (viteManualChunks) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1070,7 +1070,7 @@ export const requireResolveFromRootWithFallback = (
 }
 
 export function emptyCssComments(raw: string): string {
-  return raw.replace(multilineCommentsRE, (s) => ' '.repeat(s.length))
+  return raw.replace(multilineCommentsRE, (s) => blankReplacer(s))
 }
 
 function backwardCompatibleWorkerPlugins(plugins: any) {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1070,7 +1070,7 @@ export const requireResolveFromRootWithFallback = (
 }
 
 export function emptyCssComments(raw: string): string {
-  return raw.replace(multilineCommentsRE, (s) => blankReplacer(s))
+  return raw.replace(multilineCommentsRE, blankReplacer)
 }
 
 function backwardCompatibleWorkerPlugins(plugins: any) {

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'node:events'
 import glob from 'fast-glob'
 import type { FSWatcher, WatchOptions } from 'dep-types/chokidar'
+import { arraify } from './utils'
 import type { ResolvedConfig } from '.'
 
 export function resolveChokidarOptions(
@@ -15,7 +16,7 @@ export function resolveChokidarOptions(
       '**/node_modules/**',
       '**/test-results/**', // Playwright
       glob.escapePath(config.cacheDir) + '/**',
-      ...(Array.isArray(ignored) ? ignored : [ignored]),
+      ...arraify(ignored),
     ],
     ignoreInitial: true,
     ignorePermissionErrors: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

A tiny refactor to reuse exising node utils in a few places.

### Additional context

N/A

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
