### PR TITLE
fix: inject `__vite__mapDeps` code before sourcemap file comment

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -634,13 +634,22 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
             )
             .join(',')}]`
 
-          s.append(`\
+          const mapDepsCode = `\
 function __vite__mapDeps(indexes) {
   if (!__vite__mapDeps.viteFileDeps) {
     __vite__mapDeps.viteFileDeps = ${fileDepsCode}
   }
   return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
-}`)
+}\n`
+
+          // inject extra code before sourcemap comment
+          const mapFileCommentMatch =
+            convertSourceMap.mapFileCommentRegex.exec(code)
+          if (mapFileCommentMatch) {
+            s.appendRight(mapFileCommentMatch.index, mapDepsCode)
+          } else {
+            s.append(mapDepsCode)
+          }
 
           // there may still be markers due to inlined dynamic imports, remove
           // all the markers regardless

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -129,5 +129,10 @@ describe.runIf(isBuild)('build tests', () => {
         "version": 3,
       }
     `)
+    //
+    const js = findAssetFile(/after-preload-dynamic.*\.js$/)
+    expect(js.trim().split('\n').at(-1)).toMatch(
+      /^\/\/# sourceMappingURL=after-preload-dynamic.*\.js\.map$/,
+    )
   })
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Closes https://github.com/vitejs/vite/issues/15338

https://github.com/vitejs/vite/pull/14550 introduced `__vite__mapDeps` runtime function, which is appended to the chunk output during `generateBundle` hooks. Rollup's chunk already includes `//# sourceMappingURL=` comment at this point, thus `MagicString.append` would inject the code after such comment.

This PR fixes this issue by using `MagicString.appendRight` to inject right before the sourcemap comment if found.

Note that the issue manifested when `sourcemap: true` (i.e. separate sourcemap file) but not when `sourcemap: "inline"` since the comment was re-appended in inline case:

https://github.com/vitejs/vite/blob/0cd4f8297f3b9f8b6e5ce38e0ced40529d516c06/packages/vite/src/node/plugins/importAnalysisBuild.ts#L686-L691

While testing on browsers by previewing `playground/js-sourcemap` locally, I found that `//# sourceMappingURL` comment appearing before `__vite__mapDeps` seems to be actually fine (at least for Chrome). So, I'm a little worried that the cause of the original issue might be something different. I'll ask for the further detail in the issue.

Here is what I tested (where both "before" and "after" look working however):

```sh
pnpm -C playground/js-sourcemap build
pnpm -C playground/js-sourcemap preview
```

<details><summary>Screenshots</summary>

- before

![image](https://github.com/vitejs/vite/assets/4232207/a5d3fad6-a258-49be-bcd9-e0bc100b0326)

![image](https://github.com/vitejs/vite/assets/4232207/99265cdd-98f9-4fe0-8859-5cfac0c564d1)

- after

![image](https://github.com/vitejs/vite/assets/4232207/13f9a787-da95-44ae-9496-3d6ef90e6cc5)

![image](https://github.com/vitejs/vite/assets/4232207/48022b89-e245-43e6-aa9f-9a54c622c850)

</details>

### Additional context

A few related PRs I looked up while attempting this fix:
- https://github.com/vitejs/vite/pull/14550
- https://github.com/vitejs/vite/pull/12642

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
