### PR TITLE
fix(esbuild): update to tsconfck 3.0.1 to fix edge cases when resolving tsconfig.extends

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -135,7 +135,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.0.0",
-    "tsconfck": "^3.0.0",
+    "tsconfck": "^3.0.1",
     "tslib": "^2.6.2",
     "types": "link:./types",
     "ufo": "^1.3.2",

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -444,14 +444,7 @@ async function loadTsconfigJsonForFile(
   filename: string,
 ): Promise<TSConfigJSON> {
   try {
-    if (tsconfckCache) {
-      // shortcut, the cache stores resolved TSConfckParseResult
-      // so getting it from the cache directly we bypass async fn call wrapping it in a promise again
-      if (tsconfckCache.hasParseResult(filename)) {
-        const result = await tsconfckCache.getParseResult(filename)
-        return result.tsconfig
-      }
-    } else {
+    if (!tsconfckCache) {
       tsconfckCache = new TSConfckCache<TSConfckParseResult>()
     }
     const result = await parse(filename, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,8 +409,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       tsconfck:
-        specifier: ^3.0.0
-        version: 3.0.0(typescript@5.2.2)
+        specifier: ^3.0.1
+        version: 3.0.1(typescript@5.2.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -9401,8 +9401,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.0(typescript@5.2.2):
-    resolution: {integrity: sha512-w3wnsIrJNi7avf4Zb0VjOoodoO0woEqGgZGQm+LHH9przdUI+XDKsWAXwxHA1DaRTjeuZNcregSzr7RaA8zG9A==}
+  /tsconfck@3.0.1(typescript@5.2.2):
+    resolution: {integrity: sha512-7ppiBlF3UEddCLeI1JRx5m2Ryq+xk4JrZuq4EuYXykipebaq1dV0Fhgr1hb7CkmHt32QSgOZlcqVLEtHBG4/mg==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
update to tsconfck@3.0.1 

Changes: 
 - `"extends":".."` resolves to `../tsconfig.json` fixes #15371 
 - fix an edge case where a tsconfig read from cache did not have its extends parsed and applied if it was part of another extended config that was processed before.

Example:
```shell
tsconfig.base.json
a/tsconfig.json #extends tsconfig.base.json
a/b/tsconfig.json #extends a/tsconfig.json
a/foo.ts
a/b/bar.ts
```
```js
const a_b_tsconfig = await parse('a/b/bar.ts'); 
// both 3.0.0 and 3.0.1 return correctly extended result from tsconfig.base.json to a/b/config.json, shallow parsing a/tsconfig.json in the process.

const a_tsconfig = await parse('a/foo.ts'); 
// 3.0.0 returns content of a/tsconfig.json without applied values from tsconfig.base.json if it was previously shallow parsed
// 3.0.1 recognizes that a/tsconfig.json has not been extended yet and does it lazily before returning the value
```

Unfortunately with this change we can no longer use the direct cache access optimization as the extends parsing is done lazily to avoid the performance penalty if the intermediate tsconfig is never used apart from being extended

<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
