### PR TITLE
docs(assets): add note to inlining SVG through url()

### DIFF
--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -31,7 +31,7 @@ The behavior is similar to webpack's `file-loader`. The difference is that the i
 - TypeScript, by default, does not recognize static asset imports as valid modules. To fix this, include [`vite/client`](./features#client-types).
 
 ::: tip Inlining SVGs through `url()`
-When passing a variable of SVG string to a manually constructed `url()` through a JS framework, such as `styled-components` or `svelte`, the variable should be wrapped within double quotes.
+When passing a variable of SVG string to a manually constructed `url()` through a JS framework, such as `svelte` or `styled-components`, the variable should be wrapped within `"` double quotes.
 
 ```js
 // App.svelte
@@ -43,20 +43,6 @@ When passing a variable of SVG string to a manually constructed `url()` through 
 <main>
   <div style='background: url("{viteIcon}")'>
 </main>
-```
-
-```
-import viteIcon from 'assets/vite.vg?url'
-
-export const Div = styled.div`
-  /*
-   * Below do not work
-  background: url(${viteIcon});
-  background: url('${viteIcon}');
-  */
-  /* Only this works */
-  background: url("${viteIcon}");
-`
 ```
 
 :::

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -31,19 +31,11 @@ The behavior is similar to webpack's `file-loader`. The difference is that the i
 - TypeScript, by default, does not recognize static asset imports as valid modules. To fix this, include [`vite/client`](./features#client-types).
 
 ::: tip Inlining SVGs through `url()`
-When passing a variable of SVG string to a manually constructed `url()` through a JS framework, such as `svelte` or `styled-components`, the variable should be wrapped within `"` double quotes.
+When passing a URL of SVG to a manually constructed `url()` by JS, the variable should be wrapped within double quotes.
 
 ```js
-// App.svelte
-
-<script lang="ts">
-  import viteIcon from './assets/vite.svg'
-</script>
-
-<main>
-  {/* viteIcon should be wrapped within double quotes */}
-  <div style='background: url("{viteIcon}")'>
-</main>
+import imgUrl from './img.svg'
+document.getElementById('hero-img').style.background = 'url("${imgUrl}")'
 ```
 
 :::

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -41,6 +41,7 @@ When passing a variable of SVG string to a manually constructed `url()` through 
 </script>
 
 <main>
+  {/* viteIcon should be wrapped within double quotes */}
   <div style='background: url("{viteIcon}")'>
 </main>
 ```

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -35,7 +35,7 @@ When passing a URL of SVG to a manually constructed `url()` by JS, the variable 
 
 ```js
 import imgUrl from './img.svg'
-document.getElementById('hero-img').style.background = 'url("${imgUrl}")'
+document.getElementById('hero-img').style.background = `url("${imgUrl}")`
 ```
 
 :::

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -30,6 +30,37 @@ The behavior is similar to webpack's `file-loader`. The difference is that the i
 
 - TypeScript, by default, does not recognize static asset imports as valid modules. To fix this, include [`vite/client`](./features#client-types).
 
+::: tip Inlining SVGs through `url()`
+When passing a variable of SVG string to a manually constructed `url()` through a JS framework, such as `styled-components` or `svelte`, the variable should be wrapped within double quotes.
+
+```js
+// App.svelte
+
+<script lang="ts">
+  import viteIcon from './assets/vite.svg'
+</script>
+
+<main>
+  <div style='background: url("{viteIcon}")'>
+</main>
+```
+
+```
+import viteIcon from 'assets/vite.vg?url'
+
+export const Div = styled.div`
+  /*
+   * Below do not work
+  background: url(${viteIcon});
+  background: url('${viteIcon}');
+  */
+  /* Only this works */
+  background: url("${viteIcon}");
+`
+```
+
+:::
+
 ### Explicit URL Imports
 
 Assets that are not included in the internal list or in `assetsInclude`, can be explicitly imported as a URL using the `?url` suffix. This is useful, for example, to import [Houdini Paint Worklets](https://houdini.how/usage).


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

related #15378
related #15444

Since PR #14643, inlining SVG requires double quotes to correctly parsed on build.

There was no documentation around that, and there were 2 issues regarding it.

I have added a "note" with an example that was brought up in the issue.

## TO-BE

<img width="1248" alt="Screenshot 2024-01-07 at 19 16 59" src="https://github.com/vitejs/vite/assets/48273875/63563bf5-ab44-45fe-b39b-8cdd88291e30">

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

<img width="714" alt="Screenshot 2024-01-07 at 19 10 29" src="https://github.com/vitejs/vite/assets/48273875/47db945a-59b4-4948-8348-a3b176ccdfb5">

I wanted to put a `styled-component` example, however, eslint forced the double-quotes to convert back to single-quotes and the spacing between code blocks wasn't pretty. So, I erased the `styled-component` one.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
