### PR TITLE
feat: insert window check into preloader for Node execution

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -89,8 +89,13 @@ function preload(
   importerUrl?: string,
 ) {
   let promise: Promise<unknown> = Promise.resolve()
-  // @ts-expect-error __VITE_IS_MODERN__ will be replaced with boolean later
-  if (__VITE_IS_MODERN__ && deps && deps.length > 0) {
+  if (
+    // @ts-expect-error __VITE_IS_MODERN__ will be replaced with boolean later
+    __VITE_IS_MODERN__ &&
+    deps &&
+    deps.length > 0 &&
+    typeof window !== 'undefined'
+  ) {
     const links = document.getElementsByTagName('link')
 
     promise = Promise.all(

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -137,7 +137,7 @@ describe.runIf(isBuild)('build tests', () => {
     const map = findAssetFile(/after-preload-dynamic.*\.js\.map/)
     expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
       {
-        "mappings": "i3BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
+        "mappings": "o4BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],


### PR DESCRIPTION
### Description

Closes #15369

Allows for skipping the preloader in non-browser environments.

### Additional context

I'm struggling a bit to create a minimal test case, though I'm unfamiliar with how & when the preloader gets injected. If anyone has any ideas, I'd love to hear them. Somehow we run into this in the linked feature request but I'm unable to minimally reproduce.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
