### PR TITLE
fix: revert `package.json` change should trigger server restart (#15519)

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -70,12 +70,11 @@ export async function handleHMRUpdate(
   const isConfigDependency = config.configFileDependencies.some(
     (name) => file === name,
   )
-  const isPackageJson = fileName === 'package.json'
 
   const isEnv =
     config.inlineConfig.envFile !== false &&
     getEnvFilesForMode(config.mode, config.envDir).includes(fileName)
-  if (isConfig || isConfigDependency || isPackageJson || isEnv) {
+  if (isConfig || isConfigDependency || isEnv) {
     // auto restart server
     debugHmr?.(`[config change] ${colors.dim(shortFile)}`)
     config.logger.info(

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -64,8 +64,7 @@ export async function handleHMRUpdate(
 ): Promise<void> {
   const { ws, config, moduleGraph } = server
   const shortFile = getShortName(file, config.root)
-  const fileName = path.basename(file)
-
+  
   const isConfig = file === config.configFile
   const isConfigDependency = config.configFileDependencies.some(
     (name) => file === name,

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -64,7 +64,7 @@ export async function handleHMRUpdate(
 ): Promise<void> {
   const { ws, config, moduleGraph } = server
   const shortFile = getShortName(file, config.root)
-  
+
   const isConfig = file === config.configFile
   const isConfigDependency = config.configFileDependencies.some(
     (name) => file === name,


### PR DESCRIPTION
This reverts commit 260ebbfa96ae87e2c331d82b386e609ed865cbcb.

### Description

@btea, we discussed in today's team meeting and decided to revert this change for now as the extra server start when modifying something that isn't the field type is a DX regression.

We can keep discussing in https://github.com/vitejs/vite/pull/15543 if we should add a check for the main package.json and restart the server in case the change would affect the way the config file is loaded. I'm leaning towards documenting that changes in the package.json structure in the project requires a hard restart though.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other