### PR TITLE
fix: init dev ssr optimizer on server init

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -475,9 +475,6 @@ export async function _createServer(
       return devHtmlTransformFn(server, url, html, originalUrl)
     },
     async ssrLoadModule(url, opts?: { fixStacktrace?: boolean }) {
-      if (isDepsOptimizerEnabled(config, true)) {
-        await initDevSsrDepsOptimizer(config, server)
-      }
       return ssrLoadModule(
         url,
         server,
@@ -827,6 +824,9 @@ export async function _createServer(
       // start deps optimizer after all container plugins are ready
       if (isDepsOptimizerEnabled(config, false)) {
         await initDepsOptimizer(config, server)
+      }
+      if (isDepsOptimizerEnabled(config, true)) {
+        await initDevSsrDepsOptimizer(config, server)
       }
       warmupFiles(server)
       initingServer = undefined

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -40,11 +40,7 @@ import { ssrLoadModule } from '../ssr/ssrModuleLoader'
 import { ssrFixStacktrace, ssrRewriteStacktrace } from '../ssr/ssrStacktrace'
 import { ssrTransform } from '../ssr/ssrTransform'
 import { ERR_OUTDATED_OPTIMIZED_DEP } from '../plugins/optimizedDeps'
-import {
-  getDepsOptimizer,
-  initDepsOptimizer,
-  initDevSsrDepsOptimizer,
-} from '../optimizer'
+import { getDepsOptimizer, initDepsOptimizer } from '../optimizer'
 import { bindCLIShortcuts } from '../shortcuts'
 import type { BindCLIShortcutsOptions } from '../shortcuts'
 import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
@@ -824,9 +820,6 @@ export async function _createServer(
       // start deps optimizer after all container plugins are ready
       if (isDepsOptimizerEnabled(config, false)) {
         await initDepsOptimizer(config, server)
-      }
-      if (isDepsOptimizerEnabled(config, true)) {
-        await initDevSsrDepsOptimizer(config, server)
       }
       warmupFiles(server)
       initingServer = undefined

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -23,7 +23,8 @@ import {
   unwrapId,
 } from '../utils'
 import { checkPublicFile } from '../publicDir'
-import { getDepsOptimizer } from '../optimizer'
+import { isDepsOptimizerEnabled } from '../config'
+import { getDepsOptimizer, initDevSsrDepsOptimizer } from '../optimizer'
 import { applySourcemapIgnoreList, injectSourcesContent } from './sourcemap'
 import { isFileServingAllowed } from './middlewares/static'
 import { throwClosedServerError } from './pluginContainer'
@@ -132,6 +133,10 @@ async function doTransform(
   const { config, pluginContainer } = server
   const prettyUrl = debugCache ? prettifyUrl(url, config.root) : ''
   const ssr = !!options.ssr
+
+  if (ssr && isDepsOptimizerEnabled(config, true)) {
+    await initDevSsrDepsOptimizer(config, server)
+  }
 
   const module = await server.moduleGraph.getModuleByUrl(url, ssr)
 


### PR DESCRIPTION
### Description

We are starting warmup of ssr files using `transformRequest` on server init. The dev ssr optimizer was started lazily on `ssrLoadModule` to avoid blocking the server start. The esbuild run should be fast enough for this move to not be a regression in DX.

Edit: moved the init to be lazy in transformRequest

vite-node isn't using `ssrLoadModule` in SSR transform mode so the deps optimizer wasn't working properly in Vitest either. See:
- https://github.com/vitest-dev/vitest/issues/4910

cc @sheremet-va 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other