### PR TITLE
fix(hmr): propagate `fs.stat` failure for `hmrContext.read`

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -624,19 +624,15 @@ async function readModifiedFile(file: string): Promise<string> {
   const content = await fsp.readFile(file, 'utf-8')
   if (!content) {
     const mtime = (await fsp.stat(file)).mtimeMs
-    await new Promise((r) => {
-      let n = 0
-      const poll = async () => {
-        n++
-        const newMtime = (await fsp.stat(file)).mtimeMs
-        if (newMtime !== mtime || n > 10) {
-          r(0)
-        } else {
-          setTimeout(poll, 10)
-        }
+
+    for (let n = 0; n < 10; n++) {
+      await new Promise((r) => setTimeout(r, 10))
+      const newMtime = (await fsp.stat(file)).mtimeMs
+      if (newMtime !== mtime) {
+        break
       }
-      setTimeout(poll, 10)
-    })
+    }
+
     return await fsp.readFile(file, 'utf-8')
   } else {
     return content


### PR DESCRIPTION
### Description

This fixes an unhandled promise rejection that could occur if a file disappeared during the polling period inside `readModifiedFile` (aka `hmrContext.read`). This unhandled rejection would cause the vite server to crash.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other