### PR TITLE
chore: avoid bundling resolve dep

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -127,6 +127,10 @@ function createNodePlugins(
           src: 'const resolveId = require("./lib/resolve-id")',
           replacement: 'const resolveId = (id) => id',
         },
+        'postcss-import/lib/parse-styles.js': {
+          src: 'const resolveId = require("./resolve-id")',
+          replacement: 'const resolveId = (id) => id',
+        },
       }),
 
     commonjs({


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The LICENSE file should not change locally after this PR now.

### Additional context

With the upgrade of `postcss-import`, there's now another path we need to handle to prevent bundling the `resolve` dep.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
