### PR TITLE
docs: add tip on browser extensions to perf guide

### DIFF
--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -8,7 +8,7 @@ While Vite is fast by default, performance issues can creep in as the project's 
 
 ## Avoid Browser Extensions
 
-Some browser extensions may interfere with requests and slow down startup and reload times for large apps, especially when using browser dev tools. We recommend creating a dev-only profile without extensions while using Vite's dev server in these cases. Another option is using Incognito mode, that should also provide an extra speed up when loading your app.
+Some browser extensions may interfere with requests and slow down startup and reload times for large apps, especially when using browser dev tools. We recommend creating a dev-only profile without extensions, or switch to incognito mode, while using Vite's dev server in these cases.
 
 ## Audit Configured Vite Plugins
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -8,7 +8,7 @@ While Vite is fast by default, performance issues can creep in as the project's 
 
 ## Avoid Browser Extensions
 
-Some browser extensions may interfere with requests and slow down startup and reload times for large apps, especially when using browser dev tools. We recommend creating a dev-only profile without extensions, or switch to incognito mode, while using Vite's dev server in these cases.
+Some browser extensions may interfere with requests and slow down startup and reload times for large apps, especially when using browser dev tools. We recommend creating a dev-only profile without extensions, or switch to incognito mode, while using Vite's dev server in these cases. Incognito mode should also be faster than a regular profile without extensions.
 
 ## Audit Configured Vite Plugins
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -6,6 +6,10 @@ While Vite is fast by default, performance issues can creep in as the project's 
 - Slow page loads
 - Slow builds
 
+## Avoid Browser Extensions
+
+Some browser extensions may interfere with requests and slow down startup and reload times for large apps, especially when using browser dev tools. We recommend creating a dev-only profile without extensions while using Vite's dev server in these cases. Another option is using Incognito mode, that should also provide an extra speed up when loading your app.
+
 ## Audit Configured Vite Plugins
 
 Vite's internal and official plugins are optimized to do the least amount of work possible while providing compatibility with the broader ecosystem. For example, code transformations use regex in dev, but do a complete parse in build to ensure correctness.


### PR DESCRIPTION
### Description

See https://twitter.com/patak_dev/status/1745427465617433005

Full page reload of 10k modules with dev tools opened:
```
4.2s - With Tampermonkey + uBlock
3.3s - Only uBlock
2.5s - No extensions
2.0s - Incognito
```

Without dev tools opened, Vite's dev server loads the 10k modules in 1.7 seconds on my M1 (hitting all 304). Without extensions, the difference when having dev tools opened is only ~10%
```
2.9s - Tampermonkey + uBlock
2.3s - Only uBlock
2.2s - No extensions
1.7s - Incognito
```

Add the new section at the top because it is short and it should help that more people will see it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other