### PR TITLE
perf: stricter dynamicImportVars transform filter

### DIFF
--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -24,7 +24,8 @@ const relativePathRE = /^\.{1,2}\//
 // fast path to check if source contains a dynamic import. we check for a
 // trailing slash too as a dynamic import statement can have comments between
 // the `import` and the `(`.
-const hasDynamicImportRE = /\bimport\s*[(/]/
+const hasDynamicImportRE =
+  /\bimport\s*(?:\((?!\s*\/\*\s*@vite-ignore\s*\*\/)|\/)/
 
 interface DynamicImportRequest {
   query?: string | Record<string, string>


### PR DESCRIPTION
### Description

The `@react-refresh` virtual module has:
```js
const __hmr_import = (module)=>import(/* @vite-ignore */
__vite__injectQuery(module, 'import'));
```

This is the only dynamic import and should be ignored, but the fast short-circuit regex in the dynamic import vars plugin fails to discard this case. This PR makes the guard stricter so `@react-refresh` and other similar modules won't need to be parsed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other