### PR TITLE
test(hmr): add failing test for circular imports with entry modules

### DIFF
--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -907,6 +907,34 @@ if (import.meta.hot) {
     )
   })
 
+  test('HMR should work for circular imports with one module being an entry', async () => {
+    await page.goto(viteTestUrl + '/circular-entry/index.html')
+    const main = page.locator('.main')
+    const mainAccepted = page.locator('.main-accepted')
+    expect(await main.textContent()).toBe('[success]')
+    expect(await mainAccepted.textContent()).toBe('[success]')
+    editFile('circular-entry/other.js', (code) =>
+      code.replace(`[success]`, `[success]1`),
+    )
+    // The below wait and reload should not be needed
+    // await page.waitForTimeout(200)
+    // await page.reload()
+    await untilUpdated(() => main.textContent(), '[success]1')
+    await untilUpdated(() => mainAccepted.textContent(), '[success]1')
+
+    // Test simpler case without HMR boundary
+    await page.goto(viteTestUrl + '/circular-entry/main-only.html')
+    const main2 = page.locator('.main')
+    expect(await main2.textContent()).toBe('[success]1')
+    editFile('circular-entry/other.js', (code) =>
+      code.replace(`[success]1`, `[success]2`),
+    )
+    // The below wait and reload should not be needed
+    // await page.waitForTimeout(200)
+    // await page.reload()
+    await untilUpdated(() => main.textContent(), '[success]2')
+  })
+
   test('assets HMR', async () => {
     await page.goto(viteTestUrl)
     const el = await page.$('#logo')

--- a/playground/hmr/circular-entry/index.html
+++ b/playground/hmr/circular-entry/index.html
@@ -1,0 +1,5 @@
+<p class="main"></p>
+<p class="main-accepted"></p>
+
+<script type="module" src="./main.js"></script>
+<script type="module" src="./main-accepted.js"></script>

--- a/playground/hmr/circular-entry/main-accepted.js
+++ b/playground/hmr/circular-entry/main-accepted.js
@@ -1,0 +1,14 @@
+import { foo } from './other'
+
+// Wrap in a callback to access `foo` later
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelector('.main-accepted').innerHTML = foo
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept('./other', (newMod) => {
+    if (!newMod) return
+
+    document.querySelector('.main-accepted').innerHTML = newMod.foo
+  })
+}

--- a/playground/hmr/circular-entry/main-only.html
+++ b/playground/hmr/circular-entry/main-only.html
@@ -1,0 +1,4 @@
+<!-- This html file tests main.js only for the case where there's no HMR boundary outside of the circular loop -->
+<p class="main"></p>
+
+<script type="module" src="./main.js"></script>

--- a/playground/hmr/circular-entry/main.js
+++ b/playground/hmr/circular-entry/main.js
@@ -1,0 +1,6 @@
+import { foo } from './other'
+
+// Wrap in a callback to access `foo` later
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelector('.main').innerHTML = foo
+})

--- a/playground/hmr/circular-entry/other.js
+++ b/playground/hmr/circular-entry/other.js
@@ -1,0 +1,3 @@
+import './main.js'
+
+export const foo = '[success]'


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Copying what I've [mentioned on discord](https://discord.com/channels/804011606160703521/804439875226173480/1195016218411814943):

---

I'm currently deep into a HMR bug wrt an entry node (e.g. imported by `index.html`), not triggering a full reload. It's because we removed that full reload in Vite 5.

I spent a good hour thinking about this without any ideas, maybe y'all know something i don't see :eyes:

I made a graph explaining the dilemma:

![image](https://github.com/vitejs/vite/assets/34116392/d10d48e8-a36f-4b18-bab0-9b0f07bb674a)
(https://www.tldraw.com/s/v2_c_6byyYfbGPoqE2p5D8sjc3?viewport=54,-17,1268,775&page=page:page)

Currently the above graph does not trigger a full reload because:
1. `E` is seen to have importers (`F`) so it's not considered the "root"
2. `H` accepts HMR and will reload itself

We don't have information about `index.html` in the HMR module graph. We can only go by checking if something has no importers == "root". Even if we apply some sort of heuristic, `F` could always potentially be the "root".

---

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
