### PR TITLE
feat(build): set `hoistTransitiveImports` to false in library builds

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -603,6 +603,7 @@ export async function build(
         exports: 'auto',
         sourcemap: options.sourcemap,
         name: libOptions ? libOptions.name : undefined,
+        hoistTransitiveImports: libOptions ? false : undefined,
         // es2015 enables `generatedCode.symbols`
         // - #764 add `Symbol.toStringTag` when build es module into cjs chunk
         // - #1048 add `Symbol.toStringTag` for module default export


### PR DESCRIPTION
### Description

Rollup has an option [hoistTransitiveImports](https://rollupjs.org/configuration-options/#output-hoisttransitiveimports) to make chunks load as early as possible by adding empty imports to the entry, but it is useless for libraries:

* The library will not be the first-loaded module, which makes hoisting useless.
* Projects may use builders, in which case these extra imports are redundant.

These empty imports have also caused some confusion: https://github.com/rollup/rollup/issues/3332, https://github.com/rollup/rollup/issues/4564

This PR disable `hoistTransitiveImports` option by default in library build, make the output code more clean.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
