### PR TITLE
fix: maintain compatibility with rollup when loading commonjs module

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/import.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/import.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { transformCjsImport } from '../../plugins/importAnalysis'
+import { commonjsHelperContainer } from '../../plugins/commonjsHelper'
 
 describe('transformCjsImport', () => {
   const url = './node_modules/.vite/deps/react.js'
@@ -24,6 +25,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -41,6 +43,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -55,6 +58,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -71,6 +75,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -87,6 +92,7 @@ describe('transformCjsImport', () => {
         0,
         'modA',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(undefined)
 
@@ -102,6 +108,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(undefined)
 
@@ -117,6 +124,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -133,6 +141,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -151,6 +160,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -166,6 +176,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -181,6 +192,7 @@ describe('transformCjsImport', () => {
         0,
         '',
         config,
+        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +

--- a/packages/vite/src/node/__tests__/plugins/import.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/import.spec.ts
@@ -1,33 +1,61 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import MagicString from 'magic-string'
 import { transformCjsImport } from '../../plugins/importAnalysis'
 import { commonjsHelperContainer } from '../../plugins/commonjsHelper'
+import type { ResolvedConfig } from '../../config'
 
 describe('transformCjsImport', () => {
-  const url = './node_modules/.vite/deps/react.js'
-  const rawUrl = 'react'
-  const config: any = {
+  const defaultUrl = './node_modules/.vite/deps/react.js'
+  const defaultRawUrl = 'react'
+  const defaultConfig: any = {
     command: 'serve',
     logger: {
       warn: vi.fn(),
     },
   }
 
+  function compiler(
+    source: string,
+    options?: {
+      url?: string
+      rawUrl?: string
+      importIndex?: number
+      importer?: string
+      config?: ResolvedConfig
+    },
+  ) {
+    const commonjsHelpers = new commonjsHelperContainer()
+    const {
+      url = defaultUrl,
+      rawUrl = defaultRawUrl,
+      importIndex = 0,
+      importer = '',
+      config = defaultConfig,
+    } = options || {}
+    const compilerResult = transformCjsImport(
+      source,
+      url,
+      rawUrl,
+      importIndex,
+      importer,
+      config,
+      commonjsHelpers,
+    )
+    if (compilerResult) {
+      const s = new MagicString(compilerResult)
+      if (commonjsHelpers.collectTools.length) {
+        s.prepend(commonjsHelpers.injectHelper())
+      }
+      return s.toString()
+    }
+  }
+
   beforeEach(() => {
-    config.logger.warn.mockClear()
+    defaultConfig.logger.warn.mockClear()
   })
 
   test('import specifier', () => {
-    expect(
-      transformCjsImport(
-        'import { useState, Component } from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
+    expect(compiler('import { useState, Component } from "react"')).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const useState = __vite__cjsImport0_react["useState"]; ' +
         'const Component = __vite__cjsImport0_react["Component"]',
@@ -35,98 +63,43 @@ describe('transformCjsImport', () => {
   })
 
   test('import default specifier', () => {
-    expect(
-      transformCjsImport(
-        'import React from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
+    expect(compiler('import React from "react"')).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const React = __vite__cjsImport0_react.__esModule ? __vite__cjsImport0_react.default : __vite__cjsImport0_react',
     )
 
-    expect(
-      transformCjsImport(
-        'import { default as React } from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
+    expect(compiler('import { default as React } from "react"')).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const React = __vite__cjsImport0_react.__esModule ? __vite__cjsImport0_react.default : __vite__cjsImport0_react',
     )
   })
 
   test('import all specifier', () => {
-    expect(
-      transformCjsImport(
-        'import * as react from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
-      'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
-        'const react = __vite__cjsImport0_react',
+    expect(compiler('import * as react from "react"')).toEqual(
+      'import { mergeNamespaces as __mergeNamespaces,getDefaultExportFromCjs as __getDefaultExportFromCjs } from "/vite/commonjsHelpers";' +
+        'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
+        'const react = __mergeNamespaces({ __proto__: null, default: __getDefaultExportFromCjs(__vite__cjsImport0_react)}, [__vite__cjsImport0_react]);',
     )
   })
 
   test('export all specifier', () => {
     expect(
-      transformCjsImport(
-        'export * from "react"',
-        url,
-        rawUrl,
-        0,
-        'modA',
-        config,
-        new commonjsHelperContainer(),
-      ),
+      compiler('export * from "react"', {
+        importer: 'modA',
+      }),
     ).toBe(undefined)
 
-    expect(config.logger.warn).toBeCalledWith(
+    expect(defaultConfig.logger.warn).toBeCalledWith(
       expect.stringContaining(`export * from "react"\` in modA`),
     )
 
-    expect(
-      transformCjsImport(
-        'export * as react from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(undefined)
+    expect(compiler('export * as react from "react"')).toBe(undefined)
 
-    expect(config.logger.warn).toBeCalledTimes(1)
+    expect(defaultConfig.logger.warn).toBeCalledTimes(1)
   })
 
   test('export name specifier', () => {
-    expect(
-      transformCjsImport(
-        'export { useState, Component } from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
+    expect(compiler('export { useState, Component } from "react"')).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const __vite__cjsExport_useState = __vite__cjsImport0_react["useState"]; ' +
         'const __vite__cjsExport_Component = __vite__cjsImport0_react["Component"]; ' +
@@ -134,14 +107,8 @@ describe('transformCjsImport', () => {
     )
 
     expect(
-      transformCjsImport(
+      compiler(
         'export { useState as useStateAlias, Component as ComponentAlias } from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
@@ -152,49 +119,19 @@ describe('transformCjsImport', () => {
   })
 
   test('export default specifier', () => {
-    expect(
-      transformCjsImport(
-        'export { default } from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
+    expect(compiler('export { default } from "react"')).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const __vite__cjsExportDefault_0 = __vite__cjsImport0_react.__esModule ? __vite__cjsImport0_react.default : __vite__cjsImport0_react; ' +
         'export default __vite__cjsExportDefault_0',
     )
 
-    expect(
-      transformCjsImport(
-        'export { default as React} from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
+    expect(compiler('export { default as React} from "react"')).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const __vite__cjsExport_React = __vite__cjsImport0_react.__esModule ? __vite__cjsImport0_react.default : __vite__cjsImport0_react; ' +
         'export { __vite__cjsExport_React as React }',
     )
 
-    expect(
-      transformCjsImport(
-        'export { Component as default } from "react"',
-        url,
-        rawUrl,
-        0,
-        '',
-        config,
-        new commonjsHelperContainer(),
-      ),
-    ).toBe(
+    expect(compiler('export { Component as default } from "react"')).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const __vite__cjsExportDefault_0 = __vite__cjsImport0_react["Component"]; ' +
         'export default __vite__cjsExportDefault_0',

--- a/packages/vite/src/node/__tests__/plugins/import.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/import.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import MagicString from 'magic-string'
 import { transformCjsImport } from '../../plugins/importAnalysis'
-import { commonjsHelperContainer } from '../../plugins/commonjsHelper'
+import { CommonjsHelperContainer } from '../../plugins/commonjsHelper'
 import type { ResolvedConfig } from '../../config'
 
 describe('transformCjsImport', () => {
@@ -24,7 +24,7 @@ describe('transformCjsImport', () => {
       config?: ResolvedConfig
     },
   ) {
-    const commonjsHelpers = new commonjsHelperContainer()
+    const commonjsHelpers = new CommonjsHelperContainer()
     const {
       url = defaultUrl,
       rawUrl = defaultRawUrl,
@@ -43,8 +43,9 @@ describe('transformCjsImport', () => {
     )
     if (compilerResult) {
       const s = new MagicString(compilerResult)
-      if (commonjsHelpers.collectTools.length) {
-        s.prepend(commonjsHelpers.injectHelper())
+      const injectHelper = commonjsHelpers.injectHelper()
+      if (injectHelper) {
+        s.prepend(injectHelper)
       }
       return s.toString()
     }

--- a/packages/vite/src/node/__tests__/plugins/import.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/import.spec.ts
@@ -76,7 +76,7 @@ describe('transformCjsImport', () => {
 
   test('import all specifier', () => {
     expect(compiler('import * as react from "react"')).toEqual(
-      'import { mergeNamespaces as __mergeNamespaces,getDefaultExportFromCjs as __getDefaultExportFromCjs } from "/vite/commonjsHelpers";' +
+      'import { mergeNamespaces as __mergeNamespaces,getDefaultExportFromCjs as __getDefaultExportFromCjs } from "/commonjs-helpers.js";' +
         'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const react = __mergeNamespaces({ __proto__: null, default: __getDefaultExportFromCjs(__vite__cjsImport0_react)}, [__vite__cjsImport0_react]);',
     )

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -55,6 +55,7 @@ import { completeSystemWrapPlugin } from './plugins/completeSystemWrap'
 import { mergeConfig } from './publicUtils'
 import { webWorkerPostPlugin } from './plugins/worker'
 import { getHookHandler } from './plugins'
+import { commonjsHelperPlugin } from './plugins/commonjsHelper'
 
 export interface BuildOptions {
   /**
@@ -450,6 +451,7 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
             buildReporterPlugin(config),
           ]
         : []),
+      commonjsHelperPlugin(),
       loadFallbackPlugin(),
     ],
   }

--- a/packages/vite/src/node/plugins/commonjsHelper.ts
+++ b/packages/vite/src/node/plugins/commonjsHelper.ts
@@ -16,7 +16,6 @@ type HelperContainer = {
   compiler: (localName: string, importedName: string) => string
 } & HelperTool
 export interface CommonjsHelperContainerType {
-  collect: (helper: InteractiveInterface) => void
   translate: (
     importedName: string,
     localName: string,
@@ -80,7 +79,7 @@ export class CommonjsHelperContainer implements CommonjsHelperContainerType {
     this._init()
   }
   private _init(): void {
-    const collect = this.collect.bind(this)
+    const collect = this._collect.bind(this)
     Object.keys(this._helperContainer).forEach((importedName) => {
       const helper = this._helperContainer[importedName]
       Object.defineProperties(
@@ -103,7 +102,7 @@ export class CommonjsHelperContainer implements CommonjsHelperContainerType {
       )
     })
   }
-  collect(helper: InteractiveInterface): void {
+  private _collect(helper: InteractiveInterface): void {
     if (this._uniqueChecker.has(helper.importedName)) return
     this._uniqueChecker.add(helper.importedName)
     this._collectHelper.push(helper)

--- a/packages/vite/src/node/plugins/commonjsHelper.ts
+++ b/packages/vite/src/node/plugins/commonjsHelper.ts
@@ -1,0 +1,175 @@
+import type { Plugin } from '../plugin'
+
+interface InteractiveInterface {
+  localName: string
+  importedName: string
+}
+
+interface PropertyDescriptor {
+  configurable?: boolean
+  enumerable?: boolean
+  value?: any
+  writable?: boolean
+  get?(): any
+  set?(v: any): void
+}
+
+interface HelperTool {
+  getDefaultExportFromCjs?: PropertyDescriptor
+  mergeNamespaces?: PropertyDescriptor
+}
+type HelperContainer = {
+  init?: Record<keyof HelperTool, string>
+  collect?: (helper: InteractiveInterface) => void
+  compiler: (localName: string, importedName: string) => string
+} & HelperTool
+
+export interface commonjsHelperContainerType {
+  collectTools: Array<InteractiveInterface>
+  helperContainer: Record<string, HelperContainer>
+  init: () => void
+  collect: (helper: InteractiveInterface) => void
+  translate: (
+    importedName: string,
+    localName: string,
+    cjsModuleName: string,
+  ) => string
+  injectHelper: () => void
+}
+
+const helperModule = `
+	export const getDefaultExportFromCjs = (x) => {
+		return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+	}
+	export const mergeNamespaces = (n, m) => {
+		for (var i = 0; i < m.length; i++) {
+			const e = m[i];
+			if (typeof e !== 'string' && !Array.isArray(e)) { 
+				for (const k in e) {
+					if (k !== 'default' && !(k in n)) {
+						const d = Object.getOwnPropertyDescriptor(e, k);
+						if (d) {
+							Object.defineProperty(n, k, d.get ? d : {
+								enumerable: true,
+								get: () => e[k]
+							});
+						}
+					}
+				} 
+			}
+		}
+		return Object.freeze(Object.defineProperty(n, Symbol.toStringTag, { value: 'Module' }));
+	}
+`
+export class commonjsHelperContainer implements commonjsHelperContainerType {
+  collectTools = new Array<InteractiveInterface>()
+  uniqueChecker = new Map<string, Set<string>>()
+  helperContainer: Record<string, HelperContainer> = {
+    '*': {
+      init: {
+        mergeNamespaces: '__mergeNamespaces',
+        getDefaultExportFromCjs: '__getDefaultExportFromCjs',
+      },
+      collect: this.collect.bind(this),
+      compiler(localName, cjsModuleName) {
+        return `const ${localName} = ${this.mergeNamespaces}({
+							__proto__: null,
+							default: ${this.getDefaultExportFromCjs}(${cjsModuleName})
+						}, [${cjsModuleName}]);`
+      },
+    },
+    dynamic: {
+      init: {
+        mergeNamespaces: '__mergeNamespaces',
+        getDefaultExportFromCjs: '__getDefaultExportFromCjs',
+      },
+      collect: this.collect.bind(this),
+      compiler(localName, importedName) {
+        return `${localName} => ${this.mergeNamespaces}({
+					__proto__: null,
+					default: ${this.getDefaultExportFromCjs}(${importedName})
+				}, [${importedName}])`
+      },
+    },
+  }
+  constructor() {
+    this.init()
+  }
+  init(): void {
+    const collect = this.collect.bind(this)
+    Object.keys(this.helperContainer).forEach((importedName) => {
+      const helper = this.helperContainer[importedName]
+      if (helper.init) {
+        Object.defineProperties(
+          helper,
+          Object.keys(helper.init).reduce(
+            (accumulator, helperToolImportedName) => {
+              const helperToolLocalName =
+                helper.init![helperToolImportedName as keyof HelperTool]
+              accumulator[helperToolImportedName] = {
+                get() {
+                  collect({
+                    localName: helperToolLocalName,
+                    importedName: helperToolImportedName,
+                  })
+                  return helperToolLocalName
+                },
+              }
+              return accumulator
+            },
+            {} as PropertyDescriptorMap,
+          ),
+        )
+      }
+    })
+  }
+  collect(helper: InteractiveInterface): void {
+    if (!this.uniqueChecker.get(helper.importedName)) {
+      this.uniqueChecker.set(helper.importedName, new Set())
+    }
+    const checker = this.uniqueChecker.get(helper.importedName)
+    if (checker?.has(helper.localName)) {
+      return
+    }
+    checker?.add(helper.localName)
+    this.collectTools.push(helper)
+  }
+  translate(
+    importedName: string,
+    localName: string,
+    cjsModuleName: string,
+  ): string {
+    const compilerHelper = this.helperContainer[importedName]
+    if (compilerHelper) {
+      return compilerHelper.compiler(localName, cjsModuleName)
+    }
+    return ''
+  }
+  injectHelper(): string {
+    if (this.collectTools.length) {
+      return `import { ${[...this.collectTools].map(
+        ({ localName, importedName }) => `${importedName} as ${localName}`,
+      )} } from "${HELPERS_ID}";`
+    }
+    return ''
+  }
+}
+
+const HELPERS_ID = '/vite/commonjsHelpers'
+const resolvedHELPERS_ID = '\0' + HELPERS_ID + '.js'
+
+export function commonjsHelperPlugin(): Plugin {
+  return {
+    name: 'vite:commonjs-helper',
+    resolveId(id) {
+      if (id === HELPERS_ID) {
+        return resolvedHELPERS_ID
+      }
+    },
+    load(id) {
+      if (id === resolvedHELPERS_ID) {
+        return helperModule
+      }
+    },
+  }
+}

--- a/packages/vite/src/node/plugins/commonjsHelper.ts
+++ b/packages/vite/src/node/plugins/commonjsHelper.ts
@@ -152,19 +152,19 @@ export class commonjsHelperContainer implements commonjsHelperContainerType {
   }
 }
 
-const HELPERS_ID = '/vite/commonjsHelpers'
-const resolvedHELPERS_ID = '\0' + HELPERS_ID + '.js'
+const HELPERS_ID = '/commonjs-helpers.js'
+const RESOLVED_HELPERS_ID = '\0/commonjs-helpers.js'
 
 export function commonjsHelperPlugin(): Plugin {
   return {
     name: 'vite:commonjs-helper',
     resolveId(id) {
       if (id === HELPERS_ID) {
-        return resolvedHELPERS_ID
+        return RESOLVED_HELPERS_ID
       }
     },
     load(id) {
-      if (id === resolvedHELPERS_ID) {
+      if (id === RESOLVED_HELPERS_ID) {
         return helperModule
       }
     },

--- a/packages/vite/src/node/plugins/commonjsHelper.ts
+++ b/packages/vite/src/node/plugins/commonjsHelper.ts
@@ -72,10 +72,7 @@ export class commonjsHelperContainer implements commonjsHelperContainerType {
       },
       collect: this.collect.bind(this),
       compiler(localName, cjsModuleName) {
-        return `const ${localName} = ${this.mergeNamespaces}({
-							__proto__: null,
-							default: ${this.getDefaultExportFromCjs}(${cjsModuleName})
-						}, [${cjsModuleName}]);`
+        return `const ${localName} = ${this.mergeNamespaces}({ __proto__: null, default: ${this.getDefaultExportFromCjs}(${cjsModuleName})}, [${cjsModuleName}]);`
       },
     },
     dynamic: {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -65,7 +65,7 @@ import { browserExternalId } from './resolve'
 import { serializeDefine } from './define'
 import { WORKER_FILE_ID } from './worker'
 import type { CommonjsHelperContainerType } from './commonjsHelper'
-import { CommonjsHelperContainer } from './commonjsHelper'
+import { CommonjsHelperContainer, ImportType } from './commonjsHelper'
 
 const debug = createDebugger('vite:import-analysis')
 
@@ -881,7 +881,7 @@ export function interopNamedImports(
       expStart,
       expEnd,
       `import('${rewrittenUrl}').then(${commonjsHelpers.translate(
-        'dynamic',
+        ImportType.DynamicImport,
         'm',
         'm.default',
       )})` + getLineBreaks(exp),
@@ -1022,7 +1022,11 @@ export function transformCjsImport(
     importNames.forEach(({ importedName, localName }) => {
       if (importedName === '*') {
         lines.push(
-          commonjsHelpers.translate(importedName, localName, cjsModuleName),
+          commonjsHelpers.translate(
+            ImportType.NamespacesImport,
+            localName,
+            cjsModuleName,
+          ),
         )
       } else if (importedName === 'default') {
         lines.push(

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -64,8 +64,8 @@ import { isCSSRequest, isDirectCSSRequest } from './css'
 import { browserExternalId } from './resolve'
 import { serializeDefine } from './define'
 import { WORKER_FILE_ID } from './worker'
-import type { commonjsHelperContainerType } from './commonjsHelper'
-import { commonjsHelperContainer } from './commonjsHelper'
+import type { CommonjsHelperContainerType } from './commonjsHelper'
+import { CommonjsHelperContainer } from './commonjsHelper'
 
 const debug = createDebugger('vite:import-analysis')
 
@@ -418,7 +418,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const orderedAcceptedExports = new Array<Set<string> | undefined>(
         imports.length,
       )
-      const commonjsHelpers = new commonjsHelperContainer()
+      const commonjsHelpers = new CommonjsHelperContainer()
       await Promise.all(
         imports.map(async (importSpecifier, index) => {
           const {
@@ -734,8 +734,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
       }
 
-      if (commonjsHelpers.collectTools.length) {
-        str().prepend(commonjsHelpers.injectHelper())
+      const injectHelper = commonjsHelpers.injectHelper()
+      if (injectHelper) {
+        str().prepend(injectHelper)
       }
 
       // normalize and rewrite accepted urls
@@ -863,7 +864,7 @@ export function interopNamedImports(
   importIndex: number,
   importer: string,
   config: ResolvedConfig,
-  commonjsHelpers: commonjsHelperContainerType,
+  commonjsHelpers: CommonjsHelperContainerType,
 ): void {
   const source = str.original
   const {
@@ -942,7 +943,7 @@ export function transformCjsImport(
   importIndex: number,
   importer: string,
   config: ResolvedConfig,
-  commonjsHelpers: commonjsHelperContainerType,
+  commonjsHelpers: CommonjsHelperContainerType,
 ): string | undefined {
   const node = (
     parseJS(importExp, {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -28,7 +28,7 @@ import { genSourceMapUrl } from '../server/sourcemap'
 import { getDepsOptimizer, optimizedDepNeedsInterop } from '../optimizer'
 import { removedPureCssFilesCache } from './css'
 import { createParseErrorInfo, interopNamedImports } from './importAnalysis'
-import { commonjsHelperContainer } from './commonjsHelper'
+import { CommonjsHelperContainer } from './commonjsHelper'
 
 type FileDep = {
   url: string
@@ -302,7 +302,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       let s: MagicString | undefined
       const str = () => s || (s = new MagicString(source))
       let needPreloadHelper = false
-      const commonjsHelpers = new commonjsHelperContainer()
+      const commonjsHelpers = new CommonjsHelperContainer()
       for (let index = 0; index < imports.length; index++) {
         const {
           s: start,
@@ -404,8 +404,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
         str().prepend(`import { ${preloadMethod} } from "${preloadHelperId}";`)
       }
 
-      if (commonjsHelpers.collectTools.length) {
-        str().prepend(commonjsHelpers.injectHelper())
+      const injectHelper = commonjsHelpers.injectHelper()
+      if (injectHelper) {
+        str().prepend(injectHelper)
       }
 
       if (s) {

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -104,11 +104,8 @@ export async function resolvePlugins(
     // internal server-only plugins are always applied after everything else
     ...(isBuild
       ? []
-      : [
-          clientInjectionsPlugin(config),
-          importAnalysisPlugin(config),
-          commonjsHelperPlugin(),
-        ]),
+      : [clientInjectionsPlugin(config), importAnalysisPlugin(config)]),
+    commonjsHelperPlugin(),
   ].filter(Boolean) as Plugin[]
 }
 

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -26,6 +26,7 @@ import { assetImportMetaUrlPlugin } from './assetImportMetaUrl'
 import { metadataPlugin } from './metadata'
 import { dynamicImportVarsPlugin } from './dynamicImportVars'
 import { importGlobPlugin } from './importMetaGlob'
+import { commonjsHelperPlugin } from './commonjsHelper'
 
 export async function resolvePlugins(
   config: ResolvedConfig,
@@ -103,7 +104,11 @@ export async function resolvePlugins(
     // internal server-only plugins are always applied after everything else
     ...(isBuild
       ? []
-      : [clientInjectionsPlugin(config), importAnalysisPlugin(config)]),
+      : [
+          clientInjectionsPlugin(config),
+          importAnalysisPlugin(config),
+          commonjsHelperPlugin(),
+        ]),
   ].filter(Boolean) as Plugin[]
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/issues/15542

### Additional context

From the following repository examples:
https://github.com/XiSenao/exceptional-performance-of-loading-commonjs-modules/blob/main/src/main.js

it can be found that using `namespace imports` to load `CommonJS` modules results in inconsistent development and build behaviors. In most cases, `dynamic import` behaves as expected. That is to say,  it seems effective to rewrite in the following way.
```js
import('${rewrittenUrl}').then(m => m.default && m.default.__esModule ? m.default : ({ ...m.default, default: m.default }))
```
However, when exploring **how the `@rollup/plugin-commonjs` plugin interacts with `rollup`**, it seems that `rollup` will merge the transpiled `ESM` product through
```js
mergeNamespaces({
  __proto__: null,
  default: getDefaultExportFromCjs(rectClamp)
}, [rectClamp])
```
The logic of the `rollup` processing and the rewritten `dynamic import` are somewhat similar, but it can be found that there are still boundary scenarios that will cause inconsistencies between development and build behaviors for `dynamic imports`(e.g. only export `Array`).

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
