### PR TITLE
fix: await `configResolved` hooks of worker plugins (#15597)

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -718,9 +718,11 @@ export async function resolveConfig(
     )
 
     // run configResolved hooks
-    createPluginHookUtils(resolvedWorkerPlugins)
-      .getSortedPluginHooks('configResolved')
-      .map((hook) => hook(workerResolved))
+    await Promise.all(
+      createPluginHookUtils(resolvedWorkerPlugins)
+        .getSortedPluginHooks('configResolved')
+        .map((hook) => hook(workerResolved)),
+    )
 
     return resolvedWorkerPlugins
   }


### PR DESCRIPTION
### Description

Fix a regression introduced in Vite 5.0, port:
- #15597 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other