### PR TITLE
fix(types): mark hmr update internal types optional

### DIFF
--- a/packages/vite/types/hmrPayload.d.ts
+++ b/packages/vite/types/hmrPayload.d.ts
@@ -21,9 +21,9 @@ export interface Update {
   acceptedPath: string
   timestamp: number
   /** @internal */
-  explicitImportRequired: boolean
+  explicitImportRequired?: boolean
   /** @internal */
-  isWithinCircularImport: boolean
+  isWithinCircularImport?: boolean
 }
 
 export interface PrunePayload {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

The HMR update type can be manually emitted today like https://github.com/histoire-dev/histoire/blob/bc08dec376faa9f72335f6fa4c54283a0233a93d/packages/histoire/src/node/server.ts#L102, which broke types downstream. Marking them as optional like before for now. (`explicitImportRequired` was already optional before but I made it required in https://github.com/vitejs/vite/pull/15118

Currently these internal types are only used at https://github.com/vitejs/vite/blob/fdc142cd27e7adbf408ca067ab164c211dd26939/packages/vite/src/client/client.ts#L142-L165

### Additional context

Thanks @Akryum for spotting this.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
