### PR TITLE
perf: do not bind plugin hook context functions

### DIFF
--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -10,38 +10,6 @@ let resolveId: (id: string) => any
 let moduleGraph: ModuleGraph
 
 describe('plugin container', () => {
-  it('has bound methods', async () => {
-    expect.assertions(14)
-    const entryUrl = '/x.js'
-
-    const plugin: Plugin = {
-      name: 'p1',
-      load(id) {
-        // bound functions and bound arrow functions do not have prototype
-        expect(this.parse.prototype).equals(undefined)
-        expect(this.resolve.prototype).equals(undefined)
-        expect(this.load.prototype).equals(undefined)
-        expect(this.getModuleInfo.prototype).equals(undefined)
-        expect(this.getModuleIds.prototype).equals(undefined)
-        expect(this.addWatchFile.prototype).equals(undefined)
-        expect(this.getWatchFiles.prototype).equals(undefined)
-        expect(this.emitFile.prototype).equals(undefined)
-        expect(this.setAssetSource.prototype).equals(undefined)
-        expect(this.getFileName.prototype).equals(undefined)
-        expect(this.warn.prototype).equals(undefined)
-        expect(this.error.prototype).equals(undefined)
-        expect(this.debug.prototype).equals(undefined)
-        expect(this.info.prototype).equals(undefined)
-      },
-    }
-
-    const container = await getPluginContainer({
-      plugins: [plugin],
-    })
-
-    await container.load(entryUrl)
-  })
-
   describe('getModuleInfo', () => {
     beforeEach(() => {
       moduleGraph = new ModuleGraph((id) => resolveId(id))

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -299,20 +299,6 @@ export async function createPluginContainer(
 
     constructor(initialPlugin?: Plugin) {
       this._activePlugin = initialPlugin || null
-      this.parse = this.parse.bind(this)
-      this.resolve = this.resolve.bind(this)
-      this.load = this.load.bind(this)
-      this.getModuleInfo = this.getModuleInfo.bind(this)
-      this.getModuleIds = this.getModuleIds.bind(this)
-      this.addWatchFile = this.addWatchFile.bind(this)
-      this.getWatchFiles = this.getWatchFiles.bind(this)
-      this.emitFile = this.emitFile.bind(this)
-      this.setAssetSource = this.setAssetSource.bind(this)
-      this.getFileName = this.getFileName.bind(this)
-      this.warn = this.warn.bind(this)
-      this.error = this.error.bind(this)
-      this.debug = this.debug.bind(this)
-      this.info = this.info.bind(this)
     }
 
     parse(code: string, opts: any) {


### PR DESCRIPTION
### Description

This PR reverts 
- #14569 

Doing the 14 binds on each created plugin hook `Context` represents ~1.2% of the total work of the server using vite-dev-server-perf. Given that this feature isn't really needed, and the issue that triggered it ended up in the plugin being modified to work without binded functions I don't think we can justify the perf penalty.

I think we're still in time to revert this in Vite 5.1 given that it was added in Vite 5.0 but we didn't documented it (and it is not documented in rollup either). cc @bluwy @sapphi-red 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other