### PR TITLE
perf: avoid parseRequest

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/__snapshots__/parse.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/__snapshots__/parse.spec.ts.snap
@@ -1,10 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`parse positives > ? in url 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mo\\\\?ds/*.js", {"query":"url","import":"*"})), \`./mo?ds/\${base ?? foo}.js\`)"`;
+exports[`parse positives > ? in url 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mo\\\\?ds/*.js", {"query":"?url","import":"*"})), \`./mo?ds/\${base ?? foo}.js\`)"`;
 
-exports[`parse positives > ? in variables 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":"raw","import":"*"})), \`./mods/\${base ?? foo}.js\`)"`;
+exports[`parse positives > ? in variables 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":"?raw","import":"*"})), \`./mods/\${base ?? foo}.js\`)"`;
 
-exports[`parse positives > ? in worker 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mo\\\\?ds/*.js", {"query":"worker","import":"*"})), \`./mo?ds/\${base ?? foo}.js\`)"`;
+exports[`parse positives > ? in worker 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mo\\\\?ds/*.js", {"query":"?worker","import":"*"})), \`./mo?ds/\${base ?? foo}.js\`)"`;
 
 exports[`parse positives > alias path 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js")), \`./mods/\${base}.js\`)"`;
 
@@ -14,8 +14,8 @@ exports[`parse positives > with ../ and itself 1`] = `"__variableDynamicImportRu
 
 exports[`parse positives > with multi ../ and itself 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("../../plugins/dynamicImportVar/*.js")), \`./\${name}.js\`)"`;
 
-exports[`parse positives > with query 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":{"foo":"bar"}})), \`./mods/\${base}.js\`)"`;
+exports[`parse positives > with query 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":"?foo=bar"})), \`./mods/\${base}.js\`)"`;
 
-exports[`parse positives > with query raw 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":"raw","import":"*"})), \`./mods/\${base}.js\`)"`;
+exports[`parse positives > with query raw 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":"?raw","import":"*"})), \`./mods/\${base}.js\`)"`;
 
-exports[`parse positives > with query url 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":"url","import":"*"})), \`./mods/\${base}.js\`)"`;
+exports[`parse positives > with query url 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js", {"query":"?url","import":"*"})), \`./mods/\${base}.js\`)"`;

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -58,7 +58,6 @@ import {
   isObject,
   joinUrlSegments,
   normalizePath,
-  parseRequest,
   processSrcSet,
   removeDirectQuery,
   removeUrlQuery,
@@ -171,6 +170,7 @@ export function resolveCSSOptions(
 const cssModuleRE = new RegExp(`\\.module${CSS_LANGS_RE.source}`)
 const directRequestRE = /[?&]direct\b/
 const htmlProxyRE = /[?&]html-proxy\b/
+const htmlProxyIndexRE = /&index=(\d+)/
 const commonjsProxyRE = /\?commonjs-proxy/
 const inlineRE = /[?&]inline\b/
 const inlineCSSRE = /[?&]inline-css\b/
@@ -474,12 +474,15 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       const inlineCSS = inlineCSSRE.test(id)
       const isHTMLProxy = htmlProxyRE.test(id)
       if (inlineCSS && isHTMLProxy) {
-        const query = parseRequest(id)
         if (styleAttrRE.test(id)) {
           css = css.replace(/"/g, '&quot;')
         }
+        const index = htmlProxyIndexRE.exec(id)?.[1]
+        if (index == null) {
+          throw new Error(`HTML proxy index in "${id}" not found`)
+        }
         addToHTMLProxyTransformResult(
-          `${getHash(cleanUrl(id))}_${Number.parseInt(query!.index)}`,
+          `${getHash(cleanUrl(id))}_${Number.parseInt(index)}`,
           css,
         )
         return `export default ''`

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -10,13 +10,15 @@ import { CLIENT_ENTRY } from '../constants'
 import {
   createFilter,
   normalizePath,
-  parseRequest,
+  rawRE,
   requestQueryMaybeEscapedSplitRE,
   requestQuerySplitRE,
   transformStableResult,
+  urlRE,
 } from '../utils'
 import { toAbsoluteGlob } from './importMetaGlob'
 import { hasViteIgnoreRE } from './importAnalysis'
+import { workerOrSharedWorkerRE } from './worker'
 
 export const dynamicImportHelperId = '\0vite/dynamic-import-helper.js'
 
@@ -53,9 +55,6 @@ function parseDynamicImportPattern(
   strings: string,
 ): DynamicImportPattern | null {
   const filename = strings.slice(1, -1)
-  const rawQuery = parseRequest(filename)
-  let globParams: DynamicImportRequest | null = null
-
   const ast = (
     parseJS(strings, {
       ecmaVersion: 'latest',
@@ -73,19 +72,22 @@ function parseDynamicImportPattern(
     requestQueryMaybeEscapedSplitRE,
     2,
   )
-  const [rawPattern] = filename.split(requestQuerySplitRE, 2)
-
-  const globQuery = (['worker', 'url', 'raw'] as const).find(
-    (key) => rawQuery && key in rawQuery,
-  )
-  if (globQuery) {
-    globParams = {
-      query: globQuery,
-      import: '*',
-    }
-  } else if (rawQuery) {
-    globParams = {
-      query: rawQuery,
+  const [rawPattern, search] = filename.split(requestQuerySplitRE, 2)
+  let globParams: DynamicImportRequest | null = null
+  if (search) {
+    if (
+      workerOrSharedWorkerRE.test(search) ||
+      urlRE.test(search) ||
+      rawRE.test(search)
+    ) {
+      globParams = {
+        query: search,
+        import: '*',
+      }
+    } else {
+      globParams = {
+        query: search,
+      }
     }
   }
 

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -72,9 +72,10 @@ function parseDynamicImportPattern(
     requestQueryMaybeEscapedSplitRE,
     2,
   )
-  const [rawPattern, search] = filename.split(requestQuerySplitRE, 2)
+  let [rawPattern, search] = filename.split(requestQuerySplitRE, 2)
   let globParams: DynamicImportRequest | null = null
   if (search) {
+    search = '?' + search
     if (
       workerOrSharedWorkerRE.test(search) ||
       urlRE.test(search) ||

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -339,8 +339,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         }
       } else {
         url = await fileToUrl(cleanUrl(id), config, this)
-        url = injectQuery(url, WORKER_FILE_ID)
-        url = injectQuery(url, `type=${workerType}`)
+        url = injectQuery(url, `${WORKER_FILE_ID}&type=${workerType}`)
       }
 
       if (urlRE.test(id)) {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -28,6 +28,8 @@ interface WorkerCache {
 
 export type WorkerType = 'classic' | 'module' | 'ignore'
 
+export const workerOrSharedWorkerRE = /(\?|&)(worker|sharedworker)(?:&|$)/
+
 export const WORKER_FILE_ID = 'worker_file'
 const workerCache = new WeakMap<ResolvedConfig, WorkerCache>()
 
@@ -191,18 +193,6 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
   let server: ViteDevServer
   const isWorker = config.isWorker
 
-  const isWorkerQueryId = (id: string) => {
-    const parsedQuery = parseRequest(id)
-    if (
-      parsedQuery &&
-      (parsedQuery.worker ?? parsedQuery.sharedworker) != null
-    ) {
-      return true
-    }
-
-    return false
-  }
-
   return {
     name: 'vite:worker',
 
@@ -222,13 +212,13 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
     },
 
     load(id) {
-      if (isBuild && isWorkerQueryId(id)) {
+      if (isBuild && workerOrSharedWorkerRE.test(id)) {
         return ''
       }
     },
 
     shouldTransformCachedModule({ id }) {
-      if (isBuild && config.build.watch && isWorkerQueryId(id)) {
+      if (isBuild && config.build.watch && workerOrSharedWorkerRE.test(id)) {
         return true
       }
     },

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -175,8 +175,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             builtUrl = await workerFileToUrl(config, file)
           } else {
             builtUrl = await fileToUrl(cleanUrl(file), config, this)
-            builtUrl = injectQuery(builtUrl, WORKER_FILE_ID)
-            builtUrl = injectQuery(builtUrl, `type=${workerType}`)
+            builtUrl = injectQuery(
+              builtUrl,
+              `${WORKER_FILE_ID}&type=${workerType}`,
+            )
           }
           s.update(
             expStart,

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -8,7 +8,6 @@ import {
   cleanUrl,
   evalValue,
   injectQuery,
-  parseRequest,
   slash,
   transformStableResult,
 } from '../utils'
@@ -131,7 +130,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
     async transform(code, id, options) {
       if (!options?.ssr && isIncludeWorkerImportMetaUrl(code)) {
-        const query = parseRequest(id)
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
         const workerImportMetaUrlRE =
@@ -174,7 +172,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
           let builtUrl: string
           if (isBuild) {
-            builtUrl = await workerFileToUrl(config, file, query)
+            builtUrl = await workerFileToUrl(config, file)
           } else {
             builtUrl = await fileToUrl(cleanUrl(file), config, this)
             builtUrl = injectQuery(builtUrl, WORKER_FILE_ID)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { exec } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { URL, URLSearchParams, fileURLToPath } from 'node:url'
+import { URL, fileURLToPath } from 'node:url'
 import { builtinModules, createRequire } from 'node:module'
 import { promises as dns } from 'node:dns'
 import { performance } from 'node:perf_hooks'
@@ -1040,14 +1040,6 @@ export const multilineCommentsRE = /\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\//g
 export const singlelineCommentsRE = /\/\/.*/g
 export const requestQuerySplitRE = /\?(?!.*[/|}])/
 export const requestQueryMaybeEscapedSplitRE = /\\?\?(?!.*[/|}])/
-
-export function parseRequest(id: string): Record<string, string> | null {
-  const [_, search] = id.split(requestQuerySplitRE, 2)
-  if (!search) {
-    return null
-  }
-  return Object.fromEntries(new URLSearchParams(search))
-}
 
 export const blankReplacer = (match: string): string => ' '.repeat(match.length)
 

--- a/playground/worker/__tests__/iife/iife-worker.spec.ts
+++ b/playground/worker/__tests__/iife/iife-worker.spec.ts
@@ -161,7 +161,7 @@ test('import.meta.glob eager in worker', async () => {
 })
 
 test.runIf(isServe)('sourcemap boundary', async () => {
-  const response = page.waitForResponse(/my-worker.ts\?type=module&worker_file/)
+  const response = page.waitForResponse(/my-worker.ts\?worker_file&type=module/)
   await page.goto(viteTestUrl)
   const content = await (await response).text()
   const { mappings } = decodeSourceMapUrl(content)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

ref https://github.com/vitejs/vite/pull/14420#issuecomment-1842813275

Avoid `parseRequest` function and use plain regex instead.

Perf link too long that it doesn't work :( Here's another benchmark: https://jsperf.app/nikobo

In case that ever fails again, here's the benchmark code:

<details>
<summary>Details</summary>

```js
// Setup
// ufo
function parseQuery(parametersString = "") {
  const object = {};
  if (parametersString[0] === "?") {
    parametersString = parametersString.slice(1);
  }
  for (const parameter of parametersString.split("&")) {
    const s = parameter.match(/([^=]+)=?(.*)/) || [];
    if (s.length < 2) {
      continue;
    }
    const key = decodeQueryKey(s[1]);
    if (key === "__proto__" || key === "constructor") {
      continue;
    }
    const value = decodeQueryValue(s[2] || "");
    if (object[key] === undefined) {
      object[key] = value;
    } else if (Array.isArray(object[key])) {
      (object[key]).push(value);
    } else {
      object[key] = [object[key], value];
    }
  }
  return object;
}
const PLUS_RE = /\+/g;
function decodeQueryKey(text) {
  return decode(text.replace(PLUS_RE, " "));
}
function decodeQueryValue(text) {
  return decode(text.replace(PLUS_RE, " "));
}
function decode(text = "") {
  try {
    return decodeURIComponent("" + text);
  } catch {
    return "" + text;
  }
}

// vite
const requestQuerySplitRE = /\?(?!.*[/|}])/
function parseRequest(id){
  const [_, search] = id.split(requestQuerySplitRE, 2)
  if (!search) {
    return null
  }
  return Object.fromEntries(new URLSearchParams(search))
}

const workerRe = /(\?|&)worker(?:&|$)/
const urlRe = /(\?|&)url(?:&|$)/
const rawRe = /(\?|&)raw(?:&|$)/

// data
const urls = [
  '/foo/bar.js',
  '/foo/bar.js?worker',
  '/foo/bar.js?url',
  '/foo/bar.js?worker&url',
  '/foo/bar.js?raw',
  ''
]
  .join('__')
  .repeat(100)
  .split('__')
```

```js
// ufo test
let a = 0, b = 0, c = 0, d = 0
for (const url of urls) {
  let [_, search] = url.split(requestQuerySplitRE, 2)
  if (!search) continue
  search = '?' + search
  const query = parseQuery(search)
  if (!query) continue
  if (query.worker != null) a++
  else if (query.url != null) b++
  else if (query.raw != null) c++
  else d++
}
console.log(a, b, c, d)
```

```js
// regex test
let a = 0, b = 0, c = 0, d = 0
for (const url of urls) {
  let [_, search] = url.split(requestQuerySplitRE, 2)
  if (!search) continue
  search = '?' + search
  if (workerRe.test(search)) a++
  else if (urlRe.test(search)) b++
  else if (rawRe.test(search)) c++
  else d++
}
console.log(a, b, c, d)
```

```js
// parseRequest test
let a = 0, b = 0, c = 0, d = 0
for (const url of urls) {
  const query = parseRequest(url)
  if (!query) continue
  if (query.worker != null) a++
  else if (query.url != null) b++
  else if (query.raw != null) c++
  else d++
}
console.log(a, b, c, d)
```
</details>

The result is that the regex version is roughly 70% faster.

### Additional context

 I made individual commits removing the usage of `parseRequest` (note: I messed up the name in the 3rd commit)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
