### PR TITLE
perf: don't recalculate path.dirname(mod.file)

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -327,6 +327,7 @@ async function loadAndTransform(
     )
 
     if (path.isAbsolute(mod.file)) {
+      let modDirname
       for (
         let sourcesIndex = 0;
         sourcesIndex < normalizedMap.sources.length;
@@ -338,8 +339,9 @@ async function loadAndTransform(
           // to resolve and display them in a meaningful way (rather than
           // with absolute paths).
           if (path.isAbsolute(sourcePath)) {
+            modDirname ??= path.dirname(mod.file)
             normalizedMap.sources[sourcesIndex] = path.relative(
-              path.dirname(mod.file),
+              modDirname,
               sourcePath,
             )
           }


### PR DESCRIPTION
### Description

Small change to avoid recalculating path.dirname on every iteration

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other