### PR TITLE
feat(vite): use parse5 tools instead of own implementation

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -458,6 +458,13 @@ Repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
 
 ---------------------------------------
 
+## @parse5/tools
+License: MIT
+By: James Garbutt
+Repository: git+https://github.com/43081j/parse5-tools.git
+
+---------------------------------------
+
 ## @polka/url
 License: MIT
 By: Luke Edwards

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -121,6 +121,7 @@
     "okie": "^1.0.1",
     "open": "^8.4.2",
     "parse5": "^7.1.2",
+    "@parse5/tools": "^0.4.0",
     "periscopic": "^4.0.2",
     "picocolors": "^1.0.0",
     "picomatch": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       '@jridgewell/trace-mapping':
         specifier: ^0.3.21
         version: 0.3.21
+      '@parse5/tools':
+        specifier: ^0.4.0
+        version: 0.4.0
       '@rollup/plugin-alias':
         specifier: ^5.1.0
         version: 5.1.0(rollup@4.2.0)
@@ -3660,6 +3663,12 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
+
+  /@parse5/tools@0.4.0:
+    resolution: {integrity: sha512-mLIbnvph9mBtEoFxz+LSy8Mh89sXVECdymzdmqw9PgM/IP3Q3CKETvruKYliV3QcvJLEc7PRb7YuG5XtTpKarw==}
+    dependencies:
+      parse5: 7.1.2
+    dev: true
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}


### PR DESCRIPTION
This basically moves away from having our own type guards and traversal function to using those shipped by the parse5 org.

Some element guards have also been removed since the parse5 traversal function accepts a visitor instead of a function. For example:

```ts
traverse(node, {
  element(n) {
    // n is always an element already
  }
});
```

draft for now since im struggling to run the tests locally, will figure it out some time in the next few days

edit: well, ci seems happy other than macos timing out for some reason!

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
