### PR TITLE
refactor(hmr): provide a separate logger interface

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -134,7 +134,18 @@ const debounceReload = (time: number) => {
 const pageReload = debounceReload(50)
 
 const hmrClient = new HMRClient(
-  console,
+  {
+    error: console.error,
+    debug: console.debug,
+    updated({ acceptedPath, path }) {
+      const loggedPath =
+        acceptedPath === path ? path : `${acceptedPath} via ${path}`
+      console.debug(`[vite] hot updated: ${loggedPath}`)
+    },
+    invalidated(id, message) {
+      console.debug(`[vite] invalidate ${id}${message ? `: ${message}` : ''}`)
+    },
+  },
   {
     isReady: () => socket && socket.readyState === 1,
     send: (message) => socket.send(message),

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -134,18 +134,7 @@ const debounceReload = (time: number) => {
 const pageReload = debounceReload(50)
 
 const hmrClient = new HMRClient(
-  {
-    error: console.error,
-    debug: console.debug,
-    updated({ acceptedPath, path }) {
-      const loggedPath =
-        acceptedPath === path ? path : `${acceptedPath} via ${path}`
-      console.debug(`[vite] hot updated: ${loggedPath}`)
-    },
-    invalidated(id, message) {
-      console.debug(`[vite] invalidate ${id}${message ? `: ${message}` : ''}`)
-    },
-  },
+  console,
   {
     isReady: () => socket && socket.readyState === 1,
     send: (message) => socket.send(message),

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -18,14 +18,6 @@ interface HotCallback {
 export interface HMRLogger {
   error(msg: string | Error): void
   debug(...msg: unknown[]): void
-  /**
-   * Log when HMR update is applied
-   */
-  updated(update: Update): void
-  /**
-   * Log when a module is invalidated via "import.meta.hot.invalidate"
-   */
-  invalidated(id: string, message?: string): void
 }
 
 export interface HMRConnection {
@@ -120,7 +112,9 @@ export class HMRContext implements ViteHotContext {
       message,
     })
     this.send('vite:invalidate', { path: this.ownerPath, message })
-    this.hmrClient.logger.invalidated(this.ownerPath, message)
+    this.hmrClient.logger.debug(
+      `[vite] invalidate ${this.ownerPath}${message ? `: ${message}` : ''}`,
+    )
   }
 
   on<T extends string>(
@@ -304,7 +298,8 @@ export class HMRClient {
           deps.map((dep) => (dep === acceptedPath ? fetchedModule : undefined)),
         )
       }
-      this.logger.updated(update)
+      const loggedPath = isSelfUpdate ? path : `${acceptedPath} via ${path}`
+      this.logger.debug(`[vite] hot updated: ${loggedPath}`)
     }
   }
 }

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -23,7 +23,7 @@ export interface HMRLogger {
    */
   updated(update: Update): void
   /**
-   * Log when module is invalidated via "impoer.meta.hot.invalidate"
+   * Log when a module is invalidated via "import.meta.hot.invalidate"
    */
   invalidated(id: string, message?: string): void
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR standardizes the HMR logger interface.

- This makes it easier to provide a custom logger because we expose only used methods.
- During SSR the HMR update uses the full file path so the log is very long and not readable. This allows SSR logger to provide its own method to override the logged URL

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
