### PR TITLE
perf: avoid performance.now() call

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -226,7 +226,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         return null
       }
 
-      const msAtStart = debug && performance.now()
+      const msAtStart = debug ? performance.now() : 0
       await init
       let imports!: readonly ImportSpecifier[]
       let exports!: readonly ExportSpecifier[]
@@ -259,7 +259,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (!imports.length && !(this as any)._addedImports) {
         importerModule.isSelfAccepting = false
         debug?.(
-          `${timeFrom(msAtStart!)} ${colors.dim(
+          `${timeFrom(msAtStart)} ${colors.dim(
             `[no imports] ${prettifyUrl(importer, root)}`,
           )}`,
         )
@@ -790,7 +790,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       debug?.(
-        `${timeFrom(msAtStart!)} ${colors.dim(
+        `${timeFrom(msAtStart)} ${colors.dim(
           `[${importedUrls.size} imports rewritten] ${prettifyUrl(
             importer,
             root,

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -226,7 +226,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         return null
       }
 
-      const start = performance.now()
+      const msAtStart = debug && performance.now()
       await init
       let imports!: readonly ImportSpecifier[]
       let exports!: readonly ExportSpecifier[]
@@ -259,7 +259,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (!imports.length && !(this as any)._addedImports) {
         importerModule.isSelfAccepting = false
         debug?.(
-          `${timeFrom(start)} ${colors.dim(
+          `${timeFrom(msAtStart!)} ${colors.dim(
             `[no imports] ${prettifyUrl(importer, root)}`,
           )}`,
         )
@@ -790,7 +790,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
 
       debug?.(
-        `${timeFrom(start)} ${colors.dim(
+        `${timeFrom(msAtStart!)} ${colors.dim(
           `[${importedUrls.size} imports rewritten] ${prettifyUrl(
             importer,
             root,


### PR DESCRIPTION
### Description

We were doing this call even when not in debug mode. It took enough time to be visible in the cpuprofile.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other