### PR TITLE
docs: `build.minify` defaults to `false` for SSR

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -193,7 +193,7 @@ During the SSR build, static assets aren't emitted as it is assumed they would b
 ## build.minify
 
 - **Type:** `boolean | 'terser' | 'esbuild'`
-- **Default:** `'esbuild'`
+- **Default:** `'esbuild'` for client build, `false` for SSR build
 
 Set to `false` to disable minification, or specify the minifier to use. The default is [esbuild](https://github.com/evanw/esbuild) which is 20 ~ 40x faster than terser and only 1 ~ 2% worse compression. [Benchmarks](https://github.com/privatenumber/minification-benchmarks)
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
`build.minify` defaults to `false` for SSR. But that was not written in the docs.
https://github.com/vitejs/vite/blob/947aa53bb8ea60ce03a207421a6e7a4117385e58/packages/vite/src/node/build.ts#L338

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
