### PR TITLE
feat(imports): support import attributes - fixes #14674

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -505,7 +505,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               // Loop over every property key. Currently only strings are allows, as per spec
               obj.properties.forEach((prop) => {
                 if (
-                  prop.type == 'Property' &&
+                  prop.type === 'Property' &&
                   prop.key.type === 'Identifier' &&
                   prop.value.type === 'Literal'
                 ) {

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -209,6 +209,10 @@ test('Resolving from other package with imports field', async () => {
   expect(await page.textContent('.imports-pkg-slash')).toMatch('[success]')
 })
 
+test('Resolving import attributes', async () => {
+  expect(await page.textContent('.import-attributes')).toMatch('[success]')
+})
+
 test('Resolve doesnt interrupt page request with trailing query and .css', async () => {
   await page.goto(viteTestUrl + '/?test.css')
   expect(await page.locator('vite-error-overlay').count()).toBe(0)

--- a/playground/resolve/importattributes.js
+++ b/playground/resolve/importattributes.js
@@ -1,0 +1,3 @@
+import { msg as importAttributes } from '@virtual-file-import-attributes' with { foo: 'bar', baz: 'qux' }
+
+export const msg = importAttributes

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -167,6 +167,9 @@
 <h2>resolve package that contains # in path</h2>
 <p class="path-contains-sharp-symbol"></p>
 
+<h2>Resolving import attributes</h2>
+<p class="import-attributes">fail</p>
+
 <script type="module">
   import '@generated-content-virtual-file'
   function text(selector, text) {
@@ -384,6 +387,9 @@
     '.path-contains-sharp-symbol',
     `[success] ${contains.call('#', '#')} ${last.call('#')}`,
   )
+
+  import { msg as importAttributes } from './importattributes'
+  text('.import-attributes', importAttributes)
 </script>
 
 <style>

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -24,6 +24,10 @@ const generatedContentImports = [
   },
 ]
 
+const virtualFileImportAttributes = '@virtual-file-import-attributes'
+const virtualIdImportAttributes = '\0' + virtualFileImportAttributes
+let importAttributes = {}
+
 export default defineConfig({
   resolve: {
     extensions: ['.mjs', '.js', '.es', '.ts'],
@@ -96,6 +100,27 @@ export default defineConfig({
             '}\n\n' +
             tests
           )
+        }
+      },
+    },
+    {
+      name: 'import-attributes',
+      resolveId(id, _importer, options) {
+        if (id === virtualFileImportAttributes) {
+          importAttributes = options.attributes
+          return virtualIdImportAttributes
+        }
+      },
+      load(id) {
+        if (id === virtualIdImportAttributes) {
+          if (
+            importAttributes.foo === 'bar' &&
+            importAttributes.baz === 'qux'
+          ) {
+            return `export const msg = "[success] from custom virtual file"`
+          } else {
+            return `export const msg = "fail"`
+          }
         }
       },
     },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes https://github.com/vitejs/vite/issues/14674

Adds support for import attributes by parsing them in the import analysis plugin.

### Additional context

How this works:

- es-module-lexer provides information about where the attributes are. We already use this to clip them off.
- We grab the string, which is an object literal `{ foo: 'bar' }`
- We use Acorn to parse this string.
- Iterate over the AST to extract the values into an object
- Pass this through to resolveId where plugins can do what they want.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
