### PR TITLE
fix(ssr): support externalized builtins for webworker

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -136,7 +136,11 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
     preferRelative = false,
   } = resolveOptions
 
-  const { target: ssrTarget, noExternal: ssrNoExternal } = ssrConfig ?? {}
+  const {
+    target: ssrTarget,
+    noExternal: ssrNoExternal,
+    external: ssrExternal,
+  } = ssrConfig ?? {}
 
   // In unix systems, absolute paths inside root first needs to be checked as an
   // absolute URL (/root/root/path-to-file) resulting in failed checks before falling
@@ -395,7 +399,12 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         // externalize if building for SSR, otherwise redirect to empty module
         if (isBuiltin(id)) {
           if (ssr) {
-            if (ssrNoExternal === true) {
+            if (
+              ssrNoExternal === true &&
+              // if both noExternal and external are true, noExternal will take the higher priority and bundle it.
+              // only if the id is explicitly listed in external, we will externalize it and skip this error.
+              (ssrExternal === true || !ssrExternal?.includes(id))
+            ) {
               let message = `Cannot bundle Node.js built-in "${id}"`
               if (importer) {
                 message += ` imported from "${path.relative(

--- a/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
+++ b/playground/ssr-webworker/__tests__/ssr-webworker.spec.ts
@@ -23,6 +23,13 @@ test('respects browser export', async () => {
   )
 })
 
+test('supports nodejs_compat', async () => {
+  await page.goto(url)
+  expect(await page.textContent('.nodejs-compat')).toMatch(
+    '[success] nodejs compat',
+  )
+})
+
 test.runIf(isBuild)('inlineDynamicImports', () => {
   const dynamicJsContent = findAssetFile(/dynamic-[-\w]+\.js/, 'worker')
   expect(dynamicJsContent).toBe('')

--- a/playground/ssr-webworker/src/entry-worker.jsx
+++ b/playground/ssr-webworker/src/entry-worker.jsx
@@ -1,3 +1,4 @@
+import { equal } from 'node:assert'
 import { msg as linkedMsg } from '@vitejs/test-resolve-linked'
 import browserExportsMessage from '@vitejs/test-browser-exports'
 import workerExportsMessage from '@vitejs/test-worker-exports'
@@ -18,6 +19,7 @@ addEventListener('fetch', function (event) {
     <p>dynamic: ${loaded}</p>
     <p class="browser-exports">${browserExportsMessage}</p>
     <p class="worker-exports">${workerExportsMessage}</p>
+    <p class="nodejs-compat">${equal('a', 'a') || '[success] nodejs compat'}</p>
     `,
       {
         headers: {

--- a/playground/ssr-webworker/vite.config.js
+++ b/playground/ssr-webworker/vite.config.js
@@ -11,6 +11,9 @@ export default defineConfig({
   ssr: {
     target: 'webworker',
     noExternal: ['this-should-be-replaced-by-the-boolean'],
+    // Some webworker builds may choose to externalize node builtins as they may be implemented
+    // in the runtime, and so we can externalize it when bundling.
+    external: ['node:assert'],
   },
   plugins: [
     {

--- a/playground/ssr-webworker/worker.js
+++ b/playground/ssr-webworker/worker.js
@@ -10,6 +10,8 @@ export async function createServer(port) {
   const mf = new Miniflare({
     scriptPath: path.resolve(__dirname, 'dist/worker/entry-worker.js'),
     port,
+    modules: true,
+    compatibilityFlags: ['nodejs_compat'],
   })
   await mf.ready
   return { mf }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

webworker builds such as Cloudflare these days support ESM and [nodejs compat modules](https://developers.cloudflare.com/workers/configuration/compatibility-dates/#nodejs-compatibility-flag). So some framework may choose to `noExternal: true` but externalize the nodejs builtins so that they can be used in the runtime.

Currently our hardcoded "if `ssrNoExternal === true` => error" flow, blocks bundling when encountering imports to the builtin. To be consistent with the new description in Vite 5.1:

https://main.vitejs.dev/config/ssr-options.html#ssr-noexternal
> **ssr.noExternal** ... However, dependencies explicitly listed in ssr.external (using string[] type) can take priority and still be externalized.

If the builtins are specified in `ssr.external`, we will now allow bundling it.

### Additional context

I thought about re-using `shouldExternalize` to update the conditions, but it has its internal `isBuiltin` check that doesn't make it work.

This PR could also unblock frameworks to do a single Vite build, instead of needing a secondary esbuild bundle for cloudflare worker builds.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
