### PR TITLE
fix(ssr): mark builtin modules as side effect free

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -407,7 +407,9 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
               this.error(message)
             }
 
-            return options.idOnly ? id : { id, external: true }
+            return options.idOnly
+              ? id
+              : { id, external: true, moduleSideEffects: false }
           } else {
             if (!asSrc) {
               debug?.(

--- a/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
+++ b/playground/ssr-resolve/__tests__/ssr-resolve.spec.ts
@@ -25,3 +25,11 @@ test.runIf(isBuild)('correctly resolve entrypoints', async () => {
 
   await expect(import(`${testDir}/dist/main.mjs`)).resolves.toBeTruthy()
 })
+
+test.runIf(isBuild)(
+  'node builtins should not be bundled if not used',
+  async () => {
+    const contents = readFile('dist/main.mjs')
+    expect(contents).not.include(`node:url`)
+  },
+)

--- a/playground/ssr-resolve/main.js
+++ b/playground/ssr-resolve/main.js
@@ -6,6 +6,7 @@ import fileEntry from '@vitejs/test-entries/file'
 import pkgExportsEntry from '@vitejs/test-resolve-pkg-exports/entry'
 import deepFoo from '@vitejs/test-deep-import/foo'
 import deepBar from '@vitejs/test-deep-import/bar'
+import { used } from './util'
 
 export default `
   entries/dir: ${dirEntry}
@@ -13,4 +14,5 @@ export default `
   pkg-exports/entry: ${pkgExportsEntry}
   deep-import/foo: ${deepFoo}
   deep-import/bar: ${deepBar}
+  util: ${used(['[success]'])}
 `

--- a/playground/ssr-resolve/util.js
+++ b/playground/ssr-resolve/util.js
@@ -1,0 +1,10 @@
+import { pathToFileURL } from 'node:url'
+
+export function used(s) {
+  return s
+}
+
+// This is not used, so `node:url` should not be bundled
+export function treeshaken(s) {
+  return pathToFileURL(s)
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently all builtin modules are mark as a side-effect by default. This PR forces them as side-effect-free so they don't get imported if the code that uses it got treeshaken away.

While I think it's hard to guarantee all builtin modules (including deno and bun) in the future will remain side-effect free, I think it's probably a safe assumption for now, and we can manually mark those that are not in the future in a non-breaking way.

Having this optimization will help bundling libraries or code that may accidentally reference node builtins, but are not actually using it. There is the valid argument that the code shouldn't have referenced them in the first place though 🤔 

### Additional context

similar esbuild issue: https://github.com/evanw/esbuild/issues/705

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
