### PR TITLE
fix(node): remove timestamp query of `staticImportedUrls`

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -43,6 +43,7 @@ import {
   normalizePath,
   prettifyUrl,
   removeImportQuery,
+  removeTimestampQuery,
   stripBase,
   stripBomTag,
   timeFrom,
@@ -685,7 +686,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // `importedUrls` will be mixed with watched files for the module graph,
       // `staticImportedUrls` will only contain the static top-level imports and
       // dynamic imports
-      const staticImportedUrls = new Set(_orderedImportedUrls)
+      const staticImportedUrls = new Set(
+        _orderedImportedUrls.map((url) => removeTimestampQuery(url)),
+      )
       const acceptedUrls = mergeAcceptedUrls(orderedAcceptedUrls)
       const acceptedExports = mergeAcceptedUrls(orderedAcceptedExports)
 

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -186,6 +186,17 @@ if (!isBuild) {
       () => el.textContent(),
       'soft-invalidation/index.js is transformed 1 times. child is updated',
     )
+
+    editFile('soft-invalidation/index.js', (code) =>
+      code.replace('child is', 'child is now'),
+    )
+    editFile('soft-invalidation/child.js', (code) =>
+      code.replace('updated', 'updated?'),
+    )
+    await untilUpdated(
+      () => el.textContent(),
+      'soft-invalidation/index.js is transformed 2 times. child is now updated?',
+    )
   })
 
   test('plugin hmr handler + custom event', async () => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fixes #15607

~I would like to add some tests for it, but I am not sure how to make the imports to have the timestamp query.~

~The `playground/hmr/soft-invalidate`'s imports don't seem to have timestamp query when imported.~

~I'll try to find it my own, but if anyone can show me the way, I'll add some tests as well.~

Does this issue happen because of how `.vue` parses the `imports`?

Because in [`playground/hmr/soft-invalidate`](https://github.com/vitejs/vite/tree/df8f5a50e6fde343653ee6b2ceaa42583ff33ebc/playground/hmr/soft-invalidation), changing `child.js` after changing `index.js` triggers soft-invalidation of `index.js` and it is correctly updates the value of `foo`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
