### PR TITLE
fix: default sideEffect option is delivered to rollup

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -21,7 +21,7 @@ export type PackageCache = Map<string, PackageData>
 
 export interface PackageData {
   dir: string
-  hasSideEffects: (id: string) => boolean | 'no-treeshake'
+  hasSideEffects: (id: string) => boolean | 'no-treeshake' | null
   webResolvedImports: Record<string, string | undefined>
   nodeResolvedImports: Record<string, string | undefined>
   setResolvedCache: (key: string, entry: string, targetWeb: boolean) => void
@@ -171,7 +171,7 @@ export function loadPackageData(pkgPath: string): PackageData {
   const data = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'))
   const pkgDir = path.dirname(pkgPath)
   const { sideEffects } = data
-  let hasSideEffects: (id: string) => boolean
+  let hasSideEffects: (id: string) => boolean | null
   if (typeof sideEffects === 'boolean') {
     hasSideEffects = () => sideEffects
   } else if (Array.isArray(sideEffects)) {
@@ -191,7 +191,7 @@ export function loadPackageData(pkgPath: string): PackageData {
       resolve: pkgDir,
     })
   } else {
-    hasSideEffects = () => true
+    hasSideEffects = () => null
   }
 
   const pkg: PackageData = {


### PR DESCRIPTION
### Description

fix: https://github.com/vitejs/vite/issues/15660

### Additional context

I think the priority of `sideEffect` in `package.json` is higher than the `moduleSideEffects` configuration in `rollup`, and the configuration takes precedence over the default value `true`. When the `sideEffect` option is not specified in `package.json`, pass `null` value to `rollup`. `rollup` will determine the value of `moduleSideEffects` based on the `treeshake.moduleSideEffects` configuration item or a fallback default value of `true`. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
