### PR TITLE
fix(create-vite): turn off `react/jsx-no-target-blank` ESLint rule in React JS template

### DIFF
--- a/packages/create-vite/template-react/.eslintrc.cjs
+++ b/packages/create-vite/template-react/.eslintrc.cjs
@@ -12,6 +12,7 @@ module.exports = {
   settings: { react: { version: '18.2' } },
   plugins: ['react-refresh'],
   rules: {
+    'react/jsx-no-target-blank': 'off',
     'react-refresh/only-export-components': [
       'warn',
       { allowConstantExport: true },


### PR DESCRIPTION
Adresses: https://github.com/vitejs/vite/pull/13750#issuecomment-1879737111

Changing it upstream has already been suggested: https://github.com/jsx-eslint/eslint-plugin-react/issues/3552