### PR TITLE
fix(hmr): don't bind hmr methods to the context class

### DIFF
--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -71,7 +71,7 @@ export class HMRContext implements ViteHotContext {
     return this.hmrClient.dataMap.get(this.ownerPath)
   }
 
-  accept(deps?: any, callback?: any): void {
+  accept = (deps?: any, callback?: any): void => {
     if (typeof deps === 'function' || !deps) {
       // self-accept: hot.accept(() => {})
       this.acceptDeps([this.ownerPath], ([mod]) => deps?.(mod))
@@ -87,18 +87,18 @@ export class HMRContext implements ViteHotContext {
 
   // export names (first arg) are irrelevant on the client side, they're
   // extracted in the server for propagation
-  acceptExports(
+  acceptExports = (
     _: string | readonly string[],
     callback: (data: any) => void,
-  ): void {
+  ): void => {
     this.acceptDeps([this.ownerPath], ([mod]) => callback?.(mod))
   }
 
-  dispose(cb: (data: any) => void): void {
+  dispose = (cb: (data: any) => void): void => {
     this.hmrClient.disposeMap.set(this.ownerPath, cb)
   }
 
-  prune(cb: (data: any) => void): void {
+  prune = (cb: (data: any) => void): void => {
     this.hmrClient.pruneMap.set(this.ownerPath, cb)
   }
 
@@ -106,7 +106,7 @@ export class HMRContext implements ViteHotContext {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   decline(): void {}
 
-  invalidate(message: string): void {
+  invalidate = (message: string): void => {
     this.hmrClient.notifyListeners('vite:invalidate', {
       path: this.ownerPath,
       message,
@@ -117,10 +117,10 @@ export class HMRContext implements ViteHotContext {
     )
   }
 
-  on<T extends string>(
+  on = <T extends string>(
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
-  ): void {
+  ): void => {
     const addToMap = (map: Map<string, any[]>) => {
       const existing = map.get(event) || []
       existing.push(cb)
@@ -130,10 +130,10 @@ export class HMRContext implements ViteHotContext {
     addToMap(this.newListeners)
   }
 
-  off<T extends string>(
+  off = <T extends string>(
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
-  ): void {
+  ): void => {
     const removeFromMap = (map: Map<string, any[]>) => {
       const existing = map.get(event)
       if (existing === undefined) {
@@ -150,7 +150,10 @@ export class HMRContext implements ViteHotContext {
     removeFromMap(this.newListeners)
   }
 
-  send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void {
+  send = <T extends string>(
+    event: T,
+    data?: InferCustomEventPayload<T>,
+  ): void => {
     this.hmrClient.messenger.send(
       JSON.stringify({ type: 'custom', event, data }),
     )


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #15667

Instead of rewriting the context back to the object implementation, I decided it would be nice to keep the class for organizational purposes. Providing methods via an arrow function allows us to use `this` without binding the method because it will be transformed into something like this:

```ts
class Context {
  constructor() {
    this.accept = () => {
      this.hmtClient.send()
    }
  }
}
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
