### PR TITLE
feat: enable fs.cachedChecks by default

### DIFF
--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import colors from 'picocolors'
 import type { FSWatcher } from 'dep-types/chokidar'
 import type { ResolvedConfig } from './config'
 import {

--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -49,27 +49,10 @@ export function getFsUtils(config: ResolvedConfig): FsUtils {
       // cached fsUtils is only used in the dev server for now, and only when the watcher isn't configured
       // we can support custom ignored patterns later
       fsUtils = commonFsUtils
-    } /* TODO: Enabling for testing, we need to review if this guard is needed
-    else if (config.server.watch === null || config.server.watch?.ignored) {
-      config.logger.warn(
-        colors.yellow(
-          `${colors.bold(
-            `(!)`,
-          )} server.fs.cachedChecks isn't supported if server.watch is null or a custom server.watch.ignored is configured\n`,
-        ),
-      )
-      fsUtils = commonFsUtils
-    } */ else if (
+    } else if (
       !config.resolve.preserveSymlinks &&
       config.root !== getRealPath(config.root)
     ) {
-      config.logger.warn(
-        colors.yellow(
-          `${colors.bold(
-            `(!)`,
-          )} server.fs.cachedChecks isn't supported when resolve.preserveSymlinks is false and root is symlinked\n`,
-        ),
-      )
       fsUtils = commonFsUtils
     } else {
       fsUtils = createCachedFsUtils(config)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -194,7 +194,7 @@ export interface FileSystemServeOptions {
    * Enable caching of fs calls.
    *
    * @experimental
-   * @default false
+   * @default true
    */
   cachedChecks?: boolean
 }
@@ -989,8 +989,7 @@ export function resolveServerOptions(
     strict: server.fs?.strict ?? true,
     allow: allowDirs,
     deny,
-    cachedChecks:
-      server.fs?.cachedChecks ?? !!process.env.VITE_SERVER_FS_CACHED_CHECKS,
+    cachedChecks: server.fs?.cachedChecks ?? true,
   }
 
   if (server.origin?.endsWith('/')) {

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -46,7 +46,7 @@ export default defineConfig({
 
   server: {
     fs: {
-      cachedChecks: true,
+      cachedChecks: false,
     },
     warmup: {
       clientFiles: ['./warmup/*'],


### PR DESCRIPTION
### Description

`fs.cachedChecks` has been available and opt-in from vite@5.0.8.

See:
- https://github.com/vitejs/vite/pull/15279

In Windows, we have:
- tryFsResolve: 179.71ms -> 13.16ms (~14x faster)
- resolveId: 234ms -> 50ms (~4.7x faster)
- 5% overall

This PR switches the flag to be enabled by default.

We also consider that if there is custom watch ignore options, the user is opting into not watching these files not only HMR but also for resolving.

In future PRs we need to:
- move the public files fs caching implementation to use this new cache
- re-define the fs cache root to be the root of the monorepo instead of `root` to better support that use case
- decide if sharing cached trees is worth the extra complexity: https://github.com/vitejs/vite/pull/15294

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
