### PR TITLE
fix: add ref() and unref() to chokidar.d.ts for typescript build to work.

### DIFF
--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -45,6 +45,14 @@ class NoopWatcher extends EventEmitter implements FSWatcher {
     return {}
   }
 
+  ref() {
+    return this
+  }
+
+  unref() {
+    return this
+  }
+
   async close() {
     // noop
   }

--- a/packages/vite/src/types/chokidar.d.ts
+++ b/packages/vite/src/types/chokidar.d.ts
@@ -41,17 +41,17 @@ export class FSWatcher extends EventEmitter implements fs.FSWatcher {
   constructor(options?: WatchOptions)
 
   /**
-   * When called, requests that the Node.js event loop not exit so long as the fs.FSWatcher is active. 
+   * When called, requests that the Node.js event loop not exit so long as the fs.FSWatcher is active.
    * Calling watcher.ref() multiple times will have no effect.
    */
-  ref(): this;
+  ref(): this
 
   /**
-   * When called, the active fs.FSWatcher object will not require the Node.js event loop to remain active. 
-   * If there is no other activity keeping the event loop running, the process may exit before the fs.FSWatcher object's callback is invoked. 
+   * When called, the active fs.FSWatcher object will not require the Node.js event loop to remain active.
+   * If there is no other activity keeping the event loop running, the process may exit before the fs.FSWatcher object's callback is invoked.
    * Calling watcher.unref() multiple times will have no effect.
    */
-  unref(): this;
+  unref(): this
 
   /**
    * Add files, directories, or glob patterns for tracking. Takes an array of strings or just one

--- a/packages/vite/src/types/chokidar.d.ts
+++ b/packages/vite/src/types/chokidar.d.ts
@@ -41,6 +41,19 @@ export class FSWatcher extends EventEmitter implements fs.FSWatcher {
   constructor(options?: WatchOptions)
 
   /**
+   * When called, requests that the Node.js event loop not exit so long as the fs.FSWatcher is active. 
+   * Calling watcher.ref() multiple times will have no effect.
+   */
+  ref(): this;
+
+  /**
+   * When called, the active fs.FSWatcher object will not require the Node.js event loop to remain active. 
+   * If there is no other activity keeping the event loop running, the process may exit before the fs.FSWatcher object's callback is invoked. 
+   * Calling watcher.unref() multiple times will have no effect.
+   */
+  unref(): this;
+
+  /**
    * Add files, directories, or glob patterns for tracking. Takes an array of strings or just one
    * string.
    */


### PR DESCRIPTION
### Description

When attempting to build a vite project after updating from 5.0.8 to 5.0.12, received following error:
 ERROR(TypeScript)  Class 'import("D:/Projects/PROJECT/node_modules/vite/dist/node/index").FSWatcher' incorrectly implements interface 'import("fs").FSWatcher'.
  Type 'FSWatcher' is missing the following properties from type 'FSWatcher': ref, unref
 FILE  D:/Projects/PROJECT/node_modules/vite/dist/node/index.d.ts:68:15

    66 | // Inlined to avoid extra dependency (chokidar is bundled in the published build)
    67 |
  > 68 | declare class FSWatcher extends EventEmitter implements fs.FSWatcher {
       |               ^^^^^^^^^
    69 |   options: WatchOptions
    70 |
    71 |   /**

### Additional context
Not 100% certain if this is the perfect fix, but adding the same two methods to vite/dist/node/index.d.ts allowed build to complete successfully. (Sorry, First time contributing, have read guidelines but nearly certainly have missed something!)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
