### PR TITLE
fix(hmr): pass id in `parseImports` for better debugging DX

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -418,7 +418,7 @@ async function handleModuleSoftInvalidation(
     await init
     const source = transformResult.code
     const s = new MagicString(source)
-    const [imports] = parseImports(source)
+    const [imports] = parseImports(source, mod.id || undefined)
 
     for (const imp of imports) {
       let rawUrl = source.slice(imp.s, imp.e)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When the source get syntax errors, we see error message like this:

<img width="664" alt="image" src="https://github.com/vitejs/vite/assets/11247099/263a8ec3-bf6a-4613-bed8-914b5df06a37">

The random `@` comes from the default value of `es-module-lexer`: https://github.com/guybedford/es-module-lexer/blob/c357368bd4681011bc938ec54d48b2c6a969672b/src/lexer.ts#L156

We should provide correct file name for easier to understand what's goes wrong.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
