### PR TITLE
fix(server): only warn sourcemap in `loadTransform` when explicitly turned on

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -240,9 +240,11 @@ async function loadAndTransform(
 
         code = code.replace(convertSourceMap.mapFileCommentRegex, blankReplacer)
       } catch (e) {
-        logger.warn(`Failed to load source map for ${url}.`, {
-          timestamp: true,
-        })
+        if (server.config.build.sourcemap) {
+          logger.warn(`Failed to load source map for ${url}.`, {
+            timestamp: true,
+          })
+        }
       }
     }
   } else {


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

We got quite some warnings regarding sourcemap when we never need them, and it seems there is no way to disable it:

<img width="1232" alt="image" src="https://github.com/vitejs/vite/assets/11247099/3e1e609f-bd9b-4903-87db-0ca0191847f9">

This kind of warning is generally useless but quite annoying to the end users. I think it make more sense only to warn when sourcemap is enabled.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
