### PR TITLE
perf: use workspace root for fs cache

### DIFF
--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -8,6 +8,7 @@ import {
   safeRealpathSync,
   tryStatSync,
 } from './utils'
+import { searchForWorkspaceRoot } from './server/searchRoot'
 
 export interface FsUtils {
   existsSync: (path: string) => boolean
@@ -124,7 +125,7 @@ function pathUntilPart(root: string, parts: string[], i: number): string {
 }
 
 export function createCachedFsUtils(config: ResolvedConfig): FsUtils {
-  const root = config.root // root is resolved and normalized, so it doesn't have a trailing slash
+  const root = normalizePath(searchForWorkspaceRoot(config.root))
   const rootDirPath = `${root}/`
   const rootCache: DirentCache = { type: 'directory' } // dirents will be computed lazily
 


### PR DESCRIPTION
### Description

In monorepos, we'd like resolving files from one package to the other to go through the fs cache. For example, when there is a design system package and an app, before this PR, importing a design system component from the app won't hit the cache. We saw at internal cpuprofiles from a large enterprise app that resolving was still the bottleneck because of this.

This PR caches from the workspace root instead of the project root.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other