### PR TITLE
chore: remove unneeded normalizePath

### DIFF
--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -209,7 +209,7 @@ export function createCachedFsUtils(config: ResolvedConfig): FsUtils {
       direntCache.type === 'directory' &&
       direntCache.dirents
     ) {
-      direntCache.dirents.set(normalizePath(path.basename(file)), { type })
+      direntCache.dirents.set(path.basename(file), { type })
     }
   }
 
@@ -222,7 +222,7 @@ export function createCachedFsUtils(config: ResolvedConfig): FsUtils {
       direntCache.type === 'directory' &&
       direntCache.dirents
     ) {
-      direntCache.dirents.delete(normalizePath(path.basename(file)))
+      direntCache.dirents.delete(path.basename(file))
     }
   }
 


### PR DESCRIPTION
### Description

I sent [a commit](https://github.com/vitejs/vite/commit/3a7b65041be14950585d582b5181f5ad1189d8e4
) to fix this [failing test](https://github.com/vitejs/vite/actions/runs/7636256669/job/20810614360?pr=15704#step:13:114) to main directly.

@bluwy noticed these `normalizePath` wasn't needed.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
