### PR TITLE
test: fix proxy-bypass and proxy-hmr ports

### DIFF
--- a/playground/proxy-bypass/index.html
+++ b/playground/proxy-bypass/index.html
@@ -1,2 +1,2 @@
 root app<br />
-<iframe src="/anotherApp" style="border: 0"></iframe>
+<iframe src="/nonExistentApp" style="border: 0"></iframe>

--- a/playground/proxy-bypass/vite.config.js
+++ b/playground/proxy-bypass/vite.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
   server: {
     port: 9606,
     proxy: {
-      '/anotherApp': {
+      '/nonExistentApp': {
         target: 'http://localhost:9607',
         bypass: () => {
           return false

--- a/playground/proxy-hmr/other-app/vite.config.js
+++ b/playground/proxy-hmr/other-app/vite.config.js
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   base: '/anotherApp',
   server: {
-    port: 9607,
+    port: 9617,
     strictPort: true,
   },
 })

--- a/playground/proxy-hmr/vite.config.js
+++ b/playground/proxy-hmr/vite.config.js
@@ -2,10 +2,10 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   server: {
-    port: 9606,
+    port: 9616,
     proxy: {
       '/anotherApp': {
-        target: 'http://localhost:9607',
+        target: 'http://localhost:9617',
         ws: true,
       },
     },

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -35,9 +35,11 @@ export const ports = {
   'ssr-noexternal': 9603,
   'ssr-pug': 9604,
   'ssr-webworker': 9605,
-  'proxy-hmr': 9606, // not imported but used in `proxy-hmr/vite.config.js`
-  'proxy-hmr/other-app': 9607, // not imported but used in `proxy-hmr/other-app/vite.config.js`
-  'ssr-conditions': 9608,
+  'proxy-bypass': 9606, // not imported but used in `proxy-hmr/vite.config.js`
+  'proxy-bypass/non-existent-app': 9607, // not imported but used in `proxy-hmr/other-app/vite.config.js`
+  'proxy-hmr': 9616, // not imported but used in `proxy-hmr/vite.config.js`
+  'proxy-hmr/other-app': 9617, // not imported but used in `proxy-hmr/other-app/vite.config.js`
+  'ssr-conditions': 9620,
   'css/postcss-caching': 5005,
   'css/postcss-plugins-different-dir': 5006,
   'css/dynamic-import': 5007,


### PR DESCRIPTION
### Description

The proxy-bypass and proxy-hmr playgrounds were both using the same set of ports (9606 and 9607). This PR should solve this kind of flaky tests in CI: https://github.com/vitejs/vite/actions/runs/7522448612/job/20489645461?pr=15599#step:14:164, here the next playground was using 9608 and these three playgrounds ended up interacting between each other.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other