### PR TITLE
fix: warn on missing optional peer deps during build

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -456,10 +456,13 @@ export default new Proxy({}, {
         }
       }
       if (id.startsWith(optionalPeerDepId)) {
+        const [, peerDep, parentDep] = id.split(':')
         if (isProduction) {
+          this.warn(
+            `Could not resolve "${peerDep}" imported by "${parentDep}". Is it installed?`,
+          )
           return `export default {}`
         } else {
-          const [, peerDep, parentDep] = id.split(':')
           return `throw new Error(\`Could not resolve "${peerDep}" imported by "${parentDep}". Is it installed?\`)`
         }
       }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Closes https://github.com/vitejs/vite/issues/15733

I wrote my findings in https://github.com/vitejs/vite/issues/15733#issuecomment-1913868095 and it looks reasonable to treat this case similar to node builtin and log warning to notify users about potential issues with their build https://github.com/vitejs/vite/pull/12616

The node builtin warning happens during `resolveId` hook, but for missing peer dep, I added a warning during `load` hook since it looks simpler to implement in this way and probably there's no substantial difference for users.

I haven't added a test but verified manually on playground by:

```sh
$ pnpm -C playground/optimize-deps build

> @vitejs/test-optimize-deps@0.0.0 build /home/hiroshi/code/others/vite/playground/optimize-deps
> vite build

...
[plugin:vite:resolve] Could not resolve "foobar/baz" imported by "@vitejs/test-dep-with-optional-peer-dep-submodule". Is it installed?
[plugin:vite:resolve] Could not resolve "foobar" imported by "@vitejs/test-dep-with-optional-peer-dep". Is it installed?
...
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
