### PR TITLE
test: remove unnecessary NODE_ENV override

### DIFF
--- a/playground/optimize-deps/vite.config.js
+++ b/playground/optimize-deps/vite.config.js
@@ -3,9 +3,6 @@ import module from 'node:module'
 import { defineConfig } from 'vite'
 const require = module.createRequire(import.meta.url)
 
-// Overriding the NODE_ENV set by vitest
-process.env.NODE_ENV = ''
-
 export default defineConfig({
   resolve: {
     dedupe: ['react'],


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I noticed that currently `pnpm -C playground/optimize-deps build` is failing potentially due to this `NODE_ENV` override. The playground tests seem to be passing locally without it, so I'm wondering if this trick might be obsolete now. (ref: https://github.com/vitejs/vite/pull/8218#discussion_r879454530, https://github.com/vitejs/vite/pull/9058, https://github.com/vitejs/vite/pull/9066)

Adding `console.log("[NODE_ENV]", process.env.NODE_ENV)` in `vite.config.js`, this is how it looks:

```sh
$ pnpm test-build playground/optimize-deps 
...

stdout | file:/home/hiroshi/code/others/vite/playground-temp/optimize-deps/playground-temp/optimize-deps/vite.config.js:8:9
[NODE_ENV] production


$ pnpm test-serve playground/optimize-deps 
...

stdout | file:/home/hiroshi/code/others/vite/playground-temp/optimize-deps/playground-temp/optimize-deps/vite.config.js:8:9
[NODE_ENV] development
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
