### PR TITLE
fix: scan entries when the root is in node_modules

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -239,15 +239,16 @@ function orderedDependencies(deps: Record<string, string>) {
 }
 
 function globEntries(pattern: string | string[], config: ResolvedConfig) {
+  const rootPattern = glob.convertPathToPattern(config.root)
   return glob(pattern, {
     cwd: config.root,
     ignore: [
-      '**/node_modules/**',
-      `**/${config.build.outDir}/**`,
+      `${rootPattern}/**/node_modules/**`,
+      `${rootPattern}/**/${config.build.outDir}/**`,
       // if there aren't explicit entries, also ignore other common folders
       ...(config.optimizeDeps.entries
         ? []
-        : [`**/__tests__/**`, `**/coverage/**`]),
+        : [`${rootPattern}/**/__tests__/**`, `${rootPattern}/**/coverage/**`]),
     ],
     absolute: true,
     suppressErrors: true, // suppress EACCES errors


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixed optimizer entries in the case the root is in node_modules

### Additional context

https://github.com/vitejs/vite/discussions/15613#discussioncomment-8277522

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
