### PR TITLE
feat: warn if `?` in project root

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -477,17 +477,17 @@ export async function resolveConfig(
   const resolvedRoot = normalizePath(
     config.root ? path.resolve(config.root) : process.cwd(),
   )
-  const notAcceptableCharacters = ["#","?"]
+  const notAcceptableCharacters = ['#', '?']
 
-  notAcceptableCharacters.forEach(character => {
+  notAcceptableCharacters.forEach((character) => {
     if (resolvedRoot.includes(character)) {
       logger.warn(
         colors.yellow(
           `The project root contains the "${character}" character (${colors.cyan(resolvedRoot)}), which may not work when running Vite. Consider renaming the directory to remove the "${character}".`,
         ),
-      );
+      )
     }
-  });  
+  })
 
   const clientAlias = [
     {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -477,15 +477,17 @@ export async function resolveConfig(
   const resolvedRoot = normalizePath(
     config.root ? path.resolve(config.root) : process.cwd(),
   )
-  if (resolvedRoot.includes('#')) {
-    logger.warn(
-      colors.yellow(
-        `The project root contains the "#" character (${colors.cyan(
-          resolvedRoot,
-        )}), which may not work when running Vite. Consider renaming the directory to remove the "#".`,
-      ),
-    )
-  }
+  const notAcceptableCharacters = ["#","?"]
+
+  notAcceptableCharacters.forEach(character => {
+    if (resolvedRoot.includes(character)) {
+      logger.warn(
+        colors.yellow(
+          `The project root contains the "${character}" character (${colors.cyan(resolvedRoot)}), which may not work when running Vite. Consider renaming the directory to remove the "${character}".`,
+        ),
+      );
+    }
+  });  
 
   const clientAlias = [
     {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix #15726

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

since both `#` and `?` are targets for remaining, i use `forEach`.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
