### PR TITLE
perf: remove unnecessary regex s modifier

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -435,7 +435,7 @@ export function injectQuery(url: string, queryToInject: string): string {
   }
 
   // can't use pathname from URL since it may be relative like ../
-  const pathname = url.replace(/[?#].*$/s, '')
+  const pathname = url.replace(/[?#].*$/, '')
   const { search, hash } = new URL(url, 'http://vitejs.dev')
 
   return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -1030,7 +1030,7 @@ function __vite__injectQuery(url: string, queryToInject: string): string {
   }
 
   // can't use pathname from URL since it may be relative like ../
-  const pathname = url.replace(/[?#].*$/s, '')
+  const pathname = url.replace(/[?#].*$/, '')
   const { search, hash } = new URL(url, 'http://vitejs.dev')
 
   return `${pathname}?${queryToInject}${search ? `&` + search.slice(1) : ''}${

--- a/packages/vite/src/node/ssr/runtime/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/utils.ts
@@ -27,7 +27,7 @@ export function slash(p: string): string {
   return p.replace(windowsSlashRE, '/')
 }
 
-const postfixRE = /[?#].*$/s
+const postfixRE = /[?#].*$/
 export function cleanUrl(url: string): string {
   return url.replace(postfixRE, '')
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -295,7 +295,7 @@ export function isSameFileUri(file1: string, file2: string): boolean {
 
 export const queryRE = /\?.*$/s
 
-const postfixRE = /[?#].*$/s
+const postfixRE = /[?#].*$/
 export function cleanUrl(url: string): string {
   return url.replace(postfixRE, '')
 }


### PR DESCRIPTION
### Description

#### Minor bug fix: 

Fixes bug caused by this commit: [2687dbb](https://github.com/vitejs/vite/commit/2687dbb#r138126802)
It is just a regex equivalent replacement: 
`.` with `s` modifier is 100% equal to `[\s\S]` without `s` modifier.

`s` modifier is causing older browsers to fail with a blank page with console error such as:
`SyntaxError: invalid regular expression flag s`


### Future Consideration

Please avoid accepting PRs that include commits including regex `s` modifier/flag.

---

### What is the purpose of this pull request?

- [x] Bug fix X
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines). X
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate. X
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`). X
- [x] Update the corresponding documentation if needed. X
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
