### PR TITLE
ci: use M1 machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         node_version: [18, 20]
         include:
           # Active LTS + other OS
-          - os: macos-latest
+          - os: macos-14 # use M1 machines
             node_version: 20
           - os: windows-latest
             node_version: 20


### PR DESCRIPTION
### Description

See https://x.com/yagiznizipli/status/1752740836461167041?s=20, macos-14 runs M1 machines now

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other