### PR TITLE
feat: skip soft invalidation error when timestamp mismatch

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -430,11 +430,13 @@ export class ModuleGraph {
   ): void {
     if (ssr) {
       mod.ssrTransformResult = result
+      mod.ssrInvalidationState = undefined
     } else {
       const prevEtag = mod.transformResult?.etag
       if (prevEtag) this.etagToModuleMap.delete(prevEtag)
 
       mod.transformResult = result
+      mod.invalidationState = undefined
 
       if (result?.etag) this.etagToModuleMap.set(result.etag, mod)
     }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -430,13 +430,11 @@ export class ModuleGraph {
   ): void {
     if (ssr) {
       mod.ssrTransformResult = result
-      mod.ssrInvalidationState = undefined
     } else {
       const prevEtag = mod.transformResult?.etag
       if (prevEtag) this.etagToModuleMap.delete(prevEtag)
 
       mod.transformResult = result
-      mod.invalidationState = undefined
 
       if (result?.etag) this.etagToModuleMap.set(result.etag, mod)
     }

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -400,10 +400,13 @@ async function handleModuleSoftInvalidation(
   // Skip if not soft-invalidated
   if (!transformResult || transformResult === 'HARD_INVALIDATED') return
 
-  if (ssr ? mod.ssrTransformResult : mod.transformResult) {
-    throw new Error(
-      `Internal server error: Soft-invalidated module "${mod.url}" should not have existing transform result`,
-    )
+  // Race condition could happend when invalidation is called before this process is finished
+  if (timestamp < mod.lastInvalidationTimestamp) {
+    if (ssr ? mod.ssrTransformResult : mod.transformResult) {
+      throw new Error(
+        `Internal server error: Soft-invalidated module "${mod.url}" should not have existing transform result`,
+      )
+    }
   }
 
   let result: TransformResult


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This check will be hit on a racing condition that invalidates module `invalidateModule` being called while the project is still warming up:

https://github.com/vitejs/vite/blob/8f5cdc889332950ec13e70c14e966f844ce97501/packages/vite/src/node/server/transformRequest.ts#L403-L407

This happens on UnoCSS because UnoCSS has a virtual module, `uno.css`, that serves to generate CSS based on the scanned source code. Meaning that it will self-invalidate whenever a new module is scanned (via the `transform` hook). In that case, it could cause the entry module (that imports `uno.css` into a soft invalidate state before its transforming process finishes).

Linked Issue: fix https://github.com/unocss/unocss/issues/3472

This PR fixes the racing condition by resetting the `InvalidationState` state on the new `transformResult` set.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
