### PR TITLE
fix: judge next dirent cache type

### DIFF
--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -148,11 +148,11 @@ export function createCachedFsUtils(config: ResolvedConfig): FsUtils {
           return
         }
         if (nextDirentCache.type === 'directory_maybe_symlink') {
-          dirPath ??= pathUntilPart(root, parts, i)
+          dirPath ??= pathUntilPart(root, parts, i + 1)
           const isSymlink = fs
             .lstatSync(dirPath, { throwIfNoEntry: false })
             ?.isSymbolicLink()
-          direntCache.type = isSymlink ? 'symlink' : 'directory'
+          nextDirentCache.type = isSymlink ? 'symlink' : 'directory'
         }
         direntCache = nextDirentCache
       } else if (direntCache.type === 'symlink') {


### PR DESCRIPTION
### Description
fix: https://github.com/vitejs/vite/issues/15784
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

If I understand correctly, we need to determine the type of the next Dirent here.

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
