### PR TITLE
fix(plugin-legacy): respect modernTargets option if renderLegacyChunks disabled

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -325,6 +325,10 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
       config = _config
 
+      modernTargets = options.modernTargets || modernTargetsBabel
+      isDebug &&
+        console.log(`[@vitejs/plugin-legacy] modernTargets:`, modernTargets)
+
       if (!genLegacy || config.build.ssr) {
         return
       }
@@ -334,10 +338,6 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         browserslistLoadConfig({ path: config.root }) ||
         'last 2 versions and not dead, > 0.3%, Firefox ESR'
       isDebug && console.log(`[@vitejs/plugin-legacy] targets:`, targets)
-
-      modernTargets = options.modernTargets || modernTargetsBabel
-      isDebug &&
-        console.log(`[@vitejs/plugin-legacy] modernTargets:`, modernTargets)
 
       const getLegacyOutputFileName = (
         fileNames:


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Fixes #15788 .

If `modernPolyfills` is set to `true`, but `renderLegacyChunks` is set to false, `genLegacy` will be false and we would return early. If this return happens before `modernTargets` is initialized, the modern polyfills will be generated with the wrong (default?) target instead of the specified `modernTargets`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
#14527 is related and lead to the introduction of `modernTargets` in #15506.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
