### PR TITLE
docs(features): clarify sentences about JSX usage

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -174,7 +174,7 @@ Vite provides first-class Vue support:
 
 Vue users should use the official [@vitejs/plugin-vue-jsx](https://github.com/vitejs/vite-plugin-vue/tree/main/packages/plugin-vue-jsx) plugin, which provides Vue 3 specific features including HMR, global component resolving, directives and slots.
 
-If not using JSX with React or Vue, custom `jsxFactory` and `jsxFragment` can be configured using the [`esbuild` option](/config/shared-options.md#esbuild). For example for Preact:
+If using JSX without React or Vue, custom `jsxFactory` and `jsxFragment` can be configured using the [`esbuild` option](/config/shared-options.md#esbuild). For example for Preact:
 
 ```js
 // vite.config.js


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR clarify the third sentence on this section about JSX usage: https://vitejs.dev/guide/features.html#jsx.

In my understanding, this section explains the situation where users do use JSX in a framework other than Vue or React. But the original sentence might be read as "When users don't use JSX in React or Vue" and want to write manually like `React.createElement('div', null, 'hello')`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This was pointed out by a Japanese reader: https://github.com/vitejs/docs-ja/issues/1296

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
