### PR TITLE
docs(api-javascript): update transformIndexHtml types

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -144,7 +144,11 @@ interface ViteDevServer {
   /**
    * Apply Vite built-in HTML transforms and any plugin HTML transforms.
    */
-  transformIndexHtml(url: string, html: string, originalUrl?: string): Promise<string>
+  transformIndexHtml(
+    url: string,
+    html: string,
+    originalUrl?: string,
+  ): Promise<string>
   /**
    * Load a given URL as an instantiated module for SSR.
    */

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -144,7 +144,7 @@ interface ViteDevServer {
   /**
    * Apply Vite built-in HTML transforms and any plugin HTML transforms.
    */
-  transformIndexHtml(url: string, html: string): Promise<string>
+  transformIndexHtml(url: string, html: string, originalUrl?: string): Promise<string>
   /**
    * Load a given URL as an instantiated module for SSR.
    */


### PR DESCRIPTION
## Description

ViteDevServer transformIndexHtml api is missing the 'originalUrl' parameter

## What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other
