### PR TITLE
feat(create-vite): allow overwrite in command line

### DIFF
--- a/packages/create-vite/__tests__/cli.spec.ts
+++ b/packages/create-vite/__tests__/cli.spec.ts
@@ -97,3 +97,9 @@ test('works with the -t alias', () => {
   expect(stdout).toContain(`Scaffolding project in ${genPath}`)
   expect(templateFiles).toEqual(generatedFiles)
 })
+
+test('accepts command line override for --overwrite', () => {
+  createNonEmptyDir()
+  const { stdout } = run(['.', '--overwrite', 'ignore'], { cwd: genPath })
+  expect(stdout).not.toContain(`Current directory is not empty.`)
+})

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -253,6 +253,10 @@ async function init() {
     'projectName' | 'overwrite' | 'packageName' | 'framework' | 'variant'
   >
 
+  prompts.override({
+    overwrite: argv.overwrite,
+  });
+
   try {
     result = await prompts(
       [

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -255,7 +255,7 @@ async function init() {
 
   prompts.override({
     overwrite: argv.overwrite,
-  });
+  })
 
   try {
     result = await prompts(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When creating a new vite project in a folder with existing files, allow the "overwrite" prompt to be passed as a command line argument to avoid the prompt.

Example:

```
npm create vite@latest . -- --overwrite "ignore" --template react-ts
```

### Additional context

To be able to pass the command line param and skip the prompt will allow to automate some deploys.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Update the corresponding documentation if needed.
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
