### PR TITLE
docs: add not about disabling the cache to the performance guide

### DIFF
--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -6,9 +6,11 @@ While Vite is fast by default, performance issues can creep in as the project's 
 - Slow page loads
 - Slow builds
 
-## Avoid Browser Extensions
+## Review your Browser Setup
 
 Some browser extensions may interfere with requests and slow down startup and reload times for large apps, especially when using browser dev tools. We recommend creating a dev-only profile without extensions, or switch to incognito mode, while using Vite's dev server in these cases. Incognito mode should also be faster than a regular profile without extensions.
+
+The Vite dev server does hard caching of pre-bundled dependencies and implements fast 304 responses for source code. Disabling the cache while the Browser Dev Tools are open can have a big impact in startup and full-page reload times. Please check that "Disable Cache" isn't enabled while you work with the Vite server.
 
 ## Audit Configured Vite Plugins
 


### PR DESCRIPTION
### Description

In the latest version of Chrome there is a warning in the Network tab title when Disable Cache is on. They got some backslash so I hope they wont remove it.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other