### PR TITLE
feat: support default option for bindCLIShortcuts

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -219,7 +219,7 @@ cli
           },
         })
       }
-      server.bindCLIShortcuts({ print: true, customShortcuts })
+      server.bindCLIShortcuts({ print: true, customShortcuts, default: true })
     } catch (e) {
       const logger = createLogger(options.logLevel)
       logger.error(colors.red(`error when starting dev server:\n${e.stack}`), {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix #15781

we can now add `default: false` to disable default shortcuts.

```js
configureServer(server) {
  devServer = server

  devServer.bindCLIShortcuts({
    print: true,
    defalut: false, // disable default shortcuts
    customShortcuts: [{
      key: 'p',
      description: 'xxxx',
      action(server) {
        console.log('test')
      }
    }]
  })
}
```

### Additional context

Also fixed double binding issue.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
