### PR TITLE
feat(create-vite): set "strict: true" in tsconfig.node.json

### DIFF
--- a/packages/create-vite/template-preact-ts/tsconfig.node.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/create-vite/template-qwik-ts/tsconfig.node.json
+++ b/packages/create-vite/template-qwik-ts/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/create-vite/template-react-ts/tsconfig.node.json
+++ b/packages/create-vite/template-react-ts/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/create-vite/template-solid-ts/tsconfig.node.json
+++ b/packages/create-vite/template-solid-ts/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/create-vite/template-svelte-ts/tsconfig.node.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.node.json
@@ -3,7 +3,8 @@
     "composite": true,
     "skipLibCheck": true,
     "module": "ESNext",
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/create-vite/template-vue-ts/tsconfig.node.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "strict": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

When using `@typescript-eslint/strict-type-checked` rule set on a fresh Vite project and `vite.config.ts` is included in the files that eslint runs on, it results in the following error:

```
  0:1  error  This rule requires the `strictNullChecks` compiler option to be turned on to function correctly  @typescript-eslint/prefer-nullish-coalescing
  0:1  error  This rule requires the `strictNullChecks` compiler option to be turned on to function correctly  @typescript-eslint/no-unnecessary-condition
```

Given that we have `strict` enabled in the main `tsconfig.json` it makes sense to have it enabled here too.

Here's an example `eslint.cjs` to use in a fresh Vite project where you can see this error:

```js
module.exports = {
  root: true,
  env: { browser: true, es2020: true },
  extends: [
    "eslint:recommended",
    "plugin:@typescript-eslint/strict-type-checked",
    "plugin:@typescript-eslint/stylistic-type-checked",
  ],
  parser: "@typescript-eslint/parser",
  parserOptions: {
    project: ["./tsconfig.json", "./tsconfig.node.json"],
    tsconfigRootDir: __dirname,
  },
};
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other
