### PR TITLE
fix: disable fs.cachedChecks for custom watch ignore patterns

### DIFF
--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -45,9 +45,13 @@ const cachedFsUtilsMap = new WeakMap<ResolvedConfig, FsUtils>()
 export function getFsUtils(config: ResolvedConfig): FsUtils {
   let fsUtils = cachedFsUtilsMap.get(config)
   if (!fsUtils) {
-    if (config.command !== 'serve' || !config.server.fs.cachedChecks) {
-      // cached fsUtils is only used in the dev server for now, and only when the watcher isn't configured
-      // we can support custom ignored patterns later
+    if (
+      config.command !== 'serve' ||
+      config.server.fs.cachedChecks === false ||
+      config.server.watch?.ignored
+    ) {
+      // cached fsUtils is only used in the dev server for now
+      // it is enabled by default only when there aren't custom watcher ignored patterns configured
       fsUtils = commonFsUtils
     } else if (
       !config.resolve.preserveSymlinks &&

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -194,10 +194,10 @@ export interface FileSystemServeOptions {
   deny?: string[]
 
   /**
-   * Enable caching of fs calls.
+   * Enable caching of fs calls. It is enabled by default if no custom watch ignored patterns are provided.
    *
    * @experimental
-   * @default true
+   * @default undefined
    */
   cachedChecks?: boolean
 }
@@ -1002,7 +1002,7 @@ export function resolveServerOptions(
     strict: server.fs?.strict ?? true,
     allow: allowDirs,
     deny,
-    cachedChecks: server.fs?.cachedChecks ?? true,
+    cachedChecks: server.fs?.cachedChecks,
   }
 
   if (server.origin?.endsWith('/')) {


### PR DESCRIPTION
### Description

We're seeing issues with `fs.cachedChecks` in Vitest in playgrounds that build a SSR bundle to `dist`.

Vitest has a default ignore rule that is making files added to `dist` invisible to the new cache: https://github.com/vitest-dev/vitest/blob/6f5b42b7a8e8a3c2ddb1c6876ea474553d686e28/packages/vitest/src/defaults.ts#L78

While we find a good way to work out these issues (it may be that the tests should be reworked, or that there is a way to support this in the fs cache), this PR disables the cache by default if there are custom rules.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other