### PR TITLE
fix: pass `customLogger` to `loadConfigFromFile` (fix #15824)

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -397,6 +397,7 @@ async function loadConfigFromFile(
   configFile?: string,
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
+  customLogger?: Logger,
 ): Promise<{
   path: string
   config: UserConfig

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -459,6 +459,7 @@ export async function resolveConfig(
       configFile,
       config.root,
       config.logLevel,
+      config.customLogger,
     )
     if (loadResult) {
       config = mergeConfig(loadResult.config, config)
@@ -963,6 +964,7 @@ export async function loadConfigFromFile(
   configFile?: string,
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
+  customLogger?: Logger,
 ): Promise<{
   path: string
   config: UserConfig
@@ -1016,9 +1018,11 @@ export async function loadConfigFromFile(
       dependencies: bundled.dependencies,
     }
   } catch (e) {
-    createLogger(logLevel).error(
+    createLogger(logLevel, { customLogger }).error(
       colors.red(`failed to load config from ${resolvedPath}`),
-      { error: e },
+      {
+        error: e,
+      },
     )
     throw e
   }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -460,6 +460,7 @@ export async function resolveConfig(
       config.root,
       config.logLevel,
       config.customLogger,
+      config.clearScreen,
     )
     if (loadResult) {
       config = mergeConfig(loadResult.config, config)
@@ -965,6 +966,7 @@ export async function loadConfigFromFile(
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
   customLogger?: Logger,
+  allowClearScreen?: boolean,
 ): Promise<{
   path: string
   config: UserConfig
@@ -1018,7 +1020,7 @@ export async function loadConfigFromFile(
       dependencies: bundled.dependencies,
     }
   } catch (e) {
-    createLogger(logLevel, { customLogger }).error(
+    createLogger(logLevel, { customLogger, allowClearScreen }).error(
       colors.red(`failed to load config from ${resolvedPath}`),
       {
         error: e,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -460,7 +460,6 @@ export async function resolveConfig(
       config.root,
       config.logLevel,
       config.customLogger,
-      config.clearScreen,
     )
     if (loadResult) {
       config = mergeConfig(loadResult.config, config)
@@ -966,7 +965,6 @@ export async function loadConfigFromFile(
   configRoot: string = process.cwd(),
   logLevel?: LogLevel,
   customLogger?: Logger,
-  allowClearScreen?: boolean,
 ): Promise<{
   path: string
   config: UserConfig
@@ -1020,7 +1018,7 @@ export async function loadConfigFromFile(
       dependencies: bundled.dependencies,
     }
   } catch (e) {
-    createLogger(logLevel, { customLogger, allowClearScreen }).error(
+    createLogger(logLevel, { customLogger }).error(
       colors.red(`failed to load config from ${resolvedPath}`),
       {
         error: e,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes #15824 

Basically, it passes down the `customLogger` and `clearScreen` options from inline `build` config to `loadConfigFromFile` function where they can be utilized if read from file fails.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
