### PR TITLE
chore: revert #15746

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -239,16 +239,15 @@ function orderedDependencies(deps: Record<string, string>) {
 }
 
 function globEntries(pattern: string | string[], config: ResolvedConfig) {
-  const rootPattern = glob.convertPathToPattern(config.root)
   return glob(pattern, {
     cwd: config.root,
     ignore: [
-      `${rootPattern}/**/node_modules/**`,
-      `${rootPattern}/**/${config.build.outDir}/**`,
+      '**/node_modules/**',
+      `**/${config.build.outDir}/**`,
       // if there aren't explicit entries, also ignore other common folders
       ...(config.optimizeDeps.entries
         ? []
-        : [`${rootPattern}/**/__tests__/**`, `${rootPattern}/**/coverage/**`]),
+        : [`**/__tests__/**`, `**/coverage/**`]),
     ],
     absolute: true,
     suppressErrors: true, // suppress EACCES errors


### PR DESCRIPTION
This reverts commit c3e83bb078e84a8a2d377455801b2a689557763e.

### Description

#15746 broke VitePress. See [CI fail](https://github.com/vitejs/vite-ecosystem-ci/actions/runs/7810140169/job/21303102977)

cc @jianqi-jin @bluwy @brc-dd

Thanks @brc-dd for bisecting. It seems that `globEntries` is stuck in VitePress after this PR. [Thread in Vite Land](https://discord.com/channels/804011606160703521/1204659520044015636)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other