### PR TITLE
fix: skip not only .js but also .mjs manifest entries

### DIFF
--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -11,6 +11,8 @@ import { normalizePath, sortObjectKeys } from '../utils'
 import { generatedAssets } from './asset'
 import type { GeneratedAssetMeta } from './asset'
 
+const endsWithJSRE = /\.[cm]?js$/
+
 export type Manifest = Record<string, ManifestChunk>
 
 export interface ManifestChunk {
@@ -134,13 +136,8 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
 
           // If JS chunk and asset chunk are both generated from the same source file,
           // prioritize JS chunk as it contains more information
-          const file = manifest[src]?.file || ''
-          if (
-            file.endsWith('.js') ||
-            file.endsWith('.mjs') ||
-            file.endsWith('.cjs')
-          )
-            continue
+          const file = manifest[src]?.file
+          if (file && endsWithJSRE.test(file)) continue
 
           manifest[src] = asset
           fileNameToAsset.set(chunk.fileName, asset)

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -134,7 +134,14 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
 
           // If JS chunk and asset chunk are both generated from the same source file,
           // prioritize JS chunk as it contains more information
-          if (/\.(?:m|c)?js/.test(manifest[src]?.file ?? '')) continue
+          const { file } = manifest[src]
+          if (
+            file.endsWith('.js') ||
+            file.endsWith('.mjs') ||
+            file.endsWith('.cjs')
+          )
+            continue
+
           manifest[src] = asset
           fileNameToAsset.set(chunk.fileName, asset)
         }

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -134,7 +134,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
 
           // If JS chunk and asset chunk are both generated from the same source file,
           // prioritize JS chunk as it contains more information
-          if (manifest[src]?.file.endsWith('.js')) continue
+          if (/\.(?:m|c)?js/.test(manifest[src]?.file ?? '')) continue
           manifest[src] = asset
           fileNameToAsset.set(chunk.fileName, asset)
         }

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -134,7 +134,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
 
           // If JS chunk and asset chunk are both generated from the same source file,
           // prioritize JS chunk as it contains more information
-          const { file } = manifest[src]
+          const file = manifest[src]?.file || ''
           if (
             file.endsWith('.js') ||
             file.endsWith('.mjs') ||


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

The current manifest generation logic is faulty if `manifest[src].file` ends with `.mjs` instead of `.js`. This PR fixes it.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This bug is breaking a production app.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
