### PR TITLE
feat: `defineConfig` support generics

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -91,16 +91,22 @@ export interface ConfigEnv {
  */
 export type AppType = 'spa' | 'mpa' | 'custom'
 
-export type UserConfigFnObject = (env: ConfigEnv) => UserConfig
-export type UserConfigFnPromise = (env: ConfigEnv) => Promise<UserConfig>
-export type UserConfigFn = (env: ConfigEnv) => UserConfig | Promise<UserConfig>
+export type UserConfigFnObject<E extends Record<string, any>> = (
+  env: ConfigEnv & E,
+) => UserConfig
+export type UserConfigFnPromise<E extends Record<string, any>> = (
+  env: ConfigEnv & E,
+) => Promise<UserConfig>
+export type UserConfigFn<E extends Record<string, any>> = (
+  env: ConfigEnv & E,
+) => UserConfig | Promise<UserConfig>
 
-export type UserConfigExport =
+export type UserConfigExport<E extends Record<string, any>> =
   | UserConfig
   | Promise<UserConfig>
-  | UserConfigFnObject
-  | UserConfigFnPromise
-  | UserConfigFn
+  | UserConfigFnObject<E>
+  | UserConfigFnPromise<E>
+  | UserConfigFn<E>
 
 /**
  * Type helper to make it easier to use vite.config.ts
@@ -110,9 +116,15 @@ export type UserConfigExport =
  */
 export function defineConfig(config: UserConfig): UserConfig
 export function defineConfig(config: Promise<UserConfig>): Promise<UserConfig>
-export function defineConfig(config: UserConfigFnObject): UserConfigFnObject
-export function defineConfig(config: UserConfigExport): UserConfigExport
-export function defineConfig(config: UserConfigExport): UserConfigExport {
+export function defineConfig<E extends Record<string, any>>(
+  config: UserConfigFnObject<E>,
+): UserConfigFnObject<E>
+export function defineConfig<E extends Record<string, any>>(
+  config: UserConfigExport<E>,
+): UserConfigExport<E>
+export function defineConfig<E extends Record<string, any>>(
+  config: UserConfigExport<E>,
+): UserConfigExport<E> {
   return config
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Hey! 👋
In Electron Forge, we needs pass some custom `env` properties to `vite.config.ts`. But Vite can not support it(only types). Maybe we can supports `defineConfig` with `generics` is better. 😄

**Provider**

https://github.com/electron/forge/blob/b0cae412a745b4726193e87c9291430efb604206/packages/plugin/vite/src/ViteConfig.ts#L22-L27
<img width="701" alt="image" src="https://github.com/vitejs/vite/assets/26263658/029ad10f-f4d4-47c1-9149-b0c60788ced9">

**Consumer**

https://github.com/electron/forge/blob/b0cae412a745b4726193e87c9291430efb604206/packages/template/vite-typescript/tmpl/vite.main.config.ts#L6
<img width="515" alt="image" src="https://github.com/vitejs/vite/assets/26263658/16a90c92-8b89-40a9-b356-90e0bc91ef9e">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
