### PR TITLE
feat: add entry name to manifest

### DIFF
--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -61,6 +61,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
       function createChunk(chunk: OutputChunk): ManifestChunk {
         const manifestChunk: ManifestChunk = {
           file: chunk.fileName,
+          name: chunk.name,
         }
 
         if (chunk.facadeModuleId) {
@@ -68,7 +69,6 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
         }
         if (chunk.isEntry) {
           manifestChunk.isEntry = true
-          manifestChunk.name = chunk.name
         }
         if (chunk.isDynamicEntry) {
           manifestChunk.isDynamicEntry = true

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -21,6 +21,7 @@ export interface ManifestChunk {
   css?: string[]
   assets?: string[]
   isEntry?: boolean
+  name?: string
   isDynamicEntry?: boolean
   imports?: string[]
   dynamicImports?: string[]
@@ -67,6 +68,7 @@ export function manifestPlugin(config: ResolvedConfig): Plugin {
         }
         if (chunk.isEntry) {
           manifestChunk.isEntry = true
+          manifestChunk.name = chunk.name
         }
         if (chunk.isDynamicEntry) {
           manifestChunk.isDynamicEntry = true


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Adds `chunk.name` (the Rollup entry name) to the manifest.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This makes finding entries in the manifest much easier. Until now I was using brittle heuristics to find entries in the manifest. I've now stubmled a situation where this PR is needed (when the entry file resolves into a sibling package in a monorepo).

Meta frameworks know the entry names, so adding `chunk.name` will make it trivial to find entries in the manifest.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
