### PR TITLE
fix: optimizeDeps.entries with literal-only pattern(s)

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -238,24 +238,10 @@ function orderedDependencies(deps: Record<string, string>) {
   return Object.fromEntries(depsList)
 }
 
-function isPatternLiteral(pattern: string): boolean {
-  // According to the docs all the special characters are: $^*+?()[]
-  // So if the pattern contains any of them without a backslash ahead,
-  // it's not a literal pattern.
-  return !pattern.match(/(?<!\\)[$^*+?()[\]]/)
-}
-
-function getUnescapedPath(filepath: string, config: ResolvedConfig) {
-  const unescaped = filepath.replace(/\\([$^*+?()[\]])/g, '$1')
-  return path.isAbsolute(unescaped)
-    ? unescaped
-    : path.resolve(config.root, unescaped)
-}
-
 function globEntries(pattern: string | string[], config: ResolvedConfig) {
   const resolvedPatterns = Array.isArray(pattern) ? pattern : [pattern]
-  if (resolvedPatterns.every(isPatternLiteral)) {
-    return resolvedPatterns.map((p) => getUnescapedPath(p, config))
+  if (resolvedPatterns.every((str) => !glob.isDynamicPattern(str))) {
+    return resolvedPatterns.map((p) => path.resolve(config.root, p))
   }
   return glob(pattern, {
     cwd: config.root,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -238,7 +238,25 @@ function orderedDependencies(deps: Record<string, string>) {
   return Object.fromEntries(depsList)
 }
 
+function isPatternLiteral(pattern: string): boolean {
+  // According to the docs all the special characters are: $^*+?()[]
+  // So if the pattern contains any of them without a backslash ahead,
+  // it's not a literal pattern.
+  return !pattern.match(/(?<!\\)[$^*+?()[\]]/)
+}
+
+function getUnescapedPath(filepath: string, config: ResolvedConfig) {
+  const unescaped = filepath.replace(/\\([$^*+?()[\]])/g, '$1')
+  return path.isAbsolute(unescaped)
+    ? unescaped
+    : path.resolve(config.root, unescaped)
+}
+
 function globEntries(pattern: string | string[], config: ResolvedConfig) {
+  const resolvedPatterns = Array.isArray(pattern) ? pattern : [pattern]
+  if (resolvedPatterns.every(isPatternLiteral)) {
+    return resolvedPatterns.map((p) => getUnescapedPath(p, config))
+  }
   return glob(pattern, {
     cwd: config.root,
     ignore: [

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -20,6 +20,7 @@ import {
   SPECIAL_QUERY_RE,
 } from '../constants'
 import {
+  arraify,
   cleanUrl,
   createDebugger,
   dataUrlRE,
@@ -239,7 +240,7 @@ function orderedDependencies(deps: Record<string, string>) {
 }
 
 function globEntries(pattern: string | string[], config: ResolvedConfig) {
-  const resolvedPatterns = Array.isArray(pattern) ? pattern : [pattern]
+  const resolvedPatterns = arraify(pattern)
   if (resolvedPatterns.every((str) => !glob.isDynamicPattern(str))) {
     return resolvedPatterns.map((p) => path.resolve(config.root, p))
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Skip running `fast-glob` if `optimizeDeps.entries` is specified without any special characters like `$^*+?[]()`.

So user can specify a entry in literal value to skip the `fast-glob` ignore policy.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

https://github.com/vitejs/vite/discussions/15613#discussioncomment-8277522
https://github.com/vitejs/vite/pull/15746

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
