### PR TITLE
fix(worker): support UTF-8 encoding in inline workers (fixes #12117)

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -289,12 +289,13 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             // Using blob URL for SharedWorker results in multiple instances of a same worker
             workerConstructor === 'Worker'
               ? `${encodedJs}
+          const decodeBase64 = (base64) => new TextDecoder().decode(Uint8Array.from(atob(base64), c => c.charCodeAt(0)));
           const blob = typeof window !== "undefined" && window.Blob && new Blob([${
             workerType === 'classic'
               ? ''
               : // `URL` is always available, in `Worker[type="module"]`
                 `'URL.revokeObjectURL(import.meta.url);'+`
-          }atob(encodedJs)], { type: "text/javascript;charset=utf-8" });
+          }decodeBase64(encodedJs)], { type: "text/javascript;charset=utf-8" });
           export default function WorkerWrapper(options) {
             let objURL;
             try {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -289,12 +289,12 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             // Using blob URL for SharedWorker results in multiple instances of a same worker
             workerConstructor === 'Worker'
               ? `${encodedJs}
-          const decodeBase64 = (base64) => new TextDecoder().decode(Uint8Array.from(atob(base64), c => c.charCodeAt(0)));
+          const decodeBase64 = (base64) => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
           const blob = typeof window !== "undefined" && window.Blob && new Blob([${
             workerType === 'classic'
               ? ''
               : // `URL` is always available, in `Worker[type="module"]`
-                `'URL.revokeObjectURL(import.meta.url);'+`
+                `'URL.revokeObjectURL(import.meta.url);',`
           }decodeBase64(encodedJs)], { type: "text/javascript;charset=utf-8" });
           export default function WorkerWrapper(options) {
             let objURL;

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -50,6 +50,14 @@ test('import meta url', async () => {
   )
 })
 
+test('unicode inlined', async () => {
+  await untilUpdated(
+    () => page.textContent('.pong-inline-unicode'),
+    '•pong•',
+    true,
+  )
+})
+
 test('shared worker', async () => {
   await untilUpdated(() => page.textContent('.tick-count'), 'pong', true)
 })

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -51,6 +51,12 @@
 <code class="pong-inline-url"></code>
 
 <p>
+  import InlineWorker from '../my-worker?worker&inline'
+  <span class="classname">.pong-inline-unicode</span>
+</p>
+<code class="pong-inline-unicode"></code>
+
+<p>
   import TSOutputWorker from '../possible-ts-output-worker?worker'
   <span class="classname">.pong-ts-output</span>
 </p>

--- a/playground/worker/my-worker.ts
+++ b/playground/worker/my-worker.ts
@@ -8,6 +8,16 @@ self.onmessage = (e) => {
   if (e.data === 'ping') {
     self.postMessage({ msg, mode, bundleWithPlugin, viteSvg, metaUrl, name })
   }
+  if (e.data === 'ping-unicode') {
+    self.postMessage({
+      msg: '•pong•',
+      mode,
+      bundleWithPlugin,
+      viteSvg,
+      metaUrl,
+      name,
+    })
+  }
 }
 self.postMessage({
   msg,

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -45,6 +45,12 @@ inlineWorkerUrl.addEventListener('message', (e) => {
   text('.pong-inline-url', e.data.metaUrl)
 })
 
+const unicodeInlineWorker = new InlineWorker()
+unicodeInlineWorker.postMessage('ping-unicode')
+unicodeInlineWorker.addEventListener('message', (e) => {
+  text('.pong-inline-unicode', e.data.msg)
+})
+
 const startSharedWorker = () => {
   const sharedWorker = new mySharedWorker()
   sharedWorker.port.addEventListener('message', (event) => {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR fixes #12117. It's based on PR #12122. This PR allows inline worker to include UTF-8 characters.

### Additional context

This PR rebases #12122 into main and adds a test.


superseds close #12122

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
