### PR TITLE
docs: remove unneeded zero width space in titles

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -4,7 +4,7 @@ Vite releases follow [Semantic Versioning](https://semver.org/). You can see the
 
 A full changelog of past releases is [available on GitHub](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md).
 
-## Release Cycle​
+## Release Cycle
 
 Vite does not have a fixed release cycle.
 
@@ -18,7 +18,7 @@ The Vite team partners with the main projects in the ecosystem to test new Vite 
 
 ## Semantic Versioning Edge Cases
 
-### TypeScript Definitions​
+### TypeScript Definitions
 
 We may ship incompatible changes to TypeScript definitions between minor versions. This is because:
 
@@ -34,16 +34,16 @@ We may ship incompatible changes to TypeScript definitions between minor version
 
 Non-LTS Node.js versions (odd-numbered) are not tested as part of Vite's CI, but they should still work before their [EOL](https://endoflife.date/nodejs).
 
-## Pre Releases​
+## Pre Releases
 
 Minor releases typically go through a non-fixed number of beta releases. Major releases will go through an alpha phase and a beta phase.
 
 Pre-releases allow early adopters and maintainers from the Ecosystem to do integration and stability testing, and provide feedback. Do not use pre-releases in production. All pre-releases are considered unstable and may ship breaking changes in between. Always pin to exact versions when using pre-releases.
 
-## Deprecations​
+## Deprecations
 
 We periodically deprecate features that have been superseded by better alternatives in Minor releases. Deprecated features will continue to work with a type or logged warning. They will be removed in the next major release after entering deprecated status. The [Migration Guide](https://vitejs.dev/guide/migration.html) for each major will list these removals and document an upgrade path for them.
 
-## Experimental Features​
+## Experimental Features
 
 Some features are marked as experimental when released in a stable version of Vite. Experimental features allows us to gather real-world experience to influence their final design. The goal is to let users provide feedback by testing them in production. Experimental features themselves are considered unstable, and should only be used in a controlled manner. These features may change between Minors, so users must pin their Vite version when they rely on them. We will create [a GitHub discussion](https://github.com/vitejs/vite/discussions/categories/feedback?discussions_q=is%3Aopen+label%3Aexperimental+category%3AFeedback) for each experimental feature.


### PR DESCRIPTION
### Description
We somehow had a zero width spaces in these titles.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
