### PR TITLE
fix(runtime): runtime HMR affects only imported files

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -167,7 +167,7 @@ export async function handleHMRUpdate(
     hot.send({
       type: 'full-reload',
       path: '*',
-      trigger: path.posix.resolve(config.root, slash(file)),
+      trigger: path.resolve(config.root, slash(file)),
     })
     return
   }
@@ -274,7 +274,7 @@ export function updateModules(
     )
     hot.send({
       type: 'full-reload',
-      trigger: path.posix.resolve(config.root, slash(file)),
+      trigger: path.resolve(config.root, file),
     })
     return
   }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -166,7 +166,7 @@ export async function handleHMRUpdate(
     hot.send({
       type: 'full-reload',
       path: '*',
-      trigger: file,
+      trigger: path.posix.resolve(config.root, file),
     })
     return
   }
@@ -256,7 +256,7 @@ export function updateModules(
           isWithinCircularImport,
           // browser modules are invalidated by changing ?t= query,
           // but in ssr we control the module system, so we can directly remove them form cache
-          ssrInvalidates: getSSRInvalidatedImporters(config.root, acceptedVia),
+          ssrInvalidates: getSSRInvalidatedImporters(acceptedVia),
         }),
       ),
     )
@@ -273,7 +273,7 @@ export function updateModules(
     )
     hot.send({
       type: 'full-reload',
-      trigger: file,
+      trigger: path.posix.resolve(config.root, file),
     })
     return
   }
@@ -314,9 +314,9 @@ function populateSSRImporters(
   return seen
 }
 
-function getSSRInvalidatedImporters(root: string, module: ModuleNode) {
-  return [...populateSSRImporters(module, module.lastHMRTimestamp)].map((m) =>
-    path.posix.relative(root, m.file!),
+function getSSRInvalidatedImporters(module: ModuleNode) {
+  return [...populateSSRImporters(module, module.lastHMRTimestamp)].map(
+    (m) => m.file!,
   )
 }
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -9,7 +9,6 @@ import { CLIENT_DIR } from '../constants'
 import {
   createDebugger,
   normalizePath,
-  slash,
   unique,
   withTrailingSlash,
   wrapId,
@@ -167,7 +166,7 @@ export async function handleHMRUpdate(
     hot.send({
       type: 'full-reload',
       path: '*',
-      trigger: path.resolve(config.root, slash(file)),
+      trigger: path.resolve(config.root, file),
     })
     return
   }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -166,7 +166,7 @@ export async function handleHMRUpdate(
     hot.send({
       type: 'full-reload',
       path: '*',
-      trigger: path.resolve(config.root, file),
+      triggeredBy: path.resolve(config.root, file),
     })
     return
   }
@@ -273,7 +273,7 @@ export function updateModules(
     )
     hot.send({
       type: 'full-reload',
-      trigger: path.resolve(config.root, file),
+      triggeredBy: path.resolve(config.root, file),
     })
     return
   }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -9,6 +9,7 @@ import { CLIENT_DIR } from '../constants'
 import {
   createDebugger,
   normalizePath,
+  slash,
   unique,
   withTrailingSlash,
   wrapId,
@@ -166,7 +167,7 @@ export async function handleHMRUpdate(
     hot.send({
       type: 'full-reload',
       path: '*',
-      trigger: path.posix.resolve(config.root, file),
+      trigger: path.posix.resolve(config.root, slash(file)),
     })
     return
   }
@@ -273,7 +274,7 @@ export function updateModules(
     )
     hot.send({
       type: 'full-reload',
-      trigger: path.posix.resolve(config.root, file),
+      trigger: path.posix.resolve(config.root, slash(file)),
     })
     return
   }

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -166,7 +166,7 @@ export async function handleHMRUpdate(
     hot.send({
       type: 'full-reload',
       path: '*',
-      via: file,
+      trigger: file,
     })
     return
   }
@@ -273,7 +273,7 @@ export function updateModules(
     )
     hot.send({
       type: 'full-reload',
-      via: file,
+      trigger: file,
     })
     return
   }

--- a/packages/vite/src/node/ssr/runtime/esmRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/esmRunner.ts
@@ -34,7 +34,7 @@ export class ESModulesRunner implements ViteModuleRunner {
       context[ssrExportAllKey],
     )
 
-    Object.freeze(context[ssrModuleExportsKey])
+    Object.seal(context[ssrModuleExportsKey])
   }
 
   runExternalModule(filepath: string): Promise<any> {

--- a/packages/vite/src/node/ssr/runtime/esmRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/esmRunner.ts
@@ -34,7 +34,7 @@ export class ESModulesRunner implements ViteModuleRunner {
       context[ssrExportAllKey],
     )
 
-    Object.seal(context[ssrModuleExportsKey])
+    Object.freeze(context[ssrModuleExportsKey])
   }
 
   runExternalModule(filepath: string): Promise<any> {

--- a/packages/vite/src/node/ssr/runtime/hmrHandler.ts
+++ b/packages/vite/src/node/ssr/runtime/hmrHandler.ts
@@ -51,11 +51,11 @@ export async function handleHMRPayload(
           runtime.moduleCache.deleteByModuleId(id)
         }
       })
-      const { via } = payload
-      const clearEntrypoints = via
+      const { trigger } = payload
+      const clearEntrypoints = trigger
         ? [...runtime.entrypoints].filter((entrypoint) =>
             runtime.moduleCache.isImported({
-              importedId: via,
+              importedId: trigger,
               importedBy: entrypoint,
             }),
           )

--- a/packages/vite/src/node/ssr/runtime/hmrHandler.ts
+++ b/packages/vite/src/node/ssr/runtime/hmrHandler.ts
@@ -44,11 +44,11 @@ export async function handleHMRPayload(
       break
     }
     case 'full-reload': {
-      const { trigger } = payload
-      const clearEntrypoints = trigger
+      const { triggeredBy } = payload
+      const clearEntrypoints = triggeredBy
         ? [...runtime.entrypoints].filter((entrypoint) =>
             runtime.moduleCache.isImported({
-              importedId: trigger,
+              importedId: triggeredBy,
               importedBy: entrypoint,
             }),
           )

--- a/packages/vite/src/node/ssr/runtime/moduleCache.ts
+++ b/packages/vite/src/node/ssr/runtime/moduleCache.ts
@@ -68,10 +68,10 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
   invalidate(id: string): void {
     const module = this.get(id)
     module.evaluated = false
-    delete module.meta
-    delete module.map
-    delete module.promise
-    delete module.exports
+    module.meta = undefined
+    module.map = undefined
+    module.promise = undefined
+    module.exports = undefined
     // remove imports in case they are changed,
     // don't remove the importers because otherwise it will be empty after evaluation
     // this can create a bug when file was removed but it still triggers full-reload

--- a/packages/vite/src/node/ssr/runtime/moduleCache.ts
+++ b/packages/vite/src/node/ssr/runtime/moduleCache.ts
@@ -74,6 +74,8 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
     delete module.exports
     // remove imports in case they are changed,
     // don't remove the importers because otherwise it will be empty after evaluation
+    // this can create a bug when file was removed but it still triggers full-reload
+    // we are fine with the bug for now because it's not a common case
     module.imports?.clear()
   }
 

--- a/packages/vite/src/node/ssr/runtime/moduleCache.ts
+++ b/packages/vite/src/node/ssr/runtime/moduleCache.ts
@@ -97,7 +97,7 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
 
     const fileModule = this.getByModuleId(importedId)
     const importers = fileModule?.importers
-    // console.log(this, { importedId, importers: fileModule?.importers, imports: fileModule?.imports })
+
     if (!importers) return false
 
     if (importers.has(importedBy)) return true

--- a/packages/vite/src/node/ssr/runtime/moduleCache.ts
+++ b/packages/vite/src/node/ssr/runtime/moduleCache.ts
@@ -76,14 +76,16 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
     seen = new Set<string>(),
   ): boolean {
     importedId = this.normalize(importedId)
+    importedBy = this.normalize(importedBy)
+
+    if (importedBy === importedId) return true
+
     if (seen.has(importedId)) return false
     seen.add(importedId)
 
     const fileModule = this.getByModuleId(importedId)
     const importers = fileModule?.importers
     if (!importers) return false
-
-    importedBy = this.normalize(importedBy)
 
     if (importers.has(importedBy)) return true
 

--- a/packages/vite/src/node/ssr/runtime/moduleCache.ts
+++ b/packages/vite/src/node/ssr/runtime/moduleCache.ts
@@ -65,6 +65,40 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
     return this.deleteByModuleId(this.normalize(fsPath))
   }
 
+  isImported(
+    {
+      importedId,
+      importedBy,
+    }: {
+      importedId: string
+      importedBy: string
+    },
+    seen = new Set<string>(),
+  ): boolean {
+    importedId = this.normalize(importedId)
+    if (seen.has(importedId)) return false
+    seen.add(importedId)
+
+    const fileModule = this.getByModuleId(importedId)
+    const importers = fileModule?.importers
+    if (!importers) return false
+
+    importedBy = this.normalize(importedBy)
+
+    if (importers.has(importedBy)) return true
+
+    for (const importer of importers) {
+      if (
+        this.isImported({
+          importedBy: importedBy,
+          importedId: importer,
+        })
+      )
+        return true
+    }
+    return false
+  }
+
   /**
    * Invalidate modules that dependent on the given modules, up to the main entry
    */

--- a/packages/vite/src/node/ssr/runtime/moduleCache.ts
+++ b/packages/vite/src/node/ssr/runtime/moduleCache.ts
@@ -65,6 +65,18 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
     return this.deleteByModuleId(this.normalize(fsPath))
   }
 
+  invalidate(id: string): void {
+    const module = this.get(id)
+    module.evaluated = false
+    delete module.meta
+    delete module.map
+    delete module.promise
+    delete module.exports
+    // remove imports in case they are changed,
+    // don't remove the importers because otherwise it will be empty after evaluation
+    module.imports?.clear()
+  }
+
   isImported(
     {
       importedId,
@@ -85,6 +97,7 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
 
     const fileModule = this.getByModuleId(importedId)
     const importers = fileModule?.importers
+    // console.log(this, { importedId, importers: fileModule?.importers, imports: fileModule?.imports })
     if (!importers) return false
 
     if (importers.has(importedBy)) return true

--- a/packages/vite/src/node/ssr/runtime/runtime.ts
+++ b/packages/vite/src/node/ssr/runtime/runtime.ts
@@ -138,7 +138,7 @@ export class ViteRuntime {
 
   private invalidateFiles(files: string[]) {
     files.forEach((file) => {
-      const ids = this.fileToIdMap.get(file)
+      const ids = this.fileToIdMap.get(posixResolve(this.options.root, file))
       if (ids) {
         ids.forEach((id) => this.moduleCache.deleteByModuleId(id))
       }

--- a/packages/vite/src/node/ssr/runtime/runtime.ts
+++ b/packages/vite/src/node/ssr/runtime/runtime.ts
@@ -72,7 +72,7 @@ export class ViteRuntime {
           : options.hmr.logger || console,
         options.hmr.connection,
         ({ acceptedPath, ssrInvalidates }) => {
-          this.moduleCache.delete(acceptedPath)
+          this.moduleCache.invalidate(acceptedPath)
           if (ssrInvalidates) {
             this.invalidateFiles(ssrInvalidates)
           }
@@ -138,9 +138,9 @@ export class ViteRuntime {
 
   private invalidateFiles(files: string[]) {
     files.forEach((file) => {
-      const ids = this.fileToIdMap.get(posixResolve(this.options.root, file))
+      const ids = this.fileToIdMap.get(file)
       if (ids) {
-        ids.forEach((id) => this.moduleCache.deleteByModuleId(id))
+        ids.forEach((id) => this.moduleCache.invalidate(id))
       }
     })
   }

--- a/packages/vite/types/hmrPayload.d.ts
+++ b/packages/vite/types/hmrPayload.d.ts
@@ -36,7 +36,7 @@ export interface PrunePayload {
 export interface FullReloadPayload {
   type: 'full-reload'
   path?: string
-  via?: string
+  trigger?: string
 }
 
 export interface CustomPayload {

--- a/packages/vite/types/hmrPayload.d.ts
+++ b/packages/vite/types/hmrPayload.d.ts
@@ -36,7 +36,8 @@ export interface PrunePayload {
 export interface FullReloadPayload {
   type: 'full-reload'
   path?: string
-  trigger?: string
+  /** @internal */
+  triggeredBy?: string
 }
 
 export interface CustomPayload {

--- a/packages/vite/types/hmrPayload.d.ts
+++ b/packages/vite/types/hmrPayload.d.ts
@@ -36,6 +36,7 @@ export interface PrunePayload {
 export interface FullReloadPayload {
   type: 'full-reload'
   path?: string
+  via?: string
 }
 
 export interface CustomPayload {

--- a/playground/hmr-ssr/__tests__/hmr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr.spec.ts
@@ -511,6 +511,7 @@ describe('acceptExports', () => {
       const testFile = 'non-tested/index.js'
 
       beforeAll(async () => {
+        clientLogs.length = 0
         // so it's in the module graph
         await server.transformRequest(testFile, { ssr: true })
         await server.transformRequest('non-tested/dep.js', { ssr: true })

--- a/playground/hmr-ssr/__tests__/hmr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr.spec.ts
@@ -1097,14 +1097,6 @@ async function setupViteRuntime(
       noDiscovery: true,
       include: [],
     },
-    plugins: [
-      {
-        name: 'tessss',
-        handleHotUpdate({ file }) {
-          console.log('hot', file)
-        },
-      },
-    ],
     ...serverOptions,
   })
 

--- a/playground/hmr-ssr/__tests__/hmr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr.spec.ts
@@ -506,6 +506,54 @@ describe('acceptExports', () => {
         )
       })
     })
+
+    describe("doesn't reload if files not in the the entrypoint importers chain is changed", async () => {
+      const testFile = 'non-tested/index.js'
+
+      beforeAll(async () => {
+        // so it's in the module graph
+        await server.transformRequest(testFile, { ssr: true })
+        await server.transformRequest('non-tested/dep.js', { ssr: true })
+      })
+
+      test('does not full reload', async () => {
+        editFile(
+          testFile,
+          (code) => code + '\n\nexport const query5 = "query5"',
+        )
+        const start = Date.now()
+        // for 2 seconds check that there is no log about the file being reloaded
+        while (Date.now() - start < 2000) {
+          if (
+            clientLogs.some(
+              (log) =>
+                log.match(PROGRAM_RELOAD) ||
+                log.includes('non-tested/index.js'),
+            )
+          ) {
+            throw new Error('File was reloaded')
+          }
+          await new Promise((r) => setTimeout(r, 100))
+        }
+      }, 5_000)
+
+      test('does not update', async () => {
+        editFile('non-tested/dep.js', (code) => code + '//comment')
+        const start = Date.now()
+        // for 2 seconds check that there is no log about the file being reloaded
+        while (Date.now() - start < 2000) {
+          if (
+            clientLogs.some(
+              (log) =>
+                log.match(PROGRAM_RELOAD) || log.includes('non-tested/dep.js'),
+            )
+          ) {
+            throw new Error('File was updated')
+          }
+          await new Promise((r) => setTimeout(r, 100))
+        }
+      }, 5_000)
+    })
   })
 
   test('accepts itself when imported for side effects only (no bindings imported)', async () => {
@@ -1049,6 +1097,14 @@ async function setupViteRuntime(
       noDiscovery: true,
       include: [],
     },
+    plugins: [
+      {
+        name: 'tessss',
+        handleHotUpdate({ file }) {
+          console.log('hot', file)
+        },
+      },
+    ],
     ...serverOptions,
   })
 

--- a/playground/hmr-ssr/non-tested/dep.js
+++ b/playground/hmr-ssr/non-tested/dep.js
@@ -1,0 +1,3 @@
+export const test = 'true'
+
+import.meta.hot.accept()

--- a/playground/hmr-ssr/non-tested/index.js
+++ b/playground/hmr-ssr/non-tested/index.js
@@ -1,0 +1,9 @@
+import { test } from './dep.js'
+
+function main() {
+  test()
+}
+
+main()
+
+import.meta.hot.accept('./dep.js')


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Currently, any `full-reload` event will reload all entrypoints in Vite Runtime. This PR adds a `trigger` property to the `full-reload` payload that is used to determine if the file is imported by the entrypoint (or if it's the entrypoint).

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
