### PR TITLE
fix(deps): downgrade tsconfck

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -145,7 +145,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.0.0",
-    "tsconfck": "^3.0.2",
+    "tsconfck": "3.0.1",
     "tslib": "^2.6.2",
     "types": "link:./types",
     "ufo": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,8 +400,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       tsconfck:
-        specifier: ^3.0.2
-        version: 3.0.2(typescript@5.2.2)
+        specifier: 3.0.1
+        version: 3.0.1(typescript@5.2.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -9128,8 +9128,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.2(typescript@5.2.2):
-    resolution: {integrity: sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==}
+  /tsconfck@3.0.1(typescript@5.2.2):
+    resolution: {integrity: sha512-7ppiBlF3UEddCLeI1JRx5m2Ryq+xk4JrZuq4EuYXykipebaq1dV0Fhgr1hb7CkmHt32QSgOZlcqVLEtHBG4/mg==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
tsconfck has been updated as part of https://github.com/vitejs/vite/pull/15803. New version of the package causes qwik build to fail when tsconfig is used with "references". It might affect other frameworks or use cases, but I haven't tested those.

Looks like this is a known issue on the package's side https://github.com/dominikg/tsconfck/issues/154, however it remains not fixed as of now. The suggestion is to keep the dependency on the lower version that does not cause any issues

Please see reproduction details on the related issue https://github.com/vitejs/vite/issues/15870
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
closes https://github.com/vitejs/vite/issues/15870
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
