### PR TITLE
fix: srcSet with optional descriptor

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -338,6 +338,13 @@ describe('processSrcSetSync', () => {
       'data:image/avif;base64,aA+/0= 400w, data:image/avif;base64,bB+/9= 800w'
     expect(processSrcSetSync(base64, ({ url }) => url)).toBe(base64)
   })
+
+  test('should not break a regular URL in srcSet', async () => {
+    const source = 'https://anydomain/image.jpg'
+    expect(
+      processSrcSetSync('https://anydomain/image.jpg', ({ url }) => url),
+    ).toBe(source)
+  })
 })
 
 describe('flattenId', () => {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -767,7 +767,9 @@ interface ImageCandidate {
 const escapedSpaceCharacters = /( |\\t|\\n|\\f|\\r)+/g
 const imageSetUrlRE = /^(?:[\w\-]+\(.*?\)|'.*?'|".*?"|\S*)/
 function joinSrcset(ret: ImageCandidate[]) {
-  return ret.map(({ url, descriptor }) => `${url} ${descriptor}`).join(', ')
+  return ret
+    .map(({ url, descriptor }) => url + (descriptor ? ` ${descriptor}` : ''))
+    .join(', ')
 }
 
 function splitSrcSetDescriptor(srcs: string): ImageCandidate[] {


### PR DESCRIPTION
There is a bug processing simple `<source srcSet='someURL'>`, that adds a trailing space at the end of the URL, i.e. it becomes: `<source srcSet='someURL '>`
That creates a mismatch between SSR-generated HTML and HTML on the client side.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
