### PR TITLE
refactor(runtime): seal ES module namespace object instead of feezing

### DIFF
--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -87,10 +87,21 @@ describe('vite-runtime initialization', async () => {
 
   it('exports is not modifiable', async ({ runtime }) => {
     const mod = await runtime.executeUrl('/fixtures/simple.js')
+    expect(Object.isSealed(mod)).toBe(true)
     expect(() => {
       mod.test = 'I am modified'
     }).toThrowErrorMatchingInlineSnapshot(
       `[TypeError: Cannot set property test of [object Module] which has only a getter]`,
+    )
+    expect(() => {
+      delete mod.test
+    }).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: Cannot delete property 'test' of [object Module]]`,
+    )
+    expect(() => {
+      Object.defineProperty(mod, 'test', { value: 'I am modified' })
+    }).toThrowErrorMatchingInlineSnapshot(
+      `[TypeError: Cannot redefine property: test]`,
     )
     expect(() => {
       mod.other = 'I am added'

--- a/packages/vite/src/node/ssr/runtime/esmRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/esmRunner.ts
@@ -34,7 +34,7 @@ export class ESModulesRunner implements ViteModuleRunner {
       context[ssrExportAllKey],
     )
 
-    Object.freeze(context[ssrModuleExportsKey])
+    Object.seal(context[ssrModuleExportsKey])
   }
 
   runExternalModule(filepath: string): Promise<any> {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

According to MDN ES modules are actually [sealed](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import#module_namespace_object) and not frozen. This doesn't make any difference in the Vite case because we define getters so redefining properties always throws an error anyway.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
