### PR TITLE
fix: fs cached checks disabled by default for yarn pnp

### DIFF
--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -48,10 +48,12 @@ export function getFsUtils(config: ResolvedConfig): FsUtils {
     if (
       config.command !== 'serve' ||
       config.server.fs.cachedChecks === false ||
-      config.server.watch?.ignored
+      config.server.watch?.ignored ||
+      process.versions.pnp
     ) {
       // cached fsUtils is only used in the dev server for now
       // it is enabled by default only when there aren't custom watcher ignored patterns configured
+      // and if yarn pnp isn't used
       fsUtils = commonFsUtils
     } else if (
       !config.resolve.preserveSymlinks &&


### PR DESCRIPTION
Fixes #15910

### Description

I don't think it is worth trying to fix the fs cache for yarn pnp. For now, let's disable it by default if it is used.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other
