### PR TITLE
fix: deadlock in tsconfck for circles in references and extends

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     },
     "patchedDependencies": {
       "chokidar@3.6.0": "patches/chokidar@3.6.0.patch",
-      "sirv@2.0.4": "patches/sirv@2.0.4.patch"
+      "sirv@2.0.4": "patches/sirv@2.0.4.patch",
+      "tsconfck@3.0.2": "patches/tsconfck@3.0.2.patch"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/patches/tsconfck@3.0.2.patch
+++ b/patches/tsconfck@3.0.2.patch
@@ -1,0 +1,13 @@
+diff --git a/src/parse.js b/src/parse.js
+index 246a5939fd949d805e1bb31e3bb050fee3b34e78..f625e132e265ce9283a37dcce324c6046076df40 100644
+--- a/src/parse.js
++++ b/src/parse.js
+@@ -206,7 +206,7 @@ async function parseExtends(result, cache) {
+ 			extended.splice(
+ 				pos + 1,
+ 				0,
+-				...(await Promise.all(resolvedExtends.map((file) => parseFile(file, cache))))
++				...(await Promise.all(resolvedExtends.map((file) => parseFile(file, cache, true))))
+ 			);
+ 		} else {
+ 			// reached a leaf, backtrack to the last branching point and continue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ patchedDependencies:
   sirv@2.0.4:
     hash: amdes53ifqfntejkflpaq5ifce
     path: patches/sirv@2.0.4.patch
+  tsconfck@3.0.2:
+    hash: c6mi54ysf2x6yunnu4xiqwavba
+    path: patches/tsconfck@3.0.2.patch
 
 importers:
 
@@ -401,7 +404,7 @@ importers:
         version: 2.0.0
       tsconfck:
         specifier: ^3.0.2
-        version: 3.0.2(typescript@5.2.2)
+        version: 3.0.2(patch_hash=c6mi54ysf2x6yunnu4xiqwavba)(typescript@5.2.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -9128,7 +9131,7 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.2(typescript@5.2.2):
+  /tsconfck@3.0.2(patch_hash=c6mi54ysf2x6yunnu4xiqwavba)(typescript@5.2.2):
     resolution: {integrity: sha512-6lWtFjwuhS3XI4HsX4Zg0izOI3FU/AI9EGVlPEUMDIhvLPMD4wkiof0WCoDgW7qY+Dy198g4d9miAqUHWHFH6Q==}
     engines: {node: ^18 || >=20}
     hasBin: true
@@ -9140,6 +9143,7 @@ packages:
     dependencies:
       typescript: 5.2.2
     dev: true
+    patched: true
 
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}


### PR DESCRIPTION
### Description

Apply https://github.com/dominikg/tsconfck/pull/161 as a patch. We discussed with @dominikg and it isn't clear what is the best forward. Getting this patch in Vite core will give tsconfck more time to decide how to deal with these circles.

We may see a small regression in performance, but it shouldn't affect most users.

Fixes https://github.com/vitest-dev/vitest/issues/5182
Fixes Analog (reported by @brandonroberts)
```
npm create analog@latest analog-vite-5-1
cd analog-vite-5-1
npm install
ng serve (or) vite
```
Fixes https://github.com/vitejs/vite/issues/15870
Closes https://github.com/vitejs/vite/pull/15899

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other