### PR TITLE
fix(qwik template): change preview script

### DIFF
--- a/packages/create-vite/template-qwik-ts/package.json
+++ b/packages/create-vite/template-qwik-ts/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "serve dist"
   },
   "devDependencies": {
+    "serve": "^14.2.1",
     "typescript": "^5.2.2",
     "vite": "^5.1.3"
   },

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "npm run build; npx serve dist"
   },
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "npm run build; npx serve dist"
+    "preview": "serve dist"
   },
   "devDependencies": {
+    "serve": "^14.2.1",
     "typescript": "^5.2.2",
     "vite": "^5.1.3"
   },


### PR DESCRIPTION
### Description

Qwik use custom plugin `qwikVite` on top of Vite but with Qwik SPA configuration
```
qwikVite({ csr: true, })
``` 
the preview script fails because `qwikVite` is not optimized for this config.
With this PR we can have a temporary workaround.

Fixed https://github.com/BuilderIO/qwik/issues/4880

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
