### PR TITLE
fix(watch): build watch fails when outDir is empty string

### DIFF
--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -9,22 +9,22 @@ export function resolveChokidarOptions(
   config: ResolvedConfig,
   options: WatchOptions | undefined,
 ): WatchOptions {
-  const { ignored = [], ...otherOptions } = options ?? {}
-  const arraifyIgnored = arraify(ignored)
+  const { ignored: ignoredList, ...otherOptions } = options ?? {}
+  const ignored: WatchOptions['ignored'] = [
+    '**/.git/**',
+    '**/node_modules/**',
+    '**/test-results/**', // Playwright
+    glob.escapePath(config.cacheDir) + '/**',
+    ...arraify(ignoredList || []),
+  ]
   if (config.build.outDir) {
-    arraifyIgnored.push(
+    ignored.push(
       glob.escapePath(path.resolve(config.root, config.build.outDir)) + '/**',
     )
   }
 
   const resolvedWatchOptions: WatchOptions = {
-    ignored: [
-      '**/.git/**',
-      '**/node_modules/**',
-      '**/test-results/**', // Playwright
-      glob.escapePath(config.cacheDir) + '/**',
-      ...arraifyIgnored,
-    ],
+    ignored,
     ignoreInitial: true,
     ignorePermissionErrors: true,
     ...otherOptions,

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -13,7 +13,7 @@ export function resolveChokidarOptions(
   const arraifyIgnored = arraify(ignored)
   if (config.build.outDir) {
     arraifyIgnored.push(
-      glob.escapePath(path.resolve(config.root, config.build.outDir)),
+      glob.escapePath(path.resolve(config.root, config.build.outDir)) + '/**',
     )
   }
 

--- a/packages/vite/src/node/watch.ts
+++ b/packages/vite/src/node/watch.ts
@@ -10,6 +10,12 @@ export function resolveChokidarOptions(
   options: WatchOptions | undefined,
 ): WatchOptions {
   const { ignored = [], ...otherOptions } = options ?? {}
+  const arraifyIgnored = arraify(ignored)
+  if (config.build.outDir) {
+    arraifyIgnored.push(
+      glob.escapePath(path.resolve(config.root, config.build.outDir)),
+    )
+  }
 
   const resolvedWatchOptions: WatchOptions = {
     ignored: [
@@ -17,8 +23,7 @@ export function resolveChokidarOptions(
       '**/node_modules/**',
       '**/test-results/**', // Playwright
       glob.escapePath(config.cacheDir) + '/**',
-      glob.escapePath(path.resolve(config.root, config.build.outDir)) + '/**',
-      ...arraify(ignored),
+      ...arraifyIgnored,
     ],
     ignoreInitial: true,
     ignorePermissionErrors: true,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
fix #15951
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
