### PR TITLE
fix(create-vite): remove tsc command from qwik template

### DIFF
--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/packages/create-vite/template-qwik/package.json
+++ b/packages/create-vite/template-qwik/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "serve": "^14.2.1",
-    "typescript": "^5.2.2",
     "vite": "^5.1.3"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
No other js template runs `tsc`.
Currently, it just shows the help message and blocks the build running.
```
npm run build

> vite-project@0.0.0 build
> tsc && vite build

Version 5.3.3
tsc: The TypeScript Compiler - Version 5.3.3
                                                                                                                     TS
COMMON COMMANDS

  tsc
  Compiles the current project (tsconfig.json in the working directory.)
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
