### PR TITLE
fix: resolve directory correctly when `fs.cachedChecks: true`

### DIFF
--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -189,6 +189,10 @@ export function createCachedFsUtils(config: ResolvedConfig): FsUtils {
   function getDirentCacheFromPath(
     normalizedFile: string,
   ): DirentCache | false | undefined {
+    // path.posix.normalize may return a path either with / or without /
+    if (normalizedFile[normalizedFile.length - 1] === '/') {
+      normalizedFile = normalizedFile.slice(0, -1)
+    }
     if (normalizedFile === root) {
       return rootCache
     }

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -215,6 +215,10 @@ test('Resolve doesnt interrupt page request with trailing query and .css', async
   expect(await page.textContent('h1')).toBe('Resolve')
 })
 
+test('resolve non-normalized absolute path', async () => {
+  expect(await page.textContent('.non-normalized')).toMatch('[success]')
+})
+
 test.runIf(!isWindows)(
   'Resolve doesnt interrupt page request that clashes with local project package.json',
   async () => {

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -167,6 +167,9 @@
 <h2>resolve package that contains # in path</h2>
 <p class="path-contains-sharp-symbol"></p>
 
+<h2>resolve non normalized absolute path</h2>
+<p class="non-normalized"></p>
+
 <script type="module">
   import '@generated-content-virtual-file'
   function text(selector, text) {
@@ -384,6 +387,9 @@
     '.path-contains-sharp-symbol',
     `[success] ${contains.call('#', '#')} ${last.call('#')}`,
   )
+
+  import nonNormalizedAbsolute from '@non-normalized'
+  text('.non-normalized', nonNormalizedAbsolute)
 </script>
 
 <style>

--- a/playground/resolve/non-normalized.js
+++ b/playground/resolve/non-normalized.js
@@ -1,0 +1,1 @@
+export default '[success] non normalized absolute path'

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -103,7 +103,7 @@ export default defineConfig({
       name: 'resolve to non normalized absolute',
       async resolveId(id) {
         if (id !== '@non-normalized') return
-        return this.resolve(__dirname + '//././non-normalized.js')
+        return this.resolve(__dirname + '//././non-normalized')
       },
     },
   ],

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -103,7 +103,7 @@ export default defineConfig({
       name: 'resolve to non normalized absolute',
       async resolveId(id) {
         if (id !== '@non-normalized') return
-        return this.resolve(__dirname + '//././non-normalized')
+        return this.resolve(__dirname + '//non-normalized')
       },
     },
   ],

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -99,6 +99,13 @@ export default defineConfig({
         }
       },
     },
+    {
+      name: 'resolve to non normalized absolute',
+      async resolveId(id) {
+        if (id !== '@non-normalized') return
+        return this.resolve(__dirname + '//././non-normalized.js')
+      },
+    },
   ],
   optimizeDeps: {
     include: [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
I checked this with #15858 and #15901.


fixes #15858
fixes #15901
refs #15279

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
