### PR TITLE
docs: add canonical url in head

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -331,5 +331,16 @@ export default defineConfig({
       level: [2, 3],
     },
   },
+  transformPageData(pageData) {
+    const canonicalUrl = `${ogUrl}/${pageData.relativePath}`
+      .replace(/\/index\.md$/, '/')
+      .replace(/\.md$/, '/')
+    pageData.frontmatter.head ??= []
+    pageData.frontmatter.head.unshift([
+      'link',
+      { rel: 'canonical', href: canonicalUrl },
+    ])
+    return pageData
+  },
   buildEnd,
 })


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fixes #15342 by adding canonical URL to the `<head>` of all pages.

To check:
```sh
pnpm install
pnpm run docs-build
pnpm run docs-serve
```

### Additional context

- Why not `transformHead` instead?
    - `transformHead` was a cleaner solution, but it only adds the canonical tag to the `.html` variants of URLs, not the main pages. Canonical URLs are meant to be added to all variants of a page including the canonical page itself.
- Why `ogUrl` as the base?
    - This is the constant also used by the other-languages versions of the documentation, which point to https://ko.vitejs.dev etc. Language variants are *not* considered variants of the English documentation, and thus canonical URLs should point to their own subdomain.
    - Canonical URLs should be absolute URLs, not relative.
- Why two `.replace` calls instead of `.replace(/(?:\/index)?\.md$/, '/')`
    - This is arguably less readable, the current version is clearer in what it tries to achieve.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] ~~Ideally, include relevant tests that fail without this PR but pass with it.~~
