### PR TITLE
feat(create-vite): add custom remix option for React

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -111,6 +111,13 @@ const FRAMEWORKS: Framework[] = [
         display: 'JavaScript + SWC',
         color: yellow,
       },
+      {
+        name: 'custom-remix',
+        display: 'Remix ↗',
+        color: cyan,
+        customCommand:
+          'npm create remix@latest TARGET_DIR -- --template remix-run/remix/templates/vite',
+      },
     ],
   },
   {


### PR DESCRIPTION
### Description

Remix Vite is now stable: https://remix.run/blog/remix-vite-stable

This PR adds a jump to create-remix to the React options, in the same way we do it for Nuxt and SvelteKit.

In a future release, the Vite template will be default and we could remove the `--template` argument.

<img width="418" alt="image" src="https://github.com/vitejs/vite/assets/583075/1fdfa5e3-b020-4aad-8f54-6bd1764a293d">

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other