### PR TITLE
fix: normalize literal-only entry pattern

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -259,7 +259,9 @@ function orderedDependencies(deps: Record<string, string>) {
 function globEntries(pattern: string | string[], config: ResolvedConfig) {
   const resolvedPatterns = arraify(pattern)
   if (resolvedPatterns.every((str) => !glob.isDynamicPattern(str))) {
-    return resolvedPatterns.map((p) => path.resolve(config.root, p))
+    return resolvedPatterns.map((p) =>
+      normalizePath(path.resolve(config.root, p)),
+    )
   }
   return glob(pattern, {
     cwd: config.root,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
After merging #15853, custom `optimizeDeps.entries` may skip running `fast-glob`. In order to keep the custom `optimizeDeps.entries` result in the same format as the result returned by `fast-glob` on the windows platform, `normalizePath` is called to process the path.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
