### PR TITLE
fix(plugin-legacy): dynamic import browserslist-to-esbuild

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -209,13 +209,15 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           overriddenBuildTarget = config.build.target !== undefined
           overriddenDefaultModernTargets = options.modernTargets !== undefined
 
-          // Package is ESM only
-          const { default: browserslistToEsbuild } = await import(
-            'browserslist-to-esbuild'
-          )
-          config.build.target = options.modernTargets
-            ? browserslistToEsbuild(options.modernTargets)
-            : modernTargetsEsbuild
+          if (options.modernTargets) {
+            // Package is ESM only
+            const { default: browserslistToEsbuild } = await import(
+              'browserslist-to-esbuild'
+            )
+            config.build.target = browserslistToEsbuild(options.modernTargets)
+          } else {
+            config.build.target = modernTargetsEsbuild
+          }
         }
       }
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -24,7 +24,6 @@ import type {
 } from '@babel/core'
 import colors from 'picocolors'
 import browserslist from 'browserslist'
-import browserslistToEsbuild from 'browserslist-to-esbuild'
 import type { Options } from './types'
 import {
   detectModernBrowserCode,
@@ -189,7 +188,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   const legacyConfigPlugin: Plugin = {
     name: 'vite:legacy-config',
 
-    config(config, env) {
+    async config(config, env) {
       if (env.command === 'build' && !config.build?.ssr) {
         if (!config.build) {
           config.build = {}
@@ -209,6 +208,11 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           // See https://github.com/vitejs/vite/pull/10052#issuecomment-1242076461
           overriddenBuildTarget = config.build.target !== undefined
           overriddenDefaultModernTargets = options.modernTargets !== undefined
+
+          // Package is ESM only
+          const { default: browserslistToEsbuild } = await import(
+            'browserslist-to-esbuild'
+          )
           config.build.target = options.modernTargets
             ? browserslistToEsbuild(options.modernTargets)
             : modernTargetsEsbuild


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

fix https://github.com/vitejs/vite/pull/15988#issuecomment-1959486907

`browserslist-to-esbuild` is ESM only, so we need to dynamically import it.

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

