### PR TITLE
fix(optimizer): support extensionless imports for included glob dependencies

### DIFF
--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -137,7 +137,10 @@ export function expandGlobIds(id: string, config: ResolvedConfig): string[] {
     // for packages without exports, we can do a simple glob
     const matched = glob
       .sync(pattern, { cwd: pkgData.dir, ignore: ['node_modules'] })
-      .map((match) => path.posix.join(pkgName, slash(match)))
+      .flatMap((match) => {
+        const res = path.posix.join(pkgName, slash(match))
+        return res.endsWith('.js') ? [res, res.slice(0, -3)] : [res]
+      })
     matched.unshift(pkgName)
     return matched
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This change updates the glob expansion logic in `optimizeDeps.include` to additionally include references to external CommonJS files that are imported without an extension. With today's behaviour, the optimizer seems to only pick up deep-imports of CommonJS module that have an extension:

```
# works
import { Pet } from '@acme/pet-store-cjs/models/pet.js

# does not work - fixed by this change
import { Pet } from '@acme/pet-store-cjs/models/pet
```

This assumes the user has the following in their vite.config.js:
```js
export default defineConfig({
  optimizeDeps: {
    include: [
      "@acme/pet-store-cjs/**/*.js",
    ],
  },

  // ... other config ...
});
```
### Additional context

I experienced this issue in a PNPM workspace where a Vite app had a workspace dependency that was using CommonJS.

```
packages/
  my-vite-react-app/
    package.json  # contains "@acme/pet-store-cjs": "workspace:^",
  pet-store-cjs/
    package.json
    index.js
    models/
      pet.js
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
