### PR TITLE
feat(resolve): auto externalize node builtins for `noExternal: true` in node

### DIFF
--- a/docs/config/ssr-options.md
+++ b/docs/config/ssr-options.md
@@ -18,7 +18,7 @@ Note that the explicitly listed dependencies (using `string[]` type) will always
 
 Prevent listed dependencies from being externalized for SSR, which they will get bundled in build. By default, only linked dependencies are not externalized (for HMR). If you prefer to externalize the linked dependency, you can pass its name to the `ssr.external` option.
 
-If `true`, no dependencies are externalized. However, dependencies explicitly listed in `ssr.external` (using `string[]` type) can take priority and still be externalized. If you're building with `ssr.target: 'node'`, Node.js built-ins will also be externalized by default.
+If `true`, no dependencies are externalized. However, dependencies explicitly listed in `ssr.external` (using `string[]` type) can take priority and still be externalized. If `ssr.target: 'node'` is set, Node.js built-ins will also be externalized by default.
 
 Note that if both `ssr.noExternal: true` and `ssr.external: true` are configured, `ssr.noExternal` takes priority and no dependencies are externalized.
 

--- a/docs/config/ssr-options.md
+++ b/docs/config/ssr-options.md
@@ -18,7 +18,7 @@ Note that the explicitly listed dependencies (using `string[]` type) will always
 
 Prevent listed dependencies from being externalized for SSR, which they will get bundled in build. By default, only linked dependencies are not externalized (for HMR). If you prefer to externalize the linked dependency, you can pass its name to the `ssr.external` option.
 
-If `true`, no dependencies are externalized. However, dependencies explicitly listed in `ssr.external` (using `string[]` type) can take priority and still be externalized.
+If `true`, no dependencies are externalized. However, dependencies explicitly listed in `ssr.external` (using `string[]` type) can take priority and still be externalized. If you're building with `ssr.target: 'node'`, Node.js built-ins will also be externalized by default.
 
 Note that if both `ssr.noExternal: true` and `ssr.external: true` are configured, `ssr.noExternal` takes priority and no dependencies are externalized.
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -400,6 +400,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         if (isBuiltin(id)) {
           if (ssr) {
             if (
+              targetWeb &&
               ssrNoExternal === true &&
               // if both noExternal and external are true, noExternal will take the higher priority and bundle it.
               // only if the id is explicitly listed in external, we will externalize it and skip this error.


### PR DESCRIPTION
### Description

In this PR, when setting `ssr.noExternal: true` and `ssr.target: 'node'` (default), node builtins will be auto-externalized. Without this PR, it'll error that `Cannot bundle Node.js built-in "node:http" imported from .... Consider disabling ssr.noExternal or remove the built-in dependency.`, which I think is odd because we know we're building for node, and it's safe to auto-externalize by default.

This feature was added long ago in https://github.com/vitejs/vite/pull/4490 for webworkers. And there's also workarounds by setting node builtins in `ssr.external` manually yourself. But I figured to kick off this idea since it feels like a safe default.

### Additional context

Found this while reviewing https://github.com/withastro/astro/pull/10202. I figured for users who build to node and want to bundle everything, we can suggest `ssr.noExternal: true` only and it'll work, otherwise they need to workaround setting builtins in `ssr.external` manually.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
