### PR TITLE
fix(create-vite): ts error in the svelte-ts template

### DIFF
--- a/packages/create-vite/template-svelte-ts/src/main.ts
+++ b/packages/create-vite/template-svelte-ts/src/main.ts
@@ -2,7 +2,7 @@ import './app.css'
 import App from './App.svelte'
 
 const app = new App({
-  target: document.getElementById('app'),
+  target: document.getElementById('app')!,
 })
 
 export default app


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The ts compiler says that `null` is not assignable to `target`. This PR fixes that.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
