### PR TITLE
fix: `fsp.rm` removing files does not take effect

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -503,6 +503,7 @@ export function runOptimizeDeps(
       // are unique per run
       debug?.(colors.green(`removing cache dir ${processingCacheDir}`))
       try {
+        // When exiting the process, `fsp.rm` may not take effect, so we use `fs.rmSync`
         fs.rmSync(processingCacheDir, { recursive: true, force: true })
       } catch (error) {
         // Ignore errors

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -502,9 +502,11 @@ export function runOptimizeDeps(
       // No need to wait, we can clean up in the background because temp folders
       // are unique per run
       debug?.(colors.green(`removing cache dir ${processingCacheDir}`))
-      fsp.rm(processingCacheDir, { recursive: true, force: true }).catch(() => {
+      try {
+        fs.rmSync(processingCacheDir, { recursive: true, force: true })
+      } catch (error) {
         // Ignore errors
-      })
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When I execute `pnpm dev --debug` to start the project, a cache file will be generated in the `.vite` folder, but when I type `q` in the terminal to exit the project, the terminal will output information about removing the cache, but the corresponding cache files are not deleted.

I tried to use `fs.rmSync` to replace `fsp.rm` and the corresponding cache file could be successfully deleted.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context
I am not sure whether it is related to the operating environment. The above problems were encountered and solved in my local Windows environment, and the corresponding node version is v18.16.1.
<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
