### PR TITLE
fix: output correct error for empty import specifier

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -480,7 +480,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           // static import or valid string in dynamic import
           // If resolvable, let's resolve it
-          if (specifier) {
+          if (specifier !== undefined) {
             // skip external / data uri
             if (isExternalUrl(specifier) || isDataUrl(specifier)) {
               return


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Reported at https://github.com/vitejs/vite/discussions/8042#discussioncomment-7399549
With this PR, the error will be:

> [plugin:vite:import-analysis] Failed to resolve import "" from "index.html?html-proxy&index=0.js". Does the file exist?

I tested this by adding `import ''` in `playground/resolve/index.html`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
