### PR TITLE
feat(css): allow scoping css to importers exports

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -214,8 +214,8 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         ) {
           options.isFromTsImporter = true
         } else {
-          const moduleLang = this.getModuleInfo(importer)?.meta?.vite?.lang
-          options.isFromTsImporter = moduleLang && isTsRequest(`.${moduleLang}`)
+          const lang = this.getModuleInfo(importer)?.meta?.vite?.lang
+          options.isFromTsImporter = lang != null && isTsRequest(`.${lang}`)
         }
       }
 

--- a/packages/vite/types/metadata.d.ts
+++ b/packages/vite/types/metadata.d.ts
@@ -7,4 +7,29 @@ declare module 'rollup' {
   export interface RenderedChunk {
     viteMetadata?: ChunkMetadata
   }
+
+  export interface CustomPluginOptions {
+    vite?: {
+      /**
+       * The language for this module, e.g. `ts`, `tsx`, etc.
+       * Used to identify if this module should resolve its `*.js` imports
+       * to TypeScript files.
+       */
+      lang?: string
+      /**
+       * If this is a CSS Rollup module, you can scope to its importer's exports
+       * so that if those exports are treeshaken away, the CSS module will also
+       * be treeshaken. If multiple importers and exports are passed, if at least
+       * one of them are bundled (and not treeshaken), then the CSS will also be bundled.
+       *
+       * Example config if the CSS id is `/src/App.vue?vue&type=style&lang.css`:
+       * ```js
+       * cssScopeTo: {
+       *   '/src/App.vue': ['default']
+       * }
+       * ```
+       */
+      cssScopeTo?: Record<string, string[]>
+    }
+  }
 }

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -533,3 +533,9 @@ test.runIf(isBuild)('manual chunk path', async () => {
     findAssetFile(/dir\/dir2\/manual-chunk-[-\w]{8}\.css$/),
   ).not.toBeUndefined()
 })
+
+test.runIf(isBuild)('Scoped CSS via cssScopeTo should be treeshaken', () => {
+  const css = findAssetFile(/\.css$/, undefined, undefined, true)
+  expect(css).not.toContain('treeshake-module-b')
+  expect(css).not.toContain('treeshake-module-c')
+})

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -19,6 +19,8 @@
   <pre class="imported-css-glob"></pre>
   <pre class="imported-css-globEager"></pre>
 
+  <p class="scoped">Imported scoped CSS</p>
+
   <p class="postcss">
     <span class="nesting">PostCSS nesting plugin: this should be pink</span>
   </p>

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -12,6 +12,9 @@ appendLinkStylesheet(urlCss)
 import rawCss from './raw-imported.css?raw'
 text('.raw-imported-css', rawCss)
 
+import { cUsed, a as treeshakeScopedA } from './treeshake-scoped/index.js'
+document.querySelector('.scoped').classList.add(treeshakeScopedA(), cUsed())
+
 import mod from './mod.module.css'
 document.querySelector('.modules').classList.add(mod['apply-color'])
 text('.modules-code', JSON.stringify(mod, null, 2))

--- a/playground/css/treeshake-scoped/a-scoped.css
+++ b/playground/css/treeshake-scoped/a-scoped.css
@@ -1,0 +1,3 @@
+.treeshake-scoped-a {
+  color: red;
+}

--- a/playground/css/treeshake-scoped/a.js
+++ b/playground/css/treeshake-scoped/a.js
@@ -1,0 +1,5 @@
+import './a-scoped.css' // should be treeshaken away if `a` is not used
+
+export default function a() {
+  return 'treeshake-scoped-a'
+}

--- a/playground/css/treeshake-scoped/b-scoped.css
+++ b/playground/css/treeshake-scoped/b-scoped.css
@@ -1,0 +1,3 @@
+.treeshake-scoped-b {
+  color: red;
+}

--- a/playground/css/treeshake-scoped/b.js
+++ b/playground/css/treeshake-scoped/b.js
@@ -1,0 +1,5 @@
+import './b-scoped.css' // should be treeshaken away if `b` is not used
+
+export default function b() {
+  return 'treeshake-scoped-b'
+}

--- a/playground/css/treeshake-scoped/c-scoped.css
+++ b/playground/css/treeshake-scoped/c-scoped.css
@@ -1,0 +1,3 @@
+.treeshake-scoped-c {
+  color: red;
+}

--- a/playground/css/treeshake-scoped/c.js
+++ b/playground/css/treeshake-scoped/c.js
@@ -1,0 +1,10 @@
+import './c-scoped.css' // should be treeshaken away if `b` is not used
+
+export default function c() {
+  return 'treeshake-scoped-c'
+}
+
+export function cUsed() {
+  // used but does not depend on scoped css
+  return 'c-used'
+}

--- a/playground/css/treeshake-scoped/d-scoped.css
+++ b/playground/css/treeshake-scoped/d-scoped.css
@@ -1,0 +1,3 @@
+.treeshake-scoped-d {
+  color: red;
+}

--- a/playground/css/treeshake-scoped/d.js
+++ b/playground/css/treeshake-scoped/d.js
@@ -1,0 +1,5 @@
+import './d-scoped.css' // should be treeshaken away if `d` is not used
+
+export default function d() {
+  return 'treeshake-scoped-d'
+}

--- a/playground/css/treeshake-scoped/index.html
+++ b/playground/css/treeshake-scoped/index.html
@@ -1,0 +1,7 @@
+<h1>treeshake-scoped</h1>
+<p class="scoped-another">Imported scoped CSS</p>
+
+<script type="module">
+  import { d } from './index.js'
+  document.querySelector('.scoped-another').classList.add(d())
+</script>

--- a/playground/css/treeshake-scoped/index.js
+++ b/playground/css/treeshake-scoped/index.js
@@ -1,0 +1,3 @@
+export { default as a } from './a.js'
+export { default as b } from './b.js'
+export { default as c, cUsed } from './c.js'

--- a/playground/css/treeshake-scoped/index.js
+++ b/playground/css/treeshake-scoped/index.js
@@ -1,3 +1,4 @@
 export { default as a } from './a.js'
 export { default as b } from './b.js'
 export { default as c, cUsed } from './c.js'
+export { default as d } from './d.js'

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -10,6 +10,31 @@ globalThis.window = {}
 globalThis.location = new URL('http://localhost/')
 
 export default defineConfig({
+  plugins: [
+    {
+      // Emulate a UI framework component where a framework module would import
+      // scoped CSS files that should treeshake if the default export is not used.
+      name: 'treeshake-scoped-css',
+      enforce: 'pre',
+      async resolveId(id, importer) {
+        if (!importer || !id.endsWith('-scoped.css')) return
+
+        const resolved = await this.resolve(id, importer)
+        if (!resolved) return
+
+        return {
+          ...resolved,
+          meta: {
+            vite: {
+              cssScopeTo: {
+                [importer]: ['default'],
+              },
+            },
+          },
+        }
+      },
+    },
+  ],
   build: {
     cssTarget: 'chrome61',
     rollupOptions: {

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -38,6 +38,13 @@ export default defineConfig({
   build: {
     cssTarget: 'chrome61',
     rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, './index.html'),
+        treeshakeScoped: path.resolve(
+          __dirname,
+          './treeshake-scoped/index.html',
+        ),
+      },
       output: {
         manualChunks(id) {
           if (id.includes('manual-chunk.css')) {

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -39,7 +39,7 @@ export default defineConfig({
     cssTarget: 'chrome61',
     rollupOptions: {
       input: {
-        main: path.resolve(__dirname, './index.html'),
+        index: path.resolve(__dirname, './index.html'),
         treeshakeScoped: path.resolve(
           __dirname,
           './treeshake-scoped/index.html',

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -156,6 +156,7 @@ export function findAssetFile(
   match: string | RegExp,
   base = '',
   assets = 'assets',
+  matchAll = false,
 ): string {
   const assetsDir = path.join(testDir, 'dist', base, assets)
   let files: string[]
@@ -167,10 +168,21 @@ export function findAssetFile(
     }
     throw e
   }
-  const file = files.find((file) => {
-    return file.match(match)
-  })
-  return file ? fs.readFileSync(path.resolve(assetsDir, file), 'utf-8') : ''
+  if (matchAll) {
+    const matchedFiles = files.filter((file) => file.match(match))
+    return matchedFiles.length
+      ? matchedFiles
+          .map((file) =>
+            fs.readFileSync(path.resolve(assetsDir, file), 'utf-8'),
+          )
+          .join('')
+      : ''
+  } else {
+    const matchedFile = files.find((file) => file.match(match))
+    return matchedFile
+      ? fs.readFileSync(path.resolve(assetsDir, matchedFile), 'utf-8')
+      : ''
+  }
 }
 
 export function readManifest(base = ''): Manifest {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

closes https://github.com/vitejs/vite/issues/4389
closes https://github.com/vitejs/vite/issues/15497 (doesn't exactly fix it, but unblocks downstream to fix this)

Frameworks like Vue, Svelte, and Astro has the concept of scoped CSS. Internally, they are transformed as imports to a virtual CSS module. However, the general CSS bundling flow will assume the CSS to be global, so even if the framework component is used but treeshaken, the CSS will still be kept because Vite assumes its global.

To resolve this, Vite plugins can mark certain CSS to be scoped to certain modules' exports. For example, `/src/Foo.vue?vue&type=style&lang.css` is scoped to `/src/App.vue`'s default export.

The API this PR exposes is via `meta.vite.cssScopeTo['/src/Foo.vue'] = ['default']` set on the `/src/Foo.vue?vue&type=style&lang.css` modules in Vite plugins. Now, if `Foo.vue` is not used, the styles are also treeshaken.

### Additional context

This only works in build, in dev it will still loaded as ESM will load it as usual (we dont treeshake in dev). However, this shouldn't be an issue in dev because the CSS should be scoped and not affect anything globally.

I can't figure out a general API that works outside of Vite plugins without magic comments. Import attributes or queries don't seem feasible because they annotate the "import statement" rather than the "rollup module" itself.

I've also tested this manually in a Svelte app. From some rough implementations, it's easiest to set the `meta` on the `resolveId` hook when resolving the virtual CSS module. (implementation detail)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
