### PR TITLE
fix(assets): avoid splitting `,` inside query parameter of image URI in srcset property

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -339,6 +339,14 @@ describe('processSrcSetSync', () => {
     expect(processSrcSetSync(base64, ({ url }) => url)).toBe(base64)
   })
 
+  test('should not split the comma inside image URI', async () => {
+    const imageURIWithComma =
+      'asset.png?param1=true,param2=false 400w, asset.png?param1=true,param2=false 800w'
+    expect(processSrcSetSync(imageURIWithComma, ({ url }) => url)).toBe(
+      imageURIWithComma,
+    )
+  })
+
   test('should not break a regular URL in srcSet', async () => {
     const source = 'https://anydomain/image.jpg'
     expect(

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -347,6 +347,12 @@ describe('processSrcSetSync', () => {
     )
   })
 
+  test('should handle srcset when descriptor is not present', async () => {
+    const srcsetNoDescriptor = 'asset.png, test.png 400w,test2?param1=true.png'
+    const result = 'asset.png, test.png 400w, test2?param1=true.png'
+    expect(processSrcSetSync(srcsetNoDescriptor, ({ url }) => url)).toBe(result)
+  })
+
   test('should not break a regular URL in srcSet', async () => {
     const source = 'https://anydomain/image.jpg'
     expect(

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -348,8 +348,8 @@ describe('processSrcSetSync', () => {
   })
 
   test('should handle srcset when descriptor is not present', async () => {
-    const srcsetNoDescriptor = 'asset.png, test.png 400w,test2?param1=true.png'
-    const result = 'asset.png, test.png 400w, test2?param1=true.png'
+    const srcsetNoDescriptor = 'asset.png, test.png 400w'
+    const result = 'asset.png, test.png 400w'
     expect(processSrcSetSync(srcsetNoDescriptor, ({ url }) => url)).toBe(result)
   })
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -770,7 +770,7 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|\S[^\s?]*\?\S+,\S+/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|\?\S+,/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
   /**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -770,7 +770,7 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|[^\s?]*\?\S*,\S*/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|[^\s?]+\?\S+,\S+/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
   /**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -770,7 +770,7 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|[^\s?]+\?\S+,\S+/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|\w+\?\S+,\S+/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
   /**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -770,7 +770,7 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|\w+\?\S+,\S+/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|\S[^\s?]*\?\S+,\S+/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
   /**

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -770,10 +770,17 @@ export function processSrcSetSync(
 }
 
 const cleanSrcSetRE =
-  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+/g
+  /(?:url|image|gradient|cross-fade)\([^)]*\)|"([^"]|(?<=\\)")*"|'([^']|(?<=\\)')*'|data:\w+\/[\w.+\-]+;base64,[\w+/=]+|[^\s?]*\?\S*,\S*/g
 function splitSrcSet(srcs: string) {
   const parts: string[] = []
-  // There could be a ',' inside of url(data:...), linear-gradient(...), "data:..." or data:...
+  /**
+   * There could be a ',' inside of:
+   * - url(data:...)
+   * - linear-gradient(...)
+   * - "data:..."
+   * - data:...
+   * - query parameter ?...
+   */
   const cleanedSrcs = srcs.replace(cleanSrcSetRE, blankReplacer)
   let startIndex = 0
   let splitIndex: number


### PR DESCRIPTION
fixes #16077 

### Description

When building list of image candidates, `splitSrcSet` breaks image URIs that contain query parameters with comma delimited values i.e. `asset.png?param1=test,param2=test`.

Current implementation looks at srcset string and splits it at comma delimiters, including commas found in imageURIs. As a result, this srcset:
```
asset.png?param1=test,param2=test 400w, asset.png?param1=test,param2=test 800w,
```
...is split into 
```
["asset.png?param1=test,", "param2=test 400w", "asset.png?param1=test,", "param2=test 800w", ]
```
...creating invalid image links that do not match the original HTML. 

### Additional context

Update `splitSrcSet` to split string of srcs by commas followed by whitespace characters. This excludes commas found in the imageURI. 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
