### PR TITLE
fix: resolve relative URL generated by `renderBuiltUrl` passed to module preload

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -168,7 +168,6 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
   const renderBuiltUrl = config.experimental.renderBuiltUrl
   const isRelativeBase = config.base === './' || config.base === ''
-  const optimizeModulePreloadRelativePaths = isRelativeBase && !renderBuiltUrl
 
   const { modulePreload } = config.build
   const scriptRel =
@@ -184,7 +183,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
   // using regex over this list to workaround the fact that module preload wasn't
   // configurable.
   const assetsURL =
-    renderBuiltUrl || optimizeModulePreloadRelativePaths
+    renderBuiltUrl || isRelativeBase
       ? // If `experimental.renderBuiltUrl` is used, the dependencies might be relative to the current chunk.
         // If relative base is used, the dependencies are relative to the current chunk.
         // The importerUrl is passed as third parameter to __vitePreload in this case
@@ -343,9 +342,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           str().appendRight(
             expEnd,
             `,${isModernFlag}?${preloadMarker}:void 0${
-              optimizeModulePreloadRelativePaths || renderBuiltUrl
-                ? ',import.meta.url'
-                : ''
+              renderBuiltUrl || isRelativeBase ? ',import.meta.url' : ''
             })`,
           )
         }
@@ -623,7 +620,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                   renderedDeps = depsArray.map((d) =>
                     // Don't include the assets dir if the default asset file names
                     // are used, the path will be reconstructed by the import preload helper
-                    optimizeModulePreloadRelativePaths
+                    isRelativeBase
                       ? addFileDep(toRelativePath(d, file))
                       : addFileDep(d),
                   )

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -176,21 +176,17 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       ? `'modulepreload'`
       : `(${detectScriptRel.toString()})()`
 
-  // There are three different cases for the preload list format in __vitePreload
+  // There are two different cases for the preload list format in __vitePreload
   //
   // __vitePreload(() => import(asyncChunk), [ ...deps... ])
   //
   // This is maintained to keep backwards compatibility as some users developed plugins
   // using regex over this list to workaround the fact that module preload wasn't
   // configurable.
-  const assetsURL = renderBuiltUrl
-    ? // If `experimental.renderBuiltUrl` is used, the dependencies are already resolved.
-      // To avoid the need for `new URL(dep, import.meta.url)`, a helper `__vitePreloadRelativeDep` is
-      // used to resolve from relative paths which can be minimized.
-      `function(dep, importerUrl) { return dep[0] === '.' ? new URL(dep, importerUrl).href : dep }`
-    : optimizeModulePreloadRelativePaths
-      ? // If there isn't custom resolvers affecting the deps list, deps in the list are relative
-        // to the current chunk and are resolved to absolute URL by the __vitePreload helper itself.
+  const assetsURL =
+    renderBuiltUrl || optimizeModulePreloadRelativePaths
+      ? // If `experimental.renderBuiltUrl` is used, the dependencies might be relative to the current chunk.
+        // If relative base is used, the dependencies are relative to the current chunk.
         // The importerUrl is passed as third parameter to __vitePreload in this case
         `function(dep, importerUrl) { return new URL(dep, importerUrl).href }`
       : // If the base isn't relative, then the deps are relative to the projects `outDir` and the base

--- a/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
+++ b/playground/preload/__tests__/resolve-deps/preload-resolve-deps.spec.ts
@@ -21,7 +21,9 @@ describe.runIf(isBuild)('build', () => {
     expect(html).toMatch(
       /link rel="modulepreload".*?href="http.*?\/hello-[-\w]{8}\.js"/,
     )
-    expect(html).toMatch(/link rel="modulepreload".*?href="\/preloaded.js"/)
+    expect(html).toMatch(
+      /link rel="modulepreload".*?href="http.*?\/preloaded.js"/,
+    )
     expect(html).toMatch(
       /link rel="stylesheet".*?href="http.*?\/hello-[-\w]{8}\.css"/,
     )

--- a/playground/preload/package.json
+++ b/playground/preload/package.json
@@ -8,14 +8,14 @@
     "build": "vite build",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview",
-    "dev:resolve-deps": "vite --config vite.config-resolve-deps.ts",
-    "build:resolve-deps": "vite build --config vite.config-resolve-deps.ts",
-    "debug:resolve-deps": "node --inspect-brk ../../packages/vite/bin/vite --config vite.config-resolve-deps.ts",
-    "preview:resolve-deps": "vite preview --config vite.config-resolve-deps.ts",
-    "dev:preload-disabled": "vite --config vite.config-preload-disabled.ts",
-    "build:preload-disabled": "vite build --config vite.config-preload-disabled.ts",
-    "debug:preload-disabled": "node --inspect-brk ../../packages/vite/bin/vite --config vite.config-preload-disabled.ts",
-    "preview:preload-disabled": "vite preview --config vite.config-preload-disabled.ts"
+    "dev:resolve-deps": "vite --config vite.config-resolve-deps.js",
+    "build:resolve-deps": "vite build --config vite.config-resolve-deps.js",
+    "debug:resolve-deps": "node --inspect-brk ../../packages/vite/bin/vite --config vite.config-resolve-deps.js",
+    "preview:resolve-deps": "vite preview --config vite.config-resolve-deps.js",
+    "dev:preload-disabled": "vite --config vite.config-preload-disabled.js",
+    "build:preload-disabled": "vite build --config vite.config-preload-disabled.js",
+    "debug:preload-disabled": "node --inspect-brk ../../packages/vite/bin/vite --config vite.config-preload-disabled.js",
+    "preview:preload-disabled": "vite preview --config vite.config-preload-disabled.js"
   },
   "devDependencies": {
     "terser": "^5.31.3",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
~~Built on top of #16083~~

When `renderBuiltUrl` returned a relative URL (e.g. `/foo` or `foo`), [`assetsURL` function](https://github.com/vitejs/vite/blob/0c0aeaeb3f12d2cdc3c47557da209416c8d48fb7/packages/vite/src/node/plugins/importAnalysisBuild.ts#L180) returned a relative URL. [The preload function expects an absolute URL](https://github.com/vitejs/vite/blob/0c0aeaeb3f12d2cdc3c47557da209416c8d48fb7/packages/vite/src/node/plugins/importAnalysisBuild.ts#L96-L97) and inserted a duplicate CSS link tag.

This PR fixes that by changing the `assetsURL` function from `function(dep, importerUrl) { return dep[0] === '.' ? new URL(dep, importerUrl).href : dep }` to `function(dep, importerUrl) { return new URL(dep, importerUrl).href }`. This modification changes the behavior when a relative path that doesn't start with `.` is passed. If we want to keep the previous behavior, the function needs to be `function(dep, importerUrl) { return dep[0] === '.' ? new URL(dep, importerUrl).href : new URL(dep, document.baseURI) }`. But I think that behavior is confusing.

fixes #14463

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
