### PR TITLE
docs: add reference link for set debug environment variable on Windows

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -197,7 +197,7 @@ Custom HMR events can also be sent from plugins. See [handleHotUpdate](./api-plu
 
 ## `hot.off(event, cb)`
 
-Remove callback from the event listeners
+Remove callback from the event listeners.
 
 ## `hot.send(event, data)`
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -26,7 +26,7 @@ However, the performance of community plugins is out of Vite's control, which ma
 
    The longer it takes to transform a file, the more significant the request waterfall will be when loading the site in the browser.
 
-   You can inspect the duration it takes to transform a file using `DEBUG="vite:plugin-transform" vite` or [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect). Note that as asynchronous operations tend to provide inaccurate timings, you should treat the numbers as a rough estimate, but it should still reveal the more expensive operations.
+   You can inspect the duration it takes to transform a file using `DEBUG="vite:plugin-transform" vite` or [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect). Note that as asynchronous operations tend to provide inaccurate timings, you should treat the numbers as a rough estimate, but it should still reveal the more expensive operations. (For setting environment variables on Windows platform, please refer to the [documentation](https://github.com/debug-js/debug?tab=readme-ov-file#windows-command-prompt-notes).)
 
 ::: tip Profiling
 You can run `vite --profile`, visit the site, and press `p + enter` in your terminal to record a `.cpuprofile`. A tool like [speedscope](https://www.speedscope.app) can then be used to inspect the profile and identify the bottlenecks. You can also [share the profiles](https://chat.vitejs.dev) with the Vite team to help us identify performance issues.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -26,7 +26,7 @@ However, the performance of community plugins is out of Vite's control, which ma
 
    The longer it takes to transform a file, the more significant the request waterfall will be when loading the site in the browser.
 
-   You can inspect the duration it takes to transform a file using `DEBUG="vite:plugin-transform" vite` or [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect). Note that as asynchronous operations tend to provide inaccurate timings, you should treat the numbers as a rough estimate, but it should still reveal the more expensive operations. (For setting environment variables on Windows platform, please refer to the [documentation](https://github.com/debug-js/debug?tab=readme-ov-file#windows-command-prompt-notes).)
+   You can inspect the duration it takes to transform a file using `DEBUG="vite:plugin-transform" vite` or [vite-plugin-inspect](https://github.com/antfu/vite-plugin-inspect). Note that as asynchronous operations tend to provide inaccurate timings, you should treat the numbers as a rough estimate, but it should still reveal the more expensive operations. For setting environment variables on Windows platform, please refer to the [documentation](https://github.com/debug-js/debug?tab=readme-ov-file#windows-command-prompt-notes).
 
 ::: tip Profiling
 You can run `vite --profile`, visit the site, and press `p + enter` in your terminal to record a `.cpuprofile`. A tool like [speedscope](https://www.speedscope.app) can then be used to inspect the profile and identify the bottlenecks. You can also [share the profiles](https://chat.vitejs.dev) with the Vite team to help us identify performance issues.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The method provided in the documentation about configuring debug environment variables does not seem to apply to the Windows platform, so I decided to add a reference link about setting related environment variables on the Windows platform.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
