### PR TITLE
fix(worker): throw error when circular worker import is detected and support self referencing worker

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -328,7 +328,7 @@ export interface LegacyOptions {
 
 export interface ResolvedWorkerOptions {
   format: 'es' | 'iife'
-  plugins: () => Promise<Plugin[]>
+  plugins: (bundleChain: string[]) => Promise<Plugin[]>
   rollupOptions: RollupOptions
 }
 
@@ -357,6 +357,8 @@ export type ResolvedConfig = Readonly<
     // in nested worker bundle to find the main config
     /** @internal */
     mainConfig: ResolvedConfig | null
+    /** @internal list of bundle entry id. used to detect recursive worker bundle. */
+    bundleChain: string[]
     isProduction: boolean
     envDir: string
     env: Record<string, any>
@@ -689,7 +691,7 @@ export async function resolveConfig(
     )
   }
 
-  const createWorkerPlugins = async function () {
+  const createWorkerPlugins = async function (bundleChain: string[]) {
     // Some plugins that aren't intended to work in the bundling of workers (doing post-processing at build time for example).
     // And Plugins may also have cached that could be corrupted by being used in these extra rollup calls.
     // So we need to separate the worker plugin from the plugin that vite needs to run.
@@ -719,6 +721,7 @@ export async function resolveConfig(
       ...resolved,
       isWorker: true,
       mainConfig: resolved,
+      bundleChain,
     }
     const resolvedWorkerPlugins = await resolvePlugins(
       workerResolved,
@@ -760,6 +763,7 @@ export async function resolveConfig(
     ssr,
     isWorker: false,
     mainConfig: null,
+    bundleChain: [],
     isProduction,
     plugins: userPlugins,
     css: resolveCSSOptions(config.css),

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -111,7 +111,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(33)
+    expect(files.length).toBe(34)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))
@@ -231,6 +231,12 @@ test('import.meta.glob with eager in worker', async () => {
 
 test('self reference worker', async () => {
   expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+    'pong: main\npong: nested\n',
+  )
+})
+
+test('self reference url worker', async () => {
+  expectWithRetry(() => page.textContent('.self-reference-url-worker')).toBe(
     'pong: main\npong: nested\n',
   )
 })

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { isBuild, page, testDir, untilUpdated } from '~utils'
+import { expectWithRetry, isBuild, page, testDir, untilUpdated } from '~utils'
 
 test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong', true)
@@ -111,7 +111,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(32)
+    expect(files.length).toBe(33)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))
@@ -226,5 +226,11 @@ test('import.meta.glob with eager in worker', async () => {
     () => page.textContent('.importMetaGlobEager-worker'),
     '["',
     true,
+  )
+})
+
+test('self reference worker', async () => {
+  expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+    'pong: main\npong: nested\n',
   )
 })

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import {
+  expectWithRetry,
   isBuild,
   isServe,
   page,
@@ -74,7 +75,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/iife/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(20)
+    expect(files.length).toBe(21)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('worker_entry-my-worker'))
@@ -157,6 +158,12 @@ test('import.meta.glob eager in worker', async () => {
   await untilUpdated(
     () => page.textContent('.importMetaGlobEager-worker'),
     '["',
+  )
+})
+
+test('self reference worker', async () => {
+  expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+    'pong: main\npong: nested\n',
   )
 })
 

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -75,7 +75,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/iife/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(21)
+    expect(files.length).toBe(22)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('worker_entry-my-worker'))
@@ -163,6 +163,12 @@ test('import.meta.glob eager in worker', async () => {
 
 test('self reference worker', async () => {
   expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+    'pong: main\npong: nested\n',
+  )
+})
+
+test('self reference url worker', async () => {
+  expectWithRetry(() => page.textContent('.self-reference-url-worker')).toBe(
     'pong: main\npong: nested\n',
   )
 })

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -167,3 +167,9 @@ test('self reference worker', async () => {
     'pong: main\npong: nested\n',
   )
 })
+
+test('self reference url worker', async () => {
+  expectWithRetry(() => page.textContent('.self-reference-url-worker')).toBe(
+    'pong: main\npong: nested\n',
+  )
+})

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
-import { isBuild, page, testDir, untilUpdated } from '~utils'
+import { expectWithRetry, isBuild, page, testDir, untilUpdated } from '~utils'
 
 test('normal', async () => {
   await untilUpdated(() => page.textContent('.pong'), 'pong', true)
@@ -159,5 +159,11 @@ test('import.meta.glob with eager in worker', async () => {
     () => page.textContent('.importMetaGlobEager-worker'),
     '["',
     true,
+  )
+})
+
+test('self reference worker', async () => {
+  expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+    'pong: main\npong: nested\n',
   )
 })

--- a/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(42)
+    expect(files.length).toBe(44)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(40)
+    expect(files.length).toBe(42)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(21)
+    expect(files.length).toBe(22)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(20)
+    expect(files.length).toBe(21)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
+++ b/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
@@ -9,7 +9,7 @@ describe.runIf(isBuild)('build', () => {
     const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap/assets')
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(42)
+    expect(files.length).toBe(44)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
+++ b/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
@@ -9,7 +9,7 @@ describe.runIf(isBuild)('build', () => {
     const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap/assets')
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(40)
+    expect(files.length).toBe(42)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -159,6 +159,12 @@
 <code class="self-reference-worker"></code>
 
 <p>
+  new Worker(new URL('../self-reference-url-worker.js', import.meta.url))
+  <span class="classname">.self-reference-url-worker</span>
+</p>
+<code class="self-reference-url-worker"></code>
+
+<p>
   new Worker(new URL('../deeply-nested-worker.js', import.meta.url), { type:
   'module' })
   <span class="classname">.deeply-nested-worker</span>

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -153,6 +153,12 @@
 <code class="importMetaGlobEager-worker"></code>
 
 <p>
+  self reference worker
+  <span class="classname">.self-reference-worker</span>
+</p>
+<code class="self-reference-worker"></code>
+
+<p>
   new Worker(new URL('../deeply-nested-worker.js', import.meta.url), { type:
   'module' })
   <span class="classname">.deeply-nested-worker</span>

--- a/playground/worker/self-reference-url-worker.js
+++ b/playground/worker/self-reference-url-worker.js
@@ -1,0 +1,13 @@
+self.addEventListener('message', (e) => {
+  if (e.data === 'main') {
+    const selfWorker = new Worker(
+      new URL('./self-reference-url-worker.js', import.meta.url),
+    )
+    selfWorker.postMessage('nested')
+    selfWorker.addEventListener('message', (e) => {
+      self.postMessage(e.data)
+    })
+  }
+
+  self.postMessage(`pong: ${e.data}`)
+})

--- a/playground/worker/self-reference-worker.js
+++ b/playground/worker/self-reference-worker.js
@@ -1,0 +1,13 @@
+import SelfWorker from './self-reference-worker?worker'
+
+self.addEventListener('message', (e) => {
+  if (e.data === 'main') {
+    const selfWorker = new SelfWorker()
+    selfWorker.postMessage('nested')
+    selfWorker.addEventListener('message', (e) => {
+      self.postMessage(e.data)
+    })
+  }
+
+  self.postMessage(`pong: ${e.data}`)
+})

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -5,6 +5,7 @@ import mySharedWorker from '../my-shared-worker?sharedworker&name=shared'
 import TSOutputWorker from '../possible-ts-output-worker?worker'
 import NestedWorker from '../worker-nested-worker?worker'
 import { mode } from '../modules/workerImport'
+import SelfReferenceWorker from '../self-reference-worker?worker'
 
 function text(el, text) {
   document.querySelector(el).textContent = text
@@ -157,4 +158,10 @@ const importMetaGlobEagerWorker = new workers[
 importMetaGlobEagerWorker.postMessage('1')
 importMetaGlobEagerWorker.addEventListener('message', (e) => {
   text('.importMetaGlobEager-worker', JSON.stringify(e.data))
+})
+
+const selfReferenceWorker = new SelfReferenceWorker()
+selfReferenceWorker.postMessage('main')
+selfReferenceWorker.addEventListener('message', (e) => {
+  document.querySelector('.self-reference-worker').textContent += `${e.data}\n`
 })

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -165,3 +165,12 @@ selfReferenceWorker.postMessage('main')
 selfReferenceWorker.addEventListener('message', (e) => {
   document.querySelector('.self-reference-worker').textContent += `${e.data}\n`
 })
+
+const selfReferenceUrlWorker = new Worker(
+  new URL('../self-reference-url-worker.js', import.meta.url),
+)
+selfReferenceUrlWorker.postMessage('main')
+selfReferenceUrlWorker.addEventListener('message', (e) => {
+  document.querySelector('.self-reference-url-worker').textContent +=
+    `${e.data}\n`
+})


### PR DESCRIPTION
### Description
The first commit makes Vite to throw an error when a circular worker import is detected.
The second and third commits adds support for simple circular import cases (self reference).

fixes #7015

I didn't add support for complex cases (e.g. `worker-a.js` has `import 'worker-b.js?worker'` and `worker-b.js` has `import 'worker-a.js?worker'`). For those cases, Vite now throw errors (before this PR, the build never finished). But I think it's fine because doing that is not popular and will make the code complex. I checked that supporting the simple cases makes the build of #7015, https://github.com/vitejs/vite/issues/7015#issuecomment-1219908892, #12755, #14499, #15288, #15426, https://github.com/jamsinclair/jSquash/issues/15 pass.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
