### PR TITLE
fix: server middleware mode resolve

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -158,7 +158,7 @@ export interface ServerOptions extends CommonServerOptions {
 
 export interface ResolvedServerOptions extends ServerOptions {
   fs: Required<FileSystemServeOptions>
-  middlewareMode: Required<ServerOptions['middlewareMode']>
+  middlewareMode: Exclude<ServerOptions['middlewareMode'], undefined>
   sourcemapIgnoreList: Exclude<
     ServerOptions['sourcemapIgnoreList'],
     false | undefined

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -156,9 +156,10 @@ export interface ServerOptions extends CommonServerOptions {
     | ((sourcePath: string, sourcemapPath: string) => boolean)
 }
 
-export interface ResolvedServerOptions extends ServerOptions {
+export interface ResolvedServerOptions
+  extends Omit<ServerOptions, 'fs' | 'middlewareMode' | 'sourcemapIgnoreList'> {
   fs: Required<FileSystemServeOptions>
-  middlewareMode: Exclude<ServerOptions['middlewareMode'], undefined>
+  middlewareMode: NonNullable<ServerOptions['middlewareMode']>
   sourcemapIgnoreList: Exclude<
     ServerOptions['sourcemapIgnoreList'],
     false | undefined


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

In this merge request, https://github.com/vitejs/vite/pull/14632/files#diff-abb3345b6e3b2ec6d297c2ebc54cca85ae4487a31bac3cc9e78457f5114adb26R704 @antfu introduced object in `middlewareMode` property, but at that line of code this property is always boolean. That's why proxy WS is not working for Vite middleware mode.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
