### PR TITLE
fix(legacy): emit css assets when cssCodeSplit and modernChuns is off

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -467,7 +467,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       // we'll delete the assets from the legacy bundle to avoid emitting duplicate assets.
       // But that's still a waste of computing resource.
       // So we add this flag to avoid emitting the asset in the first place whenever possible.
-      opts.__vite_skip_asset_emit__ = true
+      opts.__vite_skip_asset_emit__ = genModern
 
       // avoid emitting assets for legacy bundle
       const needPolyfills =

--- a/playground/legacy/package.json
+++ b/playground/legacy/package.json
@@ -10,6 +10,7 @@
     "build:multiple-output": "vite --config ./vite.config-multiple-output.js build",
     "build:no-polyfills": "vite --config ./vite.config-no-polyfills.js build",
     "build:no-polyfills-no-systemjs": "vite --config ./vite.config-no-polyfills-no-systemjs.js build",
+    "build:css-code-split": "vite --config ./vite.config-css-code-split.js build",
     "build:watch": "vite --config ./vite.config-watch.js build --debug legacy",
     "debug": "node --inspect-brk ../../packages/vite/bin/vite",
     "preview": "vite preview"

--- a/playground/legacy/vite.config-css-code-split.js
+++ b/playground/legacy/vite.config-css-code-split.js
@@ -1,0 +1,21 @@
+import path from 'node:path'
+import legacy from '@vitejs/plugin-legacy'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    legacy({
+      renderModernChunks: false,
+    }),
+  ],
+
+  build: {
+    outDir: 'dist/css-code-split',
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: {
+        index: path.resolve(__dirname, 'index.html'),
+      },
+    },
+  },
+})


### PR DESCRIPTION
### Description

This change allows assets to be emitted when `renderModernChunks` is set to false
i noticed this issue when i tried using `cssCodeSplit: false` with `renderModernChunks: false`

### Additional context

Partially fixes issue #2062 #5901

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
