### PR TITLE
fix(esbuild): preserve import.meta even if esbuild.target is set to lower versions

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -22,7 +22,10 @@ import {
   tryStatSync,
   unique,
 } from '../utils'
-import { transformWithEsbuild } from '../plugins/esbuild'
+import {
+  defaultEsbuildSupported,
+  transformWithEsbuild,
+} from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET, METADATA_FILENAME } from '../constants'
 import { isWindows } from '../../shared/utils'
 import { esbuildCjsExternalPlugin, esbuildDepPlugin } from './esbuildDepPlugin'
@@ -799,8 +802,7 @@ async function prepareEsbuildOptimizerRun(
     charset: 'utf8',
     ...esbuildOptions,
     supported: {
-      'dynamic-import': true,
-      'import-meta': true,
+      ...defaultEsbuildSupported,
       ...esbuildOptions.supported,
     },
   })

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -33,6 +33,14 @@ const IIFE_BEGIN_RE =
 const validExtensionRE = /\.\w+$/
 const jsxExtensionsRE = /\.(?:j|t)sx\b/
 
+// the final build should always support dynamic import and import.meta.
+// if they need to be polyfilled, plugin-legacy should be used.
+// plugin-legacy detects these two features when checking for modern code.
+export const defaultEsbuildSupported = {
+  'dynamic-import': true,
+  'import-meta': true,
+}
+
 let server: ViteDevServer
 
 export interface ESBuildOptions extends TransformOptions {
@@ -235,6 +243,10 @@ export function esbuildPlugin(config: ResolvedConfig): Plugin {
     // Also transforming multiple times with keepNames enabled breaks
     // tree-shaking. (#9164)
     keepNames: false,
+    supported: {
+      ...defaultEsbuildSupported,
+      ...esbuildTransformOptions.supported,
+    },
   }
 
   return {
@@ -360,12 +372,8 @@ export function resolveEsbuildTranspileOptions(
     loader: 'js',
     target: target || undefined,
     format: rollupToEsbuildFormatMap[format],
-    // the final build should always support dynamic import and import.meta.
-    // if they need to be polyfilled, plugin-legacy should be used.
-    // plugin-legacy detects these two features when checking for modern code.
     supported: {
-      'dynamic-import': true,
-      'import-meta': true,
+      ...defaultEsbuildSupported,
       ...esbuildOptions.supported,
     },
   }


### PR DESCRIPTION

<!-- Thank you for contributing! -->

### Description
fixes #16147

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
