### PR TITLE
fix: `sideEffects: []` should work as `sideEffects: false`

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -176,21 +176,27 @@ export function loadPackageData(pkgPath: string): PackageData {
   if (typeof sideEffects === 'boolean') {
     hasSideEffects = () => sideEffects
   } else if (Array.isArray(sideEffects)) {
-    const finalPackageSideEffects = sideEffects.map((sideEffect) => {
-      /*
-       * The array accepts simple glob patterns to the relevant files... Patterns like *.css, which do not include a /, will be treated like **\/*.css.
-       * https://webpack.js.org/guides/tree-shaking/
-       * https://github.com/vitejs/vite/pull/11807
-       */
-      if (sideEffect.includes('/')) {
-        return sideEffect
-      }
-      return `**/${sideEffect}`
-    })
+    if (sideEffects.length <= 0) {
+      // createFilter always returns true if `includes` is an empty array
+      // but here we want it to always return false
+      hasSideEffects = () => false
+    } else {
+      const finalPackageSideEffects = sideEffects.map((sideEffect) => {
+        /*
+         * The array accepts simple glob patterns to the relevant files... Patterns like *.css, which do not include a /, will be treated like **\/*.css.
+         * https://webpack.js.org/guides/tree-shaking/
+         * https://github.com/vitejs/vite/pull/11807
+         */
+        if (sideEffect.includes('/')) {
+          return sideEffect
+        }
+        return `**/${sideEffect}`
+      })
 
-    hasSideEffects = createFilter(finalPackageSideEffects, null, {
-      resolve: pkgDir,
-    })
+      hasSideEffects = createFilter(finalPackageSideEffects, null, {
+        resolve: pkgDir,
+      })
+    }
   } else {
     hasSideEffects = () => null
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When an empty array is passed to `createFilter`, it works as `() => true`. But we want it to work as `() => false` instead here.

> If `options.include` is omitted or has zero length, filter will return `true` by default.
> https://github.com/rollup/plugins/blob/master/packages/pluginutils/README.md#createfilter

fixes  #14558

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
