### PR TITLE
fix: allow fs.deny matching for entire path

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -324,7 +324,7 @@ export default defineConfig({
 - **Type:** `string[]`
 - **Default:** `['.env', '.env.*', '*.{crt,pem}']`
 
-Blocklist for sensitive files being restricted to be served by Vite dev server. This will have higher priority than [`server.fs.allow`](#server-fs-allow). [picomatch patterns](https://github.com/micromatch/picomatch#globbing-features) are supported.
+Blocklist for sensitive paths being restricted to be served by Vite dev server. This will have higher priority than [`server.fs.allow`](#server-fs-allow). [picomatch patterns](https://github.com/micromatch/picomatch#globbing-features) are supported.
 
 ## server.origin
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -648,7 +648,7 @@ export async function _createServer(
     _forceOptimizeOnRestart: false,
     _pendingRequests: new Map(),
     _fsDenyGlob: picomatch(config.server.fs.deny, {
-      matchBase: true,
+      matchBase: false,
       nocase: true,
     }),
     _shortcutsOptions: undefined,


### PR DESCRIPTION
<!-- Thank you for contributing! you're welcome -->

### Description

`server.fs.deny` should match and deny the path

fixes GHSA-8jhw-289h-jh2g

### Additional context

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
