### PR TITLE
fix(docs): fix load error handling window reload example

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -70,7 +70,7 @@ Vite emits `vite:preloadError` event when it fails to load dynamic imports. `eve
 
 ```js
 window.addEventListener('vite:preloadError', (event) => {
-  window.reload() // for example, refresh the page
+  window.location.reload() // for example, refresh the page
 })
 ```
 


### PR DESCRIPTION


<!-- Thank you for contributing! -->

### Description

This pr makes a correction to the [Load Error Handling](https://vitejs.dev/guide/build.html#load-error-handling) example in the Building for Production documentation.

The snippet provides an example for reloading the page, but uses `window.reload`. `reload` is not a method defined on `Window`, it's defined on the `Location` object. See https://developer.mozilla.org/en-US/docs/Web/API/Location/reload

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
