### PR TITLE
perf(transformRequest): fast-path watch and sourcemap handling

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -2,14 +2,12 @@ import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import getEtag from 'etag'
-import convertSourceMap from 'convert-source-map'
 import MagicString from 'magic-string'
 import { init, parse as parseImports } from 'es-module-lexer'
 import type { PartialResolvedId, SourceDescription, SourceMap } from 'rollup'
 import colors from 'picocolors'
 import type { ModuleNode, ViteDevServer } from '..'
 import {
-  blankReplacer,
   createDebugger,
   ensureWatchedFile,
   injectQuery,
@@ -24,7 +22,11 @@ import { checkPublicFile } from '../publicDir'
 import { isDepsOptimizerEnabled } from '../config'
 import { getDepsOptimizer, initDevSsrDepsOptimizer } from '../optimizer'
 import { cleanUrl, unwrapId } from '../../shared/utils'
-import { applySourcemapIgnoreList, injectSourcesContent } from './sourcemap'
+import {
+  applySourcemapIgnoreList,
+  extractSourcemapFromFile,
+  injectSourcesContent,
+} from './sourcemap'
 import { isFileServingAllowed } from './middlewares/static'
 import { throwClosedServerError } from './pluginContainer'
 
@@ -263,21 +265,19 @@ async function loadAndTransform(
           throw e
         }
       }
-      ensureWatchedFile(server.watcher, file, config.root)
+      if (code != null) {
+        ensureWatchedFile(server.watcher, file, config.root)
+      }
     }
     if (code) {
       try {
-        map = (
-          convertSourceMap.fromSource(code) ||
-          (await convertSourceMap.fromMapFileSource(
-            code,
-            createConvertSourceMapReadMap(file),
-          ))
-        )?.toObject()
-
-        code = code.replace(convertSourceMap.mapFileCommentRegex, blankReplacer)
+        const extracted = await extractSourcemapFromFile(code, file)
+        if (extracted) {
+          code = extracted.code
+          map = extracted.map
+        }
       } catch (e) {
-        logger.warn(`Failed to load source map for ${url}.`, {
+        logger.warn(`Failed to load source map for ${file}.\n${e}`, {
           timestamp: true,
         })
       }
@@ -404,15 +404,6 @@ async function loadAndTransform(
     moduleGraph.updateModuleTransformResult(mod, result, ssr)
 
   return result
-}
-
-function createConvertSourceMapReadMap(originalFileName: string) {
-  return (filename: string) => {
-    return fsp.readFile(
-      path.resolve(path.dirname(originalFileName), filename),
-      'utf-8',
-    )
-  }
 }
 
 /**


### PR DESCRIPTION
### Description

1. Skip `ensureWatchedFile` if the file failed to load from the fs.
2. Skip removing the sourcemap comment from files if we found there's no sourcemap early on.
3. Improves sourcemap error message. (Users were having trouble with it in the past: https://github.com/vitejs/vite/issues/6981 and https://github.com/vitejs/vite/issues/10172)



### Additional context

I found these while trying to make `this.load` also work for files in the filesystem (https://github.com/vitejs/vite/pull/16018#issuecomment-1999012229), I needed to share some code from `transformRequest.ts` to `pluginContainer.ts`. But this PR applies to refactors first so it's easier to review.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
