### PR TITLE
refactor: environments as array instead of map

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -358,9 +358,7 @@ export interface UserConfig extends EnvironmentConfig {
    * Environment overrides
    * TODO: this should probably be an array, following the plugins convention
    */
-  environments?: {
-    [key: string]: EnvironmentConfig
-  }
+  environments?: (EnvironmentConfig & { name: string })[]
 }
 
 export interface HTMLOptions {

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -491,9 +491,9 @@ async function reloadOnTsconfigChange(changedFile: string) {
     )
 
     // clear module graph to remove code compiled with outdated config
-    server.environments.forEach((environment) =>
-      environment.moduleGraph.invalidateAll(),
-    )
+    for (const environment of server.environments) {
+      environment.moduleGraph.invalidateAll()
+    }
 
     // reset tsconfck so that recompile works with up2date configs
     tsconfckCache?.clear()

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -20,11 +20,11 @@ export class DevEnvironment extends Environment {
       // Merge the resolved configs, TODO: make generic on DevEnvironmentConfig
       const { resolve, optimizeDeps, dev } = this.server.config
       let resolvedConfig: DevEnvironmentConfig = { resolve, optimizeDeps, dev }
-      if (this.server.config.environments?.[this.name]) {
-        resolvedConfig = mergeConfig(
-          resolvedConfig,
-          this.server.config.environments[this.name],
-        )
+      const environmentConfig = this.server.config.environments?.find(
+        (e) => e.name === this.name,
+      )
+      if (environmentConfig) {
+        resolvedConfig = mergeConfig(resolvedConfig, environmentConfig)
       }
       if (this._inlineConfig) {
         resolvedConfig = mergeConfig(resolvedConfig, this._inlineConfig)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -315,7 +315,7 @@ export async function handleHMRUpdate(
   }
 
   const hmrTasks: HmrTask[] = []
-  for (const environment of server.environments.values()) {
+  for (const environment of server.environments) {
     hmrTasks.push({
       environment,
       run: () => applyHMR(environment),

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -63,7 +63,9 @@ export function transformRequest(
 ): Promise<TransformResult | null> {
   // Backward compatibility when only `ssr` is passed
   if (!environment) {
-    environment = server.environments.get(options.ssr ? 'ssr' : 'browser')!
+    environment = options.ssr
+      ? server.ssrEnvironment
+      : server.browserEnvironment
   }
   if (!options?.ssr) {
     // Backward compatibility


### PR DESCRIPTION
### Description

`server.environments` as `Environment[]` instead of a `Map<string, Environment>`

We are using the order of environments for the default ordering of HMR and build tasks. So it makes more sense to use the same structure as plugins and middlewares. If later on we end up adding environment hooks, and array would also be a better structure.

Sending this as a separate PR to leave better trace of the diff between the two options.