### PR TITLE
refactor: clientEnvironment instead of browserEnvironment

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -430,7 +430,7 @@ export function removeStyle(id: string): void {
 }
 
 export function createHotContext(ownerPath: string): ViteHotContext {
-  return new HMRContext(hmrClient, ownerPath, 'browser')
+  return new HMRContext(hmrClient, ownerPath, 'client')
 }
 
 /**

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -489,7 +489,7 @@ export async function buildEnvironment(
   environment?: BuildEnvironment,
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
   const options = config.build
-  const ssr = (environment && environment?.name !== 'browser') ?? !!options.ssr
+  const ssr = (environment && environment?.name !== 'client') ?? !!options.ssr
   const libOptions = options.lib
 
   config.logger.info(
@@ -1111,7 +1111,7 @@ function injectEnvironmentFlag<T extends Record<string, any>>(
   options?: T,
   environment?: BuildEnvironment,
 ): T & { ssr?: boolean; environment?: BuildEnvironment } {
-  const ssr = environment ? environment.name !== 'browser' : true
+  const ssr = environment ? environment.name !== 'client' : true
   return { ...(options ?? {}), ssr, environment } as T & {
     ssr?: boolean
     environment?: BuildEnvironment
@@ -1431,15 +1431,15 @@ export async function createViteBuilder(
   }
 
   const createBrowserEnvironment =
-    getEnvironmentConfig(defaultInlineConfig, 'browser')?.build
+    getEnvironmentConfig(defaultInlineConfig, 'client')?.build
       ?.createEnvironment ??
     defaultConfig.build?.createEnvironment ??
     ((builder: ViteBuilder, name: string) =>
       new BuildEnvironment(builder, name))
 
-  const browserEnvironment = createBrowserEnvironment(builder, 'browser')
+  const clientEnvironment = createBrowserEnvironment(builder, 'client')
 
-  environments.push(browserEnvironment)
+  environments.push(clientEnvironment)
 
   // Backward compatibility for `ssr` option
   if (defaultConfig.build.ssr) {
@@ -1459,7 +1459,7 @@ export async function createViteBuilder(
   if (defaultConfig.environments) {
     for (const environmentConfig of defaultConfig.environments) {
       if (
-        environmentConfig.name !== 'browser' &&
+        environmentConfig.name !== 'client' &&
         environmentConfig.name !== 'ssr'
       ) {
         const createEnvironment =

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -537,7 +537,7 @@ async function createDepsOptimizer(
     // Cached transform results have stale imports (resolved to
     // old locations) so they need to be invalidated before the page is
     // reloaded.
-    server.browserEnvironment.moduleGraph.invalidateAll()
+    server.clientEnvironment.moduleGraph.invalidateAll()
 
     server.hot.send({
       type: 'full-reload',

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -60,11 +60,11 @@ export function getAffectedGlobModules(
           (!negated.length || negated.every((glob) => isMatch(file, glob))),
       )
     ) {
-      const mod = server.browserEnvironment.moduleGraph.getModuleById(id)
+      const mod = server.clientEnvironment.moduleGraph.getModuleById(id)
 
       if (mod) {
         if (mod.file) {
-          server.browserEnvironment.moduleGraph.onFileChange(mod.file)
+          server.clientEnvironment.moduleGraph.onFileChange(mod.file)
         }
         modules.push(mod)
       }

--- a/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
+++ b/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
@@ -5,12 +5,9 @@ import type { ModuleNode } from '../moduleGraph'
 describe('moduleGraph', () => {
   describe('invalidateModule', () => {
     it('removes an ssr error', async () => {
-      const moduleGraph = new EnvironmentModuleGraph(
-        'browser',
-        async (url) => ({
-          id: url,
-        }),
-      )
+      const moduleGraph = new EnvironmentModuleGraph('client', async (url) => ({
+        id: url,
+      }))
       const entryUrl = '/x.js'
 
       const entryModule = await moduleGraph.ensureEntryFromUrl(entryUrl, false)
@@ -22,7 +19,7 @@ describe('moduleGraph', () => {
     })
 
     it('ensureEntryFromUrl should based on resolvedId', async () => {
-      const moduleGraph = new EnvironmentModuleGraph('browser', async (url) => {
+      const moduleGraph = new EnvironmentModuleGraph('client', async (url) => {
         if (url === '/xx.js') {
           return { id: '/x.js' }
         } else {
@@ -38,42 +35,41 @@ describe('moduleGraph', () => {
     })
 
     it('ensure backward compatibility', async () => {
-      const browserModuleGraph = new EnvironmentModuleGraph(
-        'browser',
+      const clientModuleGraph = new EnvironmentModuleGraph(
+        'client',
         async (url) => ({ id: url }),
       )
-      const ssrModuleGraph = new EnvironmentModuleGraph(
-        'node',
-        async (url) => ({ id: url }),
-      )
+      const ssrModuleGraph = new EnvironmentModuleGraph('ssr', async (url) => ({
+        id: url,
+      }))
       const moduleGraph = new ModuleGraph({
-        browser: browserModuleGraph,
+        client: clientModuleGraph,
         ssr: ssrModuleGraph,
       })
 
       const addBrowserModule = (url: string) =>
-        browserModuleGraph.ensureEntryFromUrl(url)
+        clientModuleGraph.ensureEntryFromUrl(url)
       const getBrowserModule = (url: string) =>
-        browserModuleGraph.getModuleById(url)
+        clientModuleGraph.getModuleById(url)
 
       const addServerModule = (url: string) =>
         ssrModuleGraph.ensureEntryFromUrl(url)
       const getServerModule = (url: string) => ssrModuleGraph.getModuleById(url)
 
-      const browserModule1 = await addBrowserModule('/1.js')
+      const clientModule1 = await addBrowserModule('/1.js')
       const ssrModule1 = await addServerModule('/1.js')
       const module1 = moduleGraph.getModuleById('/1.js')!
-      expect(module1._browserModule).toBe(browserModule1)
+      expect(module1._clientModule).toBe(clientModule1)
       expect(module1._ssrModule).toBe(ssrModule1)
 
       const module2b = await moduleGraph.ensureEntryFromUrl('/b/2.js')
       const module2s = await moduleGraph.ensureEntryFromUrl('/s/2.js')
-      expect(module2b._browserModule).toBe(getBrowserModule('/b/2.js'))
+      expect(module2b._clientModule).toBe(getBrowserModule('/b/2.js'))
       expect(module2s._ssrModule).toBe(getServerModule('/s/2.js'))
 
       const importersUrls = ['/1/a.js', '/1/b.js', '/1/c.js']
       ;(await Promise.all(importersUrls.map(addBrowserModule))).forEach((mod) =>
-        browserModule1.importers.add(mod),
+        clientModule1.importers.add(mod),
       )
       ;(await Promise.all(importersUrls.map(addServerModule))).forEach((mod) =>
         ssrModule1.importers.add(mod),
@@ -81,14 +77,14 @@ describe('moduleGraph', () => {
 
       expect(module1.importers.size).toBe(importersUrls.length)
 
-      const browserModule1importersValues = [...browserModule1.importers]
+      const clientModule1importersValues = [...clientModule1.importers]
       const ssrModule1importersValues = [...ssrModule1.importers]
 
       const module1importers = module1.importers
       const module1importersValues = [...module1importers.values()]
       expect(module1importersValues.length).toBe(importersUrls.length)
-      expect(module1importersValues[1]._browserModule).toBe(
-        browserModule1importersValues[1],
+      expect(module1importersValues[1]._clientModule).toBe(
+        clientModule1importersValues[1],
       )
       expect(module1importersValues[1]._ssrModule).toBe(
         ssrModule1importersValues[1],
@@ -100,8 +96,8 @@ describe('moduleGraph', () => {
         module1importersFromForEach.push(imp)
       })
       expect(module1importersFromForEach.length).toBe(importersUrls.length)
-      expect(module1importersFromForEach[1]._browserModule).toBe(
-        browserModule1importersValues[1],
+      expect(module1importersFromForEach[1]._clientModule).toBe(
+        clientModule1importersValues[1],
       )
       expect(module1importersFromForEach[1]._ssrModule).toBe(
         ssrModule1importersValues[1],

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -247,9 +247,7 @@ async function getPluginContainer(inlineConfig?: UserConfig): Promise<{
     pluginContainer,
   } as ViteDevServer
 
-  const environment = new DevEnvironment(mockedServer, 'browser', {
-    type: 'browser',
-  })
+  const environment = new DevEnvironment(mockedServer, 'client')
 
   return { pluginContainer, environment }
 }

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -52,7 +52,7 @@ export class DevEnvironment extends Environment {
   constructor(
     server: ViteDevServer,
     name: string,
-    options: {
+    options?: {
       // TODO: use `transport` instead to support any hmr channel?
       hot?: false | HMRChannel
       config?: DevEnvironmentConfig
@@ -65,8 +65,8 @@ export class DevEnvironment extends Environment {
         environment: this,
       }),
     )
-    this.hot = options.hot || createNoopHMRChannel()
-    this._inlineConfig = options.config
+    this.hot = options?.hot || createNoopHMRChannel()
+    this._inlineConfig = options?.config
   }
 
   transformRequest(url: string): Promise<TransformResult | null> {

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -262,8 +262,8 @@ export async function handleHMRUpdate(
           // Invalidate the hmrContext to force compat modules to be updated
           hmrContext = undefined
         }
-      } else if (environment.name === 'browser') {
-        // later on, we'll need: if (runtime === 'browser')
+      } else if (environment.name === 'client') {
+        // later on, we'll need: if (runtime === 'client')
         // Backward compatibility with mixed client and ssr moduleGraph
         hmrContext ??= {
           ...hotContext,
@@ -279,7 +279,7 @@ export async function handleHMRUpdate(
           hotContext.modules = filteredModules
             .map((mod) =>
               mod.id
-                ? server.browserEnvironment.moduleGraph.getModuleById(mod.id) ??
+                ? server.clientEnvironment.moduleGraph.getModuleById(mod.id) ??
                   server.ssrEnvironment.moduleGraph.getModuleById(mod.id)
                 : undefined,
             )

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -131,7 +131,7 @@ const processNodeUrl = (
   // prefix with base (dev only, base is never relative)
   const replacer = (url: string) => {
     if (server) {
-      const mod = server.browserEnvironment.moduleGraph.urlToModuleMap.get(url)
+      const mod = server.clientEnvironment.moduleGraph.urlToModuleMap.get(url)
       if (mod && mod.lastHMRTimestamp > 0) {
         url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
       }
@@ -242,10 +242,10 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     const modulePath = `${proxyModuleUrl}?html-proxy&index=${inlineModuleIndex}.${ext}`
 
     // invalidate the module so the newly cached contents will be served
-    const browserModuleGraph = server?.browserEnvironment.moduleGraph
-    const module = browserModuleGraph?.getModuleById(modulePath)
+    const clientModuleGraph = server?.clientEnvironment.moduleGraph
+    const module = clientModuleGraph?.getModuleById(modulePath)
     if (module) {
-      browserModuleGraph!.invalidateModule(module)
+      clientModuleGraph!.invalidateModule(module)
     }
     s.update(
       node.sourceCodeLocation!.startOffset,
@@ -352,14 +352,14 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
       // ensure module in graph after successful load
       const mod =
-        await server!.browserEnvironment.moduleGraph.ensureEntryFromUrl(
+        await server!.clientEnvironment.moduleGraph.ensureEntryFromUrl(
           url,
           false,
         )
       ensureWatchedFile(watcher, mod.file, config.root)
 
       const result = await server!.pluginContainer.transform(code, mod.id!, {
-        environment: server!.browserEnvironment,
+        environment: server!.clientEnvironment,
       })
       let content = ''
       if (result) {
@@ -383,14 +383,14 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       const url = `${proxyModulePath}?html-proxy&inline-css&style-attr&index=${index}.css`
 
       const mod =
-        await server!.browserEnvironment.moduleGraph.ensureEntryFromUrl(
+        await server!.clientEnvironment.moduleGraph.ensureEntryFromUrl(
           url,
           false,
         )
       ensureWatchedFile(watcher, mod.file, config.root)
 
       await server?.pluginContainer.transform(code, mod.id!, {
-        environment: server!.browserEnvironment,
+        environment: server!.clientEnvironment,
       })
 
       const hash = getHash(cleanUrl(mod.id!))

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -52,7 +52,7 @@ export function cachedTransformMiddleware(
     const ifNoneMatch = req.headers['if-none-match']
     if (ifNoneMatch) {
       const moduleByEtag =
-        server.browserEnvironment.moduleGraph.getModuleByEtag(ifNoneMatch)
+        server.clientEnvironment.moduleGraph.getModuleByEtag(ifNoneMatch)
       if (moduleByEtag?.transformResult?.etag === ifNoneMatch) {
         // For CSS requests, if the same CSS file is imported in a module,
         // the browser sends the request for the direct CSS request with the etag
@@ -143,7 +143,7 @@ export function transformMiddleware(
         } else {
           const originalUrl = url.replace(/\.map($|\?)/, '$1')
           const map = (
-            await server.browserEnvironment.moduleGraph.getModuleByUrl(
+            await server.clientEnvironment.moduleGraph.getModuleByUrl(
               originalUrl,
             )
           )?.transformResult?.map
@@ -188,7 +188,7 @@ export function transformMiddleware(
           const ifNoneMatch = req.headers['if-none-match']
           if (
             ifNoneMatch &&
-            (await server.browserEnvironment.moduleGraph.getModuleByUrl(url))
+            (await server.clientEnvironment.moduleGraph.getModuleByUrl(url))
               ?.transformResult?.etag === ifNoneMatch
           ) {
             debugCache?.(`[304] ${prettifyUrl(url, server.config.root)}`)
@@ -204,7 +204,7 @@ export function transformMiddleware(
           {
             html: req.headers.accept?.includes('text/html'),
           },
-          server.browserEnvironment,
+          server.clientEnvironment,
         )
         if (result) {
           const depsOptimizer = getDepsOptimizer(server.config, false) // non-ssr

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -156,7 +156,7 @@ type PluginContext = Omit<
 // wich are called once for all environments, or when no environment is passed in other hooks.
 // The ssrEnvironment is needed for backward compatibility when the ssr flag is passed without
 // an environment. The defaultEnvironment in the main pluginContainer in the server should be
-// the browserEnvironment for backward compatibility.
+// the clientEnvironment for backward compatibility.
 
 export async function createPluginContainer(
   config: ResolvedConfig,

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -63,13 +63,11 @@ export function transformRequest(
 ): Promise<TransformResult | null> {
   // Backward compatibility when only `ssr` is passed
   if (!environment) {
-    environment = options.ssr
-      ? server.ssrEnvironment
-      : server.browserEnvironment
+    environment = options.ssr ? server.ssrEnvironment : server.clientEnvironment
   }
   if (!options?.ssr) {
     // Backward compatibility
-    options = { ...options, ssr: environment.name !== 'browser' }
+    options = { ...options, ssr: environment.name !== 'client' }
   }
 
   if (server._restartPromise && !options.ssr) throwClosedServerError()
@@ -471,7 +469,7 @@ async function handleModuleSoftInvalidation(
 
   let result: TransformResult
   // For SSR soft-invalidation, no transformation is needed
-  if (environment.name !== 'browser') {
+  if (environment.name !== 'client') {
     result = transformResult
   }
   // For client soft-invalidation, we need to transform each imports with new timestamps if available

--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -15,7 +15,7 @@ export function warmupFiles(server: ViteDevServer): void {
   if (options?.clientFiles?.length) {
     mapFiles(options.clientFiles, root).then((files) => {
       for (const file of files) {
-        warmupFile(server, server.browserEnvironment, file)
+        warmupFile(server, server.clientEnvironment, file)
       }
     })
   }

--- a/playground/hmr/vite.config.ts
+++ b/playground/hmr/vite.config.ts
@@ -49,7 +49,7 @@ export const virtual = _virtual + '${num}';`
     configureServer(server) {
       server.hot.on('virtual:increment', async () => {
         const mod =
-          await server.browserEnvironment.moduleGraph.getModuleByUrl(
+          await server.clientEnvironment.moduleGraph.getModuleByUrl(
             '\0virtual:file',
           )
         if (mod) {

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -358,7 +358,7 @@ describe.runIf(isServe)('warmup', () => {
     // here might take a while to load
     await withRetry(async () => {
       const mod =
-        await viteServer.browserEnvironment.moduleGraph.getModuleByUrl(
+        await viteServer.clientEnvironment.moduleGraph.getModuleByUrl(
           '/warmup/warm.js',
         )
       expect(mod).toBeTruthy()

--- a/playground/module-graph/__tests__/module-graph.spec.ts
+++ b/playground/module-graph/__tests__/module-graph.spec.ts
@@ -4,7 +4,7 @@ import { isServe, page, viteServer } from '~utils'
 test.runIf(isServe)('importedUrls order is preserved', async () => {
   const el = page.locator('.imported-urls-order')
   expect(await el.textContent()).toBe('[success]')
-  const mod = await viteServer.browserEnvironment.moduleGraph.getModuleByUrl(
+  const mod = await viteServer.clientEnvironment.moduleGraph.getModuleByUrl(
     '/imported-urls-order.js',
   )
   const importedModuleIds = [...mod.importedModules].map((m) => m.url)


### PR DESCRIPTION
### Description

This PR changes `server.browserEnvironment` to `server.clientEnvironment`. The rationale is similar to the one explained at https://github.com/vitejs/vite/pull/16129#issuecomment-2002334260 regarding the switch from `server.nodeEnvironment` to `server.ssrEnvironment`.
The default environment type for `ssr` is a Node Environment. But the user may decide to use a Workerd Environment to do SSR. Naming the environment `ssr`, we get a clear way to let the user (or framework) configure the environment (and we also avoid creating a Node Environment if it won't be used).

In the case of the client environment, the default for it will be a Browser Environment. But there are users that run Vite against Electron, Tauri, Chrome Dev Extensions, etc. We don't currently officially support these environments, and we could keep that stance. But the environment API should help these users have a better way to configure Vite to work in their client environments.

We are also using `client` in this context in Vite. [`clientPort`](https://vitejs.dev/config/server-options.html#server-hmr), [`warmup.clientFiles`](https://vitejs.dev/config/server-options.html#server-warmup). It is also the way frameworks refer to this environment. `'use client'` in RSC, Nuxt's `<ClientOnly>`, etc.

Sending this as a separate PR as we didn't decide on this change yet. @sheremet-va does the above explanation makes sense?