### PR TITLE
fix(create-vite): switch to default Remix template

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -115,8 +115,7 @@ const FRAMEWORKS: Framework[] = [
         name: 'custom-remix',
         display: 'Remix ↗',
         color: cyan,
-        customCommand:
-          'npm create remix@latest TARGET_DIR -- --template remix-run/remix/templates/vite',
+        customCommand: 'npm create remix@latest TARGET_DIR',
       },
     ],
   },


### PR DESCRIPTION
### Description

We've just updated `create-remix` so that our default template is using Vite. Our `vite` template is now deprecated and will be removed once this PR is shipped. Since we're moving to Vite as the new default, we're not going to have specific templates for Vite anymore and will instead only be calling out when our templates _aren't_ using Vite.

### Additional context

Thanks again for including us in `create-vite` :)

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
