### PR TITLE
chore: add warn for spaFallback

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -204,7 +204,7 @@ export async function preview(
 
   // html fallback
   if (config.appType === 'spa' || config.appType === 'mpa') {
-    app.use(htmlFallbackMiddleware(distDir, config.appType === 'spa'))
+    app.use(htmlFallbackMiddleware(distDir, config))
   }
 
   // apply post server hooks from plugins

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -862,13 +862,7 @@ export async function _createServer(
 
   // html fallback
   if (config.appType === 'spa' || config.appType === 'mpa') {
-    middlewares.use(
-      htmlFallbackMiddleware(
-        root,
-        config.appType === 'spa',
-        getFsUtils(config),
-      ),
-    )
+    middlewares.use(htmlFallbackMiddleware(root, config, getFsUtils(config)))
   }
 
   // run post config hooks

--- a/packages/vite/src/node/server/middlewares/htmlFallback.ts
+++ b/packages/vite/src/node/server/middlewares/htmlFallback.ts
@@ -1,5 +1,8 @@
 import path from 'node:path'
+import colors from 'picocolors'
 import type { Connect } from 'dep-types/connect'
+
+import type { ResolvedConfig } from '../../config'
 import { createDebugger } from '../../utils'
 import type { FsUtils } from '../../fsUtils'
 import { commonFsUtils } from '../../fsUtils'
@@ -9,9 +12,10 @@ const debug = createDebugger('vite:html-fallback')
 
 export function htmlFallbackMiddleware(
   root: string,
-  spaFallback: boolean,
+  config: ResolvedConfig,
   fsUtils: FsUtils = commonFsUtils,
 ): Connect.NextHandleFunction {
+  const spaFallback = config.appType === 'spa'
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteHtmlFallbackMiddleware(req, res, next) {
     if (
@@ -65,7 +69,9 @@ export function htmlFallbackMiddleware(
     }
 
     if (spaFallback) {
-      debug?.(`Rewriting ${req.method} ${req.url} to /index.html`)
+      const info = `Rewriting ${req.method} ${req.url} to /index.html`
+      debug?.(info)
+      config.logger.warn(colors.yellow(info))
       req.url = '/index.html'
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

add warn for `htmlFallbackMiddleware spaFallback`, so that developer can notice the `fallback` source.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
