### PR TITLE
fix: early return on closed server only for warmup

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -31,7 +31,6 @@ import {
   ERR_OPTIMIZE_DEPS_PROCESSING_ERROR,
   ERR_OUTDATED_OPTIMIZED_DEP,
 } from '../../plugins/optimizedDeps'
-import { ERR_CLOSED_SERVER } from '../pluginContainer'
 import { getDepsOptimizer } from '../../optimizer'
 import { cleanUrl, unwrapId, withTrailingSlash } from '../../../shared/utils'
 import { NULL_BYTE_PLACEHOLDER } from '../../../shared/constants'
@@ -229,21 +228,6 @@ export function transformMiddleware(
         if (!res.writableEnded) {
           res.statusCode = 504 // status code request timeout
           res.statusMessage = 'Outdated Optimize Dep'
-          res.end()
-        }
-        // We don't need to log an error in this case, the request
-        // is outdated because new dependencies were discovered and
-        // the new pre-bundle dependencies have changed.
-        // A full-page reload has been issued, and these old requests
-        // can't be properly fulfilled. This isn't an unexpected
-        // error but a normal part of the missing deps discovery flow
-        return
-      }
-      if (e?.code === ERR_CLOSED_SERVER) {
-        // Skip if response has already been sent
-        if (!res.writableEnded) {
-          res.statusCode = 504 // status code request timeout
-          res.statusMessage = 'Outdated Request'
           res.end()
         }
         // We don't need to log an error in this case, the request


### PR DESCRIPTION
### Description

@cpojer reported he is experiencing a server crash when switching branches. It seems it is because of closed server error we throw to do an early return while restarting the server.
![image](https://github.com/vitejs/vite/assets/583075/256a1137-94ec-4b4c-bae7-764574c0cf40)

More info in this thread https://discord.com/channels/804011606160703521/1213652176707264552/1219521412692185158.

It is hard to do a minimal repro here, but he can reproduce it consistently for certain branches that differ in the config file, so a server restart is triggered.

This PR removes throwing as a mechanism for doing the shortcircuit and instead does an early return only for warmup requests. Restarting the server may be slightly slower as more request processing are going to complete their way through the pipeline, but I don't think there will be a significant diff. It is still important to avoid processing warmup requests as these could be piling up in the server due to the eager crawling of static imports.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other