### PR TITLE
feat: add an option to not start a websocket server

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -97,6 +97,10 @@ export interface ServerOptions extends CommonServerOptions {
    */
   hmr?: HmrOptions | boolean
   /**
+   * Do not start the websocket connection.
+   */
+  ws?: false
+  /**
    * Warm-up files to transform and cache the results in advance. This improves the
    * initial page load during server starts and prevents transform waterfalls.
    */

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -98,6 +98,7 @@ export interface ServerOptions extends CommonServerOptions {
   hmr?: HmrOptions | boolean
   /**
    * Do not start the websocket connection.
+   * @experimental
    */
   ws?: false
   /**

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -85,11 +85,32 @@ const wsServerEvents = [
   'message',
 ]
 
+function noop() {
+  // noop
+}
+
 export function createWebSocketServer(
   server: HttpServer | null,
   config: ResolvedConfig,
   httpsOptions?: HttpsServerOptions,
 ): WebSocketServer {
+  if (config.server.ws === false) {
+    const clients = new Set<WebSocketClient>()
+    return {
+      name: 'ws',
+      get clients() {
+        return clients
+      },
+      async close() {
+        // noop
+      },
+      on: noop as any as WebSocketServer['on'],
+      off: noop as any as WebSocketServer['off'],
+      listen: noop,
+      send: noop,
+    }
+  }
+
   let wss: WebSocketServerRaw_
   let wsHttpServer: Server | undefined = undefined
 

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -95,11 +95,10 @@ export function createWebSocketServer(
   httpsOptions?: HttpsServerOptions,
 ): WebSocketServer {
   if (config.server.ws === false) {
-    const clients = new Set<WebSocketClient>()
     return {
       name: 'ws',
       get clients() {
-        return clients
+        return new Set<WebSocketClient>()
       },
       async close() {
         // noop


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

This PR adds an option `server.ws` that can only be equal to `false`. I wasn't sure if I should change `server.hmr` type (make it nullable like the watcher?), so I added a new one. If we want to use `server.hmr`, we would need to replace all `server.hmr === false`.

Also, do we want to document this option?

Closes #14328

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
