### PR TITLE
fix: handle warmup request error correctly

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -512,7 +512,9 @@ export async function _createServer(
       return transformRequest(url, server, options)
     },
     async warmupRequest(url, options) {
-      await transformRequest(url, server, options).catch((e) => {
+      try {
+        await transformRequest(url, server, options)
+      } catch (e) {
         if (
           e?.code === ERR_OUTDATED_OPTIMIZED_DEP ||
           e?.code === ERR_CLOSED_SERVER
@@ -525,7 +527,7 @@ export async function _createServer(
           error: e,
           timestamp: true,
         })
-      })
+      }
     },
     transformIndexHtml(url, html, originalUrl) {
       return devHtmlTransformFn(server, url, html, originalUrl)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Alternative to #16216

From the stack trace, I guess this would catch the error correctly.

The reason why `.catch(e => ` cannot catch the error is because `transformRequest` throws an error in sync instead of async.
https://github.com/vitejs/vite/blob/d44342859a45a295b9497775f8716de83ca1c03d/packages/vite/src/node/server/transformRequest.ts#L58
Sync errors can only be catched by `try {} catch {}`.

The fix for it would be to change `transformRequest` to an async function (that would change the sync error into async error), or, to use `try { await transformRequest() } catch {}`. Using both `.catch` and `try {} catch {}` is also an option.
https://stackblitz.com/edit/node-zucmtr?file=index.js

I went with `try { await transformRequest() } catch {}`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
