### PR TITLE
fix: avoid SSR requests in waitForRequestIdle

### DIFF
--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -183,9 +183,14 @@ async function doTransform(
     resolved,
   )
 
-  const depsOptimizer = getDepsOptimizer(config, ssr)
-  if (!depsOptimizer?.isOptimizedDepFile(id)) {
-    server._registerRequestProcessing(id, () => result)
+  if (!ssr) {
+    // Only register client requests, server.waitForRequestsIdle should
+    // have been called server.waitForClientRequestesIdle. We can rename
+    // it as part of the environment API work
+    const depsOptimizer = getDepsOptimizer(config, ssr)
+    if (!depsOptimizer?.isOptimizedDepFile(id)) {
+      server._registerRequestProcessing(id, () => result)
+    }
   }
 
   return result

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -185,7 +185,7 @@ async function doTransform(
 
   if (!ssr) {
     // Only register client requests, server.waitForRequestsIdle should
-    // have been called server.waitForClientRequestesIdle. We can rename
+    // have been called server.waitForClientRequestsIdle. We can rename
     // it as part of the environment API work
     const depsOptimizer = getDepsOptimizer(config, ssr)
     if (!depsOptimizer?.isOptimizedDepFile(id)) {


### PR DESCRIPTION
### Description

Fixes #16245 

Tested with https://github.com/arxpoetica/inlang-sveltekit-vite-bug

The crawl end finder was only processing client requests before. When we moved to the server, we starting adding both client and SSR requests. The issue appears because the client and SSR requests share the same id space. The feature was added thinking on client requests only (see context at #16135). It should have been named `server.waitForClientRequestsIdle(id)`. This function will probably be moved to be environment specific if we move forward with the Environment API proposal.