### PR TITLE
feat(hmr): call `hotUpdate` hook with file create/delete

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -268,7 +268,7 @@ export async function handleHMRUpdate(
           // Invalidate the hmrContext to force compat modules to be updated
           hmrContext = undefined
         }
-      } else if (environment.name === 'client') {
+      } else if (environment.name === 'client' && type === 'update') {
         // later on, we'll need: if (runtime === 'client')
         // Backward compatibility with mixed client and ssr moduleGraph
         hmrContext ??= {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -382,10 +382,6 @@ export interface ViteDevServer {
   /**
    * @internal
    */
-  _importGlobMap: Map<string, { affirmed: string[]; negated: string[] }[]>
-  /**
-   * @internal
-   */
   _restartPromise: Promise<void> | null
   /**
    * @internal
@@ -739,7 +735,6 @@ export async function _createServer(
       server = _server
     },
     _restartPromise: null,
-    _importGlobMap: new Map(),
     _forceOptimizeOnRestart: false,
     _pendingRequests: new Map(),
     _safeModulesPath: new Set(),


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
The import.meta.glob plugin was using `server._importGlobMap`. If the `handleHotUpdate` hook runs on file create/delete, that variable can be moved inside the plugin by using that hook.

This PR is mostly a refactor but it changes two behaviors.

1. When creating/deleting a HTML file, Vite now reloads the page if the page is opened. (e.g. when opening `/foo.html` and `foo.html` is created or deleted, a reload will happen)
2. If a plugin has `_runHandleHotUpdateOnCreateAndDelete: true`, `handleHMRUpdate` hook will be called for `create`/`delete` events. `HmrContext` type now has `type: 'create' | 'delete' | 'update'`. I added the new property to keep backward compatibility, but maybe we can just call it for all plugins.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
