### PR TITLE
feat: environment in hooks, context vs param

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -48,6 +48,8 @@ const identifierWithTrailingDollarRE = /\b(\w+)\$\d+\b/g
 const identifierReplacements: Record<string, Record<string, string>> = {
   rollup: {
     Plugin$1: 'rollup.Plugin',
+    PluginContext$1: 'rollup.PluginContext',
+    TransformPluginContext$1: 'rollup.TransformPluginContext',
     TransformResult$2: 'rollup.TransformResult',
   },
   esbuild: {

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -5,9 +5,9 @@ import type {
   ResolveIdResult,
   Plugin as RollupPlugin,
   PluginContext as RollupPluginContext,
-
   TransformPluginContext as RollupTransformPluginContext,
-  TransformResult} from 'rollup'
+  TransformResult,
+} from 'rollup'
 import type {
   ConfigEnv,
   EnvironmentConfig,

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -2,13 +2,12 @@ import type {
   CustomPluginOptions,
   LoadResult,
   ObjectHook,
-  PluginContext,
   ResolveIdResult,
   Plugin as RollupPlugin,
-  TransformPluginContext,
-  TransformResult,
-} from 'rollup'
-export type { PluginContext } from 'rollup'
+  PluginContext as RollupPluginContext,
+
+  TransformPluginContext as RollupTransformPluginContext,
+  TransformResult} from 'rollup'
 import type {
   ConfigEnv,
   EnvironmentConfig,
@@ -44,7 +43,19 @@ import type { BuildEnvironment } from './build'
  *
  * If a plugin should be applied only for server or build, a function format
  * config file can be used to conditional determine the plugins to use.
+ *
+ * The current module environment can be accessed from the context for the
+ * buildStart, resolveId, transform, load, and buildEnd, hooks
  */
+
+export interface PluginContext extends RollupPluginContext {
+  environment?: DevEnvironment | BuildEnvironment
+}
+
+export interface TransformPluginContext extends RollupTransformPluginContext {
+  environment?: DevEnvironment | BuildEnvironment
+}
+
 export interface Plugin<A = any> extends RollupPlugin<A> {
   /**
    * Enforce plugin invocation tier similar to webpack loaders.
@@ -198,8 +209,10 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       options: {
         attributes: Record<string, string>
         custom?: CustomPluginOptions
+        /**
+         * @deprecated use this.environment
+         */
         ssr?: boolean
-        environment?: DevEnvironment | BuildEnvironment
         /**
          * @internal
          */
@@ -213,8 +226,10 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       this: PluginContext,
       id: string,
       options?: {
+        /**
+         * @deprecated use this.environment
+         */
         ssr?: boolean
-        environment?: DevEnvironment | BuildEnvironment
       },
     ) => Promise<LoadResult> | LoadResult
   >
@@ -224,8 +239,10 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       code: string,
       id: string,
       options?: {
+        /**
+         * @deprecated use this.environment
+         */
         ssr?: boolean
-        environment?: DevEnvironment | BuildEnvironment
       },
     ) => Promise<TransformResult> | TransformResult
   >

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -200,7 +200,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
 
       // Inherit HMR timestamp if this asset was invalidated
       if (server) {
-        const environment = options?.environment as DevEnvironment | undefined
+        const environment = this.environment as DevEnvironment | undefined
         const mod = environment?.moduleGraph.getModuleById(id)
         if (mod && mod.lastHMRTimestamp > 0) {
           url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -941,7 +941,7 @@ export function cssAnalysisPlugin(config: ResolvedConfig): Plugin {
         return
       }
 
-      const environment = options?.environment
+      const environment = this.environment
       const moduleGraph =
         environment?.mode === 'dev' ? environment.moduleGraph : undefined
       const thisModule = moduleGraph?.getModuleById(id)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -215,7 +215,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // running src/node/server/__tests__/pluginContainer.spec.ts
 
       const ssr = options?.ssr === true
-      const environment = (options?.environment as DevEnvironment) || undefined
+      const environment = this.environment as DevEnvironment | undefined
 
       if (!server || !environment) {
         return null

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -258,7 +258,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           } else if (server) {
             // dynamic worker type we can't know how import the env
             // so we copy /@vite/env code of server transform result into file header
-            const environment = options?.environment
+            const environment = this.environment
             const moduleGraph =
               environment?.mode === 'dev' ? environment.moduleGraph : undefined
             const module = moduleGraph?.getModuleById(ENV_ENTRY)

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -731,7 +731,6 @@ export async function createPluginContainer(
             custom: options?.custom,
             isEntry: !!options?.isEntry,
             ssr,
-            environment,
             scan,
           }),
         )
@@ -786,7 +785,7 @@ export async function createPluginContainer(
         ctx._activePlugin = plugin
         const handler = getHookHandler(plugin.load)
         const result = await handleHookPromise(
-          handler.call(ctx as any, id, { ssr, environment }),
+          handler.call(ctx as any, id, { ssr }),
         )
         if (result != null) {
           if (isObject(result)) {
@@ -822,7 +821,7 @@ export async function createPluginContainer(
         const handler = getHookHandler(plugin.transform)
         try {
           result = await handleHookPromise(
-            handler.call(ctx as any, code, id, { ssr, environment }),
+            handler.call(ctx as any, code, id, { ssr }),
           )
         } catch (e) {
           ctx.error(e)


### PR DESCRIPTION
### Description

This PR implements a change discussed with @antfu and @sheremet-va to the way Plugin hooks can access the current Environment. For reference, current implementation and docs for the feature:
- https://github.com/vitejs/vite/pull/16129
- https://github.com/vitejs/vite/pull/16089

### Context

Plugin hooks have always been able to know the current environment by the `ssr` flag passed to `resolveId`, `load` and `transform` hooks. We control dev, so we can pass it directly, and during build, [we inject it in rollup by wrapping plugin hooks](https://github.com/vitejs/vite/blob/7369016d8a0f26ad9200cf7fd0e2045ca9fd1a41/packages/vite/src/node/build.ts#L1000).

Plugin hooks use this boolean flag to access environment specific configuration (for example `config.ssr.resolve.conditions`). To access the deps optimizer associated with the environment (through a weak map against the resolved config `getDepsOptimizer(config, ssr)`, but the optimizer has a internal dep against the server). To trigger processing of imports for warmup (using `server.warmupRequest(url, { ssr })`). Between other things, where most of them aren't specific to SSR but are conditions due to the need of separating requests from the client and SSR (as in, any other environment will need to do the same, even if not used for rendering in the server).

For the Environment API, initially we thought of following the same pattern deprecating the `ssr` boolean flag and replacing it with a `environment` string options param to hooks. When we implemented this version, it become clear that this forced a coupling of plugins against the whole server. If a plugin needed to access `environment.config.resolve.conditons`, then it would have to store the `server` in `configureServer` and call `server.environments[environment]` in the hook. Same for `environment.depsOptimizer`, `environment.warmupRequest(url)`, etc. We have then an opportunity to reduce the coupling of hooks from the whole server to only the current `environment` for most plugins. So instead of passing a `environment` string, we modified the proposal to directly pass the `environment` instance. This move simplified a lot of code, and made it a lot more clear that `resolveId`, `load`, and `transform` are running against a specific environment (and that the plugin can completely ignore other environments and the server in most cases).

### Environment instance in hooks: param vs context

We discussed a bit in the last Vite team meeting about how passing the environment instance to hooks could work in Rolldown. I think that for Rolldown, having the environment inside hooks is positive if we want to port vite internal hooks to Rust in the future. If we can share the environment state, then both Rust and JS can access it.

Passing the environment instance as a param to hooks doesn't feel right though. This PR moves the current environment to the `PluginContext` instead. This is more aligned with the way Rollup is designed. So, instead of:
```js
transform(code, id, { environment }) {
  log(environment?.config)
}
```
Plugins would do:
```js
transform(code, id) {
  log(this.environment?.config)
}
```

@sapphi-red @hyf0 opening a PR so we can discuss what is the best move here, so we don't introduce a change that will later on make it difficult to refactor the code to use Rolldown.