### PR TITLE
chore: improve PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,6 @@ Before creating the pull request, please make sure you do the following:
 
 - Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
 - Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
-- Provide a description in this PR that addresses **what** the PR is solving, or .
 - Update the corresponding documentation if needed.
 - Include relevant tests that fail without this PR but pass with it.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,15 @@
-<!-- Thank you for contributing! -->
-
 ### Description
 
-<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
+<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
 
-### Additional context
+<!----------------------------------------------------------------------
+Before creating the pull request, please make sure you do the following:
 
-<!-- e.g. is there anything you'd like reviewers to focus on? -->
+- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
+- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
+- Provide a description in this PR that addresses **what** the PR is solving, or .
+- Update the corresponding documentation if needed.
+- Include relevant tests that fail without this PR but pass with it.
 
----
-
-### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->
-
-- [ ] Bug fix
-- [ ] New Feature
-- [ ] Documentation update
-- [ ] Other
-
-### Before submitting the PR, please make sure you do the following
-
-- [ ] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
-- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-- [ ] Update the corresponding documentation if needed.
-- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
+Thank you for contributing to Vite!
+----------------------------------------------------------------------->


### PR DESCRIPTION
### Description

Improve PR template. For reference, this is how our current template looks:
<img width="1291" alt="image" src="https://github.com/vitejs/vite/assets/583075/a198e0b6-6876-497f-a862-bb38f28e2da7">

If GitHub would give us PR forms, maybe we could make something more interesting. But until then, I think we should simplify our current template:
- I don't think the "purpose of this pull request" section is useful. There are a lot more PR types than the ones listed and we already have this information in the PR title as we use conventional commit (fix, feat, docs, chore, etc).
- Nobody is completing the "Before submitting the PR" section. The checkboxes doesn't render so it isn't good UX for contributors.
- Both these sections are part of the PR description after creating the PR, and they take a ton of vertical space. I have been deleting them in my PRs for a long time now (like I just did for this PR).

This is how a new PR will look like after this PR. The idea is that the contributor doesn't need to delete the comments, they will not be part of the description after creation.
<img width="1291" alt="image" src="https://github.com/vitejs/vite/assets/583075/b0af97bf-403a-4830-9d3a-45d972ba703f">

We can further improve things once we have a https://vitejs.dev/contributing link to replace the long GitHub one. I'll send a new PR later. Maybe we could have something like https://rolldown.rs/contrib-guide/ instead of redirecting to GitHub.
