### PR TITLE
fix: skip injecting `__vite__mapDeps` when it's not used

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -515,12 +515,12 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               .join(',')}]`
 
             const mapDepsCode = `\
-  function __vite__mapDeps(indexes) {
-    if (!__vite__mapDeps.viteFileDeps) {
-      __vite__mapDeps.viteFileDeps = ${fileDepsCode}
-    }
-    return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
-  }\n`
+function __vite__mapDeps(indexes) {
+  if (!__vite__mapDeps.viteFileDeps) {
+    __vite__mapDeps.viteFileDeps = ${fileDepsCode}
+  }
+  return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+}\n`
 
             // inject extra code at the top or next line of hashbang
             if (code.startsWith('#!')) {

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -498,32 +498,36 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
                 s.update(
                   markerStartPos,
                   markerStartPos + preloadMarker.length + 2,
-                  `__vite__mapDeps([${renderedDeps.join(',')}])`,
+                  renderedDeps.length > 0
+                    ? `__vite__mapDeps([${renderedDeps.join(',')}])`
+                    : `[]`,
                 )
                 rewroteMarkerStartPos.add(markerStartPos)
               }
             }
           }
 
-          const fileDepsCode = `[${fileDeps
-            .map((fileDep) =>
-              fileDep.runtime ? fileDep.url : JSON.stringify(fileDep.url),
-            )
-            .join(',')}]`
+          if (fileDeps.length > 0) {
+            const fileDepsCode = `[${fileDeps
+              .map((fileDep) =>
+                fileDep.runtime ? fileDep.url : JSON.stringify(fileDep.url),
+              )
+              .join(',')}]`
 
-          const mapDepsCode = `\
-function __vite__mapDeps(indexes) {
-  if (!__vite__mapDeps.viteFileDeps) {
-    __vite__mapDeps.viteFileDeps = ${fileDepsCode}
-  }
-  return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
-}\n`
+            const mapDepsCode = `\
+  function __vite__mapDeps(indexes) {
+    if (!__vite__mapDeps.viteFileDeps) {
+      __vite__mapDeps.viteFileDeps = ${fileDepsCode}
+    }
+    return indexes.map((i) => __vite__mapDeps.viteFileDeps[i])
+  }\n`
 
-          // inject extra code at the top or next line of hashbang
-          if (code.startsWith('#!')) {
-            s.prependLeft(code.indexOf('\n') + 1, mapDepsCode)
-          } else {
-            s.prepend(mapDepsCode)
+            // inject extra code at the top or next line of hashbang
+            if (code.startsWith('#!')) {
+              s.prependLeft(code.indexOf('\n') + 1, mapDepsCode)
+            } else {
+              s.prepend(mapDepsCode)
+            }
           }
 
           // there may still be markers due to inlined dynamic imports, remove

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -152,9 +152,22 @@ describe.runIf(isBuild)('build tests', () => {
       }
     `)
     // verify sourcemap comment is preserved at the last line
-    const js = findAssetFile(/after-preload-dynamic.*\.js$/)
+    const js = findAssetFile(/after-preload-dynamic-[-\w]{8}\.js$/)
     expect(js).toMatch(
-      /\n\/\/# sourceMappingURL=after-preload-dynamic.*\.js\.map\n$/,
+      /\n\/\/# sourceMappingURL=after-preload-dynamic-[-\w]{8}\.js\.map\n$/,
     )
+  })
+
+  test('__vite__mapDeps injected after banner', async () => {
+    const js = findAssetFile(/after-preload-dynamic-hashbang-[-\w]{8}\.js$/)
+    expect(js.split('\n').slice(0, 2)).toEqual([
+      '#!/usr/bin/env node',
+      'function __vite__mapDeps(indexes) {',
+    ])
+  })
+
+  test('no unused __vite__mapDeps', async () => {
+    const js = findAssetFile(/after-preload-dynamic-no-dep-[-\w]{8}\.js$/)
+    expect(js).not.toMatch(/__vite__mapDeps/)
   })
 })

--- a/playground/js-sourcemap/after-preload-dynamic-no-dep.js
+++ b/playground/js-sourcemap/after-preload-dynamic-no-dep.js
@@ -1,0 +1,3 @@
+import('./dynamic/dynamic-no-dep')
+
+console.log('after preload dynamic no dep')

--- a/playground/js-sourcemap/dynamic/dynamic-no-dep.js
+++ b/playground/js-sourcemap/dynamic/dynamic-no-dep.js
@@ -1,0 +1,1 @@
+console.log('dynamic/dynamic-no-dep')

--- a/playground/js-sourcemap/index.html
+++ b/playground/js-sourcemap/index.html
@@ -7,5 +7,6 @@
 <script type="module" src="./bar.ts"></script>
 <script type="module" src="./after-preload-dynamic.js"></script>
 <script type="module" src="./after-preload-dynamic-hashbang.js"></script>
+<script type="module" src="./after-preload-dynamic-no-dep.js"></script>
 <script type="module" src="./with-multiline-import.ts"></script>
 <script type="module" src="./zoo.js"></script>

--- a/playground/js-sourcemap/vite.config.js
+++ b/playground/js-sourcemap/vite.config.js
@@ -18,6 +18,9 @@ export default defineConfig({
           if (name.endsWith('after-preload-dynamic-hashbang.js')) {
             return 'after-preload-dynamic-hashbang'
           }
+          if (name.endsWith('after-preload-dynamic-no-dep.js')) {
+            return 'after-preload-dynamic-no-dep'
+          }
         },
         banner(chunk) {
           if (chunk.name.endsWith('after-preload-dynamic-hashbang')) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Following the suggestion https://github.com/vitejs/vite/pull/15732#discussion_r1536755630, I skipped injecting `__vite__mapDeps` when it's not used.

This will cover non browser cases where preload is not used at all (see `insertPreload`) since `fileDeps` will be empty in the end for those cases as well.

https://github.com/vitejs/vite/blob/716c7667feed3c185811654048b2b5bf7d7fb205/packages/vite/src/node/plugins/importAnalysisBuild.ts#L161

Here is a change of `playground/js-sourcemap/after-preload-dynamic-no-dep.js` build output:

<details><summary>before</summary>

```js
function __vite__mapDeps(indexes) {
  if (!__vite__mapDeps.viteFileDeps) {
    __vite__mapDeps.viteFileDeps = [];
  }
  return indexes.map((i) => __vite__mapDeps.viteFileDeps[i]);
}
import { _ as o } from "./after-preload-dynamic-BAkr0czH.js";
o(() => import("./dynamic-no-dep-BZ-YzFGU.js"), __vite__mapDeps([]));
console.log("after preload dynamic no dep");
//# sourceMappingURL=after-preload-dynamic-no-dep-Df4YzL2T.js.map
```

</details>

<details><summary>after</summary>

```ts
import{_ as o}from"./after-preload-dynamic-BAkr0czH.js";
o(()=>import("./dynamic-no-dep-BZ-YzFGU.js"),[]);
console.log("after preload dynamic no dep");
//# sourceMappingURL=after-preload-dynamic-no-dep-Df4YzL2T.js.map
```

</details>

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Update the corresponding documentation if needed.
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
