### PR TITLE
fix(sourcemap): don't warn even if the sourcesContent is an empty string

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -44,7 +44,7 @@ export async function injectSourcesContent(
   for (let index = 0; index < map.sources.length; index++) {
     const sourcePath = map.sources[index]
     if (
-      !sourcesContent[index] &&
+      sourcesContent[index] == null &&
       sourcePath &&
       !virtualSourceRE.test(sourcePath)
     ) {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
If `sourcesContent[i]` is an empty string, Vite showed an warning that the sourcemap points to missing source files. But if it's an empty string, it means that the content is empty rather than the content should be read from the file placed there.

For example, this happens when the library is built with esbuild and uses `define` ([esbuild try](https://esbuild.github.io/try/#dAAwLjIwLjAALS1kZWZpbmU6X0ZPT189J3sgImZvbyI6ICJiYXIiIH0nIC0tc291cmNlbWFwAGV4cG9ydCBjb25zdCBmb28gPSBfRk9PXw)). You can see `<define:_FOO_>` has `''` as a content.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md), especially the [Pull Request Guidelines](https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md#pull-request-guidelines).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Update the corresponding documentation if needed.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
