### PR TITLE
chore: deprecate splitVendorChunkPlugin

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -47,21 +47,7 @@ For example, you can specify multiple Rollup outputs with plugins that are only 
 
 ## Chunking Strategy
 
-You can configure how chunks are split using `build.rollupOptions.output.manualChunks` (see [Rollup docs](https://rollupjs.org/configuration-options/#output-manualchunks)). Until Vite 2.8, the default chunking strategy divided the chunks into `index` and `vendor`. It is a good strategy for some SPAs, but it is hard to provide a general solution for every Vite target use case. From Vite 2.9, `manualChunks` is no longer modified by default. You can continue to use the Split Vendor Chunk strategy by adding the `splitVendorChunkPlugin` in your config file:
-
-```js
-// vite.config.js
-import { splitVendorChunkPlugin } from 'vite'
-export default defineConfig({
-  plugins: [splitVendorChunkPlugin()],
-})
-```
-
-This strategy is also provided as a `splitVendorChunk({ cache: SplitVendorChunkCache })` factory, in case composition with custom logic is needed. `cache.reset()` needs to be called at `buildStart` for build watch mode to work correctly in this case.
-
-::: warning
-You should use `build.rollupOptions.output.manualChunks` function form when using this plugin. If the object form is used, the plugin won't have any effect.
-:::
+You can configure how chunks are split using `build.rollupOptions.output.manualChunks` (see [Rollup docs](https://rollupjs.org/configuration-options/#output-manualchunks)). If you use a framework, refer to their documentation for configuring how chunks are splitted.
 
 ## Load Error Handling
 

--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -26,6 +26,9 @@ export const isCSSRequest = (request: string): boolean =>
 // The cache needs to be reset on buildStart for watch mode to work correctly
 // Don't use this manualChunks strategy for ssr, lib mode, and 'umd' or 'iife'
 
+/**
+ * @deprecated use build.rollupOutput.manualChunks or framework specific configuration
+ */
 export class SplitVendorChunkCache {
   cache: Map<string, boolean>
   constructor() {
@@ -36,6 +39,9 @@ export class SplitVendorChunkCache {
   }
 }
 
+/**
+ * @deprecated use build.rollupOutput.manualChunks or framework specific configuration
+ */
 export function splitVendorChunk(
   options: { cache?: SplitVendorChunkCache } = {},
 ): GetManualChunk {
@@ -87,6 +93,9 @@ function staticImportedByEntry(
   return someImporterIs
 }
 
+/**
+ * @deprecated use build.rollupOutput.manualChunks or framework specific configuration
+ */
 export function splitVendorChunkPlugin(): Plugin {
   const caches: SplitVendorChunkCache[] = []
   function createSplitVendorChunk(output: OutputOptions, config: UserConfig) {


### PR DESCRIPTION
### Description

We extracted the default split vendor chunking strategy to a plugin so users could more easily migrate to Vite 2.8. This strategy always had edge cases (see latest here https://github.com/vitejs/vite/issues/16268). This PR deprecates the plugin, so we can remove it in Vite 6.