### PR TITLE
fix: csp nonce injection when no closing tag (#16281)

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1189,9 +1189,12 @@ export function injectNonceAttributeTagHook(
               parseRelAttr(attr.value).some((a) => processRelType.has(a)),
           ))
       ) {
-        // if there is no endTag, the end of the startTag will be `/>`
-        // therefore, the appendOffset should be 2 in this case, instead of 1
-        const appendOffset = node?.sourceCodeLocation?.endTag ? 1 : 2
+        // if the closing of the start tag includes a `/`, the offset should be 2 so the nonce
+        // is appended prior to the `/`
+        const appendOffset =
+          html.charAt(node.sourceCodeLocation!.startTag!.endOffset - 2) === '/'
+            ? 2
+            : 1
 
         s.appendRight(
           node.sourceCodeLocation!.startTag!.endOffset - appendOffset,

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1192,9 +1192,7 @@ export function injectNonceAttributeTagHook(
         // if the closing of the start tag includes a `/`, the offset should be 2 so the nonce
         // is appended prior to the `/`
         const appendOffset =
-          html.charAt(node.sourceCodeLocation!.startTag!.endOffset - 2) === '/'
-            ? 2
-            : 1
+          html[node.sourceCodeLocation!.startTag!.endOffset - 2] === '/' ? 2 : 1
 
         s.appendRight(
           node.sourceCodeLocation!.startTag!.endOffset - appendOffset,

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1189,8 +1189,12 @@ export function injectNonceAttributeTagHook(
               parseRelAttr(attr.value).some((a) => processRelType.has(a)),
           ))
       ) {
+        // if there is no endTag, the end of the startTag will be `/>`
+        // therefore, the appendOffset should be 2 in this case, instead of 1
+        const appendOffset = node?.sourceCodeLocation?.endTag ? 1 : 2
+
         s.appendRight(
-          node.sourceCodeLocation!.startTag!.endOffset - 1,
+          node.sourceCodeLocation!.startTag!.endOffset - appendOffset,
           ` nonce="${nonce}"`,
         )
       }


### PR DESCRIPTION
Not all html elements have an ending tag, for example: 
```
<link rel="stylesheet" href="/roboto.css" />
```

In such cases, the current injection func injects the nonce after the forward slash, instead of before it current result:
```
<link rel="stylesheet" href="/roboto.css" / nonce="abc123">
```

this patch corrects the behavior to:
```
<link rel="stylesheet" href="/roboto.css"  nonce="abc123"/>
```