### PR TITLE
feat(hmr): reload when HTML file is created/deleted

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -322,14 +322,6 @@ export async function handleFileAddUnlink(
 ): Promise<void> {
   const modules = [...(server.moduleGraph.getModulesByFile(file) || [])]
 
-  if (isUnlink) {
-    for (const deletedMod of modules) {
-      deletedMod.importedModules.forEach((importedMod) => {
-        importedMod.importers.delete(deletedMod)
-      })
-    }
-  }
-
   modules.push(...getAffectedGlobModules(file, server))
 
   if (modules.length > 0) {

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -121,7 +121,6 @@ export async function handleHMRUpdate(
   type: 'create' | 'delete' | 'update',
   file: string,
   server: ViteDevServer,
-  configOnly: boolean,
 ): Promise<void> {
   const { hot, config, moduleGraph } = server
   const shortFile = getShortName(file, config.root)
@@ -148,10 +147,6 @@ export async function handleHMRUpdate(
     } catch (e) {
       config.logger.error(colors.red(e))
     }
-    return
-  }
-
-  if (configOnly) {
     return
   }
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -186,29 +186,26 @@ export async function handleHMRUpdate(
         hmrContext.modules = filteredModules
       }
     }
+  }
 
-    if (!hmrContext.modules.length) {
-      // html file cannot be hot updated
-      if (file.endsWith('.html')) {
-        config.logger.info(
-          colors.green(`page reload `) + colors.dim(shortFile),
-          {
-            clear: true,
-            timestamp: true,
-          },
-        )
-        hot.send({
-          type: 'full-reload',
-          path: config.server.middlewareMode
-            ? '*'
-            : '/' + normalizePath(path.relative(config.root, file)),
-        })
-      } else {
-        // loaded but not in the module graph, probably not js
-        debugHmr?.(`[no modules matched] ${colors.dim(shortFile)}`)
-      }
-      return
+  if (!hmrContext.modules.length) {
+    // html file cannot be hot updated
+    if (file.endsWith('.html')) {
+      config.logger.info(colors.green(`page reload `) + colors.dim(shortFile), {
+        clear: true,
+        timestamp: true,
+      })
+      hot.send({
+        type: 'full-reload',
+        path: config.server.middlewareMode
+          ? '*'
+          : '/' + normalizePath(path.relative(config.root, file)),
+      })
+    } else {
+      // loaded but not in the module graph, probably not js
+      debugHmr?.(`[no modules matched] ${colors.dim(shortFile)}`)
     }
+    return
   }
 
   updateModules(shortFile, hmrContext.modules, timestamp, server)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -762,6 +762,7 @@ export async function _createServer(
         }
       }
     }
+    if (isUnlink) moduleGraph.onFileDelete(file)
     await handleFileAddUnlink(file, server, isUnlink)
     await onHMRUpdate(file, true)
   }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -730,11 +730,10 @@ export async function _createServer(
   const onHMRUpdate = async (
     type: 'create' | 'delete' | 'update',
     file: string,
-    configOnly: boolean,
   ) => {
     if (serverConfig.hmr !== false) {
       try {
-        await handleHMRUpdate(type, file, server, configOnly)
+        await handleHMRUpdate(type, file, server)
       } catch (err) {
         hot.send({
           type: 'error',
@@ -766,7 +765,7 @@ export async function _createServer(
       }
     }
     if (isUnlink) moduleGraph.onFileDelete(file)
-    await onHMRUpdate(isUnlink ? 'delete' : 'create', file, false)
+    await onHMRUpdate(isUnlink ? 'delete' : 'create', file)
   }
 
   watcher.on('change', async (file) => {
@@ -774,7 +773,7 @@ export async function _createServer(
     await container.watchChange(file, { event: 'update' })
     // invalidate module graph cache on file change
     moduleGraph.onFileChange(file)
-    await onHMRUpdate('update', file, false)
+    await onHMRUpdate('update', file)
   })
 
   getFsUtils(config).initWatcher?.(watcher)

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -148,6 +148,17 @@ export class ModuleGraph {
     }
   }
 
+  onFileDelete(file: string): void {
+    const mods = this.getModulesByFile(file)
+    if (mods) {
+      mods.forEach((mod) => {
+        mod.importedModules.forEach((importedMod) => {
+          importedMod.importers.delete(mod)
+        })
+      })
+    }
+  }
+
   invalidateModule(
     mod: ModuleNode,
     seen: Set<ModuleNode> = new Set(),


### PR DESCRIPTION
### Description

When creating/deleting a HTML file, Vite now reloads the page if the page is opened. (e.g. when opening `/foo.html` and `foo.html` is created or deleted, a reload will happen)

This PR also merges the HMR handling when a file is created/deleted with the HMR handling when a file is modified.

Split from #16249

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
