### PR TITLE
fix: update lowest node version for the create-vite package

### DIFF
--- a/packages/create-vite/package.json
+++ b/packages/create-vite/package.json
@@ -20,7 +20,7 @@
     "prepublishOnly": "npm run build"
   },
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": "^18.18.0 || >=20.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

small fix:
Update the lowest node engine for create-vite. 


Why?
create-vite will let you create a project even with a node version lower than v18.18.0, but when using a version lower than v18.18.0, you will receive the following error on packages installation:
yarn (error):
`error @typescript-eslint/eslint-plugin@7.4.0: The engine "node" is incompatible with this module. Expected version "^18.18.0 || >=20.0.0". Got "18.17.1"`

npm (warning):
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@typescript-eslint/utils@7.4.0',
npm WARN EBADENGINE   required: { node: '^18.18.0 || >=20.0.0' },
npm WARN EBADENGINE   current: { node: 'v18.17.1', npm: '9.6.7' }
npm WARN EBADENGINE }
```

