### PR TITLE
fix(hmr): trigger hmr for missing file import errored module after file creation

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -311,6 +311,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
           // fix#9534, prevent the importerModuleNode being stopped from propagating updates
           importerModule.isSelfAccepting = false
+          moduleGraph._hasResolveFailedErrorModules.add(importerModule)
           return this.error(
             `Failed to resolve import "${url}" from "${normalizePath(
               path.relative(process.cwd(), importerFile),

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -162,7 +162,7 @@ export async function handleHMRUpdate(
     return
   }
 
-  const mods = moduleGraph.getModulesByFile(file) || new Set()
+  const mods = new Set(moduleGraph.getModulesByFile(file))
   if (type === 'create' || type === 'delete') {
     for (const mod of getAffectedGlobModules(file, server)) {
       mods.add(mod)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -163,6 +163,11 @@ export async function handleHMRUpdate(
   }
 
   const mods = new Set(moduleGraph.getModulesByFile(file))
+  if (type === 'create') {
+    for (const mod of moduleGraph._hasResolveFailedErrorModules) {
+      mods.add(mod)
+    }
+  }
   if (type === 'create' || type === 'delete') {
     for (const mod of getAffectedGlobModules(file, server)) {
       mods.add(mod)

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -108,6 +108,9 @@ export class ModuleGraph {
     Promise<ModuleNode> | ModuleNode
   >()
 
+  /** @internal */
+  _hasResolveFailedErrorModules = new Set<ModuleNode>()
+
   constructor(
     private resolveId: (
       url: string,
@@ -229,6 +232,8 @@ export class ModuleGraph {
         )
       }
     })
+
+    this._hasResolveFailedErrorModules.delete(mod)
   }
 
   invalidateAll(): void {

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -962,4 +962,23 @@ if (!isBuild) {
     editFile('css-deps/dep.js', (code) => code.replace(`red`, `green`))
     await untilUpdated(() => getColor('.css-deps'), 'green')
   })
+
+  test('hmr should happen after missing file is created', async () => {
+    const file = 'missing-file/a.js'
+    const code = 'console.log("a.js")'
+
+    await untilBrowserLogAfter(
+      () =>
+        page.goto(viteTestUrl + '/missing-file/index.html', {
+          waitUntil: 'load',
+        }),
+      /connected/, // wait for HMR connection
+    )
+
+    await untilBrowserLogAfter(async () => {
+      const loadPromise = page.waitForEvent('load')
+      addFile(file, code)
+      await loadPromise
+    }, [/connected/, 'a.js'])
+  })
 }

--- a/playground/hmr/missing-file/index.html
+++ b/playground/hmr/missing-file/index.html
@@ -1,0 +1,2 @@
+<div>Page</div>
+<script type="module" src="main.js"></script>

--- a/playground/hmr/missing-file/main.js
+++ b/playground/hmr/missing-file/main.js
@@ -1,0 +1,1 @@
+import './a.js'


### PR DESCRIPTION
### Description
Built on top of #16302


Implemented the following fix described in #10663 

> Keep a shell module if an import doesn't exist so we have a direct link to the non-existent file upon creation.

fixes #10663
close #16222

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
