### PR TITLE
fix(scanner): duplicate modules for same id if glob is used in html-like types

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -409,12 +409,10 @@ function esbuildScanPlugin(
         // Avoid matching the content of the comment
         raw = raw.replace(commentRE, '<!---->')
         const isHtml = p.endsWith('.html')
-        scriptRE.lastIndex = 0
         let js = ''
         let scriptId = 0
-        let match: RegExpExecArray | null
-        while ((match = scriptRE.exec(raw))) {
-          const [, openTag, content] = match
+        const matches = raw.matchAll(scriptRE)
+        for (const [, openTag, content] of matches) {
           const typeMatch = openTag.match(typeRE)
           const type =
             typeMatch && (typeMatch[1] || typeMatch[2] || typeMatch[3])


### PR DESCRIPTION
### Description

When `await` happens in the `scriptRE.exec(raw)` loop, a different function might overwrite `scriptRE.lastIndex` causing duplicate modules to be loaded as a same id.

fixes #16211

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
