### PR TITLE
docs: fix capitalization typos

### DIFF
--- a/docs/guide/backend-integration.md
+++ b/docs/guide/backend-integration.md
@@ -116,10 +116,10 @@ If you need a custom integration, you can follow the steps in this guide to conf
 
    - A `<link rel="stylesheet">` tag for each file in the entry point chunk's `css` list
    - Recursively follow all chunks in the entry point's `imports` list and include a
-     `<link rel="stylesheet">` tag for each css file of each imported chunk.
-   - A tag for the `file` key of the entry point chunk (`<script type="module">` for Javascript,
-     or `<link rel="stylesheet">` for css)
-   - Optionally, `<link rel="modulepreload">` tag for the `file` of each imported Javascript
+     `<link rel="stylesheet">` tag for each CSS file of each imported chunk.
+   - A tag for the `file` key of the entry point chunk (`<script type="module">` for JavaScript,
+     or `<link rel="stylesheet">` for CSS)
+   - Optionally, `<link rel="modulepreload">` tag for the `file` of each imported JavaScript
      chunk, again recursively following the imports starting from the entry point chunk.
 
    Following the above example manifest, for the entry point `main.js` the following tags should be included in production:


### PR DESCRIPTION
### Description

Fixed capitalization typos in docs.

`css` -> `CSS`
`Javascript` -> `JavaScript` 

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
