### PR TITLE
docs: `shared-options` applies `twoslash`

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -42,7 +42,9 @@ Vite uses [esbuild defines](https://esbuild.github.io/api/#define) to perform re
 
 **Example:**
 
-```js
+```js twoslash
+import { defineConfig } from 'vite'
+// ---cut---
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify('v1.0.0'),
@@ -231,7 +233,9 @@ Specify options to pass to CSS pre-processors. The file extensions are used as k
 
 **Example:**
 
-```js
+```js twoslash
+import { defineConfig } from 'vite'
+// ---cut---
 export default defineConfig({
   css: {
     preprocessorOptions: {
@@ -256,7 +260,9 @@ This option can be used to inject extra code for each style content. Note that i
 
 **Example:**
 
-```js
+```js twoslash
+import { defineConfig } from 'vite'
+// ---cut---
 export default defineConfig({
   css: {
     preprocessorOptions: {
@@ -350,7 +356,9 @@ Enabling this disables named imports.
 
 `ESBuildOptions` extends [esbuild's own transform options](https://esbuild.github.io/api/#transform). The most common use case is customizing JSX:
 
-```js
+```js twoslash
+import { defineConfig } from 'vite'
+// ---cut---
 export default defineConfig({
   esbuild: {
     jsxFactory: 'h',
@@ -363,7 +371,9 @@ By default, esbuild is applied to `ts`, `jsx` and `tsx` files. You can customize
 
 In addition, you can also use `esbuild.jsxInject` to automatically inject JSX helper imports for every file transformed by esbuild:
 
-```js
+```js twoslash
+import { defineConfig } from 'vite'
+// ---cut---
 export default defineConfig({
   esbuild: {
     jsxInject: `import React from 'react'`,


### PR DESCRIPTION
### Description
Supplement #16168, some examples on the `shared-options` page apply `twoslash`.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
