### PR TITLE
perf(css): only replace empty chunk if imported

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -860,6 +860,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         for (const file in bundle) {
           const chunk = bundle[file]
           if (chunk.type === 'chunk') {
+            let chunkImportsPureCssChunk = false
             // remove pure css chunk from other chunk's imports,
             // and also register the emitted CSS files under the importer
             // chunks instead.
@@ -874,11 +875,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
                 importedAssets.forEach((file) =>
                   chunk.viteMetadata!.importedAssets.add(file),
                 )
+                chunkImportsPureCssChunk = true
                 return false
               }
               return true
             })
-            chunk.code = replaceEmptyChunk(chunk.code)
+            if (chunkImportsPureCssChunk) {
+              chunk.code = replaceEmptyChunk(chunk.code)
+            }
           }
         }
 


### PR DESCRIPTION
### Description

When replacing empty chunks for pure CSS chunks, if the current chunk doesn't import any pure CSS chunks, we can skip the replacement, and the potentially expensive regex replacement.

On a project I'm testing, it should save 90ms of work, which isn't a lot but maybe helpful for other projects 😬 
