### PR TITLE
docs: add Mastodon to “resources” in docs navigation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -150,7 +150,7 @@ export default defineConfig({
             items: [
               {
                 text: 'Mastodon',
-                link: mastodon,
+                link: 'https://elk.zone/m.webtoo.ls/@vite',
               },
               {
                 text: 'Twitter',

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -149,6 +149,10 @@ export default defineConfig({
           {
             items: [
               {
+                text: 'Mastodon',
+                link: mastodon,
+              },
+              {
                 text: 'Twitter',
                 link: 'https://twitter.com/vite_js',
               },


### PR DESCRIPTION
### Description

Same as in [vitest-dev/vitest/pull/5501](https://github.com/vitest-dev/vitest/pull/5501): the Mastodon link is missing from the “Resources” menu of the docs navigation.