### PR TITLE
feat(cli): support `-f` take affect when `-d` value is not set

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -19,7 +19,7 @@ const profileIndex = process.argv.indexOf('--profile')
 
 if (debugIndex > 0) {
   let value = process.argv[debugIndex + 1]
-  if (!value || value.startsWith('-')) {
+  if (!value || value.startsWith('-') || debugIndex + 1 === filterIndex) {
     value = 'vite:*'
   } else {
     // support debugging multiple flags with comma-separated list


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

Currently, when the `-d` option is specified but no specific value is set, but the `-f` option is set immediately, the log information printed does not meet expectations.

It is hoped that when `vite -d -f word` is executed, all debug information containing the `word` keyword will be printed.
