### PR TITLE
fix: fix accumulated stacks in error overlay

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -165,7 +165,6 @@ kbd {
 `
 
 // Error Template
-let template: HTMLElement
 const createTemplate = () =>
   h(
     'div',
@@ -214,9 +213,7 @@ export class ErrorOverlay extends HTMLElement {
   constructor(err: ErrorPayload['err'], links = true) {
     super()
     this.root = this.attachShadow({ mode: 'open' })
-
-    template ??= createTemplate()
-    this.root.appendChild(template)
+    this.root.appendChild(createTemplate())
 
     codeframeRE.lastIndex = 0
     const hasFrame = err.frame && codeframeRE.test(err.frame)

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -274,7 +274,7 @@ describe.runIf(isServe)('invalid', () => {
     expect(isVisbleOverlay).toBeFalsy()
   })
 
-  test('stack', async () => {
+  test('stack is updated', async () => {
     await page.goto(viteTestUrl + '/invalid.html')
 
     const errorOverlay = await page.waitForSelector('vite-error-overlay')

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -240,7 +240,7 @@ describe('link with props', () => {
   })
 })
 
-describe.runIf(isServe)('invalid', () => {
+describe.runIf(isServe).only('invalid', () => {
   test('should be 500 with overlay', async () => {
     const response = await page.goto(viteTestUrl + '/invalid.html')
     expect(response.status()).toBe(500)
@@ -274,15 +274,6 @@ describe.runIf(isServe)('invalid', () => {
     expect(isVisbleOverlay).toBeFalsy()
   })
 
-  test('should reload when fixed', async () => {
-    await page.goto(viteTestUrl + '/invalid.html')
-    await editFile('invalid.html', (content) => {
-      return content.replace('<div Bad', '<div> Good')
-    })
-    const content = await page.waitForSelector('text=Good HTML')
-    expect(content).toBeTruthy()
-  })
-
   test('stack', async () => {
     await page.goto(viteTestUrl + '/invalid.html')
 
@@ -304,6 +295,15 @@ describe.runIf(isServe)('invalid', () => {
     const newErrorOverlay = await page.waitForSelector('vite-error-overlay')
     const stack = await newErrorOverlay.$$eval('.stack', (m) => m[0].innerHTML)
     expect(stack).toMatch(/^Error: someError/)
+  })
+
+  test('should reload when fixed', async () => {
+    await page.goto(viteTestUrl + '/invalid.html')
+    await editFile('invalid.html', (content) => {
+      return content.replace('<div Bad', '<div> Good')
+    })
+    const content = await page.waitForSelector('text=Good HTML')
+    expect(content).toBeTruthy()
   })
 })
 

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -240,7 +240,7 @@ describe('link with props', () => {
   })
 })
 
-describe.runIf(isServe).only('invalid', () => {
+describe.runIf(isServe)('invalid', () => {
   test('should be 500 with overlay', async () => {
     const response = await page.goto(viteTestUrl + '/invalid.html')
     expect(response.status()).toBe(500)


### PR DESCRIPTION
### Description

This looks like a regression of https://github.com/vitejs/vite/pull/15852. Since `template` element became a singleton, when I show the error overlay programatically with `server.hot.send`, it accumulates the messages in `.stack` due to the mutation here: 

https://github.com/vitejs/vite/blob/5f0e6a35a34c2c9ccdc663a5b62ebe5d0c6203c6/packages/vite/src/client/overlay.ts#L269

The same test case looks like this in main:

<details><summary>Show screenshot</summary>

![image](https://github.com/vitejs/vite/assets/4232207/e7ffb898-582b-4514-a179-dd45085ac8b4)

which now looks like this:

![image](https://github.com/vitejs/vite/assets/4232207/0696609c-08ec-4bf7-95d3-c01063d64cad)

</details>

The background is that, I'm currently trying runtime error overlay ideas like https://github.com/vitejs/vite/pull/6274 and then I just spotted this odd behavior. Normally, the error overlay seems to happen after full client reload, so `template` is fresh, but when trying to show overlay multiple times, the stacks keep accumulating.

I suppose calling `createTemplate` every time wouldn't hurt much, so I simply removed `template` singleton. Before the PR https://github.com/vitejs/vite/pull/15852, it was `innerHTML` assignment, so I think it was making a fresh copy similarly.