### PR TITLE
refactor: proxy environment logger, remove hardcoded `[vite]` from hmr logger

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -175,7 +175,7 @@ const hmrClient = new HMRClient(
 async function handleMessage(payload: HMRPayload) {
   switch (payload.type) {
     case 'connected':
-      console.debug(`[vite] connected.`)
+      console.debug(`connected.`)
       hmrClient.messenger.flush()
       // proxy(nginx, docker) hmr ws maybe caused timeout,
       // so send ping package let ws keep alive.

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -136,7 +136,10 @@ const debounceReload = (time: number) => {
 const pageReload = debounceReload(50)
 
 const hmrClient = new HMRClient(
-  console,
+  {
+    error: (err) => console.error('[vite]', err),
+    debug: (...msg) => console.debug('[vite]', ...msg),
+  },
   {
     isReady: () => socket && socket.readyState === 1,
     send: (message) => socket.send(message),

--- a/packages/vite/src/module-runner/hmrHandler.ts
+++ b/packages/vite/src/module-runner/hmrHandler.ts
@@ -18,7 +18,7 @@ export async function handleHMRPayload(
   if (!hmrClient || runner.isDestroyed()) return
   switch (payload.type) {
     case 'connected':
-      hmrClient.logger.debug(`[vite] connected.`)
+      hmrClient.logger.debug(`connected.`)
       hmrClient.messenger.flush()
       break
     case 'update':
@@ -32,9 +32,7 @@ export async function handleHMRPayload(
             return hmrClient.queueUpdate(update)
           }
 
-          hmrClient.logger.error(
-            '[vite] css hmr is not supported in runner mode.',
-          )
+          hmrClient.logger.error('css hmr is not supported in runner mode.')
         }),
       )
       await hmrClient.notifyListeners('vite:afterUpdate', payload)
@@ -54,7 +52,7 @@ export async function handleHMRPayload(
 
       if (!clearEntrypoints.size) break
 
-      hmrClient.logger.debug(`[vite] program reload`)
+      hmrClient.logger.debug(`program reload`)
       await hmrClient.notifyListeners('vite:beforeFullReload', payload)
       runner.moduleCache.clear()
 
@@ -71,7 +69,7 @@ export async function handleHMRPayload(
       await hmrClient.notifyListeners('vite:error', payload)
       const err = payload.err
       hmrClient.logger.error(
-        `[vite] Internal Server Error\n${err.message}\n${err.stack}`,
+        `Internal Server Error\n${err.message}\n${err.stack}`,
       )
       break
     }

--- a/packages/vite/src/module-runner/hmrLogger.ts
+++ b/packages/vite/src/module-runner/hmrLogger.ts
@@ -6,3 +6,8 @@ export const silentConsole: HMRLogger = {
   debug: noop,
   error: noop,
 }
+
+export const hmrLogger: HMRLogger = {
+  debug: (...msg) => console.log('[vite]', ...msg),
+  error: (error) => console.log('[vite]', error),
+}

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -36,7 +36,7 @@ import {
   ssrImportMetaKey,
   ssrModuleExportsKey,
 } from './constants'
-import { silentConsole } from './hmrLogger'
+import { hmrLogger, silentConsole } from './hmrLogger'
 import { createHMRHandler } from './hmrHandler'
 import { enableSourceMapSupport } from './sourcemap/index'
 import type { RunnerTransport } from './runnerTransport'
@@ -78,7 +78,7 @@ export class ModuleRunner {
       this.hmrClient = new HMRClient(
         options.hmr.logger === false
           ? silentConsole
-          : options.hmr.logger || console,
+          : options.hmr.logger || hmrLogger,
         options.hmr.connection,
         ({ acceptedPath, invalidates }) => {
           this.moduleCache.invalidate(acceptedPath)
@@ -245,7 +245,7 @@ export class ModuleRunner {
     importer?: string,
   ): Promise<ResolvedResult> {
     if (this._destroyed) {
-      throw new Error(`[vite] Vite runtime has been destroyed.`)
+      throw new Error(`Vite module runner has been destroyed.`)
     }
     const normalized = this.idToUrlMap.get(id)
     if (normalized) {

--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -5,12 +5,16 @@ export class Environment {
   name: string
   config: ResolvedConfig
   options: ResolvedEnvironmentOptions
+  #logger: Logger | undefined
   get logger(): Logger {
+    if (this.#logger) {
+      return this.#logger
+    }
     const logger = this.config.logger
     const format = (msg: string) => {
       return `(${this.name}) ${msg}`
     }
-    return {
+    this.#logger = {
       get hasWarned() {
         return logger.hasWarned
       },
@@ -33,6 +37,7 @@ export class Environment {
         return logger.hasErrorLogged(error)
       },
     }
+    return this.#logger
   }
   constructor(
     name: string,

--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -6,7 +6,33 @@ export class Environment {
   config: ResolvedConfig
   options: ResolvedEnvironmentOptions
   get logger(): Logger {
-    return this.config.logger
+    const logger = this.config.logger
+    const format = (msg: string) => {
+      return `(${this.name}) ${msg}`
+    }
+    return {
+      get hasWarned() {
+        return logger.hasWarned
+      },
+      info(msg, opts) {
+        return logger.info(format(msg), opts)
+      },
+      warn(msg, opts) {
+        return logger.warn(format(msg), opts)
+      },
+      warnOnce(msg, opts) {
+        return logger.warnOnce(format(msg), opts)
+      },
+      error(msg, opts) {
+        return logger.error(format(msg), opts)
+      },
+      clearScreen(type) {
+        return logger.clearScreen(type)
+      },
+      hasErrorLogged(error) {
+        return logger.hasErrorLogged(error)
+      },
+    }
   }
   constructor(
     name: string,

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -116,7 +116,7 @@ export class HMRContext implements ViteHotContext {
       message,
     })
     this.hmrClient.logger.debug(
-      `[vite] invalidate ${this.ownerPath}${message ? `: ${message}` : ''}`,
+      `invalidate ${this.ownerPath}${message ? `: ${message}` : ''}`,
     )
   }
 
@@ -255,7 +255,7 @@ export class HMRClient {
       this.logger.error(err)
     }
     this.logger.error(
-      `[hmr] Failed to reload ${path}. ` +
+      `Failed to reload ${path}. ` +
         `This could be due to syntax errors or importing non-existent ` +
         `modules. (see errors above)`,
     )
@@ -316,7 +316,7 @@ export class HMRClient {
         )
       }
       const loggedPath = isSelfUpdate ? path : `${acceptedPath} via ${path}`
-      this.logger.debug(`[vite] hot updated: ${loggedPath}`)
+      this.logger.debug(`hot updated: ${loggedPath}`)
     }
   }
 }

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -1138,7 +1138,7 @@ async function setupModuleRunner(
 
   const logger = new HMRMockLogger()
   // @ts-expect-error not typed for HMR
-  globalThis.log = (...msg) => logger.debug(...msg)
+  globalThis.log = (...msg) => logger.log(...msg)
 
   runner = createServerModuleRunner(server.environments.ssr, {
     hmr: {
@@ -1157,6 +1157,12 @@ async function setupModuleRunner(
 }
 
 class HMRMockLogger {
+  log(...msg: unknown[]) {
+    const log = msg.join(' ')
+    clientLogs.push(log)
+    logsEmitter.emit('log', log)
+  }
+
   debug(...msg: unknown[]) {
     const log = ['[vite]', ...msg].join(' ')
     clientLogs.push(log)

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -1158,12 +1158,13 @@ async function setupModuleRunner(
 
 class HMRMockLogger {
   debug(...msg: unknown[]) {
-    const log = msg.join(' ')
+    const log = ['[vite]', ...msg].join(' ')
     clientLogs.push(log)
     logsEmitter.emit('log', log)
   }
   error(msg: string) {
-    clientLogs.push(msg)
-    logsEmitter.emit('log', msg)
+    const log = ['[vite]', msg].join(' ')
+    clientLogs.push(log)
+    logsEmitter.emit('log', log)
   }
 }


### PR DESCRIPTION
### Description

Added a proxy that injects the environment name whenever `this.environment.logger.{method}` is called

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
