### PR TITLE
fix: encode filename only

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -92,17 +92,19 @@ export function renderAssetUrlInJS(
     chunk.viteMetadata!.importedAssets.add(cleanUrl(file))
     const filename = file + postfix
     const replacement = toOutputFilePathInJS(
-      filename,
+      encodeURIPath(filename),
       'asset',
       chunk.fileName,
       'js',
       config,
       toRelativeRuntime,
     )
+
     const replacementString =
       typeof replacement === 'string'
-        ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
+        ? JSON.stringify(replacement).slice(1, -1)
         : `"+${replacement.runtime}+"`
+
     s.update(match.index, match.index + full.length, replacementString)
   }
 
@@ -115,7 +117,7 @@ export function renderAssetUrlInJS(
     const [full, hash] = match
     const publicUrl = publicAssetUrlMap.get(hash)!.slice(1)
     const replacement = toOutputFilePathInJS(
-      publicUrl,
+      encodeURIPath(publicUrl),
       'public',
       chunk.fileName,
       'js',
@@ -124,7 +126,7 @@ export function renderAssetUrlInJS(
     )
     const replacementString =
       typeof replacement === 'string'
-        ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
+        ? JSON.stringify(replacement).slice(1, -1)
         : `"+${replacement.runtime}+"`
     s.update(match.index, match.index + full.length, replacementString)
   }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -594,15 +594,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         chunkCSS = chunkCSS.replace(assetUrlRE, (_, fileHash, postfix = '') => {
           const filename = this.getFileName(fileHash) + postfix
           chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
-          return encodeURIPath(
-            toOutputFilePathInCss(
-              filename,
-              'asset',
-              cssAssetName,
-              'css',
-              config,
-              toRelative,
-            ),
+          return toOutputFilePathInCss(
+            encodeURIPath(filename),
+            'asset',
+            cssAssetName,
+            'css',
+            config,
+            toRelative,
           )
         })
         // resolve public URL from CSS paths
@@ -613,15 +611,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           )
           chunkCSS = chunkCSS.replace(publicAssetUrlRE, (_, hash) => {
             const publicUrl = publicAssetUrlMap.get(hash)!.slice(1)
-            return encodeURIPath(
-              toOutputFilePathInCss(
-                publicUrl,
-                'public',
-                cssAssetName,
-                'css',
-                config,
-                () => `${relativePathToPublicFromCSS}/${publicUrl}`,
-              ),
+            return toOutputFilePathInCss(
+              encodeURIPath(publicUrl),
+              'public',
+              cssAssetName,
+              'css',
+              config,
+              () => `${relativePathToPublicFromCSS}/${publicUrl}`,
             )
           })
         }
@@ -707,7 +703,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             .set(referenceId, { originalName: originalFilename })
 
           const replacement = toOutputFilePathInJS(
-            this.getFileName(referenceId),
+            encodeURIPath(this.getFileName(referenceId)),
             'asset',
             chunk.fileName,
             'js',
@@ -716,7 +712,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           )
           const replacementString =
             typeof replacement === 'string'
-              ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
+              ? JSON.stringify(replacement).slice(1, -1)
               : `"+${replacement.runtime}+"`
           s.update(start, end, replacementString)
         }

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -440,7 +440,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
               overwriteAttrValue(
                 s,
                 sourceCodeLocation!,
-                partialEncodeURIPath(toOutputPublicFilePath(url)),
+                toOutputPublicFilePath(partialEncodeURIPath(url)),
               )
             }
 
@@ -520,7 +520,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
                     overwriteAttrValue(
                       s,
                       getAttrSourceCodeLocation(node, attrKey),
-                      partialEncodeURIPath(toOutputPublicFilePath(url)),
+                      toOutputPublicFilePath(partialEncodeURIPath(url)),
                     )
                   } else if (!isExcludedUrl(url)) {
                     if (
@@ -640,7 +640,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
             s.update(
               start,
               end,
-              partialEncodeURIPath(toOutputPublicFilePath(url)),
+              toOutputPublicFilePath(partialEncodeURIPath(url)),
             )
           } else if (!isExcludedUrl(url)) {
             s.update(
@@ -909,19 +909,17 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           if (chunk) {
             chunk.viteMetadata!.importedAssets.add(cleanUrl(file))
           }
-          return encodeURIPath(toOutputAssetFilePath(file)) + postfix
+          return toOutputAssetFilePath(encodeURIPath(file)) + postfix
         })
 
         result = result.replace(publicAssetUrlRE, (_, fileHash) => {
           const publicAssetPath = toOutputPublicAssetFilePath(
-            getPublicAssetFilename(fileHash, config)!,
+            encodeURIPath(getPublicAssetFilename(fileHash, config)!),
           )
 
-          return encodeURIPath(
-            urlCanParse(publicAssetPath)
-              ? publicAssetPath
-              : normalizePath(publicAssetPath),
-          )
+          return urlCanParse(publicAssetPath)
+            ? publicAssetPath
+            : normalizePath(publicAssetPath)
         })
 
         if (chunk && canInlineEntry) {

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -408,7 +408,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           const [full, hash] = match
           const filename = fileNameHash.get(hash)!
           const replacement = toOutputFilePathInJS(
-            filename,
+            encodeURIPath(filename),
             'asset',
             chunk.fileName,
             'js',
@@ -417,7 +417,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           )
           const replacementString =
             typeof replacement === 'string'
-              ? JSON.stringify(encodeURIPath(replacement)).slice(1, -1)
+              ? JSON.stringify(replacement).slice(1, -1)
               : `"+${replacement.runtime}+"`
           s.update(match.index, match.index + full.length, replacementString)
         }


### PR DESCRIPTION
### Description

A filename `/favicon-32x32.png` with the base `/foo bar/` returns `/foo%20bar/favicon-32x32.png` as the URL, Vite should only encode the filename part (`favicon-32x32.png`). This to avoid re-encoding the base, which has already been encoded once it's parsed in the configuration validation step.

#### Before fix
An HTML code like:
```html
<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
```
Along with a base like `/Password generator app/` builds:
```html
<link rel="icon" type="image/png" sizes="32x32" href="/Password%2520generator%2520app/favicon-32x32.png" />
```

#### After fix
The same HTML code now builds:
```html
<link rel="icon" type="image/png" sizes="32x32" href="/Password%20generator%20app/favicon-32x32.png" />
```

### Additional context

Same fix has also been applied for assets URLs inside CSS and JS bundles after building.
