### PR TITLE
feat: write cspNonce to style tags

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -699,7 +699,7 @@ To deploy CSP, certain directives or configs must be set due to Vite's internals
 
 ### [`'nonce-{RANDOM}'`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#nonce-base64-value)
 
-When [`html.cspNonce`](/config/shared-options#html-cspnonce) is set, Vite adds a nonce attribute with the specified value to the output script tag and link tag for stylesheets. Note that Vite will not add a nonce attribute to other tags, such as `<style>`. Additionally, when this option is set, Vite will inject a meta tag (`<meta property="csp-nonce" nonce="PLACEHOLDER" />`).
+When [`html.cspNonce`](/config/shared-options#html-cspnonce) is set, Vite adds a nonce attribute with the specified value to any `<script>` and `<style>` tags, as well as `<link>` tags for stylesheets and module preloading. Additionally, when this option is set, Vite will inject a meta tag (`<meta property="csp-nonce" nonce="PLACEHOLDER" />`).
 
 The nonce value of a meta tag with `property="csp-nonce"` will be used by Vite whenever necessary during both dev and after build.
 

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -1184,6 +1184,7 @@ export function injectNonceAttributeTagHook(
 
       if (
         nodeName === 'script' ||
+        nodeName === 'style' ||
         (nodeName === 'link' &&
           attrs.some(
             (attr) =>

--- a/playground/csp/index.html
+++ b/playground/csp/index.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="./linked.css" />
-<style nonce="#$NONCE$#">
+<style>
   .inline {
     color: green;
   }


### PR DESCRIPTION
### Description

Split off from #16415. This PR will set the nonce attribute for any inline <style> tags in the html if `html.cspNonce` is set. This probably shouldn't be merged until #16415 gets merged to avoid writing a second nonce attribute for any existing <style nonce=""> tags, otherwise this change would be breaking.

See [comment](https://github.com/vitejs/vite/pull/16415#issuecomment-2053657754) from @sapphi-red 
> While I was working on https://github.com/vitejs/vite/pull/16052, I was thinking hard about what tags should have the nonce attribute injected. The first idea was to only inject tags that cannot be achieved by chaning the input HTML (e.g. <script type="module">). The second idea was to inject it into all tags that CSP allows using nonce (e.g. <script>, <style>). When I did that commit, I decided to go with the first idea. The reason was because I wasn't sure the whole list of tags that needs the nonce attribute to be set and another reason was because I thought it's easy to add it later rather than removing it. But it seems I forgot to skip injecting nonce attributes to script tags without type=module.
> 
> On second thought, I think it makes sense to go with the second idea. Vite already injects the nonce to <script>, <link rel="stylesheet">, <link rel="modulepreload">, <link rel="preload">. If I understand the CSP spec correctly, the only missing tag is the <style> tag.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
