### PR TITLE
fix: scripts and styles were missing from built HTML on Windows

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -775,9 +775,10 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       }
 
       for (const [id, html] of processedHtml) {
+        const normalizedId = normalizePath(id)
         const relativeUrlPath = path.posix.relative(
           config.root,
-          normalizePath(id),
+          normalizedId,
         )
         const assetsBase = getBaseInHTML(relativeUrlPath, config)
         const toOutputFilePath = (
@@ -813,7 +814,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
           (chunk) =>
             chunk.type === 'chunk' &&
             chunk.isEntry &&
-            chunk.facadeModuleId === id,
+            chunk.facadeModuleId === normalizedId,
         ) as OutputChunk | undefined
 
         let canInlineEntry = false

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -3,6 +3,7 @@ import { hasWindowsUnicodeFsBug } from '../../hasWindowsUnicodeFsBug'
 import {
   browserLogs,
   editFile,
+  expectWithRetry,
   getColor,
   isBuild,
   isServe,
@@ -372,6 +373,16 @@ describe('special character', () => {
 
   test('should fetch html proxy', async () => {
     expect(browserLogs).toContain('special character')
+  })
+})
+
+describe('relative input', () => {
+  beforeAll(async () => {
+    await page.goto(viteTestUrl + '/relative-input.html')
+  })
+
+  test('passing relative path to rollupOptions.input works', async () => {
+    await expectWithRetry(() => page.textContent('.relative-input')).toBe('OK')
   })
 })
 

--- a/playground/html/relative-input.html
+++ b/playground/html/relative-input.html
@@ -1,0 +1,3 @@
+<script type="module" src="./relative-input/main.js"></script>
+
+<p class="relative-input"></p>

--- a/playground/html/relative-input/main.js
+++ b/playground/html/relative-input/main.js
@@ -1,0 +1,1 @@
+document.querySelector('.relative-input').textContent = 'OK'

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -1,4 +1,4 @@
-import { resolve } from 'node:path'
+import { relative, resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import { hasWindowsUnicodeFsBug } from '../hasWindowsUnicodeFsBug'
 
@@ -40,6 +40,10 @@ export default defineConfig({
         serveBothFile: resolve(__dirname, 'serve/both.html'),
         serveBothFolder: resolve(__dirname, 'serve/both/index.html'),
         write: resolve(__dirname, 'write.html'),
+        relativeInput: relative(
+          process.cwd(),
+          resolve(__dirname, 'relative-input.html'),
+        ),
       },
     },
   },


### PR DESCRIPTION
### Description

Fix HTML entry file generation under Windows where different path
separation characters exists than on POSIX filesystems. This fixes issue
#15992.

The bug was not present in Vite 5.0.12, but still exists in 5.2.8.
I've traced it down to a bug in Vite which is related to path
handling and manifests itself only under Windows filesystems. The
`chunk.facadeModuleId` is something like `C:\Users\rse\xxx\index.html`
(the Windows path separation characters are in place) and the `id` is
`C:/Users/rse/xxx/index.html` (where POSIX path separation characters
are in place). As a result, the chunk is not found and hence the
tags not emitted during the HTML generation. 

The workaround by using `path.resolve()` on the
`build.rollupOptions.input` works, but it would be better if the
comparison inside Vite is fixed. This is what this PR attempts to do.

