### PR TITLE
feat: make Worker constructors configurable

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -1319,6 +1319,23 @@ Repository: component/escape-html
 
 ---------------------------------------
 
+## escape-string-regexp
+License: MIT
+By: Sindre Sorhus
+Repository: sindresorhus/escape-string-regexp
+
+> MIT License
+> 
+> Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---------------------------------------
+
 ## estree-walker
 License: MIT
 By: Rich Harris

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -121,6 +121,7 @@
     "dotenv-expand": "^11.0.6",
     "es-module-lexer": "^1.5.0",
     "escape-html": "^1.0.3",
+    "escape-string-regexp": "^5.0.0",
     "estree-walker": "^3.0.3",
     "etag": "^1.8.1",
     "fast-glob": "^3.3.2",

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_MAIN_FIELDS,
   ENV_ENTRY,
   FS_PREFIX,
+  type WORKER_KINDS,
 } from './constants'
 import type { HookHandler, Plugin, PluginWithRequiredHook } from './plugin'
 import type {
@@ -94,6 +95,12 @@ export interface ConfigEnv {
  * custom: don't include HTML middlewares
  */
 export type AppType = 'spa' | 'mpa' | 'custom'
+
+/**
+ * worker: a normal web worker (e.g. via `new Worker()`)
+ * sharedWorker: a shared worker (e.g. via `new SharedWorker()`)
+ */
+export type WorkerKind = (typeof WORKER_KINDS)[number] // = 'worker' | 'sharedworker'
 
 export type UserConfigFnObject = (env: ConfigEnv) => UserConfig
 export type UserConfigFnPromise = (env: ConfigEnv) => Promise<UserConfig>
@@ -278,6 +285,12 @@ export interface UserConfig {
       RollupOptions,
       'plugins' | 'input' | 'onwarn' | 'preserveEntrySignatures'
     >
+    /**
+     * The list of constructors to detect as Web Workers and their worker type.
+     * Use `defaults` as item to include the built-in default values in your custom configuration.
+     * @default [{constructor:'Worker',kind:'worker'},{constructor:'SharedWorker',kind:'sharedWorker'}]
+     */
+    constructors?: ('defaults' | { constructor: string; kind: WorkerKind })[]
   }
   /**
    * Whether your application is a Single Page Application (SPA),
@@ -346,6 +359,7 @@ export interface ResolvedWorkerOptions {
   format: 'es' | 'iife'
   plugins: (bundleChain: string[]) => Promise<Plugin[]>
   rollupOptions: RollupOptions
+  constructors: { constructor: string; kind: WorkerKind }[]
 }
 
 export interface InlineConfig extends UserConfig {
@@ -756,10 +770,27 @@ export async function resolveConfig(
     return resolvedWorkerPlugins
   }
 
+  const defaultWorkerConstructors: ResolvedWorkerOptions['constructors'] = [
+    { constructor: 'Worker', kind: 'worker' },
+    { constructor: 'SharedWorker', kind: 'sharedworker' },
+  ]
+
   const resolvedWorkerOptions: ResolvedWorkerOptions = {
     format: config.worker?.format || 'iife',
     plugins: createWorkerPlugins,
     rollupOptions: config.worker?.rollupOptions || {},
+    constructors:
+      config.worker?.constructors?.reduce(
+        (prev, c) => {
+          if (c === 'defaults') {
+            prev.push(...defaultWorkerConstructors)
+          } else {
+            prev.push(c)
+          }
+          return prev
+        },
+        [] as ResolvedWorkerOptions['constructors'],
+      ) || defaultWorkerConstructors,
   }
 
   resolved = {

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -52,7 +52,10 @@ export const CSS_LANGS_RE =
 
 export const OPTIMIZABLE_ENTRY_RE = /\.[cm]?[jt]s$/
 
-export const SPECIAL_QUERY_RE = /[?&](?:worker|sharedworker|raw|url)\b/
+export const WORKER_KINDS = ['worker', 'sharedworker'] as const
+export const SPECIAL_QUERY_RE = new RegExp(
+  `[?&](?:${WORKER_KINDS.join('|')}|raw|url)\\b`,
+)
 
 /**
  * Prefix for resolved fs paths, since windows paths may not be valid as URLs.

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -123,10 +123,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   const workerConstructorRE = config.worker.constructors
     .map((c) => escapeStringRegexp(c.constructor))
     .join('|')
-  const workerImportMetaUrlRE = new RegExp(
-    `\\bnew\\s+(?:${workerConstructorRE})\\s*\\(\\s*(new\\s+URL\\s*\\(\\s*('[^']+'|"[^"]+"|\`[^\`]+\`)\\s*,\\s*import\\.meta\\.url\\s*\\))`,
-    'dg',
-  )
 
   return {
     name: 'vite:worker-import-meta-url',
@@ -151,8 +147,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
 
-        // reset pattern for new matching loop
-        workerImportMetaUrlRE.lastIndex = 0
+        const workerImportMetaUrlRE = new RegExp(
+          `\\bnew\\s+(?:${workerConstructorRE})\\s*\\(\\s*(new\\s+URL\\s*\\(\\s*('[^']+'|"[^"]+"|\`[^\`]+\`)\\s*,\\s*import\\.meta\\.url\\s*\\))`,
+          'dg',
+        )
 
         let match: RegExpExecArray | null
         while ((match = workerImportMetaUrlRE.exec(cleanString))) {

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -2,6 +2,7 @@ import path from 'node:path'
 import MagicString from 'magic-string'
 import type { RollupError } from 'rollup'
 import { stripLiteral } from 'strip-literal'
+import escapeStringRegexp from 'escape-string-regexp'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { evalValue, injectQuery, transformStableResult } from '../utils'
@@ -89,12 +90,8 @@ function getWorkerType(raw: string, clean: string, i: number): WorkerType {
   return 'classic'
 }
 
-function isIncludeWorkerImportMetaUrl(code: string): boolean {
-  if (
-    (code.includes('new Worker') || code.includes('new SharedWorker')) &&
-    code.includes('new URL') &&
-    code.includes(`import.meta.url`)
-  ) {
+function includesWorkerImportMetaUrl(code: string): boolean {
+  if (code.includes('new URL') && code.includes(`import.meta.url`)) {
     return true
   }
   return false
@@ -114,21 +111,48 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     asSrc: true,
   }
 
+  function includesWorkerConstructor(code: string): boolean {
+    for (const c of config.worker.constructors) {
+      if (code.includes(`new ${c.constructor}`)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  const workerConstructorRE = config.worker.constructors
+    .map((c) => escapeStringRegexp(c.constructor))
+    .join('|')
+  const workerImportMetaUrlRE = new RegExp(
+    `\\bnew\\s+(?:${workerConstructorRE})\\s*\\(\\s*(new\\s+URL\\s*\\(\\s*('[^']+'|"[^"]+"|\`[^\`]+\`)\\s*,\\s*import\\.meta\\.url\\s*\\))`,
+    'dg',
+  )
+
   return {
     name: 'vite:worker-import-meta-url',
 
     shouldTransformCachedModule({ code }) {
-      if (isBuild && config.build.watch && isIncludeWorkerImportMetaUrl(code)) {
+      if (
+        isBuild &&
+        config.build.watch &&
+        includesWorkerConstructor(code) &&
+        includesWorkerImportMetaUrl(code)
+      ) {
         return true
       }
     },
 
     async transform(code, id, options) {
-      if (!options?.ssr && isIncludeWorkerImportMetaUrl(code)) {
+      if (
+        !options?.ssr &&
+        includesWorkerConstructor(code) &&
+        includesWorkerImportMetaUrl(code)
+      ) {
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
-        const workerImportMetaUrlRE =
-          /\bnew\s+(?:Worker|SharedWorker)\s*\(\s*(new\s+URL\s*\(\s*('[^']+'|"[^"]+"|`[^`]+`)\s*,\s*import\.meta\.url\s*\))/dg
+
+        // reset pattern for new matching loop
+        workerImportMetaUrlRE.lastIndex = 0
 
         let match: RegExpExecArray | null
         while ((match = workerImportMetaUrlRE.exec(cleanString))) {

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -111,7 +111,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(34)
+    expect(files.length).toBe(35)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -240,3 +240,11 @@ test('self reference url worker', async () => {
     'pong: main\npong: nested\n',
   )
 })
+
+test('custom constructor', async () => {
+  await untilUpdated(
+    () => page.textContent('.worker-custom-constructor'),
+    'A string',
+    true,
+  )
+})

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -75,7 +75,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/iife/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(22)
+    expect(files.length).toBe(23)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('worker_entry-my-worker'))

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -192,3 +192,11 @@ function decodeSourceMapUrl(content: string) {
     ).toString(),
   )
 }
+
+test('custom constructor', async () => {
+  await untilUpdated(
+    () => page.textContent('.worker-custom-constructor'),
+    'A string',
+    true,
+  )
+})

--- a/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(44)
+    expect(files.length).toBe(46)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(22)
+    expect(files.length).toBe(23)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
+++ b/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
@@ -9,7 +9,7 @@ describe.runIf(isBuild)('build', () => {
     const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap/assets')
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(44)
+    expect(files.length).toBe(46)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -215,6 +215,13 @@
 </p>
 <code class="module-and-worker-worker"></code>
 
+<p>
+  new Custom.Constructor(new URL('./url-worker.js', import.meta.url), { type:
+  'module' })
+  <span class="classname">.worker-custom-constructor</span>
+</p>
+<code class="worker-custom-constructor"></code>
+
 <style>
   p {
     background: rgba(0, 0, 0, 0.1);

--- a/playground/worker/url-worker-custom-constructor.js
+++ b/playground/worker/url-worker-custom-constructor.js
@@ -1,0 +1,12 @@
+self.postMessage(
+  [
+    'A string',
+    import.meta.env.BASE_URL,
+    self.location.url,
+    import.meta && import.meta.url,
+    import.meta.url,
+  ].join(' '),
+)
+
+// for sourcemap
+console.log('url-worker-custom-constructor.js')

--- a/playground/worker/vite.config-es.js
+++ b/playground/worker/vite.config-es.js
@@ -18,6 +18,10 @@ export default defineConfig({
         entryFileNames: 'assets/worker_entry-[name].js',
       },
     },
+    constructors: [
+      'defaults',
+      { constructor: 'Custom.Constructor', kind: 'worker' },
+    ],
   },
   build: {
     outDir: 'dist/es',

--- a/playground/worker/vite.config-iife.js
+++ b/playground/worker/vite.config-iife.js
@@ -49,6 +49,10 @@ export default defineConfig({
                 entryFileNames: 'assets/worker_entry-[name].js',
               },
             },
+            constructors: [
+              'defaults',
+              { constructor: 'Custom.Constructor', kind: 'worker' },
+            ],
           },
         }
       },

--- a/playground/worker/vite.config-iife.js
+++ b/playground/worker/vite.config-iife.js
@@ -19,6 +19,10 @@ export default defineConfig({
         entryFileNames: 'assets/worker_-[name].js',
       },
     },
+    constructors: [
+      'defaults',
+      { constructor: 'Custom.Constructor', kind: 'worker' },
+    ],
   },
   build: {
     outDir: 'dist/iife',

--- a/playground/worker/vite.config-relative-base-iife.js
+++ b/playground/worker/vite.config-relative-base-iife.js
@@ -18,6 +18,10 @@ export default defineConfig(({ isPreview }) => ({
         entryFileNames: 'worker-entries/worker_entry-[name]-[hash].js',
       },
     },
+    constructors: [
+      'defaults',
+      { constructor: 'Custom.Constructor', kind: 'worker' },
+    ],
   },
   build: {
     outDir: 'dist/relative-base-iife',

--- a/playground/worker/vite.config-relative-base.js
+++ b/playground/worker/vite.config-relative-base.js
@@ -18,6 +18,10 @@ export default defineConfig(({ isPreview }) => ({
         entryFileNames: 'worker-entries/worker_entry-[name]-[hash].js',
       },
     },
+    constructors: [
+      'defaults',
+      { constructor: 'Custom.Constructor', kind: 'worker' },
+    ],
   },
   build: {
     outDir: 'dist/relative-base',

--- a/playground/worker/worker-sourcemap-config.js
+++ b/playground/worker/worker-sourcemap-config.js
@@ -32,6 +32,10 @@ export default (sourcemap) => {
           entryFileNames: 'assets/[name]-worker_entry[hash].js',
         },
       },
+      constructors: [
+        'defaults',
+        { constructor: 'Custom.Constructor', kind: 'worker' },
+      ],
     },
     build: {
       outDir: `dist/iife-${typeName}/`,

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -175,13 +175,12 @@ selfReferenceUrlWorker.addEventListener('message', (e) => {
     `${e.data}\n`
 })
 
+// url import worker
 const Custom = {
   Constructor: Worker,
 }
-
-// url import worker
 const customConstructorWorker = new Custom.Constructor(
-  new URL('../url-worker.js', import.meta.url),
+  new URL('../url-worker-custom-constructor.js', import.meta.url),
   /* @vite-ignore */ workerOptions,
 )
 customConstructorWorker.addEventListener('message', (ev) =>

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -174,3 +174,16 @@ selfReferenceUrlWorker.addEventListener('message', (e) => {
   document.querySelector('.self-reference-url-worker').textContent +=
     `${e.data}\n`
 })
+
+const Custom = {
+  Constructor: Worker,
+}
+
+// url import worker
+const customConstructorWorker = new Custom.Constructor(
+  new URL('../url-worker.js', import.meta.url),
+  /* @vite-ignore */ workerOptions,
+)
+customConstructorWorker.addEventListener('message', (ev) =>
+  text('.worker-custom-constructor', JSON.stringify(ev.data)),
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
+      escape-string-regexp:
+        specifier: ^5.0.0
+        version: 5.0.0
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3


### PR DESCRIPTION
### Description

This PR addresses some first parts of #16128 

#### Background
As described in the issue the ultimate goal is to make the Web Worker generation reusable from other plugins. This way a custom plugin for a specific library can tell vite more specifically to generate workers for this specific library. 

In preparation to such flexibility, this PR adds the possibility to use alternative constructors than `Worker` and `SharedWorker`. 

#### Use Cases

1. It allows developers to adjust which type constructors are picked up as web workers. This can be useful when 3rd party libraries offer worker-alike types but during the import the constructor might get renamed. The custom aliases can also have benefits fro mocking and testing purposes. 

```js
// vite.config.js
// worker: { constructors: [ { constructor: 'NodeWorkerThreads', kind: 'worker' },  { constructor: 'ThreadsWorker', kind: 'worker' } ]

import { Worker as NodeWorkerThreads } from 'worker_threads';
import { Worker as ThreadsWorker } from 'threads'; // https://www.npmjs.com/package/threads

const nodeWorker = new NodeWorkerThreads(new URL('./worker.js', import.meta.url));
const threadsWorker = new ThreadsWorker(new URL('./worker.js', import.meta.url));
```

2. I envision as a next step that the functionality behind `workerImportMetaUrlPlugin` is exposed for plugin authors to trigger worker generation specifically for their plugin. 

3. Adding audio and paint worklets as new types of "workers" will require a certain degree of flexibility to tell vite which syntax to pick up as worklets. (e.g. `context.audioWorklet.addModule(new URL('./worklet.js', import.meta.url))` could be added as `worker: [{ function: 'context.audioWorklet.addModule', kind: 'worklet' }]` 

#### Dependency

The `escape-string-regexp` is needed as new dependency to escape the input strings in the constructor regex matching. The dependency seems quite widely adopted but is also very lightweight:

https://www.npmjs.com/package/escape-string-regexp
https://github.com/sindresorhus/escape-string-regexp/blob/main/index.js#L8