### PR TITLE
feat: deprecate ssrLoadModule

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -294,7 +294,9 @@ export class ModuleRunner {
     const mod = this.moduleCache.getByModuleId(moduleId)
 
     const request = async (dep: string, metadata?: SSRImportMetadata) => {
-      const fetchedModule = await this.cachedModule(dep, moduleId)
+      const importer =
+        (mod.meta && 'file' in mod.meta && mod.meta.file) || moduleId
+      const fetchedModule = await this.cachedModule(dep, importer)
       const depMod = this.moduleCache.getByModuleId(fetchedModule.id)
       depMod.importers!.add(moduleId)
       mod.imports!.add(fetchedModule.id)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -16,6 +16,7 @@ import launchEditorMiddleware from 'launch-editor-middleware'
 import type { SourceMap } from 'rollup'
 import picomatch from 'picomatch'
 import type { Matcher } from 'picomatch'
+import type { ModuleRunner } from 'vite/module-runner'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,
@@ -420,6 +421,10 @@ export interface ViteDevServer {
    * @internal
    */
   _configServerPort?: number | undefined
+  /**
+   * @internal
+   */
+  _ssrCompatModuleRunner?: ModuleRunner
 }
 
 export interface ResolvedServerUrls {

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -1,7 +1,6 @@
 import { pathToFileURL } from 'node:url'
 import type { FetchResult } from 'vite/module-runner'
 import type { EnvironmentModuleNode, TransformResult } from '..'
-import type { InternalResolveOptionsWithOverrideConditions } from '../plugins/resolve'
 import { tryNodeResolve } from '../plugins/resolve'
 import { isBuiltin, isExternalUrl, isFilePathESM } from '../utils'
 import { unwrapId } from '../../shared/utils'
@@ -41,27 +40,27 @@ export async function fetchModule(
     const { externalConditions, dedupe, preserveSymlinks } =
       environment.options.resolve
 
-    const resolveOptions: InternalResolveOptionsWithOverrideConditions = {
-      mainFields: ['main'],
-      conditions: [],
-      externalConditions,
-      external: [], // TODO, should it be environment.options.resolve.external?
-      noExternal: [],
-      overrideConditions: [...externalConditions, 'production', 'development'],
-      extensions: ['.js', '.cjs', '.json'],
-      dedupe,
-      preserveSymlinks,
-      isBuild: false,
-      isProduction,
-      root,
-      packageCache: environment.config.packageCache,
-    }
-
     const resolved = tryNodeResolve(
       url,
       importer,
       {
-        ...resolveOptions,
+        mainFields: ['main'],
+        conditions: [],
+        externalConditions,
+        external: [],
+        noExternal: [],
+        overrideConditions: [
+          ...externalConditions,
+          'production',
+          'development',
+        ],
+        extensions: ['.js', '.cjs', '.json'],
+        dedupe,
+        preserveSymlinks,
+        isBuild: false,
+        isProduction,
+        root,
+        packageCache: environment.config.packageCache,
         tryEsmOnly: true,
         webCompatible: environment.options.webCompatible,
         nodeCompatible: environment.options.nodeCompatible,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -30,6 +30,9 @@ export async function ssrLoadModule(
     server._ssrCompatModuleRunner ||
     (server._ssrCompatModuleRunner = createServerModuleRunner(
       server.environments.ssr,
+      {
+        sourcemapInterceptor: false,
+      },
     ))
 
   url = unwrapId(url)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -1,31 +1,9 @@
-import path from 'node:path'
-import { pathToFileURL } from 'node:url'
 import colors from 'picocolors'
+import type { ModuleRunner } from 'vite/module-runner'
 import type { ViteDevServer } from '../server'
-import { isBuiltin, isExternalUrl, isFilePathESM } from '../utils'
-import type { InternalResolveOptionsWithOverrideConditions } from '../plugins/resolve'
-import { tryNodeResolve } from '../plugins/resolve'
-import { genSourceMapUrl } from '../server/sourcemap'
-import {
-  AsyncFunction,
-  asyncFunctionDeclarationPaddingLineCount,
-  isWindows,
-  unwrapId,
-} from '../../shared/utils'
-import {
-  type SSRImportBaseMetadata,
-  analyzeImportedModDifference,
-  proxyGuardOnlyEsm,
-} from '../../shared/ssrTransform'
-import { SOURCEMAPPING_URL } from '../../shared/constants'
-import {
-  ssrDynamicImportKey,
-  ssrExportAllKey,
-  ssrImportKey,
-  ssrImportMetaKey,
-  ssrModuleExportsKey,
-} from './ssrTransform'
+import { unwrapId } from '../../shared/utils'
 import { ssrFixStacktrace } from './ssrStacktrace'
+import { createServerModuleRunner } from './runtime/serverModuleRunner'
 
 interface SSRContext {
   global: typeof globalThis
@@ -33,230 +11,57 @@ interface SSRContext {
 
 type SSRModule = Record<string, any>
 
-interface NodeImportResolveOptions
-  extends InternalResolveOptionsWithOverrideConditions {
-  legacyProxySsrExternalModules?: boolean
-}
-
-const pendingModules = new Map<string, Promise<SSRModule>>()
-const pendingImports = new Map<string, string[]>()
-const importErrors = new WeakMap<Error, { importee: string }>()
-
 export async function ssrLoadModule(
   url: string,
   server: ViteDevServer,
-  context: SSRContext = { global },
-  urlStack: string[] = [],
+  _context: SSRContext = { global },
+  _urlStack: string[] = [],
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
+  server.config.logger.warnOnce(
+    colors.yellow(
+      '`ssrLoadModule` is deprecated and will be removed in the next major version. ' +
+        'Use `createServerModuleRunner(environment).import(url)` from "vite/module-runner" ' +
+        'to load modules instead.',
+    ),
+  )
+
+  const runner =
+    server._ssrCompatModuleRunner ||
+    (server._ssrCompatModuleRunner = createServerModuleRunner(
+      server.environments.ssr,
+    ))
+
   url = unwrapId(url)
 
-  // when we instantiate multiple dependency modules in parallel, they may
-  // point to shared modules. We need to avoid duplicate instantiation attempts
-  // by register every module as pending synchronously so that all subsequent
-  // request to that module are simply waiting on the same promise.
-  const pending = pendingModules.get(url)
-  if (pending) {
-    return pending
-  }
-
-  const modulePromise = instantiateModule(
-    url,
-    server,
-    context,
-    urlStack,
-    fixStacktrace,
-  )
-  pendingModules.set(url, modulePromise)
-  modulePromise
-    .catch(() => {
-      pendingImports.delete(url)
-    })
-    .finally(() => {
-      pendingModules.delete(url)
-    })
-  return modulePromise
+  return instantiateModule(url, runner, server, fixStacktrace)
 }
 
 async function instantiateModule(
   url: string,
+  runner: ModuleRunner,
   server: ViteDevServer,
-  context: SSRContext = { global },
-  urlStack: string[] = [],
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
   const environment = server.environments.ssr
-  const moduleGraph = environment.moduleGraph
-  const mod = await moduleGraph.ensureEntryFromUrl(url)
+  const mod = await environment.moduleGraph.ensureEntryFromUrl(url)
 
   if (mod.ssrError) {
     throw mod.ssrError
   }
 
-  if (mod.ssrModule) {
-    return mod.ssrModule
-  }
-  const result =
-    mod.transformResult || (await environment.transformRequest(url))
-  if (!result) {
-    // TODO more info? is this even necessary?
-    throw new Error(`failed to load module for ssr: ${url}`)
-  }
-
-  const ssrModule = {
-    [Symbol.toStringTag]: 'Module',
-  }
-  Object.defineProperty(ssrModule, '__esModule', { value: true })
-
-  // Tolerate circular imports by ensuring the module can be
-  // referenced before it's been instantiated.
-  mod.ssrModule = ssrModule
-
-  // replace '/' with '\\' on Windows to match Node.js
-  const osNormalizedFilename = isWindows ? path.resolve(mod.file!) : mod.file!
-
-  const ssrImportMeta = {
-    dirname: path.dirname(osNormalizedFilename),
-    filename: osNormalizedFilename,
-    // The filesystem URL, matching native Node.js modules
-    url: pathToFileURL(mod.file!).toString(),
-  }
-
-  urlStack = urlStack.concat(url)
-  const isCircular = (url: string) => urlStack.includes(url)
-
-  const { isProduction, root } = server.config
-
-  const { externalConditions, dedupe, preserveSymlinks } =
-    environment.options.resolve
-
-  const resolveOptions: NodeImportResolveOptions = {
-    mainFields: ['main'],
-    conditions: [],
-    externalConditions,
-    external: [], // TODO, should it be ssr.resolve.external?
-    noExternal: [],
-    overrideConditions: [...externalConditions, 'production', 'development'],
-    extensions: ['.js', '.cjs', '.json'],
-    dedupe,
-    preserveSymlinks,
-    isBuild: false,
-    isProduction,
-    root,
-    legacyProxySsrExternalModules:
-      server.config.legacy?.proxySsrExternalModules,
-    packageCache: server.config.packageCache,
-  }
-
-  // Since dynamic imports can happen in parallel, we need to
-  // account for multiple pending deps and duplicate imports.
-  const pendingDeps: string[] = []
-
-  const ssrImport = async (dep: string, metadata?: SSRImportBaseMetadata) => {
-    try {
-      if (dep[0] !== '.' && dep[0] !== '/') {
-        return await nodeImport(dep, mod.file!, resolveOptions, metadata)
-      }
-      // convert to rollup URL because `pendingImports`, `moduleGraph.urlToModuleMap` requires that
-      dep = unwrapId(dep)
-      if (!isCircular(dep) && !pendingImports.get(dep)?.some(isCircular)) {
-        pendingDeps.push(dep)
-        if (pendingDeps.length === 1) {
-          pendingImports.set(url, pendingDeps)
-        }
-        const mod = await ssrLoadModule(
-          dep,
-          server,
-          context,
-          urlStack,
-          fixStacktrace,
-        )
-        if (pendingDeps.length === 1) {
-          pendingImports.delete(url)
-        } else {
-          pendingDeps.splice(pendingDeps.indexOf(dep), 1)
-        }
-        // return local module to avoid race condition #5470
-        return mod
-      }
-      return moduleGraph.urlToModuleMap.get(dep)?.ssrModule
-    } catch (err) {
-      // tell external error handler which mod was imported with error
-      importErrors.set(err, { importee: dep })
-
-      throw err
-    }
-  }
-
-  const ssrDynamicImport = (dep: string) => {
-    // #3087 dynamic import vars is ignored at rewrite import path,
-    // so here need process relative path
-    if (dep[0] === '.') {
-      dep = path.posix.resolve(path.dirname(url), dep)
-    }
-    return ssrImport(dep, { isDynamicImport: true })
-  }
-
-  function ssrExportAll(sourceModule: any) {
-    for (const key in sourceModule) {
-      if (key !== 'default' && key !== '__esModule') {
-        Object.defineProperty(ssrModule, key, {
-          enumerable: true,
-          configurable: true,
-          get() {
-            return sourceModule[key]
-          },
-        })
-      }
-    }
-  }
-
-  let sourceMapSuffix = ''
-  if (result.map && 'version' in result.map) {
-    const moduleSourceMap = Object.assign({}, result.map, {
-      mappings:
-        ';'.repeat(asyncFunctionDeclarationPaddingLineCount) +
-        result.map.mappings,
-    })
-    sourceMapSuffix = `\n//# ${SOURCEMAPPING_URL}=${genSourceMapUrl(moduleSourceMap)}`
-  }
-
   try {
-    const initModule = new AsyncFunction(
-      `global`,
-      ssrModuleExportsKey,
-      ssrImportMetaKey,
-      ssrImportKey,
-      ssrDynamicImportKey,
-      ssrExportAllKey,
-      '"use strict";' +
-        result.code +
-        `\n//# sourceURL=${mod.id}${sourceMapSuffix}`,
-    )
-    await initModule(
-      context.global,
-      ssrModule,
-      ssrImportMeta,
-      ssrImport,
-      ssrDynamicImport,
-      ssrExportAll,
-    )
-  } catch (e) {
+    const exports = await runner.import(url)
+    mod.ssrModule = exports
+    return exports
+  } catch (e: any) {
     mod.ssrError = e
-    const errorData = importErrors.get(e)
-
     if (e.stack && fixStacktrace) {
-      ssrFixStacktrace(e, moduleGraph)
+      ssrFixStacktrace(e, environment.moduleGraph)
     }
 
     environment.logger.error(
-      colors.red(
-        `Error when evaluating SSR module ${url}:` +
-          (errorData?.importee
-            ? ` failed to import "${errorData.importee}"`
-            : '') +
-          `\n|- ${e.stack}\n`,
-      ),
+      colors.red(`Error when evaluating SSR module ${url}:\n|- ${e.stack}\n`),
       {
         timestamp: true,
         clear: server.config.clearScreen,
@@ -266,86 +71,4 @@ async function instantiateModule(
 
     throw e
   }
-
-  return Object.freeze(ssrModule)
-}
-
-// In node@12+ we can use dynamic import to load CJS and ESM
-async function nodeImport(
-  id: string,
-  importer: string,
-  resolveOptions: NodeImportResolveOptions,
-  metadata?: SSRImportBaseMetadata,
-) {
-  let url: string
-  let filePath: string | undefined
-  if (id.startsWith('data:') || isExternalUrl(id) || isBuiltin(id)) {
-    url = id
-  } else {
-    const resolved = tryNodeResolve(
-      id,
-      importer,
-      {
-        ...resolveOptions,
-        tryEsmOnly: true,
-        webCompatible: false,
-        nodeCompatible: true,
-      },
-      undefined,
-      true,
-    )
-    if (!resolved) {
-      const err: any = new Error(
-        `Cannot find module '${id}' imported from '${importer}'`,
-      )
-      err.code = 'ERR_MODULE_NOT_FOUND'
-      throw err
-    }
-    filePath = resolved.id
-    url = pathToFileURL(resolved.id).toString()
-  }
-
-  const mod = await import(url)
-
-  if (resolveOptions.legacyProxySsrExternalModules) {
-    return proxyESM(mod)
-  } else if (filePath) {
-    analyzeImportedModDifference(
-      mod,
-      id,
-      isFilePathESM(filePath, resolveOptions.packageCache)
-        ? 'module'
-        : undefined,
-      metadata,
-    )
-    return proxyGuardOnlyEsm(mod, id)
-  } else {
-    return mod
-  }
-}
-
-// rollup-style default import interop for cjs
-function proxyESM(mod: any) {
-  // This is the only sensible option when the exports object is a primitive
-  if (isPrimitive(mod)) return { default: mod }
-
-  let defaultExport = 'default' in mod ? mod.default : mod
-
-  if (!isPrimitive(defaultExport) && '__esModule' in defaultExport) {
-    mod = defaultExport
-    if ('default' in defaultExport) {
-      defaultExport = defaultExport.default
-    }
-  }
-
-  return new Proxy(mod, {
-    get(mod, prop) {
-      if (prop === 'default') return defaultExport
-      return mod[prop] ?? defaultExport?.[prop]
-    },
-  })
-}
-
-function isPrimitive(value: any) {
-  return !value || (typeof value !== 'object' && typeof value !== 'function')
 }


### PR DESCRIPTION
### Description

Deprecate `server.ssrLoadModule` in favor of `createServerModuleRunner(environment).import(url)`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
