### PR TITLE
feat: support warmup by IDs

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -178,12 +178,12 @@ The error that appears in the Browser when the fallback happens can be ignored. 
 
 ## server.warmup
 
-- **Type:** `{ clientFiles?: string[], ssrFiles?: string[] }`
+- **Type:** `{ clientFiles?: string[], clientIds?: string[], ssrFiles?: string[], ssrIds?: string[] }`
 - **Related:** [Warm Up Frequently Used Files](/guide/performance.html#warm-up-frequently-used-files)
 
 Warm up files to transform and cache the results in advance. This improves the initial page load during server starts and prevents transform waterfalls.
 
-`clientFiles` are files that are used in the client only, while `ssrFiles` are files that are used in SSR only. They accept an array of file paths or [`fast-glob`](https://github.com/mrmlnc/fast-glob) patterns relative to the `root`.
+`clientFiles` are files that are used in the client only, while `ssrFiles` are files that are used in SSR only. They accept an array of file paths or [`fast-glob`](https://github.com/mrmlnc/fast-glob) patterns relative to the `root`. `clientIds` and `ssrIds` are IDs of modules that are requested during the warmup.
 
 Make sure to only add files that are frequently used to not overload the Vite dev server on startup.
 
@@ -192,6 +192,7 @@ export default defineConfig({
   server: {
     warmup: {
       clientFiles: ['./src/components/*.vue', './src/utils/big-utils.js'],
+      clientIds: ['virtual:custom'],
       ssrFiles: ['./src/server/modules/*.js'],
     },
   },

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -106,9 +106,17 @@ export interface ServerOptions extends CommonServerOptions {
      */
     clientFiles?: string[]
     /**
+     * The IDs of modules to be transformed and used on the client-side.
+     */
+    clientIds?: string[]
+    /**
      * The files to be transformed and used in SSR. Supports glob patterns.
      */
     ssrFiles?: string[]
+    /**
+     * The IDs of modules to be transformed and used in SSR.
+     */
+    ssrIds?: string[]
   }
   /**
    * chokidar watch options or null to disable FS watching

--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -17,12 +17,22 @@ export function warmupFiles(server: ViteDevServer): void {
       }
     })
   }
+  if (options?.clientIds?.length) {
+    for (const id of options.clientIds) {
+      server.warmupRequest(id)
+    }
+  }
   if (options?.ssrFiles?.length) {
     mapFiles(options.ssrFiles, root).then((files) => {
       for (const file of files) {
         warmupFile(server, file, true)
       }
     })
+  }
+  if (options?.ssrIds?.length) {
+    for (const id of options.ssrIds) {
+      server.warmupRequest(id, { ssr: true })
+    }
   }
 }
 

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -384,6 +384,14 @@ describe.runIf(isServe)('warmup', () => {
       expect(mod).toBeTruthy()
     })
   })
+  test('should warmup virtual:warmup', async () => {
+    // warmup transform files async during server startup, so the module check
+    // here might take a while to load
+    await withRetry(async () => {
+      const mod = await viteServer.moduleGraph.getModuleByUrl('virtual:warmup')
+      expect(mod).toBeTruthy()
+    })
+  })
 })
 
 test('html serve behavior', async () => {

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -50,6 +50,7 @@ export default defineConfig({
     },
     warmup: {
       clientFiles: ['./warmup/*'],
+      clientIds: ['virtual:warmup'],
     },
   },
 
@@ -213,6 +214,15 @@ ${
             injectTo: 'head',
           },
         ]
+      },
+    },
+    {
+      name: 'virtual-warmup-file',
+      resolveId(id) {
+        if (id === 'virtual:warmup') return '\0virtual:warmup'
+      },
+      load(id) {
+        if (id === '\0virtual:warmup') return `console.log('From virtual:warm')`
       },
     },
   ],


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR implements the `server.warmup.clientIds` and `server.warmup.ssrIds` options, which are the IDs of modules to be warmed up. For example, `['virtual:custom']`.

Slidev's starting time is a little bit too long now, and to improve this, **virtual** modules like `/@slidev/slides/3.md` should be warmed up. Currently, Vite's `server.warmup.clientFiles` only accepts files, and there seem to be no other ways.

I am not 100% sure about the naming conventions in Vite. Should the option be `clientIds` or `clientUrls`?

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
