### PR TITLE
feat: add more robust remote transport to communicate between the runner and server

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -335,7 +335,9 @@ const __require = require;
       // don't patch runner utils chunk because it should stay lightweight and we know it doesn't use require
       if (
         chunk.name === 'utils' &&
-        chunk.moduleIds.some((id) => id.endsWith('/ssr/module-runner/utils.ts'))
+        chunk.moduleIds.some((id) =>
+          id.endsWith('/ssr/module-runner/utils.ts'.replace(/\//g, path.sep)),
+        )
       )
         return
       const match = code.match(/^(?:import[\s\S]*?;\s*)+/)

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -202,7 +202,7 @@ function createModuleRunnerConfig(isProduction: boolean) {
         isProduction ? false : './dist/node',
       ),
       esbuildMinifyPlugin({ minify: false, minifySyntax: true }),
-      bundleSizeLimit(47),
+      bundleSizeLimit(48),
     ],
   })
 }

--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
-import { findStaticImports } from 'mlly'
 import path from 'node:path'
+import { findStaticImports } from 'mlly'
 import { defineConfig } from 'rollup'
 import type { Plugin, PluginContext, RenderedChunk } from 'rollup'
 import dts from 'rollup-plugin-dts'

--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { findStaticImports } from 'mlly'
+import path from 'node:path'
 import { defineConfig } from 'rollup'
 import type { Plugin, PluginContext, RenderedChunk } from 'rollup'
 import dts from 'rollup-plugin-dts'
@@ -92,10 +93,13 @@ function patchTypes(): Plugin {
       }
     },
     renderChunk(code, chunk) {
+      const directory = (dir: string) => `${path.sep}${dir}${path.sep}`
       const isNonMainChunk =
         chunk.moduleIds.length &&
         chunk.moduleIds.every(
-          (id) => id.includes('/module-runner/') || id.includes('/shared/'),
+          (id) =>
+            id.includes(directory('module-runner')) ||
+            id.includes(directory('shared')),
         )
 
       if (isNonMainChunk) {

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -5,6 +5,11 @@ export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 export { RemoteRunnerTransport } from './runnerTransport'
 
+export type {
+  RemoteRunnerTransportEvents,
+  RemoteRunnerTransportMethods,
+} from './runnerTransport'
+
 export type { RunnerTransport } from './runnerTransport'
 export type { HMRLogger, HMRConnection } from '../shared/hmr'
 export type {

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -5,11 +5,6 @@ export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 export { RemoteRunnerTransport } from './runnerTransport'
 
-export type {
-  RemoteRunnerTransportEvents,
-  RemoteRunnerTransportMethods,
-} from './runnerTransport'
-
 export type { RunnerTransport } from './runnerTransport'
 export type { HMRLogger, HMRConnection } from '../shared/hmr'
 export type {

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -39,7 +39,7 @@ import {
 import { hmrLogger, silentConsole } from './hmrLogger'
 import { createHMRHandler } from './hmrHandler'
 import { enableSourceMapSupport } from './sourcemap/index'
-import type { RunnerTransport } from './runnerTransport'
+import { RemoteRunnerTransport, type RunnerTransport } from './runnerTransport'
 
 interface ModuleRunnerDebugger {
   (formatter: unknown, ...args: unknown[]): void
@@ -74,6 +74,9 @@ export class ModuleRunner {
   ) {
     this.moduleCache = options.moduleCache ?? new ModuleCacheMap(options.root)
     this.transport = options.transport
+    if (options.transport instanceof RemoteRunnerTransport) {
+      options.transport.register(this)
+    }
     if (typeof options.hmr === 'object') {
       this.hmrClient = new HMRClient(
         options.hmr.logger === false

--- a/packages/vite/src/module-runner/runnerTransport.ts
+++ b/packages/vite/src/module-runner/runnerTransport.ts
@@ -1,9 +1,8 @@
 import type {
   TransportMethods,
-  TransportOptions} from '../shared/remoteTransport';
-import {
-  RemoteTransport
+  TransportOptions,
 } from '../shared/remoteTransport'
+import { RemoteTransport } from '../shared/remoteTransport'
 import type { FetchFunction, FetchResult } from './types'
 import type { ModuleRunner } from './runner'
 
@@ -54,7 +53,7 @@ export class RemoteRunnerTransport<
   async fetchModule(id: string, importer?: string): Promise<FetchResult> {
     // TODO: url gives a type error for some reason here, but works when
     // the class is contructed from the outside
-    return await (this.dispatch as any)('fetchModule', id, importer)
+    return await (this.invoke as any)('fetchModule', id, importer)
   }
 
   register(runner: ModuleRunner): void {

--- a/packages/vite/src/module-runner/runnerTransport.ts
+++ b/packages/vite/src/module-runner/runnerTransport.ts
@@ -1,83 +1,63 @@
+import type {
+  TransportMethods,
+  TransportOptions} from '../shared/remoteTransport';
+import {
+  RemoteTransport
+} from '../shared/remoteTransport'
 import type { FetchFunction, FetchResult } from './types'
+import type { ModuleRunner } from './runner'
 
 export interface RunnerTransport {
   fetchModule: FetchFunction
 }
 
-export class RemoteRunnerTransport implements RunnerTransport {
-  private rpcPromises = new Map<
-    string,
-    {
-      resolve: (data: any) => void
-      reject: (data: any) => void
-      timeoutId?: NodeJS.Timeout
-    }
-  >()
-
-  constructor(
-    private readonly options: {
-      send: (data: any) => void
-      onMessage: (handler: (data: any) => void) => void
-      timeout?: number
-    },
-  ) {
-    this.options.onMessage(async (data) => {
-      if (typeof data !== 'object' || !data || !data.__v) return
-
-      const promise = this.rpcPromises.get(data.i)
-      if (!promise) return
-
-      if (promise.timeoutId) clearTimeout(promise.timeoutId)
-
-      this.rpcPromises.delete(data.i)
-
-      if (data.e) {
-        promise.reject(data.e)
-      } else {
-        promise.resolve(data.r)
-      }
-    })
-  }
-
-  private resolve<T>(method: string, ...args: any[]) {
-    const promiseId = nanoid()
-    this.options.send({
-      __v: true,
-      m: method,
-      a: args,
-      i: promiseId,
-    })
-
-    return new Promise<T>((resolve, reject) => {
-      const timeout = this.options.timeout ?? 60000
-      let timeoutId
-      if (timeout > 0) {
-        timeoutId = setTimeout(() => {
-          this.rpcPromises.delete(promiseId)
-          reject(
-            new Error(
-              `${method}(${args.map((arg) => JSON.stringify(arg)).join(', ')}) timed out after ${timeout}ms`,
-            ),
-          )
-        }, timeout)
-        timeoutId?.unref?.()
-      }
-      this.rpcPromises.set(promiseId, { resolve, reject, timeoutId })
-    })
-  }
-
-  fetchModule(id: string, importer?: string): Promise<FetchResult> {
-    return this.resolve<FetchResult>('fetchModule', id, importer)
-  }
+export interface RemoteRunnerTransportMethods {
+  evaluate: (url: string) => void
 }
 
-// port from nanoid
-// https://github.com/ai/nanoid
-const urlAlphabet =
-  'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
-function nanoid(size = 21) {
-  let id = ''
-  let i = size
-  while (i--) id += urlAlphabet[(Math.random() * 64) | 0]
-  return id
+export interface RemoteRunnerTransportEvents {
+  fetchModule: FetchFunction
+}
+
+interface RemoteRunnerTransportOptions<M extends TransportMethods = any>
+  extends Omit<TransportOptions<M>, 'methods'> {
+  methods?: M
+}
+
+export class RemoteRunnerTransport<
+    M extends TransportMethods = {},
+    E extends TransportMethods = {},
+  >
+  extends RemoteTransport<
+    M & RemoteRunnerTransportMethods,
+    E & RemoteRunnerTransportEvents
+  >
+  implements RunnerTransport
+{
+  private _runner: ModuleRunner | undefined
+
+  constructor(options: RemoteRunnerTransportOptions<M>) {
+    super({
+      ...options,
+      methods: {
+        ...(options.methods as M),
+        evaluate: async (url: string) => {
+          if (!this._runner) {
+            throw new Error('[vite-transport] Runner is not registered')
+          }
+          await this._runner.import(url)
+        },
+      },
+    })
+  }
+
+  async fetchModule(id: string, importer?: string): Promise<FetchResult> {
+    // TODO: url gives a type error for some reason here, but works when
+    // the class is contructed from the outside
+    return await (this.dispatch as any)('fetchModule', id, importer)
+  }
+
+  register(runner: ModuleRunner): void {
+    this._runner = runner
+  }
 }

--- a/packages/vite/src/module-runner/runnerTransport.ts
+++ b/packages/vite/src/module-runner/runnerTransport.ts
@@ -10,14 +10,6 @@ export interface RunnerTransport {
   fetchModule: FetchFunction
 }
 
-export interface RemoteRunnerTransportMethods {
-  evaluate: (url: string) => void
-}
-
-export interface RemoteRunnerTransportEvents {
-  fetchModule: FetchFunction
-}
-
 interface RemoteRunnerTransportOptions<M extends TransportMethods = any>
   extends Omit<TransportOptions<M>, 'methods'> {
   methods?: M
@@ -27,10 +19,7 @@ export class RemoteRunnerTransport<
     M extends TransportMethods = {},
     E extends TransportMethods = {},
   >
-  extends RemoteTransport<
-    M & RemoteRunnerTransportMethods,
-    E & RemoteRunnerTransportEvents
-  >
+  extends RemoteTransport<M, E>
   implements RunnerTransport
 {
   private _runner: ModuleRunner | undefined
@@ -51,8 +40,7 @@ export class RemoteRunnerTransport<
   }
 
   async fetchModule(id: string, importer?: string): Promise<FetchResult> {
-    // TODO: url gives a type error for some reason here, but works when
-    // the class is contructed from the outside
+    // fetchModule is a special method that we don't expoe in types
     return await (this.invoke as any)('fetchModule', id, importer)
   }
 

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -17,9 +17,9 @@ export { transformWithEsbuild } from './plugins/esbuild'
 export { buildErrorMessage } from './server/middlewares/error'
 
 export { RemoteEnvironmentTransport } from './server/environmentTransport'
-export { createNodeDevEnvironment } from './server/environments/nodeEnvironment'
 export { DevEnvironment, type DevEnvironmentSetup } from './server/environment'
 export { BuildEnvironment } from './build'
+export { createNodeDevEnvironment } from './server/environments/nodeEnvironment'
 
 export { fetchModule, type FetchModuleOptions } from './ssr/fetchModule'
 export { createServerModuleRunner } from './ssr/runtime/serverModuleRunner'

--- a/packages/vite/src/node/server/environmentTransport.ts
+++ b/packages/vite/src/node/server/environmentTransport.ts
@@ -4,10 +4,9 @@ import type {
 } from 'vite/module-runner'
 import type {
   TransportMethods,
-  TransportOptions} from '../../shared/remoteTransport';
-import {
-  RemoteTransport
+  TransportOptions,
 } from '../../shared/remoteTransport'
+import { RemoteTransport } from '../../shared/remoteTransport'
 import type { DevEnvironment } from './environment'
 
 interface RemoteEnvironmentTransportOptions<M extends TransportMethods = any>
@@ -42,7 +41,7 @@ export class RemoteEnvironmentTransport<
   async evaluate(url: string): Promise<void> {
     // TODO: url gives a type error for some reason here, but works when
     // the class is contructed from the outside
-    await (this.dispatch as any)('evaluate', url)
+    await (this.invoke as any)('evaluate', url)
   }
 
   register(environment: DevEnvironment): void {

--- a/packages/vite/src/node/server/environmentTransport.ts
+++ b/packages/vite/src/node/server/environmentTransport.ts
@@ -1,8 +1,4 @@
 import type {
-  RemoteRunnerTransportEvents,
-  RemoteRunnerTransportMethods,
-} from 'vite/module-runner'
-import type {
   TransportMethods,
   TransportOptions,
 } from '../../shared/remoteTransport'
@@ -17,10 +13,7 @@ interface RemoteEnvironmentTransportOptions<M extends TransportMethods = any>
 export class RemoteEnvironmentTransport<
   M extends TransportMethods = {},
   E extends TransportMethods = {},
-> extends RemoteTransport<
-  M & RemoteRunnerTransportEvents,
-  E & RemoteRunnerTransportMethods
-> {
+> extends RemoteTransport<M, E> {
   private _environment: DevEnvironment | undefined
 
   constructor(options: RemoteEnvironmentTransportOptions<M>) {
@@ -39,8 +32,7 @@ export class RemoteEnvironmentTransport<
   }
 
   async evaluate(url: string): Promise<void> {
-    // TODO: url gives a type error for some reason here, but works when
-    // the class is contructed from the outside
+    // evaluate is a special method that we don't expoe in types
     await (this.invoke as any)('evaluate', url)
   }
 

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -1,3 +1,4 @@
+import type { ModuleRunner } from 'vite/module-runner'
 import type { DevEnvironmentSetup } from '../environment'
 import { DevEnvironment } from '../environment'
 import type { ViteDevServer } from '../index'
@@ -25,9 +26,11 @@ export function createNodeDevEnvironment(
 }
 
 class NodeDevEnvironment extends DevEnvironment {
-  private runner = createServerModuleRunner(this)
+  private runner: ModuleRunner | undefined
 
   override async evaluate(url: string): Promise<void> {
-    await this.runner.import(url)
+    if (this._ssrRunnerOptions?.transport) return super.evaluate(url)
+    const runner = this.runner || (this.runner = createServerModuleRunner(this))
+    await runner.import(url)
   }
 }

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -2,13 +2,14 @@ import type { DevEnvironmentSetup } from '../environment'
 import { DevEnvironment } from '../environment'
 import type { ViteDevServer } from '../index'
 import { asyncFunctionDeclarationPaddingLineCount } from '../../../shared/utils'
+import { createServerModuleRunner } from '../../ssr/runtime/serverModuleRunner'
 
 export function createNodeDevEnvironment(
   server: ViteDevServer,
   name: string,
   options?: DevEnvironmentSetup,
 ): DevEnvironment {
-  return new DevEnvironment(server, name, {
+  return new NodeDevEnvironment(server, name, {
     ...options,
     runner: {
       processSourceMap(map) {
@@ -21,4 +22,12 @@ export function createNodeDevEnvironment(
       ...options?.runner,
     },
   })
+}
+
+class NodeDevEnvironment extends DevEnvironment {
+  private runner = createServerModuleRunner(this)
+
+  override async evaluate(url: string): Promise<void> {
+    await this.runner.import(url)
+  }
 }

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
@@ -1,7 +1,7 @@
 import { BroadcastChannel, Worker } from 'node:worker_threads'
 import { describe, expect, it, onTestFinished } from 'vitest'
-import { DevEnvironment } from '../../../server/environment'
 import { createServer } from '../../../server'
+import { DevEnvironment } from '../../../server/environment'
 import { RemoteEnvironmentTransport } from '../../..'
 
 describe('running module runner inside a worker', () => {

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
@@ -1,12 +1,12 @@
-import { BroadcastChannel, Worker } from 'node:worker_threads'
-import { describe, expect, it, onTestFinished } from 'vitest'
+import { Worker } from 'node:worker_threads'
+import { describe, expect, it, onTestFinished, vi } from 'vitest'
 import { createServer } from '../../../server'
 import { DevEnvironment } from '../../../server/environment'
 import { RemoteEnvironmentTransport } from '../../..'
 
 describe('running module runner inside a worker', () => {
   it('correctly runs ssr code', async () => {
-    expect.assertions(1)
+    expect.assertions(6)
     const worker = new Worker(
       new URL('./fixtures/worker.mjs', import.meta.url),
       {
@@ -17,51 +17,96 @@ describe('running module runner inside a worker', () => {
       worker.on('message', () => resolve())
       worker.on('error', reject)
     })
-    const server = await createServer({
-      root: __dirname,
-      logLevel: 'error',
-      server: {
-        middlewareMode: true,
-        watch: null,
-        hmr: {
-          port: 9609,
+
+    const pong = vi.fn(() => 'pong')
+    const transform = vi.fn(() => `export const test = true`)
+    const transport = new RemoteEnvironmentTransport<
+      {
+        pong: (data: string) => void
+      },
+      {
+        import: (url: string) => { default: string }
+        ping: () => string
+      }
+    >({
+      send: (data) => worker.postMessage(data),
+      onMessage: (handler) => worker.on('message', handler),
+      methods: {
+        pong,
+      },
+    })
+
+    const server = await createWorkerServer(transport, transform)
+    onTestFinished(() => {
+      worker.terminate()
+    })
+
+    // cross communication works
+    const testModule = await transport.invoke(
+      'import',
+      './fixtures/default-string.ts',
+    )
+    expect(testModule.default).toBe('hello world')
+
+    expect(pong).not.toHaveBeenCalled()
+
+    const pinPong = await transport.invoke('ping')
+    expect(pinPong).toBe('pong')
+    expect(pong).toHaveBeenCalled()
+
+    expect(transform).not.toHaveBeenCalled()
+
+    await server.environments.worker.evaluate('virtual:worker-test')
+
+    expect(transform).toHaveBeenCalled()
+  })
+})
+
+async function createWorkerServer(
+  transport: RemoteEnvironmentTransport,
+  transform: () => string,
+) {
+  const server = await createServer({
+    root: __dirname,
+    logLevel: 'error',
+    server: {
+      middlewareMode: true,
+      watch: null,
+      hmr: {
+        port: 9609,
+      },
+    },
+    plugins: [
+      {
+        name: 'test:worker',
+        resolveId(id) {
+          if (id === 'virtual:worker-test') {
+            return `\0virtual:worker-test`
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:worker-test') {
+            return transform()
+          }
         },
       },
-      environments: {
-        worker: {
-          dev: {
-            createEnvironment: (server) => {
-              return new DevEnvironment(server, 'worker', {
-                runner: {
-                  transport: new RemoteEnvironmentTransport({
-                    send: (data) => worker.postMessage(data),
-                    onMessage: (handler) => worker.on('message', handler),
-                  }),
-                },
-              })
-            },
+    ],
+    environments: {
+      worker: {
+        dev: {
+          createEnvironment: (server) => {
+            return new DevEnvironment(server, 'worker', {
+              runner: {
+                transport,
+              },
+            })
           },
         },
       },
-    })
-    onTestFinished(() => {
-      server.close()
-      worker.terminate()
-    })
-    const channel = new BroadcastChannel('vite-worker')
-    return new Promise<void>((resolve, reject) => {
-      channel.onmessage = (event) => {
-        try {
-          expect((event as MessageEvent).data).toEqual({
-            result: 'hello world',
-          })
-        } catch (e) {
-          reject(e)
-        } finally {
-          resolve()
-        }
-      }
-      channel.postMessage({ id: './fixtures/default-string.ts' })
-    })
+    },
   })
-})
+  onTestFinished(() => {
+    server.close()
+  })
+  return server
+}

--- a/packages/vite/src/shared/remoteTransport.ts
+++ b/packages/vite/src/shared/remoteTransport.ts
@@ -29,9 +29,9 @@ export interface RequestEvent {
 
 export class RemoteTransport<
   // events that will be called when this transport is envoked from the other side of the RPC
-  M extends TransportMethods = any,
+  M extends TransportMethods = {},
   // events that will be called on the other side of the RPC, only used in types
-  E extends TransportMethods = any,
+  E extends TransportMethods = {},
 > {
   private readonly _rpcPromises = new Map<
     string,

--- a/packages/vite/src/shared/remoteTransport.ts
+++ b/packages/vite/src/shared/remoteTransport.ts
@@ -56,7 +56,7 @@ export class RemoteTransport<
     })
   }
 
-  dispatch<K extends string & keyof E>(
+  invoke<K extends string & keyof E>(
     method: K,
     ...args: Parameters<E[K]>
   ): Promise<ReturnType<E[K]>> {

--- a/packages/vite/src/shared/remoteTransport.ts
+++ b/packages/vite/src/shared/remoteTransport.ts
@@ -1,0 +1,141 @@
+export interface TransportOptions<M extends TransportMethods> {
+  send: (data: RequestEvent | ResponseEvent) => void
+  onMessage: (handler: (data: any) => void) => void
+  methods: M
+  timeout?: number
+}
+
+export type TransportMethods = Record<string, (...args: any[]) => any>
+
+export interface ResponseEvent {
+  __v: 's'
+  /** result */
+  r?: any
+  /** error */
+  e?: any
+  /** id */
+  i: string
+}
+
+export interface RequestEvent {
+  __v: 'q'
+  /** method name */
+  m: string
+  /** parameters */
+  a: any[]
+  /** id */
+  i: string
+}
+
+export class RemoteTransport<
+  // events that will be called when this transport is envoked from the other side of the RPC
+  M extends TransportMethods = any,
+  // events that will be called on the other side of the RPC, only used in types
+  E extends TransportMethods = any,
+> {
+  private readonly _rpcPromises = new Map<
+    string,
+    {
+      resolve: (data: any) => void
+      reject: (data: any) => void
+      timeoutId?: any
+    }
+  >()
+
+  constructor(private readonly _options: TransportOptions<M>) {
+    this._options.onMessage(async (_data) => {
+      if (typeof _data !== 'object' || !_data || !_data.__v) return
+
+      const data = _data as RequestEvent | ResponseEvent
+
+      if (data.__v === 'q') {
+        await this._resolveRequest(data)
+      } else {
+        await this._resolveResponse(data)
+      }
+    })
+  }
+
+  dispatch<K extends string & keyof E>(
+    method: K,
+    ...args: Parameters<E[K]>
+  ): Promise<ReturnType<E[K]>> {
+    const promiseId = nanoid()
+    this._sendRequest({
+      m: method,
+      a: args,
+      i: promiseId,
+    })
+    return new Promise((resolve, reject) => {
+      const timeout = this._options.timeout ?? 60000
+      let timeoutId
+      if (timeout > 0) {
+        timeoutId = setTimeout(() => {
+          this._rpcPromises.delete(promiseId)
+          reject(new Error(`${method} timed out after ${timeout}ms`))
+        }, timeout)
+        timeoutId?.unref?.()
+      }
+      this._rpcPromises.set(promiseId, { resolve, reject, timeoutId })
+    })
+  }
+
+  private async _resolveResponse(data: ResponseEvent) {
+    const promise = this._rpcPromises.get(data.i)
+    if (!promise) return
+
+    if (promise.timeoutId) clearTimeout(promise.timeoutId)
+
+    this._rpcPromises.delete(data.i)
+
+    if (data.e) {
+      promise.reject(data.e)
+    } else {
+      promise.resolve(data.r)
+    }
+  }
+
+  private async _resolveRequest(data: RequestEvent) {
+    const method = data.m
+    const parameters = data.a
+    try {
+      if (!(method in this._options.methods)) {
+        throw new Error(`Method not found: ${method}`)
+      }
+
+      const result = await this._options.methods[method](...parameters)
+      this._sendResponse({
+        r: result,
+        i: data.i,
+      })
+    } catch (err: any) {
+      this._sendResponse({
+        e: {
+          name: err.name,
+          message: err.message,
+          stack: err.stack,
+        },
+        i: data.i,
+      })
+    }
+  }
+
+  private _sendResponse(data: Omit<ResponseEvent, '__v'>) {
+    this._options.send({ __v: 's', ...data })
+  }
+
+  private _sendRequest(data: Omit<RequestEvent, '__v'>) {
+    this._options.send({ __v: 'q', ...data })
+  }
+}
+
+// port from nanoid
+// https://github.com/ai/nanoid
+const urlAlphabet =
+  'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
+function nanoid(size = 21) {
+  let id = ''
+  let i = size
+  while (i--) id += urlAlphabet[(Math.random() * 64) | 0]
+  return id
+}


### PR DESCRIPTION
### Description

This PR updates two primitives introduced not so long ago. By default, you can still just invoke `RemoteRunnerTransport` and `RemoteEnvironmentTransport` when needed.

```ts
import { RemoteRunnerTransport, ModuleRunner } from 'vite/module-runner'

// this is defined in the runner context
const transport = new RemoteRunnerTransport({ send, onMessage })
// auto registers, now you can call environment.evaluate(url) on the server side
const runner = new ModuleRunner({ transport })
```

```ts
import { RemoteEnvironmentTransport, DevEnvironment } from 'vite'

// this is defined on the server
const transport = new RemoteEnvironmentTransport({ send, onMessage })
const environment = new DevEnvironment(server, 'worker', { runner: { transport } }) // auto registers

// new API: "evaluate" - this will communicate with initiated remote runner transport
// before calling this, make sure that communication is established
// this method just evaluates the module, but doesn't return the module itself
await environment.evaluate('/remote-url.js')
```

The cool new thing is that you can define your own methods to communicate between the runner and the server:

```ts
import { RemoteRunnerTransport } from 'vite/module-runner'

const transport = new RemoteRunnerTransport<
  { doSomethingOnTheRunnerSide: () => Magic }
>({ 
  send, 
  onMessage,
  methods: {
    doSomethingOnTheRunnerSide() {
      // do something
      return { magic: true }
    }
  }
})
```

```ts
import { RemoteEnvironmentTransport, DevEnvironment } from 'vite'

const transport = new RemoteEnvironmentTransport<
  {}, 
  { doSomethingOnTheRunnerSide: () => Magic }
>({ send, onMessage })
const result = await transport.invoke('doSomethingOnTheRunnerSide')
// result => { magic: true }
```

The transport also returns the value unserialised, so you need to make sure that your communication channel supports sending this type of data. For the typescript usage, you can also reuse the same interface for methods/events (methods on one side will equal to events on the other).

You can also do the same the other way around:

```ts
import { RemoteRunnerTransport } from 'vite/module-runner'

const transport = new RemoteRunnerTransport<
  {}, 
  { doSomethingOnTheServer: () => Magic }
>({ send, onMessage })
const result = await transport.invoke('doSomethingOnTheServer')
// result => { magic: true }
```

```ts
import { RemoteEnvironmentTransport, DevEnvironment } from 'vite'

const transport = new RemoteEnvironmentTransport<
  { doSomethingOnTheServer: () => Magic }
>({ 
  send, 
  onMessage,
  methods: {
    doSomethingOnTheServer() {
      // do something
      return { magic: true }
    }
  }
})
```

TODO:

- [ ] Docs
