### PR TITLE
feat: decouple DevEnvironment and server

### DIFF
--- a/packages/vite/src/node/__tests__/external.spec.ts
+++ b/packages/vite/src/node/__tests__/external.spec.ts
@@ -1,6 +1,5 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, test } from 'vitest'
-import type { SSROptions } from '../ssr'
 import { resolveConfig } from '../config'
 import { createIsConfiguredAsExternal } from '../external'
 import { Environment } from '../environment'
@@ -27,6 +26,5 @@ async function createIsExternal(external?: true) {
     'serve',
   )
   const environment = new Environment('ssr', resolvedConfig)
-  console.log(environment.options)
   return createIsConfiguredAsExternal(environment)
 }

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -9,8 +9,6 @@ import type { ServerOptions } from './server'
 import type { CLIShortcut } from './shortcuts'
 import type { LogLevel } from './logger'
 import { createLogger } from './logger'
-import { resolveConfig } from './config'
-import { Environment } from './environment'
 
 const cli = cac('vite')
 
@@ -345,6 +343,8 @@ cli
   )
   .action(
     async (root: string, options: { force?: boolean } & GlobalCLIOptions) => {
+      /* TODO: do we need this command?
+
       filterDuplicateOptions(options)
       const { optimizeDeps } = await import('./optimizer')
       try {
@@ -367,6 +367,7 @@ cli
         )
         process.exit(1)
       }
+      */
     },
   )
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -20,7 +20,12 @@ import {
   ENV_ENTRY,
   FS_PREFIX,
 } from './constants'
-import type { HookHandler, Plugin, PluginWithRequiredHook } from './plugin'
+import type {
+  HookHandler,
+  Plugin,
+  PluginOption,
+  PluginWithRequiredHook,
+} from './plugin'
 import type {
   BuildEnvironmentOptions,
   BuildOptions,
@@ -35,12 +40,9 @@ import {
   resolveBuildOptions,
   resolveBuilderOptions,
 } from './build'
-import type {
-  ResolvedServerOptions,
-  ServerOptions,
-  ViteDevServer,
-} from './server'
+import type { ResolvedServerOptions, ServerOptions } from './server'
 import { resolveServerOptions } from './server'
+import { ScanEnvironment } from './optimizer/scan'
 import type { DevEnvironment } from './server/environment'
 import type { PreviewOptions, ResolvedPreviewOptions } from './preview'
 import { resolvePreviewOptions } from './preview'
@@ -78,8 +80,8 @@ import type { LogLevel, Logger } from './logger'
 import { createLogger } from './logger'
 import type { DepOptimizationConfig, DepOptimizationOptions } from './optimizer'
 import type { JsonOptions } from './plugins/json'
-import type { PluginContainer } from './server/pluginContainer'
-import { createPluginContainer } from './server/pluginContainer'
+import type { BoundedPluginContainer } from './server/pluginContainer'
+import { createBoundedPluginContainer } from './server/pluginContainer'
 import type { PackageCache } from './packages'
 import { findNearestPackageData } from './packages'
 import { loadEnv, resolveEnvPrefix } from './env'
@@ -133,20 +135,12 @@ export function defineConfig(config: UserConfigExport): UserConfigExport {
   return config
 }
 
-export type PluginOption =
-  | Plugin
-  | false
-  | null
-  | undefined
-  | PluginOption[]
-  | Promise<Plugin | false | null | undefined | PluginOption[]>
-
 export interface DevEnvironmentOptions {
   /**
    * Files tßo be pre-transformed. Supports glob patterns.
    */
   warmup?: string[]
-  /**ß
+  /**
    * Pre-transform known direct imports
    * @default true
    */
@@ -178,8 +172,8 @@ export interface DevEnvironmentOptions {
    * create the Dev Environment instance
    */
   createEnvironment?: (
-    server: ViteDevServer,
     name: string,
+    config: ResolvedConfig,
   ) => Promise<DevEnvironment> | DevEnvironment
 
   /**
@@ -189,6 +183,13 @@ export interface DevEnvironmentOptions {
    * @experimental
    */
   recoverable?: boolean
+
+  /**
+   * For environments associated with a module runner.
+   * By default it is true for the client environment and false for non-client environments.
+   * This option can also be used instead of the removed config.experimental.skipSsrTransform.
+   */
+  moduleRunnerTransform?: boolean
 
   /**
    * Defaults to true for the client environment and false for others, following node permissive
@@ -208,8 +209,8 @@ export type ResolvedDevEnvironmentOptions = Required<
   // TODO: Should we set the default at config time? For now, it is defined on server init
   createEnvironment:
     | ((
-        server: ViteDevServer,
         name: string,
+        config: ResolvedConfig,
       ) => Promise<DevEnvironment> | DevEnvironment)
     | undefined
 }
@@ -550,6 +551,8 @@ export function resolveDevEnvironmentOptions(
   dev: DevEnvironmentOptions | undefined,
   preserverSymlinks: boolean,
   environmentName: string | undefined,
+  // Backward compatibility
+  skipSsrTransform?: boolean,
 ): ResolvedDevEnvironmentOptions {
   return {
     sourcemap: dev?.sourcemap ?? { js: true },
@@ -565,27 +568,35 @@ export function resolveDevEnvironmentOptions(
     ),
     createEnvironment: dev?.createEnvironment,
     recoverable: dev?.recoverable ?? environmentName === 'client',
+    moduleRunnerTransform:
+      dev?.moduleRunnerTransform ??
+      (skipSsrTransform !== undefined && environmentName === 'ssr'
+        ? skipSsrTransform
+        : environmentName !== 'client'),
   }
 }
 
 function resolveEnvironmentOptions(
-  config: EnvironmentOptions,
+  options: EnvironmentOptions,
   resolvedRoot: string,
   logger: Logger,
   environmentName: string,
+  // Backward compatibility
+  skipSsrTransform?: boolean,
 ): ResolvedEnvironmentOptions {
-  const resolve = resolveEnvironmentResolveOptions(config.resolve, logger)
+  const resolve = resolveEnvironmentResolveOptions(options.resolve, logger)
   return {
     resolve,
-    nodeCompatible: config.nodeCompatible ?? environmentName !== 'client',
-    webCompatible: config.webCompatible ?? environmentName === 'client',
+    nodeCompatible: options.nodeCompatible ?? environmentName !== 'client',
+    webCompatible: options.webCompatible ?? environmentName === 'client',
     dev: resolveDevEnvironmentOptions(
-      config.dev,
+      options.dev,
       resolve.preserveSymlinks,
       environmentName,
+      skipSsrTransform,
     ),
     build: resolveBuildEnvironmentOptions(
-      config.build ?? {},
+      options.build ?? {},
       logger,
       resolvedRoot,
       environmentName,
@@ -906,6 +917,7 @@ export async function resolveConfig(
       resolvedRoot,
       logger,
       name,
+      config.experimental?.skipSsrTransform,
     )
   }
 
@@ -1176,29 +1188,48 @@ export async function resolveConfig(
     // create an internal resolver to be used in special scenarios, e.g.
     // optimizer & handling css @imports
     createResolver(options) {
-      let aliasContainer: PluginContainer | undefined
-      let resolverContainer: PluginContainer | undefined
+      const alias: {
+        client?: BoundedPluginContainer
+        ssr?: BoundedPluginContainer
+      } = {}
+      const resolver: {
+        client?: BoundedPluginContainer
+        ssr?: BoundedPluginContainer
+      } = {}
       const environments = this.environments ?? resolvedEnvironments
+      const createPluginContainer = async (
+        environmentName: string,
+        plugins: Plugin[],
+      ) => {
+        // The used alias and resolve plugins only use configuration options from the
+        // environment so we can safely cast to a base Environment instance to a
+        // PluginEnvironment here
+        const environment = new ScanEnvironment(environmentName, this)
+        await environment.init()
+        return createBoundedPluginContainer(environment, plugins)
+      }
       async function resolve(
         id: string,
         importer?: string,
         aliasOnly?: boolean,
         ssr?: boolean,
       ): Promise<PartialResolvedId | null> {
-        let container: PluginContainer
+        const environmentName = ssr ? 'ssr' : 'client'
+        let container: BoundedPluginContainer
         if (aliasOnly) {
-          container =
-            aliasContainer ||
-            (aliasContainer = await createPluginContainer({
-              ...resolved,
-              plugins: [aliasPlugin({ entries: resolved.resolve.alias })],
-            }))
+          let aliasContainer = alias[environmentName]
+          if (!aliasContainer) {
+            aliasContainer = alias[environmentName] =
+              await createPluginContainer(environmentName, [
+                aliasPlugin({ entries: resolved.resolve.alias }),
+              ])
+          }
+          container = aliasContainer
         } else {
-          container =
-            resolverContainer ||
-            (resolverContainer = await createPluginContainer({
-              ...resolved,
-              plugins: [
+          let resolverContainer = resolver[environmentName]
+          if (!resolverContainer) {
+            resolverContainer = resolver[environmentName] =
+              await createPluginContainer(environmentName, [
                 aliasPlugin({ entries: resolved.resolve.alias }),
                 resolvePlugin(
                   {
@@ -1215,13 +1246,11 @@ export async function resolveConfig(
                   },
                   environments,
                 ),
-              ],
-            }))
+              ])
+          }
+          container = resolverContainer
         }
-        return await container.resolveId(id, importer, {
-          ssr,
-          scan: options?.scan,
-        })
+        return await container.resolveId(id, importer, { scan: options?.scan })
       }
       return async (id, importer, aliasOnly, ssr) =>
         (await resolve(id, importer, aliasOnly, ssr))?.id

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -23,6 +23,7 @@ import {
 import type {
   HookHandler,
   Plugin,
+  PluginEnvironment,
   PluginOption,
   PluginWithRequiredHook,
 } from './plugin'
@@ -42,7 +43,7 @@ import {
 } from './build'
 import type { ResolvedServerOptions, ServerOptions } from './server'
 import { resolveServerOptions } from './server'
-import { ScanEnvironment } from './optimizer/scan'
+import { Environment } from './environment'
 import type { DevEnvironment } from './server/environment'
 import type { PreviewOptions, ResolvedPreviewOptions } from './preview'
 import { resolvePreviewOptions } from './preview'
@@ -1204,9 +1205,9 @@ export async function resolveConfig(
         // The used alias and resolve plugins only use configuration options from the
         // environment so we can safely cast to a base Environment instance to a
         // PluginEnvironment here
-        const environment = new ScanEnvironment(environmentName, this)
+        const environment = new Environment(environmentName, this)
         const pluginContainer = await createBoundedPluginContainer(
-          environment,
+          environment as PluginEnvironment,
           plugins,
         )
         await pluginContainer.buildStart({})

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -143,7 +143,7 @@ export interface DevEnvironmentOptions {
   warmup?: string[]
   /**
    * Pre-transform known direct imports
-   * @default true
+   * defaults to true for the client environment, false for the rest
    */
   preTransformRequests?: boolean
   /**
@@ -569,7 +569,8 @@ export function resolveDevEnvironmentOptions(
       dev?.sourcemapIgnoreList === false
         ? () => false
         : dev?.sourcemapIgnoreList || isInNodeModules,
-    preTransformRequests: dev?.preTransformRequests ?? true,
+    preTransformRequests:
+      dev?.preTransformRequests ?? environmentName === 'client',
     warmup: dev?.warmup ?? [],
     optimizeDeps: resolveOptimizeDepsConfig(
       dev?.optimizeDeps,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1205,8 +1205,12 @@ export async function resolveConfig(
         // environment so we can safely cast to a base Environment instance to a
         // PluginEnvironment here
         const environment = new ScanEnvironment(environmentName, this)
-        await environment.init()
-        return createBoundedPluginContainer(environment, plugins)
+        const pluginContainer = await createBoundedPluginContainer(
+          environment,
+          plugins,
+        )
+        await pluginContainer.buildStart({})
+        return pluginContainer
       }
       async function resolve(
         id: string,

--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -1,11 +1,30 @@
 import colors from 'picocolors'
 import type { Logger } from './logger'
 import type { ResolvedConfig, ResolvedEnvironmentOptions } from './config'
+import type { BoundedPlugin } from './plugin'
 
 export class Environment {
   name: string
+
   config: ResolvedConfig
   options: ResolvedEnvironmentOptions
+
+  get plugins(): BoundedPlugin[] {
+    if (!this._plugins)
+      throw new Error(
+        `${this.name} environment.plugins called before initialized`,
+      )
+    return this._plugins
+  }
+  /**
+   * @internal
+   */
+  _plugins: BoundedPlugin[] | undefined
+  /**
+   * @internal
+   */
+  _inited: boolean = false
+
   #logger: Logger | undefined
   get logger(): Logger {
     if (this.#logger) {
@@ -54,6 +73,7 @@ export class Environment {
     }
     return this.#logger
   }
+
   constructor(
     name: string,
     config: ResolvedConfig,

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -11,7 +11,10 @@ export {
 export { createServer } from './server'
 export { preview } from './preview'
 export { build, createViteBuilder } from './build'
-export { optimizeDeps } from './optimizer'
+
+// TODO: Can we remove this?
+// export { optimizeDeps } from './optimizer'
+
 export { formatPostcssSourceMap, preprocessCSS } from './plugins/css'
 export { transformWithEsbuild } from './plugins/esbuild'
 export { buildErrorMessage } from './server/middlewares/error'
@@ -36,7 +39,6 @@ export type {
   InlineConfig,
   LegacyOptions,
   PluginHookUtils,
-  PluginOption,
   ResolveFn,
   ResolvedWorkerOptions,
   ResolvedConfig,
@@ -46,6 +48,7 @@ export type {
   UserConfigFnObject,
   UserConfigFnPromise,
 } from './config'
+export type { PluginOption } from './plugin'
 export type { FilterPattern } from './utils'
 export type { CorsOptions, CorsOrigin, CommonServerOptions } from './http'
 export type {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -2,6 +2,7 @@ import colors from 'picocolors'
 import { createDebugger, getHash, promiseWithResolvers } from '../utils'
 import type { PromiseWithResolvers } from '../utils'
 import type { DevEnvironment } from '../server/environment'
+import { devToScanEnvironment } from './scan'
 import {
   addManuallyIncludedOptimizeDeps,
   addOptimizedDepInfo,
@@ -23,7 +24,7 @@ import type {
   DepOptimizationResult,
   DepsOptimizer,
   OptimizedDepInfo,
-} from '.'
+} from './index'
 
 const debug = createDebugger('vite:deps')
 
@@ -158,7 +159,7 @@ export function createDepsOptimizer(
       cachedMetadata || initDepsOptimizerMetadata(environment, sessionTimestamp)
 
     if (!cachedMetadata) {
-      environment.server._onCrawlEnd(onCrawlEnd) // TODO: depsOptimizer
+      environment._onCrawlEnd(onCrawlEnd)
       waitingForCrawlEnd = true
 
       // Enter processing state until crawl of static imports ends
@@ -195,7 +196,9 @@ export function createDepsOptimizer(
             try {
               debug?.(colors.green(`scanning for dependencies...`))
 
-              discover = discoverProjectDependencies(environment)
+              discover = discoverProjectDependencies(
+                devToScanEnvironment(environment),
+              )
               const deps = await discover.result
               discover = undefined
 

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -69,6 +69,7 @@ export class ScanEnvironment extends Environment {
       this,
       this.plugins,
     )
+    await this._pluginContainer.buildStart({})
   }
 }
 

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -22,6 +22,7 @@ import type { HmrContext, HotUpdateContext } from './server/hmr'
 import type { PreviewServerHook } from './preview'
 import type { DevEnvironment } from './server/environment'
 import type { BuildEnvironment } from './build'
+import type { ScanEnvironment } from './optimizer/scan'
 
 /**
  * Vite plugins extends the Rollup plugin interface with a few extra
@@ -53,9 +54,16 @@ import type { BuildEnvironment } from './build'
  * check if they have access to dev specific APIs.
  */
 
-export type PluginEnvironment = DevEnvironment | BuildEnvironment
+export type PluginEnvironment =
+  | DevEnvironment
+  | BuildEnvironment
+  | ScanEnvironment
 
 export interface PluginContext extends RollupPluginContext {
+  environment?: PluginEnvironment
+}
+
+export interface ResolveIdPluginContext extends RollupPluginContext {
   environment?: PluginEnvironment
 }
 
@@ -63,7 +71,107 @@ export interface TransformPluginContext extends RollupTransformPluginContext {
   environment?: PluginEnvironment
 }
 
-export interface Plugin<A = any> extends RollupPlugin<A> {
+/**
+ * There are two types of plugins in Vite. App plugins and environment plugins.
+ * Environment Plugins are defined by a constructor function that will be called
+ * once per each environment allowing users to have completely different plugins
+ * for each of them. The constructor gets the resolved environment after the server
+ * and builder has already been created simplifying config access and cache
+ * managementfor for environment specific plugins.
+ * Environment Plugins are closer to regular rollup plugins. They can't define
+ * app level hooks (like config, configResolved, configureServer, etc).
+ */
+
+export interface BasePlugin<A = any> extends RollupPlugin<A> {
+  /**
+   * Perform custom handling of HMR updates.
+   * The handler receives a context containing changed filename, timestamp, a
+   * list of modules affected by the file change, and the dev server instance.
+   *
+   * - The hook can return a filtered list of modules to narrow down the update.
+   *   e.g. for a Vue SFC, we can narrow down the part to update by comparing
+   *   the descriptors.
+   *
+   * - The hook can also return an empty array and then perform custom updates
+   *   by sending a custom hmr payload via server.hot.send().
+   *
+   * - If the hook doesn't return a value, the hmr update will be performed as
+   *   normal.
+   */
+  hotUpdate?: ObjectHook<
+    (
+      this: void,
+      ctx: HotUpdateContext,
+    ) =>
+      | Array<EnvironmentModuleNode>
+      | void
+      | Promise<Array<EnvironmentModuleNode> | void>
+  >
+
+  /**
+   * extend hooks with ssr flag
+   */
+  resolveId?: ObjectHook<
+    (
+      this: ResolveIdPluginContext,
+      source: string,
+      importer: string | undefined,
+      options: {
+        attributes: Record<string, string>
+        custom?: CustomPluginOptions
+        /**
+         * @deprecated use this.environment
+         */
+        ssr?: boolean
+        /**
+         * @internal
+         */
+        scan?: boolean
+        isEntry: boolean
+      },
+    ) => Promise<ResolveIdResult> | ResolveIdResult
+  >
+  load?: ObjectHook<
+    (
+      this: PluginContext,
+      id: string,
+      options?: {
+        /**
+         * @deprecated use this.environment
+         */
+        ssr?: boolean
+        /**
+         * @internal
+         */
+        html?: boolean
+      },
+    ) => Promise<LoadResult> | LoadResult
+  >
+  transform?: ObjectHook<
+    (
+      this: TransformPluginContext,
+      code: string,
+      id: string,
+      options?: {
+        /**
+         * @deprecated use this.environment
+         */
+        ssr?: boolean
+      },
+    ) => Promise<TransformResult> | TransformResult
+  >
+}
+
+export type BoundedPlugin<A = any> = BasePlugin<A>
+
+export interface Plugin<A = any> extends BasePlugin<A> {
+  /**
+   * Split the plugin into multiple plugins based on the environment.
+   * This hook is called when the config has already been resolved, allowing to
+   * create per environment plugin pipelines or easily inject plugins for a
+   * only specific environments.
+   */
+  split?: (environment: PluginEnvironment) => BoundedPluginOption
   /**
    * Enforce plugin invocation tier similar to webpack loaders. Hooks ordering
    * is still subject to the `order` property in the hook object.
@@ -180,84 +288,68 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       ctx: HmrContext,
     ) => Array<ModuleNode> | void | Promise<Array<ModuleNode> | void>
   >
-
-  /**
-   * Perform custom handling of HMR updates.
-   * The handler receives a context containing changed filename, timestamp, a
-   * list of modules affected by the file change, and the dev server instance.
-   *
-   * - The hook can return a filtered list of modules to narrow down the update.
-   *   e.g. for a Vue SFC, we can narrow down the part to update by comparing
-   *   the descriptors.
-   *
-   * - The hook can also return an empty array and then perform custom updates
-   *   by sending a custom hmr payload via server.hot.send().
-   *
-   * - If the hook doesn't return a value, the hmr update will be performed as
-   *   normal.
-   */
-  hotUpdate?: ObjectHook<
-    (
-      this: void,
-      ctx: HotUpdateContext,
-    ) =>
-      | Array<EnvironmentModuleNode>
-      | void
-      | Promise<Array<EnvironmentModuleNode> | void>
-  >
-
-  /**
-   * extend hooks with ssr flag
-   */
-  resolveId?: ObjectHook<
-    (
-      this: PluginContext,
-      source: string,
-      importer: string | undefined,
-      options: {
-        attributes: Record<string, string>
-        custom?: CustomPluginOptions
-        /**
-         * @deprecated use this.environment
-         */
-        ssr?: boolean
-        /**
-         * @internal
-         */
-        scan?: boolean
-        isEntry: boolean
-      },
-    ) => Promise<ResolveIdResult> | ResolveIdResult
-  >
-  load?: ObjectHook<
-    (
-      this: PluginContext,
-      id: string,
-      options?: {
-        /**
-         * @deprecated use this.environment
-         */
-        ssr?: boolean
-      },
-    ) => Promise<LoadResult> | LoadResult
-  >
-  transform?: ObjectHook<
-    (
-      this: TransformPluginContext,
-      code: string,
-      id: string,
-      options?: {
-        /**
-         * @deprecated use this.environment
-         */
-        ssr?: boolean
-      },
-    ) => Promise<TransformResult> | TransformResult
-  >
 }
 
 export type HookHandler<T> = T extends ObjectHook<infer H> ? H : T
 
 export type PluginWithRequiredHook<K extends keyof Plugin> = Plugin & {
   [P in K]: NonNullable<Plugin[P]>
+}
+
+export type BoundedPluginConstructor = (
+  Environment: PluginEnvironment,
+) => BoundedPluginOption
+
+export type MaybeBoundedPlugin = BoundedPlugin | false | null | undefined
+
+export type BoundedPluginOption =
+  | MaybeBoundedPlugin
+  | BoundedPluginOption[]
+  | Promise<MaybeBoundedPlugin | BoundedPluginOption[]>
+
+export type MaybePlugin = Plugin | false | null | undefined
+
+export type PluginOption =
+  | MaybePlugin
+  | PluginOption[]
+  | Promise<MaybePlugin | PluginOption[]>
+
+export async function resolveBoundedPlugins(
+  environment: PluginEnvironment,
+): Promise<BoundedPlugin[]> {
+  const resolvedPlugins: BoundedPlugin[] = []
+  for (const plugin of environment.config.plugins) {
+    if (plugin.split) {
+      const boundedPlugin = await plugin.split(environment)
+      if (boundedPlugin) {
+        const flatPlugins = await asyncFlattenBoundedPlugin(
+          environment,
+          boundedPlugin,
+        )
+        resolvedPlugins.push(...flatPlugins)
+      }
+    } else {
+      resolvedPlugins.push(plugin)
+    }
+  }
+  return resolvedPlugins
+}
+
+async function asyncFlattenBoundedPlugin(
+  environment: PluginEnvironment,
+  plugins: BoundedPluginOption,
+): Promise<BoundedPlugin[]> {
+  if (!Array.isArray(plugins)) {
+    plugins = [plugins]
+  }
+  do {
+    plugins = (
+      await Promise.all(
+        plugins.map((p: any) => (p && p.split ? p.split(environment) : p)),
+      )
+    )
+      .flat(Infinity)
+      .filter(Boolean) as BoundedPluginOption[]
+  } while (plugins.some((v: any) => v?.then || v?.split))
+  return plugins as BoundedPlugin[]
 }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -251,6 +251,8 @@ export function esbuildPlugin(config: ResolvedConfig): Plugin {
 
   return {
     name: 'vite:esbuild',
+    // TODO: Decouple server, the resolved config should be enough
+    // We may need a `configureWatcher` hook
     configureServer(_server) {
       server = _server
       server.watcher

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -24,6 +24,7 @@ import { assetImportMetaUrlPlugin } from './assetImportMetaUrl'
 import { metadataPlugin } from './metadata'
 import { dynamicImportVarsPlugin } from './dynamicImportVars'
 import { importGlobPlugin } from './importMetaGlob'
+import { loadFallbackPlugin } from './loadFallback'
 
 export async function resolvePlugins(
   config: ResolvedConfig,
@@ -99,6 +100,7 @@ export async function resolvePlugins(
           clientInjectionsPlugin(config),
           cssAnalysisPlugin(config),
           importAnalysisPlugin(config),
+          loadFallbackPlugin(config),
         ]),
   ].filter(Boolean) as Plugin[]
 }

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -24,7 +24,7 @@ import { assetImportMetaUrlPlugin } from './assetImportMetaUrl'
 import { metadataPlugin } from './metadata'
 import { dynamicImportVarsPlugin } from './dynamicImportVars'
 import { importGlobPlugin } from './importMetaGlob'
-import { loadFallbackPlugin } from './loadFallback'
+// TODO: import { loadFallbackPlugin } from './loadFallback'
 
 export async function resolvePlugins(
   config: ResolvedConfig,
@@ -100,7 +100,7 @@ export async function resolvePlugins(
           clientInjectionsPlugin(config),
           cssAnalysisPlugin(config),
           importAnalysisPlugin(config),
-          loadFallbackPlugin(config),
+          // TODO: loadFallbackPlugin(config),
         ]),
   ].filter(Boolean) as Plugin[]
 }

--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -1,13 +1,116 @@
 import fsp from 'node:fs/promises'
-import type { Plugin } from '..'
+import path from 'node:path'
+import type { SourceMap } from 'rollup'
 import { cleanUrl } from '../../shared/utils'
+import type { ResolvedConfig } from '../config'
+import type { Plugin } from '../plugin'
+import type { ViteDevServer } from '../server'
+import { extractSourcemapFromFile } from '../server/sourcemap'
+import { isFileServingAllowed } from '../server/middlewares/static'
+import type { DevEnvironment } from '../server/environment'
+import type { EnvironmentModuleNode } from '../server/moduleGraph'
+import { ensureWatchedFile } from '../utils'
+import { checkPublicFile } from '../publicDir'
+
+export const ERR_LOAD_URL = 'ERR_LOAD_URL'
+export const ERR_LOAD_PUBLIC_URL = 'ERR_LOAD_PUBLIC_URL'
 
 /**
  * A plugin to provide build load fallback for arbitrary request with queries.
  */
-export function loadFallbackPlugin(): Plugin {
+export function loadFallbackPlugin(config: ResolvedConfig): Plugin {
+  let server: ViteDevServer
   return {
     name: 'vite:load-fallback',
+    configureServer(_server) {
+      server = _server
+    },
+    async load(id, options) {
+      const environment = this.environment as DevEnvironment
+      if (!environment) {
+        return
+      }
+
+      let code: string | null = null
+      let map: SourceMap | null = null
+
+      // if this is an html request and there is no load result, skip ahead to
+      // SPA fallback.
+      if (options?.html && !id.endsWith('.html')) {
+        return null
+      }
+      // try fallback loading it from fs as string
+      // if the file is a binary, there should be a plugin that already loaded it
+      // as string
+      // only try the fallback if access is allowed, skip for out of root url
+      // like /service-worker.js or /api/users
+      const file = cleanUrl(id)
+      if (
+        environment.options.nodeCompatible ||
+        isFileServingAllowed(file, server)
+      ) {
+        try {
+          code = await fsp.readFile(file, 'utf-8')
+        } catch (e) {
+          if (e.code !== 'ENOENT') {
+            if (e.code === 'EISDIR') {
+              e.message = `${e.message} ${file}`
+            }
+            throw e
+          }
+        }
+        if (code != null && environment.watcher) {
+          ensureWatchedFile(environment.watcher, file, config.root)
+        }
+      }
+      if (code) {
+        try {
+          const extracted = await extractSourcemapFromFile(code, file)
+          if (extracted) {
+            code = extracted.code
+            map = extracted.map
+          }
+        } catch (e) {
+          environment.logger.warn(
+            `Failed to load source map for ${file}.\n${e}`,
+            {
+              timestamp: true,
+            },
+          )
+        }
+        return { code, map }
+      }
+
+      const isPublicFile = checkPublicFile(id, config)
+      let publicDirName = path.relative(config.root, config.publicDir)
+      if (publicDirName[0] !== '.') publicDirName = '/' + publicDirName
+      const msg = isPublicFile
+        ? `This file is in ${publicDirName} and will be copied as-is during ` +
+          `build without going through the plugin transforms, and therefore ` +
+          `should not be imported from source code. It can only be referenced ` +
+          `via HTML tags.`
+        : `Does the file exist?`
+      const importerMod: EnvironmentModuleNode | undefined =
+        environment.moduleGraph.idToModuleMap
+          .get(id)
+          ?.importers.values()
+          .next().value
+      const importer = importerMod?.file || importerMod?.url
+      const err: any = new Error(
+        `Failed to load ${id}${importer ? ` in ${importer}` : ''}. ${msg}`,
+      )
+      err.code = isPublicFile ? ERR_LOAD_PUBLIC_URL : ERR_LOAD_URL
+      throw err
+    },
+  }
+}
+
+/**
+ * A plugin to provide build load fallback for arbitrary request with queries.
+ */
+export function buildLoadFallbackPlugin(): Plugin {
+  return {
+    name: 'vite:build-load-fallback',
     async load(id) {
       try {
         const cleanedId = cleanUrl(id)

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -70,8 +70,7 @@ async function bundleWorkerEntry(
   // bundle the file as entry to support imports
   const { rollup } = await import('rollup')
   const { plugins, rollupOptions, format } = config.worker
-  const builder = { environments: {}, config } as any // TODO
-  const workerEnvironment = new BuildEnvironment(builder, 'client') // TODO: should this be 'worker'?
+  const workerEnvironment = new BuildEnvironment('client', config) // TODO: should this be 'worker'?
   const resolvedPlugins = await plugins(newBundleChain)
   const bundle = await rollup({
     ...rollupOptions,

--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -20,5 +20,7 @@ export {
 export { send } from './server/send'
 export { createLogger } from './logger'
 export { searchForWorkspaceRoot } from './server/searchRoot'
+
+// TODO: export isFileLoadingAllowed?
 export { isFileServingAllowed } from './server/middlewares/static'
 export { loadEnv, resolveEnvPrefix } from './env'

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -32,10 +32,12 @@ import type { BoundedPluginContainer } from './pluginContainer'
 
 export interface DevEnvironmentSetup {
   hot?: false | HMRChannel
+  watcher?: FSWatcher
   options?: EnvironmentOptions
   runner?: FetchModuleOptions & {
     transport?: RemoteEnvironmentTransport
   }
+  depsOptimizer?: DepsOptimizer
 }
 
 // Maybe we will rename this to DevEnvironment
@@ -98,15 +100,7 @@ export class DevEnvironment extends Environment {
   constructor(
     name: string,
     config: ResolvedConfig,
-    setup?: {
-      hot?: false | HMRChannel
-      watcher?: FSWatcher
-      options?: EnvironmentOptions
-      runner?: FetchModuleOptions & {
-        transport?: RemoteEnvironmentTransport
-      }
-      depsOptimizer?: DepsOptimizer
-    },
+    setup?: DevEnvironmentSetup,
   ) {
     let options =
       config.environments[name] ?? getDefaultResolvedEnvironmentOptions(config)

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -176,7 +176,9 @@ export class DevEnvironment extends Environment {
       this,
       this._plugins,
     )
-    await this._pluginContainer.buildStart({})
+
+    // TODO: Should buildStart be called here? It break backward compatibility if we do,
+    // and it may be better to delay it for performance
 
     // The deps optimizer init is delayed. TODO: add internal option?
 

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -176,7 +176,10 @@ export class DevEnvironment extends Environment {
       this,
       this._plugins,
     )
-    await this.depsOptimizer?.init()
+    await this._pluginContainer.buildStart({})
+
+    // The deps optimizer init is delayed. TODO: add internal option?
+
     // TODO: move warmup here
   }
 

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -1,14 +1,14 @@
+import type { ResolvedConfig } from '../../config'
 import type { DevEnvironmentSetup } from '../environment'
 import { DevEnvironment } from '../environment'
-import type { ViteDevServer } from '../index'
 import { asyncFunctionDeclarationPaddingLineCount } from '../../../shared/utils'
 
 export function createNodeDevEnvironment(
-  server: ViteDevServer,
   name: string,
+  config: ResolvedConfig,
   options?: DevEnvironmentSetup,
 ): DevEnvironment {
-  return new DevEnvironment(server, name, {
+  return new DevEnvironment(name, config, {
     ...options,
     runner: {
       processSourceMap(map) {

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -319,13 +319,7 @@ export async function handleHMRUpdate(
         return
       }
 
-      updateModules(
-        environment,
-        shortFile,
-        hotContext.modules,
-        timestamp,
-        server,
-      )
+      updateModules(environment, shortFile, hotContext.modules, timestamp)
     } catch (err) {
       environment.hot.send({
         type: 'error',
@@ -355,11 +349,9 @@ export function updateModules(
   file: string,
   modules: EnvironmentModuleNode[],
   timestamp: number,
-  server: ViteDevServer,
   afterInvalidation?: boolean,
 ): void {
-  const { hot } = environment
-  const { config } = server
+  const { hot, config } = environment
   const updates: Update[] = []
   const invalidatedModules = new Set<EnvironmentModuleNode>()
   const traversedModules = new Set<EnvironmentModuleNode>()

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -14,8 +14,6 @@ import type { FSWatcher, WatchOptions } from 'dep-types/chokidar'
 import type { Connect } from 'dep-types/connect'
 import launchEditorMiddleware from 'launch-editor-middleware'
 import type { SourceMap } from 'rollup'
-import picomatch from 'picomatch'
-import type { Matcher } from 'picomatch'
 import type { CommonServerOptions } from '../http'
 import {
   httpServerStart,
@@ -254,11 +252,12 @@ export interface ViteDevServer {
    *
    * Always sends a message to at least a WebSocket client. Any third party can
    * add a channel to the broadcaster to process messages
-   * @deprecated use `environments.get(id).hot` instead
+   * @deprecated use `environment.hot` instead
    */
   hot: HMRBroadcaster
   /**
    * Rollup plugin container that can run plugin hooks on a given file
+   * @deprecated use `environment.pluginContainer` instead
    */
   pluginContainer: PluginContainer
   /**
@@ -268,7 +267,7 @@ export interface ViteDevServer {
   /**
    * Module graph that tracks the import relationships, url to file mapping
    * and hmr state.
-   * @deprecated use environment module graphs instead
+   * @deprecated use `environment.moduleGraph` instead
    */
   moduleGraph: ModuleGraph
   /**
@@ -382,14 +381,6 @@ export interface ViteDevServer {
    * @internal
    */
   _forceOptimizeOnRestart: boolean
-  /**
-   * @internal
-   */
-  _safeModulesPath: Set<string>
-  /**
-   * @internal
-   */
-  _fsDenyGlob: Matcher
   /**
    * @internal
    */
@@ -718,21 +709,6 @@ export async function _createServer(
     },
     _restartPromise: null,
     _forceOptimizeOnRestart: false,
-
-    _safeModulesPath: new Set(),
-    _fsDenyGlob: picomatch(
-      // matchBase: true does not work as it's documented
-      // https://github.com/micromatch/picomatch/issues/89
-      // convert patterns without `/` on our side for now
-      config.server.fs.deny.map((pattern) =>
-        pattern.includes('/') ? pattern : `**/${pattern}`,
-      ),
-      {
-        matchBase: false,
-        nocase: true,
-        dot: true,
-      },
-    ),
     _shortcutsOptions: undefined,
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -458,14 +458,14 @@ export async function _createServer(
   const client_createEnvironment =
     config.environments.client?.dev?.createEnvironment ??
     ((name: string, config: ResolvedConfig) =>
-      new DevEnvironment(name, config, { hot: ws }))
+      new DevEnvironment(name, config, { hot: ws, watcher }))
 
   environments.client = await client_createEnvironment('client', config)
 
   const ssr_createEnvironment =
     config.environments.ssr?.dev?.createEnvironment ??
     ((name: string, config: ResolvedConfig) =>
-      createNodeDevEnvironment(name, config, { hot: ssrHotChannel }))
+      createNodeDevEnvironment(name, config, { hot: ssrHotChannel, watcher }))
 
   environments.ssr = await ssr_createEnvironment('ssr', config)
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -906,6 +906,11 @@ export async function _createServer(
     if (initingServer) return initingServer
 
     initingServer = (async function () {
+      // TODO: Build start should be called for all environments
+      // The ecosystem and our tests expects a single call. We need to
+      // check how to do this change to be backward compatible
+      await server.environments.client.pluginContainer.buildStart({})
+
       await Promise.all(
         Object.values(server.environments).map((environment) =>
           environment.depsOptimizer?.init(),

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -17,9 +17,10 @@ import {
   urlRE,
 } from '../../utils'
 import { send } from '../send'
-import { ERR_LOAD_URL, transformRequest } from '../transformRequest'
+import { transformRequest } from '../transformRequest'
 import { applySourcemapIgnoreList } from '../sourcemap'
 import { isHTMLProxy } from '../../plugins/html'
+import { ERR_LOAD_URL } from '../../plugins/loadFallback'
 import { DEP_VERSION_RE, FS_PREFIX } from '../../constants'
 import {
   isCSSRequest,
@@ -47,11 +48,12 @@ export function cachedTransformMiddleware(
 ): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteCachedTransformMiddleware(req, res, next) {
+    const environment = server.environments.client
+
     // check if we can return 304 early
     const ifNoneMatch = req.headers['if-none-match']
     if (ifNoneMatch) {
-      const moduleByEtag =
-        server.environments.client.moduleGraph.getModuleByEtag(ifNoneMatch)
+      const moduleByEtag = environment.moduleGraph.getModuleByEtag(ifNoneMatch)
       if (moduleByEtag?.transformResult?.etag === ifNoneMatch) {
         // For CSS requests, if the same CSS file is imported in a module,
         // the browser sends the request for the direct CSS request with the etag
@@ -80,6 +82,9 @@ export function transformMiddleware(
   const publicPath = `${publicDir.slice(root.length)}/`
 
   return async function viteTransformMiddleware(req, res, next) {
+    // TODO: We could do this for all browser like environments, and avoid the harcoded environments.client here
+    const environment = server.environments.client
+
     if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
       return next()
     }
@@ -100,7 +105,7 @@ export function transformMiddleware(
       const isSourceMap = withoutQuery.endsWith('.map')
       // since we generate source map references, handle those requests here
       if (isSourceMap) {
-        const depsOptimizer = server.environments.client.depsOptimizer
+        const depsOptimizer = environment.depsOptimizer
         if (depsOptimizer?.isOptimizedDepUrl(url)) {
           // If the browser is requesting a source map for an optimized dep, it
           // means that the dependency has already been pre-bundled and loaded
@@ -142,9 +147,7 @@ export function transformMiddleware(
         } else {
           const originalUrl = url.replace(/\.map($|\?)/, '$1')
           const map = (
-            await server.environments.client.moduleGraph.getModuleByUrl(
-              originalUrl,
-            )
+            await environment.moduleGraph.getModuleByUrl(originalUrl)
           )?.transformResult?.map
           if (map) {
             return send(req, res, JSON.stringify(map), 'json', {
@@ -187,8 +190,8 @@ export function transformMiddleware(
           const ifNoneMatch = req.headers['if-none-match']
           if (
             ifNoneMatch &&
-            (await server.environments.client.moduleGraph.getModuleByUrl(url))
-              ?.transformResult?.etag === ifNoneMatch
+            (await environment.moduleGraph.getModuleByUrl(url))?.transformResult
+              ?.etag === ifNoneMatch
           ) {
             debugCache?.(`[304] ${prettifyUrl(url, server.config.root)}`)
             res.statusCode = 304
@@ -197,16 +200,11 @@ export function transformMiddleware(
         }
 
         // resolve, load and transform using the plugin container
-        const result = await transformRequest(
-          url,
-          server,
-          {
-            html: req.headers.accept?.includes('text/html'),
-          },
-          server.environments.client,
-        )
+        const result = await transformRequest(environment, url, {
+          html: req.headers.accept?.includes('text/html'),
+        })
         if (result) {
-          const depsOptimizer = server.environments.client.depsOptimizer
+          const depsOptimizer = environment.depsOptimizer
           const type = isDirectCSSRequest(url) ? 'css' : 'js'
           const isDep =
             DEP_VERSION_RE.test(url) || depsOptimizer?.isOptimizedDepUrl(url)
@@ -271,6 +269,7 @@ export function transformMiddleware(
         return
       }
       if (e?.code === ERR_LOAD_URL) {
+        // TODO: Why not also do this on ERR_LOAD_PUBLIC_URL?
         // Let other middleware handle if we can't load the url via transformRequest
         return next()
       }

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -17,10 +17,9 @@ import {
   urlRE,
 } from '../../utils'
 import { send } from '../send'
-import { transformRequest } from '../transformRequest'
+import { ERR_LOAD_URL, transformRequest } from '../transformRequest'
 import { applySourcemapIgnoreList } from '../sourcemap'
 import { isHTMLProxy } from '../../plugins/html'
-import { ERR_LOAD_URL } from '../../plugins/loadFallback'
 import { DEP_VERSION_RE, FS_PREFIX } from '../../constants'
 import {
   isCSSRequest,

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -61,7 +61,7 @@ import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
 import MagicString from 'magic-string'
 import type { FSWatcher } from 'chokidar'
 import colors from 'picocolors'
-import type { Plugin, PluginEnvironment } from '../plugin'
+import type { BoundedPlugin, Plugin, PluginEnvironment } from '../plugin'
 import {
   combineSourcemaps,
   createDebugger,
@@ -76,9 +76,9 @@ import {
   timeFrom,
 } from '../utils'
 import { FS_PREFIX } from '../constants'
-import type { ResolvedConfig } from '../config'
 import { createPluginHookUtils, getHookHandler } from '../plugins'
 import { cleanUrl, unwrapId } from '../../shared/utils'
+import type { DevEnvironment } from './environment'
 import { buildErrorMessage } from './middlewares/error'
 import type { EnvironmentModuleNode } from './moduleGraph'
 
@@ -103,7 +103,7 @@ export interface PluginContainerOptions {
   writeFile?: (name: string, source: string | Uint8Array) => void
 }
 
-export interface PluginContainer {
+export interface BoundedPluginContainer {
   options: InputOptions
   buildStart(options: InputOptions): Promise<void>
   resolveId(
@@ -113,8 +113,6 @@ export interface PluginContainer {
       attributes?: Record<string, string>
       custom?: CustomPluginOptions
       skip?: Set<Plugin>
-      ssr?: boolean
-      environment?: PluginEnvironment
       /**
        * @internal
        */
@@ -127,17 +125,9 @@ export interface PluginContainer {
     id: string,
     options?: {
       inMap?: SourceDescription['map']
-      ssr?: boolean
-      environment?: PluginEnvironment
     },
   ): Promise<{ code: string; map: SourceMap | { mappings: '' } | null }>
-  load(
-    id: string,
-    options?: {
-      ssr?: boolean
-      environment?: PluginEnvironment
-    },
-  ): Promise<LoadResult | null>
+  load(id: string, options?: {}): Promise<LoadResult | null>
   watchChange(
     id: string,
     change: { event: 'create' | 'update' | 'delete' },
@@ -151,23 +141,28 @@ type PluginContext = Omit<
   'cache'
 >
 
-// The default environment is in buildStart, buildEnd, watchChange, and closeBundle hooks,
-// wich are called once for all environments, or when no environment is passed in other hooks.
-// The ssrEnvironment is needed for backward compatibility when the ssr flag is passed without
-// an environment. The defaultEnvironment in the main pluginContainer in the server should be
-// the client environment for backward compatibility.
-
-export async function createPluginContainer(
-  config: ResolvedConfig,
+/**
+ * Create a plugin container with a set of plugins. We pass them as a parameter
+ * instead of using environment.plugins to allow the creation of different
+ * pipelines working with the same environment (used for createIdResolver).
+ */
+export async function createBoundedPluginContainer(
+  environment: PluginEnvironment,
+  plugins: BoundedPlugin[],
   watcher?: FSWatcher,
-  environments?: Record<string, PluginEnvironment>,
-): Promise<PluginContainer> {
+): Promise<BoundedPluginContainer> {
   const {
-    plugins,
+    config,
     logger,
-    root,
-    build: { rollupOptions },
-  } = config
+    options: {
+      build: { rollupOptions },
+    },
+  } = environment
+  const { root } = config
+
+  const moduleGraph =
+    environment.mode === 'dev' ? environment.moduleGraph : undefined
+
   const { getSortedPluginHooks, getSortedPlugins } =
     createPluginHookUtils(plugins)
 
@@ -184,19 +179,6 @@ export async function createPluginContainer(
   const debugSourcemapCombine = createDebugger('vite:sourcemap-combine', {
     onlyWhenFocused: true,
   })
-
-  // Backward compatibility
-  // Users should call pluginContainer.resolveId (and load/transform) passing the environment they want to work with
-  // But there is code that is going to call it without passing an environment, or with the ssr flag to get the ssr environment
-  function resolveEnvironment(options?: {
-    ssr?: boolean
-    environment?: PluginEnvironment
-  }) {
-    const environment =
-      options?.environment ?? environments?.[options?.ssr ? 'ssr' : 'client']
-    const ssr = environment?.name === 'ssr' ? true : !!options?.ssr
-    return { environment, ssr }
-  }
 
   // ---------------------------------------------------------------------------
 
@@ -278,9 +260,9 @@ export async function createPluginContainer(
   // active plugin in that pipeline can be tracked in a concurrency-safe manner.
   // using a class to make creating new contexts more efficient
   class Context implements PluginContext {
+    environment: PluginEnvironment // TODO: | ScanEnvironment
     meta = minimalContext.meta
     ssr = false
-    environment: PluginEnvironment | undefined
     _scan = false
     _activePlugin: Plugin | null
     _activeId: string | null = null
@@ -288,7 +270,7 @@ export async function createPluginContainer(
     _resolveSkips?: Set<Plugin>
     _addedImports: Set<string> | null = null
 
-    constructor(environment?: PluginEnvironment, initialPlugin?: Plugin) {
+    constructor(initialPlugin?: Plugin) {
       this.environment = environment
       this._activePlugin = initialPlugin || null
     }
@@ -317,8 +299,6 @@ export async function createPluginContainer(
         custom: options?.custom,
         isEntry: !!options?.isEntry,
         skip,
-        ssr: this.ssr,
-        environment: this.environment,
         scan: this._scan,
       })
       if (typeof out === 'string') out = { id: out }
@@ -332,22 +312,16 @@ export async function createPluginContainer(
       } & Partial<PartialNull<ModuleOptions>>,
     ): Promise<ModuleInfo> {
       // We may not have added this to our module graph yet, so ensure it exists
-      await this._moduleGraph?.ensureEntryFromUrl(unwrapId(options.id))
+      await moduleGraph?.ensureEntryFromUrl(unwrapId(options.id))
       // Not all options passed to this function make sense in the context of loading individual files,
       // but we can at least update the module info properties we support
       this._updateModuleInfo(options.id, options)
 
-      const loadResult = await container.load(options.id, {
-        ssr: this.ssr,
-        environment: this.environment,
-      })
+      const loadResult = await container.load(options.id)
       const code =
         typeof loadResult === 'object' ? loadResult?.code : loadResult
       if (code != null) {
-        await container.transform(code, options.id, {
-          ssr: this.ssr,
-          environment: this.environment,
-        })
+        await container.transform(code, options.id)
       }
 
       const moduleInfo = this.getModuleInfo(options.id)
@@ -360,7 +334,7 @@ export async function createPluginContainer(
     }
 
     getModuleInfo(id: string) {
-      const module = this._moduleGraph?.getModuleById(id)
+      const module = moduleGraph?.getModuleById(id)
       if (!module) {
         return null
       }
@@ -383,7 +357,7 @@ export async function createPluginContainer(
     }
 
     _updateModuleLoadAddedImports(id: string) {
-      const module = this._moduleGraph?.getModuleById(id)
+      const module = moduleGraph?.getModuleById(id)
       if (module) {
         moduleNodeToLoadAddedImports.set(module, this._addedImports)
       }
@@ -391,8 +365,7 @@ export async function createPluginContainer(
 
     getModuleIds() {
       return (
-        this._moduleGraph?.idToModuleMap.keys() ??
-        Array.prototype[Symbol.iterator]()
+        moduleGraph?.idToModuleMap.keys() ?? Array.prototype[Symbol.iterator]()
       )
     }
 
@@ -447,16 +420,6 @@ export async function createPluginContainer(
 
     debug = noop
     info = noop
-
-    /**
-     * @internal
-     */
-    get _moduleGraph() {
-      // Using this.environment.mode is causing an issue with Vitest
-      return this.environment?.mode === 'dev'
-        ? this.environment.moduleGraph
-        : undefined
-    }
   }
 
   function formatError(
@@ -568,13 +531,8 @@ export async function createPluginContainer(
     sourcemapChain: NonNullable<SourceDescription['map']>[] = []
     combinedMap: SourceMap | { mappings: '' } | null = null
 
-    constructor(
-      id: string,
-      code: string,
-      environment?: PluginEnvironment,
-      inMap?: SourceMap | string,
-    ) {
-      super(environment)
+    constructor(id: string, code: string, inMap?: SourceMap | string) {
+      super()
       this.filename = id
       this.originalCode = code
       if (inMap) {
@@ -585,7 +543,7 @@ export async function createPluginContainer(
         this.sourcemapChain.push(inMap)
       }
       // Inherit `_addedImports` from the `load()` hook
-      const node = this._moduleGraph?.getModuleById(id)
+      const node = moduleGraph?.getModuleById(id)
       if (node) {
         this._addedImports = moduleNodeToLoadAddedImports.get(node) ?? null
       }
@@ -697,21 +655,25 @@ export async function createPluginContainer(
       await handleHookPromise(
         hookParallel(
           'buildStart',
-          (plugin) => new Context(environments?.client, plugin), // TODO: call buildStart per environment
+          (plugin) => new Context(plugin),
           () => [container.options as NormalizedInputOptions],
         ),
       )
     },
 
     async resolveId(rawId, importer = join(root, 'index.html'), options) {
-      const { environment, ssr } = resolveEnvironment(options)
       const skip = options?.skip
       const scan = !!options?.scan
-      const ctx = new Context(environment)
-      ctx.ssr = !!ssr
-      ctx.environment = environment
-      ctx._scan = scan
+
+      const ctx = new Context()
       ctx._resolveSkips = skip
+      ctx._scan = scan
+      /* TODO
+      if (scan) {
+        ctx.environment = devToScanEnvironment(environment as DevEnvironment)
+      }
+      */
+
       const resolveStart = debugResolve ? performance.now() : 0
       let id: string | null = null
       const partial: Partial<PartialResolvedId> = {}
@@ -730,7 +692,6 @@ export async function createPluginContainer(
             attributes: options?.attributes ?? {},
             custom: options?.custom,
             isEntry: !!options?.isEntry,
-            ssr,
             scan,
           }),
         )
@@ -775,19 +736,14 @@ export async function createPluginContainer(
     },
 
     async load(id, options) {
-      const { environment, ssr } = resolveEnvironment(options)
-      const ctx = new Context(environment)
-      ctx.ssr = !!ssr
-      ctx.environment = environment
+      const ctx = new Context()
       for (const plugin of getSortedPlugins('load')) {
         if (closed && environment?.options.dev.recoverable)
           throwClosedServerError()
         if (!plugin.load) continue
         ctx._activePlugin = plugin
         const handler = getHookHandler(plugin.load)
-        const result = await handleHookPromise(
-          handler.call(ctx as any, id, { ssr }),
-        )
+        const result = await handleHookPromise(handler.call(ctx as any, id))
         if (result != null) {
           if (isObject(result)) {
             ctx._updateModuleInfo(id, result)
@@ -801,16 +757,8 @@ export async function createPluginContainer(
     },
 
     async transform(code, id, options) {
-      const { environment, ssr } = resolveEnvironment(options)
       const inMap = options?.inMap
-      const ctx = new TransformContext(
-        id,
-        code,
-        environment,
-        inMap as SourceMap,
-      )
-      ctx.ssr = !!ssr
-      ctx.environment = environment
+      const ctx = new TransformContext(id, code, inMap as SourceMap)
       for (const plugin of getSortedPlugins('transform')) {
         if (closed && environment?.options.dev.recoverable)
           throwClosedServerError()
@@ -822,9 +770,7 @@ export async function createPluginContainer(
         let result: TransformResult | string | undefined
         const handler = getHookHandler(plugin.transform)
         try {
-          result = await handleHookPromise(
-            handler.call(ctx as any, code, id, { ssr }),
-          )
+          result = await handleHookPromise(handler.call(ctx as any, code, id))
         } catch (e) {
           ctx.error(e)
         }
@@ -880,6 +826,106 @@ export async function createPluginContainer(
         () => ctx,
         () => [],
       )
+    },
+  }
+
+  return container
+}
+
+// Backward compatiblity
+
+export interface PluginContainer {
+  options: InputOptions
+  buildStart(options: InputOptions): Promise<void>
+  resolveId(
+    id: string,
+    importer: string | undefined,
+    options?: {
+      attributes?: Record<string, string>
+      custom?: CustomPluginOptions
+      skip?: Set<Plugin>
+      ssr?: boolean
+      environment?: PluginEnvironment
+      /**
+       * @internal
+       */
+      scan?: boolean
+      isEntry?: boolean
+    },
+  ): Promise<PartialResolvedId | null>
+  transform(
+    code: string,
+    id: string,
+    options?: {
+      inMap?: SourceDescription['map']
+      ssr?: boolean
+      environment?: PluginEnvironment
+    },
+  ): Promise<{ code: string; map: SourceMap | { mappings: '' } | null }>
+  load(
+    id: string,
+    options?: {
+      ssr?: boolean
+      environment?: PluginEnvironment
+    },
+  ): Promise<LoadResult | null>
+  watchChange(
+    id: string,
+    change: { event: 'create' | 'update' | 'delete' },
+  ): Promise<void>
+  close(): Promise<void>
+}
+
+/**
+ * server.pluginContainer compatibility
+ *
+ * The default environment is in buildStart, buildEnd, watchChange, and closeBundle hooks,
+ * wich are called once for all environments, or when no environment is passed in other hooks.
+ * The ssrEnvironment is needed for backward compatibility when the ssr flag is passed without
+ * an environment. The defaultEnvironment in the main pluginContainer in the server should be
+ * the client environment for backward compatibility.
+ **/
+
+export function createPluginContainer(
+  environments: Record<string, PluginEnvironment>,
+): PluginContainer {
+  // Backward compatibility
+  // Users should call pluginContainer.resolveId (and load/transform) passing the environment they want to work with
+  // But there is code that is going to call it without passing an environment, or with the ssr flag to get the ssr environment
+  function getEnvironment(options?: { ssr?: boolean }) {
+    return environments?.[options?.ssr ? 'ssr' : 'client']
+  }
+  function getPluginContainer(options?: { ssr?: boolean }) {
+    return (getEnvironment(options) as DevEnvironment).pluginContainer!
+  }
+
+  const container: PluginContainer = {
+    get options() {
+      return (environments.client as DevEnvironment).pluginContainer!.options
+    },
+
+    async buildStart() {
+      // noop, buildStart will be called for each environment
+    },
+
+    async resolveId(rawId, importer, options) {
+      return getPluginContainer(options).resolveId(rawId, importer, options)
+    },
+
+    async load(id, options) {
+      return getPluginContainer(options).load(id, options)
+    },
+
+    async transform(code, id, options) {
+      return getPluginContainer(options).transform(code, id, options)
+    },
+
+    async watchChange(id, change) {
+      // noop, watchChange is already called for each environment
+    },
+
+    async close() {
+      // noop, close will be called for each environment
     },
   }
 

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -18,7 +18,7 @@ import {
   stripBase,
   timeFrom,
 } from '../utils'
-import { ssrParseImports , ssrTransform } from '../ssr/ssrTransform'
+import { ssrParseImports, ssrTransform } from '../ssr/ssrTransform'
 import { checkPublicFile } from '../publicDir'
 import { cleanUrl, unwrapId } from '../../shared/utils'
 import {

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -28,7 +28,7 @@ test('ssrLoad', async () => {
     await server.ssrLoadModule(moduleRelativePath)
   } catch (e) {
     expect(e.message).toBe(
-      `Failed to load ./non-existent.js in ${moduleAbsolutePath}. Does the file exist?`,
+      `Failed to load url ./non-existent.js (resolved id: ./non-existent.js) in ${moduleAbsolutePath}. Does the file exist?`,
     )
   }
 })

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -28,7 +28,7 @@ test('ssrLoad', async () => {
     await server.ssrLoadModule(moduleRelativePath)
   } catch (e) {
     expect(e.message).toBe(
-      `Failed to load url ./non-existent.js (resolved id: ./non-existent.js) in ${moduleAbsolutePath}. Does the file exist?`,
+      `Failed to load ./non-existent.js in ${moduleAbsolutePath}. Does the file exist?`,
     )
   }
 })

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
@@ -30,8 +30,8 @@ describe('running module runner inside a worker', () => {
       environments: {
         worker: {
           dev: {
-            createEnvironment: (server) => {
-              return new DevEnvironment(server, 'worker', {
+            createEnvironment: (name, config) => {
+              return new DevEnvironment(name, config, {
                 runner: {
                   transport: new RemoteEnvironmentTransport({
                     send: (data) => worker.postMessage(data),

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -73,14 +73,18 @@ export async function createModuleRunnerTester(
       ],
       ...config,
     })
-    t.runner = await createServerModuleRunner(t.server.environments.ssr, {
-      hmr: {
-        logger: false,
+    t.runner = await createServerModuleRunner(
+      t.server,
+      t.server.environments.ssr,
+      {
+        hmr: {
+          logger: false,
+        },
+        // don't override by default so Vitest source maps are correct
+        sourcemapInterceptor: false,
+        ...runnerConfig,
       },
-      // don't override by default so Vitest source maps are correct
-      sourcemapInterceptor: false,
-      ...runnerConfig,
-    })
+    )
     if (config.server?.watch) {
       await waitForWatcher(t.server)
     }

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -80,6 +80,9 @@ export async function createModuleRunnerTester(
       hmr: {
         logger: false,
       },
+      // don't override by default so Vitest source maps are correct
+      sourcemapInterceptor: false,
+      ...runnerConfig,
     })
     if (config.server?.watch) {
       await waitForWatcher(t.server)

--- a/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
@@ -82,10 +82,11 @@ function resolveSourceMapOptions(options: ServerModuleRunnerOptions) {
  * @experimental
  */
 export function createServerModuleRunner(
+  server: ViteDevServer,
   environment: DevEnvironment,
   options: ServerModuleRunnerOptions = {},
 ): ModuleRunner {
-  const hmr = createHMROptions(environment.server, options)
+  const hmr = createHMROptions(server, options)
   return new ModuleRunner(
     {
       ...options,

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -37,6 +37,8 @@ export const ssrImportMetaKey = `__vite_ssr_import_meta__`
 
 const hashbangRE = /^#!.*\n/
 
+// TODO: Should we rename to moduleRunnerTransform?
+
 export async function ssrTransform(
   code: string,
   inMap: SourceMap | { mappings: '' } | null,

--- a/playground/environment-react-ssr/vite.config.ts
+++ b/playground/environment-react-ssr/vite.config.ts
@@ -66,7 +66,7 @@ export function vitePluginSsrMiddleware({
     name: vitePluginSsrMiddleware.name,
 
     configureServer(server) {
-      const runner = createServerModuleRunner(server.environments.ssr)
+      const runner = createServerModuleRunner(server, server.environments.ssr)
       const handler: Connect.NextHandleFunction = async (req, res, next) => {
         try {
           const mod = await runner.import(entry)

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -1140,7 +1140,7 @@ async function setupModuleRunner(
   // @ts-expect-error not typed for HMR
   globalThis.log = (...msg) => logger.log(...msg)
 
-  runner = createServerModuleRunner(server.environments.ssr, {
+  runner = createServerModuleRunner(server, server.environments.ssr, {
     hmr: {
       logger,
     },

--- a/playground/ssr-html/test-network-imports.js
+++ b/playground/ssr-html/test-network-imports.js
@@ -12,9 +12,13 @@ async function runTest(userRunner) {
   })
   let mod
   if (userRunner) {
-    const runner = await createServerModuleRunner(server.environments.ssr, {
-      hmr: false,
-    })
+    const runner = await createServerModuleRunner(
+      server,
+      server.environments.ssr,
+      {
+        hmr: false,
+      },
+    )
     mod = await runner.import('/src/network-imports.js')
   } else {
     mod = await server.ssrLoadModule('/src/network-imports.js')

--- a/playground/ssr-html/test-stacktrace-runtime.js
+++ b/playground/ssr-html/test-stacktrace-runtime.js
@@ -13,7 +13,7 @@ const server = await createServer({
   },
 })
 
-const runner = await createServerModuleRunner(server.environments.ssr, {
+const runner = await createServerModuleRunner(server, server.environments.ssr, {
   sourcemapInterceptor: 'prepareStackTrace',
 })
 


### PR DESCRIPTION
### Description

- A `ViteDevServer` is no longer needed to create a `DevEnvironment`. This triggered a lot of changes to `transformRequest` and related functions
- Per environment crawler
- Per environment pending requests
- `environment.init()`
- Introduce `ScanEnvironment`, used in the optimizer scanner
- Per environment plugins using `{ split(environment) { return MyPlugin(environment) }`. We need a better name for `split`. Just a placeholder for now.

Start work to move fallback logic in transformRequest to a plugin. I reverted the change for now (leaving the code). We can check this in a future PR.