### PR TITLE
fix(hmr): watch files in workspace root

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -456,7 +456,7 @@ export async function _createServer(
     ? (chokidar.watch(
         // config file dependencies and env file might be outside of root
         [
-          root,
+          searchForWorkspaceRoot(config.root),
           ...config.configFileDependencies,
           ...getEnvFilesForMode(config.mode, config.envDir),
         ],


### PR DESCRIPTION
### Description

fixes #16399
refs #15712

We need to make these values consistent. Otherwise, the cache could be different from the actual file system.
https://github.com/vitejs/vite/blob/6a127d67ba953004ab10c21b50429050c7eadf11/packages/vite/src/node/server/index.ts#L479
https://github.com/vitejs/vite/blob/6a127d67ba953004ab10c21b50429050c7eadf11/packages/vite/src/node/fsUtils.ts#L134

Alternative fix for this is to revert #15712. I'm not sure if which is safer. Maybe reverting it in a patch and reapplying it in the next minor?

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
