### PR TITLE
fix(dev): watch publicDir explicitly to include it outside the root

### DIFF
--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -66,15 +66,17 @@ describe('watcher configuration', () => {
       publicDir: '__test_public__',
     })
     expect(watchSpy).toHaveBeenLastCalledWith(
-      expect.arrayContaining([
-        process.cwd(),
-        resolve('fake/config/dependency.js'),
-        resolve('.env'),
-        resolve('.env.local'),
-        resolve('.env.development'),
-        resolve('.env.development.local'),
-        resolve('__test_public__'),
-      ]),
+      expect.arrayContaining(
+        [
+          process.cwd(),
+          resolve('fake/config/dependency.js'),
+          resolve('.env'),
+          resolve('.env.local'),
+          resolve('.env.development'),
+          resolve('.env.development.local'),
+          resolve('__test_public__'),
+        ].map((file) => file.replace(/\\/g, '/')),
+      ),
       expect.anything(),
     )
   })

--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -1,9 +1,45 @@
-import { describe, expect, it } from 'vitest'
+import { resolve } from 'node:path'
+import {
+  type MockInstance,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import chokidar from 'chokidar'
 import { createServer } from '../index'
 
 const stubGetWatchedCode = /getWatched\(\) \{.+?return \{\};.+?\}/s
 
+let watchSpy: MockInstance<
+  Parameters<typeof chokidar.watch>,
+  ReturnType<typeof chokidar.watch>
+>
+
+vi.mock('../../config', async () => {
+  const config: typeof import('../../config') =
+    await vi.importActual('../../config')
+  const resolveConfig = config.resolveConfig
+  vi.spyOn(config, 'resolveConfig').mockImplementation(async (...args) => {
+    const resolved: Awaited<ReturnType<typeof resolveConfig>> =
+      await resolveConfig.call(config, ...args)
+    resolved.configFileDependencies.push(resolve('fake/config/dependency.js'))
+    return resolved
+  })
+  return config
+})
+
 describe('watcher configuration', () => {
+  beforeEach(() => {
+    watchSpy = vi.spyOn(chokidar, 'watch')
+  })
+
+  afterEach(() => {
+    watchSpy.mockRestore()
+  })
+
   it('when watcher is disabled, return noop watcher', async () => {
     const server = await createServer({
       server: {
@@ -20,5 +56,26 @@ describe('watcher configuration', () => {
       },
     })
     expect(server.watcher.getWatched.toString()).not.toMatch(stubGetWatchedCode)
+  })
+
+  it('should watch the root directory, config file dependencies, dotenv files, and the public directory', async () => {
+    await createServer({
+      server: {
+        watch: {},
+      },
+      publicDir: '__test_public__',
+    })
+    expect(watchSpy).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        process.cwd(),
+        resolve('fake/config/dependency.js'),
+        resolve('.env'),
+        resolve('.env.local'),
+        resolve('.env.development'),
+        resolve('.env.development.local'),
+        resolve('__test_public__'),
+      ]),
+      expect.anything(),
+    )
   })
 })

--- a/packages/vite/src/node/server/__tests__/watcher.spec.ts
+++ b/packages/vite/src/node/server/__tests__/watcher.spec.ts
@@ -25,7 +25,9 @@ vi.mock('../../config', async () => {
   vi.spyOn(config, 'resolveConfig').mockImplementation(async (...args) => {
     const resolved: Awaited<ReturnType<typeof resolveConfig>> =
       await resolveConfig.call(config, ...args)
-    resolved.configFileDependencies.push(resolve('fake/config/dependency.js'))
+    resolved.configFileDependencies.push(
+      resolve('fake/config/dependency.js').replace(/\\/g, '/'),
+    )
     return resolved
   })
   return config

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -466,6 +466,9 @@ export async function _createServer(
     config.server.hmr.channels.forEach((channel) => hot.addChannel(channel))
   }
 
+  const publicFiles = await initPublicFilesPromise
+  const { publicDir } = config
+
   if (httpServer) {
     setClientErrorHandler(httpServer, config.logger)
   }
@@ -479,6 +482,9 @@ export async function _createServer(
           root,
           ...config.configFileDependencies,
           ...getEnvFilesForMode(config.mode, config.envDir),
+          // Watch the public directory explicitly because it might be outside
+          // of the root directory.
+          ...(publicDir && publicFiles ? [publicDir] : []),
         ],
         resolvedWatchOptions,
       ) as FSWatcher)
@@ -745,8 +751,6 @@ export async function _createServer(
     }
   }
 
-  const publicFiles = await initPublicFilesPromise
-
   const onHMRUpdate = async (
     type: 'create' | 'delete' | 'update',
     file: string,
@@ -762,8 +766,6 @@ export async function _createServer(
       }
     }
   }
-
-  const { publicDir } = config
 
   const onFileAddUnlink = async (file: string, isUnlink: boolean) => {
     file = normalizePath(file)


### PR DESCRIPTION
### Description

There is an optimization in place for the `publicDir`, where the watcher keeps a live list of all the files that are in the public directory, and only serves static content at paths it knows to be part of the public directory by checking that list.

The bug occurs when the public directory is outside of the root directory. That causes it not to be watched by the current chokidar configuration. Because it is not watched, that live public files list is never updated after the server starts, which means that new files are not added to the list. Because the new files are not added to the list, the dev server static middleware will not attempt to serve them as static files.

This fix just explicitly adds the `publicDir` to the watch list, which has no effect if the public directory is inside the root, but fixes the expected behavior if the public directory is outside the root.

I didn't update the `server.watch` documentation, because it doesn't appear to be exhaustive about the watch list currently. It doesn't mention dotenv files or vite config dependencies.

fixes #16503

### Checklist

[x] Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
[x] Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
[x] Update the corresponding documentation if needed.
[x] Include relevant tests that fail without this PR but pass with it.
