### PR TITLE
fix: pin Rollup to 4.15 temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "playwright-chromium": "^1.43.1",
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
-    "rollup": "^4.13.0",
+    "rollup": ">=4.13.0 <4.16.0",
     "semver": "^7.6.0",
     "simple-git-hooks": "^2.11.1",
     "tslib": "^2.6.2",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "esbuild": "^0.20.1",
     "postcss": "^8.4.38",
-    "rollup": "^4.13.0"
+    "rollup": ">=4.13.0 <4.16.0"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
       rollup:
-        specifier: ^4.13.0
+        specifier: '>=4.13.0 <4.16.0'
         version: 4.13.0
       semver:
         specifier: ^7.6.0
@@ -242,7 +242,7 @@ importers:
         specifier: ^8.4.38
         version: 8.4.38
       rollup:
-        specifier: ^4.13.0
+        specifier: '>=4.13.0 <4.16.0'
         version: 4.13.0
     optionalDependencies:
       fsevents:


### PR DESCRIPTION
### Description

Pinning Rollup to 4.15 until the new tree-shaking algorithm in Rollup 4.16 settles down.