### PR TITLE
feat(plugin-legacy): support `additionalModernPolyfills`

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -74,7 +74,11 @@ npm add -D terser
 
   Add custom imports to the legacy polyfills chunk. Since the usage-based polyfill detection only covers ES language features, it may be necessary to manually specify additional DOM API polyfills using this option.
 
-  Note: if additional polyfills are needed for both the modern and legacy chunks, they can simply be imported in the application source code.
+### `additionalModernPolyfills`
+
+- **Type:** `string[]`
+
+  Add custom imports to the modern polyfills chunk. Since the usage-based polyfill detection only covers ES language features, it may be necessary to manually specify additional DOM API polyfills using this option.
 
 ### `modernPolyfills`
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -166,6 +166,11 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       )
     })
   }
+  if (Array.isArray(options.additionalModernPolyfills)) {
+    options.additionalModernPolyfills.forEach((i) => {
+      modernPolyfills.add(i)
+    })
+  }
   if (Array.isArray(options.polyfills)) {
     options.polyfills.forEach((i) => {
       if (i.startsWith(`regenerator`)) {

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -12,6 +12,7 @@ export interface Options {
    */
   polyfills?: boolean | string[]
   additionalLegacyPolyfills?: string[]
+  additionalModernPolyfills?: string[]
   /**
    * default: false
    */


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR introduces `additionalModernPolyfills` option that mirrors the existing `additionalLegacyPolyfills` option.
The reason this is needed for the modern chunk is because due to #5142 the following is not actually true, and the only way to ensure polyfills are loaded before application code is to use `plugin-legacy`:

> Note: if additional polyfills are needed for both the modern and legacy chunks, they can simply be imported in the application source code.

For example, this option can be used when an application only configures `modernPolyfills` but wishes to add custom polyfills for non-legacy browsers.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->