### PR TITLE
fix: dynamic-import-vars plugin normalize path issue

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/__snapshots__/parse.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/__snapshots__/parse.spec.ts.snap
@@ -8,6 +8,8 @@ exports[`parse positives > ? in worker 1`] = `"__variableDynamicImportRuntimeHel
 
 exports[`parse positives > alias path 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js")), \`./mods/\${base}.js\`)"`;
 
+exports[`parse positives > alias path with multi ../ 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("../../*.js")), \`../../\${base}.js\`)"`;
+
 exports[`parse positives > basic 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("./mods/*.js")), \`./mods/\${base}.js\`)"`;
 
 exports[`parse positives > with ../ and itself 1`] = `"__variableDynamicImportRuntimeHelper((import.meta.glob("../dynamicImportVar/*.js")), \`./\${name}.js\`)"`;

--- a/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/dynamicImportVar/parse.spec.ts
@@ -12,7 +12,10 @@ async function run(input: string) {
     (await transformDynamicImport(
       input,
       normalizePath(resolve(__dirname, 'index.js')),
-      (id) => id.replace('@', resolve(__dirname, './mods/')),
+      (id) =>
+        id
+          .replace('@', resolve(__dirname, './mods/'))
+          .replace('#', resolve(__dirname, '../../')),
       __dirname,
     )) || {}
   return `__variableDynamicImportRuntimeHelper(${glob}, \`${rawPattern}\`)`
@@ -25,6 +28,10 @@ describe('parse positives', () => {
 
   it('alias path', async () => {
     expect(await run('`@/${base}.js`')).toMatchSnapshot()
+  })
+
+  it('alias path with multi ../', async () => {
+    expect(await run('`#/${base}.js`')).toMatchSnapshot()
   })
 
   it('with query', async () => {

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -121,9 +121,9 @@ export async function transformDynamicImport(
       posix.dirname(normalizePath(importer)),
       normalizePath(resolvedFileName),
     )
-    importSource = normalizePath(
-      '`' + (relativeFileName[0] === '.' ? '' : './') + relativeFileName + '`',
-    )
+    importSource = '`' + normalizePath(
+      (relativeFileName[0] === '.' ? '' : './') + relativeFileName,
+    ) + '`'
   }
 
   const dynamicImportPattern = parseDynamicImportPattern(importSource)

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -117,13 +117,14 @@ export async function transformDynamicImport(
     if (!resolvedFileName) {
       return null
     }
-    const relativeFileName = posix.relative(
-      posix.dirname(normalizePath(importer)),
-      normalizePath(resolvedFileName),
+    const relativeFileName = normalizePath(
+      posix.relative(
+        posix.dirname(normalizePath(importer)),
+        normalizePath(resolvedFileName),
+      ),
     )
-    importSource = '`' + normalizePath(
-      (relativeFileName[0] === '.' ? '' : './') + relativeFileName,
-    ) + '`'
+    importSource =
+      '`' + (relativeFileName[0] === '.' ? '' : './') + relativeFileName + '`'
   }
 
   const dynamicImportPattern = parseDynamicImportPattern(importSource)


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Parameters wrapped with \` may produce unexpected results in `path.normalize` or `path.posix.normalize`。
For example:
```js
path.posix.normalize('../../foo')     // '../../foo'
path.posix.normalize('`../../foo`')   // 'foo`'
```
<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
