### PR TITLE
test(v6): reproduce custom environment preload injection

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -638,7 +638,27 @@ describe('resolveBuildOutputs', () => {
     })
   })
 
-  test('custom environment ssr', async () => {
+  test('ssr builtin', async () => {
+    const builder = await createBuilder({
+      root: resolve(__dirname, 'fixtures/dynamic-import'),
+      environments: {
+        ssr: {
+          build: {
+            ssr: true,
+            rollupOptions: {
+              input: {
+                index: '/entry',
+              },
+            },
+          },
+        },
+      },
+    })
+    const result = await builder.build(builder.environments.ssr)
+    expect((result as RollupOutput).output[0].code).not.toContain('preload')
+  })
+
+  test('ssr custom', async () => {
     const builder = await createBuilder({
       root: resolve(__dirname, 'fixtures/dynamic-import'),
       environments: {

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -637,6 +637,26 @@ describe('resolveBuildOutputs', () => {
       ],
     })
   })
+
+  test('custom environment ssr', async () => {
+    const builder = await createBuilder({
+      root: resolve(__dirname, 'fixtures/dynamic-import'),
+      environments: {
+        custom: {
+          build: {
+            ssr: true,
+            rollupOptions: {
+              input: {
+                index: '/entry',
+              },
+            },
+          },
+        },
+      },
+    })
+    const result = await builder.build(builder.environments.custom)
+    expect((result as RollupOutput).output[0].code).not.toContain('preload')
+  })
 })
 
 /**

--- a/packages/vite/src/node/__tests__/fixtures/dynamic-import/dep.mjs
+++ b/packages/vite/src/node/__tests__/fixtures/dynamic-import/dep.mjs
@@ -1,0 +1,1 @@
+export const hello = 'hello'

--- a/packages/vite/src/node/__tests__/fixtures/dynamic-import/entry.mjs
+++ b/packages/vite/src/node/__tests__/fixtures/dynamic-import/entry.mjs
@@ -1,0 +1,4 @@
+export async function main() {
+  const mod = await import('./dep.mjs')
+  console.log(mod)
+}


### PR DESCRIPTION
### Description

- base https://github.com/vitejs/vite/pull/16471/

@patak-dev I tested alpha.5 in https://github.com/hi-ogawa/vite-environment-examples/pull/51 and it looks like `__vitePreload` is now injected for custom environment with `ssr: true`, which wasn't the case in alpha.3.

For now I added a failing test here as you might notice something. I start to read the new builder code, so I might going to find something myself.

It looks like per-environment `resolveConfigToBuild` is not including `environmentOptions` from the root config:

https://github.com/vitejs/vite/blob/37190afc150fea4ec4586db2cef69d1f084fa224/packages/vite/src/node/build.ts#L1511