### PR TITLE
docs(env): clarify env are statically replaced

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -2,7 +2,7 @@
 
 ## Env Variables
 
-Vite exposes env variables on the special **`import.meta.env`** object. Some built-in variables are available in all cases:
+Vite exposes env variables on the special **`import.meta.env`** object, which are statically replaced at build time. Some built-in variables are available in all cases:
 
 - **`import.meta.env.MODE`**: {string} the [mode](#modes) the app is running in.
 


### PR DESCRIPTION
### Description

Helps clarify https://github.com/vitejs/vite/issues/16069 that the current env var support in build time is statically replaced only.
