### PR TITLE
fix(preload): skip preload for non-static urls

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -241,6 +241,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
       for (let index = 0; index < imports.length; index++) {
         const {
+          s: start,
           e: end,
           ss: expStart,
           se: expEnd,
@@ -255,7 +256,14 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
           str().remove(end + 1, expEnd)
         }
 
-        if (isDynamicImport && insertPreload) {
+        if (
+          isDynamicImport &&
+          insertPreload &&
+          // Only preload static urls
+          (source[start] === '"' ||
+            source[start] === "'" ||
+            source[start] === '`')
+        ) {
           needPreloadHelper = true
           str().prependLeft(expStart, `${preloadMethod}(() => `)
           str().appendRight(

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -1,5 +1,12 @@
 import { expect, test } from 'vitest'
-import { getColor, isBuild, page, serverLogs, untilUpdated } from '~utils'
+import {
+  findAssetFile,
+  getColor,
+  isBuild,
+  page,
+  serverLogs,
+  untilUpdated,
+} from '~utils'
 
 test('should load literal dynamic import', async () => {
   await page.click('.baz')
@@ -170,3 +177,9 @@ test.runIf(isBuild)(
     )
   },
 )
+
+test.runIf(isBuild)('should not preload for non-analyzable urls', () => {
+  const js = findAssetFile(/index-[-\w]{8}\.js$/)
+  // should match e.g. await import(e.jss);o(".view",p===i)
+  expect(js).to.match(/\.jss\);/)
+})


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/16241

If the source code is `import(foobar)`, which `foobar` can't be analyzed, it's very likely that we can't find any preload dependencies for it too because it's not part of the dependency graph.

This PR skips adding the `__vitePreload()` for that dynamic import in that case.
