### PR TITLE
fix(proxy): rewrite the origin header to match the target for ws proxy

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -90,7 +90,7 @@ Configure custom proxy rules for the dev server. Expects an object of `{ key: op
 
 Note that if you are using non-relative [`base`](/config/shared-options.md#base), you must prefix each key with that `base`.
 
-Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13). Note that the `changeOrigin` option changes host header to match the target URL, the origin header is always changed to match the target.
+Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13). Note that [unlike http-proxy](https://github.com/http-party/node-http-proxy/issues/1669), the `changeOrigin` option will change both host and origin headers to match the target.
 
 In some cases, you might also want to configure the underlying dev server (e.g. to add custom middlewares to the internal [connect](https://github.com/senchalabs/connect) app). In order to do that, you need to write your own [plugin](/guide/using-plugins.html) and use [configureServer](/guide/api-plugin.html#configureserver) function.
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -90,7 +90,7 @@ Configure custom proxy rules for the dev server. Expects an object of `{ key: op
 
 Note that if you are using non-relative [`base`](/config/shared-options.md#base), you must prefix each key with that `base`.
 
-Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13).
+Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13). Note that the `changeOrigin` option changes host header to match the target URL, the origin header is always changed to match the target.
 
 In some cases, you might also want to configure the underlying dev server (e.g. to add custom middlewares to the internal [connect](https://github.com/senchalabs/connect) app). In order to do that, you need to write your own [plugin](/guide/using-plugins.html) and use [configureServer](/guide/api-plugin.html#configureserver) function.
 

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -90,6 +90,19 @@ export function proxyMiddleware(
     })
 
     proxy.on('proxyReqWs', (proxyReq, req, socket, options, head) => {
+      // Browsers may send Origin headers even with same-origin
+      // requests. It is common for WebSocket servers to check the Origin
+      // header, so we have to change the Origin to match
+      // the target URL.
+      if (proxyReq.getHeader('origin') && options.target) {
+        const target =
+          typeof options.target === 'object'
+            ? `${options.target.protocol}//${options.target.host}`
+            : options.target
+
+        proxyReq.setHeader('origin', target)
+      }
+
       socket.on('error', (err) => {
         config.logger.error(
           `${colors.red(`ws proxy socket error:`)}\n${err.stack}`,

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -29,6 +29,29 @@ export interface ProxyOptions extends HttpProxy.ServerOptions {
   ) => void | null | undefined | false | string
 }
 
+const setOriginHeader = (
+  proxyReq: http.ClientRequest,
+  options: HttpProxy.ServerOptions,
+) => {
+  // Browsers may send Origin headers even with same-origin
+  // requests. It is common for WebSocket servers to check the Origin
+  // header, so if changeOrigin is true we change the Origin to match
+  // the target URL.
+  // https://github.com/http-party/node-http-proxy/issues/1669
+  if (options.changeOrigin) {
+    const { target } = options
+
+    if (proxyReq.getHeader('origin') && target) {
+      const changedOrigin =
+        typeof target === 'object'
+          ? `${target.protocol}//${target.host}`
+          : target
+
+      proxyReq.setHeader('origin', changedOrigin)
+    }
+  }
+}
+
 export function proxyMiddleware(
   httpServer: HttpServer | null,
   options: NonNullable<CommonServerOptions['proxy']>,
@@ -89,19 +112,12 @@ export function proxyMiddleware(
       }
     })
 
-    proxy.on('proxyReqWs', (proxyReq, req, socket, options, head) => {
-      // Browsers may send Origin headers even with same-origin
-      // requests. It is common for WebSocket servers to check the Origin
-      // header, so we have to change the Origin to match
-      // the target URL.
-      if (proxyReq.getHeader('origin') && options.target) {
-        const target =
-          typeof options.target === 'object'
-            ? `${options.target.protocol}//${options.target.host}`
-            : options.target
+    proxy.on('proxyReq', (proxyReq, req, res, options) => {
+      setOriginHeader(proxyReq, options)
+    })
 
-        proxyReq.setHeader('origin', target)
-      }
+    proxy.on('proxyReqWs', (proxyReq, req, socket, options, head) => {
+      setOriginHeader(proxyReq, options)
 
       socket.on('error', (err) => {
         config.logger.error(


### PR DESCRIPTION
### Description

fixes #16557 

For `ws` proxying, this PR updates the request Origin header to match the target Host value. This resolves an issue where proxying to an [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455#section-10.2) compliant server causes a 403 to be returned when request Origin and Host do not match.

I didn't see any existing tests for the proxy module but can look at adding coverage if its a blocker to merging.

**Update:**

The PR also updates docs to clarify the actual effect of the `changeOrigin` option. See https://github.com/http-party/node-http-proxy/pull/1130 which was raised in 2017 and has not been merged due to ongoing discussion about whether the option should be removed altogether. I believe clarifying this for Vite users will help them avoid assuming `changeOrigin:true` means change the origin header.