### PR TITLE
chore(npmrc): set `package-manager-strict` to false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,3 +3,4 @@ hoist-pattern[]=postcss # package/vite
 hoist-pattern[]=pug # playground/tailwind: @vue/compiler-sfc
 shell-emulator=true
 auto-install-peers=false
+package-manager-strict=false


### PR DESCRIPTION
### Description
After pnpm releases version [9.0.3](https://github.com/pnpm/pnpm/releases/tag/v9.0.3), when the local pnpm version and `packageManger` version do not match, an error message will appear and the process will exit when running `pnpm i`.

When #16489 is merged, the `pnpm-lock.yaml` file will not change even if the minor version does not match. So I think we can set `package-manager-strict=false` to disable it.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
