### PR TITLE
fix(plugin-legacy): improve deterministic polyfills discovery

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -302,7 +302,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         return
       }
 
-      // Merge discovered legacy polyfills to `modernPolyfills`
+      // Merge discovered legacy polyfills to `legacyPolyfills`
       if (chunkFileNameToPolyfills) {
         for (const { legacy } of chunkFileNameToPolyfills.values()) {
           legacy.forEach((p) => legacyPolyfills.add(p))


### PR DESCRIPTION
### Description

The polyfill bundle generated by the legacy plugin is non deterministic, because the order of calling `renderChunk()` affects the input of the finally generated polyfill bundle. 

This PR solves this issue by sorting the polyfills in need discovered by babel. The polyfills added directly from the plugin configuration is kept ordered the first, same as before.

Previously, https://github.com/vitejs/vite/issues/13672#issuecomment-1784594387 mentioned this issue.

