### PR TITLE
fix(logger): truncate log over 5000 characters long

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -81,7 +81,7 @@ export function createLogger(
     allowClearScreen && process.stdout.isTTY && !process.env.CI
   const clear = canClearScreen ? clearScreen : () => {}
 
-  function shortenMessage(msg: string) {
+  function preventOverflow(msg: string) {
     if (msg.length > MAX_LOG_CHAR) {
       const shorten = msg.slice(0, MAX_LOG_CHAR)
       const shortenLines = shorten.match(splitRE)?.length || 0
@@ -97,7 +97,7 @@ export function createLogger(
     rawMsg: string,
     options: LogErrorOptions = {},
   ) {
-    const msg = shortenMessage(rawMsg)
+    const msg = preventOverflow(rawMsg)
     if (options.timestamp) {
       const tag =
         type === 'info'

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -84,8 +84,7 @@ export function createLogger(
   function preventOverflow(msg: string) {
     if (msg.length > MAX_LOG_CHAR) {
       const shorten = msg.slice(0, MAX_LOG_CHAR)
-      const shortenLines = shorten.match(splitRE)?.length || 0
-      const lines = msg.match(splitRE)?.length || 0 - shortenLines
+      const lines = msg.slice(MAX_LOG_CHAR).match(splitRE)?.length || 0
 
       return `${shorten}\n... and ${lines} lines more`
     }

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -63,6 +63,8 @@ function getTimeFormatter() {
   return timeFormatter
 }
 
+const MAX_LOG_CHAR = 5000
+
 export function createLogger(
   level: LogLevel = 'info',
   options: LoggerOptions = {},
@@ -78,7 +80,15 @@ export function createLogger(
     allowClearScreen && process.stdout.isTTY && !process.env.CI
   const clear = canClearScreen ? clearScreen : () => {}
 
-  function format(type: LogType, msg: string, options: LogErrorOptions = {}) {
+  function format(
+    type: LogType,
+    rawMsg: string,
+    options: LogErrorOptions = {},
+  ) {
+    const msg =
+      rawMsg.length > MAX_LOG_CHAR
+        ? rawMsg.slice(0, MAX_LOG_CHAR) + '... (log truncated)'
+        : rawMsg
     if (options.timestamp) {
       const tag =
         type === 'info'

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -434,7 +434,7 @@ export function isFilePathESM(
   }
 }
 
-const splitRE = /\r?\n/
+export const splitRE = /\r?\n/g
 
 const range: number = 2
 


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

- fixes #16570 

When the log is more than 5000 characters, it gets truncated and shows that it is truncated.

### TD;LR

AS-IS

```bash
...

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
43 |  }());
44 |
45 |  const javascriptLogo = "data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20aria-hidden='true'%20role='img'%20class='iconify%20iconify--logos'%20width='32'%20height='32'%20preserveAspectRatio='xMidYMid%20meet'%20viewBox='0%200%20256%20256'%3e%3cpath%20fill='%23F7DF1E'%20d='M0%200h256v256H0V0Z'%3e%3c/path%3e%3cpath%20d='m67.312%20213.932l19.59-11.856c3.78%206.701%207.218%2012.371%2015.465%2012.371c7.905%200%2012.89-3.092%2012.89-15.12v-81.798h24.057v82.138c0%2024.917-14.606%2036.259-35.916%2036.259c-19.245%200-30.416-9.967-36.087-21.996m85.07-2.576l19.588-11.341c5.157%208.421%2011.859%2014.607%2023.715%2014.607c9.969%200%2016.325-4.984%2016.325-11.858c0-8.248-6.53-11.17-17.528-15.98l-6.013-2.58c-17.357-7.387-28.87-16.667-28.87-36.257c0-18.044%2013.747-31.792%2035.228-31.792c15.294%200%2026.292%205.328%2034.196%2019.247l-18.732%2012.03c-4.125-7.389-8.591-10.31-15.465-10.31c-7.046%200-11.514%204.468-11.514%2010.31c0%207.217%204.468%2010.14%2014.778%2014.608l6.014%202.577c20.45%208.765%2031.963%2017.7%2031.963%2037.804c0%2021.654-17.012%2033.51-39.867%2033.51c-22.339%200-36.774-10.654-43.819-24.574'%3e%3c/path%3e%3c/svg%3e";
   |  ^
46 |
47 |  const viteLogo = "/vite.svg";

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
45 |  const javascriptLogo = "data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20aria-hidden='true'%20role='img'%20class='iconify%20iconify--logos'%20width='32'%20height='32'%20preserveAspectRatio='xMidYMid%20meet'%20viewBox='0%200%20256%20256'%3e%3cpath%20fill='%23F7DF1E'%20d='M0%200h256v256H0V0Z'%3e%3c/path%3e%3cpath%20d='m67.312%20213.932l19.59-11.856c3.78%206.701%207.218%2012.371%2015.465%2012.371c7.905%200%2012.89-3.092%2012.89-15.12v-81.798h24.057v82.138c0%2024.917-14.606%2036.259-35.916%2036.259c-19.245%200-30.416-9.967-36.087-21.996m85.07-2.576l19.588-11.341c5.157%208.421%2011.859%2014.607%2023.715%2014.607c9.969%200%2016.325-4.984%2016.325-11.858c0-8.248-6.53-11.17-17.528-15.98l-6.013-2.58c-17.357-7.387-28.87-16.667-28.87-36.257c0-18.044%2013.747-31.792%2035.228-31.792c15.294%200%2026.292%205.328%2034.196%2019.247l-18.732%2012.03c-4.125-7.389-8.591-10.31-15.465-10.31c-7.046%200-11.514%204.468-11.514%2010.31c0%207.217%204.468%2010.14%2014.778%2014.608l6.014%202.577c20.45%208.765%2031.963%2017.7%2031.963%2037.804c0%2021.654-17.012%2033.51-39.867%2033.51c-22.339%200-36.774-10.654-43.819-24.574'%3e%3c/path%3e%3c/svg%3e";
46 |
47 |  const viteLogo = "/vite.svg";
   |  ^
48 |
49 |  function setupCounter(element) {

Transforming let to the configured target environment ("ie10" + 2 overrides) is not supported yet
48 |
49 |  function setupCounter(element) {
50 |    let counter = 0;
   |    ^
51 |    const setCounter = (count) => {
52 |      counter = count;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
49 |  function setupCounter(element) {
50 |    let counter = 0;
51 |    const setCounter = (count) => {
   |    ^
52 |      counter = count;
53 |      element.innerHTML = `count is ${counter}`;

    at failureErrorWithLog (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:1651:15)
    at /Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:849:29
    at responseCallbacks.<computed> (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:704:9)
    at handleIncomingPacket (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:764:9)
    at Socket.readFromStdout (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:680:7)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```

TO-BE

```bash
...

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
43 |  }());
44 |
45 |  const javascriptLogo = "data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20aria-hidden='true'%20role='img'%20class='iconify%20iconify--logos'%20width='32'%20height='32'%20preserveAspectRatio='xMidYMid%20meet'%20viewBox='0%200%20256%20256'%3e%3cpath%20fill='%23F7DF1E'%20d='M0%200h256v256H0V0Z'%3e%3c/path%3e%3cpath%20d='m67.312%20213.932l19.59-11.856c3.78%206.701%207.218%2012.371%2015.465%2012.371c7.905%200%2012.89-3.092%2012.89-15.12v-81.798h24.057v82.138c0%2024.917-14.606%2036.259-35.916%2036.259c-19.245%200-30.416-9.967-36.087-21.996m85.07-2.576l19.588-11.341c5.157%208.421%2011.859%2014.607%2023.715%2014.607c9.969%200%2016.325-4.984%2016.325-11.858c0-8.248-6.53-11.17-17.528-15.98l-6.013-2.58c-17.357-7.387-28.87-16.667-28.87-36.257c0-18.044%2013.747-31.792%2035.228-31.792c15.294%200%2026.292%205.328%2034.196%2019.247l-18.732%2012.03c-4.125-7.389-8.591-10.31-15.465-10.31c-7.046%200-11.514%204.468-11.514%2010.31c0%
... and 121 lines more
```

### Full Log

<details>
<summary>
AS-IS
</summary>

```bash
yarn run v1.22.22
$ vite build --debug
  vite:config bundled config file loaded in 41.41ms +0ms
  vite:config using resolved config: {
  vite:config   build: {
  vite:config     target: 'ie10',
  vite:config     cssTarget: 'ie10',
  vite:config     outDir: 'dist',
  vite:config     assetsDir: 'assets',
  vite:config     assetsInlineLimit: 4096,
  vite:config     cssCodeSplit: true,
  vite:config     sourcemap: false,
  vite:config     rollupOptions: {},
  vite:config     minify: 'esbuild',
  vite:config     terserOptions: {},
  vite:config     write: true,
  vite:config     emptyOutDir: null,
  vite:config     copyPublicDir: true,
  vite:config     manifest: false,
  vite:config     lib: false,
  vite:config     ssr: false,
  vite:config     ssrManifest: false,
  vite:config     ssrEmitAssets: false,
  vite:config     reportCompressedSize: true,
  vite:config     chunkSizeWarningLimit: 500,
  vite:config     watch: null,
  vite:config     commonjsOptions: { include: [Array], extensions: [Array] },
  vite:config     dynamicImportVarsOptions: { warnOnError: true, exclude: [Array] },
  vite:config     modulePreload: { polyfill: true },
  vite:config     cssMinify: true
  vite:config   },
  vite:config   configFile: '/Users/chaejun/study/vite-overflow/vite.config.mjs',
  vite:config   configFileDependencies: [ '/Users/chaejun/study/vite-overflow/vite.config.mjs' ],
  vite:config   inlineConfig: {
  vite:config     root: undefined,
  vite:config     base: undefined,
  vite:config     mode: undefined,
  vite:config     configFile: undefined,
  vite:config     logLevel: undefined,
  vite:config     clearScreen: undefined,
  vite:config     build: {}
  vite:config   },
  vite:config   root: '/Users/chaejun/study/vite-overflow',
  vite:config   base: '/',
  vite:config   rawBase: '/',
  vite:config   resolve: {
  vite:config     mainFields: [ 'browser', 'module', 'jsnext:main', 'jsnext' ],
  vite:config     conditions: [],
  vite:config     extensions: [
  vite:config       '.mjs',  '.js',
  vite:config       '.mts',  '.ts',
  vite:config       '.jsx',  '.tsx',
  vite:config       '.json'
  vite:config     ],
  vite:config     dedupe: [],
  vite:config     preserveSymlinks: false,
  vite:config     alias: [ [Object], [Object] ]
  vite:config   },
  vite:config   publicDir: '/Users/chaejun/study/vite-overflow/public',
  vite:config   cacheDir: '/Users/chaejun/study/vite-overflow/node_modules/.vite',
  vite:config   command: 'build',
  vite:config   mode: 'production',
  vite:config   ssr: {
  vite:config     target: 'node',
  vite:config     optimizeDeps: { noDiscovery: true, esbuildOptions: [Object] }
  vite:config   },
  vite:config   isWorker: false,
  vite:config   mainConfig: null,
  vite:config   bundleChain: [],
  vite:config   isProduction: true,
  vite:config   plugins: [
  vite:config     'vite:build-metadata',
  vite:config     'vite:watch-package-data',
  vite:config     'vite:pre-alias',
  vite:config     'alias',
  vite:config     'vite:modulepreload-polyfill',
  vite:config     'vite:resolve',
  vite:config     'vite:html-inline-proxy',
  vite:config     'vite:css',
  vite:config     'vite:esbuild',
  vite:config     'vite:json',
  vite:config     'vite:wasm-helper',
  vite:config     'vite:worker',
  vite:config     'vite:asset',
  vite:config     'vite:wasm-fallback',
  vite:config     'vite:define',
  vite:config     'vite:css-post',
  vite:config     'vite:build-html',
  vite:config     'vite:worker-import-meta-url',
  vite:config     'vite:asset-import-meta-url',
  vite:config     'vite:force-systemjs-wrap-complete',
  vite:config     'commonjs',
  vite:config     'vite:data-uri',
  vite:config     'vite:dynamic-import-vars',
  vite:config     'vite:import-glob',
  vite:config     'vite:build-import-analysis',
  vite:config     'vite:esbuild-transpile',
  vite:config     'vite:terser',
  vite:config     'vite:reporter',
  vite:config     'vite:load-fallback'
  vite:config   ],
  vite:config   css: { lightningcss: undefined },
  vite:config   esbuild: { jsxDev: false },
  vite:config   server: {
  vite:config     preTransformRequests: true,
  vite:config     sourcemapIgnoreList: [Function: isInNodeModules$1],
  vite:config     middlewareMode: false,
  vite:config     fs: {
  vite:config       strict: true,
  vite:config       allow: [Array],
  vite:config       deny: [Array],
  vite:config       cachedChecks: undefined
  vite:config     }
  vite:config   },
  vite:config   preview: {
  vite:config     port: undefined,
  vite:config     strictPort: undefined,
  vite:config     host: undefined,
  vite:config     https: undefined,
  vite:config     open: undefined,
  vite:config     proxy: undefined,
  vite:config     cors: undefined,
  vite:config     headers: undefined
  vite:config   },
  vite:config   envDir: '/Users/chaejun/study/vite-overflow',
  vite:config   env: { BASE_URL: '/', MODE: 'production', DEV: false, PROD: true },
  vite:config   assetsInclude: [Function: assetsInclude],
  vite:config   logger: {
  vite:config     hasWarned: false,
  vite:config     info: [Function: info],
  vite:config     warn: [Function: warn],
  vite:config     warnOnce: [Function: warnOnce],
  vite:config     error: [Function: error],
  vite:config     clearScreen: [Function: clearScreen],
  vite:config     hasErrorLogged: [Function: hasErrorLogged]
  vite:config   },
  vite:config   packageCache: Map(1) {
  vite:config     'fnpd_/Users/chaejun/study/vite-overflow' => {
  vite:config       dir: '/Users/chaejun/study/vite-overflow',
  vite:config       data: [Object],
  vite:config       hasSideEffects: [Function: hasSideEffects],
  vite:config       webResolvedImports: {},
  vite:config       nodeResolvedImports: {},
  vite:config       setResolvedCache: [Function: setResolvedCache],
  vite:config       getResolvedCache: [Function: getResolvedCache]
  vite:config     },
  vite:config     set: [Function (anonymous)]
  vite:config   },
  vite:config   createResolver: [Function: createResolver],
  vite:config   optimizeDeps: {
  vite:config     holdUntilCrawlEnd: true,
  vite:config     esbuildOptions: { preserveSymlinks: false }
  vite:config   },
  vite:config   worker: { format: 'iife', plugins: '() => plugins', rollupOptions: {} },
  vite:config   appType: 'spa',
  vite:config   experimental: { importGlobRestoreExtension: false, hmrPartialAccept: false },
  vite:config   getSortedPlugins: [Function: getSortedPlugins],
  vite:config   getSortedPluginHooks: [Function: getSortedPluginHooks]
  vite:config } +30ms
vite v5.2.11 building for production...
✓ 7 modules transformed.
  vite:esbuild esbuild error with options used:  {
  sourcemap: true,
  sourcefile: 'assets/index-!~{001}~.js',
  charset: 'utf8',
  jsxDev: false,
  loader: 'js',
  target: 'ie10',
  format: 'esm',
  supported: { 'dynamic-import': true, 'import-meta': true },
  minify: true,
  treeShaking: true,
  tsconfigRaw: { compilerOptions: { useDefineForClassFields: false } }
} +0ms
x Build failed in 50ms
error during build:
Error: [vite:esbuild-transpile] Transform failed with 13 errors:
assets/index-!~{001}~.js:2:2: ERROR: Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:6:7: ERROR: Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:6:18: ERROR: Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:10:9: ERROR: Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:10:24: ERROR: Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
...

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
1  |  true&&(function polyfill() {
2  |    const relList = document.createElement('link').relList;
   |    ^
3  |    if (relList && relList.supports && relList.supports('modulepreload')) {
4  |      return;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
4  |      return;
5  |    }
6  |    for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
   |         ^
7  |      processPreload(link);
8  |    }

Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
4  |      return;
5  |    }
6  |    for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
   |                    ^
7  |      processPreload(link);
8  |    }

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
8  |    }
9  |    new MutationObserver((mutations) => {
10 |      for (const mutation of mutations) {
   |           ^
11 |        if (mutation.type !== 'childList') {
12 |          continue;

Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
8  |    }
9  |    new MutationObserver((mutations) => {
10 |      for (const mutation of mutations) {
   |                          ^
11 |        if (mutation.type !== 'childList') {
12 |          continue;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
12 |          continue;
13 |        }
14 |        for (const node of mutation.addedNodes) {
   |             ^
15 |          if (node.tagName === 'LINK' && node.rel === 'modulepreload')
16 |            processPreload(node);

Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
12 |          continue;
13 |        }
14 |        for (const node of mutation.addedNodes) {
   |                        ^
15 |          if (node.tagName === 'LINK' && node.rel === 'modulepreload')
16 |            processPreload(node);

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
19 |    }).observe(document, { childList: true, subtree: true });
20 |    function getFetchOpts(link) {
21 |      const fetchOpts = {};
   |      ^
22 |      if (link.integrity)
23 |        fetchOpts.integrity = link.integrity;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
38 |      link.ep = true;
39 |      // prepopulate the load record
40 |      const fetchOpts = getFetchOpts(link);
   |      ^
41 |      fetch(link.href, fetchOpts);
42 |    }

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
43 |  }());
44 |
45 |  const javascriptLogo = "data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20aria-hidden='true'%20role='img'%20class='iconify%20iconify--logos'%20width='32'%20height='32'%20preserveAspectRatio='xMidYMid%20meet'%20viewBox='0%200%20256%20256'%3e%3cpath%20fill='%23F7DF1E'%20d='M0%200h256v256H0V0Z'%3e%3c/path%3e%3cpath%20d='m67.312%20213.932l19.59-11.856c3.78%206.701%207.218%2012.371%2015.465%2012.371c7.905%200%2012.89-3.092%2012.89-15.12v-81.798h24.057v82.138c0%2024.917-14.606%2036.259-35.916%2036.259c-19.245%200-30.416-9.967-36.087-21.996m85.07-2.576l19.588-11.341c5.157%208.421%2011.859%2014.607%2023.715%2014.607c9.969%200%2016.325-4.984%2016.325-11.858c0-8.248-6.53-11.17-17.528-15.98l-6.013-2.58c-17.357-7.387-28.87-16.667-28.87-36.257c0-18.044%2013.747-31.792%2035.228-31.792c15.294%200%2026.292%205.328%2034.196%2019.247l-18.732%2012.03c-4.125-7.389-8.591-10.31-15.465-10.31c-7.046%200-11.514%204.468-11.514%2010.31c0%207.217%204.468%2010.14%2014.778%2014.608l6.014%202.577c20.45%208.765%2031.963%2017.7%2031.963%2037.804c0%2021.654-17.012%2033.51-39.867%2033.51c-22.339%200-36.774-10.654-43.819-24.574'%3e%3c/path%3e%3c/svg%3e";
   |  ^
46 |
47 |  const viteLogo = "/vite.svg";

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
45 |  const javascriptLogo = "data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20aria-hidden='true'%20role='img'%20class='iconify%20iconify--logos'%20width='32'%20height='32'%20preserveAspectRatio='xMidYMid%20meet'%20viewBox='0%200%20256%20256'%3e%3cpath%20fill='%23F7DF1E'%20d='M0%200h256v256H0V0Z'%3e%3c/path%3e%3cpath%20d='m67.312%20213.932l19.59-11.856c3.78%206.701%207.218%2012.371%2015.465%2012.371c7.905%200%2012.89-3.092%2012.89-15.12v-81.798h24.057v82.138c0%2024.917-14.606%2036.259-35.916%2036.259c-19.245%200-30.416-9.967-36.087-21.996m85.07-2.576l19.588-11.341c5.157%208.421%2011.859%2014.607%2023.715%2014.607c9.969%200%2016.325-4.984%2016.325-11.858c0-8.248-6.53-11.17-17.528-15.98l-6.013-2.58c-17.357-7.387-28.87-16.667-28.87-36.257c0-18.044%2013.747-31.792%2035.228-31.792c15.294%200%2026.292%205.328%2034.196%2019.247l-18.732%2012.03c-4.125-7.389-8.591-10.31-15.465-10.31c-7.046%200-11.514%204.468-11.514%2010.31c0%207.217%204.468%2010.14%2014.778%2014.608l6.014%202.577c20.45%208.765%2031.963%2017.7%2031.963%2037.804c0%2021.654-17.012%2033.51-39.867%2033.51c-22.339%200-36.774-10.654-43.819-24.574'%3e%3c/path%3e%3c/svg%3e";
46 |
47 |  const viteLogo = "/vite.svg";
   |  ^
48 |
49 |  function setupCounter(element) {

Transforming let to the configured target environment ("ie10" + 2 overrides) is not supported yet
48 |
49 |  function setupCounter(element) {
50 |    let counter = 0;
   |    ^
51 |    const setCounter = (count) => {
52 |      counter = count;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
49 |  function setupCounter(element) {
50 |    let counter = 0;
51 |    const setCounter = (count) => {
   |    ^
52 |      counter = count;
53 |      element.innerHTML = `count is ${counter}`;

    at failureErrorWithLog (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:1651:15)
    at /Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:849:29
    at responseCallbacks.<computed> (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:704:9)
    at handleIncomingPacket (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:764:9)
    at Socket.readFromStdout (/Users/chaejun/study/vite-overflow/node_modules/esbuild/lib/main.js:680:7)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:559:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
    at Readable.push (node:internal/streams/readable:390:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

<details>
<summary>
TO-BE
</summary>

```bash
yarn run v1.22.22
$ vite build --debug
  vite:config bundled config file loaded in 56.86ms +0ms
  vite:config using resolved config: {
  vite:config   build: {
  vite:config     target: 'ie10',
  vite:config     cssTarget: 'ie10',
  vite:config     outDir: 'dist',
  vite:config     assetsDir: 'assets',
  vite:config     assetsInlineLimit: 4096,
  vite:config     cssCodeSplit: true,
  vite:config     sourcemap: false,
  vite:config     rollupOptions: {},
  vite:config     minify: 'esbuild',
  vite:config     terserOptions: {},
  vite:config     write: true,
  vite:config     emptyOutDir: null,
  vite:config     copyPublicDir: true,
  vite:config     manifest: false,
  vite:config     lib: false,
  vite:config     ssr: false,
  vite:config     ssrManifest: false,
  vite:config     ssrEmitAssets: false,
  vite:config     reportCompressedSize: true,
  vite:config     chunkSizeWarningLimit: 500,
  vite:config     watch: null,
  vite:config     commonjsOptions: { include: [Array], extensions: [Array] },
  vite:config     dynamicImportVarsOptions: { warnOnError: true, exclude: [Array] },
  vite:config     modulePreload: { polyfill: true },
  vite:config     cssMinify: true
  vite:config   },
  vite:config   configFile: '/Users/chaejun/study/vite-overflow/vite.config.mjs',
  vite:config   configFileDependencies: [ '/Users/chaejun/study/vite-overflow/vite.config.mjs' ],
  vite:config   inlineConfig: {
  vite:config     root: undefined,
  vite:config     base: undefined,
  vite:config     mode: undefined,
  vite:config     configFile: undefined,
  vite:config     logLevel: undefined,
  vite:config     clearScreen: undefined,
  vite:config     build: {}
  vite:config   },
  vite:config   root: '/Users/chaejun/study/vite-overflow',
  vite:config   base: '/',
  vite:config   rawBase: '/',
  vite:config   resolve: {
  vite:config     mainFields: [ 'browser', 'module', 'jsnext:main', 'jsnext' ],
  vite:config     conditions: [],
  vite:config     extensions: [
  vite:config       '.mjs',  '.js',
  vite:config       '.mts',  '.ts',
  vite:config       '.jsx',  '.tsx',
  vite:config       '.json'
  vite:config     ],
  vite:config     dedupe: [],
  vite:config     preserveSymlinks: false,
  vite:config     alias: [ [Object], [Object] ]
  vite:config   },
  vite:config   publicDir: '/Users/chaejun/study/vite-overflow/public',
  vite:config   cacheDir: '/Users/chaejun/study/vite-overflow/node_modules/.vite',
  vite:config   command: 'build',
  vite:config   mode: 'production',
  vite:config   ssr: {
  vite:config     target: 'node',
  vite:config     optimizeDeps: { noDiscovery: true, esbuildOptions: [Object] }
  vite:config   },
  vite:config   isWorker: false,
  vite:config   mainConfig: null,
  vite:config   bundleChain: [],
  vite:config   isProduction: true,
  vite:config   plugins: [
  vite:config     'vite:build-metadata',
  vite:config     'vite:watch-package-data',
  vite:config     'vite:pre-alias',
  vite:config     'alias',
  vite:config     'vite:modulepreload-polyfill',
  vite:config     'vite:resolve',
  vite:config     'vite:html-inline-proxy',
  vite:config     'vite:css',
  vite:config     'vite:esbuild',
  vite:config     'vite:json',
  vite:config     'vite:wasm-helper',
  vite:config     'vite:worker',
  vite:config     'vite:asset',
  vite:config     'vite:wasm-fallback',
  vite:config     'vite:define',
  vite:config     'vite:css-post',
  vite:config     'vite:build-html',
  vite:config     'vite:worker-import-meta-url',
  vite:config     'vite:asset-import-meta-url',
  vite:config     'vite:force-systemjs-wrap-complete',
  vite:config     'commonjs',
  vite:config     'vite:data-uri',
  vite:config     'vite:dynamic-import-vars',
  vite:config     'vite:import-glob',
  vite:config     'vite:build-import-analysis',
  vite:config     'vite:esbuild-transpile',
  vite:config     'vite:terser',
  vite:config     'vite:reporter',
  vite:config     'vite:load-fallback'
  vite:config   ],
  vite:config   css: { lightningcss: undefined },
  vite:config   esbuild: { jsxDev: false },
  vite:config   server: {
  vite:config     preTransformRequests: true,
  vite:config     sourcemapIgnoreList: [Function: isInNodeModules$1],
  vite:config     middlewareMode: false,
  vite:config     fs: {
  vite:config       strict: true,
  vite:config       allow: [Array],
  vite:config       deny: [Array],
  vite:config       cachedChecks: undefined
  vite:config     }
  vite:config   },
  vite:config   preview: {
  vite:config     port: undefined,
  vite:config     strictPort: undefined,
  vite:config     host: undefined,
  vite:config     https: undefined,
  vite:config     open: undefined,
  vite:config     proxy: undefined,
  vite:config     cors: undefined,
  vite:config     headers: undefined
  vite:config   },
  vite:config   envDir: '/Users/chaejun/study/vite-overflow',
  vite:config   env: { BASE_URL: '/', MODE: 'production', DEV: false, PROD: true },
  vite:config   assetsInclude: [Function: assetsInclude],
  vite:config   logger: {
  vite:config     hasWarned: false,
  vite:config     info: [Function: info],
  vite:config     warn: [Function: warn],
  vite:config     warnOnce: [Function: warnOnce],
  vite:config     error: [Function: error],
  vite:config     clearScreen: [Function: clearScreen],
  vite:config     hasErrorLogged: [Function: hasErrorLogged]
  vite:config   },
  vite:config   packageCache: Map(1) {
  vite:config     'fnpd_/Users/chaejun/study/vite-overflow' => {
  vite:config       dir: '/Users/chaejun/study/vite-overflow',
  vite:config       data: [Object],
  vite:config       hasSideEffects: [Function: hasSideEffects],
  vite:config       webResolvedImports: {},
  vite:config       nodeResolvedImports: {},
  vite:config       setResolvedCache: [Function: setResolvedCache],
  vite:config       getResolvedCache: [Function: getResolvedCache]
  vite:config     },
  vite:config     set: [Function (anonymous)]
  vite:config   },
  vite:config   createResolver: [Function: createResolver],
  vite:config   optimizeDeps: {
  vite:config     holdUntilCrawlEnd: true,
  vite:config     esbuildOptions: { preserveSymlinks: false }
  vite:config   },
  vite:config   worker: { format: 'iife', plugins: '() => plugins', rollupOptions: {} },
  vite:config   appType: 'spa',
  vite:config   experimental: { importGlobRestoreExtension: false, hmrPartialAccept: false },
  vite:config   getSortedPlugins: [Function: getSortedPlugins],
  vite:config   getSortedPluginHooks: [Function: getSortedPluginHooks]
  vite:config } +15ms
vite v5.2.11 building for production...
✓ 7 modules transformed.
  vite:esbuild esbuild error with options used:  {
  sourcemap: true,
  sourcefile: 'assets/index-!~{001}~.js',
  charset: 'utf8',
  jsxDev: false,
  loader: 'js',
  target: 'ie10',
  format: 'esm',
  supported: { 'dynamic-import': true, 'import-meta': true },
  minify: true,
  treeShaking: true,
  tsconfigRaw: { compilerOptions: { useDefineForClassFields: false } }
} +0ms
x Build failed in 44ms
error during build:
Error: [vite:esbuild-transpile] Transform failed with 13 errors:
assets/index-!~{001}~.js:2:4: ERROR: Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:6:9: ERROR: Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:6:20: ERROR: Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:10:13: ERROR: Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
assets/index-!~{001}~.js:10:28: ERROR: Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
...

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
1  |  true&&(function polyfill() {
2  |      const relList = document.createElement('link').relList;
   |      ^
3  |      if (relList && relList.supports && relList.supports('modulepreload')) {
4  |          return;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
4  |          return;
5  |      }
6  |      for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
   |           ^
7  |          processPreload(link);
8  |      }

Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
4  |          return;
5  |      }
6  |      for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
   |                      ^
7  |          processPreload(link);
8  |      }

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
8  |      }
9  |      new MutationObserver((mutations) => {
10 |          for (const mutation of mutations) {
   |               ^
11 |              if (mutation.type !== 'childList') {
12 |                  continue;

Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
8  |      }
9  |      new MutationObserver((mutations) => {
10 |          for (const mutation of mutations) {
   |                              ^
11 |              if (mutation.type !== 'childList') {
12 |                  continue;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
12 |                  continue;
13 |              }
14 |              for (const node of mutation.addedNodes) {
   |                   ^
15 |                  if (node.tagName === 'LINK' && node.rel === 'modulepreload')
16 |                      processPreload(node);

Transforming for-of loops to the configured target environment ("ie10" + 2 overrides) is not supported yet
12 |                  continue;
13 |              }
14 |              for (const node of mutation.addedNodes) {
   |                              ^
15 |                  if (node.tagName === 'LINK' && node.rel === 'modulepreload')
16 |                      processPreload(node);

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
19 |      }).observe(document, { childList: true, subtree: true });
20 |      function getFetchOpts(link) {
21 |          const fetchOpts = {};
   |          ^
22 |          if (link.integrity)
23 |              fetchOpts.integrity = link.integrity;

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
38 |          link.ep = true;
39 |          // prepopulate the load record
40 |          const fetchOpts = getFetchOpts(link);
   |          ^
41 |          fetch(link.href, fetchOpts);
42 |      }

Transforming const to the configured target environment ("ie10" + 2 overrides) is not supported yet
43 |  }());
44 |
45 |  const javascriptLogo = "data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20xmlns:xlink='http://www.w3.org/1999/xlink'%20aria-hidden='true'%20role='img'%20class='iconify%20iconify--logos'%20width='32'%20height='32'%20preserveAspectRatio='xMidYMid%20meet'%20viewBox='0%200%20256%20256'%3e%3cpath%20fill='%23F7DF1E'%20d='M0%200h256v256H0V0Z'%3e%3c/path%3e%3cpath%20d='m67.312%20213.932l19.59-11.856c3.78%206.701%207.218%2012.371%2015.465%2012.371c7.905%200%2012.89-3.092%2012.89-15.12v-81.798h24.057v82.138c0%2024.917-14.606%2036.259-35.916%2036.259c-19.245%200-30.416-9.967-36.087-21.996m85.07-2.576l19.588-11.341c5.157%208.421%2011.859%2014.607%2023.715%2014.607c9.969%200%2016.325-4.984%2016.325-11.858c0-8.248-6.53-11.17-17.528-15.98l-6.013-2.58c-17.357-7.387-28.87-16.667-28.87-36.257c0-18.044%2013.747-31.792%2035.228-31.792c15.294%200%2026.292%205.328%2034.196%2019.247l-18.732%2012.03c-4.125-7.389-8.591-10.31-15.465-10.31c-7.046%200-11.514%204.468-11.514%2010.31c0%
... and 121 lines more
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
