### PR TITLE
feat(asset): support `/*@vite-ignore*/` for `new URL(, import.meta.url)`

### DIFF
--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -11,6 +11,7 @@ import { fileToUrl } from './asset'
 import { preloadHelperId } from './importAnalysisBuild'
 import type { InternalResolveOptions } from './resolve'
 import { tryFsResolve } from './resolve'
+import { hasViteIgnoreRE } from './importAnalysis'
 
 /**
  * Convert `new URL('./foo.png', import.meta.url)` to its resolved built URL
@@ -54,6 +55,8 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
         let match: RegExpExecArray | null
         while ((match = assetImportMetaUrlRE.exec(cleanString))) {
           const [[startIndex, endIndex], [urlStart, urlEnd]] = match.indices!
+          if (hasViteIgnoreRE.test(code.slice(startIndex, urlStart))) continue
+
           const rawUrl = code.slice(urlStart, urlEnd)
 
           if (!s) s = new MagicString(code)
@@ -134,7 +137,8 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           if (!builtUrl) {
             const rawExp = code.slice(startIndex, endIndex)
             config.logger.warnOnce(
-              `\n${rawExp} doesn't exist at build time, it will remain unchanged to be resolved at runtime`,
+              `\n${rawExp} doesn't exist at build time, it will remain unchanged to be resolved at runtime. ` +
+                `If this is intended, you can use the /* @vite-ignore */ comment to suppress this warning.`,
             )
             builtUrl = url
           }

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -185,8 +185,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             s.update(
               expStart,
               expEnd,
-              // add `'' +` to skip vite:asset-import-meta-url plugin
-              `new URL('' + ${JSON.stringify(builtUrl)}, import.meta.url)`,
+              `new URL(/* @vite-ignore */ ${JSON.stringify(builtUrl)}, import.meta.url)`,
             )
           }
         }

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -14,6 +14,7 @@ import {
   page,
   readFile,
   readManifest,
+  serverLogs,
   untilUpdated,
   viteTestUrl,
   watcher,
@@ -464,7 +465,7 @@ test('new URL(`./${1 === 0 ? static : dynamic}?abc`, import.meta.url)', async ()
   )
 })
 
-test('new URL(`non-existent`, import.meta.url)', async () => {
+test("new URL(/* @vite-ignore */ 'non-existent', import.meta.url)", async () => {
   // the inlined script tag is extracted in a separate file
   const importMetaUrl = new URL(
     isBuild ? '/foo/bar/assets/index.js' : '/foo/bar/index.html',
@@ -472,6 +473,9 @@ test('new URL(`non-existent`, import.meta.url)', async () => {
   )
   expect(await page.textContent('.non-existent-import-meta-url')).toMatch(
     new URL('non-existent', importMetaUrl).pathname,
+  )
+  expect(serverLogs).not.toContainEqual(
+    expect.stringContaining("doesn't exist at build time"),
   )
 })
 

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -304,7 +304,7 @@
   <code class="dynamic-import-meta-url-2-ternary"></code>
 </p>
 
-<h2>new URL(`non-existent`, import.meta.url)</h2>
+<h2>new URL(/* @vite-ignore */ 'non-existent', import.meta.url)</h2>
 <p>
   <code class="non-existent-import-meta-url"></code>
 </p>
@@ -509,7 +509,10 @@
   import someString from './static/foo.txt?raw'
   document.querySelector('.raw-query').textContent = someString
 
-  const metaUrlNonExistent = new URL('non-existent', import.meta.url).pathname
+  const metaUrlNonExistent = new URL(
+    /* @vite-ignore */ 'non-existent',
+    import.meta.url,
+  ).pathname
   text('.non-existent-import-meta-url', metaUrlNonExistent)
 
   /**


### PR DESCRIPTION
### Description

This PR adds `/* @vite-ignore */` so that users can opt-out transformation of `new URL(, import.meta.url)`.

refs #7306
refs #14377

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
