### PR TITLE
fix(sourcemap): improve sourcemap compatibility for vue2

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -3,7 +3,7 @@ import fsp from 'node:fs/promises'
 import convertSourceMap from 'convert-source-map'
 import type { ExistingRawSourceMap, SourceMap } from 'rollup'
 import type { Logger } from '../logger'
-import { blankReplacer, createDebugger } from '../utils'
+import { blankReplacer, createDebugger, fsPathFromUrl } from '../utils'
 
 const debug = createDebugger('vite:sourcemap', {
   onlyWhenFocused: true,
@@ -53,7 +53,7 @@ export async function injectSourcesContent(
           // inject content from source file when sourcesContent is null
           sourceRootPromise ??= computeSourceRoute(map, file)
           const sourceRoot = await sourceRootPromise
-          let resolvedSourcePath = decodeURI(sourcePath)
+          let resolvedSourcePath = fsPathFromUrl(decodeURI(sourcePath))
           if (sourceRoot) {
             resolvedSourcePath = path.resolve(sourceRoot, resolvedSourcePath)
           }

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -3,7 +3,8 @@ import fsp from 'node:fs/promises'
 import convertSourceMap from 'convert-source-map'
 import type { ExistingRawSourceMap, SourceMap } from 'rollup'
 import type { Logger } from '../logger'
-import { blankReplacer, createDebugger, fsPathFromUrl } from '../utils'
+import { blankReplacer, createDebugger } from '../utils'
+import { cleanUrl } from '../../shared/utils'
 
 const debug = createDebugger('vite:sourcemap', {
   onlyWhenFocused: true,
@@ -53,7 +54,7 @@ export async function injectSourcesContent(
           // inject content from source file when sourcesContent is null
           sourceRootPromise ??= computeSourceRoute(map, file)
           const sourceRoot = await sourceRootPromise
-          let resolvedSourcePath = fsPathFromUrl(decodeURI(sourcePath))
+          let resolvedSourcePath = cleanUrl(decodeURI(sourcePath))
           if (sourceRoot) {
             resolvedSourcePath = path.resolve(sourceRoot, resolvedSourcePath)
           }


### PR DESCRIPTION
### Description

This change does match what was in #16192 but that is marked as not resolving a different problem, so I didn't want to conflate things.

Thile using vue2, and specifically the `vue2-google-maps` package which contains a vue component, the build process produces a `resolvedSourcePath` that contains query string style arguements such as:

`/home/adam/repos/vue2-map/node_modules/node_modules/.pnpm/vue2-google-maps@0.10.7/node_modules/vue2-google-maps/dist/components/placeInputImpl.js?v=c006e476&vue&type=script&src=true&lang.js`

This then leads to a `missingSources` entry since the characters after the extension do not allow for the file to be loaded such as:

```
Sourcemap for "/home/adam/repos/vue2-map/node_modules/.pnpm/vue2-google-maps@0.10.7/node_modules/vue2-google-maps/dist/components/placeInputImpl.js" points to missing source files
```

By first converting the URI to a filesystem path, we can ensure it loads the file.

