### PR TITLE
docs: add custom event types docs

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -247,6 +247,16 @@ This interface extension is utilized by `InferCustomEventPayload<T>` to infer th
 ```ts
 export type InferCustomEventPayload<T extends string> =
   T extends keyof CustomEventMap ? CustomEventMap[T] : any
+
+type CustomFooPayload = InferCustomEventPayload<'custom:foo'>
+           ^ { msg: string }
+
+import.meta.hot.on("custom:foo", (payload) => {
+  // The type of payload will be { msg: string }
+})
+import.meta.hot.on("unknown:event", (payload) => {
+  // The type of payload will be any
+})
 ```
 
 ## Further Reading

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -220,11 +220,7 @@ Send custom events back to Vite's dev server.
 
 If called before connected, the data will be buffered and sent once the connection is established.
 
-See [Client-server Communication](/guide/api-plugin.html#client-server-communication) for more details.
-
-## TypeScript for Custom Events
-
-Refer to the [Typing Custom Events](/guide/api-plugin.html#typescript-for-custom-events) section in the Plugin API Guide for more details.
+See [Client-server Communication](/guide/api-plugin.html#client-server-communication) for more details, including a section on [Typing Custom Events](/guide/api-plugin.html#typescript-for-custom-events).
 
 ## Further Reading
 

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -222,6 +222,26 @@ If called before connected, the data will be buffered and sent once the connecti
 
 See [Client-server Communication](/guide/api-plugin.html#client-server-communication) for more details.
 
+## Typescript for Custom Events
+
+It is possible It is possible to type custom events by extending the `CustomEventMap` interface:
+
+:::tip Note
+Be sure to include the .d.ts extension when specifying TypeScript declaration files. Vite exposes its exports as `/types/*` (as seen in its [package.json](https://github.com/vitejs/vite/blob/main/packages/vite/package.json#L40C1-L42)), so without the extension, the library may not know which file the module is trying to extend.
+:::
+
+```ts
+// events.d.ts
+import 'vite/types/customEvent.d.ts'
+
+declare module 'vite/types/customEvent.d.ts' {
+  interface CustomEventMap {
+    'custom:foo': { msg: string }
+    // 'event-key': payload
+  }
+}
+```
+
 ## Further Reading
 
 If you'd like to learn more about how to use the HMR API and how it works under-the-hood. Check out these resources:

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -224,10 +224,10 @@ See [Client-server Communication](/guide/api-plugin.html#client-server-communica
 
 ## Typescript for Custom Events
 
-It is possible It is possible to type custom events by extending the `CustomEventMap` interface:
+Internally, vite infers the type of a payload from the `CustomEventMap` interface, it is possible to type custom events by extending the interface:
 
 :::tip Note
-Be sure to include the .d.ts extension when specifying TypeScript declaration files. Vite exposes its exports as `/types/*` (as seen in its [package.json](https://github.com/vitejs/vite/blob/main/packages/vite/package.json#L40C1-L42)), so without the extension, the library may not know which file the module is trying to extend.
+Make sure to include the `.d.ts` extension when specifying TypeScript declaration files. Vite exposes its exports as `/types/*` (as seen in its [package.json](https://github.com/vitejs/vite/blob/main/packages/vite/package.json#L40C1-L42)), so without the extension, the library may not know which file the module is trying to extend.
 :::
 
 ```ts
@@ -240,6 +240,13 @@ declare module 'vite/types/customEvent.d.ts' {
     // 'event-key': payload
   }
 }
+```
+
+This interface extension is utilized by `InferCustomEventPayload<T>` to infer the payload type for event `T`. For more information on how this interface is utilized, refer to [this documentation](./api-hmr#hmr-api).
+
+```ts
+export type InferCustomEventPayload<T extends string> =
+  T extends keyof CustomEventMap ? CustomEventMap[T] : any
 ```
 
 ## Further Reading

--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -222,42 +222,9 @@ If called before connected, the data will be buffered and sent once the connecti
 
 See [Client-server Communication](/guide/api-plugin.html#client-server-communication) for more details.
 
-## Typescript for Custom Events
+## TypeScript for Custom Events
 
-Internally, vite infers the type of a payload from the `CustomEventMap` interface, it is possible to type custom events by extending the interface:
-
-:::tip Note
-Make sure to include the `.d.ts` extension when specifying TypeScript declaration files. Vite exposes its exports as `/types/*` (as seen in its [package.json](https://github.com/vitejs/vite/blob/main/packages/vite/package.json#L40C1-L42)), so without the extension, the library may not know which file the module is trying to extend.
-:::
-
-```ts
-// events.d.ts
-import 'vite/types/customEvent.d.ts'
-
-declare module 'vite/types/customEvent.d.ts' {
-  interface CustomEventMap {
-    'custom:foo': { msg: string }
-    // 'event-key': payload
-  }
-}
-```
-
-This interface extension is utilized by `InferCustomEventPayload<T>` to infer the payload type for event `T`. For more information on how this interface is utilized, refer to [this documentation](./api-hmr#hmr-api).
-
-```ts
-export type InferCustomEventPayload<T extends string> =
-  T extends keyof CustomEventMap ? CustomEventMap[T] : any
-
-type CustomFooPayload = InferCustomEventPayload<'custom:foo'>
-           ^ { msg: string }
-
-import.meta.hot.on("custom:foo", (payload) => {
-  // The type of payload will be { msg: string }
-})
-import.meta.hot.on("unknown:event", (payload) => {
-  // The type of payload will be any
-})
-```
+Refer to the [Typing Custom Events](/guide/api-plugin.html#typescript-for-custom-events) section in the Plugin API Guide for more details.
 
 ## Further Reading
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -623,7 +623,7 @@ export default defineConfig({
 })
 ```
 
-### Typescript for Custom Events
+### TypeScript for Custom Events
 
 Internally, vite infers the type of a payload from the `CustomEventMap` interface, it is possible to type custom events by extending the interface:
 

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -623,6 +623,42 @@ export default defineConfig({
 })
 ```
 
-### TypeScript for Custom Events
+### Typescript for Custom Events
 
-Refer to the [Typing Custom Events](./api-hmr#typescript-for-custom-events) section in the HMR API Guide for more details.
+Internally, vite infers the type of a payload from the `CustomEventMap` interface, it is possible to type custom events by extending the interface:
+
+:::tip Note
+Make sure to include the `.d.ts` extension when specifying TypeScript declaration files. Otherwise, Typescript may not know which file the module is trying to extend.
+:::
+
+```ts
+// events.d.ts
+import 'vite/types/customEvent.d.ts'
+
+declare module 'vite/types/customEvent.d.ts' {
+  interface CustomEventMap {
+    'custom:foo': { msg: string }
+    // 'event-key': payload
+  }
+}
+```
+
+This interface extension is utilized by `InferCustomEventPayload<T>` to infer the payload type for event `T`. For more information on how this interface is utilized, refer to the [HMR API Documentation](./api-hmr#hmr-api).
+
+```ts twoslash
+import 'vite/client'
+import type { InferCustomEventPayload } from 'vite/types/customEvent.d.ts'
+declare module 'vite/types/customEvent.d.ts' {
+  interface CustomEventMap {
+    'custom:foo': { msg: string }
+  }
+}
+// ---cut---
+type CustomFooPayload = InferCustomEventPayload<'custom:foo'>
+import.meta.hot?.on('custom:foo', (payload) => {
+  // The type of payload will be { msg: string }
+})
+import.meta.hot?.on('unknown:event', (payload) => {
+  // The type of payload will be any
+})
+```

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -625,16 +625,4 @@ export default defineConfig({
 
 ### TypeScript for Custom Events
 
-It is possible to type custom events by extending the `CustomEventMap` interface:
-
-```ts
-// events.d.ts
-import 'vite/types/customEvent'
-
-declare module 'vite/types/customEvent' {
-  interface CustomEventMap {
-    'custom:foo': { msg: string }
-    // 'event-key': payload
-  }
-}
-```
+Refer to the [Typing Custom Events](./api-hmr#typescript-for-custom-events) section in the HMR API Guide for more details.

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "eslint --cache --fix"
     ]
   },
-  "packageManager": "pnpm@8.15.8+sha256.691fe176eea9a8a80df20e4976f3dfb44a04841ceb885638fe2a26174f81e65e",
+  "packageManager": "pnpm@8.15.8",
   "pnpm": {
     "overrides": {
       "vite": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
       "eslint --cache --fix"
     ]
   },
-  "packageManager": "pnpm@8.15.8",
+  "packageManager": "pnpm@8.15.8+sha256.691fe176eea9a8a80df20e4976f3dfb44a04841ceb885638fe2a26174f81e65e",
   "pnpm": {
     "overrides": {
       "vite": "workspace:*"


### PR DESCRIPTION
### Description

Add documentation for behavior specified in [#16601](https://github.com/vitejs/vite/issues/16601)
* Add `.d.ts` suffix for file imports
* Move `Custom Event Types` section from `Plugin API` to `HMR API`
* Add backlink from `Plugin API` to `HMR API` referring to the moved section