### PR TITLE
feat(config): add `entryRoot` option

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -485,7 +485,8 @@ export async function build(
     ),
   )
 
-  const resolve = (p: string) => path.resolve(config.root, p)
+  const entryRoot = config.entryRoot || config.root
+  const resolve = (p: string) => path.resolve(entryRoot, p)
   const input = libOptions
     ? options.rollupOptions?.input ||
       (typeof libOptions.entry === 'string'
@@ -522,7 +523,7 @@ export async function build(
     }
   }
 
-  const outDir = resolve(options.outDir)
+  const outDir = path.resolve(config.root, options.outDir)
 
   // inject ssr arg to plugin load/transform hooks
   const plugins = (
@@ -731,7 +732,9 @@ export async function build(
     clearLine()
     if (startTime) {
       config.logger.error(
-        `${colors.red('x')} Build failed in ${displayTime(Date.now() - startTime)}`,
+        `${colors.red('x')} Build failed in ${displayTime(
+          Date.now() - startTime,
+        )}`,
       )
       startTime = undefined
     }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -136,6 +136,12 @@ export interface UserConfig {
    */
   root?: string
   /**
+   * Entry root directory. Can be an absolute path, or a path relative from the
+   * project's `root` option. If defined, any `.html` entry files are resolved
+   * relative to this directory.
+   */
+  entryRoot?: string
+  /**
    * Base public path when served in development or production.
    * @default '/'
    */
@@ -363,6 +369,7 @@ export type ResolvedConfig = Readonly<
     configFileDependencies: string[]
     inlineConfig: InlineConfig
     root: string
+    entryRoot: string
     base: string
     /** @internal */
     rawBase: string
@@ -527,6 +534,10 @@ export async function resolveConfig(
   )
 
   checkBadCharactersInPath(resolvedRoot, logger)
+
+  const resolvedEntryRoot = config.entryRoot
+    ? normalizePath(path.resolve(resolvedRoot, config.entryRoot))
+    : resolvedRoot
 
   const clientAlias = [
     {
@@ -770,6 +781,7 @@ export async function resolveConfig(
     ),
     inlineConfig,
     root: resolvedRoot,
+    entryRoot: resolvedEntryRoot,
     base: withTrailingSlash(resolvedBase),
     rawBase: resolvedBase,
     resolve: resolveOptions,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -429,7 +429,7 @@ export async function _createServer(
 
   const initPublicFilesPromise = initPublicFiles(config)
 
-  const { root, server: serverConfig } = config
+  const { root, entryRoot, server: serverConfig } = config
   const httpsOptions = await resolveHttpsConfig(config.server.https)
   const { middlewareMode } = serverConfig
 
@@ -905,7 +905,7 @@ export async function _createServer(
   if (config.appType === 'spa' || config.appType === 'mpa') {
     middlewares.use(
       htmlFallbackMiddleware(
-        root,
+        entryRoot,
         config.appType === 'spa',
         getFsUtils(config),
       ),
@@ -919,7 +919,7 @@ export async function _createServer(
 
   if (config.appType === 'spa' || config.appType === 'mpa') {
     // transform index.html
-    middlewares.use(indexHtmlMiddleware(root, server))
+    middlewares.use(indexHtmlMiddleware(entryRoot, server))
 
     // handle 404s
     middlewares.use(notFoundMiddleware())

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -435,7 +435,14 @@ export function indexHtmlMiddleware(
         try {
           let html = await fsp.readFile(filePath, 'utf-8')
           if (isDev) {
-            html = await server.transformIndexHtml(url, html, req.originalUrl)
+            const resolvedUrl =
+              '/' + path.relative(server.config.root, filePath)
+
+            html = await server.transformIndexHtml(
+              resolvedUrl,
+              html,
+              req.originalUrl,
+            )
           }
           return send(req, res, html, 'html', { headers })
         } catch (e) {

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -100,7 +100,7 @@ function getHtmlFilename(url: string, server: ViteDevServer) {
     return decodeURIComponent(fsPathFromId(url))
   } else {
     return decodeURIComponent(
-      normalizePath(path.join(server.config.entryRoot, url.slice(1))),
+      normalizePath(path.join(server.config.root, url.slice(1))),
     )
   }
 }

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -100,7 +100,7 @@ function getHtmlFilename(url: string, server: ViteDevServer) {
     return decodeURIComponent(fsPathFromId(url))
   } else {
     return decodeURIComponent(
-      normalizePath(path.join(server.config.root, url.slice(1))),
+      normalizePath(path.join(server.config.entryRoot, url.slice(1))),
     )
   }
 }


### PR DESCRIPTION
### Description

The `entryRoot` option allows customization of Vite's dev server and its Rollup build.

- For the dev server, it determines the root directory used by the `htmlFallbackMiddleware` and `indexHtmlMiddleware` handlers. This means I can place my `index.html` file in the `src` directory and Vite will resolve `/` requests to it as long as I set `entryRoot: "src"` in my Vite config. In the same scenario, any other `.html` files in my `src` directory will be resolved as expected.

  - For example, when `/foo` is requested, the dev server will look for the `src/foo.html` file. When `/foo/` is requested, it looks for `src/foo/index.html` file. Previously, the dev server would look in the project root, so I would need a `./foo` directory instead of a `./src/foo` directory (not ideal).

- For the Rollup build, `entryRoot` determines the root directory from which the default `index.html` entry is resolved. The `lib.entry` and `ssr` options are also resolved this way.

Note that if the `entryRoot` is not absolute, it's resolved like so:
```
path.resolve(config.root, entryRoot)
```

Opening this PR as a draft since I haven't written tests or updated the docs. Also I'd like some feedback before doing those things.

Fixes #306