### PR TITLE
fix(build): make SystemJSWrapRE match lazy

### DIFF
--- a/packages/vite/src/node/plugins/completeSystemWrap.ts
+++ b/packages/vite/src/node/plugins/completeSystemWrap.ts
@@ -4,7 +4,7 @@ import type { Plugin } from '../plugin'
  * make sure systemjs register wrap to had complete parameters in system format
  */
 export function completeSystemWrapPlugin(): Plugin {
-  const SystemJSWrapRE = /System.register\(.*(\(exports\)|\(\))/g
+  const SystemJSWrapRE = /System.register\(.*?(\(exports\)|\(\))/g
 
   return {
     name: 'vite:force-systemjs-wrap-complete',


### PR DESCRIPTION
### Description

fix: https://github.com/vitejs/vite/issues/16632

When ` build.rollupOptions.compact ` is set to true, ` /System.register\(. *(\(exports\)|\(\))/g ` will match to the first line of  `( )`. 
![image](https://github.com/vitejs/vite/assets/51915214/ccf96c7e-03c1-41b8-8d9d-25e20ca73ff2)

```js
const code = `System.register([],(function(exports){'use strict';return{execute:(function(){var __vite_style__ = document.createElement('style');__vite_style__.textContent = "\n.read-the-docs[data-v-1d5be6d4] {\n  color: #888;\n}\n\n.logo[data-v-58aba71c] {\n  height: 6em;\n  padding: 1.5em;\n  will-change: filter;\n  transition: filter 300ms;\n}\n.logo[data-v-58aba71c]:hover {\n  filter: drop-shadow(0 0 2em #646cffaa);\n}\n.logo.vue[data-v-58aba71c]:hover {\n  filter: drop-shadow(0 0 2em #42b883aa);\n}\n";document.head.appendChild(__vite_style__);/**
* @vue/shared v3.4.27`;
const res = code.replace(/System.register\(.*(\(exports\)|\(\))/g, (match, s1) => {
    console.log(s1) // '()'
})
```
It will incorrectly take ` (export, module) ` as argument to the ` execute ` function.
![image](https://github.com/vitejs/vite/assets/51915214/16186b7e-8e6a-4bac-b726-dfe99daaa0b1)


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
