### PR TITLE
fix: better port inuse detection

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -152,19 +152,23 @@ export async function httpServerStart(
   let { port, strictPort, host, logger } = serverOptions
 
   return new Promise((resolve, reject) => {
-    const onError = (e: Error & { code?: string }) => {
-      if (e.code === 'EADDRINUSE') {
-        if (strictPort) {
-          httpServer.removeListener('error', onError)
-          reject(new Error(`Port ${port} is already in use`))
+    const createErrorHandler = (host: string, reject: any) => {
+      const onError = (e: Error & { code?: string }) => {
+        if (e.code === 'EADDRINUSE') {
+          if (strictPort) {
+            httpServer.removeListener('error', onError)
+            reject(new Error(`Port ${port} is already in use`))
+          } else {
+            logger.info(`Port ${port} is in use, trying another one...`)
+            httpServer.listen(++port, host)
+          }
         } else {
-          logger.info(`Port ${port} is in use, trying another one...`)
-          httpServer.listen(++port, host)
+          httpServer.removeListener('error', onError)
+          reject(e)
         }
-      } else {
-        httpServer.removeListener('error', onError)
-        reject(e)
       }
+
+      return onError
     }
 
     ;(async () => {
@@ -175,8 +179,8 @@ export async function httpServerStart(
 
         for (;;) {
           allGood = true
-
-          if (hosts.length === 0) {
+          if (hosts.length === 0 || strictPort) {
+            // strictPort is true, we don't care if the port is in use
             break
           }
           for (const host of hosts) {
@@ -206,9 +210,18 @@ export async function httpServerStart(
           port++
         }
       } else {
-        httpServer.on('error', onError)
+        await new Promise((resolve, reject) => {
+          const onError = createErrorHandler(host!, reject)
+          httpServer.on('error', onError)
+          httpServer.listen(port, '0.0.0.0', () => {
+            resolve(null)
+            httpServer.close()
+          })
+        })
       }
 
+      const onError = createErrorHandler(host!, reject)
+      httpServer.on('error', onError)
       httpServer.listen(port, host, () => {
         httpServer.removeListener('error', onError)
         resolve(port)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -955,6 +955,32 @@ export async function resolveHostname(
   return { host, name }
 }
 
+export function resolveHosts(): string[] {
+  const hosts: string[] = []
+
+  Object.values(os.networkInterfaces())
+    .flatMap((nInterface) => nInterface ?? [])
+    .filter(
+      (detail) =>
+        detail &&
+        detail.address &&
+        (detail.family === 'IPv4' ||
+          // @ts-expect-error Node 18.0 - 18.3 returns number
+          detail.family === 4),
+    )
+    .forEach((detail) => {
+      let host = detail.address.replace('127.0.0.1', 'localhost')
+      // ipv6 host
+      if (host.includes(':')) {
+        host = `[${host}]`
+      }
+
+      hosts.push(host)
+    })
+
+  return hosts
+}
+
 export async function resolveServerUrls(
   server: Server,
   options: CommonServerOptions,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->


If you have lets say "localhost:5173" is taken by another process, but you set the host to `0.0.0.0` and listen to the same port, vite will not be able to detect the port is in use, and `localhost:5173` is not actually listened by vite as of now.
This PR addressed that by check every single address with the port to detect any of the address with the port was taken


follow up of #10651
Fixed #10638 