### PR TITLE
fix: account for jsx imports in config bundling

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1188,7 +1188,7 @@ async function bundleConfigFile(
       {
         name: 'inject-file-scope-variables',
         setup(build) {
-          build.onLoad({ filter: /\.[cm]?[jt]s$/ }, async (args) => {
+          build.onLoad({ filter: /\.[cm]?[jt]sx?$/ }, async (args) => {
             const contents = await fsp.readFile(args.path, 'utf-8')
             const injectValues =
               `const ${dirnameVarName} = ${JSON.stringify(
@@ -1200,7 +1200,7 @@ async function bundleConfigFile(
               )};`
 
             return {
-              loader: args.path.endsWith('ts') ? 'ts' : 'js',
+              loader: /tsx?$/.test(args.path) ? 'ts' : 'js',
               contents: injectValues + contents,
             }
           })


### PR DESCRIPTION
### Description

Seems that when importing JSX files in `vite.config.{js.ts}`, the injection of file scope variables do not work. This PR fixes that.

#### Example

```tsx
// foo.tsx
console.log(import.meta.url)
//          ^? ReferenceError: __vite_injected_original_import_meta_url is not defined
```

```tsx
// vite.config.ts
import './foo'
```