### PR TITLE
chore: patch http-proxy compatible with node22

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     },
     "patchedDependencies": {
       "chokidar@3.6.0": "patches/chokidar@3.6.0.patch",
-      "sirv@2.0.4": "patches/sirv@2.0.4.patch"
+      "sirv@2.0.4": "patches/sirv@2.0.4.patch",
+      "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/patches/http-proxy@1.18.1.patch
+++ b/patches/http-proxy@1.18.1.patch
@@ -1,0 +1,46 @@
+diff --git a/lib/http-proxy/common.js b/lib/http-proxy/common.js
+index 6513e81d80d5250ea249ea833f819ece67897c7e..486d4c896d65a3bb7cf63307af68facb3ddb886b 100644
+--- a/lib/http-proxy/common.js
++++ b/lib/http-proxy/common.js
+@@ -1,6 +1,5 @@
+ var common   = exports,
+     url      = require('url'),
+-    extend   = require('util')._extend,
+     required = require('requires-port');
+ 
+ var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
+@@ -40,10 +39,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
+   );
+ 
+   outgoing.method = options.method || req.method;
+-  outgoing.headers = extend({}, req.headers);
++  outgoing.headers = Object.assign({}, req.headers);
+ 
+   if (options.headers){
+-    extend(outgoing.headers, options.headers);
++    Object.assign(outgoing.headers, options.headers);
+   }
+ 
+   if (options.auth) {
+diff --git a/lib/http-proxy/index.js b/lib/http-proxy/index.js
+index 977a4b3622b9eaac27689f06347ea4c5173a96cd..88b2d0fcfa03c3aafa47c7e6d38e64412c45a7cc 100644
+--- a/lib/http-proxy/index.js
++++ b/lib/http-proxy/index.js
+@@ -1,5 +1,4 @@
+ var httpProxy = module.exports,
+-    extend    = require('util')._extend,
+     parse_url = require('url').parse,
+     EE3       = require('eventemitter3'),
+     http      = require('http'),
+@@ -47,9 +46,9 @@ function createRightProxy(type) {
+         args[cntr] !== res
+       ) {
+         //Copy global options
+-        requestOptions = extend({}, options);
++        requestOptions = Object.assign({}, options);
+         //Overwrite with request options
+-        extend(requestOptions, args[cntr]);
++        Object.assign(requestOptions, args[cntr]);
+ 
+         cntr--;
+       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ patchedDependencies:
   chokidar@3.6.0:
     hash: bckcfsslxcffppz65mxcq6naau
     path: patches/chokidar@3.6.0.patch
+  http-proxy@1.18.1:
+    hash: qqiqxx62zlcu62nljjmhlvexni
+    path: patches/http-proxy@1.18.1.patch
   sirv@2.0.4:
     hash: amdes53ifqfntejkflpaq5ifce
     path: patches/sirv@2.0.4.patch
@@ -344,7 +347,7 @@ importers:
         version: 3.3.2
       http-proxy:
         specifier: ^1.18.1
-        version: 1.18.1(debug@4.3.4)
+        version: 1.18.1(patch_hash=qqiqxx62zlcu62nljjmhlvexni)(debug@4.3.4)
       launch-editor-middleware:
         specifier: ^2.6.1
         version: 2.6.1
@@ -7182,7 +7185,7 @@ packages:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  /http-proxy@1.18.1(debug@4.3.4):
+  /http-proxy@1.18.1(patch_hash=qqiqxx62zlcu62nljjmhlvexni)(debug@4.3.4):
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
@@ -7192,6 +7195,7 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
+    patched: true
 
   /https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}


### PR DESCRIPTION
### Description
fix #16652

node22 deprecated the `_extend` method of the util module. The `http_proxy` package is useful for this method, but the `http_proxy` package seems to have not been updated for a long time, so it seems more convenient to directly create a patch file to solve this problem.

https://github.com/nodejs/node/pull/50488
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
