### PR TITLE
fix(css): only use files the current bundle contains

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -848,9 +848,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             .map((chunk) => [chunk.preliminaryFileName, chunk.fileName]),
         )
 
-        const pureCssChunkNames = [...pureCssChunks].map(
-          (pureCssChunk) => prelimaryNameToChunkMap[pureCssChunk.fileName],
-        )
+        // When running in watch mode the generateBundle is called once per output format
+        // in this case the `bundle` is not populated with the other output files
+        // but they are still in `pureCssChunks`.
+        // So we need to filter the names and only use those who are defined
+        const pureCssChunkNames = [...pureCssChunks]
+          .map((pureCssChunk) => prelimaryNameToChunkMap[pureCssChunk.fileName])
+          .filter(Boolean)
 
         const replaceEmptyChunk = getEmptyChunkReplacer(
           pureCssChunkNames,


### PR DESCRIPTION
### Description

If using multiple output formats like `es` and `cjs` and running vite in watch mode, then `generateBundle` will be called once per output format. The bundle on each call only contains the files for the current output format, but our `pureCSSChunks` contain all files (from all output formats). So we need to filter the chunk list to only contain valid files, as otherwise `basename` will fail with:

> The "path" argument must be of type string. Received undefined

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->


<details>
Output when adding console output:

```js
// console.warn(pureCssChunkNames)
[
  'chunks/NcMentionBubble.vue_vue_type_style_index_0_scoped_791c3b28_lang-D4yLtEdw.mjs',
  'chunks/NcRichText.vue_vue_type_style_index_0_scoped_6233f030_lang-CHHaElsZ.mjs',
  undefined,
  undefined
]
// console.warn([...pureCssChunks].map(c => c.fileName))
[
  'chunks/NcMentionBubble.vue_vue_type_style_index_0_scoped_791c3b28_lang-!~{00R}~.mjs',
  'chunks/NcRichText.vue_vue_type_style_index_0_scoped_6233f030_lang-!~{019}~.mjs',
  'chunks/NcMentionBubble.vue_vue_type_style_index_0_scoped_791c3b28_lang-!~{00R}~.cjs',
  'chunks/NcRichText.vue_vue_type_style_index_0_scoped_6233f030_lang-!~{019}~.cjs'
]
// Now the build fails with:
// [vite:css-post] The "path" argument must be of type string. Received undefined

// Here the second run for cjs is now running
// console.warn(pureCssChunkNames)
[
  undefined,
  undefined,
  'chunks/NcMentionBubble.vue_vue_type_style_index_0_scoped_791c3b28_lang-TWgAPFkJ.cjs',
  'chunks/NcRichText.vue_vue_type_style_index_0_scoped_6233f030_lang-D6wotsd_.cjs'
]
// console.warn([...pureCssChunks].map(c => c.fileName))
[
  'chunks/NcMentionBubble.vue_vue_type_style_index_0_scoped_791c3b28_lang-!~{00R}~.mjs',
  'chunks/NcRichText.vue_vue_type_style_index_0_scoped_6233f030_lang-!~{019}~.mjs',
  'chunks/NcMentionBubble.vue_vue_type_style_index_0_scoped_791c3b28_lang-!~{00R}~.cjs',
  'chunks/NcRichText.vue_vue_type_style_index_0_scoped_6233f030_lang-!~{019}~.cjs'
]
```

</details>