### PR TITLE
fix: mention `build.rollupOptions.output.manualChunks` instead of  `build.rollupOutput.manualChunks`

### DIFF
--- a/packages/vite/src/node/plugins/splitVendorChunk.ts
+++ b/packages/vite/src/node/plugins/splitVendorChunk.ts
@@ -27,7 +27,7 @@ export const isCSSRequest = (request: string): boolean =>
 // Don't use this manualChunks strategy for ssr, lib mode, and 'umd' or 'iife'
 
 /**
- * @deprecated use build.rollupOutput.manualChunks or framework specific configuration
+ * @deprecated use build.rollupOptions.output.manualChunks or framework specific configuration
  */
 export class SplitVendorChunkCache {
   cache: Map<string, boolean>
@@ -40,7 +40,7 @@ export class SplitVendorChunkCache {
 }
 
 /**
- * @deprecated use build.rollupOutput.manualChunks or framework specific configuration
+ * @deprecated use build.rollupOptions.output.manualChunks or framework specific configuration
  */
 export function splitVendorChunk(
   options: { cache?: SplitVendorChunkCache } = {},
@@ -94,7 +94,7 @@ function staticImportedByEntry(
 }
 
 /**
- * @deprecated use build.rollupOutput.manualChunks or framework specific configuration
+ * @deprecated use build.rollupOptions.output.manualChunks or framework specific configuration
  */
 export function splitVendorChunkPlugin(): Plugin {
   const caches: SplitVendorChunkCache[] = []


### PR DESCRIPTION
### Description

This is just fixing comment, but according to type definition, `build.rollupOutput` is not exists.
The correct term appears to be build.rollupOutput.manualChunks at least my environment.


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
