### PR TITLE
fix: prevent unhandledRejection if `--open` fails

### DIFF
--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -125,9 +125,11 @@ async function startBrowserProcess(
       : {}
 
     new Promise((_, reject) => {
-      open(url, options).then((subprocess) => {
-        subprocess.on('error', reject)
-      })
+      open(url, options)
+        .then((subprocess) => {
+          subprocess.on('error', reject)
+        })
+        .catch(reject)
     }).catch((err) => {
       logger.error(err.stack || err.message)
     })


### PR DESCRIPTION
### Description

Apparently the catch doesn't work unless you pass in `wait: true` in options for `open`, but doing so seems to do some other stuff as well which may not be desired so did it this way

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
