### PR TITLE
feat: back to environmentPlugins hook

### DIFF
--- a/docs/guide/api-vite-environment.md
+++ b/docs/guide/api-vite-environment.md
@@ -58,12 +58,12 @@ class DevEnvironment {
    * Resolved plugins for this environment, including the ones
    * created using the per-environment `create` hook
    */
-  plugins: IsolatedPlugin[]
+  plugins: EnvironmentPlugin[]
   /**
    * Allows to resolve, load, and transform code through the
    * environment plugins pipeline
    */
-  pluginContainer: IsolatedPluginContatiner
+  pluginContainer: EnvironmentPluginContainer
   /**
    * Resolved config options for this environment. Options at the server
    * global scope are taken as defaults for all environments, and can
@@ -888,19 +888,19 @@ function myPlugin() {
   // Share state among all environments in dev and build
   const sharedState = ...
 
-  const plugin = (environment) => {
-    // Isolated state for each environment during dev and build
-    const isolatedState = ...
-
-    return {
-      name: 'isolated-plugin',
-      transform(code, id) { ... }
-    }
+  return {
+    name: 'with-environment-plugins',
+    environmentPlugins(environment) {
+      // Isolated state for each environment during dev and build
+      const isolatedState = ...
+      return {
+        name: 'per-environment-plugin',
+        transform(code, id) { ... },
+      }
+    },
+    // Opt-in into a single instance for all environments
+    sharedDuringBuild: true
   }
-
-  // Opt-in into a single instance for all environments
-  plugin.sharedDuringBuild = true
-  return plugin
 }
 ```
 

--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -1,7 +1,7 @@
 import colors from 'picocolors'
 import type { Logger } from './logger'
 import type { ResolvedConfig, ResolvedEnvironmentOptions } from './config'
-import type { IsolatedPlugin } from './plugin'
+import type { EnvironmentPlugin } from './plugin'
 
 export class Environment {
   name: string
@@ -9,7 +9,7 @@ export class Environment {
   config: ResolvedConfig
   options: ResolvedEnvironmentOptions
 
-  get plugins(): IsolatedPlugin[] {
+  get plugins(): EnvironmentPlugin[] {
     if (!this._plugins)
       throw new Error(
         `${this.name} environment.plugins called before initialized`,
@@ -19,7 +19,7 @@ export class Environment {
   /**
    * @internal
    */
-  _plugins: IsolatedPlugin[] | undefined
+  _plugins: EnvironmentPlugin[] | undefined
   /**
    * @internal
    */

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -3,8 +3,8 @@ import aliasPlugin from '@rollup/plugin-alias'
 import type { ResolvedConfig } from './config'
 import type { Environment } from './environment'
 import type { PluginEnvironment } from './plugin'
-import type { IsolatedPluginContainer } from './server/pluginContainer'
-import { createIsolatedPluginContainer } from './server/pluginContainer'
+import type { EnvironmentPluginContainer } from './server/pluginContainer'
+import { createEnvironmentPluginContainer } from './server/pluginContainer'
 import { resolvePlugin } from './plugins/resolve'
 import type { InternalResolveOptions } from './plugins/resolve'
 import { getFsUtils } from './fsUtils'
@@ -26,7 +26,7 @@ export function createIdResolver(
 ): ResolveIdFn {
   const scan = options?.scan
 
-  const pluginContainerMap = new Map<Environment, IsolatedPluginContainer>()
+  const pluginContainerMap = new Map<Environment, EnvironmentPluginContainer>()
   async function resolve(
     environment: PluginEnvironment,
     id: string,
@@ -34,7 +34,7 @@ export function createIdResolver(
   ): Promise<PartialResolvedId | null> {
     let pluginContainer = pluginContainerMap.get(environment)
     if (!pluginContainer) {
-      pluginContainer = await createIsolatedPluginContainer(environment, [
+      pluginContainer = await createEnvironmentPluginContainer(environment, [
         aliasPlugin({ entries: config.resolve.alias }), // TODO: resolve.alias per environment?
         resolvePlugin({
           root: config.root,
@@ -56,7 +56,7 @@ export function createIdResolver(
 
   const aliasOnlyPluginContainerMap = new Map<
     Environment,
-    IsolatedPluginContainer
+    EnvironmentPluginContainer
   >()
   async function resolveAlias(
     environment: PluginEnvironment,
@@ -65,7 +65,7 @@ export function createIdResolver(
   ): Promise<PartialResolvedId | null> {
     let pluginContainer = aliasOnlyPluginContainerMap.get(environment)
     if (!pluginContainer) {
-      pluginContainer = await createIsolatedPluginContainer(environment, [
+      pluginContainer = await createEnvironmentPluginContainer(environment, [
         aliasPlugin({ entries: config.resolve.alias }), // TODO: resolve.alias per environment?
       ])
       aliasOnlyPluginContainerMap.set(environment, pluginContainer)

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -96,12 +96,7 @@ export type {
   SSROptions,
   SSRTarget,
 } from './ssr'
-export type {
-  IsolatedPlugin,
-  IsolatedPluginConstructor,
-  Plugin,
-  HookHandler,
-} from './plugin'
+export type { EnvironmentPlugin, Plugin, HookHandler } from './plugin'
 export type {
   Logger,
   LogOptions,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -35,9 +35,9 @@ import {
   virtualModulePrefix,
   virtualModuleRE,
 } from '../utils'
-import { resolveIsolatedPlugins } from '../plugin'
-import type { IsolatedPluginContainer } from '../server/pluginContainer'
-import { createIsolatedPluginContainer } from '../server/pluginContainer'
+import { resolveEnvironmentPlugins } from '../plugin'
+import type { EnvironmentPluginContainer } from '../server/pluginContainer'
+import { createEnvironmentPluginContainer } from '../server/pluginContainer'
 import { Environment } from '../environment'
 import type { DevEnvironment } from '../server/environment'
 import { transformGlobImport } from '../plugins/importMetaGlob'
@@ -47,7 +47,7 @@ import { loadTsconfigJsonForFile } from '../plugins/esbuild'
 export class ScanEnvironment extends Environment {
   mode = 'scan' as const
 
-  get pluginContainer(): IsolatedPluginContainer {
+  get pluginContainer(): EnvironmentPluginContainer {
     if (!this._pluginContainer)
       throw new Error(
         `${this.name} environment.pluginContainer called before initialized`,
@@ -57,15 +57,15 @@ export class ScanEnvironment extends Environment {
   /**
    * @internal
    */
-  _pluginContainer: IsolatedPluginContainer | undefined
+  _pluginContainer: EnvironmentPluginContainer | undefined
 
   async init(): Promise<void> {
     if (this._inited) {
       return
     }
     this._inited = true
-    this._plugins = await resolveIsolatedPlugins(this)
-    this._pluginContainer = await createIsolatedPluginContainer(
+    this._plugins = await resolveEnvironmentPlugins(this)
+    this._pluginContainer = await createEnvironmentPluginContainer(
       this,
       this.plugins,
     )
@@ -101,7 +101,7 @@ export function devToScanEnvironment(
 }
 
 type ResolveIdOptions = Omit<
-  Parameters<IsolatedPluginContainer['resolveId']>[2],
+  Parameters<EnvironmentPluginContainer['resolveId']>[2],
   'environment'
 >
 

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -307,7 +307,7 @@ function handleParseError(
  */
 export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
   const [preHooks, normalHooks, postHooks] = resolveHtmlTransforms(
-    config.plugins.filter((plugin) => typeof plugin !== 'function') as Plugin[],
+    config.plugins,
     config.logger,
   )
   preHooks.unshift(injectCspNonceMetaTagHook(config))

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -2,12 +2,7 @@ import aliasPlugin, { type ResolverFunction } from '@rollup/plugin-alias'
 import type { ObjectHook } from 'rollup'
 import type { PluginHookUtils, ResolvedConfig } from '../config'
 import { isDepsOptimizerEnabled } from '../config'
-import type {
-  HookHandler,
-  IsolatedPluginConstructor,
-  Plugin,
-  PluginWithRequiredHook,
-} from '../plugin'
+import type { HookHandler, Plugin, PluginWithRequiredHook } from '../plugin'
 import { watchPackageDataPlugin } from '../packages'
 import { getFsUtils } from '../fsUtils'
 import { jsonPlugin } from './json'
@@ -36,7 +31,7 @@ export async function resolvePlugins(
   prePlugins: Plugin[],
   normalPlugins: Plugin[],
   postPlugins: Plugin[],
-): Promise<(Plugin | IsolatedPluginConstructor)[]> {
+): Promise<Plugin[]> {
   const isBuild = config.command === 'build'
   const isWorker = config.isWorker
   const buildPlugins = isBuild
@@ -115,7 +110,7 @@ export async function resolvePlugins(
           importAnalysisPlugin(config),
           // TODO: loadFallbackPlugin(config),
         ]),
-  ].filter(Boolean) as (Plugin | IsolatedPluginConstructor)[]
+  ].filter(Boolean) as Plugin[]
 }
 
 export function createPluginHookUtils(

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -26,7 +26,6 @@ import { indexHtmlMiddleware } from './server/middlewares/indexHtml'
 import { notFoundMiddleware } from './server/middlewares/notFound'
 import { proxyMiddleware } from './server/middlewares/proxy'
 import { resolveHostname, resolveServerUrls, shouldServeFile } from './utils'
-import type { Plugin } from './plugin'
 import { printServerUrls } from './logger'
 import { bindCLIShortcuts } from './shortcuts'
 import type { BindCLIShortcutsOptions } from './shortcuts'
@@ -115,13 +114,10 @@ export async function preview(
   const clientOutDir =
     config.environments.client.build.outDir ?? config.build.outDir
   const distDir = path.resolve(config.root, clientOutDir)
-  const plugins = config.plugins.filter(
-    (plugin) => typeof plugin !== 'function',
-  ) as Plugin[]
   if (
     !fs.existsSync(distDir) &&
     // error if no plugins implement `configurePreviewServer`
-    plugins.every((plugin) => !plugin.configurePreviewServer) &&
+    config.plugins.every((plugin) => !plugin.configurePreviewServer) &&
     // error if called in CLI only. programmatic usage could access `httpServer`
     // and affect file serving
     process.argv[1]?.endsWith(path.normalize('bin/vite.js')) &&

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -16,7 +16,7 @@ import {
   createDepsOptimizer,
   createExplicitDepsOptimizer,
 } from '../optimizer/optimizer'
-import { resolveIsolatedPlugins } from '../plugin'
+import { resolveEnvironmentPlugins } from '../plugin'
 import type { DepsOptimizer } from '../optimizer'
 import { EnvironmentModuleGraph } from './moduleGraph'
 import type { HMRChannel } from './hmr'
@@ -25,10 +25,10 @@ import { transformRequest } from './transformRequest'
 import type { TransformResult } from './transformRequest'
 import {
   ERR_CLOSED_SERVER,
-  createIsolatedPluginContainer,
+  createEnvironmentPluginContainer,
 } from './pluginContainer'
 import type { RemoteEnvironmentTransport } from './environmentTransport'
-import type { IsolatedPluginContainer } from './pluginContainer'
+import type { EnvironmentPluginContainer } from './pluginContainer'
 
 export interface DevEnvironmentSetup {
   hot?: false | HMRChannel
@@ -52,7 +52,7 @@ export class DevEnvironment extends Environment {
    */
   _ssrRunnerOptions: FetchModuleOptions | undefined
 
-  get pluginContainer(): IsolatedPluginContainer {
+  get pluginContainer(): EnvironmentPluginContainer {
     if (!this._pluginContainer)
       throw new Error(
         `${this.name} environment.pluginContainer called before initialized`,
@@ -62,7 +62,7 @@ export class DevEnvironment extends Environment {
   /**
    * @internal
    */
-  _pluginContainer: IsolatedPluginContainer | undefined
+  _pluginContainer: EnvironmentPluginContainer | undefined
 
   /**
    * TODO: should this be public?
@@ -165,8 +165,8 @@ export class DevEnvironment extends Environment {
       return
     }
     this._inited = true
-    this._plugins = await resolveIsolatedPlugins(this)
-    this._pluginContainer = await createIsolatedPluginContainer(
+    this._plugins = await resolveEnvironmentPlugins(this)
+    this._pluginContainer = await createEnvironmentPluginContainer(
       this,
       this._plugins,
     )

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -4,7 +4,6 @@ import MagicString from 'magic-string'
 import type { SourceMapInput } from 'rollup'
 import type { Connect } from 'dep-types/connect'
 import type { DefaultTreeAdapterMap, Token } from 'parse5'
-import type { Plugin } from '../../plugin'
 import type { IndexHtmlTransformHook } from '../../plugins/html'
 import {
   addToHTMLProxyCache,
@@ -67,8 +66,7 @@ export function createDevHtmlTransformFn(
   originalUrl?: string,
 ) => Promise<string> {
   const [preHooks, normalHooks, postHooks] = resolveHtmlTransforms(
-    // TODO: interaction between transformIndexHtml and plugin constructors
-    config.plugins.filter((plugin) => typeof plugin !== 'function') as Plugin[],
+    config.plugins,
     config.logger,
   )
   const transformHooks = [

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -61,7 +61,7 @@ import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
 import MagicString from 'magic-string'
 import type { FSWatcher } from 'chokidar'
 import colors from 'picocolors'
-import type { IsolatedPlugin, Plugin, PluginEnvironment } from '../plugin'
+import type { EnvironmentPlugin, Plugin, PluginEnvironment } from '../plugin'
 import {
   combineSourcemaps,
   createDebugger,
@@ -103,7 +103,7 @@ export interface PluginContainerOptions {
   writeFile?: (name: string, source: string | Uint8Array) => void
 }
 
-export interface IsolatedPluginContainer {
+export interface EnvironmentPluginContainer {
   options: InputOptions
   buildStart(options: InputOptions): Promise<void>
   resolveId(
@@ -146,11 +146,11 @@ type PluginContext = Omit<
  * instead of using environment.plugins to allow the creation of different
  * pipelines working with the same environment (used for createIdResolver).
  */
-export async function createIsolatedPluginContainer(
+export async function createEnvironmentPluginContainer(
   environment: PluginEnvironment,
-  plugins: IsolatedPlugin[],
+  plugins: EnvironmentPlugin[],
   watcher?: FSWatcher,
-): Promise<IsolatedPluginContainer> {
+): Promise<EnvironmentPluginContainer> {
   const {
     config,
     logger,


### PR DESCRIPTION
### Description

We're discussing about the API for per-environment plugins. We're seeing that using the functional version is making things quite hard for back compat and typing. This is an example returning a shared plugin and a per environment one

```js
function Plugin() {
  // shared state
  return [
    {
      name: 'sp',
      configureServer(server) { ... },
    },
    (environment) => {
      // per env state
      return {
        name: 'pep',
        load(id) { ... },
      }
    }
  ]
}
```

The function looks quite nice, especially for inline plugins, but it has issues:
- If we want to add a name, we need to use `Object.defineProperty()` (we would need this if we want to use per environment plugins in our internal plugins like `vite:reporter`, if we want to support filtering)
- related to this, `config.plugins` will be a mix of `Plugin | IsolatedPluginConstructor`, and it breaks several ecosystem usage.
- `apply` in the function and `apply` in the object with same name but diff meaning
- I tried to implement `enforce` in the returned plugins, respecting the original position but is is really hard to do and full with edge cases. So we actually need `enforce` at the function plugins level.

We are thinking to get back to using a new hook to inject per environment plugins instead 
```js
function Plugin() {
  // shared state
  return {
    name: 'sp',
    configureServer(server) { ... },
    environmentPlugins(environment) {
      // per env state
      return {
        name: 'pep',
        load(id) { ... },
      }
    }
  }
}
```
This should still be quite nice for authoring, and it is explicit given the new hook name. A shared plugin can both have `configureServer` and return per environment plugins without the need of an array. All other plugin fields work as expected (`enforce`, `apply`, `name`, etc).
It was still good to try both options. The object form plus new hook is easier to work with for back compat. There may be some cases where ignoring the `environmentPlugins` hook could cause issues, but in most cases of `config.plugins` modification, it will work as is.