### PR TITLE
fix: avoid duplicating values in shared optimizeDeps config

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -950,10 +950,8 @@ export async function resolveConfig(
 
   // Backward compatibility: merge environments.client.dev.optimizeDeps back into optimizeDeps
   const resolvedConfigEnvironmentsClient = resolvedEnvironments.client
-  const patchedOptimizeDeps = mergeConfig(
-    config.optimizeDeps ?? {},
-    resolvedConfigEnvironmentsClient.dev?.optimizeDeps ?? {},
-  )
+  const patchedOptimizeDeps =
+    resolvedConfigEnvironmentsClient.dev?.optimizeDeps ?? {}
   const backwardCompatibleOptimizeDeps = {
     holdUntilCrawlEnd: true,
     ...patchedOptimizeDeps,
@@ -983,10 +981,7 @@ export async function resolveConfig(
     ...config.ssr,
     external: resolvedEnvironments.ssr?.resolve.external,
     noExternal: resolvedEnvironments.ssr?.resolve.noExternal,
-    optimizeDeps: mergeConfig(
-      config.ssr?.optimizeDeps ?? {},
-      resolvedEnvironments.ssr?.dev?.optimizeDeps ?? {},
-    ),
+    optimizeDeps: resolvedEnvironments.ssr?.dev?.optimizeDeps,
     resolve: {
       ...config.ssr?.resolve,
       conditions: resolvedEnvironments.ssr?.resolve.conditions,


### PR DESCRIPTION
the initial environment config is created from the shared config. so if we merge it back to the shared config later, it duplicates values. Because it was created from the shared config, we don't have to merge it to retain the original values.

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
