### PR TITLE
chore: change vite conf 2023 replay link

### DIFF
--- a/docs/.vitepress/theme/components/AsideSponsors.vue
+++ b/docs/.vitepress/theme/components/AsideSponsors.vue
@@ -20,7 +20,7 @@ const sponsors = computed(() => {
 <template>
   <a
     class="viteconf"
-    href="https://viteconf.org/23/replay?utm=vite-sidebar"
+    href="https://www.youtube.com/playlist?list=PLqGQbXn_GDmkOsHI7-Wrbv1GgAA4tJZhg"
     target="_blank"
   >
     <img width="22" height="22" src="/viteconf.svg" />


### PR DESCRIPTION
### Description

For ViteConf 2023's replay link: 

The old one [`https://viteconf.org/23/replay?utm=vite-sidebar`](https://viteconf.org/23/replay?utm=vite-sidebar) is broken.

Maybe use [`https://www.youtube.com/playlist?list=PLqGQbXn_GDmkOsHI7-Wrbv1GgAA4tJZhg`](https://www.youtube.com/playlist?list=PLqGQbXn_GDmkOsHI7-Wrbv1GgAA4tJZhg) instead?

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
