### PR TITLE
feat(config): allow imports from local workspace tsconfig paths (#5370)

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1068,7 +1068,7 @@ async function getPathsFromClosestTsconfig(
   resolvedPath: string,
 ): Promise<string[]> {
   const { tsconfig } = await parse(resolvedPath)
-  const paths = tsconfig?.compilerOptions?.paths
+  const paths = tsconfig?.compilerOptions?.paths || {}
   return Object.keys(paths)
 }
 

--- a/playground/config/__tests__/config.spec.ts
+++ b/playground/config/__tests__/config.spec.ts
@@ -24,3 +24,32 @@ it('loadConfigFromFile', async () => {
     }
   `)
 })
+
+it('resolves imports of tsconfig paths on loadConfigFromFile', async () => {
+  const { config } = await loadConfigFromFile(
+    {} as any,
+    resolve(__dirname, '../packages/tsconfig-paths/vite.config.ts'),
+    resolve(__dirname, '../packages/tsconfig-paths'),
+  )
+
+  expect(config).toMatchInlineSnapshot(`
+    {
+      "array": [
+        [
+          1,
+          3,
+        ],
+        [
+          2,
+          4,
+        ],
+      ],
+      "foo": [
+        1,
+        2,
+        3,
+        4,
+      ],
+    }
+  `)
+})

--- a/playground/config/packages/tsconfig-paths/tsconfig.json
+++ b/playground/config/packages/tsconfig-paths/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["vite.config.ts"]
+}

--- a/playground/config/packages/tsconfig-paths/vite.config.ts
+++ b/playground/config/packages/tsconfig-paths/vite.config.ts
@@ -1,4 +1,7 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+// @ts-ignore
 import { array } from '@test/siblings'
+// @ts-ignore
 import { foo } from '@test/wildcard/foo'
 
 export default {

--- a/playground/config/packages/tsconfig-paths/vite.config.ts
+++ b/playground/config/packages/tsconfig-paths/vite.config.ts
@@ -1,0 +1,7 @@
+import { array } from '@test/siblings'
+import { foo } from '@test/wildcard/foo'
+
+export default {
+  array,
+  foo,
+}

--- a/playground/config/packages/wildcard/foo/index.ts
+++ b/playground/config/packages/wildcard/foo/index.ts
@@ -1,0 +1,1 @@
+export const foo = [1, 2, 3, 4]

--- a/playground/config/tsconfig.json
+++ b/playground/config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@test/siblings": ["packages/siblings/foo.ts"],
+      "@test/wildcard/*": ["packages/wildcard/*"]
+    }
+  }
+}


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Fixes #5370  nrwl/nx#17019 remix-run/remix#9171

Uses existing `tsconfck` dependency to loads the nearest tsconfig file if it exists, grabs any `paths` from `compilerOptions` and then makes sure these are not caught by the `externalise-deps` plugin when resolving imports in the config file.

This functionality is isolated to `loadConfigFromFile` so does not need to replicate functionality from `tsconfig-paths` or similar, nor does it duplicate any existing plugins like `vite-tsconfig-paths` or `@esbuild-plugins/tsconfig-paths`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
