### PR TITLE
feat: only shared plugins

### DIFF
--- a/packages/vite/src/node/__tests_dts__/plugin.ts
+++ b/packages/vite/src/node/__tests_dts__/plugin.ts
@@ -1,9 +1,9 @@
 /**
- * This is a developement only file for testing types.
+ * This is a development only file for testing types.
  */
 import type { Plugin as RollupPlugin } from 'rollup'
 import type { Equal, ExpectExtends, ExpectTrue } from '@type-challenges/utils'
-import type { EnvironmentPlugin, PluginContextExtension } from '../plugin'
+import type { Plugin, PluginContextExtension } from '../plugin'
 import type { ROLLUP_HOOKS } from '../constants'
 import type {
   GetHookContextMap,
@@ -11,7 +11,7 @@ import type {
   RollupPluginHooks,
 } from '../typeUtils'
 
-type EnvironmentPluginHooksContext = GetHookContextMap<EnvironmentPlugin>
+type EnvironmentPluginHooksContext = GetHookContextMap<Plugin>
 type EnvironmentPluginHooksContextMatched = {
   [K in keyof EnvironmentPluginHooksContext]: EnvironmentPluginHooksContext[K] extends PluginContextExtension
     ? never
@@ -19,20 +19,20 @@ type EnvironmentPluginHooksContextMatched = {
 }
 
 type HooksMissingExtension = NonNeverKeys<EnvironmentPluginHooksContextMatched>
-type HooksMissingInConstans = Exclude<
+type HooksMissingInConstants = Exclude<
   RollupPluginHooks,
   (typeof ROLLUP_HOOKS)[number]
 >
 
 export type cases = [
   // Ensure environment plugin hooks are superset of rollup plugin hooks
-  ExpectTrue<ExpectExtends<RollupPlugin, EnvironmentPlugin>>,
+  ExpectTrue<ExpectExtends<RollupPlugin, Plugin>>,
 
   // Ensure all Rollup hooks have Vite's plugin context extension
   ExpectTrue<Equal<HooksMissingExtension, never>>,
 
   // Ensure the `ROLLUP_HOOKS` constant is up-to-date
-  ExpectTrue<Equal<HooksMissingInConstans, never>>,
+  ExpectTrue<Equal<HooksMissingInConstants, never>>,
 ]
 
 export {}

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -1,7 +1,7 @@
 import colors from 'picocolors'
 import type { Logger } from './logger'
 import type { ResolvedConfig, ResolvedEnvironmentOptions } from './config'
-import type { EnvironmentPlugin } from './plugin'
+import type { Plugin } from './plugin'
 
 export class PartialEnvironment {
   name: string
@@ -61,7 +61,7 @@ export class PartialEnvironment {
 }
 
 export class BaseEnvironment extends PartialEnvironment {
-  get plugins(): EnvironmentPlugin[] {
+  get plugins(): Plugin[] {
     if (!this._plugins)
       throw new Error(
         `${this.name} environment.plugins called before initialized`,
@@ -72,7 +72,7 @@ export class BaseEnvironment extends PartialEnvironment {
   /**
    * @internal
    */
-  _plugins: EnvironmentPlugin[] | undefined
+  _plugins: Plugin[] | undefined
   /**
    * @internal
    */

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1480,12 +1480,13 @@ export class BuildEnvironment extends BaseEnvironment {
     super(name, config, options)
   }
 
+  // TODO: This could be sync, discuss if applyToEnvironment should support async
   async init(): Promise<void> {
     if (this._initiated) {
       return
     }
     this._initiated = true
-    this._plugins = await resolveEnvironmentPlugins(this)
+    this._plugins = resolveEnvironmentPlugins(this)
   }
 }
 

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -52,13 +52,7 @@ export type {
   DevEnvironmentOptions,
   ResolvedDevEnvironmentOptions,
 } from './config'
-export type {
-  EnvironmentPlugin,
-  Plugin,
-  EnvironmentPluginOptionArray,
-  PluginOption,
-  HookHandler,
-} from './plugin'
+export type { Plugin, PluginOption, HookHandler } from './plugin'
 export type { FilterPattern } from './utils'
 export type { CorsOptions, CorsOrigin, CommonServerOptions } from './http'
 export type {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -64,7 +64,7 @@ export class ScanEnvironment extends BaseEnvironment {
       return
     }
     this._initiated = true
-    this._plugins = await resolveEnvironmentPlugins(this)
+    this._plugins = resolveEnvironmentPlugins(this)
     this._pluginContainer = await createEnvironmentPluginContainer(
       this,
       this.plugins,

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -164,7 +164,7 @@ export class DevEnvironment extends BaseEnvironment {
       return
     }
     this._initiated = true
-    this._plugins = await resolveEnvironmentPlugins(this)
+    this._plugins = resolveEnvironmentPlugins(this)
     this._pluginContainer = await createEnvironmentPluginContainer(
       this,
       this._plugins,

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -61,7 +61,7 @@ import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
 import MagicString from 'magic-string'
 import type { FSWatcher } from 'chokidar'
 import colors from 'picocolors'
-import type { EnvironmentPlugin, Plugin } from '../plugin'
+import type { Plugin } from '../plugin'
 import {
   combineSourcemaps,
   createDebugger,
@@ -149,7 +149,7 @@ type PluginContext = Omit<
  */
 export async function createEnvironmentPluginContainer(
   environment: Environment,
-  plugins: EnvironmentPlugin[],
+  plugins: Plugin[],
   watcher?: FSWatcher,
 ): Promise<EnvironmentPluginContainer> {
   const {


### PR DESCRIPTION
We kept discussing about Environment Plugins today. Especially from the perspective of a plugin author and we are finding the fact that we have two different plugin types hard to work with:

1. A plugin author may create a `UnoCssEnvironmentPlugin` that is a `(environment) => EnvironmentPlugin` to implement its internals. It can be used inside `environmentPlugins` but also exported. So the plugin will export both `UnoCssPlugin` and `UnoCssEnvironmentPlugin`. The user normally will use the shared plugin, and if it needs to have it per environment, it could use the `UnoCssEnvironmentPlugin`

Using the environment plugin sounds complex from the user side. It may not even be possible to do if there is some global configuration required without extra coordination. All plugins would also need to be reworked to expose both plugin types. We could think of `environmentPlugins` as an internal tool only, and not something we expose to users, but we can justify to add it in that case.

2. One of the benefits of Environment Plugins was having access to the `Environment` instance. So there is no need for `this.environment`. Local state can also be used without issues. There is no need for a `WeakMap<Environment, Data>` to avoid cross-environment pollution.

This is great, but at the same time, it pushes us to have two mental models when authoring plugins. Environment Plugins can't be added to the main pipeline, and Shared Plugins can't be safely added to the environment pipeline (because some hooks may not be executed).

So, we're rethinking if we need two kinds of plugins at all. It may be better to enforce the use of `this.environment` for all plugins so they can be used in multiple environments or in a single one without any issues.

Instead of the `environmentPlugins` hook or the `(environment) => EnvironmentPlugin` ideas, we could go back to environment filtering. This was discussed when we started working on the Environment API proposal, but at that point it seemed that it didn't fit well. `apply` is run before `config` so that hook can't be used.
The idea would be to keep only shared plugins, and add a new `applyForEnvironment(environment)` hook (name to be discussed)

```js
const UnoCssPlugin = () => {
  // shared global state
  return {
    buildStart() {
      // init per environment state with WeakMap<Environment,Data>, this.environmnet
      // we could also have this.data (the context is per plugin + environment already)
      // if we find a good way to type it
    },
    configureServer() {
      // use global hooks normally
    },
    applyForEnvironment(environment) {
      // return true if this plugin should be active in this environment
    },
    resolveId(id, importer) {
      // only called for enabled environments
    }
  }
}
```

We then have a single plugin type, and a way to define per environment plugins that don't diverge from current usage