### PR TITLE
feat: non nullable this.environment

### DIFF
--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -21,13 +21,6 @@ export function usePerEnvironmentState<State>(
   const stateMap = new WeakMap<Environment, State>()
   return function (context: PluginContext) {
     const { environment } = context
-    if (!environment) {
-      context.error(
-        new Error(
-          `Per environment state called with undefined environment. You may be using a Vite v6+ plugin in Vite v5 or Rollup.`,
-        ),
-      )
-    }
     let state = stateMap.get(environment)
     if (!state) {
       state = initial(environment)

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -8,7 +8,6 @@ export {
   resolveConfig,
   sortUserPlugins,
 } from './config'
-export { defineVitePlugin } from './plugin'
 export { createServer } from './server'
 export { preview } from './preview'
 export { build, createBuilder } from './build'
@@ -52,12 +51,7 @@ export type {
   DevEnvironmentOptions,
   ResolvedDevEnvironmentOptions,
 } from './config'
-export type {
-  Plugin,
-  PluginOption,
-  PluginWithEnvironment,
-  HookHandler,
-} from './plugin'
+export type { Plugin, PluginOption, HookHandler } from './plugin'
 export type { Environment } from './environment'
 export type { FilterPattern } from './utils'
 export type { CorsOptions, CorsOrigin, CommonServerOptions } from './http'

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -55,12 +55,8 @@ import type { Environment } from './environment'
 export interface PluginContextExtension {
   /**
    * Vite-specific environment instance
-   *
-   * Will always be defined in Vite 6+. Keep the type optional for backward compatible.
-   *
-   * @see TODO:link-to-docs
    */
-  environment?: Environment
+  environment: Environment
 }
 
 export interface PluginContext
@@ -328,35 +324,4 @@ export function resolveEnvironmentPlugins(environment: Environment): Plugin[] {
     (plugin) =>
       !plugin.applyToEnvironment || plugin.applyToEnvironment(environment),
   )
-}
-
-/**
- * Internal type to make sure `this.environment` is always defined
- *
- * Should be used via `defineVitePlugin`
- */
-export type PluginWithEnvironment = {
-  [K in keyof Plugin]: Plugin[K] extends ObjectHook<infer H>
-    ? ObjectHook<HandlerWithEnvironment<H>>
-    : HandlerWithEnvironment<Plugin[K]>
-}
-
-export type HandlerWithEnvironment<H> = H extends (
-  this: infer This,
-  ...args: infer Args
-) => infer Returns
-  ? This extends { environment?: Environment }
-    ? (this: This & { environment: Environment }, ...args: Args) => Returns
-    : H
-  : H
-
-/**
- * Type utility to define a Vite-specific plugin where `this.environment` is always defined.
- *
- * Should only be used when you expect the plugin **only** runs on Vite 6+.
- *
- * It does an internal cast to returns a Rollup-compatible plugin type so you can pass into the array as before.
- */
-export function defineVitePlugin(plugin: PluginWithEnvironment): Plugin {
-  return plugin as Plugin
 }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -227,8 +227,6 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
     },
 
     generateBundle(_, bundle) {
-      const environment = this.environment!
-
       // Remove empty entry point file
       for (const file in bundle) {
         const chunk = bundle[file]
@@ -243,7 +241,10 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       }
 
       // do not emit assets for SSR build
-      if (config.command === 'build' && !environment.options.build.emitAssets) {
+      if (
+        config.command === 'build' &&
+        !this.environment.options.build.emitAssets
+      ) {
         for (const file in bundle) {
           if (
             bundle[file].type === 'asset' &&

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -90,7 +90,6 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
       }
     },
     async transform(code, id, options) {
-      if (!this.environment) return
       // TODO: !environment.options.nodeCompatible ?
       // TODO: Remove options?.ssr, Vitest currently hijacks this plugin
       const ssr = options?.ssr ?? this.environment.name !== 'client'

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -556,7 +556,6 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
     },
 
     async renderChunk(code, chunk, opts) {
-      if (!this.environment) return
       const generatedAssets = generatedAssetsMap.get(this.environment)!
 
       let chunkCSS = ''

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -119,8 +119,6 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     name: 'vite:define',
 
     async transform(code, id) {
-      if (!this.environment) return
-
       if (this.environment.name === 'client' && !isBuild) {
         // for dev we inject actual global defines in the vite client to
         // avoid the transform cost. see the `clientInjection` and

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -328,7 +328,6 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
     async transform(html, id) {
       if (id.endsWith('.html')) {
-        if (!this.environment) return
         const { modulePreload } = this.environment.options.build
 
         id = normalizePath(id)
@@ -691,7 +690,6 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     },
 
     async generateBundle(options, bundle) {
-      if (!this.environment) return
       const { modulePreload } = this.environment.options.build
 
       const analyzedChunk: Map<OutputChunk, number> = new Map()

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -205,7 +205,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:import-analysis',
 
     async transform(source, importer) {
-      if (!this.environment) return
       const environment = this.environment as DevEnvironment
       const ssr = environment.name !== 'client' // TODO
       const moduleGraph = environment.moduleGraph

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -340,7 +340,6 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     },
 
     generateBundle({ format }, bundle) {
-      if (!this.environment) return
       const ssr = this.environment.name !== 'client' // TODO
       if (format !== 'es' || ssr || isWorker) {
         return

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -67,24 +67,23 @@ export function importGlobPlugin(config: ResolvedConfig): Plugin {
         config.logger,
       )
       if (result) {
-        if (this.environment) {
-          const allGlobs = result.matches.map((i) => i.globsResolved)
-          if (!importGlobMaps.has(this.environment)) {
-            importGlobMaps.set(this.environment, new Map())
-          }
-          importGlobMaps.get(this.environment)!.set(
-            id,
-            allGlobs.map((globs) => {
-              const affirmed: string[] = []
-              const negated: string[] = []
-
-              for (const glob of globs) {
-                ;(glob[0] === '!' ? negated : affirmed).push(glob)
-              }
-              return { affirmed, negated }
-            }),
-          )
+        const allGlobs = result.matches.map((i) => i.globsResolved)
+        if (!importGlobMaps.has(this.environment)) {
+          importGlobMaps.set(this.environment, new Map())
         }
+        importGlobMaps.get(this.environment)!.set(
+          id,
+          allGlobs.map((globs) => {
+            const affirmed: string[] = []
+            const negated: string[] = []
+
+            for (const glob of globs) {
+              ;(glob[0] === '!' ? negated : affirmed).push(glob)
+            }
+            return { affirmed, negated }
+          }),
+        )
+
         return transformStableResult(result.s, id, config)
       }
     },

--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -23,7 +23,6 @@ export function loadFallbackPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:load-fallback',
     async load(id, options) {
-      if (!this.environment) return
       const environment = this.environment as DevEnvironment
 
       let code: string | null = null

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -39,7 +39,6 @@ export function manifestPlugin(): Plugin {
     },
 
     generateBundle({ format }, bundle) {
-      if (!this.environment) return
       const { root } = this.environment.config
       const buildOptions = this.environment.options.build
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -217,7 +217,7 @@ export function resolvePlugin(
       // The resolve plugin is used for createIdResolver and the depsOptimizer should be
       // disabled in that case, so deps optimization is opt-in when creating the plugin.
       const depsOptimizer =
-        resolveOptions.optimizeDeps && this.environment?.mode === 'dev'
+        resolveOptions.optimizeDeps && this.environment.mode === 'dev'
           ? this.environment?.depsOptimizer
           : undefined
 
@@ -229,7 +229,7 @@ export function resolvePlugin(
       const isRequire: boolean =
         resolveOpts?.custom?.['node-resolve']?.isRequire ?? false
 
-      const environmentName = this.environment?.name ?? (ssr ? 'ssr' : 'client')
+      const environmentName = this.environment.name ?? (ssr ? 'ssr' : 'client')
       const currentEnvironmentOptions =
         this.environment?.options || environmentsOptions?.[environmentName]
       const environmentResolveOptions = currentEnvironmentOptions?.resolve
@@ -247,7 +247,7 @@ export function resolvePlugin(
         scan: resolveOpts?.scan ?? resolveOptions.scan,
       }
 
-      const depsOptimizerOptions = this.environment?.options.dev.optimizeDeps
+      const depsOptimizerOptions = this.environment.options.dev.optimizeDeps
 
       const resolvedImports = resolveSubpathImports(id, importer, options)
       if (resolvedImports) {
@@ -409,7 +409,7 @@ export function resolvePlugin(
       if (bareImportRE.test(id)) {
         const external =
           options.externalize &&
-          shouldExternalize(this.environment!, id, importer) // TODO
+          shouldExternalize(this.environment, id, importer)
         if (
           !external &&
           asSrc &&

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -76,7 +76,7 @@ async function bundleWorkerEntry(
     ...rollupOptions,
     input,
     plugins: resolvedPlugins.map((p) =>
-      injectEnvironmentToHooks(p, workerEnvironment),
+      injectEnvironmentToHooks(workerEnvironment, p),
     ),
     onwarn(warning, warn) {
       onRollupWarning(warning, warn, config)


### PR DESCRIPTION
### Description

We decided to try to make `this.environment` non-nullable, as we can still get a clear error message if a vite 6+ only plugin is used in a context it was not designed for.

For now, we are removing `defineVitePlugin` too. We could have a `defineRollupCompatiblePlugin` in the future but we don't think this is needed right now.

cc @bluwy 