### PR TITLE
Remove swc templates from Getting Started page

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -85,7 +85,7 @@ pnpm create vite my-vue-app --template vue
 bun create vite my-vue-app --template vue
 ```
 
-See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
+See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
 
 ## Community Templates
 


### PR DESCRIPTION
### Description

This commit removes the `react-swc-ts` and `react-swc` templates as they no longer exist.

However, I propose it should still be somehow mentioned that there is an option to use swc in place of Babel. I'm leaving the way to approach this up to discussion.
