### PR TITLE
docs: assign code for each deprecation changes, provide option to opt-in

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -264,6 +264,10 @@ export default defineConfig({
               text: 'Migration from v4',
               link: '/guide/migration',
             },
+            {
+              text: 'Deprecations Guide',
+              link: '/deprecations/',
+            },
           ],
         },
         {
@@ -327,6 +331,33 @@ export default defineConfig({
             {
               text: 'Worker Options',
               link: '/config/worker-options',
+            },
+          ],
+        },
+      ],
+      '/deprecations/': [
+        {
+          text: 'Deprecations Guide',
+          link: '/deprecations/',
+        },
+        {
+          text: 'Deprecations List',
+          items: [
+            {
+              text: 'VD001 - handleHotUpdate()',
+              link: '/deprecations/vd001',
+            },
+            {
+              text: 'VD002 - options.ssr',
+              link: '/deprecations/vd002',
+            },
+            {
+              text: 'VD003 - Dev Server APIs',
+              link: '/deprecations/vd003',
+            },
+            {
+              text: 'VD004 - ssrLoadModule',
+              link: '/deprecations/vd004',
             },
           ],
         },

--- a/docs/deprecations/index.md
+++ b/docs/deprecations/index.md
@@ -1,0 +1,5 @@
+# Deprecations Guide
+
+A list of guides for planned future deprecations/removals in Vite.
+
+// TODO:

--- a/docs/deprecations/vd001.md
+++ b/docs/deprecations/vd001.md
@@ -1,0 +1,23 @@
+# VD001 - Plugin Hook `handleHotUpdate`
+
+Deprecate plugin hook `handleHotUpdate` in favor of [`hotUpdate` hook](/guide/api-vite-environment#the-hotupdate-hook) to be Environment API aware, and handle additional watch events with `create` and `delete`.
+
+::: tip Future Deprecation
+The deprecation is plannde in the future, where you could start migrating your plugin to use the new API if you move fast. To identify your usage, set `future.deprecationWarnings.pluginHookHandleHotUpdate` to `true` in your vite config.
+:::
+
+Affect scope: `Vite Plugin Authors`
+
+| Stages           | Version                                  |
+| ---------------- | ---------------------------------------- |
+| First Introduced | `v6.0.0`                                 |
+| Deprecation      | (planned in `v7.0.0`)                    |
+| Feature Removal  | (currently no plan to remove completely) |
+
+## Motivation
+
+// TODO:
+
+## Migration Guide
+
+// TODO:

--- a/docs/deprecations/vd002.md
+++ b/docs/deprecations/vd002.md
@@ -42,4 +42,4 @@ export function myPlugin(): Plugin {
 }
 ```
 
-For a more robust long term implemtation, plugin should provide handling for [multiple environments](TODO).
+For a more robust long term implemtation, plugin should provide handling for [multiple environments](/guide/api-vite-environment.html#accessing-the-current-environment-in-hooks).

--- a/docs/deprecations/vd002.md
+++ b/docs/deprecations/vd002.md
@@ -1,0 +1,45 @@
+# VD002 - Plugin Hook Argument `options.ssr`
+
+Deprecate plugin hook argument `options.ssr` in `resolveId`, `load` and `transform` in favor of the `this.environment` plugin context property.
+
+::: tip Future Deprecation
+The deprecation is plannde in the future, where you could start migrating your plugin to use the new API if you move fast. To identify your usage, set `future.deprecationWarnings.pluginHookSsrArgument` to `true` in your vite config.
+:::
+
+Affect scope: `Vite Plugin Authors`
+
+| Stages           | Version                                  |
+| ---------------- | ---------------------------------------- |
+| First Introduced | `v6.0.0`                                 |
+| Deprecation      | (planned in `v7.0.0`)                    |
+| Feature Removal  | (currently no plan to remove completely) |
+
+## Motivation
+
+// TODO:
+
+## Migration Guide
+
+For the existing plugin to do a quick migration, replace the `options.ssr` argument with `this.environment.name !== 'client'` in the `resolveId`, `load` and `transform` hooks:
+
+```ts
+import { Plugin } from 'vite'
+
+export function myPlugin(): Plugin {
+  return {
+    name: 'my-plugin',
+    resolveId(id, importer, options) {
+      const isSSR = options.ssr // [!CODE --]
+      const isSSR = this.environment.name !== 'client' // [!CODE ++]
+
+      if (isSSR) {
+        // SSR specific logic
+      } else {
+        // Client specific logic
+      }
+    },
+  }
+}
+```
+
+For a more robust long term implemtation, plugin should provide handling for [multiple environments](TODO).

--- a/docs/deprecations/vd003.md
+++ b/docs/deprecations/vd003.md
@@ -1,0 +1,27 @@
+# VD003 - Dev Server APIs
+
+Multiple APIs from ViteDevServer related to module graph has replaced with more isolated Environment APIs.
+
+- `server.moduleGraph` -> [`environment.moduleGraph`](/guide/api-vite-environment#separate-module-graphs)
+- `server.transformRequest` -> `environment.transformRequest`
+- `server.resolve` -> `environment.resolve`
+
+::: tip Future Deprecation
+The deprecation is plannde in the future, where you could start migrating your plugin to use the new API if you move fast. To identify your usage, set `future.deprecationWarnings` in your vite config.
+:::
+
+Affect scope: `Vite Plugin Authors`
+
+| Stages           | Version                                  |
+| ---------------- | ---------------------------------------- |
+| First Introduced | `v6.0.0`                                 |
+| Deprecation      | (planned in `v7.0.0`)                    |
+| Feature Removal  | (currently no plan to remove completely) |
+
+## Motivation
+
+// TODO:
+
+## Migration Guide
+
+// TODO:

--- a/docs/deprecations/vd003.md
+++ b/docs/deprecations/vd003.md
@@ -4,7 +4,6 @@ Multiple APIs from ViteDevServer related to module graph has replaced with more 
 
 - `server.moduleGraph` -> [`environment.moduleGraph`](/guide/api-vite-environment#separate-module-graphs)
 - `server.transformRequest` -> `environment.transformRequest`
-- `server.resolve` -> `environment.resolve`
 
 ::: tip Future Deprecation
 The deprecation is plannde in the future, where you could start migrating your plugin to use the new API if you move fast. To identify your usage, set `future.deprecationWarnings` in your vite config.

--- a/docs/deprecations/vd004.md
+++ b/docs/deprecations/vd004.md
@@ -1,0 +1,23 @@
+# VD004 - `ssrLoadModule`
+
+`server.ssrLoadModule` has been replaced new [Module Runner](/guide/api-vite-environment#modulerunner).
+
+::: tip Future Deprecation
+The deprecation is plannde in the future, where you could start migrating your plugin to use the new API if you move fast. To identify your usage, set `future.deprecationWarnings.ssrLoadModule` to `true` in your vite config.
+:::
+
+Affect scope: `Vite Plugin Authors`
+
+| Stages           | Version                                  |
+| ---------------- | ---------------------------------------- |
+| First Introduced | `v6.0.0`                                 |
+| Deprecation      | (planned in `v7.0.0`)                    |
+| Feature Removal  | (currently no plan to remove completely) |
+
+## Motivation
+
+// TODO:
+
+## Migration Guide
+
+// TODO:

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -88,6 +88,7 @@ import { loadEnv, resolveEnvPrefix } from './env'
 import type { ResolvedSSROptions, SSROptions } from './ssr'
 import { resolveSSROptions } from './ssr'
 import { FutureCompatEnvironment } from './baseEnvironment'
+import type { FutureDeprecationWarningsOptions } from './deprecations'
 
 const debug = createDebugger('vite:config')
 const promisifiedRealpath = promisify(fs.realpath)
@@ -358,6 +359,10 @@ export interface UserConfig extends DefaultEnvironmentOptions {
    */
   experimental?: ExperimentalOptions
   /**
+   * Options to opt-in to future behavior
+   */
+  future?: FutureOptions
+  /**
    * Legacy options
    *
    * Features under this field only follow semver for patches, they could be removed in a
@@ -441,6 +446,15 @@ export interface HTMLOptions {
    * Make sure that this placeholder will be replaced with a unique value for each request by the server.
    */
   cspNonce?: string
+}
+
+export interface FutureOptions {
+  /**
+   * Emit warning messages for deprecated/will-deprecated features at runtime.
+   *
+   * Setting to `true` to enable all warnings
+   */
+  deprecationWarnings?: boolean | FutureDeprecationWarningsOptions
 }
 
 export interface ExperimentalOptions {
@@ -1186,6 +1200,7 @@ export async function resolveConfig(
       hmrPartialAccept: false,
       ...config.experimental,
     },
+    future: config.future,
 
     // Backward compatibility, users should use environment.config.dev.optimizeDeps
     optimizeDeps: backwardCompatibleOptimizeDeps,

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -71,7 +71,10 @@ export function warnFutureDeprecation(
   msg = colors.yellow(msg)
 
   const docs = `${docsURL}/deprecations/${_futureDeprecationCode[type].toLowerCase()}`
-  msg += `\n       ${colors.underline(docs)}`
+  msg +=
+    colors.gray(`\n  ${stacktrace ? '├' : '└'}─── `) +
+    colors.underline(docs) +
+    '\n'
 
   if (stacktrace) {
     const stack = new Error().stack
@@ -80,19 +83,16 @@ export function warnFutureDeprecation(
         .split('\n')
         .slice(3)
         .filter((i) => !i.includes('/node_modules/vite/dist/'))
-      if (stacks.length) {
-        msg +=
-          '\n' +
-          colors.dim(
-            stacks
-              .map(
-                (i, idx) =>
-                  `  ${idx === stacks.length - 1 ? '└' : '│'} ${i.trim()}`,
-              )
-              .join('\n'),
-          ) +
-          '\n'
-      }
+      if (stacks.length === 0) stacks.push('No stack trace found.')
+      msg +=
+        colors.dim(
+          stacks
+            .map(
+              (i, idx) =>
+                `  ${idx === stacks.length - 1 ? '└' : '│'} ${i.trim()}`,
+            )
+            .join('\n'),
+        ) + '\n'
     }
   }
   config.logger.warnOnce(msg)

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -1,0 +1,107 @@
+import colors from 'picocolors'
+import type { ResolvedConfig } from './config'
+
+// TODO: switch to production docs URL
+const docsURL = 'https://deploy-preview-16471--vite-docs-main.netlify.app'
+
+export interface FutureDeprecationWarningsOptions {
+  // TODO: have a "migration guide" page for each deprecation
+  pluginHookHandleHotUpdate?: boolean
+  pluginHookSsrArgument?: boolean
+
+  serverModuleGraph?: boolean
+  serverHot?: boolean
+  serverTransformRequest?: boolean
+
+  ssrLoadModule?: boolean
+}
+
+const _futureDeprecationCode = {
+  pluginHookHandleHotUpdate: 'VD001',
+  pluginHookSsrArgument: 'VD002',
+
+  serverModuleGraph: 'VD003',
+  serverHot: 'VD003',
+  serverTransformRequest: 'VD003',
+
+  ssrLoadModule: 'VD004',
+} satisfies Record<keyof FutureDeprecationWarningsOptions, string>
+
+const _futureDeprecationMessages = {
+  pluginHookHandleHotUpdate:
+    'Plugin hook `handleHotUpdate()` is replaced with `hotUpdate()`.',
+  pluginHookSsrArgument:
+    'Plugin hook `options.ssr` is replaced with `this.environment.name !== "client"`.',
+
+  serverModuleGraph:
+    'The `server.moduleGraph` is replaced with `this.environment.moduleGraph`.',
+  serverHot: 'The `server.hot` is replaced with `this.environment.hot`.',
+  serverTransformRequest:
+    'The `server.transformRequest` is replaced with `this.environment.transformRequest`.',
+
+  ssrLoadModule:
+    'The `server.ssrLoadModule` is replaced with Environment Runner.',
+} satisfies Record<keyof FutureDeprecationWarningsOptions, string>
+
+let _ignoreDeprecationWarnings = false
+
+/**
+ * Warn about future deprecations.
+ */
+export function warnFutureDeprecation(
+  config: ResolvedConfig,
+  type: keyof FutureDeprecationWarningsOptions,
+  extraMessage?: string,
+  stacktrace = true,
+): void {
+  if (_ignoreDeprecationWarnings) return
+
+  if (!config.future?.deprecationWarnings) return
+
+  if (
+    config.future.deprecationWarnings !== true &&
+    !config.future.deprecationWarnings[type]
+  )
+    return
+
+  let msg = `[vite future] [${_futureDeprecationCode[type]}] ${_futureDeprecationMessages[type]}`
+  if (extraMessage) {
+    msg += ` ${extraMessage}`
+  }
+  msg = colors.yellow(msg)
+
+  const docs = `${docsURL}/deprecations/${_futureDeprecationCode[type].toLowerCase()}`
+  msg += `\n       ${colors.underline(docs)}`
+
+  if (stacktrace) {
+    const stack = new Error().stack
+    if (stack) {
+      const stacks = stack
+        .split('\n')
+        .slice(3)
+        .filter((i) => !i.includes('/node_modules/vite/dist/'))
+      if (stacks.length) {
+        msg +=
+          '\n' +
+          colors.dim(
+            stacks
+              .map(
+                (i, idx) =>
+                  `  ${idx === stacks.length - 1 ? '└' : '│'} ${i.trim()}`,
+              )
+              .join('\n'),
+          ) +
+          '\n'
+      }
+    }
+  }
+  config.logger.warnOnce(msg)
+}
+
+export function ignoreDeprecationWarnings<T>(fn: () => T): T {
+  const before = _ignoreDeprecationWarnings
+  _ignoreDeprecationWarnings = true
+  const ret = fn()
+  _ignoreDeprecationWarnings = before
+  return ret
+}

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -5,7 +5,6 @@ import type { ResolvedConfig } from './config'
 const docsURL = 'https://deploy-preview-16471--vite-docs-main.netlify.app'
 
 export interface FutureDeprecationWarningsOptions {
-  // TODO: have a "migration guide" page for each deprecation
   pluginHookHandleHotUpdate?: boolean
   pluginHookSsrArgument?: boolean
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -45,6 +45,7 @@ import type { BindCLIShortcutsOptions } from '../shortcuts'
 import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
+import { warnFutureDeprecation } from '../deprecations'
 import {
   createNoopWatcher,
   getResolvedOutDirs,
@@ -526,7 +527,10 @@ export async function _createServer(
 
     environments,
     pluginContainer,
-    moduleGraph,
+    get moduleGraph() {
+      warnFutureDeprecation(config, 'serverModuleGraph')
+      return moduleGraph
+    },
 
     resolvedUrls: null, // will be set on listen
     ssrTransform(
@@ -543,6 +547,11 @@ export async function _createServer(
     // that is part of the internal control flow for the vite dev server to be able to bail
     // out and do the html fallback
     transformRequest(url, options) {
+      warnFutureDeprecation(
+        config,
+        'serverTransformRequest',
+        'server.transformRequest() is deprecated. Use environment.transformRequest() instead.',
+      )
       const environment = server.environments[options?.ssr ? 'ssr' : 'client']
       return transformRequest(environment, url, options)
     },
@@ -569,6 +578,8 @@ export async function _createServer(
       return devHtmlTransformFn(server, url, html, originalUrl)
     },
     async ssrLoadModule(url, opts?: { fixStacktrace?: boolean }) {
+      warnFutureDeprecation(config, 'ssrLoadModule')
+
       return ssrLoadModule(
         url,
         server,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -506,7 +506,7 @@ export async function _createServer(
 
   // Backward compatibility
 
-  const moduleGraph = new ModuleGraph({
+  let moduleGraph = new ModuleGraph({
     client: () => environments.client.moduleGraph,
     ssr: () => environments.ssr.moduleGraph,
   })
@@ -530,6 +530,9 @@ export async function _createServer(
     get moduleGraph() {
       warnFutureDeprecation(config, 'serverModuleGraph')
       return moduleGraph
+    },
+    set moduleGraph(graph) {
+      moduleGraph = graph
     },
 
     resolvedUrls: null, // will be set on listen

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -79,6 +79,7 @@ import { FS_PREFIX } from '../constants'
 import { createPluginHookUtils, getHookHandler } from '../plugins'
 import { cleanUrl, unwrapId } from '../../shared/utils'
 import type { Environment } from '../environment'
+import { warnFutureDeprecation } from '../deprecations'
 import type { DevEnvironment } from './environment'
 import { buildErrorMessage } from './middlewares/error'
 import type { EnvironmentModuleNode } from './moduleGraph'
@@ -736,7 +737,13 @@ export async function createEnvironmentPluginContainer(
     },
 
     async load(id, options) {
-      options = options ? { ...options, ssr } : { ssr }
+      options = {
+        ...options,
+        get ssr() {
+          warnFutureDeprecation(config, 'pluginHookSsrArgument')
+          return ssr
+        },
+      }
       const ctx = new Context()
       for (const plugin of getSortedPlugins('load')) {
         if (closed && environment?.options.dev.recoverable)
@@ -760,7 +767,13 @@ export async function createEnvironmentPluginContainer(
     },
 
     async transform(code, id, options) {
-      options = options ? { ...options, ssr } : { ssr }
+      options = {
+        ...options,
+        get ssr() {
+          warnFutureDeprecation(config, 'pluginHookSsrArgument')
+          return ssr
+        },
+      }
       const inMap = options?.inMap
       const ctx = new TransformContext(id, code, inMap as SourceMap)
       for (const plugin of getSortedPlugins('transform')) {


### PR DESCRIPTION
Assign code for each deprecations/future breaking changes we have, provide each a docs page to communicate with migration guides. (https://github.com/vitejs/vite/pull/17305/files#diff-dec483f20d5b5946a0879042e0894a3850672e347b12bfee87695d1b808bc82e)

For future deprecations, we provide config entries for early adopters to test the check the usage of those future-depreations features.

```ts
export default defineConfig({
  future: {
    deprecationWarnings: {
      serverModuleGraph: true,
      pluginHookHandleHotUpdate: true
    }
  }
})
```

Then users will get runtime warnings with stacktrace to locate the usage of those APIs:

<img width="1112" alt="Screenshot 2024-05-24 at 18 10 06" src="https://github.com/vitejs/vite/assets/11247099/64dcffce-71cb-4dd2-ac85-bf10a9649781">

