### PR TITLE
test(v6): test nested virtual module invalidation

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -63,7 +63,7 @@ test('import.meta.filename/dirname returns same value with Node', async () => {
   expect(viteValue.filename).toBe(filename)
 })
 
-test('virtual module invalidation', async () => {
+test('virtual module invalidation simple', async () => {
   const server = await createServer({
     configFile: false,
     root,
@@ -100,6 +100,68 @@ test('virtual module invalidation', async () => {
 
   const modNode = server.moduleGraph.getModuleById('\0virtual:test')
   server.moduleGraph.invalidateModule(modNode!)
+
+  const mod3 = await server.ssrLoadModule('virtual:test')
+  expect(mod3.default).toEqual(2)
+})
+
+test('virtual module invalidation nested', async () => {
+  const server = await createServer({
+    configFile: false,
+    root,
+    logLevel: 'silent',
+    optimizeDeps: {
+      noDiscovery: true,
+    },
+    plugins: [
+      {
+        name: 'test-virtual',
+        resolveId(id) {
+          if (id === 'virtual:test') {
+            return '\0virtual:test'
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:test') {
+            return `
+              import testDep from "virtual:test-dep";
+              export default testDep;
+            `
+          }
+        },
+      },
+      {
+        name: 'test-virtual-dep',
+        resolveId(id) {
+          if (id === 'virtual:test-dep') {
+            return '\0virtual:test-dep'
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:test-dep') {
+            return `
+              globalThis.__virtual_test_state2 ??= 0;
+              globalThis.__virtual_test_state2++;
+              export default globalThis.__virtual_test_state2;
+            `
+          }
+        },
+      },
+    ],
+  })
+  await server.pluginContainer.buildStart({})
+
+  const mod1 = await server.ssrLoadModule('virtual:test')
+  expect(mod1.default).toEqual(1)
+  const mod2 = await server.ssrLoadModule('virtual:test')
+  expect(mod2.default).toEqual(1)
+
+  server.moduleGraph.invalidateModule(
+    server.moduleGraph.getModuleById('\0virtual:test')!,
+  )
+  server.moduleGraph.invalidateModule(
+    server.moduleGraph.getModuleById('\0virtual:test-dep')!,
+  )
 
   const mod3 = await server.ssrLoadModule('virtual:test')
   expect(mod3.default).toEqual(2)


### PR DESCRIPTION
### Description

Investigating Remix CI and it looks like virtual module invalidation is still not working same when they are nested like this.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
