### PR TITLE
docs: add commands to install Vite inside an existing folder

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -67,6 +67,30 @@ $ bun create vite
 
 :::
 
+The commands above create a new folder and install Vite in it. During the installation, you will be prompted to give the new folder a name of your choice. 
+
+Add a dot to the end of the commands as shown below to install Vite in an existing folder. 
+
+::: code-group
+
+```bash [NPM]
+$ npm create vite@latest .
+```
+
+```bash [Yarn]
+$ yarn create vite .
+```
+
+```bash [PNPM]
+$ pnpm create vite .
+```
+
+```bash [Bun]
+$ bun create vite .
+```
+
+:::
+
 Then follow the prompts!
 
 You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold a Vite + Vue project, run:


### PR DESCRIPTION
### Description

The Getting Started guide lists commands to install Vite, but all the listed commands install Vite inside a new folder created during installation. 

The guide is missing the commands for installing Vite inside an existing folder. I am adding them to help users who may not know the commands, to help reduce confusion and provide clarity. 