### PR TITLE
fix: avoid externalizing plugins that resolve to local files in monorepos

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1165,6 +1165,10 @@ async function bundleConfigFile(
               }
               if (idFsPath && isImport) {
                 idFsPath = pathToFileURL(idFsPath).href
+                if (!idFsPath.includes('/node_modules/')) {
+                  // resolved to a local import, consider it as a relative path
+                  return
+                }
               }
               if (
                 idFsPath &&


### PR DESCRIPTION
## Context

Vite currently bundles the config file during development using ESBuild and all the relative imports are marked as "no external" because they are not matched in [this regex](https://github.com/vitejs/vite/blob/6a085d0467ca3b044b4f2108a323af3305a0eae7/packages/vite/src/node/config.ts#L1125), meaning that the imported code is read and bundled in the config.

This is great because it allows reloading the imported local plugins without restarting the process by calling `viteDevServer.restart()`. Otherwise, Node would cache the external imports (import cache) and wouldn't reload the code even if it changes.

## Problem

We have a few plugins in a monorepo together with a project template and we'd like to reload the plugins in the template dev server when they change. The problem is that the template is [importing](https://github.com/Shopify/hydrogen/blob/main/templates/skeleton/vite.config.ts#L2-L3) the local plugins using NPM workspaces (e.g. published NPM name `@shopify/hydrogen/vite`) instead of relative paths like `../../packages/hydrogen/dist/plugin.js`.

Therefore, our plugins are treated as [external imports](https://github.com/vitejs/vite/blob/6a085d0467ca3b044b4f2108a323af3305a0eae7/packages/vite/src/node/config.ts#L1182) and Node's import cache makes it impossible to reload the plugin without restarting the whole dev server process.

## Changes

Vite already [follow symlinks in monorepos for in-app dependencies](https://vitejs.dev/guide/dep-pre-bundling.html#monorepos-and-linked-dependencies) so I think it would be more consistent if it did the same for plugins in the config file. This PR makes it so imports that resolve to local files are not marked as external anymore.

I'm not sure if this is the correct fix so please let me know what you think.