### PR TITLE
feat(resolve): add support for accessing default conditions using `...` in `overrideConditions`

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1089,24 +1089,31 @@ function resolveExportsOrImports(
   targetWeb: boolean,
   type: 'imports' | 'exports',
 ) {
+  const defaultlConditions = new Set([
+    'production',
+    'development',
+    'module',
+    ...options.conditions,
+  ])
+
   const additionalConditions = new Set(
-    options.overrideConditions || [
-      'production',
-      'development',
-      'module',
-      ...options.conditions,
-    ],
+    options.overrideConditions || defaultlConditions,
   )
 
-  const conditions = [...additionalConditions].filter((condition) => {
-    switch (condition) {
-      case 'production':
-        return options.isProduction
-      case 'development':
-        return !options.isProduction
-    }
-    return true
-  })
+  if (options.overrideConditions && additionalConditions.has('...')) {
+    additionalConditions.delete('...')
+    defaultlConditions.forEach((condition) => {
+      additionalConditions.add(condition)
+    })
+  }
+
+  if (options.isProduction) {
+    additionalConditions.delete('development')
+  } else {
+    additionalConditions.delete('production')
+  }
+
+  const conditions = [...additionalConditions]
 
   const fn = type === 'imports' ? imports : exports
   const result = fn(pkg, key, {

--- a/playground/resolve/custom-condition-with-default/index.custom.js
+++ b/playground/resolve/custom-condition-with-default/index.custom.js
@@ -1,0 +1,1 @@
+export const msg = '[success] custom condition'

--- a/playground/resolve/custom-condition-with-default/index.js
+++ b/playground/resolve/custom-condition-with-default/index.js
@@ -1,0 +1,1 @@
+export const msg = '[fail]'

--- a/playground/resolve/custom-condition-with-default/package.json
+++ b/playground/resolve/custom-condition-with-default/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@vitejs/test-resolve-custom-condition",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "custom": {
+        "import": "./index.custom.js",
+        "require": "./index.js"
+      }
+    }
+  }
+}

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -28,7 +28,7 @@ export default defineConfig({
   resolve: {
     extensions: ['.mjs', '.js', '.es', '.ts'],
     mainFields: ['browser', 'custom', 'module'],
-    conditions: ['custom'],
+    conditions: ['custom', '...'],
   },
   define: {
     VITE_CONFIG_DEP_TEST: a,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

mimic webpack's behavior, providing users with access to default options.

[webpack docs](https://webpack.js.org/configuration/resolve/#:~:text=Note%20that%20using%20resolve.extensions%20like%20above%20will%20override%20the%20default%20array%2C%20meaning%20that%20webpack%20will%20no%20longer%20try%20to%20resolve%20modules%20using%20the%20default%20extensions.%20However%20you%20can%20use%20%27...%27%20to%20access%20the%20default%20extensions%3A)

[webpack usage](https://github.com/webpack/webpack/blob/2953d23a87d89b3bd07cf73336ee34731196c62e/lib/config/defaults.js#L1458-L1470)

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
