### PR TITLE
fix(resolve): prioritize `main` field over `mainFields` for `require`s

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1003,6 +1003,11 @@ export function resolvePackageEntry(
       )
     }
 
+    // if the operation is a require give precedence to the main field
+    if (!entryPoint && options.isRequire) {
+      entryPoint ||= data.main
+    }
+
     // fallback to mainFields if still not resolved
     if (!entryPoint) {
       for (const field of options.mainFields) {

--- a/playground/resolve/__tests__/resolve.spec.ts
+++ b/playground/resolve/__tests__/resolve.spec.ts
@@ -79,6 +79,12 @@ test('import and require resolve using module condition', async () => {
   ).toMatch('[success]')
 })
 
+test('require resolve using main condition', async () => {
+  expect(
+    await page.textContent('.exports-with-main-condition-required'),
+  ).toMatch('[success]')
+})
+
 test('implicit dir/index.js', async () => {
   expect(await page.textContent('.index')).toMatch('[success]')
 })

--- a/playground/resolve/exports-with-main-condition-required/index.cjs
+++ b/playground/resolve/exports-with-main-condition-required/index.cjs
@@ -1,0 +1,2 @@
+const { msg } = require('@vitejs/test-resolve-exports-with-main-condition')
+module.exports = { msg }

--- a/playground/resolve/exports-with-main-condition-required/package.json
+++ b/playground/resolve/exports-with-main-condition-required/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-resolve-exports-with-main-condition-required",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.cjs",
+  "dependencies": {
+    "@vitejs/test-resolve-exports-with-main-condition": "link:../exports-with-main-condition"
+  }
+}

--- a/playground/resolve/exports-with-main-condition/index.cjs
+++ b/playground/resolve/exports-with-main-condition/index.cjs
@@ -1,0 +1,2 @@
+/* eslint-disable i/no-commonjs */
+module.exports.msg = '[success] exports with main condition (index.cjs)'

--- a/playground/resolve/exports-with-main-condition/index.custom.mjs
+++ b/playground/resolve/exports-with-main-condition/index.custom.mjs
@@ -1,0 +1,1 @@
+export const msg = '[fail] exports with main condition (index.custom.mjs)'

--- a/playground/resolve/exports-with-main-condition/package.json
+++ b/playground/resolve/exports-with-main-condition/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/test-resolve-exports-with-main-condition",
+  "private": true,
+  "version": "1.0.0",
+  "main": "index.cjs",
+  "custom": "index.custom.mjs"
+}

--- a/playground/resolve/index.html
+++ b/playground/resolve/index.html
@@ -43,6 +43,9 @@
 <p class="exports-with-module-condition">fail</p>
 <p class="exports-with-module-condition-required">fail</p>
 
+<h2>Prioritize `main` field over `mainFields` for `require` call</h2>
+<p class="exports-with-main-condition-required">fail</p>
+
 <h2>Resolving top level with imports field</h2>
 <p class="imports-top-level">fail</p>
 
@@ -236,6 +239,12 @@
   text(
     '.exports-with-module-condition-required',
     exportsWithModuleConditionRequired,
+  )
+
+  import { msg as exportsWithMainConditionRequired } from '@vitejs/test-resolve-exports-with-main-condition-required'
+  text(
+    '.exports-with-main-condition-required',
+    exportsWithMainConditionRequired,
   )
 
   // imports field

--- a/playground/resolve/package.json
+++ b/playground/resolve/package.json
@@ -38,6 +38,8 @@
     "@vitejs/test-resolve-exports-with-module": "link:./exports-with-module",
     "@vitejs/test-resolve-exports-with-module-condition": "link:./exports-with-module-condition",
     "@vitejs/test-resolve-exports-with-module-condition-required": "link:./exports-with-module-condition-required",
+    "@vitejs/test-resolve-exports-with-main-condition": "link:./exports-with-main-condition",
+    "@vitejs/test-resolve-exports-with-main-condition-required": "link:./exports-with-main-condition-required",
     "@vitejs/test-resolve-linked": "workspace:*",
     "@vitejs/test-resolve-imports-pkg": "link:./imports-path/other-pkg",
     "@vitejs/test-resolve-sharp-dir": "link:./sharp-dir"

--- a/playground/resolve/vite.config.js
+++ b/playground/resolve/vite.config.js
@@ -110,6 +110,7 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       '@vitejs/test-resolve-exports-with-module-condition-required',
+      '@vitejs/test-resolve-exports-with-main-condition-required',
       '@vitejs/test-require-pkg-with-module-field',
       '@vitejs/test-resolve-sharp-dir',
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1188,6 +1188,12 @@ importers:
       '@vitejs/test-resolve-exports-path':
         specifier: link:./exports-path
         version: link:exports-path
+      '@vitejs/test-resolve-exports-with-main-condition':
+        specifier: link:./exports-with-main-condition
+        version: link:exports-with-main-condition
+      '@vitejs/test-resolve-exports-with-main-condition-required':
+        specifier: link:./exports-with-main-condition-required
+        version: link:exports-with-main-condition-required
       '@vitejs/test-resolve-exports-with-module':
         specifier: link:./exports-with-module
         version: link:exports-with-module
@@ -1257,6 +1263,14 @@ importers:
   playground/resolve/exports-legacy-fallback/dir: {}
 
   playground/resolve/exports-path: {}
+
+  playground/resolve/exports-with-main-condition: {}
+
+  playground/resolve/exports-with-main-condition-required:
+    dependencies:
+      '@vitejs/test-resolve-exports-with-main-condition':
+        specifier: link:../exports-with-main-condition
+        version: link:../exports-with-main-condition
 
   playground/resolve/exports-with-module: {}
 


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

When a `require` is performed the modules resolution currently prioritizes the [`mainFields` option](https://vitejs.dev/config/shared-options.html#resolve-mainfields) over the fact that a `require` has been used, this (especially given the default `mainFields` value) can lead to `require`s being resolved to browser entries instead of a potential cjs `module` entry. This PR addresses this by priotizing a potential `main` field over the `mainField`.

___

### Details on how we encountered this issue

This was encountered as an issue when trying to run Remix code inside the `workerd` runtime via the environments API, there we encountered situations in which some modules imported via `require` would `require` packages but would receive esm entries instead of cjs ones, causing the following issue:
```
TypeError: Cannot use require() to import an ES Module.
```
This happened when
`react-router-dom` ([package.json](https://www.npmjs.com/package/react-router-dom/v/6.23.1?activeTab=code)) was being `require`d from `@remix-run/react` ([code](https://www.npmjs.com/package/@remix-run/react/v/2.9.2?activeTab=code))

by adding some ad-hoc hacks to make the above work this issue would show up again
for `react-router` ([packae.json](https://www.npmjs.com/package/react-router?activeTab=code)) `require`d from `react-router-dom` itself ([code](https://www.npmjs.com/package/react-router-dom/v/6.23.1?activeTab=code))

by also hacking the above we'd re-encounter the issue with:
`@remix-run/router` ([package.json](https://www.npmjs.com/package/@remix-run/router/v/1.16.1?activeTab=code)) being `require`d from `react-router` ([code](https://www.npmjs.com/package/react-router/v/6.23.1?activeTab=code))
 
and so on...

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
