### PR TITLE
fix: gracefully shutdown preview server on `SIGTERM` (fix #12990)

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -145,16 +145,14 @@ export async function preview(
 
   const closeHttpServer = createServerCloseFn(httpServer)
 
-  const close = () => {
-    teardownSIGTERMListener(closeServerAndExit)
-    return closeHttpServer()
-  }
-
   const server: PreviewServer = {
     config,
     middlewares: app,
     httpServer,
-    close,
+    async close() {
+      teardownSIGTERMListener(closeServerAndExit)
+      await closeHttpServer()
+    },
     resolvedUrls: null,
     printUrls() {
       if (server.resolvedUrls) {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -26,7 +26,6 @@ import { indexHtmlMiddleware } from './server/middlewares/indexHtml'
 import { notFoundMiddleware } from './server/middlewares/notFound'
 import { proxyMiddleware } from './server/middlewares/proxy'
 import {
-  createCloseServerAndExitFn,
   resolveHostname,
   resolveServerUrls,
   setupSIGTERMListener,
@@ -147,7 +146,7 @@ export async function preview(
   const closeHttpServer = createServerCloseFn(httpServer)
 
   const close = () => {
-    teardownSIGTERMListener(closeServerAndExitFn)
+    teardownSIGTERMListener(closeServerAndExit)
     return closeHttpServer()
   }
 
@@ -169,9 +168,15 @@ export async function preview(
     },
   }
 
-  const closeServerAndExitFn = createCloseServerAndExitFn(server)
+  const closeServerAndExit = async () => {
+    try {
+      await server.close()
+    } finally {
+      process.exit()
+    }
+  }
 
-  setupSIGTERMListener(closeServerAndExitFn)
+  setupSIGTERMListener(closeServerAndExit)
 
   // apply server hooks from plugins
   const postHooks: ((() => void) | void)[] = []

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -2,7 +2,7 @@ import readline from 'node:readline'
 import colors from 'picocolors'
 import { restartServerWithUrls } from './server'
 import type { ViteDevServer } from './server'
-import { isDevServer } from './utils'
+import { closeServerAndExit, isDevServer } from './utils'
 import type { PreviewServer } from './preview'
 import { openBrowser } from './server/openBrowser'
 
@@ -126,7 +126,7 @@ const BASE_DEV_SHORTCUTS: CLIShortcut<ViteDevServer>[] = [
     key: 'q',
     description: 'quit',
     async action(server) {
-      await server.close().finally(() => process.exit())
+      closeServerAndExit(server)
     },
   },
 ]
@@ -149,11 +149,7 @@ const BASE_PREVIEW_SHORTCUTS: CLIShortcut<PreviewServer>[] = [
     key: 'q',
     description: 'quit',
     action(server) {
-      try {
-        server.httpServer.close()
-      } finally {
-        process.exit()
-      }
+      closeServerAndExit(server.httpServer)
     },
   },
 ]

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -2,7 +2,7 @@ import readline from 'node:readline'
 import colors from 'picocolors'
 import { restartServerWithUrls } from './server'
 import type { ViteDevServer } from './server'
-import { closeServerAndExit, isDevServer } from './utils'
+import { isDevServer } from './utils'
 import type { PreviewServer } from './preview'
 import { openBrowser } from './server/openBrowser'
 
@@ -126,7 +126,11 @@ const BASE_DEV_SHORTCUTS: CLIShortcut<ViteDevServer>[] = [
     key: 'q',
     description: 'quit',
     async action(server) {
-      closeServerAndExit(server)
+      try {
+        await server.close()
+      } finally {
+        process.exit()
+      }
     },
   },
 ]
@@ -148,8 +152,12 @@ const BASE_PREVIEW_SHORTCUTS: CLIShortcut<PreviewServer>[] = [
   {
     key: 'q',
     description: 'quit',
-    action(server) {
-      closeServerAndExit(server.httpServer)
+    async action(server) {
+      try {
+        await server.close()
+      } finally {
+        process.exit()
+      }
     },
   },
 ]

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1439,21 +1439,6 @@ export function partialEncodeURIPath(uri: string): string {
   return filePath.replaceAll('%', '%25') + postfix
 }
 
-export const closeServerAndExit = async (
-  server: ViteDevServer | PreviewServer | PreviewServer['httpServer'],
-): Promise<void> => {
-  try {
-    await server.close()
-  } finally {
-    process.exit()
-  }
-}
-
-export const createCloseServerAndExitFn =
-  (server: ViteDevServer | PreviewServer): (() => Promise<void>) =>
-  () =>
-    closeServerAndExit(server)
-
 export const setupSIGTERMListener = (callback: () => Promise<void>): void => {
   process.once('SIGTERM', callback)
   if (process.env.CI !== 'true') {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1438,3 +1438,34 @@ export function partialEncodeURIPath(uri: string): string {
   const postfix = filePath !== uri ? uri.slice(filePath.length) : ''
   return filePath.replaceAll('%', '%25') + postfix
 }
+
+export const closeServerAndExit = async (
+  server: ViteDevServer | PreviewServer | PreviewServer['httpServer'],
+): Promise<void> => {
+  try {
+    await server.close()
+  } finally {
+    process.exit()
+  }
+}
+
+export const createCloseServerAndExitFn =
+  (server: ViteDevServer | PreviewServer): (() => Promise<void>) =>
+  () =>
+    closeServerAndExit(server)
+
+export const setupSIGTERMListener = (callback: () => Promise<void>): void => {
+  process.once('SIGTERM', callback)
+  if (process.env.CI !== 'true') {
+    process.stdin.on('end', callback)
+  }
+}
+
+export const teardownSIGTERMListener = (
+  callback: () => Promise<void>,
+): void => {
+  process.off('SIGTERM', callback)
+  if (process.env.CI !== 'true') {
+    process.stdin.off('end', callback)
+  }
+}


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
fixes #12990

In the following manual tests the `alias` playground is opened in the left terminal, which runs the preview server.
In the right terminal, a `SIGTERM` signal is sent (`kill -15`) to the left one.
On the main branch, the `preview` command exits with code `1`, and on the PR branch with code `0`.

Main branch manual test:

https://github.com/vitejs/vite/assets/18152197/606267b4-c4c2-48c3-a449-9c7934aea779

PR branch manual test:

https://github.com/vitejs/vite/assets/18152197/d6ff2646-dcbb-4f64-a6d9-42379c2bcb38



<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
