### PR TITLE
fix(plugin-legacy): group discovered polyfills by output

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -160,7 +160,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   const legacyPolyfills = new Set<string>()
   // When discovering polyfills in `renderChunk`, the hook may be non-deterministic, so we group the
   // modern and legacy polyfills in a sorted chunks map for each rendered outputs before merging them.
-  const outputToChunkFileNameToPolyfills = new Map<
+  const outputToChunkFileNameToPolyfills = new WeakMap<
     NormalizedOutputOptions,
     Map<string, { modern: Set<string>; legacy: Set<string> }> | null
   >()

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -159,10 +159,11 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
   const modernPolyfills = new Set<string>()
   const legacyPolyfills = new Set<string>()
   // When discovering polyfills in `renderChunk`, the hook may be non-deterministic, so we group the
-  // modern and legacy polyfills in a sorted map before merging them.
-  let chunkFileNameToPolyfills:
-    | Map<string, { modern: Set<string>; legacy: Set<string> }>
-    | undefined
+  // modern and legacy polyfills in a sorted chunks map for each rendered outputs before merging them.
+  const outputToChunkFileNameToPolyfills = new Map<
+    NormalizedOutputOptions,
+    Map<string, { modern: Set<string>; legacy: Set<string> }> | null
+  >()
 
   if (Array.isArray(options.modernPolyfills) && genModern) {
     options.modernPolyfills.forEach((i) => {
@@ -267,12 +268,18 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         return
       }
 
+      const chunkFileNameToPolyfills =
+        outputToChunkFileNameToPolyfills.get(opts)
+      if (chunkFileNameToPolyfills == null) {
+        throw new Error(
+          'Internal @vitejs/plugin-legacy error: discovered polyfills should exist',
+        )
+      }
+
       if (!isLegacyBundle(bundle, opts)) {
         // Merge discovered modern polyfills to `modernPolyfills`
-        if (chunkFileNameToPolyfills) {
-          for (const { modern } of chunkFileNameToPolyfills.values()) {
-            modern.forEach((p) => modernPolyfills.add(p))
-          }
+        for (const { modern } of chunkFileNameToPolyfills.values()) {
+          modern.forEach((p) => modernPolyfills.add(p))
         }
         if (!modernPolyfills.size) {
           return
@@ -303,10 +310,8 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
 
       // Merge discovered legacy polyfills to `legacyPolyfills`
-      if (chunkFileNameToPolyfills) {
-        for (const { legacy } of chunkFileNameToPolyfills.values()) {
-          legacy.forEach((p) => legacyPolyfills.add(p))
-        }
+      for (const { legacy } of chunkFileNameToPolyfills.values()) {
+        legacy.forEach((p) => legacyPolyfills.add(p))
       }
 
       // legacy bundle
@@ -348,8 +353,9 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
     enforce: 'post',
     apply: 'build',
 
-    renderStart() {
-      chunkFileNameToPolyfills = undefined
+    renderStart(opts) {
+      // Empty the nested map for this output
+      outputToChunkFileNameToPolyfills.set(opts, null)
     },
 
     configResolved(_config) {
@@ -438,6 +444,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       }
 
       // On first run, intialize the map with sorted chunk file names
+      let chunkFileNameToPolyfills = outputToChunkFileNameToPolyfills.get(opts)
       if (chunkFileNameToPolyfills == null) {
         chunkFileNameToPolyfills = new Map()
         for (const fileName in chunks) {
@@ -446,8 +453,14 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
             legacy: new Set(),
           })
         }
+        outputToChunkFileNameToPolyfills.set(opts, chunkFileNameToPolyfills)
       }
-      const polyfillsDiscovered = chunkFileNameToPolyfills.get(chunk.fileName)!
+      const polyfillsDiscovered = chunkFileNameToPolyfills.get(chunk.fileName)
+      if (polyfillsDiscovered == null) {
+        throw new Error(
+          `Internal @vitejs/plugin-legacy error: discovered polyfills for ${chunk.fileName} should exist`,
+        )
+      }
 
       if (!isLegacyChunk(chunk, opts)) {
         if (


### PR DESCRIPTION
### Description

Since merging https://github.com/vitejs/vite/pull/16566, it caused CI to be flaky as in Rollup watch mode, the `renderStart` and `renderChunk` hooks are all running overlapping due to Rollup writing each output in parallel: https://github.com/rollup/rollup/blob/1a7da5ac529d543ad8fffd1cdfbf9a80040a1176/src/watch/watch.ts#L205-L216

In contrary to Vite where we write each output serially: https://github.com/vitejs/vite/blob/6236846416923ec8a30b908a247052564bcd5e43/packages/vite/src/node/build.ts#L762-L765

If we want to, we can fix watch mode to write serially manually, but I figured to fix this in plugin-legacy itself first. By grouping each output to its own map, we can handle the chunks in `renderChunk` in parallel.

I also updated the code to use the variables defensively to prevent issues like this in the future. I needed to hook into the Rollup watcher error event in order to get the error message:

```
  error: [vite:legacy-post-process] [BABEL] unknown file: Cannot read properties of undefined (reading 'legacy') (While processing: "base$0")
      at apply (file:///Users/bjorn/Work/oss/vite/packages/plugin-legacy/dist/index.mjs:454:72)
      at sync (/Users/bjorn/Work/oss/vite/node_modules/.pnpm/@babel+core@7.24.6/node_modules/@babel/core/src/gensync-utils/async.ts:31:25)
      at sync (/Users/bjorn/Work/oss/vite/node_modules/.pnpm/gensync@1.0.0-beta.2/node_modules/gensync/index.js:182:19)
      at factory (/Users/bjorn/Work/oss/vite/node_modules/.pnpm/gensync@1.0.0-beta.2/node_modules/gensync/index.js:210:24)
      at Generator.next (<anonymous>)
      at /Users/bjorn/Work/oss/vite/node_modules/.pnpm/@babel+core@7.24.6/node_modules/@babel/core/src/config/full.ts:271:23
      at Generator.next (<anonymous>)
```
