### PR TITLE
feat(typescript): update tsconfck to add support for `${configDir}` replacement in ts 5.5

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -147,7 +147,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.1.0",
-    "tsconfck": "^3.0.3",
+    "tsconfck": "^3.1.0",
     "tslib": "^2.6.2",
     "types": "link:./types",
     "ufo": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,8 +410,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       tsconfck:
-        specifier: ^3.0.3
-        version: 3.0.3(typescript@5.2.2)
+        specifier: ^3.1.0
+        version: 3.1.0(typescript@5.2.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -10061,8 +10061,8 @@ packages:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /tsconfck@3.0.3(typescript@5.2.2):
-    resolution: {integrity: sha512-4t0noZX9t6GcPTfBAbIbbIU4pfpCwh0ueq3S4O/5qXI1VwK1outmxhe9dOiEWqMz3MW2LKgDTpqWV+37IWuVbA==}
+  /tsconfck@3.1.0(typescript@5.2.2):
+    resolution: {integrity: sha512-CMjc5zMnyAjcS9sPLytrbFmj89st2g+JYtY/c02ug4Q+CZaAtCgbyviI0n1YvjZE/pzoc6FbNsINS13DOL1B9w==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
### Description

Typescript 5.5 is going to be released on June 18th according to https://github.com/microsoft/TypeScript/issues/57475

Adding support in 5.3 helps our users to adpot this new feature.

see https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#the-configdir-template-variable-for-configuration-files

implementation in tsconfck: https://github.com/dominikg/tsconfck/pull/172


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
