### PR TITLE
fix(css): handle url replacing when preprocessing with lightningcss

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2780,6 +2780,8 @@ async function compileLightningCSS(
         if (urlReplacer) {
           const replaceUrl = await urlReplacer(dep.url, id)
           css = css.replace(dep.placeholder, () => replaceUrl)
+        } else {
+          css = css.replace(dep.placeholder, () => dep.url)
         }
         break
       default:


### PR DESCRIPTION
### Description

When using `preprocessCSS` with lightningcss, `urlReplacer` is undefined, so the css urls should be left intact but we didn't replace the placeholder back to original in this case.

(from astro) closes https://github.com/withastro/astro/issues/11060#issuecomment-2140304375
