### PR TITLE
fix: use environment config root for hmr filename

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -203,7 +203,7 @@ export async function handleHMRUpdate(
 
   // (dev only) the client itself cannot be hot updated.
   if (file.startsWith(withTrailingSlash(normalizedClientDir))) {
-    environments.forEach(({ hot }) =>
+    environments.forEach(({ config, hot }) =>
       hot.send({
         type: 'full-reload',
         path: '*',
@@ -370,9 +370,10 @@ export async function handleHMRUpdate(
           )
           environment.hot.send({
             type: 'full-reload',
-            path: config.server.middlewareMode
+            path: environment.config.server.middlewareMode
               ? '*'
-              : '/' + normalizePath(path.relative(config.root, file)),
+              : '/' +
+                normalizePath(path.relative(environment.config.root, file)),
           })
         } else {
           // loaded but not in the module graph, probably not js
@@ -383,7 +384,7 @@ export async function handleHMRUpdate(
         return
       }
 
-      updateModules(environment, shortFile, context.modules, timestamp)
+      updateModules(environment, file, context.modules, timestamp)
     } catch (err) {
       environment.hot.send({
         type: 'error',


### PR DESCRIPTION
### Description

When using multiple environments with different `root` in the configuration, HMR emits incorrect file paths as `shortName` is resolved using the main config instead of the environment's config.

This PR fixes the issue by not using the resolved short filename for the `updateModules` call and using the environment config when working against a specific environment.

No tests failed, Vite dev server works as expected, but HMR payload is incorrect as it contains a non-existing `triggeredBy` path.

Fixes #17393 