### PR TITLE
chore: add error recovery option to LightningCSSOptions

### DIFF
--- a/packages/vite/src/types/lightningcss.d.ts
+++ b/packages/vite/src/types/lightningcss.d.ts
@@ -19,4 +19,5 @@ export type LightningCSSOptions = {
   pseudoClasses?: PseudoClasses
   unusedSymbols?: string[]
   cssModules?: CSSModulesConfig
+  errorRecovery?: boolean
 }


### PR DESCRIPTION
### Description

When using lightningcss in the CSS transformer, the following error was displayed:

![invalid-media-query](https://github.com/vitejs/vite/assets/57742720/dac3befa-7258-4292-904c-737c3e32ac03)

To circumvent this, it was necessary to use the errorRecovery option in LightningCSS. However, the current type definition of LightningCSSOption within Vite did not include errorRecovery. Therefore, I added it in this Pull Request.