### PR TITLE
docs(api-javascript): document preprocessCSS

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -446,4 +446,8 @@ interface PreprocessCSSResult {
 }
 ```
 
-Pre-processes `.css`, `.scss`, `.sass`, `.less`, `.styl` and `.stylus` files to plain CSS so it can be used in browsers or parsed by other tools. Similar to the [built-in CSS pre-processing support](/guide/features#css-pre-processors), the corresponding pre-processor must be installed if used. The pre-processor is inferred from the `filename` extension. Note that pre-processing will not resolve URLs in `url()` or `image-set()`.
+Pre-processes `.css`, `.scss`, `.sass`, `.less`, `.styl` and `.stylus` files to plain CSS so it can be used in browsers or parsed by other tools. Similar to the [built-in CSS pre-processing support](/guide/features#css-pre-processors), the corresponding pre-processor must be installed if used.
+
+The pre-processor used is inferred from the `filename` extension. If the `filename` ends with `.module.{ext}`, it is inferred as a [CSS module](https://github.com/css-modules/css-modules) and the returned result will include a `modules` object mapping the original class names to the transformed ones.
+
+Note that pre-processing will not resolve URLs in `url()` or `image-set()`.

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -424,3 +424,26 @@ async function loadConfigFromFile(
 ```
 
 Load a Vite config file manually with esbuild.
+
+## `preprocessCSS`
+
+- **Experimental:** [Give Feedback](https://github.com/vitejs/vite/discussions/13815)
+
+**Type Signature:**
+
+```ts
+async function preprocessCSS(
+  code: string,
+  filename: string,
+  config: ResolvedConfig,
+): Promise<PreprocessCSSResult>
+
+interface PreprocessCSSResult {
+  code: string
+  map?: SourceMapInput
+  modules?: Record<string, string>
+  deps?: Set<string>
+}
+```
+
+Pre-processes `.css`, `.scss`, `.sass`, `.less`, `.styl` and `.stylus` files to plain CSS so it can be used in browsers or parsed by other tools. Similar to the [built-in CSS pre-processing support](/guide/features#css-pre-processors), the corresponding pre-processor must be installed if used. The pre-processor is inferred from the `filename` extension. Note that pre-processing will not resolve URLs in `url()` or `image-set()`.


### PR DESCRIPTION
### Description

Document `preprocessCSS`. I often see users who want to use this but unsure how to. I hope this is enough or a good start explaining what it's about.

Also, I noticed we never quite link the function to the feedback discussion: https://github.com/vitejs/vite/discussions/13815. This should add it.