### PR TITLE
chore: pin ci windows node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - os: macos-latest
             node_version: 20
           - os: windows-latest
-            node_version: 20
+            node_version: 20.13.1 # 20.14.0 keeps causing a native `node::SetCppgcReference+18123` error in Vitest
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"


### PR DESCRIPTION
### Description

Pin to 20.13.1. Maybe this will fix the error.

```

  #  node (vitest)[4740]:  at c:\ws\src\node_file.cc:966
  #  Assertion failed: (req_wrap_async) != nullptr

----- Native stack trace -----

 ✓ packages/vite/src/node/__tests__/plugins/importGlob/utils.spec.ts  (6 tests) 8ms
 ✓ packages/vite/src/node/server/__tests__/moduleGraph.spec.ts  (2 tests) 9ms
 ✓ packages/vite/src/node/__tests__/plugins/json.spec.ts  (1 test) 4ms
 ✓ packages/vite/src/node/ssr/__tests__/ssrExternal.spec.ts  (2 tests) 47ms
 1: 00007FF638F46CEB node::SetCppgcReference+18123
 2: 00007FF638EB6B31 v8::base::CPU::num_virtual_address_bits+82705
 3: 00007FF638E9A402 v8::base::CPU::has_fpu+49202
 4: 00007FF6398E65EE v8::SharedValueConveyor::SharedValueConveyor+416270
 5: 00007FF6398E61EA v8::SharedValueConveyor::SharedValueConveyor+415242
 6: 00007FF6398E64AF v8::SharedValueConveyor::SharedValueConveyor+415951
 7: 00007FF6398E6320 v8::SharedValueConveyor::SharedValueConveyor+415552
 8: 00007FF6399E198E v8::PropertyDescriptor::writable+677838
 9: 0000028920129A3E 

----- JavaScript stack trace -----

1: access (node:internal/fs/promises:604:13)
2: search (D:\a\vite\vite\node_modules\.pnpm\lilconfig@3.0.0\node_modules\lilconfig\dist\index.js:105:43)


 ELIFECYCLE  Command failed with exit code 134.
Error: Process completed with exit code 1.
```