### PR TITLE
fix(vite-client): fix issue with CSS file update in web worker

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -207,6 +207,10 @@ async function handleMessage(payload: HMRPayload) {
 
           // css-update
           // this is only sent when a css file referenced with <link> is updated
+          // in web worker, the document is not available yet
+          if (!hasDocument) {
+            return Promise.resolve()
+          }
           const { path, timestamp } = update
           const searchUrl = cleanUrl(path)
           // can't use querySelector with `[href*=]` here since the link may be


### PR DESCRIPTION
### Description

In webworker websocket, you will also receive hmr events, but the css update events are not filtered, which leads to incorrect document access.