### PR TITLE
docs: add use secure

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -122,6 +122,12 @@ export default defineConfig({
           // proxy will be an instance of 'http-proxy'
         },
       },
+      // Using secure when proxy https unable to verify the certificate
+      '/api': {
+        target: 'https://jsonplaceholder.typicode.com',
+        changeOrigin: true,
+        secure: false
+      },
       // Proxying websockets or socket.io: ws://localhost:5173/socket.io -> ws://localhost:5174/socket.io
       '/socket.io': {
         target: 'ws://localhost:5174',


### PR DESCRIPTION
Using secure when proxy https unable to verify the certificate

### Description

When proxy requests to https, sometimes certificates cannot be verified

