### PR TITLE
test: wait networkidle before assert

### DIFF
--- a/playground/fs-serve/__tests__/base/fs-serve-base.spec.ts
+++ b/playground/fs-serve/__tests__/base/fs-serve-base.spec.ts
@@ -8,7 +8,11 @@ const stringified = JSON.stringify(testJSON)
 describe.runIf(isServe)('main', () => {
   beforeAll(async () => {
     const srcPrefix = viteTestUrl.endsWith('/') ? '' : '/'
-    await page.goto(viteTestUrl + srcPrefix + 'src/')
+    await page.goto(viteTestUrl + srcPrefix + 'src/', {
+      // while networkidle is discouraged, we use here because we're not using playwright's retry-able assertions,
+      // and refactoring the code below to manually retry would be harder to read.
+      waitUntil: 'networkidle',
+    })
   })
 
   test('default import', async () => {


### PR DESCRIPTION
### Description

I noticed the fail here: https://github.com/vitejs/vite/actions/runs/9459987381/job/26058036169?pr=17439

The browser page does many `fetch()` and we're not properly waiting for it to be completed before asserting.
