### PR TITLE
chore: test windows with node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - os: macos-latest
             node_version: 20
           - os: windows-latest
-            node_version: 20.13.1 # 20.14.0 keeps causing a native `node::SetCppgcReference+18123` error in Vitest
+            node_version: 20
       fail-fast: false
 
     name: "Build&Test: node-${{ matrix.node_version }}, ${{ matrix.os }}"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,6 +436,8 @@ importers:
 
   packages/vite/src/node/server/__tests__/fixtures/pnpm/nested: {}
 
+  packages/vite/src/node/server/__tests__/fixtures/watcher: {}
+
   packages/vite/src/node/server/__tests__/fixtures/yarn: {}
 
   packages/vite/src/node/server/__tests__/fixtures/yarn/nested: {}


### PR DESCRIPTION
### Description

I forgot to do this together with https://github.com/vitejs/vite/pull/17448

Since we no longer use threads for unit tests on windows, we should no longer have issues with the latest node 20 version.
