### PR TITLE
fix(create-vite): update tsconfig with moduleDetection force

### DIFF
--- a/packages/create-vite/template-lit-ts/tsconfig.json
+++ b/packages/create-vite/template-lit-ts/tsconfig.json
@@ -12,6 +12,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleDetection": "force",
     "noEmit": true,
 
     /* Linting */

--- a/packages/create-vite/template-preact-ts/tsconfig.app.json
+++ b/packages/create-vite/template-preact-ts/tsconfig.app.json
@@ -17,6 +17,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxImportSource": "preact",

--- a/packages/create-vite/template-qwik-ts/tsconfig.app.json
+++ b/packages/create-vite/template-qwik-ts/tsconfig.app.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
     "jsxImportSource": "@builder.io/qwik",

--- a/packages/create-vite/template-react-ts/tsconfig.app.json
+++ b/packages/create-vite/template-react-ts/tsconfig.app.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
 

--- a/packages/create-vite/template-solid-ts/tsconfig.app.json
+++ b/packages/create-vite/template-solid-ts/tsconfig.app.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleDetection": "force",
     "noEmit": true,
     "jsx": "preserve",
     "jsxImportSource": "solid-js",

--- a/packages/create-vite/template-svelte-ts/tsconfig.json
+++ b/packages/create-vite/template-svelte-ts/tsconfig.json
@@ -13,7 +13,8 @@
      */
     "allowJs": true,
     "checkJs": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "moduleDetection": "force"
   },
   "include": ["src/**/*.ts", "src/**/*.js", "src/**/*.svelte"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/packages/create-vite/template-vanilla-ts/tsconfig.json
+++ b/packages/create-vite/template-vanilla-ts/tsconfig.json
@@ -11,6 +11,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleDetection": "force",
     "noEmit": true,
 
     /* Linting */

--- a/packages/create-vite/template-vue-ts/tsconfig.app.json
+++ b/packages/create-vite/template-vue-ts/tsconfig.app.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "moduleDetection": "force",
     "noEmit": true,
     "jsx": "preserve",
 


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/17443

#### Problem solved:
With the current configuration, the application may compile successfully but fail at runtime. 

Reproducible example here:[https://stackblitz.com/edit/vitejs-vite-srbrdd]( https://stackblitz.com/edit/vitejs-vite-srbrdd?file=tsconfig.json)

#### Reproduction

https://stackblitz.com/edit/vitejs-vite-srbrdd?file=tsconfig.json

#### Steps to reproduce

1. Start a new typescript react project: [https://vite.new/react-ts](https://vite.new/react-ts)
2. Add a new `ts` file inside the `src` folder (for example `newfile.ts`) with this content: `const MY_CONST = 1`
3. Print the value of the constant inside `App.tsx` : `{MY_CONST}`,

At this point, you should be able to compile (with `npx tsc --noEmit`) or build the app ( `npm run build` ) without errors, but the app fails at runtime ( `npm run dev` ) in the preview. 



#### Notes:
I was only able to reproduce this with the react and react templates.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
