### PR TITLE
fix(build): handle preload treeshaking for commas

### DIFF
--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -193,6 +193,12 @@ test('dynamic import treeshaken log', async () => {
   expect(log).not.toContain('treeshaken removed')
 })
 
+test('dynamic import syntax parsing', async () => {
+  const log = browserLogs.join('\n')
+  expect(log).toContain('treeshaken syntax foo')
+  expect(log).toContain('treeshaken syntax default')
+})
+
 test.runIf(isBuild)('dynamic import treeshaken file', async () => {
   expect(findAssetFile(/treeshaken.+\.js$/)).not.toContain('treeshaken removed')
 })

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -138,6 +138,7 @@ import(`../nested/nested/${base}.js`).then((mod) => {
 ;(async function () {
   const { foo } = await import('./treeshaken/treeshaken.js')
   const { bar, default: tree } = await import('./treeshaken/treeshaken.js')
+  const default2 = (await import('./treeshaken/treeshaken.js')).default
   const baz1 = (await import('./treeshaken/treeshaken.js')).baz1
   const baz2 = (await import('./treeshaken/treeshaken.js')).baz2.log
   const baz3 = (await import('./treeshaken/treeshaken.js')).baz3?.log
@@ -145,18 +146,35 @@ import(`../nested/nested/${base}.js`).then((mod) => {
     ({ baz4 }) => baz4,
   )
   const baz5 = await import('./treeshaken/treeshaken.js').then(function ({
-    baz5,
-  }) {
-    return baz5
-  })
+      baz5,
+    }) {
+      return baz5
+    }),
+    { baz6 } = await import('./treeshaken/treeshaken.js')
   foo()
   bar()
   tree()
+  ;(await import('./treeshaken/treeshaken.js')).default()
+  default2()
   baz1()
   baz2()
   baz3()
   baz4()
   baz5()
+  baz6()
+})()
+// Test syntax parsing only
+;(async function () {
+  const default1 = await import('./treeshaken/syntax.js').then(
+    (mod) => mod.default,
+  )
+  const default2 = (await import('./treeshaken/syntax.js')).default,
+    other = () => {}
+  const foo = await import('./treeshaken/syntax.js').then((mod) => mod.foo)
+  default1()
+  default2()
+  other()
+  foo()
 })()
 
 import(`../nested/static.js`).then((mod) => {

--- a/playground/dynamic-import/nested/treeshaken/syntax.js
+++ b/playground/dynamic-import/nested/treeshaken/syntax.js
@@ -1,0 +1,6 @@
+export const foo = () => {
+  console.log('treeshaken syntax foo')
+}
+export default () => {
+  console.log('treeshaken syntax default')
+}

--- a/playground/dynamic-import/nested/treeshaken/treeshaken.js
+++ b/playground/dynamic-import/nested/treeshaken/treeshaken.js
@@ -23,6 +23,9 @@ export const baz4 = () => {
 export const baz5 = () => {
   console.log('treeshaken baz5')
 }
+export const baz6 = () => {
+  console.log('treeshaken baz6')
+}
 export const removed = () => {
   console.log('treeshaken removed')
 }


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/17466

We didn't handle the case for syntax like this.

```js
const foo = (await import('foo')).foo, bar = ...
```

The trailing comma was incorrectly captured by the regex. I updated it to capture the `.foo` part properly.

---

I also added additional handling for leading commas:

```js
const foo = ..., { bar } = await import('bar')
```

I adjusted the first portion of the regex to accommodate it.