### PR TITLE
fix(build): handle preload treeshaking for braces

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -42,7 +42,7 @@ const preloadMarkerRE = new RegExp(preloadMarker, 'g')
 const dynamicImportPrefixRE = /import\s*\(/
 
 const dynamicImportTreeshakenRE =
-  /((?:\bconst\s+|\blet\s+|\bvar\s+|,\s*)(\{[^}.]+\})\s*=\s*await\s+import\([^)]+\))|(\(\s*await\s+import\([^)]+\)\s*\)(\??\.[\w$]+))|\bimport\([^)]+\)(\s*\.then\([^{]*?\(\s*\{([^}.]+)\})/g
+  /((?:\bconst\s+|\blet\s+|\bvar\s+|,\s*)(\{[^}.]+\})\s*=\s*await\s+import\([^)]+\))|(\(\s*await\s+import\([^)]+\)\s*\)(\??\.[\w$]+))|\bimport\([^)]+\)(\s*\.then\(\s*(?:function\s*)?\(\s*\{([^}.]+)\}\))/g
 
 function toRelativePath(filename: string, importer: string) {
   const relPath = path.posix.relative(path.posix.dirname(importer), filename)
@@ -285,7 +285,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
 
           /* handle `import('foo').then(({foo})=>{})`
            *
-           * match[5]: `.then(({foo}`
+           * match[5]: `.then(({foo})`
            * match[6]: `foo`
            * import end: `import('foo').`
            *                           ^

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -171,10 +171,15 @@ import(`../nested/nested/${base}.js`).then((mod) => {
   const default2 = (await import('./treeshaken/syntax.js')).default,
     other = () => {}
   const foo = await import('./treeshaken/syntax.js').then((mod) => mod.foo)
+  const foo2 = await import('./treeshaken/syntax.js').then(
+    ({ foo = {} }) => foo,
+  )
+  await import('./treeshaken/syntax.js').then((mod) => mod.foo({ foo }))
   default1()
   default2()
   other()
   foo()
+  foo2()
 })()
 
 import(`../nested/static.js`).then((mod) => {


### PR DESCRIPTION
### Description
fix https://github.com/vitejs/vite/issues/17478

Handle the cases shown in the issue above. The third part of the regex was to lax to support `import(...).then(function ({ ... })` so I tighten it up so it's not too greedy.

---

While fixing this, I started to notice that regexes would fall apart as long as someone sets fallback values, like:

```js
const { foo = "fallback" } = await import(...)

await import(...).then(({ foo = "fallback" }) => {})
```

The `"fallback"` could be anything that tricks the regex to end early. However, I think it's very rare for dynamic imports to have fallback values, so we can see how far regex goes before needing to go with an AST approach. Or maybe until then we can rethink preload transforms.