### PR TITLE
fix(worker): nested inlined worker always fallbacked to data URI worker instead of using blob worker

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -305,7 +305,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
             workerConstructor === 'Worker'
               ? `${encodedJs}
           const decodeBase64 = (base64) => Uint8Array.from(atob(base64), c => c.charCodeAt(0));
-          const blob = typeof window !== "undefined" && window.Blob && new Blob([${
+          const blob = typeof self !== "undefined" && self.Blob && new Blob([${
             workerType === 'classic'
               ? ''
               : // `URL` is always available, in `Worker[type="module"]`
@@ -314,11 +314,11 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
           export default function WorkerWrapper(options) {
             let objURL;
             try {
-              objURL = blob && (window.URL || window.webkitURL).createObjectURL(blob);
+              objURL = blob && (self.URL || self.webkitURL).createObjectURL(blob);
               if (!objURL) throw ''
               const worker = new ${workerConstructor}(objURL, ${workerTypeOption});
               worker.addEventListener("error", () => {
-                (window.URL || window.webkitURL).revokeObjectURL(objURL);
+                (self.URL || self.webkitURL).revokeObjectURL(objURL);
               });
               return worker;
             } catch(e) {
@@ -331,7 +331,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
               // otherwise the worker fails to run
               workerType === 'classic'
                 ? ` finally {
-                    objURL && (window.URL || window.webkitURL).revokeObjectURL(objURL);
+                    objURL && (self.URL || self.webkitURL).revokeObjectURL(objURL);
                   }`
                 : ''
             }

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -127,10 +127,10 @@ describe.runIf(isBuild)('build', () => {
     expect(content).toMatch(`new Worker("/es/assets`)
     expect(content).toMatch(`new SharedWorker("/es/assets`)
     // inlined worker
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
-    expect(content).toMatch(`window.Blob`)
+    expect(content).toMatch(`(self.URL||self.webkitURL).createObjectURL`)
+    expect(content).toMatch(`self.Blob`)
     expect(content).toMatch(
-      /try\{if\(\w+=\w+&&\(window\.URL\|\|window\.webkitURL\)\.createObjectURL\(\w+\),!\w+\)throw""/,
+      /try\{if\(\w+=\w+&&\(self\.URL\|\|self\.webkitURL\)\.createObjectURL\(\w+\),!\w+\)throw""/,
     )
     // inlined shared worker
     expect(content).toMatch(

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -91,8 +91,8 @@ describe.runIf(isBuild)('build', () => {
     expect(content).toMatch(`new Worker("/iife/assets`)
     expect(content).toMatch(`new SharedWorker("/iife/assets`)
     // inlined
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
-    expect(content).toMatch(`window.Blob`)
+    expect(content).toMatch(`(self.URL||self.webkitURL).createObjectURL`)
+    expect(content).toMatch(`self.Blob`)
   })
 
   test('worker emitted and import.meta.url in nested worker (build)', async () => {

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -90,8 +90,8 @@ describe.runIf(isBuild)('build', () => {
     expect(content).toMatch(`new Worker(""+new URL("../worker-entries/`)
     expect(content).toMatch(`new SharedWorker(""+new URL("../worker-entries/`)
     // inlined
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
-    expect(content).toMatch(`window.Blob`)
+    expect(content).toMatch(`(self.URL||self.webkitURL).createObjectURL`)
+    expect(content).toMatch(`self.Blob`)
   })
 
   test('worker emitted and import.meta.url in nested worker (build)', async () => {

--- a/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
@@ -106,8 +106,8 @@ describe.runIf(isBuild)('build', () => {
     )
 
     // inlined
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
-    expect(content).toMatch(`window.Blob`)
+    expect(content).toMatch(`(self.URL||self.webkitURL).createObjectURL`)
+    expect(content).toMatch(`self.Blob`)
 
     expect(workerNestedWorkerContent).toMatch(
       `new Worker("/iife-sourcemap-hidden/assets/sub-worker`,

--- a/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
@@ -87,8 +87,8 @@ describe.runIf(isBuild)('build', () => {
     )
 
     // inlined
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
-    expect(content).toMatch(`window.Blob`)
+    expect(content).toMatch(`(self.URL||self.webkitURL).createObjectURL`)
+    expect(content).toMatch(`self.Blob`)
 
     expect(workerNestedWorkerContent).toMatch(
       `new Worker("/iife-sourcemap-inline/assets/sub-worker`,

--- a/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
+++ b/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
@@ -107,8 +107,8 @@ describe.runIf(isBuild)('build', () => {
     )
 
     // inlined
-    expect(content).toMatch(`(window.URL||window.webkitURL).createObjectURL`)
-    expect(content).toMatch(`window.Blob`)
+    expect(content).toMatch(`(self.URL||self.webkitURL).createObjectURL`)
+    expect(content).toMatch(`self.Blob`)
 
     expect(workerNestedWorkerContent).toMatch(
       `new Worker("/iife-sourcemap/assets/sub-worker`,


### PR DESCRIPTION
### Description

fix #17507

Creating a WebWorker inside a WebWorker will the self.origin value being null.
Beacause WebWorker was created using a Data URL.

