### PR TITLE
docs: clarify when `transformIndexHtml` hook runs or not

### DIFF
--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -400,7 +400,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
   ```
 
   ::: warning Note
-  This hook may not always be run if you are using a framework: it is up to the framework to call `server.transformIndexHtml`.
+  This hook won't be called if you are using a framework that has custom handling of entry files (for example [SvelteKit](https://github.com/sveltejs/kit/discussions/8269#discussioncomment-4509145).
   :::
 
 ### `handleHotUpdate`

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -400,7 +400,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
   ```
 
   ::: warning Note
-  This plugin may not always be run if you are using a framework. It is up to the framework to call this hook.
+  This hook may not always be run if you are using a framework: it is up to the framework to call `server.transformIndexHtml`.
   :::
 
 ### `handleHotUpdate`

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -400,7 +400,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
   ```
 
   ::: warning Note
-  This plugin will not run when [`appType`](https://vitejs.dev/config/shared-options.html#apptype) is `"custom"`. HTML middlewares should be handled at the framework level.
+  This plugin may not always be run if you are using a framework. It is up to the framework to call this hook.
   :::
 
 ### `handleHotUpdate`

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -363,6 +363,10 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
   }
   ```
 
+  ::: warning Note
+  This plugin will not run when [`appType`](https://vitejs.dev/config/shared-options.html#apptype) is `"custom"`. HTML middlewares should be handled at the framework level.
+  :::
+
   **Full Hook Signature:**
 
   ```ts

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -363,10 +363,6 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
   }
   ```
 
-  ::: warning Note
-  This plugin will not run when [`appType`](https://vitejs.dev/config/shared-options.html#apptype) is `"custom"`. HTML middlewares should be handled at the framework level.
-  :::
-
   **Full Hook Signature:**
 
   ```ts
@@ -402,6 +398,10 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
     injectTo?: 'head' | 'body' | 'head-prepend' | 'body-prepend'
   }
   ```
+
+  ::: warning Note
+  This plugin will not run when [`appType`](https://vitejs.dev/config/shared-options.html#apptype) is `"custom"`. HTML middlewares should be handled at the framework level.
+  :::
 
 ### `handleHotUpdate`
 


### PR DESCRIPTION
### Description

Fixes some confusion around `transformIndexHtml` hook

Related https://github.com/sveltejs/kit/issues/12391 and https://github.com/sveltejs/kit/discussions/8269

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
