### PR TITLE
chore(deps): update es-module-lexer to 1.5.4

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -116,7 +116,7 @@
     "dep-types": "link:./src/types",
     "dotenv": "^16.4.5",
     "dotenv-expand": "^11.0.6",
-    "es-module-lexer": "^1.5.3",
+    "es-module-lexer": "^1.5.4",
     "escape-html": "^1.0.3",
     "estree-walker": "^3.0.3",
     "etag": "^1.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,8 +311,8 @@ importers:
         specifier: ^11.0.6
         version: 11.0.6
       es-module-lexer:
-        specifier: ^1.5.3
-        version: 1.5.3
+        specifier: ^1.5.4
+        version: 1.5.4
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -4307,8 +4307,8 @@ packages:
     resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==}
     hasBin: true
 
-  es-module-lexer@1.5.3:
-    resolution: {integrity: sha512-i1gCgmR9dCl6Vil6UKPI/trA69s08g/syhiDK9TG0Nf1RJjjFI+AzoWW7sPufzkgYAn861skuCwJa0pIIHYxvg==}
+  es-module-lexer@1.5.4:
+    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
 
   es5-ext@0.10.64:
     resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
@@ -9531,7 +9531,7 @@ snapshots:
       prr: 1.0.1
     optional: true
 
-  es-module-lexer@1.5.3: {}
+  es-module-lexer@1.5.4: {}
 
   es5-ext@0.10.64:
     dependencies:
@@ -11538,7 +11538,7 @@ snapshots:
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.13.0)
       debug: 4.3.5
-      es-module-lexer: 1.5.3
+      es-module-lexer: 1.5.4
       esbuild: 0.21.5
       get-tsconfig: 4.7.2
       rollup: 4.13.0


### PR DESCRIPTION
### Description

Bumps es-module-lexer to 1.5.4, to pick up a fix for a parse error that can show up post-minification in 
`vite:build-import-analysis`'s `renderBundle` as:

```
x Build failed in 59.25s
error during build:
[vite:build-import-analysis] [plugin vite:build-import-analysis] assets/index-CzUoSXHE.js (701:14832): Parse error @:701:14832

<...snip minified source...>
```

You could also just regenerate the latest renovate PR, #17553 I guess.