### PR TITLE
fix(proxy): replace changeOrigin changes in 5.3.0 with new rewriteWsOrigin option

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -90,7 +90,7 @@ Configure custom proxy rules for the dev server. Expects an object of `{ key: op
 
 Note that if you are using non-relative [`base`](/config/shared-options.md#base), you must prefix each key with that `base`.
 
-Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13). Note that [Unlike http-proxy](https://github.com/http-party/node-http-proxy/issues/1669), the `rewriteWsOrigin` option will rewrite a WebScocket request Origin header to match the target. **Exercise caution as rewriting the Origin can leave the proxying open to [CSRF attacks](https://owasp.org/www-community/attacks/csrf).**
+Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13).
 
 In some cases, you might also want to configure the underlying dev server (e.g. to add custom middlewares to the internal [connect](https://github.com/senchalabs/connect) app). In order to do that, you need to write your own [plugin](/guide/using-plugins.html) and use [configureServer](/guide/api-plugin.html#configureserver) function.
 
@@ -123,9 +123,11 @@ export default defineConfig({
         },
       },
       // Proxying websockets or socket.io: ws://localhost:5173/socket.io -> ws://localhost:5174/socket.io
+      // Exercise caution using `rewriteWsOrigin` as it can leave the proxying open to CSRF attacks.
       '/socket.io': {
         target: 'ws://localhost:5174',
         ws: true,
+        rewriteWsOrigin: true,
       },
     },
   },

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -90,7 +90,7 @@ Configure custom proxy rules for the dev server. Expects an object of `{ key: op
 
 Note that if you are using non-relative [`base`](/config/shared-options.md#base), you must prefix each key with that `base`.
 
-Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13). Note that [unlike http-proxy](https://github.com/http-party/node-http-proxy/issues/1669), the `changeOrigin` option will change both host and origin headers to match the target.
+Extends [`http-proxy`](https://github.com/http-party/node-http-proxy#options). Additional options are [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/middlewares/proxy.ts#L13). Note that [Unlike http-proxy](https://github.com/http-party/node-http-proxy/issues/1669), the `rewriteWsOrigin` option will rewrite a WebScocket request Origin header to match the target. **Exercise caution as rewriting the Origin can leave the proxying open to [CSRF attacks](https://owasp.org/www-community/attacks/csrf).**
 
 In some cases, you might also want to configure the underlying dev server (e.g. to add custom middlewares to the internal [connect](https://github.com/senchalabs/connect) app). In order to do that, you need to write your own [plugin](/guide/using-plugins.html) and use [configureServer](/guide/api-plugin.html#configureserver) function.
 

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -29,16 +29,15 @@ export interface ProxyOptions extends HttpProxy.ServerOptions {
   ) => void | null | undefined | false | string
 }
 
-const setOriginHeader = (
+const rewriteOriginHeader = (
   proxyReq: http.ClientRequest,
   options: HttpProxy.ServerOptions,
 ) => {
   // Browsers may send Origin headers even with same-origin
   // requests. It is common for WebSocket servers to check the Origin
-  // header, so if changeOrigin is true we change the Origin to match
+  // header, so if rewriteWsOrigin is true we change the Origin to match
   // the target URL.
-  // https://github.com/http-party/node-http-proxy/issues/1669
-  if (options.changeOrigin) {
+  if (options.rewriteWsOrigin) {
     const { target } = options
 
     if (proxyReq.getHeader('origin') && target) {
@@ -112,12 +111,8 @@ export function proxyMiddleware(
       }
     })
 
-    proxy.on('proxyReq', (proxyReq, req, res, options) => {
-      setOriginHeader(proxyReq, options)
-    })
-
     proxy.on('proxyReqWs', (proxyReq, req, socket, options, head) => {
-      setOriginHeader(proxyReq, options)
+      rewriteOriginHeader(proxyReq, options)
 
       socket.on('error', (err) => {
         config.logger.error(

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -27,11 +27,15 @@ export interface ProxyOptions extends HttpProxy.ServerOptions {
     res: http.ServerResponse,
     options: ProxyOptions,
   ) => void | null | undefined | false | string
+  /**
+   * rewrite the Origin header of a WebSocket request to match the the target
+   */
+  rewriteWsOrigin?: boolean | undefined
 }
 
 const rewriteOriginHeader = (
   proxyReq: http.ClientRequest,
-  options: HttpProxy.ServerOptions,
+  options: ProxyOptions,
   config: ResolvedConfig,
 ) => {
   // Browsers may send Origin headers even with same-origin

--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -29,6 +29,8 @@ export interface ProxyOptions extends HttpProxy.ServerOptions {
   ) => void | null | undefined | false | string
   /**
    * rewrite the Origin header of a WebSocket request to match the the target
+   *
+   * **Exercise caution as rewriting the Origin can leave the proxying open to [CSRF attacks](https://owasp.org/www-community/attacks/csrf).**
    */
   rewriteWsOrigin?: boolean | undefined
 }

--- a/packages/vite/src/types/http-proxy.d.ts
+++ b/packages/vite/src/types/http-proxy.d.ts
@@ -212,8 +212,6 @@ export namespace HttpProxy {
     localAddress?: string | undefined
     /** Changes the origin of the host header to the target URL. */
     changeOrigin?: boolean | undefined
-    /** Rewrites the Origin header of a WebSocket request to match the the target */
-    rewriteWsOrigin?: boolean | undefined
     /** specify whether you want to keep letter case of response header key */
     preserveHeaderKeyCase?: boolean | undefined
     /** Basic authentication i.e. 'user:password' to compute an Authorization header. */

--- a/packages/vite/src/types/http-proxy.d.ts
+++ b/packages/vite/src/types/http-proxy.d.ts
@@ -212,6 +212,8 @@ export namespace HttpProxy {
     localAddress?: string | undefined
     /** Changes the origin of the host header to the target URL. */
     changeOrigin?: boolean | undefined
+    /** Rewrites the Origin header of a WebSocket request to match the the target */
+    rewriteWsOrigin?: boolean | undefined
     /** specify whether you want to keep letter case of response header key */
     preserveHeaderKeyCase?: boolean | undefined
     /** Basic authentication i.e. 'user:password' to compute an Authorization header. */


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

fixes #17562
fixes #17520 

This PR reverts the change to the changeOrigin option released in 5.3.0 and adds an alternative  solution:

- A new `rewriteWsOrigin` option which rewrites the Origin header for WebSocket requests only
- Check for `headersSent` prior to rewriting, logging a warning if it does not rewrite
- Update docs for new option and warns about the security implications

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
