### PR TITLE
docs: switch Polyfill.io to Cloudflare hosted version

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -13,7 +13,7 @@ The production bundle assumes support for modern JavaScript. By default, Vite ta
 
 You can specify custom targets via the [`build.target` config option](/config/build-options.md#build-target), where the lowest target is `es2015`.
 
-Note that by default, Vite only handles syntax transforms and **does not cover polyfills**. You can check out [Polyfill.io](https://polyfill.io/) which is a service that automatically generates polyfill bundles based on the user's browser UserAgent string.
+Note that by default, Vite only handles syntax transforms and **does not cover polyfills**. You can check out [Polyfill JS](https://cdnjs.cloudflare.com/polyfill/) which is a service that automatically generates polyfill bundles based on the user's browser UserAgent string.
 
 Legacy browsers can be supported via [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy), which will automatically generate legacy chunks and corresponding ES language feature polyfills. The legacy chunks are conditionally loaded only in browsers that do not have native ESM support.
 


### PR DESCRIPTION
The developer of Polyfill JS has been recommending not using polyfill.io [for a while](https://x.com/triblondon/status/1761852117579427975).

Currently on HN there is a conversation about [potential supply chain attack on polyfill.io](https://news.ycombinator.com/item?id=40791829).

Looks like CloudFlare went ahead and hosted their own in anticipation of this: https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk

