### PR TITLE
fix(typescript): correctly expand ${configDir} in tsconfig.json

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -146,7 +146,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.1.0",
-    "tsconfck": "^3.1.0",
+    "tsconfck": "^3.1.1",
     "tslib": "^2.6.3",
     "types": "link:./types",
     "ufo": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,8 +401,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       tsconfck:
-        specifier: ^3.1.0
-        version: 3.1.0(typescript@5.2.2)
+        specifier: ^3.1.1
+        version: 3.1.1(typescript@5.2.2)
       tslib:
         specifier: ^2.6.3
         version: 2.6.3
@@ -6417,8 +6417,8 @@ packages:
       '@swc/wasm':
         optional: true
 
-  tsconfck@3.1.0:
-    resolution: {integrity: sha512-CMjc5zMnyAjcS9sPLytrbFmj89st2g+JYtY/c02ug4Q+CZaAtCgbyviI0n1YvjZE/pzoc6FbNsINS13DOL1B9w==}
+  tsconfck@3.1.1:
+    resolution: {integrity: sha512-00eoI6WY57SvZEVjm13stEVE90VkEdJAFGgpFLTsZbJyW/LwFQ7uQxJHWpZ2hzSWgCPKc9AnBnNP+0X7o3hAmQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
@@ -11973,7 +11973,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tsconfck@3.1.0(typescript@5.2.2):
+  tsconfck@3.1.1(typescript@5.2.2):
     optionalDependencies:
       typescript: 5.2.2
 


### PR DESCRIPTION
### Description

tsconfck @ 3.1.0 contained a bug that caused `${configDir}` to be expanded incorrectly (missing a path segment). see https://github.com/dominikg/tsconfck/pull/179 for the fix

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
