### PR TITLE
feat: support `resolve.alias` per environment in Environment API

### DIFF
--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -1,0 +1,101 @@
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { createServer } from '../server'
+import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
+import type { ResolveIdFn } from '../idResolver'
+import { createIdResolver } from '../idResolver'
+import { normalizePath } from '../utils'
+
+const root = fileURLToPath(new URL('./', import.meta.url))
+
+async function createDevServer() {
+  const server = await createServer({
+    configFile: false,
+    root,
+    logLevel: 'silent',
+    plugins: [
+      (() => {
+        let idResolver: ResolveIdFn
+        return {
+          name: 'environment-alias-test-plugin',
+          configResolved(config) {
+            idResolver = createIdResolver(config, {})
+          },
+          async resolveId(id) {
+            return await idResolver(this.environment, id)
+          },
+        }
+      })(),
+    ],
+    environments: {
+      client: {
+        resolve: {
+          alias: [
+            {
+              find: 'mod',
+              replacement: '/fixtures/environment-alias/test.client.js',
+            },
+          ],
+        },
+      },
+      ssr: {
+        resolve: {
+          alias: [
+            {
+              find: 'mod',
+              replacement: '/fixtures/environment-alias/test.ssr.js',
+            },
+          ],
+        },
+      },
+      rsc: {
+        resolve: {
+          alias: [
+            {
+              find: 'mod',
+              replacement: '/fixtures/environment-alias/test.rsc.js',
+            },
+          ],
+        },
+      },
+    },
+  })
+
+  const moduleRunner = createServerModuleRunner(server.environments.rsc)
+  return { server, moduleRunner }
+}
+
+test('alias', async () => {
+  expect.assertions(7)
+  const { server, moduleRunner } = await createDevServer()
+
+  const [clientId, ssrId, rscId, clientReq, ssrReq, rscReq, rscMod] =
+    await Promise.all([
+      server.environments.client.pluginContainer.resolveId('mod'),
+      server.environments.ssr.pluginContainer.resolveId('mod'),
+      server.environments.rsc.pluginContainer.resolveId('mod'),
+      server.environments.client.transformRequest('mod'),
+      server.environments.ssr.transformRequest('mod'),
+      server.environments.rsc.transformRequest('mod'),
+      moduleRunner.import('mod'),
+    ])
+
+  expect(clientId?.id).toEqual(
+    normalizePath(
+      path.join(root, '/fixtures/environment-alias/test.client.js'),
+    ),
+  )
+  expect(ssrId?.id).toEqual(
+    normalizePath(path.join(root, '/fixtures/environment-alias/test.ssr.js')),
+  )
+  expect(rscId?.id).toEqual(
+    normalizePath(path.join(root, '/fixtures/environment-alias/test.rsc.js')),
+  )
+
+  expect(clientReq?.code ?? '').toContain('(client)')
+  expect(ssrReq?.code ?? '').toContain('(ssr)')
+  expect(rscReq?.code ?? '').toContain('(rsc)')
+
+  expect(rscMod?.msg).toContain('(rsc)')
+})

--- a/packages/vite/src/node/__tests__/fixtures/environment-alias/test.client.js
+++ b/packages/vite/src/node/__tests__/fixtures/environment-alias/test.client.js
@@ -1,0 +1,1 @@
+export const msg = `[success] (client) alias to mod path`

--- a/packages/vite/src/node/__tests__/fixtures/environment-alias/test.rsc.js
+++ b/packages/vite/src/node/__tests__/fixtures/environment-alias/test.rsc.js
@@ -1,0 +1,1 @@
+export const msg = `[success] (rsc) alias to mod path`

--- a/packages/vite/src/node/__tests__/fixtures/environment-alias/test.ssr.js
+++ b/packages/vite/src/node/__tests__/fixtures/environment-alias/test.ssr.js
@@ -1,0 +1,1 @@
+export const msg = `[success] (ssr) alias to mod path`

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -40,7 +40,7 @@ export function createIdResolver(
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
         [
-          aliasPlugin({ entries: config.resolve.alias }), // TODO: resolve.alias per environment?
+          aliasPlugin({ entries: environment.options.resolve.alias }), // TODO: resolve.alias per environment?
           resolvePlugin({
             root: config.root,
             isProduction: config.isProduction,
@@ -74,7 +74,7 @@ export function createIdResolver(
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
         [
-          aliasPlugin({ entries: config.resolve.alias }), // TODO: resolve.alias per environment?
+          aliasPlugin({ entries: environment.options.resolve.alias }), // TODO: resolve.alias per environment?
         ],
       )
       aliasOnlyPluginContainerMap.set(environment, pluginContainer)

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -40,7 +40,7 @@ export function createIdResolver(
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
         [
-          aliasPlugin({ entries: environment.options.resolve.alias }), // TODO: resolve.alias per environment?
+          aliasPlugin({ entries: environment.options.resolve.alias }),
           resolvePlugin({
             root: config.root,
             isProduction: config.isProduction,

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -74,7 +74,7 @@ export function createIdResolver(
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
         [
-          aliasPlugin({ entries: environment.options.resolve.alias }), // TODO: resolve.alias per environment?
+          aliasPlugin({ entries: environment.options.resolve.alias }),
         ],
       )
       aliasOnlyPluginContainerMap.set(environment, pluginContainer)


### PR DESCRIPTION
### Description

This PR implements the suggested solution in #17582 and adds a test playground named `environment-alias` to check that the new alias plugin is using the `resolve.alias` specified per environment.