### PR TITLE
fix(lib): remove pure CSS dynamic import

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -403,7 +403,9 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
         return
       }
 
-      if (ssr || isWorker) {
+      // If preload is not enabled, we parse through each imports and remove any imports to pure CSS chunks
+      // as they are removed from the bundle
+      if (!insertPreload) {
         const removedPureCssFiles = removedPureCssFilesCache.get(config)
         if (removedPureCssFiles && removedPureCssFiles.size > 0) {
           for (const file in bundle) {

--- a/playground/lib/__tests__/lib.spec.ts
+++ b/playground/lib/__tests__/lib.spec.ts
@@ -67,6 +67,14 @@ describe.runIf(isBuild)('build', () => {
     expect(code).toMatch(/await import\("\.\/message-[-\w]{8}.js"\)/)
   })
 
+  test('Library mode does not have any reference to pure CSS chunks', async () => {
+    const code = readFile('dist/lib/dynamic-import-message.es.mjs')
+
+    // Does not import pure CSS chunks and replaced by `Promise.resolve({})` instead
+    expect(code).not.toMatch(/await import\("\.\/dynamic-[-\w]{8}.js"\)/)
+    expect(code).toMatch(/await Promise.resolve\(\{.*\}\)/)
+  })
+
   test('@import hoist', async () => {
     serverLogs.forEach((log) => {
       // no warning from esbuild css minifier


### PR DESCRIPTION
### Description
fix https://github.com/vitejs/vite/issues/17548

Similar to https://github.com/vitejs/vite/pull/17371 but for lib mode. The original condition needed to add `config.build.lib` check which becomes similar to the `insertPreload` variable:

https://github.com/vitejs/vite/blob/410f01ccdf6548e8e8ed4a1081420c45e73c5dc6/packages/vite/src/node/plugins/importAnalysisBuild.ts#L164

So I used the variable instead.