### PR TITLE
fix: lazily evaluate __vite__mapDeps files

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -657,7 +657,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               )
               .join(',')}]`
 
-            const mapDepsCode = `const __vite__fileDeps=${fileDepsCode},__vite__mapDeps=i=>i.map(i=>__vite__fileDeps[i]);\n`
+            const mapDepsCode = `const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=${fileDepsCode})))=>i.map(i=>d[i]);\n`
 
             // inject extra code at the top or next line of hashbang
             if (code.startsWith('#!')) {

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -164,7 +164,7 @@ describe.runIf(isBuild)('build tests', () => {
     const js = findAssetFile(/after-preload-dynamic-hashbang-[-\w]{8}\.js$/)
     expect(js.split('\n').slice(0, 2)).toEqual([
       '#!/usr/bin/env node',
-      expect.stringContaining('const __vite__fileDeps=['),
+      expect.stringContaining('const __vite__mapDeps=(i'),
     ])
   })
 


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/17575

Uses alternate code from https://github.com/vitejs/vite/pull/16184. The code length is actually the same. I renamed some minified variables so it helps readability a bit.