### PR TITLE
fix(css): include `.css?url` in assets field of manifest

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -709,8 +709,10 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             .get(config)!
             .set(referenceId, { originalName: originalFilename })
 
+          const filename = this.getFileName(referenceId)
+          chunk.viteMetadata!.importedAssets.add(cleanUrl(filename))
           const replacement = toOutputFilePathInJS(
-            this.getFileName(referenceId),
+            filename,
             'asset',
             chunk.fileName,
             'js',

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -36,6 +36,7 @@ describe.runIf(isBuild)('build', () => {
   test('manifest', async () => {
     const manifest = readManifest('dev')
     const htmlEntry = manifest['index.html']
+    const mainTsEntry = manifest['main.ts']
     const cssAssetEntry = manifest['global.css']
     const pcssAssetEntry = manifest['foo.pcss']
     const scssAssetEntry = manifest['nested/blue.scss']
@@ -44,6 +45,10 @@ describe.runIf(isBuild)('build', () => {
     const iconEntrypointEntry = manifest['icon.png']
     expect(htmlEntry.css.length).toEqual(1)
     expect(htmlEntry.assets.length).toEqual(1)
+    expect(mainTsEntry.assets?.length ?? 0).toBeGreaterThanOrEqual(1)
+    expect(mainTsEntry.assets).toContainEqual(
+      expect.stringMatching(/assets\/url-[-\w]{8}\.css/),
+    )
     expect(cssAssetEntry?.file).not.toBeUndefined()
     expect(cssAssetEntry?.isEntry).toEqual(true)
     expect(pcssAssetEntry?.file).not.toBeUndefined()

--- a/playground/backend-integration/frontend/entrypoints/main.ts
+++ b/playground/backend-integration/frontend/entrypoints/main.ts
@@ -1,4 +1,10 @@
 import 'vite/modulepreload-polyfill'
+import cssUrl from '../styles/url.css?url'
+
+const cssLink = document.createElement('link')
+cssLink.rel = 'stylesheet'
+cssLink.href = cssUrl
+document.querySelector('head').appendChild(cssLink)
 
 export const colorClass = 'text-black'
 

--- a/playground/backend-integration/frontend/entrypoints/main.ts
+++ b/playground/backend-integration/frontend/entrypoints/main.ts
@@ -4,7 +4,7 @@ import cssUrl from '../styles/url.css?url'
 const cssLink = document.createElement('link')
 cssLink.rel = 'stylesheet'
 cssLink.href = cssUrl
-document.querySelector('head').appendChild(cssLink)
+document.querySelector('head').prepend(cssLink)
 
 export const colorClass = 'text-black'
 

--- a/playground/backend-integration/frontend/styles/url.css
+++ b/playground/backend-integration/frontend/styles/url.css
@@ -1,0 +1,3 @@
+.url {
+  color: red;
+}


### PR DESCRIPTION
### Description

fixes #17484

The manifest in the repro changes from
```
  "_stuff.js": {
    "file": "chunks/stuff.js",
    "name": "stuff",
    "assets": [
      "assets/text.txt"
    ]
  }
```
to
```
  "_stuff.js": {
    "file": "chunks/stuff.js",
    "name": "stuff",
    "assets": [
      "assets/text.txt",
      "assets/styles.css"
    ]
  },
```

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
