### PR TITLE
chore: move shinigami to team emeriti

### DIFF
--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -186,6 +186,5 @@ export const emeriti = [
       { icon: 'github', link: 'https://github.com/Shinigami92' },
       { icon: 'mastodon', link: 'https://elk.zone/mas.to/@Shini92' },
     ],
-    sponsor: 'https://github.com/sponsors/Shinigami92',
   },
 ]

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -100,19 +100,6 @@ export const core = [
     sponsor: 'https://github.com/sponsors/sheremet-va',
   },
   {
-    avatar: 'https://github.com/Shinigami92.png',
-    name: 'Shinigami',
-    title: 'Maintainer',
-    org: 'Faker',
-    orgLink: 'https://fakerjs.dev',
-    desc: 'Passionate TypeScript enthusiast working extensively with Vue SPA and pug.',
-    links: [
-      { icon: 'github', link: 'https://github.com/Shinigami92' },
-      { icon: 'mastodon', link: 'https://elk.zone/mas.to/@Shini92' },
-    ],
-    sponsor: 'https://github.com/sponsors/Shinigami92',
-  },
-  {
     avatar: 'https://github.com/sodatea.png',
     name: 'Haoqun Jiang',
     title: 'Developer',
@@ -187,5 +174,18 @@ export const emeriti = [
     name: 'Nihal Gonsalves',
     title: 'Senior Software Engineer',
     links: [{ icon: 'github', link: 'https://github.com/nihalgonsalves' }],
+  },
+  {
+    avatar: 'https://github.com/Shinigami92.png',
+    name: 'Shinigami',
+    title: 'Senior Frontend Engineer',
+    org: 'Faker',
+    orgLink: 'https://fakerjs.dev',
+    desc: 'Passionate TypeScript enthusiast working extensively with Vue SPA.',
+    links: [
+      { icon: 'github', link: 'https://github.com/Shinigami92' },
+      { icon: 'mastodon', link: 'https://elk.zone/mas.to/@Shini92' },
+    ],
+    sponsor: 'https://github.com/sponsors/Shinigami92',
   },
 ]


### PR DESCRIPTION
After a very long thinking phase I came to the conclusion that I cant handle required effort for being a Vite "Core" Team member anymore 🥲  

I have to much work with projects like https://github.com/salsita/node-pg-migrate and https://github.com/faker-js/faker, but also many other things
I will still be available here and there and I will e.g. be a happy moderator for ViteConf as the two last years
Also I bring Vite and Vue ecosystem into everything I touch ^^ may it company work or open source

I hope this decision will reduce some internal pressure I give to myself and I can focus on more important things for my scope
Vite... just works for me 😄 

MANY THANKS to all the persons I meet along this journey

- @yyx990803 
- @patak-dev 
- @antfu 
- @danielroe 
- @JessicaSachs 
- @sheremet-va 
- @ArnaudBarre 
- @Niputi 
- and many other persons

Without Vite I would not have worked with these people 🫶🥲 