### PR TITLE
docs: show usage with `satisfies` operator

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -44,7 +44,15 @@ export default defineConfig({
 })
 ```
 
-Vite also directly supports TS config files. You can use `vite.config.ts` with the `defineConfig` helper as well.
+Vite also supports TypeScript config files. You can use `vite.config.ts` with the `defineConfig` helper function above, or with the `satisfies` operator:
+
+```ts
+import type { UserConfig } from 'vite'
+
+export default {
+  // ...
+} satisfies UserConfig
+```
 
 ## Conditional Config
 


### PR DESCRIPTION
### Description

TypeScript 4.9 added the [satisfies operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html) which fits this use case perfectly. This PR updates the docs to demonstrate that usage. This should probably be the recommendation for most TS projects, as long as they are using at least 4.9 (released Nov '22). Definitely open to challenges on phrasing or ordering.