### PR TITLE
chore: add `create-preact` recommendation to Preact templates

### DIFF
--- a/packages/create-vite/template-preact-ts/src/app.tsx
+++ b/packages/create-vite/template-preact-ts/src/app.tsx
@@ -29,8 +29,9 @@ export function App() {
         Check out{' '}
         <a href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app" target="_blank">
             create-preact
-      </a>
-      , the official Preact + Vite starter
+        </a>
+        , the official Preact + Vite starter
+      </p>
       <p class="read-the-docs">
         Click on the Vite and Preact logos to learn more
       </p>

--- a/packages/create-vite/template-preact-ts/src/app.tsx
+++ b/packages/create-vite/template-preact-ts/src/app.tsx
@@ -25,6 +25,12 @@ export function App() {
           Edit <code>src/app.tsx</code> and save to test HMR
         </p>
       </div>
+      <p>
+        Check out{' '}
+        <a href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app" target="_blank">
+            create-preact
+      </a>
+      , the official Preact + Vite starter
       <p class="read-the-docs">
         Click on the Vite and Preact logos to learn more
       </p>

--- a/packages/create-vite/template-preact-ts/src/app.tsx
+++ b/packages/create-vite/template-preact-ts/src/app.tsx
@@ -27,8 +27,11 @@ export function App() {
       </div>
       <p>
         Check out{' '}
-        <a href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app" target="_blank">
-            create-preact
+        <a
+          href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app"
+          target="_blank"
+        >
+          create-preact
         </a>
         , the official Preact + Vite starter
       </p>

--- a/packages/create-vite/template-preact/src/app.jsx
+++ b/packages/create-vite/template-preact/src/app.jsx
@@ -29,8 +29,9 @@ export function App() {
         Check out{' '}
         <a href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app" target="_blank">
             create-preact
-      </a>
-      , the official Preact + Vite starter
+        </a>
+        , the official Preact + Vite starter
+      </p>
       <p class="read-the-docs">
         Click on the Vite and Preact logos to learn more
       </p>

--- a/packages/create-vite/template-preact/src/app.jsx
+++ b/packages/create-vite/template-preact/src/app.jsx
@@ -25,6 +25,12 @@ export function App() {
           Edit <code>src/app.jsx</code> and save to test HMR
         </p>
       </div>
+      <p>
+        Check out{' '}
+        <a href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app" target="_blank">
+            create-preact
+      </a>
+      , the official Preact + Vite starter
       <p class="read-the-docs">
         Click on the Vite and Preact logos to learn more
       </p>

--- a/packages/create-vite/template-preact/src/app.jsx
+++ b/packages/create-vite/template-preact/src/app.jsx
@@ -27,8 +27,11 @@ export function App() {
       </div>
       <p>
         Check out{' '}
-        <a href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app" target="_blank">
-            create-preact
+        <a
+          href="https://preactjs.com/guide/v10/getting-started#create-a-vite-powered-preact-app"
+          target="_blank"
+        >
+          create-preact
         </a>
         , the official Preact + Vite starter
       </p>


### PR DESCRIPTION
### Description

Like the [Vue template does](https://github.com/vitejs/vite/blob/167006e74751a66776f4f48316262449b19bf186/packages/create-vite/template-vue/src/components/HelloWorld.vue#L22-L27), I think we, Preact, would prefer to nudge users towards our own initializer which offers a bit more Preact-specific functionality and allows us to control the defaults of a bit better.