### PR TITLE
fix (client): client will not query document when in no document env

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -204,6 +204,9 @@ async function handleMessage(payload: HMRPayload) {
           if (update.type === 'js-update') {
             return hmrClient.queueUpdate(update)
           }
+          if (!hasDocument) {
+            return;
+          }
 
           // css-update
           // this is only sent when a css file referenced with <link> is updated

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -205,7 +205,7 @@ async function handleMessage(payload: HMRPayload) {
             return hmrClient.queueUpdate(update)
           }
           if (!hasDocument) {
-            return;
+            return
           }
 
           // css-update


### PR DESCRIPTION
### Description
I have a webworker (along with a larger frontend app) hooked up to HMR and the vite client script continues to error when trying to update css files because the vite client is querying the `document` even though it doesn't not exist in a web worker environment. This simple change will not try to update css links in environments where `document` is not available. 
