### PR TITLE
fix(build): skip preload treeshaking for nested braces

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -42,7 +42,7 @@ const preloadMarkerRE = new RegExp(preloadMarker, 'g')
 const dynamicImportPrefixRE = /import\s*\(/
 
 const dynamicImportTreeshakenRE =
-  /((?:\bconst\s+|\blet\s+|\bvar\s+|,\s*)(\{[^}.=]+\})\s*=\s*await\s+import\([^)]+\))|(\(\s*await\s+import\([^)]+\)\s*\)(\??\.[\w$]+))|\bimport\([^)]+\)(\s*\.then\(\s*(?:function\s*)?\(\s*\{([^}.=]+)\}\))/g
+  /((?:\bconst\s+|\blet\s+|\bvar\s+|,\s*)(\{[^{}.=]+\})\s*=\s*await\s+import\([^)]+\))|(\(\s*await\s+import\([^)]+\)\s*\)(\??\.[\w$]+))|\bimport\([^)]+\)(\s*\.then\(\s*(?:function\s*)?\(\s*\{([^{}.=]+)\}\))/g
 
 function toRelativePath(filename: string, importer: string) {
   const relPath = path.posix.relative(path.posix.dirname(importer), filename)

--- a/playground/dynamic-import/nested/index.js
+++ b/playground/dynamic-import/nested/index.js
@@ -175,11 +175,21 @@ import(`../nested/nested/${base}.js`).then((mod) => {
     ({ foo = {} }) => foo,
   )
   await import('./treeshaken/syntax.js').then((mod) => mod.foo({ foo }))
+  const obj = [
+    '',
+    {
+      async lazy() {
+        const { foo } = await import('./treeshaken/treeshaken.js')
+        return { foo: aaa(foo) }
+      },
+    },
+  ]
   default1()
   default2()
   other()
   foo()
   foo2()
+  obj[1].lazy()
 })()
 
 import(`../nested/static.js`).then((mod) => {


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/17655

The problem is because the regex captures like this:

<img width="740" alt="image" src="https://github.com/user-attachments/assets/4af73dbc-529c-48fd-8613-ed6656d65ffa">

This PR fixes as:

<img width="742" alt="image" src="https://github.com/user-attachments/assets/8c1de012-0465-4e2a-86bd-1003978342fb">
