### PR TITLE
fix: :bug: fix the issue 17689, cache process env value on startup to…

### DIFF
--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -49,9 +49,19 @@ export function loadEnv(
     process.env.BROWSER_ARGS = parsed.BROWSER_ARGS
   }
 
+  const cachedProcessEnvOnFirstStartup =
+    global.__vite_cached_env_on_startup ?? null
+  if (cachedProcessEnvOnFirstStartup == null) {
+    global.__vite_cached_env_on_startup = process.env
+  }
+  const processEnvOrCachedProcessEnv: NodeJS.ProcessEnv =
+    cachedProcessEnvOnFirstStartup == null
+      ? process.env
+      : cachedProcessEnvOnFirstStartup
+
   // let environment variables use each other. make a copy of `process.env` so that `dotenv-expand`
   // doesn't re-assign the expanded values to the global `process.env`.
-  const processEnv = { ...process.env } as DotenvPopulateInput
+  const processEnv = { ...processEnvOrCachedProcessEnv } as DotenvPopulateInput
   expand({ parsed, processEnv })
 
   // only keys that start with prefix are exposed to client
@@ -63,9 +73,10 @@ export function loadEnv(
 
   // check if there are actual env variables starting with VITE_*
   // these are typically provided inline and should be prioritized
-  for (const key in process.env) {
+  // We do this only first time loadEnv is called.
+  for (const key in processEnvOrCachedProcessEnv) {
     if (prefixes.some((prefix) => key.startsWith(prefix))) {
-      env[key] = process.env[key] as string
+      env[key] = processEnvOrCachedProcessEnv[key] as string
     }
   }
 

--- a/packages/vite/src/types/shims.d.ts
+++ b/packages/vite/src/types/shims.d.ts
@@ -40,3 +40,5 @@ declare interface HTMLLinkElement {}
 declare var __vite_profile_session: import('node:inspector').Session | undefined
 // eslint-disable-next-line no-var
 declare var __vite_start_time: number | undefined
+// eslint-disable-next-line no-var
+declare var __vite_cached_env_on_startup: NodeJS.ProcessEnv | null


### PR DESCRIPTION
… allow changing process.env in vite.config.js without impact to loadEnv function

### Description

fixes #17689 , this fix caches process.env values on vite server startup in order to enable developers to change process.env in vite.config.js using loadEnv while not losing the ability to hot reload env value changes in dot env files without the need for a server restart. 

This PR enables developers to do this;
```javascript
import { defineConfig, loadEnv } from "vite";
import react from "@vitejs/plugin-react";

// https://vitejs.dev/config/
export default ({ mode }) => {
  process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };

  console.log("process.env.VITE_CHANGE_ME", process.env.VITE_CHANGE_ME);

  return defineConfig({
    plugins: [react()],
  });
};

```
also making the currently most voted answer on [StackOverflow](https://stackoverflow.com/a/70711383/10224829) working correctly and improving DX.
