### PR TITLE
revert: fix(logger): truncate log over 5000 characters long (#16581)

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -80,15 +80,15 @@ export function createLogger(
 
   function format(type: LogType, msg: string, options: LogErrorOptions = {}) {
     if (options.timestamp) {
-      const tag =
-        type === 'info'
-          ? colors.cyan(colors.bold(prefix))
-          : type === 'warn'
-            ? colors.yellow(colors.bold(prefix))
-            : colors.red(colors.bold(prefix))
-      return `${colors.dim(
-        getTimeFormatter().format(new Date()),
-      )} ${tag} ${msg}`
+      let tag = ''
+      if (type === 'info') {
+        tag = colors.cyan(colors.bold(prefix))
+      } else if (type === 'warn') {
+        tag = colors.yellow(colors.bold(prefix))
+      } else {
+        tag = colors.red(colors.bold(prefix))
+      }
+      return `${colors.dim(getTimeFormatter().format(new Date()))} ${tag} ${msg}`
     } else {
       return msg
     }

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -4,7 +4,6 @@ import readline from 'node:readline'
 import colors from 'picocolors'
 import type { RollupError } from 'rollup'
 import type { ResolvedServerUrls } from './server'
-import { splitRE } from './utils'
 
 export type LogType = 'error' | 'warn' | 'info'
 export type LogLevel = LogType | 'silent'
@@ -64,8 +63,6 @@ function getTimeFormatter() {
   return timeFormatter
 }
 
-const MAX_LOG_CHAR = 5000
-
 export function createLogger(
   level: LogLevel = 'info',
   options: LoggerOptions = {},
@@ -81,22 +78,7 @@ export function createLogger(
     allowClearScreen && process.stdout.isTTY && !process.env.CI
   const clear = canClearScreen ? clearScreen : () => {}
 
-  function preventOverflow(msg: string) {
-    if (msg.length > MAX_LOG_CHAR) {
-      const shorten = msg.slice(0, MAX_LOG_CHAR)
-      const lines = msg.slice(MAX_LOG_CHAR).match(splitRE)?.length || 0
-
-      return `${shorten}\n... and ${lines} lines more`
-    }
-    return msg
-  }
-
-  function format(
-    type: LogType,
-    rawMsg: string,
-    options: LogErrorOptions = {},
-  ) {
-    const msg = preventOverflow(rawMsg)
+  function format(type: LogType, msg: string, options: LogErrorOptions = {}) {
     if (options.timestamp) {
       const tag =
         type === 'info'


### PR DESCRIPTION
### Description

- fix : #17632 

Thanks to https://github.com/alexeyraspopov/picocolors/pull/64, no longer needed to truncate logs over >5K characters long.

It was kind of tricky to add some tests, so I made a related test for ‘picocolors’, which was the root problem. The following is the related PR:

- https://github.com/alexeyraspopov/picocolors/pull/74

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
