### PR TITLE
fix(v6): fix maximum call stack error in `ModuleRunner.isCurcularImport`

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -162,8 +162,16 @@ export class ModuleRunner {
     return false
   }
 
-  private isCurcularImport(importers: Set<string>, moduleId: string) {
+  private isCurcularImport(
+    importers: Set<string>,
+    moduleId: string,
+    visited = new Set<string>(),
+  ) {
     for (const importer of importers) {
+      if (visited.has(importer)) {
+        continue
+      }
+      visited.add(importer)
       if (importer === moduleId) {
         return true
       }
@@ -172,7 +180,7 @@ export class ModuleRunner {
       ) as Required<ModuleCache>
       if (
         mod.importers.size &&
-        this.isCurcularImport(mod.importers, moduleId)
+        this.isCurcularImport(mod.importers, moduleId, visited)
       ) {
         return true
       }

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -153,7 +153,7 @@ export class ModuleRunner {
     return exports
   }
 
-  private isCurcularModule(mod: Required<ModuleCache>) {
+  private isCircularModule(mod: Required<ModuleCache>) {
     for (const importedFile of mod.imports) {
       if (mod.importers.has(importedFile)) {
         return true
@@ -162,7 +162,7 @@ export class ModuleRunner {
     return false
   }
 
-  private isCurcularImport(
+  private isCircularImport(
     importers: Set<string>,
     moduleId: string,
     visited = new Set<string>(),
@@ -180,7 +180,7 @@ export class ModuleRunner {
       ) as Required<ModuleCache>
       if (
         mod.importers.size &&
-        this.isCurcularImport(mod.importers, moduleId, visited)
+        this.isCircularImport(mod.importers, moduleId, visited)
       ) {
         return true
       }
@@ -207,8 +207,8 @@ export class ModuleRunner {
     // check circular dependency
     if (
       callstack.includes(moduleId) ||
-      this.isCurcularModule(mod) ||
-      this.isCurcularImport(importers, moduleId)
+      this.isCircularModule(mod) ||
+      this.isCircularImport(importers, moduleId)
     ) {
       if (mod.exports) return this.processImport(mod.exports, meta, metadata)
     }

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/action.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/action.js
@@ -1,0 +1,1 @@
+export function someAction() {}

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/entry-cyclic.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/entry-cyclic.js
@@ -1,0 +1,3 @@
+export default async function main() {
+	await import("./entry.js");
+}

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/entry.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/entry.js
@@ -1,0 +1,9 @@
+export async function setupCyclic() {
+	const mod = await import("./entry-cyclic.js");
+	await mod.default();
+}
+
+export async function importAction(id) {
+	const action = await import(/* @vite-ignore */ id);
+	console.log(action);
+}

--- a/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/entry.js
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fixtures/cyclic/entry.js
@@ -4,6 +4,5 @@ export async function setupCyclic() {
 }
 
 export async function importAction(id) {
-	const action = await import(/* @vite-ignore */ id);
-	console.log(action);
+	return await import(/* @vite-ignore */ id);
 }

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -227,6 +227,7 @@ describe('module runner initialization', async () => {
     // action.js
     const mod = await runner.import('/fixtures/cyclic/entry')
     await mod.setupCyclic()
-    await mod.importAction('/fixtures/cyclic/action')
+    const action = await mod.importAction('/fixtures/cyclic/action')
+    expect(action).toBeDefined()
   })
 })

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -218,4 +218,15 @@ describe('module runner initialization', async () => {
       expect(posix.join(root, './fixtures')).toBe(dirname)
     }
   })
+
+  it(`no maximum call stack error ModuleRunner.isCurcularImport`, async ({
+    runner,
+  }) => {
+    // entry.js ⇔ entry-cyclic.js
+    //   ⇓
+    // action.js
+    const mod = await runner.import('/fixtures/cyclic/entry')
+    await mod.setupCyclic()
+    await mod.importAction('/fixtures/cyclic/action')
+  })
 })


### PR DESCRIPTION
### Description

While testing v6 https://pkg.pr.new/vite@4e81092 in https://github.com/hi-ogawa/vite-plugins/pull/297, I'm seeing `ModuleRunner.isCurcularImport` maximum call stack error when dynamic importing a server action.

I added a test case and verified the fix. (I also patched locally on my project and verified it's fixed).