### PR TITLE
fix(importMetaGlob): handle alias that starts with hash

### DIFF
--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -563,12 +563,7 @@ export async function toAbsoluteGlob(
       custom: { 'vite:import-glob': { isSubImportsPattern } },
     })) || glob,
   )
-  // If matching a subpath import, the returned path is relative and doesn't look absolute.
-  // If it matches an alias that starts with `#`, the path will be absolute.
-  if (isSubImportsPattern && !isAbsolute(resolved)) {
-    return join(root, resolved)
-  }
-  if (isSubImportsPattern || isAbsolute(resolved)) {
+  if (isAbsolute(resolved)) {
     return pre + globSafeResolvedPath(resolved, glob)
   }
 

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -563,10 +563,12 @@ export async function toAbsoluteGlob(
       custom: { 'vite:import-glob': { isSubImportsPattern } },
     })) || glob,
   )
-  if (isSubImportsPattern) {
+  // If matching a subpath import, the returned path is relative and doesn't look absolute.
+  // If it matches an alias that starts with `#`, the path will be absolute.
+  if (isSubImportsPattern && !isAbsolute(resolved)) {
     return join(root, resolved)
   }
-  if (isAbsolute(resolved)) {
+  if (isSubImportsPattern || isAbsolute(resolved)) {
     return pre + globSafeResolvedPath(resolved, glob)
   }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -203,7 +203,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
         id = resolvedImports
 
         if (resolveOpts.custom?.['vite:import-glob']?.isSubImportsPattern) {
-          return id
+          return normalizePath(path.join(root, id))
         }
       }
 

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -240,6 +240,10 @@ test('escapes special chars in globs without mangling user supplied glob suffix'
   expect(expectedNames).toEqual(foundAliasNames)
 })
 
-test('sub imports', async () => {
-  expect(await page.textContent('.sub-imports')).toMatch('bar foo')
+test('subpath imports', async () => {
+  expect(await page.textContent('.subpath-imports')).toMatch('bar foo')
+})
+
+test('#alias imports', async () => {
+  expect(await page.textContent('.hash-alias-imports')).toMatch('bar foo')
 })

--- a/playground/glob-import/index.html
+++ b/playground/glob-import/index.html
@@ -21,20 +21,16 @@
 <pre class="escape-relative"></pre>
 <h2>Escape alias glob</h2>
 <pre class="escape-alias"></pre>
-<h2>Sub imports</h2>
-<pre class="sub-imports"></pre>
+<h2>Subpath imports</h2>
+<pre class="subpath-imports"></pre>
+<h2>#alias imports</h2>
+<pre class="hash-alias-imports"></pre>
 <h2>In package</h2>
 <pre class="in-package"></pre>
 
 <script type="module" src="./dir/index.js"></script>
 <script type="module">
   function useImports(modules, selector) {
-    for (const path in modules) {
-      modules[path]().then((mod) => {
-        console.log(path, mod)
-      })
-    }
-
     const keys = Object.keys(modules)
     Promise.all(keys.map((key) => modules[key]())).then((mods) => {
       const res = {}
@@ -137,7 +133,6 @@
   const globs = import.meta.glob('/escape/**/glob.js', {
     eager: true,
   })
-  console.log(globs)
   globalThis.globs = globs
   const relative = Object.entries(globs)
     .filter(([_, mod]) => Object.keys(mod?.relative ?? {}).length === 1)
@@ -152,9 +147,19 @@
 </script>
 
 <script type="module">
-  const subImports = import.meta.glob('#imports/*', { eager: true })
+  const subpathImports = import.meta.glob('#imports/*', { eager: true })
+  document.querySelector('.subpath-imports').textContent = Object.values(
+    subpathImports,
+  )
+    .map((mod) => mod.default)
+    .join(' ')
+</script>
 
-  document.querySelector('.sub-imports').textContent = Object.values(subImports)
+<script type="module">
+  const hashAliasImports = import.meta.glob('#alias/*', { eager: true })
+  document.querySelector('.hash-alias-imports').textContent = Object.values(
+    hashAliasImports,
+  )
     .map((mod) => mod.default)
     .join(' ')
 </script>

--- a/playground/glob-import/vite.config.ts
+++ b/playground/glob-import/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
     alias: {
       ...escapeAliases,
       '@dir': path.resolve(__dirname, './dir/'),
+      '#alias': path.resolve(__dirname, './imports-path/'),
     },
   },
   build: {


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/17614
ref https://github.com/vitejs/vite/pull/12467

The `importMetaGlob` logic always assumed globs that starts with `#` are subpath imports, and so the resolved path is relative and should join to the root. However, aliases that starts with `#` could resolve too, which returns an absolute path.

Due to the previous assumption, the root and absolute path was joined, causing an invalid path for globbing.

This PR fixes it by returning the subpath imports resolved path as absolute instead, preventing the need for any special handling. This means the `pre + globSafeResolvedPath(resolved, glob)` part also gets executed for subpath imports, which I think it's more correct and handles the edge cases there.

