### PR TITLE
docs: improve additional command line options by code-group

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -71,19 +71,26 @@ Then follow the prompts!
 
 You can also directly specify the project name and the template you want to use via additional command line options. For example, to scaffold a Vite + Vue project, run:
 
-```bash
+::: code-group
+
+```bash [NPM]
 # npm 7+, extra double-dash is needed:
-npm create vite@latest my-vue-app -- --template vue
-
-# yarn
-yarn create vite my-vue-app --template vue
-
-# pnpm
-pnpm create vite my-vue-app --template vue
-
-# bun
-bun create vite my-vue-app --template vue
+$ npm create vite@latest my-vue-app -- --template vue
 ```
+
+```bash [Yarn]
+$ yarn create vite my-vue-app --template vue
+```
+
+```bash [PNPM]
+$ pnpm create vite my-vue-app --template vue
+```
+
+```bash [Bun]
+$ bun create vite my-vue-app --template vue
+```
+
+:::
 
 See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
 


### PR DESCRIPTION
# background
Consistent with the style above and more concise

before：

![image](https://github.com/user-attachments/assets/1cceb505-0091-44b2-a270-8b3e9c74c39b)


after：
![image](https://github.com/user-attachments/assets/138f06c9-de88-4cd6-b8c0-b9fcec6f165f)
