### PR TITLE
fix(build): env output is not stable

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -195,7 +195,7 @@ export async function replaceDefine(
  */
 export function serializeDefine(define: Record<string, any>): string {
   let res = `{`
-  const keys = Object.keys(define)
+  const keys = Object.keys(define).sort()
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const val = define[key]


### PR DESCRIPTION
make env output sequence stable

### Description

If use `import.meta.env` directly, the output maybe not stable. 
some variable is defined in vite.config.js, otherwise it can merge in .env file and environment in cli. 
so the output string is different, this will causes the output files with different [hashcode] .

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
