### PR TITLE
fix(build): env output is not stable

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -195,7 +195,7 @@ export async function replaceDefine(
  */
 export function serializeDefine(define: Record<string, any>): string {
   let res = `{`
-  const keys = Object.keys(define)
+  const keys = Object.keys(define).sort()
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i]
     const val = define[key]


### PR DESCRIPTION
make env output sequence stable

Description
If use import.meta.env directly, the output maybe not stable.
some variable is defined in vite.config.js, otherwise it can merge in .env file and environment in cli.
so the output string is different, this will causes the output files with different [hashcode] .