### PR TITLE
feat: environment api config options rework

### DIFF
--- a/docs/changes/this-environment-in-hooks.md
+++ b/docs/changes/this-environment-in-hooks.md
@@ -14,7 +14,7 @@ Affect scope: `Vite Plugin Authors`
 
 ## Motivation
 
-`this.environment` not only allow the plugin hook implementation to know the current environment name, it also gives access to the environment config options, module graph information, and transform pipeline (`environment.options`, `environment.moduleGraph`, `environment.transformRequest()`). Having the environment instance available in the context allows plugin authors to avoid the dependency of the whole dev server (typically cached at startup through the `configureServer` hook).
+`this.environment` not only allow the plugin hook implementation to know the current environment name, it also gives access to the environment config options, module graph information, and transform pipeline (`environment.config`, `environment.moduleGraph`, `environment.transformRequest()`). Having the environment instance available in the context allows plugin authors to avoid the dependency of the whole dev server (typically cached at startup through the `configureServer` hook).
 
 ## Migration Guide
 

--- a/docs/guide/api-vite-environment.md
+++ b/docs/guide/api-vite-environment.md
@@ -75,7 +75,7 @@ class DevEnvironment {
    * global scope are taken as defaults for all environments, and can
    * be overridden (resolve conditions, external, optimizedDeps)
    */
-  options: ResolvedDevEnvironmentOptions
+  config: ResolvedConfig & ResolvedDevEnvironmentOptions
 
   constructor(name, config, { hot, options }: DevEnvironmentSetup)
 
@@ -882,7 +882,7 @@ In a future major (Vite 7 or 8), we aim to have complete alignment:
 
 There will also be a single `ResolvedConfig` instance shared during build, allowing for caching at entire app build process level in the same way as we have been doing with `WeakMap<ResolvedConfig, CachedData>` during dev.
 
-For Vite 6, we need to do a smaller step to keep backward compatibility. Ecosystem plugins are currently using `config.build` instead of `environment.options.build` to access configuration, so we need to create a new `ResolvedConfig` per environment by default. A project can opt-in into sharing the full config and plugins pipeline setting `builder.sharedConfigBuild` to `true`.
+For Vite 6, we need to do a smaller step to keep backward compatibility. Ecosystem plugins are currently using `config.build` instead of `environment.config.build` to access configuration, so we need to create a new `ResolvedConfig` per environment by default. A project can opt-in into sharing the full config and plugins pipeline setting `builder.sharedConfigBuild` to `true`.
 
 This option would only work of a small subset of projects at first, so plugin authors can opt-in for a particular plugin to be shared by setting the `sharedDuringBuild` flag to `true`. This allows for easily sharing state both for regular plugins:
 

--- a/docs/guide/api-vite-environment.md
+++ b/docs/guide/api-vite-environment.md
@@ -481,11 +481,11 @@ The Vite server has a shared plugin pipeline, but when a module is processed it 
 A plugin could use the `environment` instance to:
 
 - Only apply logic for certain environments.
-- Change the way they work depending on the configuration for the environment, which can be accessed using `environment.options`. The vite core resolve plugin modifies the way it resolves ids based on `environment.options.resolve.conditions` for example.
+- Change the way they work depending on the configuration for the environment, which can be accessed using `environment.config`. The vite core resolve plugin modifies the way it resolves ids based on `environment.config.resolve.conditions` for example.
 
 ```ts
   transform(code, id) {
-    console.log(this.enviroment.options.resolve.conditions)
+    console.log(this.environment.config.resolve.conditions)
   }
 ```
 

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -11,9 +11,12 @@ export class PartialEnvironment {
 
   config: ResolvedConfig & ResolvedEnvironmentOptions
 
-  // TODO: keep for back-compat with earlier v6 alpha versions
-
-  // options: ResolvedEnvironmentOptions
+  /**
+   * @deprecated use environment.config instead
+   **/
+  get options(): ResolvedEnvironmentOptions {
+    return this._options
+  }
 
   _options: ResolvedEnvironmentOptions
 

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -5,9 +5,18 @@ import type { Plugin } from './plugin'
 
 export class PartialEnvironment {
   name: string
-  config: ResolvedConfig
+  getTopLevelConfig(): ResolvedConfig {
+    return this._topLevelConfig
+  }
+  // config: ResolvedConfig
+
   options: ResolvedEnvironmentOptions
   logger: Logger
+
+  /**
+   * @internal
+   */
+  _topLevelConfig: ResolvedConfig
 
   constructor(
     name: string,
@@ -15,7 +24,7 @@ export class PartialEnvironment {
     options: ResolvedEnvironmentOptions = config.environments[name],
   ) {
     this.name = name
-    this.config = config
+    this._topLevelConfig = config
     this.options = options
     const environment = colors.dim(`(${this.name})`)
     const colorIndex =

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -8,9 +8,15 @@ export class PartialEnvironment {
   getTopLevelConfig(): ResolvedConfig {
     return this._topLevelConfig
   }
-  // config: ResolvedConfig
 
-  options: ResolvedEnvironmentOptions
+  config: ResolvedConfig & ResolvedEnvironmentOptions
+
+  // TODO: keep for back-compat with earlier v6 alpha versions
+
+  // options: ResolvedEnvironmentOptions
+
+  _options: ResolvedEnvironmentOptions
+
   logger: Logger
 
   /**
@@ -20,12 +26,26 @@ export class PartialEnvironment {
 
   constructor(
     name: string,
-    config: ResolvedConfig,
-    options: ResolvedEnvironmentOptions = config.environments[name],
+    topLevelConfig: ResolvedConfig,
+    options: ResolvedEnvironmentOptions = topLevelConfig.environments[name],
   ) {
     this.name = name
-    this._topLevelConfig = config
-    this.options = options
+    this._topLevelConfig = topLevelConfig
+    this._options = options
+    this.config = new Proxy(
+      options as ResolvedConfig & ResolvedEnvironmentOptions,
+      {
+        get: (target, prop: keyof ResolvedConfig) => {
+          if (prop === 'logger') {
+            return this.logger
+          }
+          if (prop in target) {
+            return this._options[prop as keyof ResolvedEnvironmentOptions]
+          }
+          return this._topLevelConfig[prop]
+        },
+      },
+    )
     const environment = colors.dim(`(${this.name})`)
     const colorIndex =
       [...environment].reduce((acc, c) => acc + c.charCodeAt(0), 0) %
@@ -33,37 +53,37 @@ export class PartialEnvironment {
     const infoColor = environmentColors[colorIndex || 0]
     this.logger = {
       get hasWarned() {
-        return config.logger.hasWarned
+        return topLevelConfig.logger.hasWarned
       },
       info(msg, opts) {
-        return config.logger.info(msg, {
+        return topLevelConfig.logger.info(msg, {
           ...opts,
           environment: infoColor(environment),
         })
       },
       warn(msg, opts) {
-        return config.logger.warn(msg, {
+        return topLevelConfig.logger.warn(msg, {
           ...opts,
           environment: colors.yellow(environment),
         })
       },
       warnOnce(msg, opts) {
-        return config.logger.warnOnce(msg, {
+        return topLevelConfig.logger.warnOnce(msg, {
           ...opts,
           environment: colors.yellow(environment),
         })
       },
       error(msg, opts) {
-        return config.logger.error(msg, {
+        return topLevelConfig.logger.error(msg, {
           ...opts,
           environment: colors.red(environment),
         })
       },
       clearScreen(type) {
-        return config.logger.clearScreen(type)
+        return topLevelConfig.logger.clearScreen(type)
       },
       hasErrorLogged(error) {
-        return config.logger.hasErrorLogged(error)
+        return topLevelConfig.logger.hasErrorLogged(error)
       },
     }
   }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1541,7 +1541,7 @@ export async function createBuilder(
       return config.builder.buildApp(builder)
     },
     async build(environment: BuildEnvironment) {
-      return buildEnvironment(environment.config, environment)
+      return buildEnvironment(environment.getTopLevelConfig(), environment)
     },
   }
 

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -559,7 +559,7 @@ export async function buildEnvironment(
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
   const options = config.build
   const { logger } = environment
-  const ssr = environment.options.ssr
+  const ssr = environment.config.consumer === 'server'
 
   logger.info(
     colors.cyan(
@@ -719,7 +719,7 @@ export async function buildEnvironment(
 
       const format = output.format || 'es'
       const jsExt =
-        !environment.options.webCompatible || libOptions
+        !environment.config.webCompatible || libOptions
           ? resolveOutputJsExtension(
               format,
               findNearestPackageData(config.root, config.packageCache)?.data
@@ -760,8 +760,8 @@ export async function buildEnvironment(
         inlineDynamicImports:
           output.format === 'umd' ||
           output.format === 'iife' ||
-          (environment.options.ssr &&
-            environment.options.webCompatible &&
+          (environment.config.consumer === 'server' &&
+            environment.config.webCompatible &&
             (typeof input === 'string' || Object.keys(input).length === 1)),
         ...output,
       }
@@ -1264,7 +1264,7 @@ function injectSsrFlag<T extends Record<string, any>>(
   options?: T,
   environment?: BuildEnvironment,
 ): T & { ssr?: boolean } {
-  const ssr = environment?.options.ssr ?? true
+  const ssr = environment ? environment.config.consumer === 'server' : true
   return { ...(options ?? {}), ssr } as T & {
     ssr?: boolean
   }
@@ -1560,7 +1560,7 @@ export async function createBuilder(
     let environmentConfig = config
     if (!config.builder.sharedConfigBuild) {
       const patchConfig = (resolved: ResolvedConfig) => {
-        // Until the ecosystem updates to use `environment.options.build` instead of `config.build`,
+        // Until the ecosystem updates to use `environment.config.build` instead of `config.build`,
         // we need to make override `config.build` for the current environment.
         // We can deprecate `config.build` in ResolvedConfig and push everyone to upgrade, and later
         // remove the default values that shouldn't be used at all once the config is resolved

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -228,9 +228,9 @@ export interface SharedEnvironmentOptions {
   resolve?: EnvironmentResolveOptions
   /**
    * Define if this environment is used for Server Side Rendering
-   * @default true if it isn't the client environment
+   * @default 'server' if it isn't the client environment
    */
-  ssr?: boolean
+  consumer?: 'client' | 'server'
   /**
    * Runtime Compatibility
    * Temporal options, we should remove these in favor of fine-grained control
@@ -262,7 +262,7 @@ export type ResolvedEnvironmentResolveOptions =
 
 export type ResolvedEnvironmentOptions = {
   resolve: ResolvedEnvironmentResolveOptions
-  ssr: boolean
+  consumer: 'client' | 'server'
   nodeCompatible: boolean
   webCompatible: boolean
   injectInvalidationTimestamp: boolean
@@ -273,7 +273,7 @@ export type ResolvedEnvironmentOptions = {
 export type DefaultEnvironmentOptions = Omit<
   EnvironmentOptions,
   | 'build'
-  | 'ssr'
+  | 'consumer'
   | 'nodeCompatible'
   | 'webCompatible'
   | 'injectInvalidationTimestamp'
@@ -623,10 +623,11 @@ function resolveEnvironmentOptions(
 ): ResolvedEnvironmentOptions {
   const resolve = resolveEnvironmentResolveOptions(options.resolve, logger)
   const isClientEnvironment = environmentName === 'client'
-  const ssr = options.ssr ?? !isClientEnvironment
+  const consumer =
+    (options.consumer ?? isClientEnvironment) ? 'client' : 'server'
   return {
     resolve,
-    ssr,
+    consumer,
     nodeCompatible: options.nodeCompatible ?? !isClientEnvironment,
     webCompatible: options.webCompatible ?? isClientEnvironment,
     injectInvalidationTimestamp:
@@ -661,7 +662,7 @@ export function getDefaultResolvedEnvironmentOptions(
 ): ResolvedEnvironmentOptions {
   return {
     resolve: config.resolve,
-    ssr: true,
+    consumer: 'server',
     nodeCompatible: true,
     webCompatible: false,
     injectInvalidationTimestamp: false,
@@ -1219,7 +1220,7 @@ export async function resolveConfig(
     },
     future: config.future,
 
-    // Backward compatibility, users should use environment.options.dev.optimizeDeps
+    // Backward compatibility, users should use environment.config.dev.optimizeDeps
     optimizeDeps: backwardCompatibleOptimizeDeps,
     ssr,
 
@@ -1320,7 +1321,7 @@ export async function resolveConfig(
 
   // Backward compatibility hook, modify the resolved config before it is used
   // to create internal plugins. For example, `config.build.ssr`. Once we rework
-  // internal plugins to use environment.options, we can remove the dual
+  // internal plugins to use environment.config, we can remove the dual
   // patchConfig/patchPlugins and have a single patchConfig before configResolved
   // gets called
   patchConfig?.(resolved)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1219,7 +1219,7 @@ export async function resolveConfig(
     },
     future: config.future,
 
-    // Backward compatibility, users should use environment.config.dev.optimizeDeps
+    // Backward compatibility, users should use environment.options.dev.optimizeDeps
     optimizeDeps: backwardCompatibleOptimizeDeps,
     ssr,
 

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -28,7 +28,7 @@ const deprecationCode = {
 
 const deprecationMessages = {
   pluginHookSsrArgument:
-    'Plugin hook `options.ssr` is replaced with `this.environment.options.ssr`.',
+    "Plugin hook `options.ssr` is replaced with `this.environment.config.consumer === 'server'`.",
   pluginHookHandleHotUpdate:
     'Plugin hook `handleHotUpdate()` is replaced with `hotUpdate()`.',
 

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -52,8 +52,8 @@ export function isConfiguredAsExternal(
 export function createIsConfiguredAsExternal(
   environment: PartialEnvironment,
 ): (id: string, importer?: string) => boolean {
-  const { config, options } = environment
-  const { root } = config
+  const topLevelConfig = environment.getTopLevelConfig()
+  const { options } = environment
   const { external, noExternal } = options.resolve
   const noExternalFilter =
     typeof noExternal !== 'boolean' &&
@@ -64,7 +64,7 @@ export function createIsConfiguredAsExternal(
 
   const resolveOptions: InternalResolveOptions = {
     ...options.resolve,
-    root,
+    root: topLevelConfig.root,
     isProduction: false,
     isBuild: true,
     conditions: targetConditions,
@@ -85,7 +85,7 @@ export function createIsConfiguredAsExternal(
         id,
         // Skip passing importer in build to avoid externalizing non-hoisted dependencies
         // unresolvable from root (which would be unresolvable from output bundles also)
-        config.command === 'build' ? undefined : importer,
+        topLevelConfig.command === 'build' ? undefined : importer,
         resolveOptions,
         undefined,
         true,

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -53,23 +53,23 @@ export function createIsConfiguredAsExternal(
   environment: PartialEnvironment,
 ): (id: string, importer?: string) => boolean {
   const topLevelConfig = environment.getTopLevelConfig()
-  const { options } = environment
-  const { external, noExternal } = options.resolve
+  const { resolve, webCompatible, nodeCompatible } = environment.config
+  const { external, noExternal } = resolve
   const noExternalFilter =
     typeof noExternal !== 'boolean' &&
     !(Array.isArray(noExternal) && noExternal.length === 0) &&
     createFilter(undefined, noExternal, { resolve: false })
 
-  const targetConditions = options.resolve?.externalConditions || []
+  const targetConditions = resolve.externalConditions || []
 
   const resolveOptions: InternalResolveOptions = {
-    ...options.resolve,
+    ...resolve,
     root: topLevelConfig.root,
     isProduction: false,
     isBuild: true,
     conditions: targetConditions,
-    webCompatible: options.webCompatible,
-    nodeCompatible: options.nodeCompatible,
+    webCompatible,
+    nodeCompatible,
   }
 
   const isExternalizable = (

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -40,7 +40,7 @@ export function createIdResolver(
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
         [
-          aliasPlugin({ entries: environment.options.resolve.alias }),
+          aliasPlugin({ entries: environment.config.resolve.alias }),
           resolvePlugin({
             root: config.root,
             isProduction: config.isProduction,
@@ -73,7 +73,7 @@ export function createIdResolver(
     if (!pluginContainer) {
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
-        [aliasPlugin({ entries: environment.options.resolve.alias })],
+        [aliasPlugin({ entries: environment.config.resolve.alias })],
       )
       aliasOnlyPluginContainerMap.set(environment, pluginContainer)
     }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -53,7 +53,8 @@ export function esbuildDepPlugin(
   external: string[],
 ): Plugin {
   const topLevelConfig = environment.getTopLevelConfig()
-  const { extensions } = environment.options.dev.optimizeDeps
+  const { isProduction } = topLevelConfig
+  const { extensions } = environment.config.dev.optimizeDeps
 
   // remove optimizable extensions from `externalTypes` list
   const allExternalTypes = extensions
@@ -112,8 +113,8 @@ export function esbuildDepPlugin(
         namespace: 'optional-peer-dep',
       }
     }
-    // TODO: Should this be environment.options.nodeCompatible or a more fine-grained option?
-    if (environment.options.ssr && isBuiltin(resolved)) {
+    // TODO: Should this be environment.config.nodeCompatible or a more fine-grained option?
+    if (environment.config.consumer === 'server' && isBuiltin(resolved)) {
       return
     }
     if (isExternalUrl(resolved)) {
@@ -235,7 +236,7 @@ export function esbuildDepPlugin(
       build.onLoad(
         { filter: /.*/, namespace: 'browser-external' },
         ({ path }) => {
-          if (topLevelConfig.isProduction) {
+          if (isProduction) {
             return {
               contents: 'module.exports = {}',
             }
@@ -278,7 +279,7 @@ module.exports = Object.create(new Proxy({}, {
       build.onLoad(
         { filter: /.*/, namespace: 'optional-peer-dep' },
         ({ path }) => {
-          if (topLevelConfig.isProduction) {
+          if (isProduction) {
             return {
               contents: 'module.exports = {}',
             }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -52,7 +52,7 @@ export function esbuildDepPlugin(
   qualified: Record<string, string>,
   external: string[],
 ): Plugin {
-  const config = environment.config
+  const topLevelConfig = environment.getTopLevelConfig()
   const { extensions } = environment.options.dev.optimizeDeps
 
   // remove optimizable extensions from `externalTypes` list
@@ -66,14 +66,14 @@ export function esbuildDepPlugin(
   const cjsPackageCache: PackageCache = new Map()
 
   // default resolver which prefers ESM
-  const _resolve = createIdResolver(config, {
+  const _resolve = createIdResolver(topLevelConfig, {
     asSrc: false,
     scan: true,
     packageCache: esmPackageCache,
   })
 
   // cjs resolver that prefers Node
-  const _resolveRequire = createIdResolver(config, {
+  const _resolveRequire = createIdResolver(topLevelConfig, {
     asSrc: false,
     isRequire: true,
     scan: true,
@@ -235,7 +235,7 @@ export function esbuildDepPlugin(
       build.onLoad(
         { filter: /.*/, namespace: 'browser-external' },
         ({ path }) => {
-          if (config.isProduction) {
+          if (topLevelConfig.isProduction) {
             return {
               contents: 'module.exports = {}',
             }
@@ -278,7 +278,7 @@ module.exports = Object.create(new Proxy({}, {
       build.onLoad(
         { filter: /.*/, namespace: 'optional-peer-dep' },
         ({ path }) => {
-          if (config.isProduction) {
+          if (topLevelConfig.isProduction) {
             return {
               contents: 'module.exports = {}',
             }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -291,7 +291,7 @@ export async function optimizeExplicitEnvironmentDeps(
 ): Promise<DepOptimizationMetadata> {
   const cachedMetadata = await loadCachedDepOptimizationMetadata(
     environment,
-    environment.options.dev.optimizeDeps.force ?? false, // TODO: should force be per-environment?
+    environment.config.dev.optimizeDeps.force ?? false, // TODO: should force be per-environment?
     false,
   )
   if (cachedMetadata) {
@@ -734,7 +734,7 @@ async function prepareEsbuildOptimizerRun(
   const flatIdDeps: Record<string, string> = {}
   const idToExports: Record<string, ExportsData> = {}
 
-  const { optimizeDeps } = environment.options.dev
+  const { optimizeDeps } = environment.config.dev
 
   const { plugins: pluginsFromConfig = [], ...esbuildOptions } =
     optimizeDeps?.esbuildOptions ?? {}
@@ -766,7 +766,7 @@ async function prepareEsbuildOptimizerRun(
     ),
   }
 
-  const platform = environment.options.webCompatible ? 'browser' : 'node'
+  const platform = environment.config.webCompatible ? 'browser' : 'node'
 
   const external = [...(optimizeDeps?.exclude ?? [])]
 
@@ -817,7 +817,7 @@ export async function addManuallyIncludedOptimizeDeps(
   deps: Record<string, string>,
 ): Promise<void> {
   const { logger } = environment
-  const { optimizeDeps } = environment.options.dev
+  const { optimizeDeps } = environment.config.dev
   const optimizeDepsInclude = optimizeDeps?.include ?? []
   if (optimizeDepsInclude.length) {
     const unableToOptimize = (id: string, msg: string) => {
@@ -1066,7 +1066,7 @@ export async function extractExportsData(
 ): Promise<ExportsData> {
   await init
 
-  const { optimizeDeps } = environment.options.dev
+  const { optimizeDeps } = environment.config.dev
 
   const esbuildOptions = optimizeDeps?.esbuildOptions ?? {}
   if (optimizeDeps.extensions?.some((ext) => filePath.endsWith(ext))) {
@@ -1119,7 +1119,7 @@ function needsInterop(
   exportsData: ExportsData,
   output?: { exports: string[] },
 ): boolean {
-  if (environmet.options.dev.optimizeDeps?.needsInterop?.includes(id)) {
+  if (environmet.config.dev.optimizeDeps?.needsInterop?.includes(id)) {
     return true
   }
   const { hasModuleSyntax, exports } = exportsData
@@ -1162,7 +1162,7 @@ const lockfileNames = lockfileFormats.map((l) => l.name)
 function getConfigHash(environment: Environment): string {
   // Take config into account
   // only a subset of config options that can affect dep optimization
-  const { optimizeDeps } = environment.options.dev
+  const { optimizeDeps } = environment.config.dev
   const topLevelConfig = environment.getTopLevelConfig()
   const content = JSON.stringify(
     {

--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -44,7 +44,7 @@ export function createDepsOptimizer(
 
   let closed = false
 
-  const options = environment.options.dev.optimizeDeps
+  const options = environment.config.dev.optimizeDeps
 
   const { noDiscovery, holdUntilCrawlEnd } = options
 
@@ -748,7 +748,7 @@ export function createExplicitDepsOptimizer(
     run: () => {},
 
     close: async () => {},
-    options: environment.options.dev.optimizeDeps,
+    options: environment.config.dev.optimizeDeps,
   }
 
   let inited = false

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -11,8 +11,8 @@ import { createIdResolver } from '../idResolver'
 export function createOptimizeDepsIncludeResolver(
   environment: Environment,
 ): (id: string) => Promise<string | undefined> {
-  const { config } = environment
-  const resolve = createIdResolver(config, {
+  const topLevelConfig = environment.getTopLevelConfig()
+  const resolve = createIdResolver(topLevelConfig, {
     asSrc: false,
     scan: true,
     ssrOptimizeCheck: environment.options.ssr,
@@ -29,8 +29,8 @@ export function createOptimizeDepsIncludeResolver(
     const nestedPath = id.substring(lastArrowIndex + 1).trim()
     const basedir = nestedResolveBasedir(
       nestedRoot,
-      config.root,
-      config.resolve.preserveSymlinks,
+      topLevelConfig.root,
+      topLevelConfig.resolve.preserveSymlinks,
     )
     return await resolve(
       environment,

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -15,7 +15,7 @@ export function createOptimizeDepsIncludeResolver(
   const resolve = createIdResolver(topLevelConfig, {
     asSrc: false,
     scan: true,
-    ssrOptimizeCheck: environment.options.ssr,
+    ssrOptimizeCheck: environment.config.consumer === 'server',
     packageCache: new Map(),
   })
   return async (id: string) => {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -82,8 +82,8 @@ export function devToScanEnvironment(
     get name() {
       return environment.name
     },
-    get config() {
-      return environment.config
+    getTopLevelConfig() {
+      return environment.getTopLevelConfig()
     },
     get options() {
       return environment.options
@@ -135,15 +135,15 @@ export function scanImports(environment: ScanEnvironment): {
   let entries: string[]
 
   const scanContext = { cancelled: false }
-
+  const topLevelConfig = environment.getTopLevelConfig()
   const esbuildContext: Promise<BuildContext | undefined> = computeEntries(
-    environment.config,
+    topLevelConfig,
   ).then((computedEntries) => {
     entries = computedEntries
 
     if (!entries.length) {
       if (
-        !environment.config.optimizeDeps.entries &&
+        !topLevelConfig.optimizeDeps.entries &&
         !environment.options.dev.optimizeDeps.include
       ) {
         environment.logger.warn(
@@ -299,7 +299,7 @@ async function prepareEsbuildScanner(
   let tsconfigRaw = esbuildOptions.tsconfigRaw
   if (!tsconfigRaw && !esbuildOptions.tsconfig) {
     const tsconfigResult = await loadTsconfigJsonForFile(
-      path.join(environment.config.root, '_dummy.js'),
+      path.join(environment.getTopLevelConfig().root, '_dummy.js'),
     )
     if (tsconfigResult.compilerOptions?.experimentalDecorators) {
       tsconfigRaw = { compilerOptions: { experimentalDecorators: true } }
@@ -426,7 +426,7 @@ function esbuildScanPlugin(
     const result = await transformGlobImport(
       transpiledContents,
       id,
-      environment.config.root,
+      environment.getTopLevelConfig().root,
       resolve,
     )
 
@@ -717,7 +717,7 @@ function esbuildScanPlugin(
         if (ext === 'mjs') ext = 'js'
 
         // TODO: Why are we using config.esbuild instead of config.optimizeDeps.esbuildOptions here?
-        const esbuildConfig = environment.config.esbuild
+        const esbuildConfig = environment.getTopLevelConfig().esbuild
         let contents = await fsp.readFile(id, 'utf-8')
         if (ext.endsWith('x') && esbuildConfig && esbuildConfig.jsxInject) {
           contents = esbuildConfig.jsxInject + `\n` + contents

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -73,7 +73,7 @@ export class ScanEnvironment extends BaseEnvironment {
   }
 }
 
-// Restric access to the module graph and the server while scanning
+// Restrict access to the module graph and the server while scanning
 export function devToScanEnvironment(
   environment: DevEnvironment,
 ): ScanEnvironment {
@@ -85,11 +85,12 @@ export function devToScanEnvironment(
     getTopLevelConfig() {
       return environment.getTopLevelConfig()
     },
-    /* deprecate for backcompat
+    /**
+     * @deprecated use environment.config instead
+     **/
     get options() {
       return environment.options
     },
-    */
     get config() {
       return environment.config
     },

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -85,8 +85,13 @@ export function devToScanEnvironment(
     getTopLevelConfig() {
       return environment.getTopLevelConfig()
     },
+    /* deprecate for backcompat
     get options() {
       return environment.options
+    },
+    */
+    get config() {
+      return environment.config
     },
     get logger() {
       return environment.logger
@@ -144,7 +149,7 @@ export function scanImports(environment: ScanEnvironment): {
     if (!entries.length) {
       if (
         !topLevelConfig.optimizeDeps.entries &&
-        !environment.options.dev.optimizeDeps.include
+        !environment.config.dev.optimizeDeps.include
       ) {
         environment.logger.warn(
           colors.yellow(
@@ -289,7 +294,7 @@ async function prepareEsbuildScanner(
   const plugin = esbuildScanPlugin(environment, deps, missing, entries)
 
   const { plugins = [], ...esbuildOptions } =
-    environment.options.dev.optimizeDeps.esbuildOptions ?? {}
+    environment.config.dev.optimizeDeps.esbuildOptions ?? {}
 
   // The plugin pipeline automatically loads the closest tsconfig.json.
   // But esbuild doesn't support reading tsconfig.json if the plugin has resolved the path (https://github.com/evanw/esbuild/issues/2265).
@@ -395,7 +400,7 @@ function esbuildScanPlugin(
     return res
   }
 
-  const optimizeDepsOptions = environment.options.dev.optimizeDeps
+  const optimizeDepsOptions = environment.config.dev.optimizeDeps
   const include = optimizeDepsOptions.include
   const exclude = [
     ...(optimizeDepsOptions.exclude ?? []),

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -325,8 +325,10 @@ type FalsyPlugin = false | null | undefined
 export type PluginOption = Thenable<Plugin | FalsyPlugin | PluginOption[]>
 
 export function resolveEnvironmentPlugins(environment: Environment): Plugin[] {
-  return environment.config.plugins.filter(
-    (plugin) =>
-      !plugin.applyToEnvironment || plugin.applyToEnvironment(environment),
-  )
+  return environment
+    .getTopLevelConfig()
+    .plugins.filter(
+      (plugin) =>
+        !plugin.applyToEnvironment || plugin.applyToEnvironment(environment),
+    )
 }

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -217,7 +217,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       if (s) {
         return {
           code: s.toString(),
-          map: this.environment?.options.build.sourcemap
+          map: this.environment.config.build.sourcemap
             ? s.generateMap({ hires: 'boundary' })
             : null,
         }
@@ -243,7 +243,7 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       // do not emit assets for SSR build
       if (
         config.command === 'build' &&
-        !this.environment.options.build.emitAssets
+        !this.environment.config.build.emitAssets
       ) {
         for (const file in bundle) {
           if (
@@ -425,7 +425,7 @@ const shouldInline = (
 ): boolean => {
   const environment = pluginContext.environment
   const topLevelConfig = environment.getTopLevelConfig()
-  const { assetsInlineLimit } = environment.options.build
+  const { assetsInlineLimit } = environment.config.build
   if (topLevelConfig.build.lib) return true
   if (pluginContext.getModuleInfo(id)?.isEntry) return false
   if (forceInline !== undefined) return forceInline

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -39,11 +39,10 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
   return {
     name: 'vite:asset-import-meta-url',
-    async transform(code, id, options) {
+    async transform(code, id) {
       const { environment } = this
       if (
-        environment &&
-        !environment.options.ssr &&
+        environment.config.consumer === 'client' &&
         id !== preloadHelperId &&
         id !== CLIENT_ENTRY &&
         code.includes('new URL') &&

--- a/packages/vite/src/node/plugins/clientInjections.ts
+++ b/packages/vite/src/node/plugins/clientInjections.ts
@@ -91,7 +91,7 @@ export function clientInjectionsPlugin(config: ResolvedConfig): Plugin {
     },
     async transform(code, id, options) {
       // TODO: Remove options?.ssr, Vitest currently hijacks this plugin
-      const ssr = options?.ssr ?? this.environment.options.ssr
+      const ssr = options?.ssr ?? this.environment.config.consumer === 'server'
       if (id === normalizedClientEntry || id === normalizedEnvEntry) {
         return injectConfigValues(code)
       } else if (!ssr && code.includes('process.env.NODE_ENV')) {

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -164,7 +164,8 @@ export async function replaceDefine(
     define = { ...define, 'import.meta.env': marker }
   }
 
-  const esbuildOptions = environment.config.esbuild || {}
+  const topLevelConfig = environment.getTopLevelConfig()
+  const esbuildOptions = topLevelConfig.esbuild || {}
 
   const result = await transform(code, {
     loader: 'js',
@@ -173,7 +174,7 @@ export async function replaceDefine(
     define,
     sourcefile: id,
     sourcemap:
-      environment.config.command === 'build'
+      topLevelConfig.command === 'build'
         ? !!environment.options.build.sourcemap
         : true,
   })

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -61,7 +61,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     // This is a place where using `!options.nodeCompatible` fails and it is confusing why
     // Do we need a per-environment replaceProcessEnv option?
     // Is it useful to have define be configured per-environment?
-    const replaceProcessEnv = environment.options.webCompatible
+    const replaceProcessEnv = environment.config.webCompatible
 
     const define: Record<string, string> = {
       ...(replaceProcessEnv ? processEnv : {}),
@@ -71,7 +71,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     }
 
     // Additional define fixes based on `ssr` value
-    const ssr = environment.options.ssr
+    const ssr = environment.config.consumer === 'server'
 
     if ('import.meta.env.SSR' in define) {
       define['import.meta.env.SSR'] = ssr + ''
@@ -116,7 +116,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     name: 'vite:define',
 
     async transform(code, id) {
-      if (!this.environment.options.ssr && !isBuild) {
+      if (this.environment.config.consumer === 'client' && !isBuild) {
         // for dev we inject actual global defines in the vite client to
         // avoid the transform cost. see the `clientInjection` and
         // `importAnalysis` plugin.
@@ -175,7 +175,7 @@ export async function replaceDefine(
     sourcefile: id,
     sourcemap:
       topLevelConfig.command === 'build'
-        ? !!environment.options.build.sourcemap
+        ? !!environment.config.build.sourcemap
         : true,
   })
 

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -172,7 +172,7 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
 
   const getFilter = usePerEnvironmentState((environment: Environment) => {
     const { include, exclude } =
-      environment.options.build.dynamicImportVarsOptions
+      environment.config.build.dynamicImportVarsOptions
     return createFilter(include, exclude)
   })
 
@@ -246,7 +246,7 @@ export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
             config.root,
           )
         } catch (error) {
-          if (environment.options.build.dynamicImportVarsOptions.warnOnError) {
+          if (environment.config.build.dynamicImportVarsOptions.warnOnError) {
             this.warn(error)
           } else {
             this.error(error)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -329,7 +329,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
 
     async transform(html, id) {
       if (id.endsWith('.html')) {
-        const { modulePreload } = this.environment.options.build
+        const { modulePreload } = this.environment.config.build
 
         id = normalizePath(id)
         const relativeUrlPath = path.posix.relative(config.root, id)
@@ -691,7 +691,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     },
 
     async generateBundle(options, bundle) {
-      const { modulePreload } = this.environment.options.build
+      const { modulePreload } = this.environment.config.build
 
       const analyzedChunk: Map<OutputChunk, number> = new Map()
       const inlineEntryChunk = new Set<string>()
@@ -863,7 +863,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         }
 
         // inject css link when cssCodeSplit is false
-        if (this.environment?.options.build.cssCodeSplit === false) {
+        if (this.environment.config.build.cssCodeSplit === false) {
           const cssChunk = Object.values(bundle).find(
             (chunk) => chunk.type === 'asset' && chunk.name === 'style.css',
           ) as OutputAsset | undefined

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -217,7 +217,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
 
     async transform(source, importer) {
       const environment = this.environment as DevEnvironment
-      const ssr = environment.options.ssr
+      const ssr = environment.config.consumer === 'server'
       const moduleGraph = environment.moduleGraph
 
       if (canSkipImportAnalysis(importer)) {
@@ -361,7 +361,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
 
         // make the URL browser-valid
-        if (environment.options.injectInvalidationTimestamp) {
+        if (environment.config.injectInvalidationTimestamp) {
           // mark non-js/css imports with `?import`
           if (isExplicitImportRequired(url)) {
             url = injectQuery(url, 'import')
@@ -624,7 +624,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             if (
               !isDynamicImport &&
               isLocalImport &&
-              environment.options.dev.preTransformRequests
+              environment.config.dev.preTransformRequests
             ) {
               // pre-transform known direct imports
               // These requests will also be registered in transformRequest to be awaited

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -157,7 +157,7 @@ function preload(
 }
 
 function getModulePreloadData(environment: Environment) {
-  const { modulePreload } = environment.options.build
+  const { modulePreload } = environment.config.build
   const topLevelConfig = environment.getTopLevelConfig()
   const resolveModulePreloadDependencies =
     modulePreload && modulePreload.resolveDependencies
@@ -194,7 +194,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     load(id) {
       const { environment } = this
       if (environment && id === preloadHelperId) {
-        const { modulePreload } = environment.options.build
+        const { modulePreload } = environment.config.build
 
         const { customModulePreloadPaths, optimizeModulePreloadRelativePaths } =
           getModulePreloadData(environment)
@@ -390,7 +390,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (s) {
         return {
           code: s.toString(),
-          map: environment.options.build.sourcemap
+          map: environment.config.build.sourcemap
             ? s.generateMap({ hires: 'boundary' })
             : null,
         }
@@ -403,7 +403,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (environment && code.indexOf(isModernFlag) > -1) {
         const re = new RegExp(isModernFlag, 'g')
         const isModern = String(format === 'es')
-        if (environment.options.build.sourcemap) {
+        if (environment.config.build.sourcemap) {
           const s = new MagicString(code)
           let match: RegExpExecArray | null
           while ((match = re.exec(code))) {
@@ -483,8 +483,8 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
         return
       }
-      const buildSourcemap = this.environment.options.build.sourcemap
-      const { modulePreload } = this.environment.options.build
+      const buildSourcemap = this.environment.config.build.sourcemap
+      const { modulePreload } = this.environment.config.build
       const { customModulePreloadPaths, optimizeModulePreloadRelativePaths } =
         getModulePreloadData(this.environment)
 

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -158,14 +158,15 @@ function preload(
 
 function getModulePreloadData(environment: Environment) {
   const { modulePreload } = environment.options.build
-  const { config } = environment
+  const topLevelConfig = environment.getTopLevelConfig()
   const resolveModulePreloadDependencies =
     modulePreload && modulePreload.resolveDependencies
-  const renderBuiltUrl = config.experimental.renderBuiltUrl
+  const renderBuiltUrl = topLevelConfig.experimental.renderBuiltUrl
   const customModulePreloadPaths = !!(
     resolveModulePreloadDependencies || renderBuiltUrl
   )
-  const isRelativeBase = config.base === './' || config.base === ''
+  const isRelativeBase =
+    topLevelConfig.base === './' || topLevelConfig.base === ''
   const optimizeModulePreloadRelativePaths =
     isRelativeBase && !customModulePreloadPaths
   return {

--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -40,7 +40,7 @@ export function loadFallbackPlugin(config: ResolvedConfig): Plugin {
       // like /service-worker.js or /api/users
       const file = cleanUrl(id)
       if (
-        this.environment.options.nodeCompatible ||
+        this.environment.config.nodeCompatible ||
         isFileLoadingAllowed(config, file) // Do we need fsPathFromId here?
       ) {
         try {

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -40,7 +40,7 @@ export function manifestPlugin(): Plugin {
 
     generateBundle({ format }, bundle) {
       const { root } = this.environment.getTopLevelConfig()
-      const buildOptions = this.environment.options.build
+      const buildOptions = this.environment.config.build
 
       function getChunkName(chunk: OutputChunk) {
         return getChunkOriginalFileName(chunk, root, format)

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -39,7 +39,7 @@ export function manifestPlugin(): Plugin {
     },
 
     generateBundle({ format }, bundle) {
-      const { root } = this.environment.config
+      const { root } = this.environment.getTopLevelConfig()
       const buildOptions = this.environment.options.build
 
       function getChunkName(chunk: OutputChunk) {

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -93,8 +93,8 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       code: string | Uint8Array,
     ): Promise<number | null> {
       if (
-        environment.options.build.ssr ||
-        !environment.options.build.reportCompressedSize
+        environment.config.build.ssr ||
+        !environment.config.build.reportCompressedSize
       ) {
         return null
       }
@@ -135,7 +135,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
         }
       },
       async log(output: OutputBundle, outDir?: string) {
-        const chunkLimit = environment.options.build.chunkSizeWarningLimit
+        const chunkLimit = environment.config.build.chunkSizeWarningLimit
 
         let hasLargeChunks = false
 
@@ -200,11 +200,11 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
               config.root,
               path.resolve(
                 config.root,
-                outDir ?? environment.options.build.outDir,
+                outDir ?? environment.config.build.outDir,
               ),
             ),
           )
-          const assetsDir = path.join(environment.options.build.assetsDir, '/')
+          const assetsDir = path.join(environment.config.build.assetsDir, '/')
 
           for (const group of groups) {
             const filtered = entries.filter((e) => e.group === group.name)
@@ -253,9 +253,9 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
 
         if (
           hasLargeChunks &&
-          environment.options.build.minify &&
+          environment.config.build.minify &&
           !config.build.lib &&
-          !environment.options.build.ssr
+          !environment.config.build.ssr
         ) {
           environment.logger.warn(
             colors.yellow(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -163,7 +163,7 @@ interface ResolvePluginOptions {
   idOnly?: boolean
 
   /**
-   * @deprecated environment.options are used instead
+   * @deprecated environment.config are used instead
    */
   ssrConfig?: SSROptions
 }
@@ -231,7 +231,7 @@ export function resolvePlugin(
 
       const environmentName = this.environment.name ?? (ssr ? 'ssr' : 'client')
       const currentEnvironmentOptions =
-        this.environment?.options || environmentsOptions?.[environmentName]
+        this.environment?.config || environmentsOptions?.[environmentName]
       const environmentResolveOptions = currentEnvironmentOptions?.resolve
       if (!environmentResolveOptions) {
         throw new Error(
@@ -247,7 +247,7 @@ export function resolvePlugin(
         scan: resolveOpts?.scan ?? resolveOptions.scan,
       }
 
-      const depsOptimizerOptions = this.environment.options.dev.optimizeDeps
+      const depsOptimizerOptions = this.environment.config.dev.optimizeDeps
 
       const resolvedImports = resolveSubpathImports(id, importer, options)
       if (resolvedImports) {

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -127,7 +127,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(code, id) {
-      if (!this.environment.options.ssr && isIncludeWorkerImportMetaUrl(code)) {
+      if (
+        this.environment.config.consumer === 'client' &&
+        isIncludeWorkerImportMetaUrl(code)
+      ) {
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
         const workerImportMetaUrlRE =

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -136,7 +136,7 @@ export class DevEnvironment extends BaseEnvironment {
       })
     })
 
-    const { optimizeDeps } = this.options.dev
+    const { optimizeDeps } = this.config.dev
     if (setup.depsOptimizer) {
       this.depsOptimizer = setup.depsOptimizer
     } else if (isDepOptimizationDisabled(optimizeDeps)) {

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -274,7 +274,7 @@ function invalidateModule(
         (m.message ? ` ${m.message}` : ''),
       { timestamp: true },
     )
-    const file = getShortName(mod.file!, environment.config.root)
+    const file = getShortName(mod.file!, environment.getTopLevelConfig().root)
     updateModules(
       environment,
       file,

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -431,7 +431,7 @@ export function updateModules(
   timestamp: number,
   afterInvalidation?: boolean,
 ): void {
-  const { hot, config } = environment
+  const { hot } = environment
   const updates: Update[] = []
   const invalidatedModules = new Set<EnvironmentModuleNode>()
   const traversedModules = new Set<EnvironmentModuleNode>()
@@ -486,7 +486,7 @@ export function updateModules(
     )
     hot.send({
       type: 'full-reload',
-      triggeredBy: path.resolve(config.root, file),
+      triggeredBy: path.resolve(environment.getTopLevelConfig().root, file),
     })
     return
   }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -283,7 +283,7 @@ class EnvironmentPluginContainer {
   async resolveId(
     rawId: string,
     importer: string | undefined = join(
-      this.environment.config.root,
+      this.environment.getTopLevelConfig().root,
       'index.html',
     ),
     options?: {
@@ -336,7 +336,7 @@ class EnvironmentPluginContainer {
       debugPluginResolve?.(
         timeFrom(pluginResolveStart),
         plugin.name,
-        prettifyUrl(id, this.environment.config.root),
+        prettifyUrl(id, this.environment.getTopLevelConfig().root),
       )
 
       // resolveId() is hookFirst - first non-null result is returned.
@@ -423,7 +423,7 @@ class EnvironmentPluginContainer {
       debugPluginTransform?.(
         timeFrom(start),
         plugin.name,
-        prettifyUrl(id, this.environment.config.root),
+        prettifyUrl(id, this.environment.getTopLevelConfig().root),
       )
       if (isObject(result)) {
         if (result.code !== undefined) {
@@ -599,7 +599,7 @@ class PluginContext implements Omit<RollupPluginContext, 'cache'> {
       ensureWatchedFile(
         this._container.watcher,
         id,
-        this.environment.config.root,
+        this.environment.getTopLevelConfig().root,
       )
   }
 

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -224,7 +224,7 @@ class EnvironmentPluginContainer {
 
   async resolveRollupOptions(): Promise<InputOptions> {
     if (!this._resolvedRollupOptions) {
-      let options = this.environment.options.build.rollupOptions
+      let options = this.environment.config.build.rollupOptions
       for (const optionsHook of this.getSortedPluginHooks('options')) {
         if (this._closed) {
           throwClosedServerError()
@@ -299,14 +299,14 @@ class EnvironmentPluginContainer {
   ): Promise<PartialResolvedId | null> {
     const skip = options?.skip
     const scan = !!options?.scan
-    const ssr = this.environment.options.ssr
+    const ssr = this.environment.config.consumer === 'server'
     const ctx = new ResolveIdContext(this, skip, scan)
 
     const resolveStart = debugResolve ? performance.now() : 0
     let id: string | null = null
     const partial: Partial<PartialResolvedId> = {}
     for (const plugin of this.getSortedPlugins('resolveId')) {
-      if (this._closed && this.environment?.options.dev.recoverable)
+      if (this._closed && this.environment.config.dev.recoverable)
         throwClosedServerError()
       if (!plugin.resolveId) continue
       if (skip?.has(plugin)) continue
@@ -365,11 +365,11 @@ class EnvironmentPluginContainer {
   }
 
   async load(id: string, options?: {}): Promise<LoadResult | null> {
-    const ssr = this.environment.options.ssr
+    const ssr = this.environment.config.consumer === 'server'
     options = options ? { ...options, ssr } : { ssr }
     const ctx = new LoadPluginContext(this)
     for (const plugin of this.getSortedPlugins('load')) {
-      if (this._closed && this.environment?.options.dev.recoverable)
+      if (this._closed && this.environment?.config.dev.recoverable)
         throwClosedServerError()
       if (!plugin.load) continue
       ctx._plugin = plugin
@@ -396,7 +396,7 @@ class EnvironmentPluginContainer {
       inMap?: SourceDescription['map']
     },
   ): Promise<{ code: string; map: SourceMap | { mappings: '' } | null }> {
-    const ssr = this.environment.options.ssr
+    const ssr = this.environment.config.consumer === 'server'
     const optionsWithSSR = options ? { ...options, ssr } : { ssr }
     const inMap = options?.inMap
 
@@ -404,7 +404,7 @@ class EnvironmentPluginContainer {
     ctx._addedImports = this._getAddedImports(id)
 
     for (const plugin of this.getSortedPlugins('transform')) {
-      if (this._closed && this.environment?.options.dev.recoverable)
+      if (this._closed && this.environment?.config.dev.recoverable)
         throwClosedServerError()
       if (!plugin.transform) continue
 

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -73,10 +73,10 @@ export function transformRequest(
   // Backward compatibility when only `ssr` is passed
   if (!options?.ssr) {
     // Backward compatibility
-    options = { ...options, ssr: environment.options.ssr }
+    options = { ...options, ssr: environment.config.consumer === 'server' }
   }
 
-  if (environment._closing && environment?.options.dev.recoverable)
+  if (environment._closing && environment.config.dev.recoverable)
     throwClosedServerError()
 
   const cacheKey = `${options.html ? 'html:' : ''}${url}`
@@ -275,7 +275,7 @@ async function loadAndTransform(
     // only try the fallback if access is allowed, skip for out of root url
     // like /service-worker.js or /api/users
     if (
-      environment.options.nodeCompatible ||
+      environment.config.nodeCompatible ||
       isFileLoadingAllowed(topLevelConfig, file)
     ) {
       try {
@@ -340,7 +340,7 @@ async function loadAndTransform(
     throw err
   }
 
-  if (environment._closing && environment.options.dev.recoverable)
+  if (environment._closing && environment.config.dev.recoverable)
     throwClosedServerError()
 
   // ensure module in graph after successful load
@@ -412,10 +412,10 @@ async function loadAndTransform(
     }
   }
 
-  if (environment._closing && environment.options.dev.recoverable)
+  if (environment._closing && environment.config.dev.recoverable)
     throwClosedServerError()
 
-  const result = environment.options.dev.moduleRunnerTransform
+  const result = environment.config.dev.moduleRunnerTransform
     ? await ssrTransform(
         code,
         normalizedMap,
@@ -466,7 +466,7 @@ async function handleModuleSoftInvalidation(
   let result: TransformResult
   // No transformation is needed if it's disabled manually
   // This is primarily for backwards compatible SSR
-  if (!environment.options.injectInvalidationTimestamp) {
+  if (!environment.config.injectInvalidationTimestamp) {
     result = transformResult
   }
   // We need to transform each imports with new timestamps if available
@@ -509,7 +509,7 @@ async function handleModuleSoftInvalidation(
           s.overwrite(start, end, replacedUrl)
         }
 
-        if (imp.d === -1 && environment.options.dev.preTransformRequests) {
+        if (imp.d === -1 && environment.config.dev.preTransformRequests) {
           // pre-transform known direct imports
           environment.warmupRequest(hmrUrl)
         }

--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -10,7 +10,7 @@ import type { DevEnvironment } from './environment'
 export function warmupFiles(server: ViteDevServer): void {
   const { root } = server.config
   for (const environment of Object.values(server.environments)) {
-    mapFiles(environment.options.dev.warmup, root).then((files) => {
+    mapFiles(environment.config.dev.warmup, root).then((files) => {
       for (const file of files) {
         warmupFile(server, server.environments.client, file)
       }

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -37,7 +37,7 @@ export async function fetchModule(
   }
 
   if (url[0] !== '.' && url[0] !== '/') {
-    const { isProduction, root } = environment.config
+    const { isProduction, root } = environment.getTopLevelConfig()
     const { externalConditions, dedupe, preserveSymlinks } =
       environment.options.resolve
 
@@ -61,7 +61,7 @@ export async function fetchModule(
         isBuild: false,
         isProduction,
         root,
-        packageCache: environment.config.packageCache,
+        packageCache: environment.getTopLevelConfig().packageCache,
         tryEsmOnly: true,
         webCompatible: environment.options.webCompatible,
         nodeCompatible: environment.options.nodeCompatible,
@@ -77,7 +77,10 @@ export async function fetchModule(
       throw err
     }
     const file = pathToFileURL(resolved.id).toString()
-    const type = isFilePathESM(resolved.id, environment.config.packageCache)
+    const type = isFilePathESM(
+      resolved.id,
+      environment.getTopLevelConfig().packageCache,
+    )
       ? 'module'
       : 'commonjs'
     return { externalize: file, type }

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -39,7 +39,7 @@ export async function fetchModule(
   if (url[0] !== '.' && url[0] !== '/') {
     const { isProduction, root } = environment.getTopLevelConfig()
     const { externalConditions, dedupe, preserveSymlinks } =
-      environment.options.resolve
+      environment.config.resolve
 
     const resolved = tryNodeResolve(
       url,
@@ -63,8 +63,8 @@ export async function fetchModule(
         root,
         packageCache: environment.getTopLevelConfig().packageCache,
         tryEsmOnly: true,
-        webCompatible: environment.options.webCompatible,
-        nodeCompatible: environment.options.nodeCompatible,
+        webCompatible: environment.config.webCompatible,
+        nodeCompatible: environment.config.nodeCompatible,
       },
       undefined,
       true,

--- a/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
+++ b/packages/vite/src/node/ssr/runtime/serverModuleRunner.ts
@@ -37,7 +37,10 @@ function createHMROptions(
   environment: DevEnvironment,
   options: ServerModuleRunnerOptions,
 ) {
-  if (environment.config.server.hmr === false || options.hmr === false) {
+  if (
+    environment.getTopLevelConfig().server.hmr === false ||
+    options.hmr === false
+  ) {
     return false
   }
   if (options.hmr?.connection) {
@@ -90,7 +93,7 @@ export function createServerModuleRunner(
   return new ModuleRunner(
     {
       ...options,
-      root: environment.config.root,
+      root: environment.getTopLevelConfig().root,
       transport: {
         fetchModule: (id, importer, options) =>
           environment.fetchModule(id, importer, options),


### PR DESCRIPTION
### Description

Building on top of:
- https://github.com/vitejs/vite/pull/17753

For reference, before #17753, we had:
- `environment.config` is the top level config (i.e. `environment.config.root`)
- `environment.options` is the `ResolvedEnvironmentOptions`, equivalent to `environment.config.environments[environment.name]` (i.e. `environment.options.resolve.conditions`)

The motivation for #17753 is that `environment.config` being the top level config (the shared config instance that has the default values) is error prone `environment.config.resolve.conditions` should never be used. We discussed deprecating these defaults from `ResolvedConfig` and then removing them but that will take a while. We could make the type of `environment.config` more strict even if the default options are in the object, but there are other issues.

Having the top level config as `environment.getTopLevelConfig()` brought two things to the spotlight:
- Most of the access for the config is for `root` and `base`. It would be good to have a more ergonomic way to access these instead of `environment.getTopLevelConfig().root`
- We may make other config options per-environment in the future. Every time we do it, users will need to move from `config.flag` to `environment.options.flag`

This PR leaves `environment.getTopLevelConfig()` for when the shared instance is needed, and removes `environment.options` in favor of `environment.config` that has type `ResolvedConfig & ResolvedEnvironmentOptions` (maybe the type could be improved). It is currently implemented as:
```ts
    this.config = new Proxy(
      options as ResolvedConfig & ResolvedEnvironmentOptions,
      {
        get: (target, prop: keyof ResolvedConfig) => {
          if (prop === 'logger') {
            return this.logger
          }
          if (prop in target) {
            return this._options[prop as keyof ResolvedEnvironmentOptions]
          }
          return this._topLevelConfig[prop]
        },
      },
    )
```

This solves the two issues above and avoids confusion. `environment.config` always returns the configuration for this environment (it doesn't matter if the options are per-environment or shared). There are no longer issues with users accessing the defaults by mistake.

Notes: The PR also changes the `ssr` flag for `EnvironmentOptions` introduced at https://github.com/vitejs/vite/pull/16471/commits/90185f793247023e5d2464ff38fe8929582acf28 because it collides with the `ssr` object in `ResolvedConfig`. This was confusing in that commit already but I couldn't came up with a better name. We discussed with @sheremet-va and settled down on renaming it to `consumer: 'client' | 'server'` for now.
