### PR TITLE
fix(mergeConfig): don't recreate server.hmr.server instance

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -1,3 +1,4 @@
+import http from 'node:http'
 import { describe, expect, test } from 'vitest'
 import type { InlineConfig } from '..'
 import type { PluginOption, UserConfig, UserConfigExport } from '../config'
@@ -183,6 +184,18 @@ describe('mergeConfig', () => {
     // merging either ways, `ssr.noExternal: true` should take highest priority
     expect(mergeConfig(baseConfig, newConfig)).toEqual(mergedConfig)
     expect(mergeConfig(newConfig, baseConfig)).toEqual(mergedConfig)
+  })
+
+  test('handles server.hmr.server', () => {
+    const httpServer = http.createServer()
+
+    const baseConfig = { server: { hmr: { server: httpServer } } }
+    const newConfig = { server: { hmr: { server: httpServer } } }
+
+    const mergedConfig = mergeConfig(baseConfig, newConfig)
+
+    // Server instance should not be recreated
+    expect(mergedConfig.server.hmr.server).toBe(httpServer)
   })
 
   test('throws error with functions', () => {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1110,6 +1110,9 @@ function mergeConfigRecursively(
         ...backwardCompatibleWorkerPlugins(value),
       ]
       continue
+    } else if (key === 'server' && rootPath === 'server.hmr') {
+      merged[key] = value
+      continue
     }
 
     if (Array.isArray(existing) || Array.isArray(value)) {


### PR DESCRIPTION
### Description

Currently, the `mergeConfig` function recursively goes through objects and overrides them. This works for the most part, except for the `server.hmr.server` property which is a `Server` class/object. 

The problem is that the `mergeConfig` function treats it like a normal JS object and effectively clones it. This turns it into a standard object which doesn't work. And it also breaks reference to the object.

We either need to modify the `isObject` function to check for classes, or for now, I've added an if statement to handle the special case, following the other precedence.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
