### PR TITLE
fix: wait for restart behind reverse-proxy

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -335,7 +335,7 @@ async function waitForSuccessfulPing(
     // but will reject a networking error.
     // When running on middleware mode, it returns status 426, and an cors error happens if mode is not no-cors
     try {
-      await fetch(`${pingHostProtocol}://${hostAndPath}`, {
+      const res = await fetch(`${pingHostProtocol}://${hostAndPath}`, {
         mode: 'no-cors',
         headers: {
           // Custom headers won't be included in a request with no-cors so (ab)use one of the
@@ -343,7 +343,8 @@ async function waitForSuccessfulPing(
           Accept: 'text/x-vite-ping',
         },
       })
-      return true
+      if (res.status !== 502)
+        return true
     } catch {}
     return false
   }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -343,6 +343,7 @@ async function waitForSuccessfulPing(
           Accept: 'text/x-vite-ping',
         },
       })
+      // Reverse-proxies usually respond with 502 when the host is unreachable
       if (res.status !== 502)
         return true
     } catch {}

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -344,8 +344,7 @@ async function waitForSuccessfulPing(
         },
       })
       // Reverse-proxies usually respond with 502 when the host is unreachable
-      if (res.status !== 502)
-        return true
+      if (res.status !== 502) return true
     } catch {}
     return false
   }


### PR DESCRIPTION
### Description

When behind a reverse-proxy, the ping loop returns too early, because reverse-proxies usually respond with 502 when the host is unreachable.

Before the fix: on vite server restart, the browser shows a 502 blank page
After the fix: the browser waits until vite is restarted behind a reverse-proxy
