### PR TITLE
refactor(create-vite): use named imports for react

### DIFF
--- a/packages/create-vite/template-react-ts/src/main.tsx
+++ b/packages/create-vite/template-react-ts/src/main.tsx
@@ -6,5 +6,5 @@ import './index.css'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 )

--- a/packages/create-vite/template-react-ts/src/main.tsx
+++ b/packages/create-vite/template-react-ts/src/main.tsx
@@ -3,9 +3,8 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-const root = createRoot(document.getElementById('root') as HTMLDivElement)
-root.render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 )

--- a/packages/create-vite/template-react-ts/src/main.tsx
+++ b/packages/create-vite/template-react-ts/src/main.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+const root = createRoot(document.getElementById('root') as HTMLDivElement)
+root.render(
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 )

--- a/packages/create-vite/template-react/src/main.jsx
+++ b/packages/create-vite/template-react/src/main.jsx
@@ -6,5 +6,5 @@ import './index.css'
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 )

--- a/packages/create-vite/template-react/src/main.jsx
+++ b/packages/create-vite/template-react/src/main.jsx
@@ -1,10 +1,11 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+const root = createRoot(document.getElementById('root'))
+root.render(
+  <StrictMode>
     <App />
-  </React.StrictMode>,
+  </StrictMode>,
 )

--- a/packages/create-vite/template-react/src/main.jsx
+++ b/packages/create-vite/template-react/src/main.jsx
@@ -3,9 +3,8 @@ import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
 
-const root = createRoot(document.getElementById('root'))
-root.render(
+createRoot(document.getElementById('root')).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 )


### PR DESCRIPTION
### Description

This PR refactors the default Vite templates for React, in order to utilize named imports from react-dom/client instead of importing the entire ReactDOM namespace.

The reasons for change were:
- Clarity: Using named imports makes it explicit which part of the module is being used. This can improve code readability and maintainability.
- Potential Bundle Size Reduction: If your build system supports tree-shaking (which Vite does), using named imports can potentially reduce the bundle size by excluding unused parts of the module vs bringing in the entire ReactDOM namespace.
- Consistency: I frequently find myself and my colleagues making this adjustment when starting new projects to ensure we are using the latest React practices.