### PR TITLE
fix(v6/build): set `sharedConfigBuild: true` when using `build` api

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -677,6 +677,30 @@ describe('resolveBuildOutputs', () => {
     const result = await builder.build(builder.environments.custom)
     expect((result as RollupOutput).output[0].code).not.toContain('preload')
   })
+
+  test('default sharedConfigBuild true on build api', async () => {
+    let counter = 0
+    await build({
+      root: resolve(__dirname, 'fixtures/emit-assets'),
+      build: {
+        ssr: true,
+        rollupOptions: {
+          input: {
+            index: '/entry',
+          },
+        },
+      },
+      plugins: [
+        {
+          name: 'test-plugin',
+          config() {
+            counter++
+          },
+        },
+      ],
+    })
+    expect(counter).toBe(1)
+  })
 })
 
 /**

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -514,6 +514,7 @@ export async function resolveBuildPlugins(config: ResolvedConfig): Promise<{
 export async function build(
   inlineConfig: InlineConfig = {},
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
+  inlineConfig.builder ??= { sharedConfigBuild: true }
   const builder = await createBuilder(inlineConfig)
 
   if (builder.config.build.lib) {


### PR DESCRIPTION
### Description

While investigating Vite 6 CI failure on Rakkasjs, the issue seems to be coming from `@vavite/multibuild` https://github.com/cyco130/vavite/tree/main/packages/multibuild and its custom hooks are not working correctly (e.g. https://github.com/rakkasjs/rakkasjs/blob/1dc106be8c3ad66fcb7d32f36818787330521b24/packages/rakkasjs/src/features/run-server-side/vite-plugin.ts#L163-L169).

`@vavite/multibuild` seems to expect `config/configResolved` are called only once for each `build`, but on Vite 6, this is not the case unless `sharedConfigBuild: true`.
However considering that `build` API can only build one environment anyway, it might make sense to actually set `sharedConfigBuild: true` for this use case by default and that might help some exotic usage of `config/configResolved` to work even on Vite 6. So that's what this PR proposes.