### PR TITLE
perf: improve regex performance

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,11 @@ const require = createRequire(import.meta.url)
 const pkg = require('./package.json')
 const pkgVite = require('./packages/vite/package.json')
 
+// Some rules work better with typechecking enabled, but as enabling it is slow,
+// we only do so when linting in IDEs for now. If you want to lint with typechecking
+// explicitly, set this to `true` manually.
+const shouldTypeCheck = typeof process.env.VSCODE_PID === 'string'
+
 export default tseslint.config(
   {
     ignores: [
@@ -34,6 +39,12 @@ export default tseslint.config(
       parserOptions: {
         sourceType: 'module',
         ecmaVersion: 2022,
+        project: shouldTypeCheck
+          ? [
+              './packages/*/tsconfig.json',
+              './packages/vite/src/*/tsconfig.json',
+            ]
+          : undefined,
       },
       globals: {
         ...globals.es2021,
@@ -283,6 +294,27 @@ export default tseslint.config(
     rules: {
       'no-console': 'off',
       '@typescript-eslint/ban-ts-comment': 'off',
+    },
+  },
+  {
+    name: 'disables/typechecking',
+    files: [
+      '**/*.js',
+      '**/*.mjs',
+      '**/*.cjs',
+      '**/*.d.ts',
+      '**/*.d.cts',
+      '**/__tests__/**',
+      'docs/**',
+      'playground/**',
+      'scripts/**',
+      'vitest.config.ts',
+      'vitest.config.e2e.ts',
+    ],
+    languageOptions: {
+      parserOptions: {
+        project: false,
+      },
     },
   },
 )

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -120,7 +120,7 @@ const legacyEnvVarMarker = `__VITE_IS_LEGACY__`
 const _require = createRequire(import.meta.url)
 
 const nonLeadingHashInFileNameRE = /[^/]+\[hash(?::\d+)?\]/
-const prefixedHashInFileNameRE = /\W?\[hash(:\d+)?\]/
+const prefixedHashInFileNameRE = /\W?\[hash(?::\d+)?\]/
 
 function viteLegacyPlugin(options: Options = {}): Plugin[] {
   let config: ResolvedConfig

--- a/packages/plugin-legacy/tsconfig.json
+++ b/packages/plugin-legacy/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src"],
+  "include": ["build.config.ts", "src"],
   "exclude": ["**/*.spec.ts"],
   "compilerOptions": {
     "outDir": "dist",

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -275,7 +275,7 @@ const __require = require;
     name: 'cjs-chunk-patch',
     renderChunk(code, chunk) {
       if (!chunk.fileName.includes('chunks/dep-')) return
-      const match = code.match(/^(?:import[\s\S]*?;\s*)+/)
+      const match = /^(?:import[\s\S]*?;\s*)+/.exec(code)
       const index = match ? match.index! + match[0].length : 0
       const s = new MagicString(code)
       // inject after the last `import`

--- a/packages/vite/rollupLicensePlugin.ts
+++ b/packages/vite/rollupLicensePlugin.ts
@@ -68,7 +68,7 @@ export default function licensePlugin(
                 '\n' +
                 licenseText
                   .trim()
-                  .replace(/(\r\n|\r)/g, '\n')
+                  .replace(/\r\n|\r/g, '\n')
                   .split('\n')
                   .map((line) => `> ${line}`)
                   .join('\n') +

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -109,7 +109,7 @@ export function expandGlobIds(id: string, config: ResolvedConfig): string[] {
                 // `filePath`: "./dist/glob/foo-browser/foo.js"
                 // we need to revert the file path back to the export key by
                 // matching value regex and replacing the capture groups to the key
-                const matched = slash(filePath).match(exportsValueGlobRe)
+                const matched = exportsValueGlobRe.exec(slash(filePath))
                 // `matched`: [..., 'foo', 'foo']
                 if (matched) {
                   let allGlobSame = matched.length === 2

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -413,10 +413,10 @@ function esbuildScanPlugin(
         let scriptId = 0
         const matches = raw.matchAll(scriptRE)
         for (const [, openTag, content] of matches) {
-          const typeMatch = openTag.match(typeRE)
+          const typeMatch = typeRE.exec(openTag)
           const type =
             typeMatch && (typeMatch[1] || typeMatch[2] || typeMatch[3])
-          const langMatch = openTag.match(langRE)
+          const langMatch = langRE.exec(openTag)
           const lang =
             langMatch && (langMatch[1] || langMatch[2] || langMatch[3])
           // skip non type module script
@@ -440,7 +440,7 @@ function esbuildScanPlugin(
           } else if (p.endsWith('.astro')) {
             loader = 'ts'
           }
-          const srcMatch = openTag.match(srcRE)
+          const srcMatch = srcRE.exec(openTag)
           if (srcMatch) {
             const src = srcMatch[1] || srcMatch[2] || srcMatch[3]
             js += `import ${JSON.stringify(src)}\n`
@@ -480,7 +480,7 @@ function esbuildScanPlugin(
 
             const virtualModulePath = JSON.stringify(virtualModulePrefix + key)
 
-            const contextMatch = openTag.match(contextRE)
+            const contextMatch = contextRE.exec(openTag)
             const context =
               contextMatch &&
               (contextMatch[1] || contextMatch[2] || contextMatch[3])

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -195,7 +195,7 @@ const inlineCSSRE = /[?&]inline-css\b/
 const styleAttrRE = /[?&]style-attr\b/
 const functionCallRE = /^[A-Z_][\w-]*\(/i
 const transformOnlyRE = /[?&]transform-only\b/
-const nonEscapedDoubleQuoteRe = /(?<!\\)(")/g
+const nonEscapedDoubleQuoteRe = /(?<!\\)"/g
 
 const cssBundleName = 'style.css'
 
@@ -1223,7 +1223,7 @@ async function compileCSS(
   // crawl them in order to register watch dependencies.
   const needInlineImport = code.includes('@import')
   const hasUrl = cssUrlRE.test(code) || cssImageSetRE.test(code)
-  const lang = id.match(CSS_LANGS_RE)?.[1] as CssLang | undefined
+  const lang = CSS_LANGS_RE.exec(id)?.[1] as CssLang | undefined
   const postcssConfig = await resolvePostcssConfig(config)
 
   // 1. plain css that needs no processing
@@ -1295,7 +1295,7 @@ async function compileCSS(
         },
         async load(id) {
           const code = await fs.promises.readFile(id, 'utf-8')
-          const lang = id.match(CSS_LANGS_RE)?.[1] as CssLang | undefined
+          const lang = CSS_LANGS_RE.exec(id)?.[1] as CssLang | undefined
           if (isPreProcessor(lang)) {
             const result = await compileCSSPreprocessors(
               id,
@@ -2892,7 +2892,7 @@ export const convertTargets = (
   const targets: LightningCSSOptions['targets'] = {}
 
   const entriesWithoutES = arraify(esbuildTarget).flatMap((e) => {
-    const match = e.match(esRE)
+    const match = esRE.exec(e)
     if (!match) return e
     const year = Number(match[1])
     if (!esMap[year]) throw new Error(`Unsupported target "${e}"`)

--- a/packages/vite/src/node/plugins/dataUri.ts
+++ b/packages/vite/src/node/plugins/dataUri.ts
@@ -31,7 +31,7 @@ export function dataURIPlugin(): Plugin {
         return
       }
 
-      const match = uri.pathname.match(dataUriRE)
+      const match = dataUriRE.exec(uri.pathname)
       if (!match) {
         return
       }

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -28,7 +28,7 @@ const debug = createDebugger('vite:esbuild')
 // IIFE content looks like `var MyLib = function() {`.
 // Spaces are removed and parameters are mangled when minified
 const IIFE_BEGIN_RE =
-  /(const|var)\s+\S+\s*=\s*function\([^()]*\)\s*\{\s*"use strict";/
+  /(?:const|var)\s+\S+\s*=\s*function\([^()]*\)\s*\{\s*"use strict";/
 
 const validExtensionRE = /\.\w+$/
 const jsxExtensionsRE = /\.(?:j|t)sx\b/

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -47,7 +47,7 @@ interface ScriptAssetsUrl {
 }
 
 const htmlProxyRE =
-  /\?html-proxy=?(?:&inline-css)?(?:&style-attr)?&index=(\d+)\.(js|css)$/
+  /\?html-proxy=?(?:&inline-css)?(?:&style-attr)?&index=(\d+)\.(?:js|css)$/
 const isHtmlProxyRE = /\?html-proxy\b/
 
 const inlineCSSRE = /__VITE_INLINE_CSS__([a-z\d]{8}_\d+)__/g
@@ -99,7 +99,7 @@ export function htmlInlineProxyPlugin(config: ResolvedConfig): Plugin {
     },
 
     load(id) {
-      const proxyMatch = id.match(htmlProxyRE)
+      const proxyMatch = htmlProxyRE.exec(id)
       if (proxyMatch) {
         const index = Number(proxyMatch[1])
         const file = cleanUrl(id)
@@ -237,7 +237,7 @@ export function overwriteAttrValue(
     sourceCodeLocation.startOffset,
     sourceCodeLocation.endOffset,
   )
-  const valueStart = srcString.match(attrValueStartRE)
+  const valueStart = attrValueStartRE.exec(srcString)
   if (!valueStart) {
     // overwrite attr value can only be called for a well-defined value
     throw new Error(
@@ -1354,7 +1354,7 @@ export async function applyHtmlTransforms(
   return html
 }
 
-const importRE = /\bimport\s*("[^"]*[^\\]"|'[^']*[^\\]');*/g
+const importRE = /\bimport\s*(?:"[^"]*[^\\]"|'[^']*[^\\]');*/g
 const commentRE = /\/\*[\s\S]*?\*\/|\/\/.*$/gm
 function isEntirelyImport(code: string) {
   // only consider "side-effect" imports, which match <script type=module> semantics exactly

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -384,7 +384,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             // (e.g. vue blocks), inherit importer's version query
             // do not do this for unknown type imports, otherwise the appended
             // query can break 3rd party plugin's extension checks.
-            const versionMatch = importer.match(DEP_VERSION_RE)
+            const versionMatch = DEP_VERSION_RE.exec(importer)
             if (versionMatch) {
               url = injectQuery(url, versionMatch[1])
             }

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -272,7 +272,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
            *                                  ^
            */
           if (match[3]) {
-            let names = match[4].match(/\.([^.?]+)/)?.[1] || ''
+            let names = /\.([^.?]+)/.exec(match[4])?.[1] || ''
             // avoid `default` keyword error
             if (names === 'default') {
               names = 'default: __vite_default__'

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -35,7 +35,7 @@ export function optimizedDepsPlugin(config: ResolvedConfig): Plugin {
       if (depsOptimizer?.isOptimizedDepFile(id)) {
         const metadata = depsOptimizer.metadata
         const file = cleanUrl(id)
-        const versionMatch = id.match(DEP_VERSION_RE)
+        const versionMatch = DEP_VERSION_RE.exec(file)
         const browserHash = versionMatch
           ? versionMatch[1].split('=')[1]
           : undefined

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -717,7 +717,7 @@ export function tryNodeResolve(
   const { root, dedupe, isBuild, preserveSymlinks, packageCache } = options
 
   // check for deep import, e.g. "my-lib/foo"
-  const deepMatch = id.match(deepImportRE)
+  const deepMatch = deepImportRE.exec(id)
   // package name doesn't include postfixes
   // trim them to support importing package with queries (e.g. `import css from 'normalize.css?inline'`)
   const pkgId = deepMatch ? deepMatch[1] || deepMatch[2] : cleanUrl(id)

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -37,7 +37,7 @@ export function buildErrorMessage(
 
 function cleanStack(stack: string) {
   return stack
-    .split(/\n/g)
+    .split(/\n/)
     .filter((l) => /^\s*at/.test(l))
     .join('\n')
 }

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -92,7 +92,7 @@ async function ssrTransformScript(
   const declaredConst = new Set<string>()
 
   // hoist at the start of the file, after the hashbang
-  const hoistIndex = code.match(hashbangRE)?.[0].length ?? 0
+  const hoistIndex = hashbangRE.exec(code)?.[0].length ?? 0
 
   function defineImport(
     index: number,

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -57,7 +57,7 @@ export const createFilter = _createFilter as (
 
 const replaceSlashOrColonRE = /[/:]/g
 const replaceDotRE = /\./g
-const replaceNestedIdRE = /(\s*>\s*)/g
+const replaceNestedIdRE = /\s*>\s*/g
 const replaceHashRE = /#/g
 export const flattenId = (id: string): string => {
   const flatId = limitFlattenIdLength(
@@ -558,7 +558,7 @@ export function emptyDir(dir: string, skip?: string[]): void {
   if (skip?.length) {
     for (const file of skip) {
       if (path.dirname(file) !== '.') {
-        const matched = file.match(splitFirstDirRE)
+        const matched = splitFirstDirRE.exec(file)
         if (matched) {
           nested ??= new Map()
           const [, nestedDir, skipPath] = matched
@@ -656,7 +656,7 @@ function windowsMappedRealpathSync(path: string) {
   }
   return realPath
 }
-const parseNetUseRE = /^(\w+)? +(\w:) +([^ ]+)\s/
+const parseNetUseRE = /^\w* +(\w:) +([^ ]+)\s/
 let firstSafeRealPathSyncRun = false
 
 function windowsSafeRealPathSync(path: string): string {
@@ -691,8 +691,8 @@ function optimizeSafeRealPathSync() {
     // OK           Y:        \\NETWORKA\Foo         Microsoft Windows Network
     // OK           Z:        \\NETWORKA\Bar         Microsoft Windows Network
     for (const line of lines) {
-      const m = line.match(parseNetUseRE)
-      if (m) windowsNetworkMap.set(m[3], m[2])
+      const m = parseNetUseRE.exec(line)
+      if (m) windowsNetworkMap.set(m[2], m[1])
     }
     if (windowsNetworkMap.size === 0) {
       safeRealpathSync = fs.realpathSync.native
@@ -724,7 +724,7 @@ interface ImageCandidate {
   url: string
   descriptor: string
 }
-const escapedSpaceCharacters = /( |\\t|\\n|\\f|\\r)+/g
+const escapedSpaceCharacters = /(?: |\\t|\\n|\\f|\\r)+/g
 const imageSetUrlRE = /^(?:[\w\-]+\(.*?\)|'.*?'|".*?"|\S*)/
 function joinSrcset(ret: ImageCandidate[]) {
   return ret

--- a/packages/vite/src/runtime/moduleCache.ts
+++ b/packages/vite/src/runtime/moduleCache.ts
@@ -156,9 +156,7 @@ export class ModuleCacheMap extends Map<string, ModuleCache> {
     const mod = this.get(moduleId)
     if (mod.map) return mod.map
     if (!mod.meta || !('code' in mod.meta)) return null
-    const mapString = mod.meta.code.match(
-      VITE_RUNTIME_SOURCEMAPPING_REGEXP,
-    )?.[1]
+    const mapString = VITE_RUNTIME_SOURCEMAPPING_REGEXP.exec(mod.meta.code)?.[1]
     if (!mapString) return null
     const baseFile = mod.meta.file || moduleId.split('?')[0]
     mod.map = new DecodedMap(JSON.parse(decodeBase64(mapString)), baseFile)


### PR DESCRIPTION
### Description

Follow-up from https://github.com/vitejs/vite/pull/17788

This PR enables eslint typechecking when it runs in IDEs as typechecking is slow to be enabled by default. I fiddled with other options, but this seems like the best balance that doesn't affect local DX but still encourages better code written.

With that setup (and the rules added from #17788), I'm able to detect additional places where some regex refactors help improve performance, especially for using `RegExp#exec` is faster than `String#match`.

I had previously ran some benchmarks from https://github.com/lukeed/polka/pull/210, which showed that `RegExp#exec` is consistently faster than `String#match`, especially for longer regex or strings.