### PR TITLE
feat: resolved createEnvironment

### DIFF
--- a/docs/guide/api-vite-environment.md
+++ b/docs/guide/api-vite-environment.md
@@ -403,9 +403,9 @@ export default {
   environments: {
     rsc: {
       dev: {
-        createEnvironment(name, config) {
+        createEnvironment(name, config, setup) {
           // Called with 'rsc' and the resolved config during dev
-          return createNodeDevEnvironment(name, config)
+          return createNodeDevEnvironment(name, config, setup)
         }
       },
       build: {
@@ -434,8 +434,8 @@ function createWorkedEnvironment(userConfig) {
         ],
       },
       dev: {
-        createEnvironment(name, config) {
-          return createWorkerdDevEnvironment(name, config)
+        createEnvironment(name, config, setup) {
+          return createWorkerdDevEnvironment(name, config, setup)
         },
       },
       build: {

--- a/docs/guide/api-vite-environment.md
+++ b/docs/guide/api-vite-environment.md
@@ -323,7 +323,6 @@ function createWorkerdDevEnvironment(name: string, config: ResolvedConfig, conte
     runner: {
       transport,
     },
-    watcher: context.watcher
   })
   return workerdDevEnvironment
 }
@@ -799,7 +798,6 @@ function createWorkerEnvironment(name, config, context) {
         onMessage: (listener) => worker.on('message', listener),
       }),
     },
-    watcher: context.watcher
   })
 }
 

--- a/docs/guide/api-vite-environment.md
+++ b/docs/guide/api-vite-environment.md
@@ -306,7 +306,7 @@ One of the goals of this feature is to provide a customizable API to process and
 ```ts
 import { DevEnvironment, RemoteEnvironmentTransport } from 'vite'
 
-function createWorkerdDevEnvironment(name: string, config: ResolvedConfig, options?: DevEnvironmentOptions) {
+function createWorkerdDevEnvironment(name: string, config: ResolvedConfig, context: DevEnvironmentContext) {
   const hot = /* ... */
   const connection = /* ... */
   const transport = new RemoteEnvironmentTransport({
@@ -317,12 +317,13 @@ function createWorkerdDevEnvironment(name: string, config: ResolvedConfig, optio
   const workerdDevEnvironment = new DevEnvironment(name, config, {
     options: {
       resolve: { conditions: ['custom'] },
-      ...options,
+      ...context.options,
     },
     hot,
     runner: {
       transport,
     },
+    watcher: context.watcher
   })
   return workerdDevEnvironment
 }
@@ -336,7 +337,7 @@ const ssrEnvironment = createWorkerdEnvironment('ssr', config)
 
 ## Environment Configuration
 
-Environments are explicitely configured with the `environments` config option.
+Environments are explicitly configured with the `environments` config option.
 
 ```js
 export default {
@@ -403,9 +404,12 @@ export default {
   environments: {
     rsc: {
       dev: {
-        createEnvironment(name, config, setup) {
+        createEnvironment(name, config, { watcher }) {
           // Called with 'rsc' and the resolved config during dev
-          return createNodeDevEnvironment(name, config, setup)
+          return createNodeDevEnvironment(name, config, {
+            hot: customHotChannel(),
+            watcher
+          })
         }
       },
       build: {
@@ -434,8 +438,11 @@ function createWorkedEnvironment(userConfig) {
         ],
       },
       dev: {
-        createEnvironment(name, config, setup) {
-          return createWorkerdDevEnvironment(name, config, setup)
+        createEnvironment(name, config, { watcher }) {
+          return createWorkerdDevEnvironment(name, config, {
+            hot: customHotChannel(),
+            watcher,
+          })
         },
       },
       build: {
@@ -782,15 +789,17 @@ const runner = new ModuleRunner(
 import { BroadcastChannel } from 'node:worker_threads'
 import { createServer, RemoteEnvironmentTransport, DevEnvironment } from 'vite'
 
-function createWorkerEnvironment(name, config) {
+function createWorkerEnvironment(name, config, context) {
   const worker = new Worker('./worker.js')
   return new DevEnvironment(name, config, {
+    hot: /* custom hot channel */,
     runner: {
       transport: new RemoteEnvironmentTransport({
         send: (data) => worker.postMessage(data),
         onMessage: (listener) => worker.on('message', listener),
       }),
     },
+    watcher: context.watcher
   })
 }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -213,7 +213,7 @@ export interface DevEnvironmentOptions {
   // fs: { strict?: boolean, allow, deny }
 }
 
-function createDefaultClientDevEnvironment(
+function defaultCreateClientDevEnvironment(
   name: string,
   config: ResolvedConfig,
   context: CreateDevEnvironmentContext,
@@ -223,7 +223,7 @@ function createDefaultClientDevEnvironment(
   })
 }
 
-function createDefaultSsrDevEnvironment(
+function defaultCreateSsrDevEnvironment(
   name: string,
   config: ResolvedConfig,
 ): DevEnvironment {
@@ -232,14 +232,10 @@ function createDefaultSsrDevEnvironment(
   })
 }
 
-function createDefaultDevEnvironment(
-  name: string,
-  config: ResolvedConfig,
-  context: CreateDevEnvironmentContext,
-): DevEnvironment {
-  return config.environments[name].consumer === 'client'
-    ? createDefaultClientDevEnvironment(name, config, context)
-    : createDefaultSsrDevEnvironment(name, config)
+function defaultCreateDevEnvironment(name: string, config: ResolvedConfig) {
+  return new DevEnvironment(name, config, {
+    hot: false,
+  })
 }
 
 export type ResolvedDevEnvironmentOptions = Required<DevEnvironmentOptions>
@@ -630,7 +626,13 @@ export function resolveDevEnvironmentOptions(
       preserverSymlinks,
       environmentName,
     ),
-    createEnvironment: dev?.createEnvironment ?? createDefaultDevEnvironment,
+    createEnvironment:
+      dev?.createEnvironment ??
+      (environmentName === 'client'
+        ? defaultCreateClientDevEnvironment
+        : environmentName === 'ssr'
+          ? defaultCreateSsrDevEnvironment
+          : defaultCreateDevEnvironment),
     recoverable: dev?.recoverable ?? environmentName === 'client',
     moduleRunnerTransform:
       dev?.moduleRunnerTransform ??

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -10,7 +10,6 @@ import type { Alias, AliasOptions } from 'dep-types/alias'
 import aliasPlugin from '@rollup/plugin-alias'
 import { build } from 'esbuild'
 import type { PartialResolvedId, RollupOptions } from 'rollup'
-import type { FSWatcher } from 'dep-types/chokidar'
 import { withTrailingSlash } from '../shared/utils'
 import {
   CLIENT_ENTRY,
@@ -143,7 +142,6 @@ export function defineConfig(config: UserConfigExport): UserConfigExport {
 
 export interface CreateDevEnvironmentContext {
   ws: WebSocketServer
-  watcher: FSWatcher
 }
 
 export interface DevEnvironmentOptions {
@@ -222,18 +220,15 @@ function createDefaultClientDevEnvironment(
 ) {
   return new DevEnvironment(name, config, {
     hot: context.ws,
-    watcher: context.watcher,
   })
 }
 
 function createDefaultSsrDevEnvironment(
   name: string,
   config: ResolvedConfig,
-  context: CreateDevEnvironmentContext,
 ): DevEnvironment {
   return createNodeDevEnvironment(name, config, {
     hot: createServerHotChannel(),
-    watcher: context.watcher,
   })
 }
 
@@ -244,7 +239,7 @@ function createDefaultDevEnvironment(
 ): DevEnvironment {
   return config.environments[name].consumer === 'client'
     ? createDefaultClientDevEnvironment(name, config, context)
-    : createDefaultSsrDevEnvironment(name, config, context)
+    : createDefaultSsrDevEnvironment(name, config)
 }
 
 export type ResolvedDevEnvironmentOptions = Required<DevEnvironmentOptions>

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -21,7 +21,10 @@ export { buildErrorMessage } from './server/middlewares/error'
 
 export { RemoteEnvironmentTransport } from './server/environmentTransport'
 export { createNodeDevEnvironment } from './server/environments/nodeEnvironment'
-export { DevEnvironment, type DevEnvironmentSetup } from './server/environment'
+export {
+  DevEnvironment,
+  type DevEnvironmentContext,
+} from './server/environment'
 export { BuildEnvironment } from './build'
 
 export { fetchModule, type FetchModuleOptions } from './ssr/fetchModule'

--- a/packages/vite/src/node/plugins/loadFallback.ts
+++ b/packages/vite/src/node/plugins/loadFallback.ts
@@ -53,8 +53,12 @@ export function loadFallbackPlugin(config: ResolvedConfig): Plugin {
             throw e
           }
         }
-        if (code != null && environment.watcher) {
-          ensureWatchedFile(environment.watcher, file, config.root)
+        if (code != null && environment.pluginContainer.watcher) {
+          ensureWatchedFile(
+            environment.pluginContainer.watcher,
+            file,
+            config.root,
+          )
         }
       }
       if (code) {

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -222,7 +222,7 @@ async function getDevEnvironment(
   // @ts-expect-error This plugin requires a ViteDevServer instance.
   config.plugins = config.plugins.filter((p) => !p.name.includes('pre-alias'))
 
-  const environment = new DevEnvironment('client', config, { hot: false })
+  const environment = new DevEnvironment('client', config)
   await environment.init()
 
   return environment

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -222,7 +222,10 @@ async function getDevEnvironment(
   // @ts-expect-error This plugin requires a ViteDevServer instance.
   config.plugins = config.plugins.filter((p) => !p.name.includes('pre-alias'))
 
-  const environment = new DevEnvironment('client', config)
+  const environment = new DevEnvironment('client', config, {
+    hot: false,
+    watcher: false,
+  })
   await environment.init()
 
   return environment

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -222,10 +222,7 @@ async function getDevEnvironment(
   // @ts-expect-error This plugin requires a ViteDevServer instance.
   config.plugins = config.plugins.filter((p) => !p.name.includes('pre-alias'))
 
-  const environment = new DevEnvironment('client', config, {
-    hot: false,
-    watcher: false,
-  })
+  const environment = new DevEnvironment('client', config, { hot: false })
   await environment.init()
 
   return environment

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -32,7 +32,7 @@ import {
 import type { RemoteEnvironmentTransport } from './environmentTransport'
 
 export interface DevEnvironmentSetup {
-  hot: false | HotChannel
+  hot?: HotChannel
   watcher?: FSWatcher
   options?: EnvironmentOptions
   runner?: FetchModuleOptions & {
@@ -100,14 +100,14 @@ export class DevEnvironment extends BaseEnvironment {
   constructor(
     name: string,
     config: ResolvedConfig,
-    setup: DevEnvironmentSetup,
+    setup?: DevEnvironmentSetup,
   ) {
     let options =
       config.environments[name] ?? getDefaultResolvedEnvironmentOptions(config)
-    if (setup.options) {
+    if (setup?.options) {
       options = mergeConfig(
         options,
-        setup.options,
+        setup?.options,
       ) as ResolvedEnvironmentOptions
     }
     super(name, config, options)
@@ -118,16 +118,16 @@ export class DevEnvironment extends BaseEnvironment {
       this.pluginContainer!.resolveId(url, undefined),
     )
 
-    this.hot = setup.hot || createNoopHotChannel()
-    this.watcher = setup.watcher
+    this.hot = setup?.hot ?? createNoopHotChannel()
+    this.watcher = setup?.watcher
 
     this._onCrawlEndCallbacks = []
     this._crawlEndFinder = setupOnCrawlEnd(() => {
       this._onCrawlEndCallbacks.forEach((cb) => cb())
     })
 
-    this._ssrRunnerOptions = setup.runner || {}
-    setup.runner?.transport?.register(this)
+    this._ssrRunnerOptions = setup?.runner ?? {}
+    setup?.runner?.transport?.register(this)
 
     this.hot.on('vite:invalidate', async ({ path, message }) => {
       invalidateModule(this, {
@@ -137,7 +137,7 @@ export class DevEnvironment extends BaseEnvironment {
     })
 
     const { optimizeDeps } = this.config.dev
-    if (setup.depsOptimizer) {
+    if (setup?.depsOptimizer) {
       this.depsOptimizer = setup.depsOptimizer
     } else if (isDepOptimizationDisabled(optimizeDeps)) {
       this.depsOptimizer = undefined
@@ -146,7 +146,7 @@ export class DevEnvironment extends BaseEnvironment {
       // environments `noDiscovery` has no effect and a simpler explicit deps
       // optimizer is used that only optimizes explicitly included dependencies
       // so it doesn't need to reload the environment. Now that we have proper HMR
-      // and full reload for general environments, we can enable autodiscovery for
+      // and full reload for general environments, we can enable auto-discovery for
       // them in the future
       this.depsOptimizer = (
         optimizeDeps.noDiscovery || name !== 'client'

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -123,8 +123,8 @@ export class DevEnvironment extends BaseEnvironment {
       this._onCrawlEndCallbacks.forEach((cb) => cb())
     })
 
-    this._ssrRunnerOptions = context?.runner ?? {}
-    context?.runner?.transport?.register(this)
+    this._ssrRunnerOptions = context.runner ?? {}
+    context.runner?.transport?.register(this)
 
     this.hot.on('vite:invalidate', async ({ path, message }) => {
       invalidateModule(this, {
@@ -134,7 +134,7 @@ export class DevEnvironment extends BaseEnvironment {
     })
 
     const { optimizeDeps } = this.config.dev
-    if (context?.depsOptimizer) {
+    if (context.depsOptimizer) {
       this.depsOptimizer = context.depsOptimizer
     } else if (isDepOptimizationDisabled(optimizeDeps)) {
       this.depsOptimizer = undefined

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -33,7 +33,6 @@ import type { RemoteEnvironmentTransport } from './environmentTransport'
 
 export interface DevEnvironmentContext {
   hot: false | HotChannel
-  watcher: false | FSWatcher
   options?: EnvironmentOptions
   runner?: FetchModuleOptions & {
     transport?: RemoteEnvironmentTransport
@@ -45,7 +44,6 @@ export class DevEnvironment extends BaseEnvironment {
   mode = 'dev' as const // TODO: should this be 'serve'?
   moduleGraph: EnvironmentModuleGraph
 
-  watcher?: FSWatcher
   depsOptimizer?: DepsOptimizer
   /**
    * @internal
@@ -119,7 +117,6 @@ export class DevEnvironment extends BaseEnvironment {
     )
 
     this.hot = context.hot || createNoopHotChannel()
-    this.watcher = context.watcher || undefined
 
     this._onCrawlEndCallbacks = []
     this._crawlEndFinder = setupOnCrawlEnd(() => {
@@ -156,7 +153,7 @@ export class DevEnvironment extends BaseEnvironment {
     }
   }
 
-  async init(): Promise<void> {
+  async init(options?: { watcher?: FSWatcher }): Promise<void> {
     if (this._initiated) {
       return
     }
@@ -165,6 +162,7 @@ export class DevEnvironment extends BaseEnvironment {
     this._pluginContainer = await createEnvironmentPluginContainer(
       this,
       this._plugins,
+      options?.watcher,
     )
 
     // TODO: Should buildStart be called here? It break backward compatibility if we do,

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -1,15 +1,27 @@
 import type { ResolvedConfig } from '../../config'
 import type { DevEnvironmentSetup } from '../environment'
 import { DevEnvironment } from '../environment'
+import { createServerHotChannel } from '../hmr'
 import { asyncFunctionDeclarationPaddingLineCount } from '../../../shared/utils'
+
+export function createNodeSsrDevEnvironment(
+  name: string,
+  config: ResolvedConfig,
+  setup?: DevEnvironmentSetup,
+): DevEnvironment {
+  return createNodeDevEnvironment(name, config, {
+    ...setup,
+    hot: createServerHotChannel(),
+  })
+}
 
 export function createNodeDevEnvironment(
   name: string,
   config: ResolvedConfig,
-  options: DevEnvironmentSetup,
+  setup?: DevEnvironmentSetup,
 ): DevEnvironment {
   return new DevEnvironment(name, config, {
-    ...options,
+    ...setup,
     runner: {
       processSourceMap(map) {
         // this assumes that "new AsyncFunction" is used to create the module
@@ -18,7 +30,7 @@ export function createNodeDevEnvironment(
             ';'.repeat(asyncFunctionDeclarationPaddingLineCount) + map.mappings,
         })
       },
-      ...options?.runner,
+      ...setup?.runner,
     },
   })
 }

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -1,27 +1,15 @@
 import type { ResolvedConfig } from '../../config'
-import type { DevEnvironmentSetup } from '../environment'
+import type { DevEnvironmentContext } from '../environment'
 import { DevEnvironment } from '../environment'
-import { createServerHotChannel } from '../hmr'
 import { asyncFunctionDeclarationPaddingLineCount } from '../../../shared/utils'
-
-export function createNodeSsrDevEnvironment(
-  name: string,
-  config: ResolvedConfig,
-  setup?: DevEnvironmentSetup,
-): DevEnvironment {
-  return createNodeDevEnvironment(name, config, {
-    ...setup,
-    hot: createServerHotChannel(),
-  })
-}
 
 export function createNodeDevEnvironment(
   name: string,
   config: ResolvedConfig,
-  setup?: DevEnvironmentSetup,
+  context: DevEnvironmentContext,
 ): DevEnvironment {
   return new DevEnvironment(name, config, {
-    ...setup,
+    ...context,
     runner: {
       processSourceMap(map) {
         // this assumes that "new AsyncFunction" is used to create the module
@@ -30,7 +18,7 @@ export function createNodeDevEnvironment(
             ';'.repeat(asyncFunctionDeclarationPaddingLineCount) + map.mappings,
         })
       },
-      ...setup?.runner,
+      ...context.runner,
     },
   })
 }

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -485,13 +485,12 @@ export async function _createServer(
       config,
       {
         ws,
-        watcher,
       },
     )
   }
 
   for (const environment of Object.values(environments)) {
-    await environment.init()
+    await environment.init({ watcher })
   }
 
   // Backward compatibility
@@ -571,7 +570,6 @@ export async function _createServer(
     },
     async ssrLoadModule(url, opts?: { fixStacktrace?: boolean }) {
       warnFutureDeprecation(config, 'ssrLoadModule')
-
       return ssrLoadModule(url, server, undefined, opts?.fixStacktrace)
     },
     ssrFixStacktrace(e) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -484,7 +484,7 @@ export async function _createServer(
       name,
       config,
       {
-        hot: ws,
+        ws,
         watcher,
       },
     )

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -85,7 +85,6 @@ import { errorMiddleware } from './middlewares/error'
 import type { HmrOptions, HotBroadcaster } from './hmr'
 import {
   createDeprecatedHotBroadcaster,
-  createServerHotChannel,
   handleHMRUpdate,
   updateModules,
 } from './hmr'
@@ -94,8 +93,7 @@ import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
 import { searchForWorkspaceRoot } from './searchRoot'
 import { warmupFiles } from './warmup'
-import { DevEnvironment } from './environment'
-import { createNodeDevEnvironment } from './environments/nodeEnvironment'
+import type { DevEnvironment } from './environment'
 
 export interface ServerOptions extends CommonServerOptions {
   /**
@@ -452,7 +450,6 @@ export async function _createServer(
     : await resolveHttpServer(serverConfig, middlewares, httpsOptions)
 
   const ws = createWebSocketServer(httpServer, config, httpsOptions)
-  const ssrHotChannel = createServerHotChannel()
 
   const publicFiles = await initPublicFilesPromise
   const { publicDir } = config
@@ -480,33 +477,17 @@ export async function _createServer(
 
   const environments: Record<string, DevEnvironment> = {}
 
-  const client_createEnvironment =
-    config.environments.client?.dev?.createEnvironment ??
-    ((name: string, config: ResolvedConfig) =>
-      new DevEnvironment(name, config, { hot: ws, watcher }))
-
-  environments.client = await client_createEnvironment('client', config)
-
-  const ssr_createEnvironment =
-    config.environments.ssr?.dev?.createEnvironment ??
-    ((name: string, config: ResolvedConfig) =>
-      createNodeDevEnvironment(name, config, { hot: ssrHotChannel, watcher }))
-
-  environments.ssr = await ssr_createEnvironment('ssr', config)
-
-  for (const [name, EnvironmentOptions] of Object.entries(
+  for (const [name, environmentOptions] of Object.entries(
     config.environments,
   )) {
-    // TODO: move client and ssr inside the loop?
-    if (name !== 'client' && name !== 'ssr') {
-      const createEnvironment =
-        EnvironmentOptions.dev?.createEnvironment ??
-        ((name: string, config: ResolvedConfig) =>
-          new DevEnvironment(name, config, {
-            hot: ws, // TODO: what should we use here?
-          }))
-      environments[name] = await createEnvironment(name, config)
-    }
+    environments[name] = await environmentOptions.dev.createEnvironment(
+      name,
+      config,
+      {
+        hot: ws,
+        watcher,
+      },
+    )
   }
 
   for (const environment of Object.values(environments)) {

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -153,8 +153,6 @@ async function doTransform(
 ) {
   url = removeTimestampQuery(url)
 
-  await environment.init()
-
   const { pluginContainer } = environment
 
   let module = await environment.moduleGraph.getModuleByUrl(url)
@@ -286,8 +284,12 @@ async function loadAndTransform(
           throw e
         }
       }
-      if (code != null && environment.watcher) {
-        ensureWatchedFile(environment.watcher, file, config.root)
+      if (code != null && environment.pluginContainer.watcher) {
+        ensureWatchedFile(
+          environment.pluginContainer.watcher,
+          file,
+          config.root,
+        )
       }
     }
     if (code) {

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
@@ -30,7 +30,7 @@ describe('running module runner inside a worker', () => {
       environments: {
         worker: {
           dev: {
-            createEnvironment: (name, config, context) => {
+            createEnvironment: (name, config) => {
               return new DevEnvironment(name, config, {
                 runner: {
                   transport: new RemoteEnvironmentTransport({
@@ -38,7 +38,6 @@ describe('running module runner inside a worker', () => {
                     onMessage: (handler) => worker.on('message', handler),
                   }),
                 },
-                watcher: context.watcher,
                 hot: false,
               })
             },

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
@@ -30,7 +30,7 @@ describe('running module runner inside a worker', () => {
       environments: {
         worker: {
           dev: {
-            createEnvironment: (name, config) => {
+            createEnvironment: (name, config, context) => {
               return new DevEnvironment(name, config, {
                 runner: {
                   transport: new RemoteEnvironmentTransport({
@@ -38,6 +38,8 @@ describe('running module runner inside a worker', () => {
                     onMessage: (handler) => worker.on('message', handler),
                   }),
                 },
+                watcher: context.watcher,
+                hot: false,
               })
             },
           },


### PR DESCRIPTION
### Description

Environment options `dev.createEnvironment` and `build.createEnvironment` were not resolved in the config stage. They remained undefined, and later the default was set in the builder and server while creating the environments. This PR requires both in the `ResolvedConfig`, and forces us to properly define their type. `dev.createEnvironment` was not taking the third `setup` parameter (so the watcher was not received by custom environments or for the `client` and `ssr` envs when defining a custom `createEnvironment`).

Now that is exposed, we may need a better name than `setup` for this parameter.