### PR TITLE
fix: opt-in server.fs.cachedChecks

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -334,7 +334,7 @@ Blocklist for sensitive files being restricted to be served by Vite dev server. 
 - **Default:** `false`
 - **Experimental**
 
-The `fs.cachedChecks` optimization caches filenames of accessed directories to avoid repeated filesystem operations. In Windows in particular, this could result in a performance boost. It is disabled by default because there are edge cases when writing a file in a cached folder and immediately importing it.
+Caches filenames of accessed directories to avoid repeated filesystem operations. Particularly in Windows, this could result in a performance boost. It is disabled by default due to edge cases when writing a file in a cached folder and immediately importing it.
 
 ## server.origin
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -328,6 +328,14 @@ export default defineConfig({
 
 Blocklist for sensitive files being restricted to be served by Vite dev server. This will have higher priority than [`server.fs.allow`](#server-fs-allow). [picomatch patterns](https://github.com/micromatch/picomatch#globbing-features) are supported.
 
+## server.fs.cachedChecks
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Experimental**
+
+The `fs.cachedChecks` optimization caches filenames of accessed directories to avoid repeated filesystem operations. In Windows in particular, this could result in a performance boost. It is disabled by default because there are edge cases when writing a file in a cached folder and immediately importing it.
+
 ## server.origin
 
 - **Type:** `string`

--- a/packages/vite/src/node/fsUtils.ts
+++ b/packages/vite/src/node/fsUtils.ts
@@ -46,12 +46,14 @@ export function getFsUtils(config: ResolvedConfig): FsUtils {
   if (!fsUtils) {
     if (
       config.command !== 'serve' ||
-      config.server.fs.cachedChecks === false ||
+      config.server.fs.cachedChecks !== true ||
       config.server.watch?.ignored ||
       process.versions.pnp
     ) {
       // cached fsUtils is only used in the dev server for now
-      // it is enabled by default only when there aren't custom watcher ignored patterns configured
+      // it is disabled by default due to potential edge cases when writing a file
+      // and reading it immediately
+      // It is also disabled when there aren't custom watcher ignored patterns configured
       // and if yarn pnp isn't used
       fsUtils = commonFsUtils
     } else if (


### PR DESCRIPTION
### Description

Make `server.fs.cachedChecks` false by default. Even if technically this issue https://github.com/vitejs/vite/issues/17760 is a rare edge case in the way current frameworks and tools are implemented (as we have been using cachedChecks for a while now), it should work correctly and we don't have a good fix for it at this point.

We should move to opt-in cached checks for now. In some large apps, specially on Windows, it would still be a good idea to enable it but we will let that to the user. Node has been working on improving fs access so we're discussing a potential deprecation of this cache. It will also not be share by access by rolldown later on if we keep it.

We can keep https://github.com/vitejs/vite/issues/17760 open for now if we'd like to explore a solution. If we can't find a way to fix it, I'm leaning towards removal of the cache.