### PR TITLE
fix(ssr): fix `global` variable name conflict

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -563,7 +563,7 @@ export async function _createServer(
       return devHtmlTransformFn(server, url, html, originalUrl)
     },
     async ssrLoadModule(url, opts?: { fixStacktrace?: boolean }) {
-      return ssrLoadModule(url, server, undefined, opts?.fixStacktrace)
+      return ssrLoadModule(url, server, opts?.fixStacktrace)
     },
     async ssrFetchModule(url: string, importer?: string) {
       return ssrFetchModule(server, url, importer)

--- a/packages/vite/src/node/ssr/__tests__/fixtures/global/export.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/global/export.js
@@ -1,0 +1,1 @@
+export const global = 'ok'

--- a/packages/vite/src/node/ssr/__tests__/fixtures/global/test.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/global/test.js
@@ -1,0 +1,1 @@
+export default global

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -62,3 +62,15 @@ test('import.meta.filename/dirname returns same value with Node', async () => {
   expect(viteValue.dirname).toBe(path.dirname(filename))
   expect(viteValue.filename).toBe(filename)
 })
+
+test('can export global', async () => {
+  const server = await createDevServer()
+  const mod = await server.ssrLoadModule('/fixtures/global/export.js')
+  expect(mod.global).toBe('ok')
+})
+
+test('can access nodejs global', async () => {
+  const server = await createDevServer()
+  const mod = await server.ssrLoadModule('/fixtures/global/test.js')
+  expect(mod.default).toBe(globalThis)
+})

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -213,7 +213,6 @@ async function instantiateModule(
 
   try {
     const initModule = new AsyncFunction(
-      `global`,
       ssrModuleExportsKey,
       ssrImportMetaKey,
       ssrImportKey,
@@ -224,7 +223,6 @@ async function instantiateModule(
         `\n//# sourceURL=${mod.id}${sourceMapSuffix}`,
     )
     await initModule(
-      context.global,
       ssrModule,
       ssrImportMeta,
       ssrImport,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -27,10 +27,6 @@ import {
 } from './ssrTransform'
 import { ssrFixStacktrace } from './ssrStacktrace'
 
-interface SSRContext {
-  global: typeof globalThis
-}
-
 type SSRModule = Record<string, any>
 
 interface NodeImportResolveOptions
@@ -45,7 +41,6 @@ const importErrors = new WeakMap<Error, { importee: string }>()
 export async function ssrLoadModule(
   url: string,
   server: ViteDevServer,
-  context: SSRContext = { global },
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
   url = unwrapId(url)
@@ -59,7 +54,7 @@ export async function ssrLoadModule(
     return pending
   }
 
-  const modulePromise = instantiateModule(url, server, context, fixStacktrace)
+  const modulePromise = instantiateModule(url, server, fixStacktrace)
   pendingModules.set(url, modulePromise)
   modulePromise
     .catch(() => {
@@ -74,7 +69,6 @@ export async function ssrLoadModule(
 async function instantiateModule(
   url: string,
   server: ViteDevServer,
-  context: SSRContext = { global },
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
   const { moduleGraph } = server
@@ -169,7 +163,7 @@ async function instantiateModule(
         }
       }
 
-      return ssrLoadModule(dep, server, context, fixStacktrace)
+      return ssrLoadModule(dep, server, fixStacktrace)
     } catch (err) {
       // tell external error handler which mod was imported with error
       importErrors.set(err, { importee: dep })


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/17698

Passing `global` as ssr evaluation parameter is probably not necessary since `ssrLoadModule` is assumed to run on NodeJs and `global` should be available anyways.

Looking at v5 vite runtime, v6 module runner, and vite-node, they don't pass `global` at all and it looks safe to just remove it on `ssrLoadModule` side without breaking anything.

https://github.com/vitejs/vite/blob/6bdff8b807341a5f6c616558a2ddc9b5d0eb62ab/packages/vite/src/runtime/esmRunner.ts#L17-L24