### PR TITLE
perf(ssr): do a single-pass over AST with node cache arrays

### DIFF
--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -2,6 +2,9 @@ import path from 'node:path'
 import MagicString from 'magic-string'
 import type { SourceMap } from 'rollup'
 import type {
+  ExportAllDeclaration,
+  ExportDefaultDeclaration,
+  ExportNamedDeclaration,
   Function as FunctionNode,
   Identifier,
   ImportDeclaration,
@@ -132,12 +135,20 @@ async function ssrTransformScript(
   }
 
   const imports: (ImportDeclaration & { start: number; end: number })[] = []
-  const exports: Node[] = []
+  const exports: ((
+    | ExportNamedDeclaration
+    | ExportDefaultDeclaration
+    | ExportAllDeclaration
+  ) & { start: number; end: number })[] = []
 
   for (const node of ast.body as Node[]) {
     if (node.type === 'ImportDeclaration') {
       imports.push(node)
-    } else if (node.type.startsWith('Export')) {
+    } else if (
+      node.type === 'ExportNamedDeclaration' ||
+      node.type === 'ExportDefaultDeclaration' ||
+      node.type === 'ExportAllDeclaration'
+    ) {
       exports.push(node)
     }
   }

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -130,53 +130,67 @@ async function ssrTransformScript(
     )
   }
 
-  // 1. check all import statements and record id -> importName map
+  // Temporary reference allocations
+  const imports = []
+  const exports = []
+
   for (const node of ast.body as Node[]) {
+    if (node.type === 'ImportDeclaration') {
+      imports.push(node)
+    } else if (node.type.startsWith('Export')) {
+      exports.push(node)
+    }
+  }
+
+  // 1. check all import statements and record id -> importName map
+  // and deallocate the imports array
+  while (imports.length > 0) {
+    const node = imports.shift()!
     // import foo from 'foo' --> foo -> __import_foo__.default
     // import { baz } from 'foo' --> baz -> __import_foo__.baz
     // import * as ok from 'foo' --> ok -> __import_foo__
-    if (node.type === 'ImportDeclaration') {
-      const importId = defineImport(hoistIndex, node.source.value as string, {
-        importedNames: node.specifiers
-          .map((s) => {
-            if (s.type === 'ImportSpecifier')
-              return s.imported.type === 'Identifier'
-                ? s.imported.name
-                : // @ts-expect-error TODO: Estree types don't consider arbitrary module namespace specifiers yet
-                  s.imported.value
-            else if (s.type === 'ImportDefaultSpecifier') return 'default'
-          })
-          .filter(isDefined),
-      })
-      s.remove(node.start, node.end)
-      for (const spec of node.specifiers) {
-        if (spec.type === 'ImportSpecifier') {
-          if (spec.imported.type === 'Identifier') {
-            idToImportMap.set(
-              spec.local.name,
-              `${importId}.${spec.imported.name}`,
-            )
-          } else {
-            idToImportMap.set(
-              spec.local.name,
-              `${importId}[${
-                // @ts-expect-error TODO: Estree types don't consider arbitrary module namespace specifiers yet
-                JSON.stringify(spec.imported.value)
-              }]`,
-            )
-          }
-        } else if (spec.type === 'ImportDefaultSpecifier') {
-          idToImportMap.set(spec.local.name, `${importId}.default`)
+    const importId = defineImport(hoistIndex, node.source.value as string, {
+      importedNames: node.specifiers
+        .map((s) => {
+          if (s.type === 'ImportSpecifier')
+            return s.imported.type === 'Identifier'
+              ? s.imported.name
+              : // @ts-expect-error TODO: Estree types don't consider arbitrary module namespace specifiers yet
+                s.imported.value
+          else if (s.type === 'ImportDefaultSpecifier') return 'default'
+        })
+        .filter(isDefined),
+    })
+    s.remove(node.start, node.end)
+    for (const spec of node.specifiers) {
+      if (spec.type === 'ImportSpecifier') {
+        if (spec.imported.type === 'Identifier') {
+          idToImportMap.set(
+            spec.local.name,
+            `${importId}.${spec.imported.name}`,
+          )
         } else {
-          // namespace specifier
-          idToImportMap.set(spec.local.name, importId)
+          idToImportMap.set(
+            spec.local.name,
+            `${importId}[${
+              // @ts-expect-error TODO: Estree types don't consider arbitrary module namespace specifiers yet
+              JSON.stringify(spec.imported.value)
+            }]`,
+          )
         }
+      } else if (spec.type === 'ImportDefaultSpecifier') {
+        idToImportMap.set(spec.local.name, `${importId}.default`)
+      } else {
+        // namespace specifier
+        idToImportMap.set(spec.local.name, importId)
       }
     }
   }
 
   // 2. check all export statements and define exports
-  for (const node of ast.body as Node[]) {
+  // and deallocate the exports array
+  while (exports.length > 0) {
+    const node = exports.shift()!
     // named exports
     if (node.type === 'ExportNamedDeclaration') {
       if (node.declaration) {


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

I have noticed in the Nuxt dev server flamegraph with the Node inspector that quite some time is spent on `ssrTransformScript`. Looked for areas where time can be reduced and noticed that it's not necessary to do multiple passes over the entire AST. This could be a win for larger files, by isolating the import/export decls once and deallocating the 2 cache arrays while processing them to only temporarily create the references.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
