### PR TITLE
fix(build): windows platform build output path error

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -594,7 +594,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
         const toRelative = (filename: string) => {
           // relative base + extracted CSS
-          const relativePath = path.posix.relative(cssAssetDirname!, filename)
+          const relativePath = normalizePath(
+            path.relative(cssAssetDirname!, filename),
+          )
           return relativePath[0] === '.' ? relativePath : './' + relativePath
         }
 
@@ -615,9 +617,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         })
         // resolve public URL from CSS paths
         if (encodedPublicUrls) {
-          const relativePathToPublicFromCSS = path.posix.relative(
-            cssAssetDirname!,
-            '',
+          const relativePathToPublicFromCSS = normalizePath(
+            path.relative(cssAssetDirname!, ''),
           )
           chunkCSS = chunkCSS.replace(publicAssetUrlRE, (_, hash) => {
             const publicUrl = publicAssetUrlMap.get(hash)!.slice(1)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -594,9 +594,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
         const toRelative = (filename: string) => {
           // relative base + extracted CSS
-          const relativePath = normalizePath(
-            path.relative(cssAssetDirname!, filename),
-          )
+          const relativePath = path.relative(cssAssetDirname!, filename)
           return relativePath[0] === '.' ? relativePath : './' + relativePath
         }
 
@@ -617,8 +615,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         })
         // resolve public URL from CSS paths
         if (encodedPublicUrls) {
-          const relativePathToPublicFromCSS = normalizePath(
-            path.relative(cssAssetDirname!, ''),
+          const relativePathToPublicFromCSS = path.relative(
+            cssAssetDirname!,
+            '',
           )
           chunkCSS = chunkCSS.replace(publicAssetUrlRE, (_, hash) => {
             const publicUrl = publicAssetUrlMap.get(hash)!.slice(1)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -594,7 +594,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
         const toRelative = (filename: string) => {
           // relative base + extracted CSS
-          const relativePath = path.relative(cssAssetDirname!, filename)
+          const relativePath = normalizePath(
+            path.relative(cssAssetDirname!, filename),
+          )
           return relativePath[0] === '.' ? relativePath : './' + relativePath
         }
 
@@ -615,9 +617,8 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         })
         // resolve public URL from CSS paths
         if (encodedPublicUrls) {
-          const relativePathToPublicFromCSS = path.relative(
-            cssAssetDirname!,
-            '',
+          const relativePathToPublicFromCSS = normalizePath(
+            path.relative(cssAssetDirname!, ''),
           )
           chunkCSS = chunkCSS.replace(publicAssetUrlRE, (_, hash) => {
             const publicUrl = publicAssetUrlMap.get(hash)!.slice(1)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -330,7 +330,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     async transform(html, id) {
       if (id.endsWith('.html')) {
         id = normalizePath(id)
-        const relativeUrlPath = path.posix.relative(config.root, id)
+        const relativeUrlPath = normalizePath(path.relative(config.root, id))
         const publicPath = `/${relativeUrlPath}`
         const publicBase = getBaseInHTML(relativeUrlPath, config)
 
@@ -776,7 +776,9 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       }
 
       for (const [normalizedId, html] of processedHtml) {
-        const relativeUrlPath = path.posix.relative(config.root, normalizedId)
+        const relativeUrlPath = normalizePath(
+          path.relative(config.root, normalizedId),
+        )
         const assetsBase = getBaseInHTML(relativeUrlPath, config)
         const toOutputFilePath = (
           filename: string,

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -330,7 +330,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     async transform(html, id) {
       if (id.endsWith('.html')) {
         id = normalizePath(id)
-        const relativeUrlPath = normalizePath(path.relative(config.root, id))
+        const relativeUrlPath = path.relative(config.root, id)
         const publicPath = `/${relativeUrlPath}`
         const publicBase = getBaseInHTML(relativeUrlPath, config)
 
@@ -776,9 +776,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       }
 
       for (const [normalizedId, html] of processedHtml) {
-        const relativeUrlPath = normalizePath(
-          path.relative(config.root, normalizedId),
-        )
+        const relativeUrlPath = path.relative(config.root, normalizedId)
         const assetsBase = getBaseInHTML(relativeUrlPath, config)
         const toOutputFilePath = (
           filename: string,

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -330,7 +330,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     async transform(html, id) {
       if (id.endsWith('.html')) {
         id = normalizePath(id)
-        const relativeUrlPath = path.relative(config.root, id)
+        const relativeUrlPath = normalizePath(path.relative(config.root, id))
         const publicPath = `/${relativeUrlPath}`
         const publicBase = getBaseInHTML(relativeUrlPath, config)
 
@@ -776,7 +776,9 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
       }
 
       for (const [normalizedId, html] of processedHtml) {
-        const relativeUrlPath = path.relative(config.root, normalizedId)
+        const relativeUrlPath = normalizePath(
+          path.relative(config.root, normalizedId),
+        )
         const assetsBase = getBaseInHTML(relativeUrlPath, config)
         const toOutputFilePath = (
           filename: string,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

fix #17584
`path.posix.relative` and `path.relative` resolve differently when the path starts with lowercase.
```ts
import path from 'node:path'
path.posix.relative('c:/a', 'C:/a/index.html') // => '../../C:/a/index.html'
path.relative('c:/a',  'C:/a/index.html') // => 'index.html'

```