### PR TITLE
fix(create-vite): remove eslint overrides

### DIFF
--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -25,8 +25,5 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.0",
     "vite": "^5.4.0"
-  },
-  "overrides": {
-    "eslint": "$eslint"
   }
 }


### PR DESCRIPTION
### Description

fix https://github.com/vitejs/vite/issues/17832

we don't need the override anymore as we're using typescript-eslint v8