### PR TITLE
test: disable network-imports test

### DIFF
--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -106,7 +106,11 @@ describe.runIf(isServe)('stacktrace', () => {
   })
 })
 
-describe.runIf(isServe).skip('network-imports', () => {
+// --experimental-network-imports is going to be dropped
+// https://github.com/nodejs/node/pull/53822
+const noNetworkImports = Number(process.version.match(/^v(\d+)\./)[1]) >= 22
+
+describe.runIf(isServe && !noNetworkImports)('network-imports', () => {
   test('with Vite SSR', async () => {
     await execFileAsync(
       'node',

--- a/playground/ssr-html/__tests__/ssr-html.spec.ts
+++ b/playground/ssr-html/__tests__/ssr-html.spec.ts
@@ -106,7 +106,7 @@ describe.runIf(isServe)('stacktrace', () => {
   })
 })
 
-describe.runIf(isServe)('network-imports', () => {
+describe.runIf(isServe).skip('network-imports', () => {
   test('with Vite SSR', async () => {
     await execFileAsync(
       'node',


### PR DESCRIPTION
### Description

- related https://github.com/nodejs/node/pull/53822

Though Node has decided to drop network import feature https://github.com/nodejs/node/pull/53822, the code needed on Vite side to make it work was a one-liner to externalizing `http` import https://github.com/vitejs/vite/pull/15599/, so I'm thinking we don't need to revert that part.

But, I'm not sure what to do with existing tests. Whether we skip it for specific Node version or completely remove them. For now, I added node v22 check to skip tests.