### PR TITLE
fix: align CorsOptions.origin type with @types/cors

### DIFF
--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -75,7 +75,10 @@ export interface CommonServerOptions {
 export interface CorsOptions {
   origin?:
     | CorsOrigin
-    | ((origin: string, cb: (err: Error, origins: CorsOrigin) => void) => void)
+    | ((
+        origin: string | undefined,
+        cb: (err: Error, origins: CorsOrigin) => void,
+      ) => void)
   methods?: string | string[]
   allowedHeaders?: string | string[]
   exposedHeaders?: string | string[]


### PR DESCRIPTION
### Description

This patch updates the `CorsOptions.origin` type to more closely match [the same type present in the `@types/cors` package](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cors/index.d.ts#L8). Without this change, plugin developers may find it difficult to use the CORS middleware with the config provided by Vite without encountering TypeScript errors.

Beyond aligning the types and making integrations easier, the type is more correct now since the `Origin` header may not be present, meaning that [the middleware would provide `undefined` in its place](https://github.com/expressjs/cors/blob/791983ebc0407115bc8ae8e64830d440da995938/lib/index.js#L219).

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
