### PR TITLE
fix(worker): handle self reference url worker in dependency for build

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -292,7 +292,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
 
       let urlCode: string
       if (isBuild) {
-        if (isWorker && this.getModuleInfo(cleanUrl(id))?.isEntry) {
+        if (isWorker && config.bundleChain.at(-1) === cleanUrl(id)) {
           urlCode = 'self.location.href'
         } else if (inlineRE.test(id)) {
           const chunk = await bundleWorkerEntry(config, id)

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -171,8 +171,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           if (
             isBuild &&
             config.isWorker &&
-            // TODO: why isEntry is false when worker is from node_modules?
-            // this.getModuleInfo(cleanUrl(file))?.isEntry
             config.bundleChain.at(-1) === cleanUrl(file)
           ) {
             s.update(expStart, expEnd, 'self.location.href')

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -171,7 +171,9 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           if (
             isBuild &&
             config.isWorker &&
-            this.getModuleInfo(cleanUrl(file))?.isEntry
+            // TODO: why isEntry is false when worker is from node_modules?
+            // this.getModuleInfo(cleanUrl(file))?.isEntry
+            config.bundleChain.at(-1) === cleanUrl(file)
           ) {
             s.update(expStart, expEnd, 'self.location.href')
           } else {

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -111,7 +111,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(34)
+    expect(files.length).toBe(35)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -75,7 +75,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/iife/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(22)
+    expect(files.length).toBe(23)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('worker_entry-my-worker'))
@@ -171,6 +171,12 @@ test('self reference url worker', async () => {
   expectWithRetry(() => page.textContent('.self-reference-url-worker')).toBe(
     'pong: main\npong: nested\n',
   )
+})
+
+test('self reference url worker in dependency', async () => {
+  await expectWithRetry(() =>
+    page.textContent('.self-reference-url-worker-dep'),
+  ).toBe('pong: main\npong: nested\n')
 })
 
 test.runIf(isServe)('sourcemap boundary', async () => {

--- a/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(44)
+    expect(files.length).toBe(46)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
@@ -10,7 +10,7 @@ describe.runIf(isBuild)('build', () => {
 
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(22)
+    expect(files.length).toBe(23)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
+++ b/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
@@ -9,7 +9,7 @@ describe.runIf(isBuild)('build', () => {
     const assetsDir = path.resolve(testDir, 'dist/iife-sourcemap/assets')
     const files = fs.readdirSync(assetsDir)
     // should have 2 worker chunk
-    expect(files.length).toBe(44)
+    expect(files.length).toBe(46)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const indexSourcemap = getSourceMapUrl(content)

--- a/playground/worker/dep-self-reference-url-worker/index.js
+++ b/playground/worker/dep-self-reference-url-worker/index.js
@@ -1,0 +1,9 @@
+export function startWorker(handler) {
+  const worker = new Worker(new URL('./worker.js', import.meta.url), {
+    type: 'module',
+  })
+  worker.postMessage('main')
+  worker.addEventListener('message', (e) => {
+    handler(e)
+  })
+}

--- a/playground/worker/dep-self-reference-url-worker/package.json
+++ b/playground/worker/dep-self-reference-url-worker/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vitejs/test-dep-self-reference-url-worker",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "main": "index.js"
+}

--- a/playground/worker/dep-self-reference-url-worker/worker.js
+++ b/playground/worker/dep-self-reference-url-worker/worker.js
@@ -1,0 +1,14 @@
+// copy of playground/worker/self-reference-url-worker.js
+self.addEventListener('message', (e) => {
+  if (e.data === 'main') {
+    const selfWorker = new Worker(new URL('./worker.js', import.meta.url), {
+      type: 'module',
+    })
+    selfWorker.postMessage('nested')
+    selfWorker.addEventListener('message', (e) => {
+      self.postMessage(e.data)
+    })
+  }
+
+  self.postMessage(`pong: ${e.data}`)
+})

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -165,6 +165,11 @@
 <code class="self-reference-url-worker"></code>
 
 <p>
+  <span class="classname">.self-reference-url-worker-dep</span>
+</p>
+<code class="self-reference-url-worker-dep"></code>
+
+<p>
   new Worker(new URL('../deeply-nested-worker.js', import.meta.url), { type:
   'module' })
   <span class="classname">.deeply-nested-worker</span>

--- a/playground/worker/package.json
+++ b/playground/worker/package.json
@@ -28,6 +28,7 @@
     "debug": "node --inspect-brk ../../packages/vite/bin/vite"
   },
   "dependencies": {
+    "@vitejs/test-dep-self-reference-url-worker": "file:./dep-self-reference-url-worker",
     "@vitejs/test-dep-to-optimize": "file:./dep-to-optimize"
   }
 }

--- a/playground/worker/vite.config-iife.js
+++ b/playground/worker/vite.config-iife.js
@@ -51,4 +51,7 @@ export default defineConfig({
     },
   ],
   cacheDir: 'node_modules/.vite-iife',
+  optimizeDeps: {
+    exclude: ['@vitejs/test-dep-self-reference-url-worker'],
+  },
 })

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -6,6 +6,7 @@ import TSOutputWorker from '../possible-ts-output-worker?worker'
 import NestedWorker from '../worker-nested-worker?worker'
 import { mode } from '../modules/workerImport'
 import SelfReferenceWorker from '../self-reference-worker?worker'
+import * as depSelfReferenceUrlWorker from '@vitejs/test-dep-self-reference-url-worker'
 
 function text(el, text) {
   document.querySelector(el).textContent = text
@@ -172,5 +173,10 @@ const selfReferenceUrlWorker = new Worker(
 selfReferenceUrlWorker.postMessage('main')
 selfReferenceUrlWorker.addEventListener('message', (e) => {
   document.querySelector('.self-reference-url-worker').textContent +=
+    `${e.data}\n`
+})
+
+depSelfReferenceUrlWorker.startWorker((e) => {
+  document.querySelector('.self-reference-url-worker-dep').textContent +=
     `${e.data}\n`
 })

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -1,3 +1,4 @@
+import * as depSelfReferenceUrlWorker from '@vitejs/test-dep-self-reference-url-worker'
 import myWorker from '../my-worker.ts?worker'
 import InlineWorker from '../my-worker.ts?worker&inline'
 import InlineSharedWorker from '../my-inline-shared-worker?sharedworker&inline'
@@ -6,7 +7,6 @@ import TSOutputWorker from '../possible-ts-output-worker?worker'
 import NestedWorker from '../worker-nested-worker?worker'
 import { mode } from '../modules/workerImport'
 import SelfReferenceWorker from '../self-reference-worker?worker'
-import * as depSelfReferenceUrlWorker from '@vitejs/test-dep-self-reference-url-worker'
 
 function text(el, text) {
   document.querySelector(el).textContent = text

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1555,9 +1555,14 @@ importers:
 
   playground/worker:
     dependencies:
+      '@vitejs/test-dep-self-reference-url-worker':
+        specifier: file:./dep-self-reference-url-worker
+        version: file:playground/worker/dep-self-reference-url-worker
       '@vitejs/test-dep-to-optimize':
         specifier: file:./dep-to-optimize
         version: file:playground/worker/dep-to-optimize
+
+  playground/worker/dep-self-reference-url-worker: {}
 
   playground/worker/dep-to-optimize: {}
 
@@ -3323,6 +3328,9 @@ packages:
 
   '@vitejs/test-dep-relative-to-main@file:playground/optimize-deps/dep-relative-to-main':
     resolution: {directory: playground/optimize-deps/dep-relative-to-main, type: directory}
+
+  '@vitejs/test-dep-self-reference-url-worker@file:playground/worker/dep-self-reference-url-worker':
+    resolution: {directory: playground/worker/dep-self-reference-url-worker, type: directory}
 
   '@vitejs/test-dep-that-imports@file:playground/external/dep-that-imports':
     resolution: {directory: playground/external/dep-that-imports, type: directory}
@@ -8609,6 +8617,8 @@ snapshots:
   '@vitejs/test-dep-optimize-with-glob@file:playground/optimize-deps/dep-optimize-with-glob': {}
 
   '@vitejs/test-dep-relative-to-main@file:playground/optimize-deps/dep-relative-to-main': {}
+
+  '@vitejs/test-dep-self-reference-url-worker@file:playground/worker/dep-self-reference-url-worker': {}
 
   '@vitejs/test-dep-that-imports@file:playground/external/dep-that-imports(typescript@5.5.3)':
     dependencies:


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/17843

Oddly `this.getModuleInfo(...).isEntry` is becoming `false` when the worker entry is from node_modules. I think we can equivalently check this based on `config.bundleChain`, so I put this as a quick fix. Probably I'll dig into this further.

---

Coming back after some digging, I think what's happening is that rollup is going through following steps:
- `rollup({ input: "..../node_modules/.../worker.js", ...})` from `bundleWorkerEntry`
- rollup calls `resolveId(input)` but there's no `isEntry: true` at this point
- `commonjs--resolver` plugin's `resolveId` calls `this.load(".../node_modules/.../worker.js")` ([link](https://github.com/rollup/plugins/blob/8550c4b1925b246adbd3af48ed0e5f74f822c951/packages/commonjs/src/resolve-id.js#L149)) which leads to `workerImportMetaUrlPlugin.transform`. Note that this happens only for dependencies because Vite uses `commonjsPlugin({ include: /node_modules/, ... })`.

Based on this, I think checking `config.bundleChain.at(-1)` seems more robust. 