### PR TITLE
test: fix non-awaited `expectWithRetry` tests

### DIFF
--- a/playground/optimize-deps/__tests__/optimize-deps.spec.ts
+++ b/playground/optimize-deps/__tests__/optimize-deps.spec.ts
@@ -140,7 +140,7 @@ test('dep with optional peer dep', async () => {
 })
 
 test('dep with optional peer dep submodule', async () => {
-  expectWithRetry(() =>
+  await expectWithRetry(() =>
     page.textContent('.dep-with-optional-peer-dep-submodule'),
   ).toMatch(`[success]`)
   if (isServe) {

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -230,13 +230,13 @@ test('import.meta.glob with eager in worker', async () => {
 })
 
 test('self reference worker', async () => {
-  expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+  await expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
     'pong: main\npong: nested\n',
   )
 })
 
 test('self reference url worker', async () => {
-  expectWithRetry(() => page.textContent('.self-reference-url-worker')).toBe(
-    'pong: main\npong: nested\n',
-  )
+  await expectWithRetry(() =>
+    page.textContent('.self-reference-url-worker'),
+  ).toBe('pong: main\npong: nested\n')
 })

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -162,15 +162,15 @@ test('import.meta.glob eager in worker', async () => {
 })
 
 test('self reference worker', async () => {
-  expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+  await expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
     'pong: main\npong: nested\n',
   )
 })
 
 test('self reference url worker', async () => {
-  expectWithRetry(() => page.textContent('.self-reference-url-worker')).toBe(
-    'pong: main\npong: nested\n',
-  )
+  await expectWithRetry(() =>
+    page.textContent('.self-reference-url-worker'),
+  ).toBe('pong: main\npong: nested\n')
 })
 
 test.runIf(isServe)('sourcemap boundary', async () => {

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -163,13 +163,13 @@ test('import.meta.glob with eager in worker', async () => {
 })
 
 test('self reference worker', async () => {
-  expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
+  await expectWithRetry(() => page.textContent('.self-reference-worker')).toBe(
     'pong: main\npong: nested\n',
   )
 })
 
 test('self reference url worker', async () => {
-  expectWithRetry(() => page.textContent('.self-reference-url-worker')).toBe(
-    'pong: main\npong: nested\n',
-  )
+  await expectWithRetry(() =>
+    page.textContent('.self-reference-url-worker'),
+  ).toBe('pong: main\npong: nested\n')
 })

--- a/playground/worker/self-reference-url-worker.js
+++ b/playground/worker/self-reference-url-worker.js
@@ -2,6 +2,9 @@ self.addEventListener('message', (e) => {
   if (e.data === 'main') {
     const selfWorker = new Worker(
       new URL('./self-reference-url-worker.js', import.meta.url),
+      {
+        type: 'module',
+      },
     )
     selfWorker.postMessage('nested')
     selfWorker.addEventListener('message', (e) => {

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -168,6 +168,9 @@ selfReferenceWorker.addEventListener('message', (e) => {
 
 const selfReferenceUrlWorker = new Worker(
   new URL('../self-reference-url-worker.js', import.meta.url),
+  {
+    type: 'module',
+  },
 )
 selfReferenceUrlWorker.postMessage('main')
 selfReferenceUrlWorker.addEventListener('message', (e) => {


### PR DESCRIPTION
### Description

I spotted a few places `expectWithRetry` without await and `self-reference-url-worker.js` tests were actually failing by:

```
Uncaught SyntaxError: Cannot use 'import.meta' outside a module
```

Since `new URL(..., import.meta.url)` requires esm worker, I added `new Worker(..., { type: "module" })` to fix this.