### PR TITLE
ci: skip entire job if unrelated files were changed instead of steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   changed:
     name: Get changed files
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.changed-files.outputs.only_changed == 'true' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   changed:
+    name: Get changed files
     runs-on: macos-14
     outputs:
       should_skip: ${{ steps.changed-files.outputs.only_changed == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
   # install playwright binary manually (because pnpm only runs install script once)
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
-  # Vitest auto retry on flaky segfault
-  VITEST_SEGFAULT_RETRY: 3
 
 # Remove default permissions of GITHUB_TOKEN for security
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
@@ -33,7 +31,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changed:
+    runs-on: macos-14
+    outputs:
+      should_skip: ${{ steps.changed-files.outputs.only_changed == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44.5.7
+        with:
+          files: |
+            docs/**
+            .github/**
+            !.github/workflows/ci.yml
+            packages/create-vite/template**
+            **.md
+
   test:
+    needs: changed
+    if: needs.changed.outputs.should_skip != 'true'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:
@@ -56,48 +75,33 @@ jobs:
           # Assume PRs are less than 50 commits
           fetch-depth: 50
 
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44.5.7
-        with:
-          files: |
-            docs/**
-            .github/**
-            !.github/workflows/ci.yml
-            packages/create-vite/template**
-            **.md
-
       - name: Install pnpm
-        if: steps.changed-files.outputs.only_changed != 'true'
         uses: pnpm/action-setup@v4.0.0
 
       - name: Set node version to ${{ matrix.node_version }}
-        if: steps.changed-files.outputs.only_changed != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
           cache: "pnpm"
 
       - name: Install deps
-        if: steps.changed-files.outputs.only_changed != 'true'
         run: pnpm install
 
       # Install playwright's binary under custom directory to cache
       - name: (non-windows) Set Playwright path and Get playwright version
-        if: runner.os != 'Windows' && steps.changed-files.outputs.only_changed != 'true'
+        if: runner.os != 'Windows'
         run: |
           echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/playwright-bin" >> $GITHUB_ENV
           PLAYWRIGHT_VERSION="$(pnpm ls --depth 0 --json -w playwright-chromium | jq --raw-output '.[0].devDependencies["playwright-chromium"].version')"
           echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
       - name: (windows) Set Playwright path and Get playwright version
-        if: runner.os == 'Windows' && steps.changed-files.outputs.only_changed != 'true'
+        if: runner.os == 'Windows'
         run: |
           echo "PLAYWRIGHT_BROWSERS_PATH=$HOME\.cache\playwright-bin" >> $env:GITHUB_ENV
           $env:PLAYWRIGHT_VERSION="$(pnpm ls --depth 0 --json -w playwright-chromium | jq --raw-output '.[0].devDependencies["playwright-chromium"].version')"
           echo "PLAYWRIGHT_VERSION=$env:PLAYWRIGHT_VERSION" >> $env:GITHUB_ENV
 
       - name: Cache Playwright's binary
-        if: steps.changed-files.outputs.only_changed != 'true'
         uses: actions/cache@v4
         with:
           key: ${{ runner.os }}-playwright-bin-v1-${{ env.PLAYWRIGHT_VERSION }}
@@ -106,24 +110,19 @@ jobs:
             ${{ runner.os }}-playwright-bin-v1-
 
       - name: Install Playwright
-        if: steps.changed-files.outputs.only_changed != 'true'
         # does not need to explicitly set chromium after https://github.com/microsoft/playwright/issues/14862 is solved
         run: pnpm playwright install chromium
 
       - name: Build
-        if: steps.changed-files.outputs.only_changed != 'true'
         run: pnpm run build
 
       - name: Test unit
-        if: steps.changed-files.outputs.only_changed != 'true'
         run: pnpm run test-unit
 
       - name: Test serve
-        if: steps.changed-files.outputs.only_changed != 'true'
         run: pnpm run test-serve
 
       - name: Test build
-        if: steps.changed-files.outputs.only_changed != 'true'
         run: pnpm run test-build
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ env:
   NODE_OPTIONS: --max-old-space-size=6144
   # install playwright binary manually (because pnpm only runs install script once)
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+  # Vitest auto retry on flaky segfault
+  VITEST_SEGFAULT_RETRY: 3
 
 # Remove default permissions of GITHUB_TOKEN for security
 # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
@@ -38,7 +40,11 @@ jobs:
       should_skip: ${{ steps.changed-files.outputs.only_changed == 'true' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Assume PRs are less than 50 commits
+          fetch-depth: 50
 
       - name: Get changed files
         id: changed-files
@@ -72,9 +78,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          # Assume PRs are less than 50 commits
-          fetch-depth: 50
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4.0.0


### PR DESCRIPTION
### Description

This PR moves the "changed-files" condition before the "test" job. This ensures that we don't spin up useless jobs that will all be skipped anyway. Skipped jobs are also visible in the "CI" section of the PR, unlike skipped steps which makes it easier to notice if all jobs have actually run.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
