### PR TITLE
fix: dynamic import assets in inline worker

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -135,16 +135,14 @@ function replaceDynamicImportsPlugin(config: ResolvedConfig): Plugin {
     generateBundle(options, bundle) {
       for (const [_, output] of Object.entries(bundle)) {
         if (output.type === 'chunk' && output.isEntry === true) {
-          output.dynamicImports.forEach((importUrl) => {
-            output.code = output.code.replace(
-              importRE,
-              (match, extractedUrl) => {
-                if (areFilesEqual(extractedUrl, importUrl)) {
-                  return `import(self.location.origin + "${config.rawBase + importUrl}")`
-                }
-                return match
-              },
+          output.code = output.code.replace(importRE, (match, extractedUrl) => {
+            const importUrl = output.dynamicImports.find((url) =>
+              areFilesEqual(extractedUrl, url),
             )
+            if (importUrl) {
+              return `import(self.location.origin + "${config.rawBase + importUrl}")`
+            }
+            return match
           })
         }
       }

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -131,21 +131,21 @@ function areFilesEqual(path1: string, path2: string) {
 }
 
 function replaceUrlForDynamicImportsPlugin(config: ResolvedConfig): Plugin {
-  let absolutePath = config.build.outDir
-  if (absolutePath.startsWith('./')) {
-    absolutePath = absolutePath.slice(2) // Removes the './'
+  let outDir = config.build.outDir
+  if (outDir.startsWith('./')) {
+    outDir = outDir.slice(2) // Removes the './'
   }
   // Filter out the first folder
-  absolutePath = absolutePath
+  let basePath = outDir
     .split('/')
     .filter((path) => path)
     .slice(1)
     .join('/')
 
-  if (absolutePath === '') {
-    absolutePath = '/'
+  if (basePath === '') {
+    basePath = '/'
   } else {
-    absolutePath = `/${absolutePath}/`
+    basePath = `/${basePath}/`
   }
 
   return {
@@ -158,7 +158,7 @@ function replaceUrlForDynamicImportsPlugin(config: ResolvedConfig): Plugin {
               areFilesEqual(extractedUrl, url),
             )
             if (importUrl) {
-              return `import(self.location.origin + "${absolutePath + importUrl}")`
+              return `import(self.location.origin + "${basePath + importUrl}")`
             }
             return match
           })

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -55,6 +55,7 @@ function saveEmitWorkerAsset(
 async function bundleWorkerEntry(
   config: ResolvedConfig,
   id: string,
+  isInline?: boolean,
 ): Promise<OutputChunk> {
   const input = cleanUrl(id)
   const newBundleChain = [...config.bundleChain, input]
@@ -73,7 +74,7 @@ async function bundleWorkerEntry(
     input,
     plugins: [
       await plugins(newBundleChain),
-      replaceDynamicImportsPlugin(config),
+      isInline && replaceDynamicImportsPlugin(config),
     ],
     onwarn(warning, warn) {
       onRollupWarning(warning, warn, config)
@@ -325,7 +326,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
         if (isWorker && this.getModuleInfo(cleanUrl(id))?.isEntry) {
           urlCode = 'self.location.href'
         } else if (inlineRE.test(id)) {
-          const chunk = await bundleWorkerEntry(config, id)
+          const chunk = await bundleWorkerEntry(config, id, true)
           const encodedJs = `const encodedJs = "${Buffer.from(
             chunk.code,
           ).toString('base64')}";`

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -240,3 +240,16 @@ test('self reference url worker', async () => {
     'pong: main\npong: nested\n',
   )
 })
+
+test('dynamic import assets or libs in inline worker', async () => {
+  await untilUpdated(
+    () => page.textContent('.dynamic-import-assets-inline-worker'),
+    'The vite.svg was loaded successfully.',
+    true,
+  )
+  await untilUpdated(
+    () => page.textContent('.dynamic-import-libs-inline-worker'),
+    'The @vitejs/test-dep-to-optimize was loaded successfully.',
+    true,
+  )
+})

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -111,7 +111,7 @@ describe.runIf(isBuild)('build', () => {
   test('inlined code generation', async () => {
     const assetsDir = path.resolve(testDir, 'dist/es/assets')
     const files = fs.readdirSync(assetsDir)
-    expect(files.length).toBe(34)
+    expect(files.length).toBe(36)
     const index = files.find((f) => f.includes('main-module'))
     const content = fs.readFileSync(path.resolve(assetsDir, index), 'utf-8')
     const worker = files.find((f) => f.includes('my-worker'))

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -173,3 +173,16 @@ test('self reference url worker', async () => {
     'pong: main\npong: nested\n',
   )
 })
+
+test('dynamic import assets or libs in inline worker', async () => {
+  await untilUpdated(
+    () => page.textContent('.dynamic-import-assets-inline-worker'),
+    'The vite.svg was loaded successfully.',
+    true,
+  )
+  await untilUpdated(
+    () => page.textContent('.dynamic-import-libs-inline-worker'),
+    'The @vitejs/test-dep-to-optimize was loaded successfully.',
+    true,
+  )
+})

--- a/playground/worker/dynamic-import-assets-inline-worker.js
+++ b/playground/worker/dynamic-import-assets-inline-worker.js
@@ -1,0 +1,21 @@
+self.onmessage = function (e) {
+  import('./vite.svg').then((res) => {
+    self.postMessage({
+      type: 'assets',
+      msg: 'The vite.svg was loaded successfully.',
+    })
+  })
+
+  import('@vitejs/test-dep-to-optimize')
+    .then((get) => {
+      console.log('imported dynamically', get)
+      self.postMessage({
+        type: 'libs',
+        msg: 'The @vitejs/test-dep-to-optimize was loaded successfully.',
+      })
+    })
+    .catch((e) => console.error('imported dynamically', e))
+}
+
+// for sourcemap
+console.log('dynamic-import-assets-inline-worker.js')

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -215,6 +215,14 @@
 </p>
 <code class="module-and-worker-worker"></code>
 
+<p>
+  dynamic import some resources or libraries inline worker
+  <span class="classname">.dynamic-import-assets-inline-worker</span>
+</p>
+<code class="dynamic-import-assets-inline-worker"></code>
+<br />
+<code class="dynamic-import-libs-inline-worker"></code>
+
 <style>
   p {
     background: rgba(0, 0, 0, 0.1);

--- a/playground/worker/worker/main-format-es.js
+++ b/playground/worker/worker/main-format-es.js
@@ -51,7 +51,9 @@ importMetaGlobWorker.addEventListener('message', (e) => {
 })
 
 const dynamicImportInlineWorker = new DynamicImportInlineWorker()
+
 dynamicImportInlineWorker.postMessage('1')
+
 dynamicImportInlineWorker.addEventListener('message', (e) => {
   text(
     `.dynamic-import-${e.data.type}-inline-worker`,

--- a/playground/worker/worker/main-format-es.js
+++ b/playground/worker/worker/main-format-es.js
@@ -1,6 +1,7 @@
 // run when format es
 import NestedWorker from '../emit-chunk-nested-worker?worker'
 import ImportMetaGlobWorker from '../importMetaGlob.worker?worker'
+import DynamicImportInlineWorker from '../dynamic-import-assets-inline-worker.js?worker&inline'
 
 function text(el, text) {
   document.querySelector(el).textContent = text
@@ -47,4 +48,13 @@ importMetaGlobWorker.postMessage('1')
 
 importMetaGlobWorker.addEventListener('message', (e) => {
   text('.importMetaGlob-worker', JSON.stringify(e.data))
+})
+
+const dynamicImportInlineWorker = new DynamicImportInlineWorker()
+dynamicImportInlineWorker.postMessage('1')
+dynamicImportInlineWorker.addEventListener('message', (e) => {
+  text(
+    `.dynamic-import-${e.data.type}-inline-worker`,
+    JSON.stringify(e.data.msg),
+  )
 })


### PR DESCRIPTION
fix #17825

After using inline, the code will be converted to base64 encoding, so that the relative path in the worker file cannot get the corresponding actual file path