### PR TITLE
docs: reload after invalidate

### DIFF
--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -65,7 +65,6 @@ Return an empty array and perform a full reload:
 
 ```js
 handleHotUpdate({ server, modules, timestamp }) {
-  server.ws.send({ type: 'full-reload' })
   // Invalidate modules manually
   const invalidatedModules = new Set()
   for (const mod of modules) {
@@ -76,13 +75,13 @@ handleHotUpdate({ server, modules, timestamp }) {
       true
     )
   }
+  server.ws.send({ type: 'full-reload' })
   return []
 }
 
 // Migrate to:
 
 hotUpdate({ modules, timestamp }) {
-  this.environment.hot.send({ type: 'full-reload' })
   // Invalidate modules manually
   const invalidatedModules = new Set()
   for (const mod of modules) {
@@ -93,6 +92,7 @@ hotUpdate({ modules, timestamp }) {
       true
     )
   }
+  this.environment.hot.send({ type: 'full-reload' })
   return []
 }
 ```

--- a/docs/guide/api-plugin.md
+++ b/docs/guide/api-plugin.md
@@ -432,7 +432,6 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
 
     ```js
     handleHotUpdate({ server, modules, timestamp }) {
-      server.ws.send({ type: 'full-reload' })
       // Invalidate modules manually
       const invalidatedModules = new Set()
       for (const mod of modules) {
@@ -443,6 +442,7 @@ Vite plugins can also provide hooks that serve Vite-specific purposes. These hoo
           true
         )
       }
+      server.ws.send({ type: 'full-reload' })
       return []
     }
     ```

--- a/docs/guide/api-vite-environment.md
+++ b/docs/guide/api-vite-environment.md
@@ -553,7 +553,6 @@ The hook can choose to:
     if (this.environment.name !== 'client')
       return
 
-    this.environment.hot.send({ type: 'full-reload' })
     // Invalidate modules manually
     const invalidatedModules = new Set()
     for (const mod of modules) {
@@ -564,6 +563,7 @@ The hook can choose to:
         true
       )
     }
+    this.environment.hot.send({ type: 'full-reload' })
     return []
   }
   ```


### PR DESCRIPTION
### Description

I guess the reload should happen after the modules are invalidated. It would be fine in most cases as the invalidate won't take much time though.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
