### PR TITLE
refactor: remove `handleHotUpdate` from watch-package-data plugin

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -260,11 +260,6 @@ export function watchPackageDataPlugin(packageCache: PackageCache): Plugin {
         invalidatePackageData(packageCache, path.normalize(id))
       }
     },
-    handleHotUpdate({ file }) {
-      if (file.endsWith('/package.json')) {
-        invalidatePackageData(packageCache, path.normalize(file))
-      }
-    },
   }
 }
 


### PR DESCRIPTION
### Description

While reading the env API PR, I noticed that this `handleHotUpdate` hook is not needed for watch-package-data plugin.

`watchChange` hook is always called before `handleHotUpdate` hook, so the package data is already invalidated.
https://github.com/vitejs/vite/blob/6dbed4bc73d907da21086f7217c26af7367a385e/packages/vite/src/node/server/index.ts#L764-L793

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
