### PR TITLE
fix: typings for vite:preloadError

### DIFF
--- a/packages/vite/client.d.ts
+++ b/packages/vite/client.d.ts
@@ -251,15 +251,6 @@ declare interface VitePreloadErrorEvent extends Event {
   payload: Error
 }
 
-declare interface Window {
-  addEventListener(
-    type: 'vite:preloadError',
-    listener: (this: Window, ev: VitePreloadErrorEvent) => unknown,
-    options?: boolean | AddEventListenerOptions,
-  ): void
-  removeEventListener(
-    type: 'vite:preloadError',
-    listener: (this: Window, ev: VitePreloadErrorEvent) => unknown,
-    options?: boolean | EventListenerOptions,
-  ): void
+declare interface WindowEventMap {
+  'vite:preloadError': VitePreloadErrorEvent
 }


### PR DESCRIPTION
### Description

In #17615 typings for `vite:preloadError` were added.

With that changes `tsc` started showing errors for my code. Please follow [TS Playground link](https://www.typescriptlang.org/play/?ts=5.6.0-dev.20240809#code/JYOwLgpgTgZghgYwgAgOIRNYCCiA3DMAFTigHMIwAeI-QgOTgFsUIAPSEAEwGdkewUUGQA0yWgXDJ2nXsjrgAfMgDeAKACQcLlwVgAMsAEZoALmQAKMAE8ADhHMSGzCGIA2RzmcsRJYR3oAlMgAvMp4APbAXMFhyJHRapoA9Mn8ESwAFhEA7mLAMMjaun6GxphQyEbIXBAIbqQQXMhgmdU5cNZirdAo1SAR0lBQEVBqyBPIqUU6emVeUFZ2DuJ6jCzuniZQ5ha+hAF+seFRMeYJXGoAvkkIESACM1zz26HINGsu0hwYcgJCIFEqz831kfD0igsmh4EQArlAkOZ0BVsHoSORKB8-OtXMDCIoRONJvtwDjDs4NmpAudTqFlOoNDD4UgAHTFOZbCp7bEuMQWY6qK6Ba5JaY2exFFjcKVgNSgSCwRAoADqoC4uVUmnZpU50CW9nMAHIELCBBk9IbNuVvFY2jxzKruLkxCT-PIjnTkLCQABrAY5EBiCK2MDAe48AD85hUQppiRuammOVGPvtVTAyBYcAeLUycAz4pQLmlhBqEQgPBAhozUAgtgaSGQo2AZFAcDcLTswh4ahyatybNmOuti0NLB4PDgFEtlgFMeF03VFarGeTUB95kLVRAMF6IEb9zc1mQdwe0WgfC3xa4MuQACNYRmBhnm62QO3O7Zu2pii8uX2nTyZAxwrSdpwXNJ2HrbBgAzHh7AQApsHzMMQCbQot1sUgXAVPgmDgH0K3TZA1x9H8dD-aAqBAicpwgGcIQsAD1SAmiwPowIgA) for an example.

Errors occur because during type inference of `addEventListener` callback argument Typescript only finds vite's type amendment and ignores original typings.

I've created an [issue](https://github.com/microsoft/TypeScript/issues/59576) in Typescript repo, but there I received an answer that there is no any problem on Typescript side and there is a more proper way to write typings, so that errors won't occur. My PR contains this change.