### PR TITLE
fix(build): avoid re-define `__vite_import_meta_env__`

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -117,15 +117,15 @@ describe('definePlugin', () => {
         'console.log(__vite_import_meta_env__);\nconst env = import.meta.env;',
       ),
     ).toMatch(
-      /const __vite_import_meta_env__\$ = .*;\nconsole.log\(__vite_import_meta_env__\);\nconst env = __vite_import_meta_env__\$;/,
+      /const __vite_import_meta_env__1 = .*;\nconsole.log\(__vite_import_meta_env__\);\nconst env = __vite_import_meta_env__1;/,
     )
 
     expect(
       await transform(
-        'console.log(__vite_import_meta_env__, __vite_import_meta_env__$);\n const env = import.meta.env;',
+        'console.log(__vite_import_meta_env__, __vite_import_meta_env__1);\n const env = import.meta.env;',
       ),
     ).toMatch(
-      /const __vite_import_meta_env__\$\$ = .*;\nconsole.log\(__vite_import_meta_env__, __vite_import_meta_env__\$\);\nconst env = __vite_import_meta_env__\$\$;/,
+      /const __vite_import_meta_env__2 = .*;\nconsole.log\(__vite_import_meta_env__, __vite_import_meta_env__1\);\nconst env = __vite_import_meta_env__2;/,
     )
 
     expect(
@@ -133,7 +133,7 @@ describe('definePlugin', () => {
         'console.log(__vite_import_meta_env__);\nconst env = import.meta.env;\nconsole.log(import.meta.env.UNDEFINED);',
       ),
     ).toMatch(
-      /const __vite_import_meta_env__\$ = .*;\nconsole.log\(__vite_import_meta_env__\);\nconst env = __vite_import_meta_env__\$;\nconsole.log\(undefined {26}\);/,
+      /const __vite_import_meta_env__1 = .*;\nconsole.log\(__vite_import_meta_env__\);\nconst env = __vite_import_meta_env__1;\nconsole.log\(undefined {26}\);/,
     )
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -127,5 +127,13 @@ describe('definePlugin', () => {
     ).toMatch(
       /const __vite_import_meta_env__\$\$ = .*;\nconsole.log\(__vite_import_meta_env__, __vite_import_meta_env__\$\);\nconst env = __vite_import_meta_env__\$\$;/,
     )
+
+    expect(
+      await transform(
+        'console.log(__vite_import_meta_env__);\nconst env = import.meta.env;\nconsole.log(import.meta.env.UNDEFINED);',
+      ),
+    ).toMatch(
+      /const __vite_import_meta_env__\$ = .*;\nconsole.log\(__vite_import_meta_env__\);\nconst env = __vite_import_meta_env__\$;\nconsole.log\(undefined {26}\);/,
+    )
   })
 })

--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -109,4 +109,23 @@ describe('definePlugin', () => {
       /const __vite_import_meta_env__ = .*;\nconst env = __vite_import_meta_env__;/,
     )
   })
+
+  test('already has marker', async () => {
+    const transform = await createDefinePluginTransform()
+    expect(
+      await transform(
+        'console.log(__vite_import_meta_env__);\nconst env = import.meta.env;',
+      ),
+    ).toMatch(
+      /const __vite_import_meta_env__\$ = .*;\nconsole.log\(__vite_import_meta_env__\);\nconst env = __vite_import_meta_env__\$;/,
+    )
+
+    expect(
+      await transform(
+        'console.log(__vite_import_meta_env__, __vite_import_meta_env__$);\n const env = import.meta.env;',
+      ),
+    ).toMatch(
+      /const __vite_import_meta_env__\$\$ = .*;\nconsole.log\(__vite_import_meta_env__, __vite_import_meta_env__\$\);\nconst env = __vite_import_meta_env__\$\$;/,
+    )
+  })
 })

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -9,7 +9,6 @@ import { isHTMLRequest } from './html'
 const nonJsRe = /\.json(?:$|\?)/
 const isNonJsRequest = (request: string): boolean => nonJsRe.test(request)
 const importMetaEnvMarker = '__vite_import_meta_env__'
-const importMetaEnvKeyRe = new RegExp(`${importMetaEnvMarker}\\..+?\\b`, 'g')
 
 export function definePlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
@@ -140,8 +139,9 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       const result = await replaceDefine(code, id, define, config)
 
       // Replace `import.meta.env.*` with undefined
-      result.code = result.code.replaceAll(importMetaEnvKeyRe, (m) =>
-        'undefined'.padEnd(m.length),
+      result.code = result.code.replaceAll(
+        new RegExp(`${escapeRegex(marker)}\\..+?\\b`, 'g'),
+        (m) => 'undefined'.padEnd(m.length),
       )
 
       // If there's bare `import.meta.env` references, prepend the banner


### PR DESCRIPTION
Closes #17874

### Description

This was brought up at https://github.com/vitejs/vite/pull/17648#issuecomment-2278411720 and discussed at https://github.com/vitejs/vite/issues/17874

### Reproduction
https://github.com/silverwind/vite-import-meta/pull/1