### PR TITLE
fix(sass): replace default import with ESM module import

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2313,8 +2313,9 @@ const makeModernCompilerScssWorker = (
     async run(sassPath, data, options) {
       // need pathToFileURL for windows since import("D:...") fails
       // https://github.com/nodejs/node/issues/31710
-      const sass: typeof Sass = (await import(pathToFileURL(sassPath).href))
-        .default
+      const fileUrl = pathToFileURL(sassPath).href
+      const sass: typeof Sass =
+        (await import(fileUrl)).default ?? (await import(fileUrl))
       compiler ??= await sass.initAsyncCompiler()
 
       const sassOptions = { ...options } as Sass.StringOptions<'async'>


### PR DESCRIPTION
### Description

Replaces default import from `sass` with module import. Default `sass` import [is deprecated](https://github.com/sass/dart-sass/blob/main/CHANGELOG.md#1634) and does not work with [tsx imports](https://github.com/vitejs/vite/issues/5370#issuecomment-2159518486).

Without this change we get `Pre-transform error: [sass] Cannot read properties of undefined (reading 'initAsyncCompiler')` error   and it is not possible for us to migrate to sass compiler API + `sass-embedded` package.

@hi-ogawa, can you please help reviewing this?

