### PR TITLE
test: test `server.origin`

### DIFF
--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -30,11 +30,18 @@ describe('asset imports from js', () => {
       if (isBuild) {
         expect(text).toMatch(/\/dev\/assets\/logo-[-\w]{8}\.png/)
       } else {
+        // asset url is prefixed with server.origin
         expect(text).toMatch(
-          `http://localhost:${ports['backend-integration']}/dev/@fs`,
+          `http://localhost:${ports['backend-integration']}/dev/@fs/`,
         )
         expect(text).toMatch(/\/dev\/@fs\/.+?\/images\/logo\.png/)
       }
+
+      expect(
+        await page
+          .locator('.asset-reference.outside-root .asset-preview')
+          .evaluate((el: HTMLImageElement) => el.naturalWidth > 0),
+      ).toBe(true)
     })
   })
 })

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -24,7 +24,7 @@ test('should have no 404s', () => {
 describe('asset imports from js', () => {
   test('file outside root', async () => {
     // assert valid image src https://github.com/microsoft/playwright/issues/6046#issuecomment-1799585719
-    await vi.waitFor(() =>
+    await vi.waitUntil(() =>
       page
         .locator('.asset-reference.outside-root .asset-preview')
         .evaluate((el: HTMLImageElement) => el.naturalWidth > 0),

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -27,7 +27,6 @@ describe('asset imports from js', () => {
       const text = await page.textContent(
         '.asset-reference.outside-root .asset-url',
       )
-      console.log({ text })
       if (isBuild) {
         expect(text).toMatch(/\/dev\/assets\/logo-[-\w]{8}\.png/)
       } else {

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -23,26 +23,25 @@ test('should have no 404s', () => {
 
 describe('asset imports from js', () => {
   test('file outside root', async () => {
-    await vi.waitFor(async () => {
-      const text = await page.textContent(
-        '.asset-reference.outside-root .asset-url',
-      )
-      if (isBuild) {
-        expect(text).toMatch(/\/dev\/assets\/logo-[-\w]{8}\.png/)
-      } else {
-        // asset url is prefixed with server.origin
-        expect(text).toMatch(
-          `http://localhost:${ports['backend-integration']}/dev/@fs/`,
-        )
-        expect(text).toMatch(/\/dev\/@fs\/.+?\/images\/logo\.png/)
-      }
+    // assert valid image src https://github.com/microsoft/playwright/issues/6046#issuecomment-1799585719
+    await vi.waitFor(() =>
+      page
+        .locator('.asset-reference.outside-root .asset-preview')
+        .evaluate((el: HTMLImageElement) => el.naturalWidth > 0),
+    )
 
-      expect(
-        await page
-          .locator('.asset-reference.outside-root .asset-preview')
-          .evaluate((el: HTMLImageElement) => el.naturalWidth > 0),
-      ).toBe(true)
-    })
+    const text = await page.textContent(
+      '.asset-reference.outside-root .asset-url',
+    )
+    if (isBuild) {
+      expect(text).toMatch(/\/dev\/assets\/logo-[-\w]{8}\.png/)
+    } else {
+      // asset url is prefixed with server.origin
+      expect(text).toMatch(
+        `http://localhost:${ports['backend-integration']}/dev/@fs/`,
+      )
+      expect(text).toMatch(/\/dev\/@fs\/.+?\/images\/logo\.png/)
+    }
   })
 })
 

--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -26,8 +26,6 @@ function BackendIntegrationExample() {
           // same port in playground/test-utils.ts
           port: 5009,
           strictPort: true,
-          // TODO: should this be automatically inferred from dev server address?
-          // (see "boolean or string" discussions in https://github.com/vitejs/vite/pull/4337)
           origin: 'http://localhost:5009',
         },
         build: {

--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -26,7 +26,7 @@ function BackendIntegrationExample() {
           // same port in playground/test-utils.ts
           port: 5009,
           strictPort: true,
-          // TODO: shouldn't this be automatically inferred from dev server address?
+          // TODO: should this be automatically inferred from dev server address?
           // (see "boolean or string" discussions in https://github.com/vitejs/vite/pull/4337)
           origin: 'http://localhost:5009',
         },

--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -22,6 +22,14 @@ function BackendIntegrationExample() {
       entrypoints.push(['bar.css', path.resolve(__dirname, './dir/foo.css')])
 
       return {
+        server: {
+          // same port in playground/test-utils.ts
+          port: 5009,
+          strictPort: true,
+          // TODO: shouldn't this be automatically inferred from dev server address?
+          // (see "boolean or string" discussions in https://github.com/vitejs/vite/pull/4337)
+          origin: 'http://localhost:5009',
+        },
         build: {
           manifest: true,
           outDir,

--- a/playground/tailwind/vite.config.ts
+++ b/playground/tailwind/vite.config.ts
@@ -27,11 +27,6 @@ export default defineConfig({
     // to make tests faster
     minify: false,
   },
-  server: {
-    // This option caused issues with HMR,
-    // although it should not affect the build
-    origin: 'http://localhost:8080',
-  },
   plugins: [
     {
       name: 'delay view',

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -46,6 +46,7 @@ export const ports = {
   'css/postcss-plugins-different-dir': 5006,
   'css/dynamic-import': 5007,
   'css/lightningcss-proxy': 5008,
+  'backend-integration': 5009,
 }
 export const hmrPorts = {
   'optimize-missing-deps': 24680,


### PR DESCRIPTION
### Description

This PR adds a test case for `server.origin` (introduced long time ago in https://github.com/vitejs/vite/pull/5104). The playground here doesn't actually have a separate server, so it doesn't really make sense, but this confirms that url asset is served with `server.origin` prefix as intended.

I also made a PR on https://github.com/sapphi-red/vite-setup-catalogue/pull/39 to update an example to show case the actual usage with backend.