### PR TITLE
refactor: remove redundant prepend/strip base

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -268,9 +268,10 @@ export async function fileToUrl(
   }
 }
 
-export function fileToDevUrlWithoutBase(
+export function fileToDevUrl(
   id: string,
   config: ResolvedConfig,
+  skipBase = false,
 ): string {
   let rtn: string
   if (checkPublicFile(id, config)) {
@@ -284,15 +285,11 @@ export function fileToDevUrlWithoutBase(
     // (this is special handled by the serve static middleware
     rtn = path.posix.join(FS_PREFIX, id)
   }
-  return rtn
-}
-
-function fileToDevUrl(id: string, config: ResolvedConfig) {
+  if (skipBase) {
+    return rtn
+  }
   const base = joinUrlSegments(config.server?.origin ?? '', config.decodedBase)
-  return joinUrlSegments(
-    base,
-    removeLeadingSlash(fileToDevUrlWithoutBase(id, config)),
-  )
+  return joinUrlSegments(base, removeLeadingSlash(rtn))
 }
 
 export function getPublicAssetFilename(

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -268,7 +268,10 @@ export async function fileToUrl(
   }
 }
 
-function fileToDevUrl(id: string, config: ResolvedConfig) {
+export function fileToDevUrlWithoutBase(
+  id: string,
+  config: ResolvedConfig,
+): string {
   let rtn: string
   if (checkPublicFile(id, config)) {
     // in public dir during dev, keep the url as-is
@@ -281,8 +284,15 @@ function fileToDevUrl(id: string, config: ResolvedConfig) {
     // (this is special handled by the serve static middleware
     rtn = path.posix.join(FS_PREFIX, id)
   }
+  return rtn
+}
+
+function fileToDevUrl(id: string, config: ResolvedConfig) {
   const base = joinUrlSegments(config.server?.origin ?? '', config.decodedBase)
-  return joinUrlSegments(base, removeLeadingSlash(rtn))
+  return joinUrlSegments(
+    base,
+    removeLeadingSlash(fileToDevUrlWithoutBase(id, config)),
+  )
 }
 
 export function getPublicAssetFilename(

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -74,7 +74,7 @@ import type { TransformPluginContext } from '../server/pluginContainer'
 import { addToHTMLProxyTransformResult } from './html'
 import {
   assetUrlRE,
-  fileToDevUrlWithoutBase,
+  fileToDevUrl,
   fileToUrl,
   generatedAssets,
   publicAssetUrlCache,
@@ -1000,7 +1000,7 @@ export function cssAnalysisPlugin(config: ResolvedConfig): Plugin {
               isCSSRequest(file)
                 ? moduleGraph.createFileOnlyEntry(file)
                 : await moduleGraph.ensureEntryFromUrl(
-                    fileToDevUrlWithoutBase(file, config),
+                    fileToDevUrl(file, config, /* skipBase */ true),
                     ssr,
                   ),
             )

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -65,7 +65,6 @@ import {
   removeDirectQuery,
   removeUrlQuery,
   requireResolveFromRootWithFallback,
-  stripBase,
   stripBomTag,
   urlRE,
 } from '../utils'
@@ -75,6 +74,7 @@ import type { TransformPluginContext } from '../server/pluginContainer'
 import { addToHTMLProxyTransformResult } from './html'
 import {
   assetUrlRE,
+  fileToDevUrlWithoutBase,
   fileToUrl,
   generatedAssets,
   publicAssetUrlCache,
@@ -995,16 +995,12 @@ export function cssAnalysisPlugin(config: ResolvedConfig): Plugin {
           // record deps in the module graph so edits to @import css can trigger
           // main import to hot update
           const depModules = new Set<string | ModuleNode>()
-          const devBase = config.base
           for (const file of pluginImports) {
             depModules.add(
               isCSSRequest(file)
                 ? moduleGraph.createFileOnlyEntry(file)
                 : await moduleGraph.ensureEntryFromUrl(
-                    stripBase(
-                      await fileToUrl(file, config, this),
-                      (config.server?.origin ?? '') + devBase,
-                    ),
+                    fileToDevUrlWithoutBase(file, config),
                     ssr,
                   ),
             )


### PR DESCRIPTION
### Description

While looking around some changes related to `server.origin` feature, I spotted https://github.com/vitejs/vite/pull/5571 made a fix by stripping a base properly in css dependencies. I think the another way to look at this is simply not prepend a base in the first place, so I extracted that part as `fileToDevUrlWithoutBase`.

This probably helps centralizing base related manipulation since it looks like there was already slight inconsistency between prepending `joinUrlSegments(config.server?.origin ?? '', config.decodedBase)` and stripping `(config.server?.origin ?? '') + config.base`.