### PR TITLE
fix(css): fix sass `file://` reference

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1096,7 +1096,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
         })
         sassResolve = async (...args) => {
           const id = args[0]
-          if (id.startsWith('file:')) {
+          if (id.startsWith('file://')) {
             const fileUrl = new URL(id)
             if (fs.existsSync(fileUrl)) {
               return fileURLToPath(fileUrl)

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -93,6 +93,7 @@ test('sass', async () => {
     isBuild ? /ok-[-\w]+\.png/ : `${viteTestUrl}/ok.png`,
   )
   expect(await getColor(partialImport)).toBe('orchid')
+  expect(await getColor(await page.$('.sass-file-absolute'))).toBe('orange')
 
   editFile('sass.scss', (code) =>
     code.replace('color: $injectedColor', 'color: red'),

--- a/playground/css/file-absolute.scss
+++ b/playground/css/file-absolute.scss
@@ -1,0 +1,3 @@
+.sass-file-absolute {
+  color: orange;
+}

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -41,6 +41,9 @@
   <p class="sass-dep">
     @import dependency w/ no scss entrypoint: this should be lavender
   </p>
+  <p class="sass-file-absolute">
+    @import "file:///xxx/absolute-path.scss" should be orange
+  </p>
 
   <p class="less">Less: This should be blue</p>
   <p class="less-at-import">

--- a/playground/css/sass.scss
+++ b/playground/css/sass.scss
@@ -6,6 +6,7 @@
 @import 'virtual-dep'; // virtual file added through importer
 @import '=/pkg-dep'; // package w/out sass field
 @import '=/weapp.wxss'; // wxss file
+@import 'virtual-file-absolute';
 
 .sass {
   /* injected via vite.config.js */

--- a/playground/css/vite.config-sass-modern-compiler.js
+++ b/playground/css/vite.config-sass-modern-compiler.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import baseConfig from './vite.config.js'
+import configSassModern from './vite.config-sass-modern.js'
 
 export default defineConfig({
   ...baseConfig,
@@ -8,23 +9,7 @@ export default defineConfig({
     preprocessorOptions: {
       ...baseConfig.css.preprocessorOptions,
       scss: {
-        api: 'modern-compiler',
-        additionalData: `$injectedColor: orange;`,
-        importers: [
-          {
-            canonicalize(url) {
-              return url === 'virtual-dep'
-                ? new URL('custom-importer:virtual-dep')
-                : null
-            },
-            load() {
-              return {
-                contents: ``,
-                syntax: 'scss',
-              }
-            },
-          },
-        ],
+        ...configSassModern.css.preprocessorOptions.scss,
       },
     },
   },

--- a/playground/css/vite.config-sass-modern.js
+++ b/playground/css/vite.config-sass-modern.js
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vite'
 import baseConfig from './vite.config.js'
+import { pathToFileURL } from 'node:url'
+import path from 'node:path'
 
 export default defineConfig({
   ...baseConfig,
@@ -20,6 +22,19 @@ export default defineConfig({
             load() {
               return {
                 contents: ``,
+                syntax: 'scss',
+              }
+            },
+          },
+          {
+            canonicalize(url) {
+              return url === 'virtual-file-absolute'
+                ? new URL('custom-importer:virtual-file-absolute')
+                : null
+            },
+            load() {
+              return {
+                contents: `@import "${pathToFileURL(path.join(import.meta.dirname, 'file-absolute.scss')).href}"`,
                 syntax: 'scss',
               }
             },

--- a/playground/css/vite.config-sass-modern.js
+++ b/playground/css/vite.config-sass-modern.js
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import baseConfig from './vite.config.js'
 import { pathToFileURL } from 'node:url'
 import path from 'node:path'
+import { defineConfig } from 'vite'
+import baseConfig from './vite.config.js'
 
 export default defineConfig({
   ...baseConfig,

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { pathToFileURL } from 'node:url'
 import stylus from 'stylus'
 import { defineConfig } from 'vite'
 
@@ -64,6 +65,13 @@ export default defineConfig({
         importer: [
           function (url) {
             return url === 'virtual-dep' ? { contents: '' } : null
+          },
+          function (url) {
+            return url === 'virtual-file-absolute'
+              ? {
+                  contents: `@import "${pathToFileURL(path.join(import.meta.dirname, 'file-absolute.scss')).href}"`,
+                }
+              : null
           },
           function (url) {
             return url.endsWith('.wxss') ? { contents: '' } : null


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/pull/17754#issuecomment-2300136711

Sass modern API removes the support `file:` reference in https://github.com/sass/dart-sass/pull/2077, so it needs to be implemented on Vite's custom importer. 