### PR TITLE
fix: allow getting URL of JS files in publicDir

### DIFF
--- a/packages/vite/src/node/server/middlewares/static.ts
+++ b/packages/vite/src/node/server/middlewares/static.ts
@@ -16,6 +16,7 @@ import {
   isSameFileUri,
   normalizePath,
   removeLeadingSlash,
+  urlRE,
 } from '../../utils'
 import {
   cleanUrl,
@@ -86,7 +87,9 @@ export function servePublicMiddleware(
     if (
       (publicFiles && !publicFiles.has(toFilePath(req.url!))) ||
       isImportRequest(req.url!) ||
-      isInternalRequest(req.url!)
+      isInternalRequest(req.url!) ||
+      // for `/public-file.js?url` to be transformed
+      urlRE.test(req.url!)
     ) {
       return next()
     }

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -143,6 +143,18 @@ describe('asset imports from js', () => {
         "
       `)
   })
+
+  test('from /public (js)', async () => {
+    expect(await page.textContent('.public-js-import')).toMatch(
+      '/foo/bar/raw.js',
+    )
+    expect(await page.textContent('.public-js-import-content'))
+      .toMatchInlineSnapshot(`
+        "document.querySelector('.raw-js').textContent =
+          '[success] Raw js from /public loaded'
+        "
+      `)
+  })
 })
 
 describe('css url() references', () => {

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -31,6 +31,10 @@
     From publicDir (json): <code class="public-json-import"></code> Content:
     <code class="public-json-import-content"></code>
   </li>
+  <li>
+    From publicDir (js): <code class="public-js-import"></code> Content:
+    <code class="public-js-import-content"></code>
+  </li>
 </ul>
 
 <h2>CSS url references</h2>
@@ -439,6 +443,13 @@
   ;(async () => {
     const res = await fetch(publicJsonUrl)
     text('.public-json-import-content', await res.text())
+  })()
+
+  import publicJsUrl from '/raw.js?url'
+  text('.public-js-import', publicJsUrl)
+  ;(async () => {
+    const res = await fetch(publicJsUrl)
+    text('.public-js-import-content', await res.text())
   })()
 
   import svgFrag from './nested/fragment.svg'


### PR DESCRIPTION
### Description

`import foo from '/public-file.js?url'` was returning the default export instead of the URL in dev. In build, it was correctly returning the URL.

fixes https://github.com/vitejs/vite/issues/16648
refs https://github.com/vitejs/vite/pull/13422


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
