### PR TITLE
fix: improve CJS warning trace information

### DIFF
--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -26,11 +26,23 @@ asyncFunctions.forEach((name) => {
 function warnCjsUsage() {
   if (process.env.VITE_CJS_IGNORE_WARNING) return
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
-  Error.stackTraceLimit = 15
-  const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
-  log(
+  console.warn(
     yellow(
       `The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.`,
     ),
   )
+  if (process.env.VITE_CJS_TRACE) {
+    const e = {}
+    const stackTraceLimit = Error.stackTraceLimit
+    Error.stackTraceLimit = 100
+    Error.captureStackTrace(e)
+    Error.stackTraceLimit = stackTraceLimit
+    console.log(
+      e.stack
+        .split('\n')
+        .slice(1)
+        .filter((line) => !line.includes('(node:'))
+        .join('\n'),
+    )
+  }
 }

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -26,6 +26,7 @@ asyncFunctions.forEach((name) => {
 function warnCjsUsage() {
   if (process.env.VITE_CJS_IGNORE_WARNING) return
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
+  Error.stackTraceLimit = 15
   const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
   log(
     yellow(


### PR DESCRIPTION
### Description

VITE_CJS_TRACE=true doesn't give any useful information currently, it's all `node:internal/modules/cjs/loader` methods.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
