### PR TITLE
fix(preload): add crossorigin attribute in CSS link tags

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -125,8 +125,8 @@ function preload(
         link.rel = isCss ? 'stylesheet' : scriptRel
         if (!isCss) {
           link.as = 'script'
-          link.crossOrigin = ''
         }
+        link.crossOrigin = ''
         link.href = dep
         if (cspNonce) {
           link.setAttribute('nonce', cspNonce)


### PR DESCRIPTION
Fixes: https://github.com/vitejs/vite/issues/17929

We noticed that after the migration to Vite5, in production, most CSS imports contain the `crossorigin` attribute (after https://github.com/vitejs/vite/pull/12991).   
But in some cases, we noticed it was missing.  
For example: 
```html
<!-- In most pages this asset is added with crossorigin -->
<link rel="stylesheet" crossorigin src="cdn.blabla.test/some-css-123123.css">

<!--In other pages is added without -->
<link rel="stylesheet" src="cdn.blabla.test/some-css-123123.css">
```

This PR: https://github.com/vitejs/vite/pull/12991, added to Vite 5 the `crossorigin` attribute to CSS tags.  
But we are missing to add it here, ending with inconsistent tags.  