### PR TITLE
fix(css): fix sass modern source map

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2438,6 +2438,12 @@ const scssProcessor = (
           ? JSON.parse(result.map.toString())
           : undefined
 
+        if (map) {
+          map.sources = map.sources.map((url) =>
+            url.startsWith('file://') ? normalizePath(fileURLToPath(url)) : url,
+          )
+        }
+
         return {
           code: result.css.toString(),
           map,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2276,11 +2276,6 @@ const makeModernScssWorker = (
         ]
 
         const result = await sass.compileStringAsync(data, sassOptions)
-        if (result.sourceMap) {
-          result.sourceMap.sources = result.sourceMap.sources.map((url) =>
-            url.startsWith('file://') ? fileURLToPath(url) : url,
-          )
-        }
         return {
           css: result.css,
           map: result.sourceMap ? JSON.stringify(result.sourceMap) : undefined,
@@ -2367,11 +2362,6 @@ const makeModernCompilerScssWorker = (
       ]
 
       const result = await compiler.compileStringAsync(data, sassOptions)
-      if (result.sourceMap) {
-        result.sourceMap.sources = result.sourceMap.sources.map((url) =>
-          url.startsWith('file://') ? fileURLToPath(url) : url,
-        )
-      }
       return {
         css: result.css,
         map: result.sourceMap ? JSON.stringify(result.sourceMap) : undefined,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2276,6 +2276,11 @@ const makeModernScssWorker = (
         ]
 
         const result = await sass.compileStringAsync(data, sassOptions)
+        if (result.sourceMap) {
+          result.sourceMap.sources = result.sourceMap.sources.map((url) =>
+            url.startsWith('file://') ? fileURLToPath(url) : url,
+          )
+        }
         return {
           css: result.css,
           map: result.sourceMap ? JSON.stringify(result.sourceMap) : undefined,
@@ -2362,6 +2367,11 @@ const makeModernCompilerScssWorker = (
       ]
 
       const result = await compiler.compileStringAsync(data, sassOptions)
+      if (result.sourceMap) {
+        result.sourceMap.sources = result.sourceMap.sources.map((url) =>
+          url.startsWith('file://') ? fileURLToPath(url) : url,
+        )
+      }
       return {
         css: result.css,
         map: result.sourceMap ? JSON.stringify(result.sourceMap) : undefined,

--- a/playground/css-sourcemap/__tests__/sass-modern-compiler/sass-modern-compiler.spec.ts
+++ b/playground/css-sourcemap/__tests__/sass-modern-compiler/sass-modern-compiler.spec.ts
@@ -1,0 +1,1 @@
+import '../css-sourcemap.spec'

--- a/playground/css-sourcemap/__tests__/sass-modern/sass-modern.spec.ts
+++ b/playground/css-sourcemap/__tests__/sass-modern/sass-modern.spec.ts
@@ -1,0 +1,1 @@
+import '../css-sourcemap.spec'

--- a/playground/css-sourcemap/vite.config-sass-modern-compiler.js
+++ b/playground/css-sourcemap/vite.config-sass-modern-compiler.js
@@ -1,0 +1,15 @@
+import { defineConfig, mergeConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    css: {
+      preprocessorOptions: {
+        sass: {
+          api: 'modern-compiler',
+        },
+      },
+    },
+  }),
+)

--- a/playground/css-sourcemap/vite.config-sass-modern.js
+++ b/playground/css-sourcemap/vite.config-sass-modern.js
@@ -1,0 +1,15 @@
+import { defineConfig, mergeConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    css: {
+      preprocessorOptions: {
+        sass: {
+          api: 'modern',
+        },
+      },
+    },
+  }),
+)

--- a/playground/css-sourcemap/vite.config.js
+++ b/playground/css-sourcemap/vite.config.js
@@ -31,9 +31,6 @@ export default defineConfig({
           }
         },
       },
-      sass: {
-        api: 'modern-compiler',
-      },
     },
   },
   build: {

--- a/playground/css-sourcemap/vite.config.js
+++ b/playground/css-sourcemap/vite.config.js
@@ -31,6 +31,9 @@ export default defineConfig({
           }
         },
       },
+      sass: {
+        api: 'modern-compiler',
+      },
     },
   },
   build: {

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -52,6 +52,16 @@ export async function setup({ provide }: GlobalSetupContext): Promise<void> {
     path.resolve(tempDir, 'css__sass-modern-compiler'),
     { recursive: true },
   )
+  await fs.cp(
+    path.resolve(tempDir, 'css-sourcemap'),
+    path.resolve(tempDir, 'css-sourcemap__sass-modern'),
+    { recursive: true },
+  )
+  await fs.cp(
+    path.resolve(tempDir, 'css-sourcemap'),
+    path.resolve(tempDir, 'css-sourcemap__sass-modern-compiler'),
+    { recursive: true },
+  )
 }
 
 export async function teardown(): Promise<void> {

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -42,26 +42,18 @@ export async function setup({ provide }: GlobalSetupContext): Promise<void> {
       }
     })
   // also setup dedicated copy for "variant" tests
-  await fs.cp(
-    path.resolve(tempDir, 'css'),
-    path.resolve(tempDir, 'css__sass-modern'),
-    { recursive: true },
-  )
-  await fs.cp(
-    path.resolve(tempDir, 'css'),
-    path.resolve(tempDir, 'css__sass-modern-compiler'),
-    { recursive: true },
-  )
-  await fs.cp(
-    path.resolve(tempDir, 'css-sourcemap'),
-    path.resolve(tempDir, 'css-sourcemap__sass-modern'),
-    { recursive: true },
-  )
-  await fs.cp(
-    path.resolve(tempDir, 'css-sourcemap'),
-    path.resolve(tempDir, 'css-sourcemap__sass-modern-compiler'),
-    { recursive: true },
-  )
+  for (const [original, variants] of [
+    ['css', ['sass-modern', 'sass-modern-compiler']],
+    ['css-sourcemap', ['sass-modern', 'sass-modern-compiler']],
+  ] as const) {
+    for (const variant of variants) {
+      await fs.cp(
+        path.resolve(tempDir, original),
+        path.resolve(tempDir, `${original}__${variant}`),
+        { recursive: true },
+      )
+    }
+  }
 }
 
 export async function teardown(): Promise<void> {


### PR DESCRIPTION
### Description

I just noticed `playground/css-sourcemap` is broken for modern api when switching the default api in https://github.com/vitejs/vite/pull/17937.
