### PR TITLE
fix: backward compat for setting values in resolvedConfig hook

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1390,6 +1390,12 @@ export async function resolveConfig(
     'ssr.',
   )
 
+  // For backward compat, set ssr environment build.emitAssets with the same value as build.ssrEmitAssets that might be changed in configResolved hook
+  // https://github.com/vikejs/vike/blob/953614cea7b418fcc0309b5c918491889fdec90a/vike/node/plugin/plugins/buildConfig.ts#L67
+  if (resolved.environments.ssr) {
+    resolved.environments.ssr.build.emitAssets = resolved.build.ssrEmitAssets
+  }
+
   debug?.(`using resolved config: %O`, {
     ...resolved,
     plugins: resolved.plugins.map((p) => p.name),

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1393,7 +1393,8 @@ export async function resolveConfig(
   // For backward compat, set ssr environment build.emitAssets with the same value as build.ssrEmitAssets that might be changed in configResolved hook
   // https://github.com/vikejs/vike/blob/953614cea7b418fcc0309b5c918491889fdec90a/vike/node/plugin/plugins/buildConfig.ts#L67
   if (resolved.environments.ssr) {
-    resolved.environments.ssr.build.emitAssets = resolved.build.ssrEmitAssets
+    resolved.environments.ssr.build.emitAssets =
+      resolved.build.ssrEmitAssets || resolved.build.emitAssets
   }
 
   debug?.(`using resolved config: %O`, {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1396,6 +1396,14 @@ export async function resolveConfig(
     resolved.environments.ssr.build.emitAssets =
       resolved.build.ssrEmitAssets || resolved.build.emitAssets
   }
+  // For backward compat, set client environment dev.optimizeDeps with the same value as root optimizeDeps that might be changed in configResolved hook
+  // https://github.com/vikejs/vike/blob/953614cea7b418fcc0309b5c918491889fdec90a/vike/node/plugin/plugins/devConfig/index.ts#L70
+  if (resolved.environments.client) {
+    resolved.environments.client.dev.optimizeDeps.include =
+      resolved.optimizeDeps.include
+    resolved.environments.client.dev.optimizeDeps.entries =
+      resolved.optimizeDeps.entries
+  }
 
   debug?.(`using resolved config: %O`, {
     ...resolved,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1000,17 +1000,11 @@ export async function resolveConfig(
   )
 
   // Backward compatibility: merge environments.client.dev.optimizeDeps back into optimizeDeps
-  const resolvedConfigEnvironmentsClient = resolvedEnvironments.client
-  const patchedOptimizeDeps = resolvedConfigEnvironmentsClient.dev?.optimizeDeps
-
-  const backwardCompatibleOptimizeDeps = {
-    holdUntilCrawlEnd: true,
-    ...patchedOptimizeDeps,
-    esbuildOptions: {
-      preserveSymlinks: resolvedDefaultEnvironmentResolve.preserveSymlinks,
-      ...patchedOptimizeDeps.esbuildOptions,
-    },
-  }
+  // The same object is assigned back for backward compatibility. The ecosystem is modifying
+  // optimizeDeps in the ResolvedConfig hook, so these changes will be reflected on the
+  // client environment.
+  const backwardCompatibleOptimizeDeps =
+    resolvedEnvironments.client.dev.optimizeDeps
 
   // TODO: Deprecate and remove resolve, dev and build options at the root level of the resolved config
 
@@ -1395,14 +1389,6 @@ export async function resolveConfig(
   if (resolved.environments.ssr) {
     resolved.environments.ssr.build.emitAssets =
       resolved.build.ssrEmitAssets || resolved.build.emitAssets
-  }
-  // For backward compat, set client environment dev.optimizeDeps with the same value as root optimizeDeps that might be changed in configResolved hook
-  // https://github.com/vikejs/vike/blob/953614cea7b418fcc0309b5c918491889fdec90a/vike/node/plugin/plugins/devConfig/index.ts#L70
-  if (resolved.environments.client) {
-    resolved.environments.client.dev.optimizeDeps.include =
-      resolved.optimizeDeps.include
-    resolved.environments.client.dev.optimizeDeps.entries =
-      resolved.optimizeDeps.entries
   }
 
   debug?.(`using resolved config: %O`, {


### PR DESCRIPTION
### Description

Vike sets `build.emitAssets` in resolvedConfig hook and that was working in v5, but in v6 this is now ignored.
I guess we don't support updating config values in resolvedConfig hook, but we don't explicitly document anywhere that we don't support that, too (the types are shallow readonly rather than deep readonly...).
I'm not sure if we should merge this PR, but this PR would make ecosystem-ci pass for Vike.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
