### PR TITLE
fix: cache parallel moduleInfo calls

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -273,7 +273,6 @@ export class ModuleRunner {
     if (!cachedModule) {
       cachedModule = this.moduleCache.getByModuleId(url)
     }
-    console.log('cached module', url, cachedModule)
 
     const isCached = !!(typeof cachedModule === 'object' && cachedModule.meta)
 


### PR DESCRIPTION
### Description

Fix a use case when runner imports several different modules that rely on the same module. This is very race condition-reliant, so I wasn't able to make a test case for this, but it breaks SvelteKit, so at least we have the ecosystem test.

The error happens when the module is executed in one parallel call, but it's not resolved yet in another parallel call, so the second call invalidates the first call.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
