### PR TITLE
fix(css): fix directory index import in sass modern api

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2099,6 +2099,7 @@ const makeScssWorker = (
   resolvers: CSSAtImportResolvers,
   alias: Alias[],
   maxWorkers: number | undefined,
+  packageName: 'sass' | 'sass-embedded',
 ) => {
   const internalImporter = async (
     url: string,
@@ -2116,6 +2117,9 @@ const makeScssWorker = (
           '$',
           resolvers.sass,
         )
+        if (packageName === 'sass-embedded') {
+          return data
+        }
         return fixScssBugImportValue(data)
       } catch (data) {
         return data
@@ -2408,7 +2412,12 @@ const scssProcessor = (
             ? makeModernCompilerScssWorker(resolvers, options.alias, maxWorkers)
             : api === 'modern'
               ? makeModernScssWorker(resolvers, options.alias, maxWorkers)
-              : makeScssWorker(resolvers, options.alias, maxWorkers),
+              : makeScssWorker(
+                  resolvers,
+                  options.alias,
+                  maxWorkers,
+                  sassPackage.name,
+                ),
         )
       }
       const worker = workerMap.get(options.alias)!

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1095,9 +1095,8 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
           preferRelative: true,
         })
         sassResolve = async (...args) => {
-          const id = args[0]
-          if (id.startsWith('file://')) {
-            args[0] = fileURLToPath(id)
+          if (args[0].startsWith('file://')) {
+            args[0] = fileURLToPath(args[0])
           }
           return resolver(...args)
         }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1097,10 +1097,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
         sassResolve = async (...args) => {
           const id = args[0]
           if (id.startsWith('file://')) {
-            const fileUrl = new URL(id)
-            if (fs.existsSync(fileUrl)) {
-              return fileURLToPath(fileUrl)
-            }
+            args[0] = fileURLToPath(id)
           }
           return resolver(...args)
         }

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -94,6 +94,7 @@ test('sass', async () => {
   )
   expect(await getColor(partialImport)).toBe('orchid')
   expect(await getColor(await page.$('.sass-file-absolute'))).toBe('orange')
+  expect(await getColor(await page.$('.sass-dir-index'))).toBe('orange')
 
   editFile('sass.scss', (code) =>
     code.replace('color: $injectedColor', 'color: red'),

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -44,6 +44,7 @@
   <p class="sass-file-absolute">
     @import "file:///xxx/absolute-path.scss" should be orange
   </p>
+  <p class="sass-dir-index">@import "./dir" should be orange</p>
 
   <p class="less">Less: This should be blue</p>
   <p class="less-at-import">

--- a/playground/css/sass.scss
+++ b/playground/css/sass.scss
@@ -7,6 +7,7 @@
 @import '=/pkg-dep'; // package w/out sass field
 @import '=/weapp.wxss'; // wxss file
 @import 'virtual-file-absolute';
+@import '=/scss-dir/main.scss'; // "./dir" reference from vite custom importer
 
 .sass {
   /* injected via vite.config.js */

--- a/playground/css/scss-dir/dir/index.scss
+++ b/playground/css/scss-dir/dir/index.scss
@@ -1,0 +1,3 @@
+.sass-dir-index {
+  color: orange;
+}

--- a/playground/css/scss-dir/main.scss
+++ b/playground/css/scss-dir/main.scss
@@ -1,0 +1,1 @@
+@import './dir';


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/17959

~New test case fails on legacy api with `sass-embedded` but succeeds with `sass`. It looks like they way custom importer is called is different and potentially a bug on sass side.~ It turned out `fixScssBugImportValue` returning both `{ file, contents }` confuses sass-embedded. This bug seems specific to `sass` package, so I skipped `fixScssBugImportValue`.