### PR TITLE
test: fix flaky "should reload" test

### DIFF
--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -7,6 +7,7 @@ import {
   isBuild,
   isServe,
   page,
+  untilBrowserLogAfter,
   viteServer,
   viteTestUrl,
   withRetry,
@@ -298,8 +299,11 @@ describe.runIf(isServe)('invalid', () => {
   })
 
   test('should reload when fixed', async () => {
-    await page.goto(viteTestUrl + '/invalid.html')
-    await editFile('invalid.html', (content) => {
+    await untilBrowserLogAfter(
+      () => page.goto(viteTestUrl + '/invalid.html'),
+      /connected/, // wait for HMR connection
+    )
+    editFile('invalid.html', (content) => {
       return content.replace('<div Bad', '<div> Good')
     })
     const content = await page.waitForSelector('text=Good HTML')


### PR DESCRIPTION
### Description

This PR aims to fix these flaky fails:

```
FAIL  playground/html/__tests__/html.spec.ts > invalid > should reload when fixed
TimeoutError: page.waitForSelector: Timeout 30000ms exceeded.
```

- https://github.com/vitejs/vite/actions/runs/10574356157/job/29295732783
- https://github.com/vitejs/vite/actions/runs/10574356157/job/29295733095
- https://github.com/vitejs/vite/actions/runs/10404765015/job/28813957732
- https://github.com/vitejs/vite/actions/runs/10404765015/job/28813958478
- https://github.com/vitejs/vite/actions/runs/10400016933/job/28799828524
- https://github.com/vitejs/vite/actions/runs/10400016933/job/28799828681

(All links includes the same error message.)

I'm not sure if it will actually fix the fail because I wasn't able to reproduce it locally though.


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
