### PR TITLE
fix: use `optimizeDeps.entries`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -911,13 +911,10 @@ export async function resolveConfig(
   checkBadCharactersInPath(resolvedRoot, logger)
 
   // Backward compatibility: merge optimizeDeps into environments.client.dev.optimizeDeps as defaults
-  // TODO: should entries and force be in EnvironmentOptions?
-  const { entries, force, ...deprecatedClientOptimizeDepsConfig } =
-    config.optimizeDeps ?? {}
   const configEnvironmentsClient = config.environments!.client!
   configEnvironmentsClient.dev ??= {}
   configEnvironmentsClient.dev.optimizeDeps = mergeConfig(
-    deprecatedClientOptimizeDepsConfig,
+    config.optimizeDeps ?? {},
     configEnvironmentsClient.dev.optimizeDeps ?? {},
   )
 


### PR DESCRIPTION
### Description

SvelteKit sets `optimizeDeps.entries` and have tests that expects the dependencies in other pages to be optimized before accessing (https://github.com/sveltejs/kit/blob/45cb8c5f305b4d9e61a32e19af8059dc0da4c255/packages/kit/test/apps/dev-only/test/test.js#L90-L98).

This PR merges the values in `optimizeDeps.entries` into `environment.client.dev.optimizeDeps` to fix that fail.

refs https://github.com/vitejs/vite/pull/17957#issuecomment-2312636767

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
