### PR TITLE
fix(v6): fix `ViteDevServer.environments` type

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -276,10 +276,7 @@ export interface ViteDevServer {
   /**
    * Module execution environments attached to the Vite server.
    */
-  environments: Record<
-    'client' | 'ssr' | (string & Record<string, never>),
-    DevEnvironment
-  >
+  environments: Record<'client' | 'ssr' | (string & {}), DevEnvironment>
   /**
    * Module graph that tracks the import relationships, url to file mapping
    * and hmr state.


### PR DESCRIPTION
### Description

This change happened in merge main https://github.com/vitejs/vite/commit/7ad8380b74ba3d120620e84a5604e8c5233cc45f#diff-abb3345b6e3b2ec6d297c2ebc54cca85ae4487a31bac3cc9e78457f5114adb26R273-R276 but I don't think this is intended?
I noticed the type error in https://github.com/hi-ogawa/vite-environment-examples/pull/101

Also there were a type error in own unit tests here `server.environments.rsc`, but it looks like no typechecking is done for these files.
https://github.com/vitejs/vite/blob/3cc38cb0466df11f0f201af30d86c0226fec1eac/packages/vite/src/node/__tests__/environment.spec.ts#L77