### PR TITLE
fix: injects scripts into html files without any JS in mpa mode

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -510,7 +510,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       if (!chunk) return
       if (!chunk.moduleIds.some((moduleId) => moduleId.endsWith('.js'))) {
         return {
-          html: html.replace(/<script .*? type="module".*?<\/script>/g, ''),
+          html,
           tags: [],
         }
       }

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -508,6 +508,12 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
     transformIndexHtml(html, { chunk }) {
       if (config.build.ssr) return
       if (!chunk) return
+      if (!chunk.moduleIds.some((moduleId) => moduleId.endsWith('.js'))) {
+        return {
+          html: html.replace(/<script .*? type="module".*?<\/script>/g, ''),
+          tags: [],
+        }
+      }
       if (chunk.fileName.includes('-legacy')) {
         // The legacy bundle is built first, and its index.html isn't actually emitted if
         // modern bundle will be generated. Here we simply record its corresponding legacy chunk.

--- a/playground/legacy/__tests__/mpa/legacy-mpa.spec.ts
+++ b/playground/legacy/__tests__/mpa/legacy-mpa.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from 'vitest'
+import { isBuild, page, viteTestUrl } from '~utils'
+
+test.runIf(isBuild)('includes a script tag for Mpa', async () => {
+  await page.goto(viteTestUrl + '/mpa/only-element.html')
+
+  expect(await page.locator('script').count()).toBe(0)
+  expect(await page.locator('#vite-legacy-polyfill').count()).toBe(0)
+})

--- a/playground/legacy/mpa/index.html
+++ b/playground/legacy/mpa/index.html
@@ -1,0 +1,3 @@
+<meta charset="UTF-8" />
+<div id="app"></div>
+<script type="module" src="./index.js"></script>

--- a/playground/legacy/mpa/index.js
+++ b/playground/legacy/mpa/index.js
@@ -1,0 +1,1 @@
+document.querySelector('app').innerHTML = '👋'

--- a/playground/legacy/mpa/only-element.html
+++ b/playground/legacy/mpa/only-element.html
@@ -1,0 +1,2 @@
+<meta charset="UTF-8" />
+<div id="app"></div>

--- a/playground/legacy/package.json
+++ b/playground/legacy/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build --debug legacy",
+    "build:multiple-input": "vite --config vite.config-multiple-input.js build",
     "build:custom-filename": "vite --config ./vite.config-custom-filename.js build  --debug legacy",
     "build:multiple-output": "vite --config ./vite.config-multiple-output.js build",
     "build:no-polyfills": "vite --config ./vite.config-no-polyfills.js build",

--- a/playground/legacy/vite.config-multiple-input.js
+++ b/playground/legacy/vite.config-multiple-input.js
@@ -1,0 +1,24 @@
+import path from 'node:path'
+import legacy from '@vitejs/plugin-legacy'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  appType: 'mpa',
+  base: './',
+  plugins: [
+    legacy({
+      targets: 'IE 11',
+      modernPolyfills: true,
+    }),
+  ],
+
+  build: {
+    // outDir: 'dist/mpa',
+    rollupOptions: {
+      input: {
+        index: path.resolve(__dirname, 'mpa/index.html'),
+        'only-element': path.resolve(__dirname, 'mpa/only-element.html'),
+      },
+    },
+  },
+})


### PR DESCRIPTION
fix issues #17943
I'm not confident that my solution is sound, and if there are no issues, I plan to add unit tests.

The result after running locally:
<img width="1272" alt="截屏2024-08-29 09 48 17" src="https://github.com/user-attachments/assets/690288c0-2f7c-41f9-83ce-a695d1c0626b">

