### PR TITLE
fix: createResolver compat

### DIFF
--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from 'vitest'
 import { createServer } from '../server'
 import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
 import type { ResolveIdFn } from '../idResolver'
-import { createIdResolver } from '../idResolver'
+import { createBackCompatIdResolver } from '../idResolver'
 import { normalizePath } from '../utils'
 
 const root = fileURLToPath(new URL('./', import.meta.url))
@@ -20,7 +20,7 @@ async function createDevServer() {
         return {
           name: 'environment-alias-test-plugin',
           configResolved(config) {
-            idResolver = createIdResolver(config, {})
+            idResolver = createBackCompatIdResolver(config)
           },
           async resolveId(id) {
             return await idResolver(this.environment, id)

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -17,12 +17,32 @@ export type ResolveIdFn = (
 ) => Promise<string | undefined>
 
 /**
+ * Some projects like Astro were overriding config.createResolver to add a custom
+ * alias plugin. For the client and ssr environments, we root through it to avoid
+ * breaking changes for now.
+ */
+export function createBackCompatIdResolver(
+  config: ResolvedConfig,
+  options?: Partial<InternalResolveOptions>,
+): ResolveIdFn {
+  const compatResolve = config.createResolver(options)
+  let resolve: ResolveIdFn
+  return async (environment, id, importer, aliasOnly) => {
+    if (environment.name === 'client' || environment.name === 'ssr') {
+      return compatResolve(id, importer, aliasOnly, environment.name === 'ssr')
+    }
+    resolve ??= createIdResolver(config, options)
+    return resolve(environment, id, importer, aliasOnly)
+  }
+}
+
+/**
  * Create an internal resolver to be used in special scenarios, e.g.
  * optimizer and handling css @imports
  */
 export function createIdResolver(
   config: ResolvedConfig,
-  options: Partial<InternalResolveOptions>,
+  options?: Partial<InternalResolveOptions>,
 ): ResolveIdFn {
   const scan = options?.scan
 

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -13,7 +13,7 @@ import {
 import { browserExternalId, optionalPeerDepId } from '../plugins/resolve'
 import { isCSSRequest, isModuleCSSRequest } from '../plugins/css'
 import type { Environment } from '../environment'
-import { createIdResolver } from '../idResolver'
+import { createBackCompatIdResolver } from '../idResolver'
 
 const externalWithConversionNamespace =
   'vite:dep-pre-bundle:external-conversion'
@@ -66,19 +66,22 @@ export function esbuildDepPlugin(
   const cjsPackageCache: PackageCache = new Map()
 
   // default resolver which prefers ESM
-  const _resolve = createIdResolver(environment.getTopLevelConfig(), {
+  const _resolve = createBackCompatIdResolver(environment.getTopLevelConfig(), {
     asSrc: false,
     scan: true,
     packageCache: esmPackageCache,
   })
 
   // cjs resolver that prefers Node
-  const _resolveRequire = createIdResolver(environment.getTopLevelConfig(), {
-    asSrc: false,
-    isRequire: true,
-    scan: true,
-    packageCache: cjsPackageCache,
-  })
+  const _resolveRequire = createBackCompatIdResolver(
+    environment.getTopLevelConfig(),
+    {
+      asSrc: false,
+      isRequire: true,
+      scan: true,
+      packageCache: cjsPackageCache,
+    },
+  )
 
   const resolve = (
     id: string,

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -6,13 +6,13 @@ import { escapeRegex, getNpmPackageName } from '../utils'
 import { resolvePackageData } from '../packages'
 import { slash } from '../../shared/utils'
 import type { Environment } from '../environment'
-import { createIdResolver } from '../idResolver'
+import { createBackCompatIdResolver } from '../idResolver'
 
 export function createOptimizeDepsIncludeResolver(
   environment: Environment,
 ): (id: string) => Promise<string | undefined> {
   const topLevelConfig = environment.getTopLevelConfig()
-  const resolve = createIdResolver(topLevelConfig, {
+  const resolve = createBackCompatIdResolver(topLevelConfig, {
     asSrc: false,
     scan: true,
     ssrOptimizeCheck: environment.config.consumer === 'server',

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -6,7 +6,7 @@ import type { ResolvedConfig } from '../config'
 import { injectQuery, isParentDirectory, transformStableResult } from '../utils'
 import { CLIENT_ENTRY } from '../constants'
 import { slash } from '../../shared/utils'
-import { createIdResolver } from '../idResolver'
+import { createBackCompatIdResolver } from '../idResolver'
 import type { ResolveIdFn } from '../idResolver'
 import { fileToUrl } from './asset'
 import { preloadHelperId } from './importAnalysisBuild'
@@ -107,7 +107,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             file = slash(path.resolve(path.dirname(id), url))
             file = tryFsResolve(file, fsResolveOptions) ?? file
           } else {
-            assetResolver ??= createIdResolver(config, {
+            assetResolver ??= createBackCompatIdResolver(config, {
               extensions: [],
               mainFields: [],
               tryIndex: false,

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -69,7 +69,7 @@ import {
 } from '../utils'
 import type { Logger } from '../logger'
 import { cleanUrl, slash } from '../../shared/utils'
-import { createIdResolver } from '../idResolver'
+import { createBackCompatIdResolver } from '../idResolver'
 import type { ResolveIdFn } from '../idResolver'
 import { PartialEnvironment } from '../baseEnvironment'
 import type { TransformPluginContext } from '../server/pluginContainer'
@@ -261,7 +261,7 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
   let moduleCache: Map<string, Record<string, string>>
 
-  const idResolver = createIdResolver(config, {
+  const idResolver = createBackCompatIdResolver(config, {
     preferRelative: true,
     tryIndex: false,
     extensions: [],
@@ -1065,7 +1065,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
   let lessResolve: ResolveIdFn | undefined
   return {
     get css() {
-      return (cssResolve ??= createIdResolver(config, {
+      return (cssResolve ??= createBackCompatIdResolver(config, {
         extensions: ['.css'],
         mainFields: ['style'],
         conditions: ['style'],
@@ -1076,7 +1076,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
 
     get sass() {
       if (!sassResolve) {
-        const resolver = createIdResolver(config, {
+        const resolver = createBackCompatIdResolver(config, {
           extensions: ['.scss', '.sass', '.css'],
           mainFields: ['sass', 'style'],
           conditions: ['sass', 'style'],
@@ -1099,7 +1099,7 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
     },
 
     get less() {
-      return (lessResolve ??= createIdResolver(config, {
+      return (lessResolve ??= createBackCompatIdResolver(config, {
         extensions: ['.less', '.css'],
         mainFields: ['less', 'style'],
         conditions: ['less', 'style'],

--- a/packages/vite/src/node/plugins/dynamicImportVars.ts
+++ b/packages/vite/src/node/plugins/dynamicImportVars.ts
@@ -7,7 +7,7 @@ import { dynamicImportToGlob } from '@rollup/plugin-dynamic-import-vars'
 import type { Plugin } from '../plugin'
 import type { ResolvedConfig } from '../config'
 import { CLIENT_ENTRY } from '../constants'
-import { createIdResolver } from '../idResolver'
+import { createBackCompatIdResolver } from '../idResolver'
 import {
   createFilter,
   normalizePath,
@@ -164,7 +164,7 @@ export async function transformDynamicImport(
 }
 
 export function dynamicImportVarsPlugin(config: ResolvedConfig): Plugin {
-  const resolve = createIdResolver(config, {
+  const resolve = createBackCompatIdResolver(config, {
     preferRelative: true,
     tryIndex: false,
     extensions: [],

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -5,7 +5,7 @@ import { stripLiteral } from 'strip-literal'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { evalValue, injectQuery, transformStableResult } from '../utils'
-import { createIdResolver } from '../idResolver'
+import { createBackCompatIdResolver } from '../idResolver'
 import type { ResolveIdFn } from '../idResolver'
 import { cleanUrl, slash } from '../../shared/utils'
 import type { WorkerType } from './worker'
@@ -159,7 +159,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
             file = path.resolve(path.dirname(id), url)
             file = tryFsResolve(file, fsResolveOptions) ?? file
           } else {
-            workerResolver ??= createIdResolver(config, {
+            workerResolver ??= createBackCompatIdResolver(config, {
               extensions: [],
               tryIndex: false,
               preferRelative: true,


### PR DESCRIPTION
### Description

@sapphi-red was digging into Astro issues and found that they are patching [config.createResolver](https://github.com/withastro/astro/blob/8bab2339374763d19dbc4cc2c7ce4ad8a2a49694/packages/astro/src/vite-plugin-config-alias/index.ts#L113-L149). We need to offer a way to let projects inject their own alias plugins if we want to move forward here.

This PR is a stop-gap attempt to keep the `config.createResolver` override hack working for the client and ssr environments for backward compatibility.