### PR TITLE
fix: waitForRequestIdle locked

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1251,15 +1251,15 @@ function setupOnCrawlEnd(onCrawlEnd: () => void): CrawlEndFinder {
     if (ignoredId) {
       seenIds.add(ignoredId)
       markIdAsDone(ignoredId)
+    } else {
+      checkIfCrawlEndAfterTimeout()
     }
     return onCrawlEndPromiseWithResolvers.promise
   }
 
   function markIdAsDone(id: string): void {
-    if (registeredIds.has(id)) {
-      registeredIds.delete(id)
-      checkIfCrawlEndAfterTimeout()
-    }
+    registeredIds.delete(id)
+    checkIfCrawlEndAfterTimeout()
   }
 
   function checkIfCrawlEndAfterTimeout() {


### PR DESCRIPTION
### Description

Fixes #17980

Nuxt starts two dev servers, using one of them only for the client and one for SSR. For some reason, the SSR server is still calling load on `index.css?direct`. There aren't other client requests to this server so the `waitForRequestsIdle('index.css?direct')` never resolves as there aren't any `checkIfCrawlEndAfterTimeout` calls with the current guard in `markIdAsDone`. This PR fixes the issue in the reproduction, and also guards against calling. `waitForRequestsIdle()` in a clean server where no other client request is issued.