### PR TITLE
fix(deps): bump tsconfck 

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -147,7 +147,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.1.0",
-    "tsconfck": "^3.1.1",
+    "tsconfck": "^3.1.2",
     "tslib": "^2.7.0",
     "types": "link:./types",
     "ufo": "^1.5.4",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -147,7 +147,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.1.0",
-    "tsconfck": "^3.1.2",
+    "tsconfck": "^3.1.3",
     "tslib": "^2.7.0",
     "types": "link:./types",
     "ufo": "^1.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,8 +398,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       tsconfck:
-        specifier: ^3.1.2
-        version: 3.1.2(typescript@5.5.3)
+        specifier: ^3.1.3
+        version: 3.1.3(typescript@5.5.3)
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
@@ -6647,8 +6647,8 @@ packages:
       '@swc/wasm':
         optional: true
 
-  tsconfck@3.1.2:
-    resolution: {integrity: sha512-+ou7a8s3EsUeBPDXiLSZA5cD6QBjqbPfl56cz+1Gm6k1zEPU/t6vG9aZdKaxxwCWx8eGzvX+UkWdvJDhgrNeHA==}
+  tsconfck@3.1.3:
+    resolution: {integrity: sha512-ulNZP1SVpRDesxeMLON/LtWM8HIgAJEIVpVVhBM6gsmvQ8+Rh+ZG7FWGvHh7Ah3pRABwVJWklWCr/BTZSv0xnQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
@@ -12404,7 +12404,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tsconfck@3.1.2(typescript@5.5.3):
+  tsconfck@3.1.3(typescript@5.5.3):
     optionalDependencies:
       typescript: 5.5.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,8 +398,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       tsconfck:
-        specifier: ^3.1.1
-        version: 3.1.1(typescript@5.5.3)
+        specifier: ^3.1.2
+        version: 3.1.2(typescript@5.5.3)
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
@@ -6647,8 +6647,8 @@ packages:
       '@swc/wasm':
         optional: true
 
-  tsconfck@3.1.1:
-    resolution: {integrity: sha512-00eoI6WY57SvZEVjm13stEVE90VkEdJAFGgpFLTsZbJyW/LwFQ7uQxJHWpZ2hzSWgCPKc9AnBnNP+0X7o3hAmQ==}
+  tsconfck@3.1.2:
+    resolution: {integrity: sha512-+ou7a8s3EsUeBPDXiLSZA5cD6QBjqbPfl56cz+1Gm6k1zEPU/t6vG9aZdKaxxwCWx8eGzvX+UkWdvJDhgrNeHA==}
     engines: {node: ^18 || >=20}
     hasBin: true
     peerDependencies:
@@ -12404,7 +12404,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  tsconfck@3.1.1(typescript@5.5.3):
+  tsconfck@3.1.2(typescript@5.5.3):
     optionalDependencies:
       typescript: 5.5.3
 


### PR DESCRIPTION
to consume fix for resolving  of tsconfig files extended from node_modules

see https://github.com/dominikg/tsconfck/issues/188

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
