### PR TITLE
fix: cjs warning respect the logLevel flag

### DIFF
--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -25,6 +25,10 @@ asyncFunctions.forEach((name) => {
 
 function warnCjsUsage() {
   if (process.env.VITE_CJS_IGNORE_WARNING) return
+  const isSilent = process.argv.some((arg) =>
+    /^(-l|--logLevel)=(['"]?)silent\2$/.test(arg),
+  )
+  if (isSilent) return
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
   const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
   log(

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -25,10 +25,18 @@ asyncFunctions.forEach((name) => {
 
 function warnCjsUsage() {
   if (process.env.VITE_CJS_IGNORE_WARNING) return
-  const isSilent = process.argv.some((arg) =>
-    /^(-l|--logLevel)=(['"]?)silent\2$/.test(arg),
+  const logLevelIndex = process.argv.findIndex((arg) =>
+    /^(?:-l|--logLevel)/.test(arg),
   )
-  if (isSilent) return
+  if (logLevelIndex > 0) {
+    const logLevelValue = process.argv[logLevelIndex + 1]
+    if (logLevelValue === 'silent' || logLevelValue === 'error') {
+      return
+    }
+    if (/silent|error/.test(process.argv[logLevelIndex])) {
+      return
+    }
+  }
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
   const log = process.env.VITE_CJS_TRACE ? console.trace : console.warn
   log(


### PR DESCRIPTION
### Description
Perhaps when the logLevel option is set to `silent`, warning messages about formatting do not need to be printed either.
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
