### PR TITLE
refactor: remove `injectInvalidationTimestamp` option

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -248,13 +248,6 @@ export interface SharedEnvironmentOptions {
    * Temporal options, we should remove these in favor of fine-grained control
    */
   webCompatible?: boolean // was ssr.target === 'webworker'
-  /**
-   * Should Vite inject timestamp if module is invalidated
-   * Disabling this will break built-in HMR support
-   * @experimental
-   * @default true
-   */
-  injectInvalidationTimestamp?: boolean
 }
 
 export interface EnvironmentOptions extends SharedEnvironmentOptions {
@@ -276,14 +269,13 @@ export type ResolvedEnvironmentOptions = {
   resolve: ResolvedEnvironmentResolveOptions
   consumer: 'client' | 'server'
   webCompatible: boolean
-  injectInvalidationTimestamp: boolean
   dev: ResolvedDevEnvironmentOptions
   build: ResolvedBuildEnvironmentOptions
 }
 
 export type DefaultEnvironmentOptions = Omit<
   EnvironmentOptions,
-  'build' | 'consumer' | 'webCompatible' | 'injectInvalidationTimestamp'
+  'build' | 'consumer' | 'webCompatible'
 > & {
   // Includes lib mode support
   build?: BuildOptions
@@ -643,8 +635,6 @@ function resolveEnvironmentOptions(
     resolve,
     consumer,
     webCompatible: options.webCompatible ?? consumer === 'client',
-    injectInvalidationTimestamp:
-      options.injectInvalidationTimestamp ?? consumer === 'client',
     dev: resolveDevEnvironmentOptions(
       options.dev,
       resolve.preserveSymlinks,
@@ -680,7 +670,6 @@ export function getDefaultResolvedEnvironmentOptions(
     resolve: config.resolve,
     consumer: 'server',
     webCompatible: false,
-    injectInvalidationTimestamp: false,
     dev: config.dev,
     build: config.build,
   }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -360,7 +360,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
 
         // make the URL browser-valid
-        if (environment.config.injectInvalidationTimestamp) {
+        if (environment.config.consumer === 'client') {
           // mark non-js/css imports with `?import`
           if (isExplicitImportRequired(url)) {
             url = injectQuery(url, 'import')

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -457,9 +457,8 @@ async function handleModuleSoftInvalidation(
   }
 
   let result: TransformResult
-  // No transformation is needed if it's disabled manually
-  // This is primarily for backwards compatible SSR
-  if (!environment.config.injectInvalidationTimestamp) {
+  // For SSR soft-invalidation, no transformation is needed
+  if (environment.config.consumer === 'server') {
     result = transformResult
   }
   // We need to transform each imports with new timestamps if available

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -18,7 +18,7 @@ import {
   stripBase,
   timeFrom,
 } from '../utils'
-import { ssrParseImports, ssrTransform } from '../ssr/ssrTransform'
+import { ssrTransform } from '../ssr/ssrTransform'
 import { checkPublicFile } from '../publicDir'
 import { cleanUrl, unwrapId } from '../../shared/utils'
 import {
@@ -458,19 +458,15 @@ async function handleModuleSoftInvalidation(
 
   let result: TransformResult
   // For SSR soft-invalidation, no transformation is needed
-  if (environment.config.consumer === 'server') {
+  if (transformResult.ssr) {
     result = transformResult
   }
   // We need to transform each imports with new timestamps if available
   else {
+    await init
     const source = transformResult.code
     const s = new MagicString(source)
-    const imports = transformResult.ssr
-      ? await ssrParseImports(mod.url, source)
-      : await (async () => {
-          await init
-          return parseImports(source, mod.id || undefined)[0]
-        })()
+    const [imports] = parseImports(source, mod.id || undefined)
 
     for (const imp of imports) {
       let rawUrl = source.slice(imp.s, imp.e)


### PR DESCRIPTION
### Description

Removing `injectInvalidationTimestamp` since we don't use it anymore.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
