### PR TITLE
fix: expose `createServerHotChannel` and validate `createNodeDevEnvironment` context

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -29,6 +29,7 @@ export { BuildEnvironment } from './build'
 
 export { fetchModule, type FetchModuleOptions } from './ssr/fetchModule'
 export { createServerModuleRunner } from './ssr/runtime/serverModuleRunner'
+export { createServerHotChannel } from './server/hmr'
 export { ServerHMRConnector } from './ssr/runtime/serverHmrConnector'
 export { ssrTransform as moduleRunnerTransform } from './ssr/ssrTransform'
 export type { ModuleRunnerTransformOptions } from './ssr/ssrTransform'

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -8,6 +8,12 @@ export function createNodeDevEnvironment(
   config: ResolvedConfig,
   context: DevEnvironmentContext,
 ): DevEnvironment {
+  if (context.hot == null) {
+    throw new Error(
+      '`hot` is a required option. Either explicitly opt out of HMR by setting `hot: false` or provide a hot channel.',
+    )
+  }
+
   return new DevEnvironment(name, config, {
     ...context,
     runner: {


### PR DESCRIPTION
### Description

Environments require an explicit `hot` channel or `false` to avoid potential performance hits when you actually don't need any HMR, but setting `hmr` to `false` by default can be confusing when you expect HMR to work out of the box. I think throwing an explicit error is the best of both worlds here.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
