### PR TITLE
fix: mark ScanEnvironment internal

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -259,11 +259,15 @@ function removeInternal(s: MagicString, node: any): boolean {
     })
   ) {
     // Examples:
-    // function a(foo: string, /* @internal */ bar: number)
-    //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    // strip trailing comma
-    const end = s.original[node.end] === ',' ? node.end + 1 : node.end
-    s.remove(node.leadingComments[0].start, end)
+    // function a(foo: string, /* @internal */ bar: number, baz: boolean)
+    //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    // type Enum = Foo | /* @internal */ Bar | Baz
+    //                   ^^^^^^^^^^^^^^^^^^^^^
+    // strip trailing comma or pipe
+    const trailingRe = /\s*[,|]/y
+    trailingRe.lastIndex = node.end
+    const trailingStr = trailingRe.exec(s.original)?.[0] ?? ''
+    s.remove(node.leadingComments[0].start, node.end + trailingStr.length)
     return true
   }
   return false

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -3,6 +3,13 @@ import type { Logger } from './logger'
 import type { ResolvedConfig, ResolvedEnvironmentOptions } from './config'
 import type { Plugin } from './plugin'
 
+const environmentColors = [
+  colors.blue,
+  colors.magenta,
+  colors.green,
+  colors.gray,
+]
+
 export class PartialEnvironment {
   name: string
   getTopLevelConfig(): ResolvedConfig {
@@ -122,16 +129,17 @@ export class BaseEnvironment extends PartialEnvironment {
 }
 
 /**
- * This is used both to avoid users to hardcode conditions like
- * !scan && !build => dev
+ * This class discourages users from inversely checking the `mode`
+ * to determine the type of environment, e.g.
+ *
+ * ```js
+ * const isDev = environment.mode !== 'build' // bad
+ * const isDev = environment.mode === 'dev'   // good
+ * ```
+ *
+ * You should also not check against `"unknown"` specfically. It's
+ * a placeholder for more possible environment types.
  */
-export class FutureCompatEnvironment extends BaseEnvironment {
-  mode = 'futureCompat' as const
+export class UnknownEnvironment extends BaseEnvironment {
+  mode = 'unknown' as const
 }
-
-const environmentColors = [
-  colors.blue,
-  colors.magenta,
-  colors.green,
-  colors.gray,
-]

--- a/packages/vite/src/node/environment.ts
+++ b/packages/vite/src/node/environment.ts
@@ -1,14 +1,14 @@
 import type { DevEnvironment } from './server/environment'
 import type { BuildEnvironment } from './build'
 import type { ScanEnvironment } from './optimizer/scan'
-import type { FutureCompatEnvironment } from './baseEnvironment'
+import type { UnknownEnvironment } from './baseEnvironment'
 import type { PluginContext } from './plugin'
 
 export type Environment =
   | DevEnvironment
   | BuildEnvironment
-  | ScanEnvironment
-  | FutureCompatEnvironment
+  | /** @internal */ ScanEnvironment
+  | UnknownEnvironment
 
 /**
  * Creates a function that hides the complexities of a WeakMap with an initial value


### PR DESCRIPTION
### Description

And rename `FutureCompatEnvironment` as `UnknownEnvironment`.

Discussion: https://github.com/vitejs/vite/pull/16471#discussion_r1741107653

NOTE: The `ScanEnvironment` class still exist in `index.d.ts`, but it's not exported. We should probably look into better dts treeshaking in the future.
