### PR TITLE
refactor: update future options

### DIFF
--- a/docs/changes/hotupdate-hook.md
+++ b/docs/changes/hotupdate-hook.md
@@ -9,7 +9,7 @@ We're planning to deprecate the `handleHotUpdate` plugin hook in favor of [`hotU
 Affected scope: `Vite Plugin Authors`
 
 ::: warning Future Deprecation
-`hotUpdate` was first introduced in `v6.0`. The deprecation of `handleHotUpdate` is planned for `v7.0`. We don't yet recommend moving away from `handleHotUpdate` yet. If you want to experiment and give us feedback, you can use the `future.deprecationWarnings.pluginHookHandleHotUpdate` to `true` in your vite config.
+`hotUpdate` was first introduced in `v6.0`. The deprecation of `handleHotUpdate` is planned for `v7.0`. We don't yet recommend moving away from `handleHotUpdate` yet. If you want to experiment and give us feedback, you can use the `future.removePluginHookHandleHotUpdate` to `"warn"` in your vite config.
 :::
 
 ## Motivation

--- a/docs/changes/per-environment-apis.md
+++ b/docs/changes/per-environment-apis.md
@@ -13,7 +13,15 @@ Multiple APIs from ViteDevServer related to module graph has replaced with more 
 Affect scope: `Vite Plugin Authors`
 
 ::: warning Future Deprecation
-The Environment instance was first introduced at `v6.0`. The deprecation of `server.moduleGraph` and other methods that are now in environments is planned for `v7.0`. We don't recommend moving away from server methods yet. To identify your usage, set `future.deprecationWarnings` in your vite config.
+The Environment instance was first introduced at `v6.0`. The deprecation of `server.moduleGraph` and other methods that are now in environments is planned for `v7.0`. We don't recommend moving away from server methods yet. To identify your usage, set these in your vite config.
+
+```ts
+future: {
+  removeServerModuleGraph: 'warn',
+  removeServerTransformRequest: 'warn',
+}
+```
+
 :::
 
 ## Motivation

--- a/docs/changes/ssr-using-modulerunner.md
+++ b/docs/changes/ssr-using-modulerunner.md
@@ -9,7 +9,7 @@ Give us feedback at [Environment API feedback discussion](https://github.com/vit
 Affect scope: `Vite Plugin Authors`
 
 ::: warning Future Deprecation
-`ModuleRunner` was first introduce in `v6.0`. The deprecation of `server.ssrLoadModule` is planned for a future major. To identify your usage, set `future.deprecationWarnings.ssrLoadModule` to `true` in your vite config.
+`ModuleRunner` was first introduce in `v6.0`. The deprecation of `server.ssrLoadModule` is planned for a future major. To identify your usage, set `future.removeSrLoadModule` to `"warn"` in your vite config.
 :::
 
 ## Motivation

--- a/docs/changes/this-environment-in-hooks.md
+++ b/docs/changes/this-environment-in-hooks.md
@@ -9,7 +9,7 @@ Before Vite 6, only two environments were available: `client` and `ssr`. A singl
 Affect scope: `Vite Plugin Authors`
 
 ::: warning Future Deprecation
-`this.environment` was introduced in `v6.0`. The deprecation of `options.ssr` is planned for `v7.0`. At that point we'll start recommending migrating your plugins to use the new API. To identify your usage, set `future.deprecationWarnings.pluginHookSsrArgument` to `true` in your vite config.
+`this.environment` was introduced in `v6.0`. The deprecation of `options.ssr` is planned for `v7.0`. At that point we'll start recommending migrating your plugins to use the new API. To identify your usage, set `future.removePluginHookSsrArgument` to `"warn"` in your vite config.
 :::
 
 ## Motivation

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -86,7 +86,6 @@ import type { ResolvedSSROptions, SSROptions } from './ssr'
 import { resolveSSROptions } from './ssr'
 import { PartialEnvironment } from './baseEnvironment'
 import { createIdResolver } from './idResolver'
-import type { FutureDeprecationWarningsOptions } from './deprecations'
 
 const debug = createDebugger('vite:config')
 const promisifiedRealpath = promisify(fs.realpath)
@@ -453,12 +452,14 @@ export interface HTMLOptions {
 }
 
 export interface FutureOptions {
-  /**
-   * Emit warning messages for deprecated/will-deprecated features at runtime.
-   *
-   * Setting to `true` to enable all warnings
-   */
-  deprecationWarnings?: boolean | FutureDeprecationWarningsOptions
+  removePluginHookHandleHotUpdate?: 'warn' | false
+  removePluginHookSsrArgument?: 'warn' | false
+
+  removeServerModuleGraph?: 'warn' | false
+  removeServerHot?: 'warn' | false
+  removeServerTransformRequest?: 'warn' | false
+
+  removeSsrLoadModule?: 'warn' | false
 }
 
 export interface ExperimentalOptions {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -452,14 +452,14 @@ export interface HTMLOptions {
 }
 
 export interface FutureOptions {
-  removePluginHookHandleHotUpdate?: 'warn' | false
-  removePluginHookSsrArgument?: 'warn' | false
+  removePluginHookHandleHotUpdate?: 'warn'
+  removePluginHookSsrArgument?: 'warn'
 
-  removeServerModuleGraph?: 'warn' | false
-  removeServerHot?: 'warn' | false
-  removeServerTransformRequest?: 'warn' | false
+  removeServerModuleGraph?: 'warn'
+  removeServerHot?: 'warn'
+  removeServerTransformRequest?: 'warn'
 
-  removeSsrLoadModule?: 'warn' | false
+  removeSsrLoadModule?: 'warn'
 }
 
 export interface ExperimentalOptions {

--- a/packages/vite/src/node/deprecations.ts
+++ b/packages/vite/src/node/deprecations.ts
@@ -1,46 +1,35 @@
 import colors from 'picocolors'
-import type { ResolvedConfig } from './config'
+import type { FutureOptions, ResolvedConfig } from './config'
 
 // TODO: switch to production docs URL
 const docsURL = 'https://deploy-preview-16471--vite-docs-main.netlify.app'
 
-export interface FutureDeprecationWarningsOptions {
-  pluginHookHandleHotUpdate?: boolean
-  pluginHookSsrArgument?: boolean
-
-  serverModuleGraph?: boolean
-  serverHot?: boolean
-  serverTransformRequest?: boolean
-
-  ssrLoadModule?: boolean
-}
-
 const deprecationCode = {
-  pluginHookSsrArgument: 'changes/this-environment-in-hooks',
-  pluginHookHandleHotUpdate: 'changes/hotupdate-hook',
+  removePluginHookSsrArgument: 'changes/this-environment-in-hooks',
+  removePluginHookHandleHotUpdate: 'changes/hotupdate-hook',
 
-  serverModuleGraph: 'changes/per-environment-apis',
-  serverHot: 'changes/per-environment-apis',
-  serverTransformRequest: 'changes/per-environment-apis',
+  removeServerModuleGraph: 'changes/per-environment-apis',
+  removeServerHot: 'changes/per-environment-apis',
+  removeServerTransformRequest: 'changes/per-environment-apis',
 
-  ssrLoadModule: 'changes/ssr-using-modulerunner',
-} satisfies Record<keyof FutureDeprecationWarningsOptions, string>
+  removeSsrLoadModule: 'changes/ssr-using-modulerunner',
+} satisfies Record<keyof FutureOptions, string>
 
 const deprecationMessages = {
-  pluginHookSsrArgument:
+  removePluginHookSsrArgument:
     "Plugin hook `options.ssr` is replaced with `this.environment.config.consumer === 'server'`.",
-  pluginHookHandleHotUpdate:
+  removePluginHookHandleHotUpdate:
     'Plugin hook `handleHotUpdate()` is replaced with `hotUpdate()`.',
 
-  serverModuleGraph:
+  removeServerModuleGraph:
     'The `server.moduleGraph` is replaced with `this.environment.moduleGraph`.',
-  serverHot: 'The `server.hot` is replaced with `this.environment.hot`.',
-  serverTransformRequest:
+  removeServerHot: 'The `server.hot` is replaced with `this.environment.hot`.',
+  removeServerTransformRequest:
     'The `server.transformRequest` is replaced with `this.environment.transformRequest`.',
 
-  ssrLoadModule:
+  removeSsrLoadModule:
     'The `server.ssrLoadModule` is replaced with Environment Runner.',
-} satisfies Record<keyof FutureDeprecationWarningsOptions, string>
+} satisfies Record<keyof FutureOptions, string>
 
 let _ignoreDeprecationWarnings = false
 
@@ -50,17 +39,14 @@ let _ignoreDeprecationWarnings = false
  */
 export function warnFutureDeprecation(
   config: ResolvedConfig,
-  type: keyof FutureDeprecationWarningsOptions,
+  type: keyof FutureOptions,
   extraMessage?: string,
   stacktrace = true,
 ): void {
-  if (_ignoreDeprecationWarnings) return
-
-  if (!config.future?.deprecationWarnings) return
-
   if (
-    config.future.deprecationWarnings !== true &&
-    !config.future.deprecationWarnings[type]
+    _ignoreDeprecationWarnings ||
+    !config.future ||
+    config.future[type] !== 'warn'
   )
     return
 

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -293,7 +293,7 @@ export async function handleHMRUpdate(
       } else if (type === 'update') {
         warnFutureDeprecation(
           config,
-          'pluginHookHandleHotUpdate',
+          'removePluginHookHandleHotUpdate',
           `Used in plugin "${plugin.name}".`,
           false,
         )

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -528,7 +528,7 @@ export async function _createServer(
     environments,
     pluginContainer,
     get moduleGraph() {
-      warnFutureDeprecation(config, 'serverModuleGraph')
+      warnFutureDeprecation(config, 'removeServerModuleGraph')
       return moduleGraph
     },
     set moduleGraph(graph) {
@@ -552,7 +552,7 @@ export async function _createServer(
     transformRequest(url, options) {
       warnFutureDeprecation(
         config,
-        'serverTransformRequest',
+        'removeServerTransformRequest',
         'server.transformRequest() is deprecated. Use environment.transformRequest() instead.',
       )
       const environment = server.environments[options?.ssr ? 'ssr' : 'client']
@@ -581,7 +581,7 @@ export async function _createServer(
       return devHtmlTransformFn(server, url, html, originalUrl)
     },
     async ssrLoadModule(url, opts?: { fixStacktrace?: boolean }) {
-      warnFutureDeprecation(config, 'ssrLoadModule')
+      warnFutureDeprecation(config, 'removeSsrLoadModule')
       return ssrLoadModule(url, server, opts?.fixStacktrace)
     },
     ssrFixStacktrace(e) {


### PR DESCRIPTION
### Description

From https://github.com/vitejs/vite/pull/16471#discussion_r1740429158 (removed `false` because it's confusing)

This change is what I figured `future` options could be. We can discuss whether this is what we want or not here.

```ts
export interface FutureOptions {
  removePluginHookHandleHotUpdate?: 'warn'
  removePluginHookSsrArgument?: 'warn'

  removeServerModuleGraph?: 'warn'
  removeServerHot?: 'warn'
  removeServerTransformRequest?: 'warn'

  removeSsrLoadModule?: 'warn'
}
```

My idea is that:

- `future` options contain a list of top-level properties (feature change names), and users have a choice to opt-in to that breaking change.
- The signature will be `future.<name>?: "warn"` or `future.<name>?: true`
  - `"warn"` variant is used only when we're unsure this is a change we'll land. Users can try out by opting to `"warn"`.
  - `true` variant is used when we're sure of this change, and you can opt into this breaking change now. Warnings are already emitted regardless of the option, but `true` would make them hard errors.

---

Reading the major changes documentation, I could probably see why it landed with `future.deprecationWarnings` in the first place, so this PR may make that page a little odd. My suggestion (if we go along with this) is that in the major changes page:

- If a feature is `"warn"`, put into the "Future" section (Rename as "Considering" to not overload the future term?)
- If a feature is `true`, put into the "Current" section
- If a feature is part of previous major, or we walk back on it, put into the "Past" section (Maybe want a "Rejected" section?)
