### PR TITLE
fix: always resolve runner's entry point

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -1,12 +1,6 @@
 import type { ViteHotContext } from 'types/hot'
 import { HMRClient, HMRContext } from '../shared/hmr'
-import {
-  cleanUrl,
-  isPrimitive,
-  isWindows,
-  unwrapId,
-  wrapId,
-} from '../shared/utils'
+import { cleanUrl, isPrimitive, isWindows, unwrapId } from '../shared/utils'
 import { analyzeImportedModDifference } from '../shared/ssrTransform'
 import { ModuleCacheMap } from './moduleCache'
 import type {
@@ -93,7 +87,6 @@ export class ModuleRunner {
    * URL to execute. Accepts file path, server path or id relative to the root.
    */
   public async import<T = any>(url: string): Promise<T> {
-    url = this.normalizeEntryUrl(url)
     const fetchedModule = await this.cachedModule(url)
     return await this.cachedRequest(url, fetchedModule)
   }
@@ -123,21 +116,6 @@ export class ModuleRunner {
    */
   public isDestroyed(): boolean {
     return this.destroyed
-  }
-
-  // we don't use moduleCache.normalize because this URL doesn't have to follow the same rules
-  // this URL is something that user passes down manually, and is later resolved by fetchModule
-  // moduleCache.normalize is used on resolved "file" property
-  private normalizeEntryUrl(url: string) {
-    // expect fetchModule to resolve relative module correctly
-    if (url[0] === '.') {
-      return url
-    }
-    url = normalizeAbsoluteUrl(url, this.root)
-    // if it's a server url (starts with a slash), keep it, otherwise assume a virtual module
-    // /id.js -> /id.js
-    // virtual:custom -> /@id/virtual:custom
-    return url[0] === '/' ? url : wrapId(url)
   }
 
   private processImport(

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -939,25 +939,21 @@ test('hmr works for self-accepted module within circular imported files', async 
   })
 })
 
-test(
-  'hmr should not reload if no accepted within circular imported files',
-  { retry: 5 },
-  async () => {
-    await setupModuleRunner('/circular/index')
-    const el = () => hmr('.circular')
-    expect(el()).toBe(
-      // tests in the browser check that there is an error, but vite runtime just returns undefined in those cases
-      'mod-a -> mod-b -> mod-c -> undefined (expected no error)',
-    )
-    editFile('circular/mod-b.js', (code) =>
-      code.replace(`mod-b ->`, `mod-b (edited) ->`),
-    )
-    await untilUpdated(
-      () => el(),
-      'mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)',
-    )
-  },
-)
+test('hmr should not reload if no accepted within circular imported files', async () => {
+  await setupModuleRunner('/circular/index')
+  const el = () => hmr('.circular')
+  expect(el()).toBe(
+    // tests in the browser check that there is an error, but vite runtime just returns undefined in those cases
+    'mod-a -> mod-b -> mod-c -> undefined (expected no error)',
+  )
+  editFile('circular/mod-b.js', (code) =>
+    code.replace(`mod-b ->`, `mod-b (edited) ->`),
+  )
+  await untilUpdated(
+    () => el(),
+    'mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)',
+  )
+})
 
 test('assets HMR', async () => {
   await setupModuleRunner('/hmr.ts')

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -939,21 +939,25 @@ test('hmr works for self-accepted module within circular imported files', async 
   })
 })
 
-test('hmr should not reload if no accepted within circular imported files', async () => {
-  await setupModuleRunner('/circular/index')
-  const el = () => hmr('.circular')
-  expect(el()).toBe(
-    // tests in the browser check that there is an error, but vite runtime just returns undefined in those cases
-    'mod-a -> mod-b -> mod-c -> undefined (expected no error)',
-  )
-  editFile('circular/mod-b.js', (code) =>
-    code.replace(`mod-b ->`, `mod-b (edited) ->`),
-  )
-  await untilUpdated(
-    () => el(),
-    'mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)',
-  )
-})
+test(
+  'hmr should not reload if no accepted within circular imported files',
+  { retry: 5 },
+  async () => {
+    await setupModuleRunner('/circular/index')
+    const el = () => hmr('.circular')
+    expect(el()).toBe(
+      // tests in the browser check that there is an error, but vite runtime just returns undefined in those cases
+      'mod-a -> mod-b -> mod-c -> undefined (expected no error)',
+    )
+    editFile('circular/mod-b.js', (code) =>
+      code.replace(`mod-b ->`, `mod-b (edited) ->`),
+    )
+    await untilUpdated(
+      () => el(),
+      'mod-a -> mod-b (edited) -> mod-c -> undefined (expected no error)',
+    )
+  },
+)
 
 test('assets HMR', async () => {
   await setupModuleRunner('/hmr.ts')

--- a/playground/hmr-ssr/unresolved.ts
+++ b/playground/hmr-ssr/unresolved.ts
@@ -1,0 +1,20 @@
+export const foo = 1
+hmr('.app', foo)
+
+if (import.meta.hot) {
+  import.meta.hot.accept(({ foo }) => {
+    log('(self-accepting 1) foo is now:', foo)
+  })
+
+  import.meta.hot.accept(({ foo }) => {
+    log('(self-accepting 2) foo is now:', foo)
+  })
+
+  import.meta.hot.dispose(() => {
+    log(`foo was:`, foo)
+  })
+}
+
+function hmr(key: string, value: unknown) {
+  ;(globalThis.__HMR__ as any)[key] = String(value)
+}


### PR DESCRIPTION
### Description

Related: https://github.com/vitejs/vite/discussions/16358#discussioncomment-10530118

Passing down a non-resolved ID to the module runner works for loading files, but it creates invalid module cache entries that don't work with HMR. 

```ts
cons runner = new ModuleRunner()

// all of the IDs are different from the module cache id
runner.import('./some-module')
runner.import('./some-module.ts')
runner.import('/some-module')
```

To resolve this, we always need to resolve entry points the same way Vite resolves URLs in the import analysis plugin. I see two possible solutions:

1. Share the code between the import analysis plugin and `fetchModule` (implemented in this PR)
2. Run the entry point module in some kind of "inlined" or "virtual" wrapper so the code is processed by Vite - this requires the user to define a plugin for this sort of thing, or we can have a built-in plugin that just injects an ID into an `import`, but this will probably break HMR in some way:

```ts
load(id) {
  return `export * from '${id}'`
}
```

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
