### PR TITLE
docs: update changes page

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -266,7 +266,7 @@ export default defineConfig({
               link: '/guide/migration',
             },
             {
-              text: 'Major Changes',
+              text: 'Breaking Changes',
               link: '/changes/',
             },
           ],
@@ -338,7 +338,7 @@ export default defineConfig({
       ],
       '/changes/': [
         {
-          text: 'Major Changes',
+          text: 'Breaking Changes',
           link: '/changes/',
         },
         {

--- a/docs/changes/index.md
+++ b/docs/changes/index.md
@@ -1,6 +1,6 @@
 # Breaking Changes
 
-List of breaking changes in Vite including API deprecations, removals, and changes. Most of the changes below can be opt-in using the `future` option in your Vite config.
+List of breaking changes in Vite including API deprecations, removals, and changes. Most of the changes below can be opt-in using the [`future` option](/config/shared-options.html#future) in your Vite config.
 
 ## Planned
 

--- a/docs/changes/index.md
+++ b/docs/changes/index.md
@@ -1,16 +1,18 @@
-# Major Changes
+# Breaking Changes
 
-This is a list of major changes in Vite and planned future deprecations/removals.
+List of breaking changes in Vite including API deprecations, removals, and changes. Most of the changes below can be opt-in using the `future` option in your Vite config.
 
-## Current
+## Planned
 
-We're reaching out to framework, plugin authors, and users to apply these changes. Deprecation or usage warnings will guide you where possible.
+These changes are planned for the next major version of Vite. The deprecation or usage warnings will guide you where possible, and we're reaching out to framework, plugin authors, and users to apply these changes.
 
-## Future
+- _No planned changes yet_
 
-These are experimental APIs that intend to improve upon current usage patterns. There are more experimental APIs that the ones listed here. For a complete list of experimental features, please checkout the [Experimental Label in Vite GitHub Discussions](https://github.com/vitejs/vite/discussions/categories/feedback?discussions_q=label%3Aexperimental+category%3AFeedback).
+## Considering
 
-We don't recommend switching to these APIs yet. They are included in Vite to help us gather feedback. Please check these proposals and let us know how they work in your use case using the linked Discussions in each.
+These changes are being considered and are often experimental APIs that intend to improve upon current usage patterns. As not all changes are listed here, please check out the [Experimental Label in Vite GitHub Discussions](https://github.com/vitejs/vite/discussions/categories/feedback?discussions_q=label%3Aexperimental+category%3AFeedback) for the full list.
+
+We don't recommend switching to these APIs yet. They are included in Vite to help us gather feedback. Please check these proposals and let us know how they work in your use case in each's linked GitHub Discussions.
 
 - [`this.environment` in Hooks](/changes/this-environment-in-hooks)
 - [HMR `hotUpdate` Plugin Hook](/changes/hotupdate-hook)
@@ -20,4 +22,6 @@ We don't recommend switching to these APIs yet. They are included in Vite to hel
 
 ## Past
 
-The following are changes done in the past, where the usage that replaced are no longer used by a significant portion of users.
+The changes below has been done or reverted. They are no longer relevant in the current major version.
+
+- _No past changes yet_

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -490,3 +490,12 @@ Whether your application is a Single Page Application (SPA), a [Multi Page Appli
 - `'custom'`: don't include HTML middlewares
 
 Learn more in Vite's [SSR guide](/guide/ssr#vite-cli). Related: [`server.middlewareMode`](./server-options#server-middlewaremode).
+
+## future
+
+- **Type:** `Record<string, 'warn' | undefined>`
+- **Related:** [Breaking Changes](/changes)
+
+Enable future breaking changes to prepare for a smooth migration to the next major version of Vite. The list may be updated, added, or removed at any time as new features are developed.
+
+See the [Breaking Changes](/changes) page for details of the possible options.

--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -494,8 +494,8 @@ Learn more in Vite's [SSR guide](/guide/ssr#vite-cli). Related: [`server.middlew
 ## future
 
 - **Type:** `Record<string, 'warn' | undefined>`
-- **Related:** [Breaking Changes](/changes)
+- **Related:** [Breaking Changes](/changes/)
 
 Enable future breaking changes to prepare for a smooth migration to the next major version of Vite. The list may be updated, added, or removed at any time as new features are developed.
 
-See the [Breaking Changes](/changes) page for details of the possible options.
+See the [Breaking Changes](/changes/) page for details of the possible options.

--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -898,7 +898,7 @@ The current Vite server API are not yet deprecated and are backward compatible w
 
 The `server.moduleGraph` returns a mixed view of the client and ssr module graphs. Backward compatible mixed module nodes will be returned from all its methods. The same scheme is used for the module nodes passed to `handleHotUpdate`.
 
-We don't recommend switching to Environment API yet. We are aiming for a good portion of the user base to adopt Vite 6 before so plugins don't need to maintain two versions. Checkout the future major changes section for information on future deprecations and upgrade path:
+We don't recommend switching to Environment API yet. We are aiming for a good portion of the user base to adopt Vite 6 before so plugins don't need to maintain two versions. Checkout the future breaking changes section for information on future deprecations and upgrade path:
 
 - [`this.environment` in Hooks](/changes/this-environment-in-hooks)
 - [HMR `hotUpdate` Plugin Hook](/changes/hotupdate-hook)


### PR DESCRIPTION
### Description

related https://github.com/vitejs/vite/pull/18011

I think I got carried away updating the changes page, but feel free to point out if you don't agree with something. Or if this change is not worth it.

- Renamed "Major changes" -> "Breaking changes" (I think major changes are always breaking changes, so better to use a familiar term?)
- Renamed the sections to "Planned", "Considering", "Past"
  - "Planned": We've decided this is a breaking change we want to do in the future
  - "Considering": Still considering if we want to do this breaking change
  - "Past": Past breaking changes, or things we have decided not to do
- Added a `future` option docs in the shared-options.md page.