### PR TITLE
fix: store backwards compatible `ssrModule` and `ssrError`

### DIFF
--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -126,7 +126,7 @@ export class ModuleRunner {
     if (!('externalize' in fetchResult)) {
       return exports
     }
-    const { id, type } = fetchResult
+    const { url: id, type } = fetchResult
     if (type !== 'module' && type !== 'commonjs') return exports
     analyzeImportedModDifference(exports, id, type, metadata)
     return exports
@@ -175,7 +175,7 @@ export class ModuleRunner {
   ): Promise<any> {
     const mod = mod_ as Required<ModuleCache>
     const meta = mod.meta!
-    const moduleId = meta.id
+    const moduleId = meta.url
 
     const { importers } = mod
 
@@ -291,7 +291,7 @@ export class ModuleRunner {
       this.moduleCache.invalidateModule(mod)
     }
 
-    fetchedModule.id = moduleId
+    fetchedModule.url = moduleId
     mod.meta = fetchedModule
 
     if (file) {
@@ -312,15 +312,15 @@ export class ModuleRunner {
     _callstack: string[],
   ): Promise<any> {
     const fetchResult = mod.meta!
-    const moduleId = fetchResult.id
-    const callstack = [..._callstack, moduleId]
+    const moduleUrl = fetchResult.url
+    const callstack = [..._callstack, moduleUrl]
 
     const request = async (dep: string, metadata?: SSRImportMetadata) => {
-      const importer = ('file' in fetchResult && fetchResult.file) || moduleId
+      const importer = ('file' in fetchResult && fetchResult.file) || moduleUrl
       const fetchedModule = await this.cachedModule(dep, importer)
-      const resolvedId = fetchedModule.meta!.id
+      const resolvedId = fetchedModule.meta!.url
       const depMod = this.moduleCache.getByModuleId(resolvedId)
-      depMod.importers!.add(moduleId)
+      depMod.importers!.add(moduleUrl)
       mod.imports!.add(resolvedId)
 
       return this.cachedRequest(dep, fetchedModule, callstack, metadata)
@@ -354,7 +354,7 @@ export class ModuleRunner {
       )
     }
 
-    const modulePath = cleanUrl(file || moduleId)
+    const modulePath = cleanUrl(file || moduleUrl)
     // disambiguate the `<UNIT>:/` on windows: see nodejs/node#31710
     const href = posixPathToFileHref(modulePath)
     const filename = modulePath
@@ -391,8 +391,8 @@ export class ModuleRunner {
           if (!this.hmrClient) {
             throw new Error(`[module runner] HMR client was destroyed.`)
           }
-          this.debug?.('[module runner] creating hmr context for', moduleId)
-          hotContext ||= new HMRContext(this.hmrClient, moduleId)
+          this.debug?.('[module runner] creating hmr context for', moduleUrl)
+          hotContext ||= new HMRContext(this.hmrClient, moduleUrl)
           return hotContext
         },
         set: (value) => {

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -143,7 +143,7 @@ export class ModuleRunner {
 
   private isCircularImport(
     importers: Set<string>,
-    moduleId: string,
+    moduleUrl: string,
     visited = new Set<string>(),
   ) {
     for (const importer of importers) {
@@ -151,7 +151,7 @@ export class ModuleRunner {
         continue
       }
       visited.add(importer)
-      if (importer === moduleId) {
+      if (importer === moduleUrl) {
         return true
       }
       const mod = this.moduleCache.getByModuleId(
@@ -159,7 +159,7 @@ export class ModuleRunner {
       ) as Required<ModuleCache>
       if (
         mod.importers.size &&
-        this.isCircularImport(mod.importers, moduleId, visited)
+        this.isCircularImport(mod.importers, moduleUrl, visited)
       ) {
         return true
       }
@@ -175,7 +175,7 @@ export class ModuleRunner {
   ): Promise<any> {
     const mod = mod_ as Required<ModuleCache>
     const meta = mod.meta!
-    const moduleId = meta.url
+    const moduleUrl = meta.url
 
     const { importers } = mod
 
@@ -185,9 +185,9 @@ export class ModuleRunner {
 
     // check circular dependency
     if (
-      callstack.includes(moduleId) ||
+      callstack.includes(moduleUrl) ||
       this.isCircularModule(mod) ||
-      this.isCircularImport(importers, moduleId)
+      this.isCircularImport(importers, moduleUrl)
     ) {
       if (mod.exports) return this.processImport(mod.exports, meta, metadata)
     }
@@ -196,13 +196,13 @@ export class ModuleRunner {
     if (this.debug) {
       debugTimer = setTimeout(() => {
         const getStack = () =>
-          `stack:\n${[...callstack, moduleId]
+          `stack:\n${[...callstack, moduleUrl]
             .reverse()
             .map((p) => `  - ${p}`)
             .join('\n')}`
 
         this.debug!(
-          `[module runner] module ${moduleId} takes over 2s to load.\n${getStack()}`,
+          `[module runner] module ${moduleUrl} takes over 2s to load.\n${getStack()}`,
         )
       }, 2000)
     }
@@ -284,24 +284,24 @@ export class ModuleRunner {
     const query = idQuery ? `?${idQuery}` : ''
     const file = 'file' in fetchedModule ? fetchedModule.file : undefined
     const fileId = file ? `${file}${query}` : url
-    const moduleId = this.moduleCache.normalize(fileId)
-    const mod = this.moduleCache.getByModuleId(moduleId)
+    const moduleUrl = this.moduleCache.normalize(fileId)
+    const mod = this.moduleCache.getByModuleId(moduleUrl)
 
     if ('invalidate' in fetchedModule && fetchedModule.invalidate) {
       this.moduleCache.invalidateModule(mod)
     }
 
-    fetchedModule.url = moduleId
+    fetchedModule.url = moduleUrl
     mod.meta = fetchedModule
 
     if (file) {
       const fileModules = this.fileToIdMap.get(file) || []
-      fileModules.push(moduleId)
+      fileModules.push(moduleUrl)
       this.fileToIdMap.set(file, fileModules)
     }
 
-    this.urlToIdMap.set(url, moduleId)
-    this.urlToIdMap.set(unwrapId(url), moduleId)
+    this.urlToIdMap.set(url, moduleUrl)
+    this.urlToIdMap.set(unwrapId(url), moduleUrl)
     return mod
   }
 

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -128,7 +128,6 @@ export interface ViteFetchResult {
 
 export type ResolvedResult = (ExternalFetchResult | ViteFetchResult) & {
   url: string
-  serverId: string
 }
 
 export type FetchFunction = (

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -117,13 +117,18 @@ export interface ViteFetchResult {
    */
   file: string | null
   /**
+   * Module ID in the server module graph.
+   */
+  serverId: string
+  /**
    * Invalidate module on the client side.
    */
   invalidate: boolean
 }
 
 export type ResolvedResult = (ExternalFetchResult | ViteFetchResult) & {
-  id: string
+  url: string
+  serverId: string
 }
 
 export type FetchFunction = (

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -137,6 +137,7 @@ export async function fetchModule(
   return {
     code: result.code,
     file: mod.file,
+    serverId: mod.id!,
     invalidate: !cached,
   }
 }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -80,14 +80,14 @@ class SSRCompatModuleRunner extends ModuleRunner {
     const serverId = mod.meta?.serverId
     // serverId doesn't exist for external modules
     if (!serverId) {
-      return this.directRequest(id, mod, _callstack)
+      return super.directRequest(id, mod, _callstack)
     }
 
     const viteMod =
       this.server.environments.ssr.moduleGraph.getModuleById(serverId)
 
     if (!viteMod) {
-      return this.directRequest(id, mod, _callstack)
+      return super.directRequest(id, mod, _callstack)
     }
 
     try {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -78,6 +78,7 @@ class SSRCompatModuleRunner extends ModuleRunner {
     _callstack: string[],
   ): Promise<any> {
     const serverId = mod.meta?.serverId
+    // serverId doesn't exist for external modules
     if (!serverId) {
       return this.directRequest(id, mod, _callstack)
     }

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -78,14 +78,13 @@ class SSRCompatModuleRunner extends ModuleRunner {
     _callstack: string[],
   ): Promise<any> {
     const viteMod = this.server.environments.ssr.moduleGraph.getModuleById(
-      mod.meta!.id,
+      mod.meta!.serverId,
     )
-    // TODO: should never happen
+
     if (!viteMod) {
-      throw new Error(
-        `Module ${mod.meta!.id} not found in module graph. This is a bug in Vite.`,
-      )
+      return await this.directRequest(id, mod, _callstack)
     }
+
     try {
       const exports = await super.directRequest(id, mod, _callstack)
       viteMod.ssrModule = exports

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -77,7 +77,7 @@ class SSRCompatModuleRunner extends ModuleRunner {
     mod: ModuleCache,
     _callstack: string[],
   ): Promise<any> {
-    const serverId = mod.meta?.serverId
+    const serverId = mod.meta && 'serverId' in mod.meta && mod.meta.serverId
     // serverId doesn't exist for external modules
     if (!serverId) {
       return super.directRequest(id, mod, _callstack)

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -77,12 +77,16 @@ class SSRCompatModuleRunner extends ModuleRunner {
     mod: ModuleCache,
     _callstack: string[],
   ): Promise<any> {
-    const viteMod = this.server.environments.ssr.moduleGraph.getModuleById(
-      mod.meta!.serverId,
-    )
+    const serverId = mod.meta?.serverId
+    if (!serverId) {
+      return this.directRequest(id, mod, _callstack)
+    }
+
+    const viteMod =
+      this.server.environments.ssr.moduleGraph.getModuleById(serverId)
 
     if (!viteMod) {
-      return await this.directRequest(id, mod, _callstack)
+      return this.directRequest(id, mod, _callstack)
     }
 
     try {


### PR DESCRIPTION
### Description

The previous `ssrLoadModule` compat layer only stored the entry point's `ssrModule`, this cases issues with astro.

This PR makes it so that every time the module is requested, we store the `ssrModule` value on the server's moduleGraph.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
