### PR TITLE
refactor: remove custom resolveOptions from pre-alias plugin

### DIFF
--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -53,10 +53,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
           if (depsOptimizer.options.noDiscovery) {
             return
           }
-          const resolved = await this.resolve(id, importer, {
-            ...options,
-            custom: { ...options.custom, 'vite:pre-alias': true },
-          })
+          const resolved = await this.resolve(id, importer, options)
           if (resolved && !depsOptimizer.isOptimizedDepFile(resolved.id)) {
             const optimizeDeps = depsOptimizer.options
             const resolvedId = cleanUrl(resolved.id)


### PR DESCRIPTION
### Description

This resolve option was added by #12851. But given that build-time dep-optimization is now removed, we don't need to add this anymore.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
