### PR TITLE
fix(preload): allow ignoring dep errors

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -81,7 +81,8 @@ function preload(
   deps?: string[],
   importerUrl?: string,
 ) {
-  let promise: Promise<PromiseSettledResult<unknown>[] | void> = Promise.resolve()
+  let promise: Promise<PromiseSettledResult<unknown>[] | void> =
+    Promise.resolve()
   // @ts-expect-error __VITE_IS_MODERN__ will be replaced with boolean later
   if (__VITE_IS_MODERN__ && deps && deps.length > 0) {
     const links = document.getElementsByTagName('link')
@@ -144,20 +145,21 @@ function preload(
     )
   }
 
-  return promise
-    .then((res) => {
-      for (const item of res || []) {
-        if (item.status !== 'rejected') continue
+  return promise.then((res) => {
+    for (const item of res || []) {
+      if (item.status !== 'rejected') continue
 
-        const e = new Event('vite:preloadError', { cancelable: true }) as VitePreloadErrorEvent
-        e.payload = item.reason
-        window.dispatchEvent(e)
-        if (!e.defaultPrevented) {
-          throw item.reason
-        }
+      const e = new Event('vite:preloadError', {
+        cancelable: true,
+      }) as VitePreloadErrorEvent
+      e.payload = item.reason
+      window.dispatchEvent(e)
+      if (!e.defaultPrevented) {
+        throw item.reason
       }
-      return baseModule()
-    })
+    }
+    return baseModule()
+  })
 }
 
 /**

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -140,7 +140,7 @@ describe.runIf(isBuild)('build tests', () => {
     expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
       {
         "ignoreList": [],
-        "mappings": ";63BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
+        "mappings": ";s8BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],


### PR DESCRIPTION
### Description

resolves https://github.com/vitejs/vite/issues/18042

This allows individual failures of dep preloads without a chain reaction (which Promise.all forces). By default the behaviour is the same, but if frameworks or users call `e.preventDefault` on the chunk errors it is still possible for the preload/import to succeed, which is I think valid in the case of CSS failures.