### PR TITLE
test: move glob test root to reduce snapshot change

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -40,7 +40,7 @@ export const parent = /* #__PURE__ */ Object.assign({
 
 
 });
-export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/css.spec.ts": () => import("../../css.spec.ts?url").then(m => m["default"]),"/define.spec.ts": () => import("../../define.spec.ts?url").then(m => m["default"]),"/esbuild.spec.ts": () => import("../../esbuild.spec.ts?url").then(m => m["default"]),"/import.spec.ts": () => import("../../import.spec.ts?url").then(m => m["default"]),"/importGlob/fixture-b/a.ts": () => import("../fixture-b/a.ts?url").then(m => m["default"]),"/importGlob/fixture-b/b.ts": () => import("../fixture-b/b.ts?url").then(m => m["default"]),"/importGlob/fixture-b/index.ts": () => import("../fixture-b/index.ts?url").then(m => m["default"]),"/json.spec.ts": () => import("../../json.spec.ts?url").then(m => m["default"])
+export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/fixture-b/a.ts": () => import("../fixture-b/a.ts?url").then(m => m["default"]),"/fixture-b/b.ts": () => import("../fixture-b/b.ts?url").then(m => m["default"]),"/fixture-b/index.ts": () => import("../fixture-b/index.ts?url").then(m => m["default"]),"/fixture.spec.ts": () => import("../fixture.spec.ts?url").then(m => m["default"]),"/parse.spec.ts": () => import("../parse.spec.ts?url").then(m => m["default"]),"/utils.spec.ts": () => import("../utils.spec.ts?url").then(m => m["default"])
 
 
 });
@@ -95,7 +95,7 @@ export const parent = /* #__PURE__ */ Object.assign({
 
 
 });
-export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/css.spec.ts": () => import("../../css.spec.ts?url&lang.ts").then(m => m["default"]),"/define.spec.ts": () => import("../../define.spec.ts?url&lang.ts").then(m => m["default"]),"/esbuild.spec.ts": () => import("../../esbuild.spec.ts?url&lang.ts").then(m => m["default"]),"/import.spec.ts": () => import("../../import.spec.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/a.ts": () => import("../fixture-b/a.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/b.ts": () => import("../fixture-b/b.ts?url&lang.ts").then(m => m["default"]),"/importGlob/fixture-b/index.ts": () => import("../fixture-b/index.ts?url&lang.ts").then(m => m["default"]),"/json.spec.ts": () => import("../../json.spec.ts?url&lang.ts").then(m => m["default"])
+export const rootMixedRelative = /* #__PURE__ */ Object.assign({"/fixture-b/a.ts": () => import("../fixture-b/a.ts?url&lang.ts").then(m => m["default"]),"/fixture-b/b.ts": () => import("../fixture-b/b.ts?url&lang.ts").then(m => m["default"]),"/fixture-b/index.ts": () => import("../fixture-b/index.ts?url&lang.ts").then(m => m["default"]),"/fixture.spec.ts": () => import("../fixture.spec.ts?url&lang.ts").then(m => m["default"]),"/parse.spec.ts": () => import("../parse.spec.ts?url&lang.ts").then(m => m["default"]),"/utils.spec.ts": () => import("../utils.spec.ts?url&lang.ts").then(m => m["default"])
 
 
 });

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture.spec.ts
@@ -1,15 +1,15 @@
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
 import { promises as fs } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { transformGlobImport } from '../../../plugins/importMetaGlob'
 import { transformWithEsbuild } from '../../../plugins/esbuild'
 
-const __dirname = resolve(fileURLToPath(import.meta.url), '..')
+const __dirname = resolve(dirname(fileURLToPath(import.meta.url)))
 
 describe('fixture', async () => {
   const resolveId = (id: string) => id
-  const root = resolve(__dirname, '..')
+  const root = __dirname
 
   it('transform', async () => {
     const id = resolve(__dirname, './fixture-a/index.ts')


### PR DESCRIPTION
### Description

Moved glob test root to reduce snapshot diff when adding unit tests for other plugins.

For example, #17589 adds `packages/vite/src/node/__tests__/plugins/terser.spec.ts` and that causes the glob test to fail: https://github.com/vitejs/vite/actions/runs/10749825079/job/29815203095#step:11:126
I think this is confusing for new contributors.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
