### PR TITLE
fix(build): declare `preload-helper` has no side effects

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -173,7 +173,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:build-import-analysis',
     resolveId(id) {
       if (id === preloadHelperId) {
-        return { id, moduleSideEffects: false }
+        return id
       }
     },
 
@@ -203,7 +203,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
               // is appended inside __vitePreload too.
               `function(dep) { return ${JSON.stringify(config.base)}+dep }`
         const preloadCode = `const scriptRel = ${scriptRel};const assetsURL = ${assetsURL};const seen = {};export const ${preloadMethod} = ${preload.toString()}`
-        return preloadCode
+        return { code: preloadCode, moduleSideEffects: false }
       }
     },
 

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -173,7 +173,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:build-import-analysis',
     resolveId(id) {
       if (id === preloadHelperId) {
-        return id
+        return { id, moduleSideEffects: false }
       }
     },
 
@@ -184,7 +184,7 @@ export function buildImportAnalysisPlugin(config: ResolvedConfig): Plugin {
         const scriptRel =
           modulePreload && modulePreload.polyfill
             ? `'modulepreload'`
-            : `(${detectScriptRel.toString()})()`
+            : `/* @__PURE__ */ (${detectScriptRel.toString()})()`
 
         // There are two different cases for the preload list format in __vitePreload
         //


### PR DESCRIPTION
### Description

When there's is at least one dynamic import and the modulePreload is false, it will introduce a `detectScriptRel` function. But when the content imported dynamically is unused, the `detectScriptRel` will not be tree-shaken.

Minimum reproductible set: https://stackblitz.com/edit/vitejs-vite-8iwu7r?file=src%2Fmain.ts

There is a `b.ts` which exports a `b`:

```typescript
export const b = 2;
```

And a `a.ts` which exports a `a` and a `b` that dynamically imports `b` from `b.ts`:

```typescript
export const a = 1;

export async function b() {
  const b = (await import('./b.ts')).b;
  return b;
}
```

Then only use `a` in entry `main.ts`.

```typescript
import { a } from './a.ts';

console.log(a);
```

Finally bundle it. It will present a IIFE of `detectScriptRel` in the product:

```typescript
(function detectScriptRel() {
  const relList = typeof document !== "undefined" && document.createElement("link").relList;
  return relList && relList.supports && relList.supports("modulepreload") ? "modulepreload" : "preload";
})();
const a = 1;
console.log(a);
```

And the config of vite is:

```typescript
import { defineConfig } from 'vite';

export default defineConfig({
  build: {
    minify: false,
    modulePreload: false,
  },
});
```