### PR TITLE
fix: allow scanning exports from `script module` in svelte

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -359,7 +359,8 @@ const srcRE = /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const typeRE = /\btype\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const langRE = /\blang\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const svelteScriptModuleRE =
-  /\bcontext\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))|\b(?<!=)(?<!['"])(module)\b(?!['"])(?![^>]+['"]\s*>)/i
+  /\bcontext\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
+const svelteModuleRE = /\s(module)\b/i
 
 function esbuildScanPlugin(
   environment: ScanEnvironment,
@@ -568,12 +569,11 @@ function esbuildScanPlugin(
             // star exports, we need to ignore exports in <script>
             if (p.endsWith('.svelte')) {
               const contextMatch = svelteScriptModuleRE.exec(openTag)
+              const moduleMatch = svelteModuleRE.exec(openTag)
               const context =
-                contextMatch &&
-                (contextMatch[1] ||
-                  contextMatch[2] ||
-                  contextMatch[3] ||
-                  contextMatch[4])
+                (contextMatch &&
+                  (contextMatch[1] || contextMatch[2] || contextMatch[3])) ||
+                (moduleMatch && moduleMatch[1])
 
               if (context !== 'module') {
                 addedImport = true

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -561,20 +561,27 @@ function esbuildScanPlugin(
 
             const virtualModulePath = JSON.stringify(virtualModulePrefix + key)
 
-            const contextMatch = contextRE.exec(openTag)
-            const context =
-              contextMatch &&
-              (contextMatch[1] ||
-                contextMatch[2] ||
-                contextMatch[3] ||
-                contextMatch[4])
+            let addedImport = false
 
             // Especially for Svelte files, exports in <script context="module"> means module exports,
             // exports in <script> means component props. To avoid having two same export name from the
             // star exports, we need to ignore exports in <script>
-            if (p.endsWith('.svelte') && context !== 'module') {
-              js += `import ${virtualModulePath}\n`
-            } else {
+            if (p.endsWith('.svelte')) {
+              const contextMatch = contextRE.exec(openTag)
+              const context =
+                contextMatch &&
+                (contextMatch[1] ||
+                  contextMatch[2] ||
+                  contextMatch[3] ||
+                  contextMatch[4])
+
+              if (context !== 'module') {
+                addedImport = true
+                js += `import ${virtualModulePath}\n`
+              }
+            }
+
+            if (!addedImport) {
               js += `export * from ${virtualModulePath}\n`
             }
           }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -360,7 +360,7 @@ const typeRE = /\btype\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const langRE = /\blang\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const svelteScriptModuleRE =
   /\bcontext\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
-const svelteModuleRE = /\s(module)\b/i
+const svelteModuleRE = /\smodule\b/i
 
 function esbuildScanPlugin(
   environment: ScanEnvironment,
@@ -573,7 +573,7 @@ function esbuildScanPlugin(
               const context =
                 (contextMatch &&
                   (contextMatch[1] || contextMatch[2] || contextMatch[3])) ||
-                (moduleMatch && moduleMatch[1])
+                moduleMatch
 
               if (context !== 'module') {
                 addedImport = true

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -563,7 +563,7 @@ function esbuildScanPlugin(
 
             let addedImport = false
 
-            // Especially for Svelte files, exports in <script context="module"> means module exports,
+            // For Svelte files, exports in <script context="module"> or <script module> means module exports,
             // exports in <script> means component props. To avoid having two same export name from the
             // star exports, we need to ignore exports in <script>
             if (p.endsWith('.svelte')) {

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -568,14 +568,16 @@ function esbuildScanPlugin(
             // exports in <script> means component props. To avoid having two same export name from the
             // star exports, we need to ignore exports in <script>
             if (p.endsWith('.svelte')) {
-              const contextMatch = svelteScriptModuleRE.exec(openTag)
-              const moduleMatch = svelteModuleRE.exec(openTag)
-              const context =
-                (contextMatch &&
-                  (contextMatch[1] || contextMatch[2] || contextMatch[3])) ||
-                moduleMatch
-
-              if (context !== 'module') {
+              let isModule = svelteModuleRE.test(openTag) // test for svelte5 <script module> syntax
+              if (!isModule) {
+                // fallback, test for svelte4 <script context="module"> syntax
+                const contextMatch = svelteScriptModuleRE.exec(openTag)
+                const context =
+                  contextMatch &&
+                  (contextMatch[1] || contextMatch[2] || contextMatch[3])
+                isModule = context === 'module'
+              }
+              if (!isModule) {
                 addedImport = true
                 js += `import ${virtualModulePath}\n`
               }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -358,7 +358,7 @@ export const commentRE = /<!--.*?-->/gs
 const srcRE = /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const typeRE = /\btype\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const langRE = /\blang\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
-const contextRE =
+const svelteScriptModuleRE =
   /\bcontext\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))|\b(?<!=)(?<!['"])(module)\b(?!['"])(?![^>]+['"]\s*>)/i
 
 function esbuildScanPlugin(
@@ -567,7 +567,7 @@ function esbuildScanPlugin(
             // exports in <script> means component props. To avoid having two same export name from the
             // star exports, we need to ignore exports in <script>
             if (p.endsWith('.svelte')) {
-              const contextMatch = contextRE.exec(openTag)
+              const contextMatch = svelteScriptModuleRE.exec(openTag)
               const context =
                 contextMatch &&
                 (contextMatch[1] ||

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -358,7 +358,8 @@ export const commentRE = /<!--.*?-->/gs
 const srcRE = /\bsrc\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const typeRE = /\btype\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
 const langRE = /\blang\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
-const contextRE = /\bcontext\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))/i
+const contextRE =
+  /\bcontext\s*=\s*(?:"([^"]+)"|'([^']+)'|([^\s'">]+))|\b(?<!=)(?<!['"])(module)\b(?!['"])(?![^>]+['"]\s*>)/i
 
 function esbuildScanPlugin(
   environment: ScanEnvironment,
@@ -563,7 +564,10 @@ function esbuildScanPlugin(
             const contextMatch = contextRE.exec(openTag)
             const context =
               contextMatch &&
-              (contextMatch[1] || contextMatch[2] || contextMatch[3])
+              (contextMatch[1] ||
+                contextMatch[2] ||
+                contextMatch[3] ||
+                contextMatch[4])
 
             // Especially for Svelte files, exports in <script context="module"> means module exports,
             // exports in <script> means component props. To avoid having two same export name from the


### PR DESCRIPTION
### Description

Svelte 5 recently changed the old

```svelte
<script context="module">
```

with a shorter

```svelte
<script module>
```

However the scanner for dependencies uses a regex to find the exports in a svelte script module. This meant that stuff exported from `<script module>` [were not found](https://github.com/sveltejs/svelte/issues/13039).

Curiously the app actually worked fine but esbuild is throwing an error for a missing dependency and that could throw off some people (also maybe there are some side effects to this error that i'm missing).

### What i did

I ended up modifying the current regex to include also check for `module`. The regex looks a bit more complex because it handles the case where users might have something like

```svelte
<script stuff="module">
```
maybe it's a stupid concern but i would say better be safe than sorry. If you think a single regex is too complex to parse for contributors we can split the checks in two and run `test` twice, up to you.

### Tests

I was not able to think of a way to test this but we plan to add a test for this in ecosystem ci directly in `vite-plugin-svelte` cc @dominikg 