### PR TITLE
fix: backport #17997, ensure req.url matches moduleByEtag URL to avoid incorrect 304

### DIFF
--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -52,7 +52,10 @@ export function cachedTransformMiddleware(
     const ifNoneMatch = req.headers['if-none-match']
     if (ifNoneMatch) {
       const moduleByEtag = server.moduleGraph.getModuleByEtag(ifNoneMatch)
-      if (moduleByEtag?.transformResult?.etag === ifNoneMatch) {
+      if (
+        moduleByEtag?.transformResult?.etag === ifNoneMatch &&
+        moduleByEtag?.url === req.url
+      ) {
         // For CSS requests, if the same CSS file is imported in a module,
         // the browser sends the request for the direct CSS request with the etag
         // from the imported CSS module. We ignore the etag in this case.


### PR DESCRIPTION
- https://github.com/vitejs/vite/pull/17997
