### PR TITLE
fix: fix incorrect environment consumer option resolution

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -641,7 +641,7 @@ function resolveEnvironmentOptions(
   )
   const isClientEnvironment = environmentName === 'client'
   const consumer =
-    (options.consumer ?? isClientEnvironment) ? 'client' : 'server'
+    options.consumer ?? (isClientEnvironment ? 'client' : 'server')
   return {
     resolve,
     consumer,


### PR DESCRIPTION
### Description

In the `resolveEnvironmentOptions` function there seem to be an expression that incorrectly resolves environment `consumer` options set to `server` to `client` instead:
![Screenshot 2024-09-11 at 12 32 32](https://github.com/user-attachments/assets/ec61a703-f370-4832-bc43-82cc1b2ee9e9)

This PR addresses this issue

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
