### PR TITLE
feat: expose `EnvironmentOptions` type

### DIFF
--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -53,6 +53,7 @@ export type {
   UserConfigFn,
   UserConfigFnObject,
   UserConfigFnPromise,
+  EnvironmentOptions,
   DevEnvironmentOptions,
   ResolvedDevEnvironmentOptions,
 } from './config'


### PR DESCRIPTION
### Description

As an environment author I might like to implement a factory function like:
```ts
export function createMyEnvironment(
  options: ...
) {
  return {
    dev: {
      ...
    },
    build: {
      ...
    },
    ...
  };
}
```
([example](https://github.com/dario-piotrowicz/vite-environment-6.0.0-alpha-experimentations/blob/36817cc8442e9063dd20dcbfd3b03354168bc6ac/packages/vite-environment-provider-cloudflare/src/index.ts#L118-L140))

The problem here would be that no type checking nor autocompletion would be applied to the return type, so I might need to manually type `dev`, `build` etc... if I want to have type checking/autocompletion there (for example in my [example](https://github.com/dario-piotrowicz/vite-environment-6.0.0-alpha-experimentations/blob/36817cc8442e9063dd20dcbfd3b03354168bc6ac/packages/vite-environment-provider-cloudflare/src/index.ts#L118-L140) notice how I had to set the `createEnvironment` arguments and return types).

There are also fields on the top environment object that I'd like to have types for too, such as [`consumer`](https://github.com/vitejs/vite/blob/587ad7b17beba50279eaf46b06c5bf5559c4f36e/packages/vite/src/node/config.ts#L249).

So I think it would be pretty convenient to expose the `EnvironmentOptions` type to vite users.

I am not sure if this was simply missed or exposing this type was considered but not done on purpose for some reason, I figured I could just open this PR and see what you guys say 🙂

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
