### PR TITLE
fix(config): treat all files as ESM on deno

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1508,7 +1508,8 @@ export async function loadConfigFromFile(
     return null
   }
 
-  const isESM = isFilePathESM(resolvedPath)
+  const isESM =
+    typeof process.versions.deno === 'string' || isFilePathESM(resolvedPath)
 
   try {
     const bundled = await bundleConfigFile(resolvedPath, isESM)


### PR DESCRIPTION
### Description

The CJS detection logic that checks whether the CJS entry of vite itself is used is based around `package.json` detection. With Deno this assumption is not true anymore as most Deno projects don't have a `package.json` file. Instead they either have a `deno.json` or a `deno.jsonc` file. Projects in Deno are always in ESM too.

When using vite in Deno you'd always see this warning unless you added a `package.json` with `type: module`:

<img width="785" alt="Screenshot 2024-09-11 at 14 48 08" src="https://github.com/user-attachments/assets/43f6d560-0b27-46be-8c7a-4c153ab35738">

Ultimately, this is caused by the check here https://github.com/vitejs/vite/blob/35cf59c9d53ef544eb5f2fe2f9ff4d6cb225e63b/packages/vite/src/node/utils.ts#L430

Which infers that the current project is in CJS. This PR addresses that by making vite aware of Deno projects. When running inside Deno, we'll not just check for `package.json`, but also `deno.json` and `deno.jsonc` too.

<img width="788" alt="Screenshot 2024-09-11 at 14 50 53" src="https://github.com/user-attachments/assets/7a2a80e3-5829-4f55-b5a8-8eac0c81dfc7">

I'm not too familiar with the testing setup here in vite and would need some pointers for adding a test. Where do these go here?

Fixes https://github.com/denoland/deno/issues/25574