### PR TITLE
fix(vite)!: refactor "module cache" to "evaluated modules", pass down module to "runInlinedModule"

### DIFF
--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -704,7 +704,7 @@ export interface ModuleRunnerOptions {
   /**
    * Custom module cache. If not provided, it creates a separate module cache for each module runner instance.
    */
-  moduleGraph?: ModuleRunnerGraph
+  evaluatedModules?: EvaluatedModules
 }
 ```
 

--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -644,7 +644,7 @@ export class ModuleRunner {
 
 The module evaluator in `ModuleRunner` is responsible for executing the code. Vite exports `ESModulesEvaluator` out of the box, it uses `new AsyncFunction` to evaluate the code. You can provide your own implementation if your JavaScript runtime doesn't support unsafe evaluation.
 
-Module runner exposes `import` method. When Vite server triggers `full-reload` HMR event, all affected modules will be re-executed. Be aware that Module Runner doesn't update `exports` object when this happens (it overrides it), you would need to run `import` or get the module from `moduleCache` again if you rely on having the latest `exports` object.
+Module runner exposes `import` method. When Vite server triggers `full-reload` HMR event, all affected modules will be re-executed. Be aware that Module Runner doesn't update `exports` object when this happens (it overrides it), you would need to run `import` or get the module from `moduleGraph` again if you rely on having the latest `exports` object.
 
 **Example Usage:**
 
@@ -704,7 +704,7 @@ export interface ModuleRunnerOptions {
   /**
    * Custom module cache. If not provided, it creates a separate module cache for each module runner instance.
    */
-  moduleCache?: ModuleCacheMap
+  moduleGraph?: ModuleRunnerGraph
 }
 ```
 

--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -644,7 +644,7 @@ export class ModuleRunner {
 
 The module evaluator in `ModuleRunner` is responsible for executing the code. Vite exports `ESModulesEvaluator` out of the box, it uses `new AsyncFunction` to evaluate the code. You can provide your own implementation if your JavaScript runtime doesn't support unsafe evaluation.
 
-Module runner exposes `import` method. When Vite server triggers `full-reload` HMR event, all affected modules will be re-executed. Be aware that Module Runner doesn't update `exports` object when this happens (it overrides it), you would need to run `import` or get the module from `moduleGraph` again if you rely on having the latest `exports` object.
+Module runner exposes `import` method. When Vite server triggers `full-reload` HMR event, all affected modules will be re-executed. Be aware that Module Runner doesn't update `exports` object when this happens (it overrides it), you would need to run `import` or get the module from `evaluatedModules` again if you rely on having the latest `exports` object.
 
 **Example Usage:**
 

--- a/packages/vite/src/module-runner/evaluatedModules.ts
+++ b/packages/vite/src/module-runner/evaluatedModules.ts
@@ -8,7 +8,7 @@ const MODULE_RUNNER_SOURCEMAPPING_REGEXP = new RegExp(
   `//# ${SOURCEMAPPING_URL}=data:application/json;base64,(.+)`,
 )
 
-export class ModuleRunnerNode {
+export class EvaluatedModuleNode {
   public importers = new Set<string>()
   public imports = new Set<string>()
   public evaluated = false
@@ -26,10 +26,10 @@ export class ModuleRunnerNode {
   }
 }
 
-export class ModuleRunnerGraph {
-  public readonly idToModuleMap = new Map<string, ModuleRunnerNode>()
-  public readonly fileToModulesMap = new Map<string, Set<ModuleRunnerNode>>()
-  public readonly urlToIdModuleMap = new Map<string, ModuleRunnerNode>()
+export class EvaluatedModules {
+  public readonly idToModuleMap = new Map<string, EvaluatedModuleNode>()
+  public readonly fileToModulesMap = new Map<string, Set<EvaluatedModuleNode>>()
+  public readonly urlToIdModuleMap = new Map<string, EvaluatedModuleNode>()
 
   /**
    * Returns the module node by the resolved module ID. Usually, module ID is
@@ -38,7 +38,7 @@ export class ModuleRunnerGraph {
    * Module runner graph will have 1 to 1 mapping with the server module graph.
    * @param id Resolved module ID
    */
-  public getModuleById(id: string): ModuleRunnerNode | undefined {
+  public getModuleById(id: string): EvaluatedModuleNode | undefined {
     return this.idToModuleMap.get(id)
   }
 
@@ -48,7 +48,7 @@ export class ModuleRunnerGraph {
    * multiple modules for the same file.
    * @param file The file system path of the module
    */
-  public getModulesByFile(file: string): Set<ModuleRunnerNode> | undefined {
+  public getModulesByFile(file: string): Set<EvaluatedModuleNode> | undefined {
     return this.fileToModulesMap.get(file)
   }
 
@@ -57,7 +57,7 @@ export class ModuleRunnerGraph {
    * Unlike module graph on the server, the URL is not resolved and is used as is.
    * @param url Server URL that was used in the import statement
    */
-  public getModuleByUrl(url: string): ModuleRunnerNode | undefined {
+  public getModuleByUrl(url: string): EvaluatedModuleNode | undefined {
     return this.urlToIdModuleMap.get(unwrapId(url))
   }
 
@@ -68,14 +68,14 @@ export class ModuleRunnerGraph {
    * @param id Resolved module ID
    * @param url URL that was used in the import statement
    */
-  public ensureModule(id: string, url: string): ModuleRunnerNode {
+  public ensureModule(id: string, url: string): EvaluatedModuleNode {
     id = normalizeModuleId(id)
     if (this.idToModuleMap.has(id)) {
       const moduleNode = this.idToModuleMap.get(id)!
       this.urlToIdModuleMap.set(url, moduleNode)
       return moduleNode
     }
-    const moduleNode = new ModuleRunnerNode(id, url)
+    const moduleNode = new EvaluatedModuleNode(id, url)
     this.idToModuleMap.set(id, moduleNode)
     this.urlToIdModuleMap.set(url, moduleNode)
 
@@ -85,7 +85,7 @@ export class ModuleRunnerGraph {
     return moduleNode
   }
 
-  public invalidateModule(node: ModuleRunnerNode): void {
+  public invalidateModule(node: EvaluatedModuleNode): void {
     node.evaluated = false
     node.meta = undefined
     node.map = undefined

--- a/packages/vite/src/module-runner/evaluatedModules.ts
+++ b/packages/vite/src/module-runner/evaluatedModules.ts
@@ -95,7 +95,7 @@ export class EvaluatedModules {
     // don't remove the importers because otherwise it will be empty after evaluation
     // this can create a bug when file was removed but it still triggers full-reload
     // we are fine with the bug for now because it's not a common case
-    node.imports?.clear()
+    node.imports.clear()
   }
 
   /**
@@ -103,7 +103,7 @@ export class EvaluatedModules {
    * source map. If the source map is not inlined, it will return null.
    * @param id Resolved module ID
    */
-  getModuleSourceMapById(id: string): null | DecodedMap {
+  getModuleSourceMapById(id: string): DecodedMap | null {
     const mod = this.getModuleById(id)
     if (!mod) return null
     if (mod.map) return mod.map
@@ -112,8 +112,7 @@ export class EvaluatedModules {
       mod.meta.code,
     )?.[1]
     if (!mapString) return null
-    const baseFile = mod.file
-    mod.map = new DecodedMap(JSON.parse(decodeBase64(mapString)), baseFile)
+    mod.map = new DecodedMap(JSON.parse(decodeBase64(mapString)), mod.file)
     return mod.map
   }
 

--- a/packages/vite/src/module-runner/hmrHandler.ts
+++ b/packages/vite/src/module-runner/hmrHandler.ts
@@ -122,7 +122,7 @@ class Queue {
 
 function getModulesByFile(runner: ModuleRunner, file: string) {
   const modules: string[] = []
-  for (const [_, mod] of runner.moduleGraph.idToModuleMap.entries()) {
+  for (const mod of runner.moduleGraph.idToModuleMap.values()) {
     if (mod.meta && 'file' in mod.meta && mod.meta.file === file) {
       modules.push(mod.url)
     }
@@ -158,7 +158,7 @@ function findAllEntrypoints(
   runner: ModuleRunner,
   entrypoints = new Set<string>(),
 ): Set<string> {
-  for (const [_, mod] of runner.moduleGraph.idToModuleMap.entries()) {
+  for (const mod of runner.moduleGraph.idToModuleMap.values()) {
     if (mod.importers && !mod.importers.size) {
       entrypoints.add(mod.url)
     }

--- a/packages/vite/src/module-runner/hmrHandler.ts
+++ b/packages/vite/src/module-runner/hmrHandler.ts
@@ -54,7 +54,7 @@ export async function handleHotPayload(
 
       hmrClient.logger.debug(`program reload`)
       await hmrClient.notifyListeners('vite:beforeFullReload', payload)
-      runner.moduleGraph.clear()
+      runner.evaluatedModules.clear()
 
       for (const url of clearEntrypointUrls) {
         await runner.import(url)
@@ -121,7 +121,7 @@ class Queue {
 }
 
 function getModulesByFile(runner: ModuleRunner, file: string): string[] {
-  const nodes = runner.moduleGraph.getModulesByFile(file)
+  const nodes = runner.evaluatedModules.getModulesByFile(file)
   if (!nodes) {
     return []
   }
@@ -137,7 +137,7 @@ function getModulesEntrypoints(
   for (const moduleId of modules) {
     if (visited.has(moduleId)) continue
     visited.add(moduleId)
-    const module = runner.moduleGraph.getModuleById(moduleId)
+    const module = runner.evaluatedModules.getModuleById(moduleId)
     if (!module) {
       continue
     }
@@ -156,7 +156,7 @@ function findAllEntrypoints(
   runner: ModuleRunner,
   entrypoints = new Set<string>(),
 ): Set<string> {
-  for (const mod of runner.moduleGraph.idToModuleMap.values()) {
+  for (const mod of runner.evaluatedModules.idToModuleMap.values()) {
     if (mod.importers && !mod.importers.size) {
       entrypoints.add(mod.url)
     }

--- a/packages/vite/src/module-runner/hmrHandler.ts
+++ b/packages/vite/src/module-runner/hmrHandler.ts
@@ -122,9 +122,9 @@ class Queue {
 
 function getModulesByFile(runner: ModuleRunner, file: string) {
   const modules: string[] = []
-  for (const [id, mod] of runner.moduleGraph.idToModuleMap.entries()) {
+  for (const [_, mod] of runner.moduleGraph.idToModuleMap.entries()) {
     if (mod.meta && 'file' in mod.meta && mod.meta.file === file) {
-      modules.push(id)
+      modules.push(mod.url)
     }
   }
   return modules
@@ -144,7 +144,7 @@ function getModulesEntrypoints(
       continue
     }
     if (module.importers && !module.importers.size) {
-      entrypoints.add(moduleId)
+      entrypoints.add(module.url)
       continue
     }
     for (const importer of module.importers || []) {
@@ -158,9 +158,9 @@ function findAllEntrypoints(
   runner: ModuleRunner,
   entrypoints = new Set<string>(),
 ): Set<string> {
-  for (const [id, mod] of runner.moduleGraph.idToModuleMap.entries()) {
+  for (const [_, mod] of runner.moduleGraph.idToModuleMap.entries()) {
     if (mod.importers && !mod.importers.size) {
-      entrypoints.add(id)
+      entrypoints.add(mod.url)
     }
   }
   return entrypoints

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -1,6 +1,6 @@
 // this file should re-export only things that don't rely on Node.js or other runner features
 
-export { ModuleCacheMap } from './moduleCache'
+export { ModuleRunnerGraph, type ModuleRunnerNode } from './moduleCache'
 export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 export { RemoteRunnerTransport } from './runnerTransport'
@@ -10,7 +10,6 @@ export type { HMRLogger, HMRConnection } from '../shared/hmr'
 export type {
   ModuleEvaluator,
   ModuleRunnerContext,
-  ModuleCache,
   FetchResult,
   FetchFunction,
   FetchFunctionOptions,

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -1,6 +1,6 @@
 // this file should re-export only things that don't rely on Node.js or other runner features
 
-export { ModuleRunnerGraph, type ModuleRunnerNode } from './moduleCache'
+export { EvaluatedModules, type EvaluatedModuleNode } from './evaluatedModules'
 export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 export { RemoteRunnerTransport } from './runnerTransport'

--- a/packages/vite/src/module-runner/moduleCache.ts
+++ b/packages/vite/src/module-runner/moduleCache.ts
@@ -105,47 +105,6 @@ export class ModuleRunnerGraph {
     this.idToModuleMap.clear()
     this.fileToModuleMap.clear()
   }
-
-  /**
-   * Invalidate modules that dependent on the given modules, up to the main entry
-   */
-  invalidateDepTree(
-    ids: string[] | Set<string>,
-    invalidated = new Set<string>(),
-  ): Set<string> {
-    for (const _id of ids) {
-      const id = normalizeModuleId(_id)
-      if (invalidated.has(id)) continue
-      invalidated.add(id)
-      const mod = this.getModuleById(id)
-      if (mod?.importers) this.invalidateDepTree(mod.importers, invalidated)
-      if (mod) this.invalidateModule(mod)
-    }
-    return invalidated
-  }
-
-  /**
-   * Invalidate dependency modules of the given modules, down to the bottom-level dependencies
-   */
-  invalidateSubDepTree(
-    ids: string[] | Set<string>,
-    invalidated = new Set<string>(),
-  ): Set<string> {
-    for (const _id of ids) {
-      const id = normalizeModuleId(_id)
-      if (invalidated.has(id)) continue
-      invalidated.add(id)
-      const subIds = Array.from(this.idToModuleMap.entries())
-        .filter(([, mod]) => mod.importers?.has(id))
-        .map(([key]) => key)
-      if (subIds.length) {
-        this.invalidateSubDepTree(subIds, invalidated)
-      }
-      const mod = this.getModuleById(id)
-      if (mod) this.invalidateModule(mod)
-    }
-    return invalidated
-  }
 }
 
 // unique id that is not available as "$bare_import" like "test"

--- a/packages/vite/src/module-runner/moduleCache.ts
+++ b/packages/vite/src/module-runner/moduleCache.ts
@@ -29,7 +29,7 @@ export class ModuleRunnerNode {
     public id: string,
     public url: string,
   ) {
-    this.file = cleanUrl(url)
+    this.file = cleanUrl(id)
   }
 }
 

--- a/packages/vite/src/module-runner/moduleCache.ts
+++ b/packages/vite/src/module-runner/moduleCache.ts
@@ -11,7 +11,6 @@ const MODULE_RUNNER_SOURCEMAPPING_REGEXP = new RegExp(
 export class ModuleRunnerNode {
   public importers = new Set<string>()
   public imports = new Set<string>()
-  public lastInvalidationTimestamp = 0
   public evaluated = false
   public meta: ResolvedResult | undefined
   public promise: Promise<any> | undefined

--- a/packages/vite/src/module-runner/moduleCache.ts
+++ b/packages/vite/src/module-runner/moduleCache.ts
@@ -49,8 +49,8 @@ export class ModuleRunnerGraph {
    * multiple modules for the same file.
    * @param file The file system path of the module
    */
-  public getModulesByFile(file: string): Set<ModuleRunnerNode> {
-    return this.fileToModulesMap.get(file) || new Set()
+  public getModulesByFile(file: string): Set<ModuleRunnerNode> | undefined {
+    return this.fileToModulesMap.get(file)
   }
 
   /**

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -36,15 +36,9 @@ interface ModuleRunnerDebugger {
 }
 
 export class ModuleRunner {
-  /**
-   * Holds the cache of modules
-   * Keys of the map are ids
-   */
   public moduleGraph: ModuleRunnerGraph
   public hmrClient?: HMRClient
 
-  // private readonly urlToIdMap = new Map<string, string>()
-  // private readonly fileToIdMap = new Map<string, string[]>()
   private readonly envProxy = new Proxy({} as any, {
     get(_, p) {
       throw new Error(
@@ -129,9 +123,9 @@ export class ModuleRunner {
     if (!('externalize' in fetchResult)) {
       return exports
     }
-    const { url: id, type } = fetchResult
+    const { url, type } = fetchResult
     if (type !== 'module' && type !== 'commonjs') return exports
-    analyzeImportedModDifference(exports, id, type, metadata)
+    analyzeImportedModDifference(exports, url, type, metadata)
     return exports
   }
 
@@ -229,10 +223,9 @@ export class ModuleRunner {
   ): Promise<ModuleRunnerNode> {
     url = normalizeAbsoluteUrl(url, this.root)
 
-    const cachedModule = this.moduleGraph.getModuleById(url)
-
     let cached = this.moduleInfoCache.get(url)
     if (!cached) {
+      const cachedModule = this.moduleGraph.getModuleByUrl(url)
       cached = this.getModuleInformation(url, importer, cachedModule).finally(
         () => {
           this.moduleInfoCache.delete(url)

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -1,10 +1,10 @@
 import type { ViteHotContext } from 'types/hot'
 import { HMRClient, HMRContext } from '../shared/hmr'
-import { cleanUrl, isPrimitive, isWindows, unwrapId } from '../shared/utils'
+import { cleanUrl, isPrimitive, isWindows } from '../shared/utils'
 import { analyzeImportedModDifference } from '../shared/ssrTransform'
-import { ModuleCacheMap } from './moduleCache'
+import type { ModuleRunnerNode } from './moduleCache'
+import { ModuleRunnerGraph } from './moduleCache'
 import type {
-  ModuleCache,
   ModuleEvaluator,
   ModuleRunnerContext,
   ModuleRunnerImportMeta,
@@ -40,11 +40,11 @@ export class ModuleRunner {
    * Holds the cache of modules
    * Keys of the map are ids
    */
-  public moduleCache: ModuleCacheMap
+  public moduleGraph: ModuleRunnerGraph
   public hmrClient?: HMRClient
 
-  private readonly urlToIdMap = new Map<string, string>()
-  private readonly fileToIdMap = new Map<string, string[]>()
+  // private readonly urlToIdMap = new Map<string, string>()
+  // private readonly fileToIdMap = new Map<string, string[]>()
   private readonly envProxy = new Proxy({} as any, {
     get(_, p) {
       throw new Error(
@@ -55,7 +55,10 @@ export class ModuleRunner {
   private readonly transport: RunnerTransport
   private readonly resetSourceMapSupport?: () => void
   private readonly root: string
-  private readonly moduleInfoCache = new Map<string, Promise<ModuleCache>>()
+  private readonly moduleInfoCache = new Map<
+    string,
+    Promise<ModuleRunnerNode>
+  >()
 
   private destroyed = false
 
@@ -66,7 +69,8 @@ export class ModuleRunner {
   ) {
     const root = this.options.root
     this.root = root[root.length - 1] === '/' ? root : `${root}/`
-    this.moduleCache = options.moduleCache ?? new ModuleCacheMap(options.root)
+    this.moduleGraph =
+      options.moduleGraph ?? new ModuleRunnerGraph(options.root)
     this.transport = options.transport
     if (typeof options.hmr === 'object') {
       this.hmrClient = new HMRClient(
@@ -95,8 +99,7 @@ export class ModuleRunner {
    * Clear all caches including HMR listeners.
    */
   public clearCache(): void {
-    this.moduleCache.clear()
-    this.urlToIdMap.clear()
+    this.moduleGraph.clear()
     this.hmrClient?.clear()
   }
 
@@ -132,7 +135,7 @@ export class ModuleRunner {
     return exports
   }
 
-  private isCircularModule(mod: Required<ModuleCache>) {
+  private isCircularModule(mod: ModuleRunnerNode) {
     for (const importedFile of mod.imports) {
       if (mod.importers.has(importedFile)) {
         return true
@@ -154,10 +157,9 @@ export class ModuleRunner {
       if (importer === moduleUrl) {
         return true
       }
-      const mod = this.moduleCache.getByModuleId(
-        importer,
-      ) as Required<ModuleCache>
+      const mod = this.moduleGraph.getModuleById(importer)
       if (
+        mod &&
         mod.importers.size &&
         this.isCircularImport(mod.importers, moduleUrl, visited)
       ) {
@@ -168,14 +170,13 @@ export class ModuleRunner {
   }
 
   private async cachedRequest(
-    id: string,
-    mod_: ModuleCache,
+    url: string,
+    mod: ModuleRunnerNode,
     callstack: string[] = [],
     metadata?: SSRImportMetadata,
   ): Promise<any> {
-    const mod = mod_ as Required<ModuleCache>
     const meta = mod.meta!
-    const moduleUrl = meta.url
+    const moduleId = meta.id
 
     const { importers } = mod
 
@@ -185,9 +186,9 @@ export class ModuleRunner {
 
     // check circular dependency
     if (
-      callstack.includes(moduleUrl) ||
+      callstack.includes(moduleId) ||
       this.isCircularModule(mod) ||
-      this.isCircularImport(importers, moduleUrl)
+      this.isCircularImport(importers, moduleId)
     ) {
       if (mod.exports) return this.processImport(mod.exports, meta, metadata)
     }
@@ -196,13 +197,13 @@ export class ModuleRunner {
     if (this.debug) {
       debugTimer = setTimeout(() => {
         const getStack = () =>
-          `stack:\n${[...callstack, moduleUrl]
+          `stack:\n${[...callstack, moduleId]
             .reverse()
             .map((p) => `  - ${p}`)
             .join('\n')}`
 
         this.debug!(
-          `[module runner] module ${moduleUrl} takes over 2s to load.\n${getStack()}`,
+          `[module runner] module ${moduleId} takes over 2s to load.\n${getStack()}`,
         )
       }, 2000)
     }
@@ -212,7 +213,7 @@ export class ModuleRunner {
       if (mod.promise)
         return this.processImport(await mod.promise, meta, metadata)
 
-      const promise = this.directRequest(id, mod, callstack)
+      const promise = this.directRequest(url, mod, callstack)
       mod.promise = promise
       mod.evaluated = false
       return this.processImport(await promise, meta, metadata)
@@ -222,14 +223,13 @@ export class ModuleRunner {
     }
   }
 
-  private async cachedModule(url: string, importer?: string) {
+  private async cachedModule(
+    url: string,
+    importer?: string,
+  ): Promise<ModuleRunnerNode> {
     url = normalizeAbsoluteUrl(url, this.root)
 
-    const normalized = this.urlToIdMap.get(url)
-    let cachedModule = normalized && this.moduleCache.getByModuleId(normalized)
-    if (!cachedModule) {
-      cachedModule = this.moduleCache.getByModuleId(url)
-    }
+    const cachedModule = this.moduleGraph.getModuleById(url)
 
     let cached = this.moduleInfoCache.get(url)
     if (!cached) {
@@ -249,8 +249,8 @@ export class ModuleRunner {
   private async getModuleInformation(
     url: string,
     importer: string | undefined,
-    cachedModule: ModuleCache | undefined,
-  ): Promise<ModuleCache> {
+    cachedModule: ModuleRunnerNode | undefined,
+  ): Promise<ModuleRunnerNode> {
     if (this.destroyed) {
       throw new Error(`Vite module runner has been destroyed.`)
     }
@@ -277,60 +277,48 @@ export class ModuleRunner {
       return cachedModule
     }
 
-    // base moduleId on "file" and not on id
-    // if `import(variable)` is called it's possible that it doesn't have an extension for example
-    // if we used id for that, then a module will be duplicated
-    const idQuery = url.split('?')[1]
-    const query = idQuery ? `?${idQuery}` : ''
-    const file = 'file' in fetchedModule ? fetchedModule.file : undefined
-    const fileId = file ? `${file}${query}` : url
-    const moduleUrl = this.moduleCache.normalize(fileId)
-    const mod = this.moduleCache.getByModuleId(moduleUrl)
+    const moduleId =
+      'externalize' in fetchedModule
+        ? fetchedModule.externalize
+        : fetchedModule.id
+    const moduleUrl = 'url' in fetchedModule ? fetchedModule.url : url
+    const module = this.moduleGraph.ensureModule(moduleId, moduleUrl)
 
     if ('invalidate' in fetchedModule && fetchedModule.invalidate) {
-      this.moduleCache.invalidateModule(mod)
+      this.moduleGraph.invalidateModule(module)
     }
 
     fetchedModule.url = moduleUrl
-    mod.meta = fetchedModule
+    fetchedModule.id = moduleId
+    module.meta = fetchedModule
 
-    if (file) {
-      const fileModules = this.fileToIdMap.get(file) || []
-      fileModules.push(moduleUrl)
-      this.fileToIdMap.set(file, fileModules)
-    }
-
-    this.urlToIdMap.set(url, moduleUrl)
-    this.urlToIdMap.set(unwrapId(url), moduleUrl)
-    return mod
+    return module
   }
 
   // override is allowed, consider this a public API
   protected async directRequest(
-    id: string,
-    mod: ModuleCache,
+    url: string,
+    mod: ModuleRunnerNode,
     _callstack: string[],
   ): Promise<any> {
     const fetchResult = mod.meta!
-    const moduleUrl = fetchResult.url
-    const callstack = [..._callstack, moduleUrl]
+    const moduleId = fetchResult.id
+    const callstack = [..._callstack, moduleId]
 
     const request = async (dep: string, metadata?: SSRImportMetadata) => {
-      const importer = ('file' in fetchResult && fetchResult.file) || moduleUrl
-      const fetchedModule = await this.cachedModule(dep, importer)
-      const resolvedId = fetchedModule.meta!.url
-      const depMod = this.moduleCache.getByModuleId(resolvedId)
-      depMod.importers!.add(moduleUrl)
-      mod.imports!.add(resolvedId)
+      const importer = ('file' in fetchResult && fetchResult.file) || moduleId
+      const depMod = await this.cachedModule(dep, importer)
+      depMod.importers!.add(moduleId)
+      mod.imports!.add(depMod.id)
 
-      return this.cachedRequest(dep, fetchedModule, callstack, metadata)
+      return this.cachedRequest(dep, depMod, callstack, metadata)
     }
 
     const dynamicRequest = async (dep: string) => {
       // it's possible to provide an object with toString() method inside import()
       dep = String(dep)
       if (dep[0] === '.') {
-        dep = posixResolve(posixDirname(id), dep)
+        dep = posixResolve(posixDirname(url), dep)
       }
       return request(dep, { isDynamicImport: true })
     }
@@ -348,13 +336,13 @@ export class ModuleRunner {
     if (code == null) {
       const importer = callstack[callstack.length - 2]
       throw new Error(
-        `[module runner] Failed to load "${id}"${
+        `[module runner] Failed to load "${url}"${
           importer ? ` imported from ${importer}` : ''
         }`,
       )
     }
 
-    const modulePath = cleanUrl(file || moduleUrl)
+    const modulePath = cleanUrl(file || moduleId)
     // disambiguate the `<UNIT>:/` on windows: see nodejs/node#31710
     const href = posixPathToFileHref(modulePath)
     const filename = modulePath
@@ -391,8 +379,8 @@ export class ModuleRunner {
           if (!this.hmrClient) {
             throw new Error(`[module runner] HMR client was destroyed.`)
           }
-          this.debug?.('[module runner] creating hmr context for', moduleUrl)
-          hotContext ||= new HMRContext(this.hmrClient, moduleUrl)
+          this.debug?.('[module runner] creating hmr context for', moduleId)
+          hotContext ||= new HMRContext(this.hmrClient, moduleId)
           return hotContext
         },
         set: (value) => {
@@ -411,7 +399,7 @@ export class ModuleRunner {
 
     this.debug?.('[module runner] executing', href)
 
-    await this.evaluator.runInlinedModule(context, code, id)
+    await this.evaluator.runInlinedModule(context, code, url)
 
     return exports
   }

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -361,6 +361,12 @@ export class ModuleRunner {
       glob() {
         throw new Error('[module runner] "import.meta.glob" is not supported.')
       },
+
+      // TODO: this is a proposal to start a discussion
+      environment: {
+        module: mod,
+        moduleGraph: this.moduleGraph,
+      },
     }
     const exports = Object.create(null)
     Object.defineProperty(exports, Symbol.toStringTag, {

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -354,12 +354,6 @@ export class ModuleRunner {
       glob() {
         throw new Error('[module runner] "import.meta.glob" is not supported.')
       },
-
-      // TODO: this is a proposal to start a discussion
-      environment: {
-        module: mod,
-        moduleGraph: this.moduleGraph,
-      },
     }
     const exports = Object.create(null)
     Object.defineProperty(exports, Symbol.toStringTag, {

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -385,8 +385,8 @@ export class ModuleRunner {
           if (!this.hmrClient) {
             throw new Error(`[module runner] HMR client was destroyed.`)
           }
-          this.debug?.('[module runner] creating hmr context for', moduleId)
-          hotContext ||= new HMRContext(this.hmrClient, moduleId)
+          this.debug?.('[module runner] creating hmr context for', mod.url)
+          hotContext ||= new HMRContext(this.hmrClient, mod.url)
           return hotContext
         },
         set: (value) => {

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -352,7 +352,10 @@ export class ModuleRunner {
       },
       // should be replaced during transformation
       glob() {
-        throw new Error('[module runner] "import.meta.glob" is not supported.')
+        throw new Error(
+          `[module runner] "import.meta.glob" is statically replaced during ` +
+            `file transformation. Make sure to reference it by the full name.`,
+        )
       },
     }
     const exports = Object.create(null)

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -394,7 +394,7 @@ export class ModuleRunner {
 
     this.debug?.('[module runner] executing', href)
 
-    await this.evaluator.runInlinedModule(context, code, url)
+    await this.evaluator.runInlinedModule(context, code, mod)
 
     return exports
   }

--- a/packages/vite/src/module-runner/sourcemap/interceptor.ts
+++ b/packages/vite/src/module-runner/sourcemap/interceptor.ts
@@ -1,7 +1,7 @@
 import type { OriginalMapping } from '@jridgewell/trace-mapping'
 import type { ModuleRunner } from '../runner'
 import { posixDirname, posixResolve } from '../utils'
-import type { ModuleCacheMap } from '../moduleCache'
+import type { ModuleRunnerGraph } from '../moduleCache'
 import { slash } from '../../shared/utils'
 import { DecodedMap, getOriginalPosition } from './decoder'
 
@@ -21,7 +21,7 @@ export interface InterceptorOptions {
 const sourceMapCache: Record<string, CachedMapEntry> = {}
 const fileContentsCache: Record<string, string> = {}
 
-const moduleGraphs = new Set<ModuleCacheMap>()
+const moduleGraphs = new Set<ModuleRunnerGraph>()
 const retrieveFileHandlers = new Set<RetrieveFileHandler>()
 const retrieveSourceMapHandlers = new Set<RetrieveSourceMapHandler>()
 
@@ -46,7 +46,7 @@ let overridden = false
 const originalPrepare = Error.prepareStackTrace
 
 function resetInterceptor(runner: ModuleRunner, options: InterceptorOptions) {
-  moduleGraphs.delete(runner.moduleCache)
+  moduleGraphs.delete(runner.moduleGraph)
   if (options.retrieveFile) retrieveFileHandlers.delete(options.retrieveFile)
   if (options.retrieveSourceMap)
     retrieveSourceMapHandlers.delete(options.retrieveSourceMap)
@@ -64,7 +64,7 @@ export function interceptStackTrace(
     Error.prepareStackTrace = prepareStackTrace
     overridden = true
   }
-  moduleGraphs.add(runner.moduleCache)
+  moduleGraphs.add(runner.moduleGraph)
   if (options.retrieveFile) retrieveFileHandlers.add(options.retrieveFile)
   if (options.retrieveSourceMap)
     retrieveSourceMapHandlers.add(options.retrieveSourceMap)
@@ -102,8 +102,8 @@ function supportRelativeURL(file: string, url: string) {
 }
 
 function getRunnerSourceMap(position: OriginalMapping): CachedMapEntry | null {
-  for (const moduleCache of moduleGraphs) {
-    const sourceMap = moduleCache.getSourceMap(position.source!)
+  for (const moduleGraph of moduleGraphs) {
+    const sourceMap = moduleGraph.getModuleSourceMapById(position.source!)
     if (sourceMap) {
       return {
         url: position.source,

--- a/packages/vite/src/module-runner/sourcemap/interceptor.ts
+++ b/packages/vite/src/module-runner/sourcemap/interceptor.ts
@@ -1,7 +1,7 @@
 import type { OriginalMapping } from '@jridgewell/trace-mapping'
 import type { ModuleRunner } from '../runner'
 import { posixDirname, posixResolve } from '../utils'
-import type { ModuleRunnerGraph } from '../moduleCache'
+import type { EvaluatedModules } from '../evaluatedModules'
 import { slash } from '../../shared/utils'
 import { DecodedMap, getOriginalPosition } from './decoder'
 
@@ -21,7 +21,7 @@ export interface InterceptorOptions {
 const sourceMapCache: Record<string, CachedMapEntry> = {}
 const fileContentsCache: Record<string, string> = {}
 
-const moduleGraphs = new Set<ModuleRunnerGraph>()
+const evaluatedModulesCache = new Set<EvaluatedModules>()
 const retrieveFileHandlers = new Set<RetrieveFileHandler>()
 const retrieveSourceMapHandlers = new Set<RetrieveSourceMapHandler>()
 
@@ -46,11 +46,11 @@ let overridden = false
 const originalPrepare = Error.prepareStackTrace
 
 function resetInterceptor(runner: ModuleRunner, options: InterceptorOptions) {
-  moduleGraphs.delete(runner.moduleGraph)
+  evaluatedModulesCache.delete(runner.evaluatedModules)
   if (options.retrieveFile) retrieveFileHandlers.delete(options.retrieveFile)
   if (options.retrieveSourceMap)
     retrieveSourceMapHandlers.delete(options.retrieveSourceMap)
-  if (moduleGraphs.size === 0) {
+  if (evaluatedModulesCache.size === 0) {
     Error.prepareStackTrace = originalPrepare
     overridden = false
   }
@@ -64,7 +64,7 @@ export function interceptStackTrace(
     Error.prepareStackTrace = prepareStackTrace
     overridden = true
   }
-  moduleGraphs.add(runner.moduleGraph)
+  evaluatedModulesCache.add(runner.evaluatedModules)
   if (options.retrieveFile) retrieveFileHandlers.add(options.retrieveFile)
   if (options.retrieveSourceMap)
     retrieveSourceMapHandlers.add(options.retrieveSourceMap)
@@ -102,7 +102,7 @@ function supportRelativeURL(file: string, url: string) {
 }
 
 function getRunnerSourceMap(position: OriginalMapping): CachedMapEntry | null {
-  for (const moduleGraph of moduleGraphs) {
+  for (const moduleGraph of evaluatedModulesCache) {
     const sourceMap = moduleGraph.getModuleSourceMapById(position.source!)
     if (sourceMap) {
       return {

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -5,7 +5,7 @@ import type {
   DefineImportMetadata,
   SSRImportMetadata,
 } from '../shared/ssrTransform'
-import type { ModuleRunnerGraph } from './moduleCache'
+import type { EvaluatedModules } from './evaluatedModules'
 import type {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -168,7 +168,7 @@ export interface ModuleRunnerOptions {
   /**
    * Custom module cache. If not provided, creates a separate module cache for each ModuleRunner instance.
    */
-  moduleGraph?: ModuleRunnerGraph
+  evaluatedModules?: EvaluatedModules
 }
 
 export interface ImportMetaEnv {

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -5,7 +5,7 @@ import type {
   DefineImportMetadata,
   SSRImportMetadata,
 } from '../shared/ssrTransform'
-import type { ModuleRunnerGraph } from './moduleCache'
+import type { ModuleRunnerGraph, ModuleRunnerNode } from './moduleCache'
 import type {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -31,6 +31,12 @@ export interface ModuleRunnerImportMeta extends ImportMeta {
   url: string
   env: ImportMetaEnv
   hot?: ViteHotContext
+
+  // TODO: this is a proposal to start a discussion
+  environment: {
+    module: ModuleRunnerNode
+    moduleGraph: ModuleRunnerGraph
+  }
   [key: string]: any
 }
 

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -5,7 +5,7 @@ import type {
   DefineImportMetadata,
   SSRImportMetadata,
 } from '../shared/ssrTransform'
-import type { EvaluatedModules } from './evaluatedModules'
+import type { EvaluatedModuleNode, EvaluatedModules } from './evaluatedModules'
 import type {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -49,12 +49,12 @@ export interface ModuleEvaluator {
    * Run code that was transformed by Vite.
    * @param context Function context
    * @param code Transformed code
-   * @param id ID that was used to fetch the module
+   * @param module The module node
    */
   runInlinedModule(
     context: ModuleRunnerContext,
     code: string,
-    id: string,
+    module: Readonly<EvaluatedModuleNode>,
   ): Promise<any>
   /**
    * Run externalized module.

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -13,7 +13,6 @@ import type {
   ssrImportMetaKey,
   ssrModuleExportsKey,
 } from './constants'
-import type { DecodedMap } from './sourcemap/decoder'
 import type { InterceptorOptions } from './sourcemap/interceptor'
 import type { RunnerTransport } from './runnerTransport'
 
@@ -64,19 +63,6 @@ export interface ModuleEvaluator {
   runExternalModule(file: string): Promise<any>
 }
 
-export interface ModuleCache {
-  promise?: Promise<any>
-  exports?: any
-  evaluated?: boolean
-  map?: DecodedMap
-  meta?: ResolvedResult
-  /**
-   * Module ids that imports this module
-   */
-  importers?: Set<string>
-  imports?: Set<string>
-}
-
 export type FetchResult =
   | CachedFetchResult
   | ExternalFetchResult
@@ -101,7 +87,7 @@ export interface ExternalFetchResult {
    * Type of the module. Will be used to determine if import statement is correct.
    * For example, if Vite needs to throw an error if variable is not actually exported
    */
-  type?: 'module' | 'commonjs' | 'builtin' | 'network'
+  type: 'module' | 'commonjs' | 'builtin' | 'network'
 }
 
 export interface ViteFetchResult {

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -5,7 +5,7 @@ import type {
   DefineImportMetadata,
   SSRImportMetadata,
 } from '../shared/ssrTransform'
-import type { ModuleRunnerGraph, ModuleRunnerNode } from './moduleCache'
+import type { ModuleRunnerGraph } from './moduleCache'
 import type {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -31,12 +31,6 @@ export interface ModuleRunnerImportMeta extends ImportMeta {
   url: string
   env: ImportMetaEnv
   hot?: ViteHotContext
-
-  // TODO: this is a proposal to start a discussion
-  environment: {
-    module: ModuleRunnerNode
-    moduleGraph: ModuleRunnerGraph
-  }
   [key: string]: any
 }
 

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -5,7 +5,7 @@ import type {
   DefineImportMetadata,
   SSRImportMetadata,
 } from '../shared/ssrTransform'
-import type { ModuleCacheMap } from './moduleCache'
+import type { ModuleRunnerGraph } from './moduleCache'
 import type {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -119,7 +119,11 @@ export interface ViteFetchResult {
   /**
    * Module ID in the server module graph.
    */
-  serverId: string
+  id: string
+  /**
+   * Module URL used in the import.
+   */
+  url: string
   /**
    * Invalidate module on the client side.
    */
@@ -128,6 +132,7 @@ export interface ViteFetchResult {
 
 export type ResolvedResult = (ExternalFetchResult | ViteFetchResult) & {
   url: string
+  id: string
 }
 
 export type FetchFunction = (
@@ -177,7 +182,7 @@ export interface ModuleRunnerOptions {
   /**
    * Custom module cache. If not provided, creates a separate module cache for each ModuleRunner instance.
    */
-  moduleCache?: ModuleCacheMap
+  moduleGraph?: ModuleRunnerGraph
 }
 
 export interface ImportMetaEnv {

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -137,7 +137,8 @@ export async function fetchModule(
   return {
     code: result.code,
     file: mod.file,
-    serverId: mod.id!,
+    id: mod.id!,
+    url: mod.url,
     invalidate: !cached,
   }
 }

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
@@ -52,7 +52,7 @@ describe('module runner initialization', async () => {
       resolvePath(import.meta.url, './fixtures/throws-error-method.ts'),
       (code) => '\n\n\n\n\n' + code + '\n',
     )
-    runner.moduleCache.clear()
+    runner.moduleGraph.clear()
     server.environments.ssr.moduleGraph.invalidateAll()
 
     const methodErrorNew = await getError(async () => {

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
@@ -52,7 +52,7 @@ describe('module runner initialization', async () => {
       resolvePath(import.meta.url, './fixtures/throws-error-method.ts'),
       (code) => '\n\n\n\n\n' + code + '\n',
     )
-    runner.moduleGraph.clear()
+    runner.evaluatedModules.clear()
     server.environments.ssr.moduleGraph.invalidateAll()
 
     const methodErrorNew = await getError(async () => {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -1,5 +1,5 @@
 import colors from 'picocolors'
-import type { ModuleRunnerNode } from 'vite/module-runner'
+import type { EvaluatedModuleNode } from 'vite/module-runner'
 import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
 import type { ViteDevServer } from '../server'
 import { unwrapId } from '../../shared/utils'
@@ -74,7 +74,7 @@ class SSRCompatModuleRunner extends ModuleRunner {
 
   protected override async directRequest(
     url: string,
-    mod: ModuleRunnerNode,
+    mod: EvaluatedModuleNode,
     _callstack: string[],
   ): Promise<any> {
     const id = mod.meta && 'id' in mod.meta && mod.meta.id

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -3,6 +3,7 @@ import type { EvaluatedModuleNode } from 'vite/module-runner'
 import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
 import type { ViteDevServer } from '../server'
 import { unwrapId } from '../../shared/utils'
+import type { DevEnvironment } from '../server/environment'
 import { ssrFixStacktrace } from './ssrStacktrace'
 
 type SSRModule = Record<string, any>
@@ -12,13 +13,14 @@ export async function ssrLoadModule(
   server: ViteDevServer,
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
-  server._ssrCompatModuleRunner ||= new SSRCompatModuleRunner(server)
+  const environment = server.environments.ssr
+  server._ssrCompatModuleRunner ||= new SSRCompatModuleRunner(environment)
   url = unwrapId(url)
 
   return instantiateModule(
     url,
     server._ssrCompatModuleRunner,
-    server,
+    environment,
     fixStacktrace,
   )
 }
@@ -26,10 +28,9 @@ export async function ssrLoadModule(
 async function instantiateModule(
   url: string,
   runner: ModuleRunner,
-  server: ViteDevServer,
+  environment: DevEnvironment,
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
-  const environment = server.environments.ssr
   const mod = await environment.moduleGraph.ensureEntryFromUrl(url)
 
   if (mod.ssrError) {
@@ -47,7 +48,7 @@ async function instantiateModule(
       colors.red(`Error when evaluating SSR module ${url}:\n|- ${e.stack}\n`),
       {
         timestamp: true,
-        clear: server.config.clearScreen,
+        clear: environment.config.clearScreen,
         error: e,
       },
     )
@@ -57,13 +58,13 @@ async function instantiateModule(
 }
 
 class SSRCompatModuleRunner extends ModuleRunner {
-  constructor(private server: ViteDevServer) {
+  constructor(private environment: DevEnvironment) {
     super(
       {
-        root: server.environments.ssr.config.root,
+        root: environment.config.root,
         transport: {
           fetchModule: (id, importer, options) =>
-            server.environments.ssr.fetchModule(id, importer, options),
+            environment.fetchModule(id, importer, options),
         },
         sourcemapInterceptor: false,
         hmr: false,
@@ -75,22 +76,22 @@ class SSRCompatModuleRunner extends ModuleRunner {
   protected override async directRequest(
     url: string,
     mod: EvaluatedModuleNode,
-    _callstack: string[],
+    callstack: string[],
   ): Promise<any> {
     const id = mod.meta && 'id' in mod.meta && mod.meta.id
     // serverId doesn't exist for external modules
     if (!id) {
-      return super.directRequest(url, mod, _callstack)
+      return super.directRequest(url, mod, callstack)
     }
 
-    const viteMod = this.server.environments.ssr.moduleGraph.getModuleById(id)
+    const viteMod = this.environment.moduleGraph.getModuleById(id)
 
     if (!viteMod) {
-      return super.directRequest(id, mod, _callstack)
+      return super.directRequest(id, mod, callstack)
     }
 
     try {
-      const exports = await super.directRequest(id, mod, _callstack)
+      const exports = await super.directRequest(id, mod, callstack)
       viteMod.ssrModule = exports
       return exports
     } catch (err) {

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -1,5 +1,5 @@
 import colors from 'picocolors'
-import type { ModuleCache } from 'vite/module-runner'
+import type { ModuleRunnerNode } from 'vite/module-runner'
 import { ESModulesEvaluator, ModuleRunner } from 'vite/module-runner'
 import type { ViteDevServer } from '../server'
 import { unwrapId } from '../../shared/utils'
@@ -73,18 +73,17 @@ class SSRCompatModuleRunner extends ModuleRunner {
   }
 
   protected override async directRequest(
-    id: string,
-    mod: ModuleCache,
+    url: string,
+    mod: ModuleRunnerNode,
     _callstack: string[],
   ): Promise<any> {
-    const serverId = mod.meta && 'serverId' in mod.meta && mod.meta.serverId
+    const id = mod.meta && 'id' in mod.meta && mod.meta.id
     // serverId doesn't exist for external modules
-    if (!serverId) {
-      return super.directRequest(id, mod, _callstack)
+    if (!id) {
+      return super.directRequest(url, mod, _callstack)
     }
 
-    const viteMod =
-      this.server.environments.ssr.moduleGraph.getModuleById(serverId)
+    const viteMod = this.server.environments.ssr.moduleGraph.getModuleById(id)
 
     if (!viteMod) {
       return super.directRequest(id, mod, _callstack)


### PR DESCRIPTION
### Description

This PR refactors vite-node's `moduleCache` into `EvaluatedModules` that resembles what Vite already has on the server. 

----

This is not part of the PR as of September 23, it will be a separate discussion.

This PR also add a new proposal to extend `import.meta` with `.environment` property:

```ts
// this is only available for modules that run inside the module runner

import.meta.environment.module // current module
import.meta.environment.moduleGraph // access to module graph

// or
import.meta.hot.module // current module
import.meta.hot.moduleGraph // access to module graph
```

The goal here is to have easy access to the module graph.

I am personally not sold on the "environment" name - we already have `import.meta.env` for environment variables. And it doesn't reference the actual server `environment` which makes it a bit confusing. This is more of a "module context" - or maybe we don't even need a single property to hold this, and we can just put in on `import.meta`, but I am not sure how future-proof it is (`module` seems like a generic name that might be available there in some EcmaScript proposal)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
