### PR TITLE
fix(preload): throw error preloading module as well

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -145,20 +145,23 @@ function preload(
     )
   }
 
+  function handlePreloadError(err: Error) {
+    const e = new Event('vite:preloadError', {
+      cancelable: true,
+    }) as VitePreloadErrorEvent
+    e.payload = err
+    window.dispatchEvent(e)
+    if (!e.defaultPrevented) {
+      throw err
+    }
+  }
+
   return promise.then((res) => {
     for (const item of res || []) {
       if (item.status !== 'rejected') continue
-
-      const e = new Event('vite:preloadError', {
-        cancelable: true,
-      }) as VitePreloadErrorEvent
-      e.payload = item.reason
-      window.dispatchEvent(e)
-      if (!e.defaultPrevented) {
-        throw item.reason
-      }
+      handlePreloadError(item.reason)
     }
-    return baseModule()
+    return baseModule().catch(handlePreloadError)
   })
 }
 

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -140,7 +140,7 @@ describe.runIf(isBuild)('build tests', () => {
     expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
       {
         "ignoreList": [],
-        "mappings": ";s8BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
+        "mappings": ";+8BAAA,OAAO,2BAAuB,EAAC,wBAE/B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],


### PR DESCRIPTION
### Description

https://github.com/vitejs/vite/pull/18046

This addresses a regression where errors actually calling the preloaded module did not trigger a `vite:preloadError` event any more.

cc: @patak-dev 