### PR TITLE
fix(minify): set the default value of esbuild's legalComments option to external

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1885,7 +1885,8 @@ function resolveMinifyCssEsbuildOptions(
     logLevel: options.logLevel,
     logLimit: options.logLimit,
     logOverride: options.logOverride,
-    legalComments: options.legalComments,
+    legalComments:
+      options.legalComments === 'linked' ? 'external' : options.legalComments,
   }
 
   if (

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -329,6 +329,10 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
 
       if (res.legalComments) {
         collectLegalComments.push(res.legalComments)
+
+        if (config.esbuild && config.esbuild.legalComments === 'linked') {
+          res.code += '\n/*! For license information please see LEGAL.txt */'
+        }
       }
 
       if (config.build.lib) {
@@ -364,7 +368,7 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
     generateBundle(options) {
       if (collectLegalComments.length && options.dir) {
         this.emitFile({
-          fileName: '.LEGAL.txt',
+          fileName: 'LEGAL.txt',
           type: 'asset',
           source: collectLegalComments.join('\n'),
         })

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -166,7 +166,7 @@ export async function transformWithEsbuild(
   }
 
   const resolvedOptions: TransformOptions = {
-    legalComments: 'external',
+    legalComments: 'linked',
     sourcemap: true,
     // ensure source file name contains full query
     sourcefile: filename,
@@ -368,7 +368,7 @@ export const buildEsbuildPlugin = (config: ResolvedConfig): Plugin => {
     generateBundle(options) {
       if (collectLegalComments.length && options.dir) {
         this.emitFile({
-          fileName: 'LEGAL.txt',
+          name: 'LEGAL.txt',
           type: 'asset',
           source: collectLegalComments.join('\n'),
         })

--- a/playground/minify/__tests__/minify.spec.ts
+++ b/playground/minify/__tests__/minify.spec.ts
@@ -16,7 +16,7 @@ function getJsAndCssContent(assetsDir: string) {
 }
 
 function getLegalFileContent(assetsDir: string) {
-  return readFile(path.resolve(assetsDir, '.LEGAL.txt'))
+  return readFile(path.resolve(assetsDir, 'LEGAL.txt'))
 }
 
 describe.runIf(isBuild)('minify', () => {
@@ -49,7 +49,7 @@ describe.runIf(isBuild)('minify', () => {
     expect(cssContent.endsWith('/*! explicit comment */')).toBeTruthy()
   })
 
-  test('Move all legal comments to a .LEGAL.txt file but to not link to them.', () => {
+  test('Move all legal comments to a LEGAL.txt file but to not link to them.', () => {
     const { jsContent, cssContent } = getJsAndCssContent(
       path.resolve(testDir, 'dist/external/assets'),
     )
@@ -57,6 +57,21 @@ describe.runIf(isBuild)('minify', () => {
       path.resolve(testDir, 'dist/external'),
     )
     expect(jsContent).not.toContain('/*! explicit comment */')
+    expect(cssContent).not.toContain('/*! explicit comment */')
+    expect(legaContent).toContain('/*! explicit comment */')
+  })
+
+  test('Move all legal comments to a LEGAL.txt file and link to them with a comment.', () => {
+    const { jsContent, cssContent } = getJsAndCssContent(
+      path.resolve(testDir, 'dist/linked/assets'),
+    )
+    const legaContent = getLegalFileContent(
+      path.resolve(testDir, 'dist/linked'),
+    )
+    expect(jsContent).not.toContain('/*! explicit comment */')
+    expect(jsContent).toContain(
+      '/*! For license information please see LEGAL.txt */',
+    )
     expect(cssContent).not.toContain('/*! explicit comment */')
     expect(legaContent).toContain('/*! explicit comment */')
   })

--- a/playground/minify/__tests__/minify.spec.ts
+++ b/playground/minify/__tests__/minify.spec.ts
@@ -1,21 +1,63 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 import { isBuild, readFile, testDir } from '~utils'
 
-test.runIf(isBuild)('no minifySyntax', () => {
-  const assetsDir = path.resolve(testDir, 'dist/assets')
+function getJsAndCssContent(assetsDir: string) {
   const files = fs.readdirSync(assetsDir)
 
   const jsFile = files.find((f) => f.endsWith('.js'))
-  const jsContent = readFile(path.resolve(assetsDir, jsFile))
+  const jsContent = readFile(path.resolve(assetsDir, jsFile)).trim()
 
   const cssFile = files.find((f) => f.endsWith('.css'))
-  const cssContent = readFile(path.resolve(assetsDir, cssFile))
+  const cssContent = readFile(path.resolve(assetsDir, cssFile)).trim()
 
-  expect(jsContent).toContain('{console.log("hello world")}')
-  expect(jsContent).not.toContain('/*! explicit comment */')
+  return { jsContent, cssContent }
+}
 
-  expect(cssContent).toContain('color:#ff0000')
-  expect(cssContent).not.toContain('/*! explicit comment */')
+function getLegalFileContent(assetsDir: string) {
+  return readFile(path.resolve(assetsDir, '.LEGAL.txt'))
+}
+
+describe.runIf(isBuild)('minify', () => {
+  test('Do not preserve any legal comments', () => {
+    const { jsContent, cssContent } = getJsAndCssContent(
+      path.resolve(testDir, 'dist/none/assets'),
+    )
+
+    expect(jsContent).toContain('{console.log("hello world")}')
+    expect(jsContent).not.toContain('/*! explicit comment */')
+
+    expect(cssContent).toContain('color:#ff0000')
+    expect(cssContent).not.toContain('/*! explicit comment */')
+  })
+
+  test('Preserve legal comments', () => {
+    const { jsContent, cssContent } = getJsAndCssContent(
+      path.resolve(testDir, 'dist/inline/assets'),
+    )
+
+    expect(jsContent).toContain('/*! explicit comment */')
+    expect(cssContent).toContain('/*! explicit comment */')
+  })
+
+  test('Move all legal comments to the end of the file.', () => {
+    const { jsContent, cssContent } = getJsAndCssContent(
+      path.resolve(testDir, 'dist/eof/assets'),
+    )
+    expect(jsContent.endsWith('/*! explicit comment */')).toBeTruthy()
+    expect(cssContent.endsWith('/*! explicit comment */')).toBeTruthy()
+  })
+
+  test('Move all legal comments to a .LEGAL.txt file but to not link to them.', () => {
+    const { jsContent, cssContent } = getJsAndCssContent(
+      path.resolve(testDir, 'dist/external/assets'),
+    )
+    const legaContent = getLegalFileContent(
+      path.resolve(testDir, 'dist/external'),
+    )
+    expect(jsContent).not.toContain('/*! explicit comment */')
+    expect(cssContent).not.toContain('/*! explicit comment */')
+    expect(legaContent).toContain('/*! explicit comment */')
+  })
 })

--- a/playground/minify/__tests__/serve.ts
+++ b/playground/minify/__tests__/serve.ts
@@ -1,0 +1,39 @@
+// this is automatically detected by playground/vitestSetup.ts and will replace
+// the default e2e test serve behavior
+
+import path from 'node:path'
+import { ports, rootDir } from '~utils'
+
+export const port = ports.lib
+
+export async function serve() {
+  const { build } = await import('vite')
+  await build({
+    root: rootDir,
+    configFile: path.resolve(__dirname, '../vite.legal-comments-eof.config.js'),
+  })
+
+  await build({
+    root: rootDir,
+    configFile: path.resolve(
+      __dirname,
+      '../vite.legal-comments-external.config.js',
+    ),
+  })
+
+  await build({
+    root: rootDir,
+    configFile: path.resolve(
+      __dirname,
+      '../vite.legal-comments-inline.config.js',
+    ),
+  })
+
+  await build({
+    root: rootDir,
+    configFile: path.resolve(
+      __dirname,
+      '../vite.legal-comments-none.config.js',
+    ),
+  })
+}

--- a/playground/minify/__tests__/serve.ts
+++ b/playground/minify/__tests__/serve.ts
@@ -36,4 +36,12 @@ export async function serve() {
       '../vite.legal-comments-none.config.js',
     ),
   })
+
+  await build({
+    root: rootDir,
+    configFile: path.resolve(
+      __dirname,
+      '../vite.legal-comments-linked.config.js',
+    ),
+  })
 }

--- a/playground/minify/vite.legal-comments-eof.config.js
+++ b/playground/minify/vite.legal-comments-eof.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    legalComments: 'eof',
+    minifySyntax: false,
+  },
+  build: {
+    outDir: 'dist/eof',
+  },
+})

--- a/playground/minify/vite.legal-comments-external.config.js
+++ b/playground/minify/vite.legal-comments-external.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    legalComments: 'external',
+    minifySyntax: false,
+  },
+  build: {
+    outDir: 'dist/external',
+  },
+})

--- a/playground/minify/vite.legal-comments-inline.config.js
+++ b/playground/minify/vite.legal-comments-inline.config.js
@@ -2,7 +2,10 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   esbuild: {
-    legalComments: 'none',
+    legalComments: 'inline',
     minifySyntax: false,
+  },
+  build: {
+    outDir: 'dist/inline',
   },
 })

--- a/playground/minify/vite.legal-comments-linked.config.js
+++ b/playground/minify/vite.legal-comments-linked.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    legalComments: 'linked',
+    minifySyntax: false,
+  },
+  build: {
+    outDir: 'dist/linked',
+  },
+})

--- a/playground/minify/vite.legal-comments-none.config.js
+++ b/playground/minify/vite.legal-comments-none.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  esbuild: {
+    legalComments: 'none',
+    minifySyntax: false,
+  },
+  build: {
+    outDir: 'dist/none',
+  },
+})


### PR DESCRIPTION
Fixes https://github.com/vitejs/vite/issues/17892

According to the issue, legal comments from files are split into a separate file by default. However, I have a few questions:

1. Should `external` be the default value of `legalComments`?

2. All comments are output to a file named `LEGAL.txt`, but should there be an option to specify the output path/filename?