### PR TITLE
fix(css): fix missing source file warning with sass modern api custom importer

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2300,7 +2300,7 @@ const makeModernScssWorker = (
               fileURLToPath(canonicalUrl),
               options.filename,
             )
-            return { contents, syntax }
+            return { contents, syntax, sourceMapUrl: canonicalUrl }
           },
         }
         sassOptions.importers = [
@@ -2394,7 +2394,7 @@ const makeModernCompilerScssWorker = (
           )
           const contents =
             result.contents ?? (await fsp.readFile(result.file, 'utf-8'))
-          return { contents, syntax }
+          return { contents, syntax, sourceMapUrl: canonicalUrl }
         },
       }
       sassOptions.importers = [

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -13,7 +13,7 @@ const debug = createDebugger('vite:sourcemap', {
 // Virtual modules should be prefixed with a null byte to avoid a
 // false positive "missing source" warning. We also check for certain
 // prefixes used for special handling in esbuildDepPlugin.
-const virtualSourceRE = /^(?:dep:|browser-external:|virtual:|data:)|\0/
+const virtualSourceRE = /^(?:dep:|browser-external:|virtual:)|\0/
 
 interface SourceMapLike {
   sources: string[]

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -13,7 +13,7 @@ const debug = createDebugger('vite:sourcemap', {
 // Virtual modules should be prefixed with a null byte to avoid a
 // false positive "missing source" warning. We also check for certain
 // prefixes used for special handling in esbuildDepPlugin.
-const virtualSourceRE = /^(?:dep:|browser-external:|virtual:)|\0/
+const virtualSourceRE = /^(?:dep:|browser-external:|virtual:|data:)|\0/
 
 interface SourceMapLike {
   sources: string[]

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -139,14 +139,19 @@ describe.runIf(isServe)('serve', () => {
     expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
       {
         "ignoreList": [],
-        "mappings": "AACE;EACE",
+        "mappings": "AAGE;EACE,UCJM",
         "sources": [
           "/root/imported.sass",
+          "/root/imported-nested.sass",
         ],
         "sourcesContent": [
-          ".imported
+          "@import "/imported-nested.sass"
+
+      .imported
         &-sass
-          color: red
+          color: $primary
+      ",
+          "$primary: red
       ",
         ],
         "version": 3,

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -133,53 +133,25 @@ describe.runIf(isServe)('serve', () => {
     `)
   })
 
-  test('imported sass', async (context) => {
+  test('imported sass', async () => {
     const css = await getStyleTagContentIncluding('.imported-sass ')
     const map = extractSourcemap(css)
-    if (context.task.file.filepath.includes('sass-modern')) {
-      expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
-        {
-          "ignoreList": [],
-          "mappings": "AAGE;EACE,UCJM",
-          "sources": [
-            "/root/imported.sass",
-            "data:;charset=utf-8,$primary:%20red%0A",
-          ],
-          "sourcesContent": [
-            "@import "/imported-nested.sass"
-
-        .imported
-          &-sass
-            color: $primary
-        ",
-            null,
-          ],
-          "version": 3,
-        }
-      `)
-    } else {
-      expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
-        {
-          "ignoreList": [],
-          "mappings": "AAGE;EACE,UCJM",
-          "sources": [
-            "/root/imported.sass",
-            "/root/imported-nested.sass",
-          ],
-          "sourcesContent": [
-            "@import "/imported-nested.sass"
-
-        .imported
-          &-sass
-            color: $primary
-        ",
-            "$primary: red
-        ",
-          ],
-          "version": 3,
-        }
-      `)
-    }
+    expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
+      {
+        "ignoreList": [],
+        "mappings": "AACE;EACE",
+        "sources": [
+          "/root/imported.sass",
+        ],
+        "sourcesContent": [
+          ".imported
+        &-sass
+          color: red
+      ",
+        ],
+        "version": 3,
+      }
+    `)
   })
 
   test('imported sass module', async () => {

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -133,25 +133,53 @@ describe.runIf(isServe)('serve', () => {
     `)
   })
 
-  test('imported sass', async () => {
+  test('imported sass', async (context) => {
     const css = await getStyleTagContentIncluding('.imported-sass ')
     const map = extractSourcemap(css)
-    expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
-      {
-        "ignoreList": [],
-        "mappings": "AACE;EACE",
-        "sources": [
-          "/root/imported.sass",
-        ],
-        "sourcesContent": [
-          ".imported
-        &-sass
-          color: red
-      ",
-        ],
-        "version": 3,
-      }
-    `)
+    if (context.task.file.filepath.includes('sass-modern')) {
+      expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
+        {
+          "ignoreList": [],
+          "mappings": "AAGE;EACE,UCJM",
+          "sources": [
+            "/root/imported.sass",
+            "data:;charset=utf-8,$primary:%20red%0A",
+          ],
+          "sourcesContent": [
+            "@import "/imported-nested.sass"
+
+        .imported
+          &-sass
+            color: $primary
+        ",
+            null,
+          ],
+          "version": 3,
+        }
+      `)
+    } else {
+      expect(formatSourcemapForSnapshot(map)).toMatchInlineSnapshot(`
+        {
+          "ignoreList": [],
+          "mappings": "AAGE;EACE,UCJM",
+          "sources": [
+            "/root/imported.sass",
+            "/root/imported-nested.sass",
+          ],
+          "sourcesContent": [
+            "@import "/imported-nested.sass"
+
+        .imported
+          &-sass
+            color: $primary
+        ",
+            "$primary: red
+        ",
+          ],
+          "version": 3,
+        }
+      `)
+    }
   })
 
   test('imported sass module', async () => {

--- a/playground/css-sourcemap/imported-nested.sass
+++ b/playground/css-sourcemap/imported-nested.sass
@@ -1,0 +1,1 @@
+$primary: red

--- a/playground/css-sourcemap/imported-nested.sass
+++ b/playground/css-sourcemap/imported-nested.sass
@@ -1,1 +1,0 @@
-$primary: red

--- a/playground/css-sourcemap/imported.sass
+++ b/playground/css-sourcemap/imported.sass
@@ -1,3 +1,5 @@
+@import "/imported-nested.sass"
+
 .imported
   &-sass
-    color: red
+    color: $primary

--- a/playground/css-sourcemap/imported.sass
+++ b/playground/css-sourcemap/imported.sass
@@ -1,5 +1,3 @@
-@import "/imported-nested.sass"
-
 .imported
   &-sass
-    color: $primary
+    color: red


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/18111

~I added `data:` to "missing source" false positive list since Sass modern API uses `data:...` when the code is loaded from custom importer. This would mean `css.devSourcemap` works only for the initial import of sass files, which is pretty bad, but I couldn't find any solution for this.~ EDIT: `sourceMapUrl` works https://github.com/vitejs/vite/pull/18113#issuecomment-2354596568