### PR TITLE
fix: avoid DOM Clobbering gadget in `getRelativeUrlFromDocument`

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1297,7 +1297,7 @@ const getRelativeUrlFromDocument = (relativePath: string, umd = false) =>
   getResolveUrl(
     `'${escapeId(partialEncodeURIPath(relativePath))}', ${
       umd ? `typeof document === 'undefined' ? location.href : ` : ''
-    }document.currentScript && document.currentScript.src || document.baseURI`,
+    }document.currentScript && document.currentScript.tagName.toUpperCase() === 'SCRIPT' && document.currentScript.src || document.baseURI`,
   )
 
 const getFileUrlFromFullPath = (path: string) =>


### PR DESCRIPTION
### Description

This patch fixes the DOM Clobbering gadget in the `getRelativeUrlFromDocument` function. 

Reference: https://github.com/vitejs/vite/security/advisories/GHSA-64vr-g452-qvp3