### PR TITLE
fix: update pnpm/active-setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,13 @@ jobs:
 
       - name: Install pnpm (node 14, pnpm 7)
         if: steps.changed-files.outputs.only_changed != 'true' && matrix.node_version == 14
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v4.0.0
         with:
           version: 7
 
       - name: Install pnpm
         if: steps.changed-files.outputs.only_changed != 'true' && matrix.node_version != 14
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v4.0.0
 
       - name: Set node version to ${{ matrix.node_version }}
         if: steps.changed-files.outputs.only_changed != 'true'
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v4.0.0
 
       - name: Set node version to 18
         uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2.4.0
+        uses: pnpm/action-setup@v4.0.0
 
       - name: Set node version to 16.x
         uses: actions/setup-node@v3


### PR DESCRIPTION
### Description

Update https://github.com/pnpm/action-setup, as v2 doesn't work anymore for newer versions of Node.