### PR TITLE
fix(css): ensure sass compiler initialized only once

### DIFF
--- a/playground/css/__tests__/sass-modern-compiler-build/sass-modern-compiler.spec.ts
+++ b/playground/css/__tests__/sass-modern-compiler-build/sass-modern-compiler.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import { findAssetFile, isBuild } from '~utils'
+
+test.runIf(isBuild)('sass modern compiler build multiple entries', () => {
+  expect(findAssetFile(/entry1/, 'sass-modern-compiler-build'))
+    .toMatchInlineSnapshot(`
+    ".entry1{color:red}
+    "
+  `)
+  expect(findAssetFile(/entry2/, 'sass-modern-compiler-build'))
+    .toMatchInlineSnapshot(`
+    ".entry2{color:#00f}
+    "
+  `)
+})

--- a/playground/css/sass-modern-compiler-build/entry1.scss
+++ b/playground/css/sass-modern-compiler-build/entry1.scss
@@ -1,0 +1,3 @@
+.entry1 {
+  color: red;
+}

--- a/playground/css/sass-modern-compiler-build/entry2.scss
+++ b/playground/css/sass-modern-compiler-build/entry2.scss
@@ -1,0 +1,3 @@
+.entry2 {
+  color: blue;
+}

--- a/playground/css/vite.config-sass-modern-compiler-build.js
+++ b/playground/css/vite.config-sass-modern-compiler-build.js
@@ -1,0 +1,27 @@
+import path from 'node:path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    outDir: 'dist/sass-modern-compiler-build',
+    rollupOptions: {
+      input: {
+        entry1: path.join(
+          import.meta.dirname,
+          'sass-modern-compiler-build/entry1.scss',
+        ),
+        entry2: path.join(
+          import.meta.dirname,
+          'sass-modern-compiler-build/entry2.scss',
+        ),
+      },
+    },
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler',
+      },
+    },
+  },
+})


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/18127

The test I added doesn't fail on main since Vitest probably just exits regardless of hanging resource. However, it can be used to test it manually and this hangs on main:

```sh
pnpm -C playground/css build -c vite.config-sass-modern-compiler-build.js
```