### PR TITLE
fix: attempt to fix sass resolving root of package instead of subfolder

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1071,7 +1071,7 @@ export function resolvePackageEntry(
         options.mainFields[0] === 'sass' &&
         !options.extensions.includes(path.extname(entry))
       ) {
-        entry = ''
+        entry = path.dirname(entry);
         skipPackageJson = true
       } else {
         // resolve object browser field in package.json

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1071,7 +1071,7 @@ export function resolvePackageEntry(
         options.mainFields[0] === 'sass' &&
         !options.extensions.includes(path.extname(entry))
       ) {
-        entry = path.dirname(entry);
+        entry = path.dirname(entry)
         skipPackageJson = true
       } else {
         // resolve object browser field in package.json


### PR DESCRIPTION
### Description

This PR attempts to fix the issue seen in this issue:  https://github.com/vitejs/vite/issues/18134

Currently, the process for resolving SASS files is looking at the root of the directory and fails if the build files are in a subfolder.