### PR TITLE
fix: use `config.consumer` instead of `options?.ssr` / `config.build.ssr`

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -452,7 +452,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       codeSplitEmitQueue = createSerialPromiseQueue()
     },
 
-    async transform(css, id, options) {
+    async transform(css, id) {
       if (
         !isCSSRequest(id) ||
         commonjsProxyRE.test(id) ||
@@ -510,7 +510,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           return null
         }
         // server only
-        if (options?.ssr) {
+        if (this.environment.config.consumer !== 'client') {
           return modulesCode || `export default ${JSON.stringify(css)}`
         }
         if (inlined) {
@@ -783,7 +783,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             })
             generatedAssets.set(referenceId, { originalFileName, isEntry })
             chunk.viteMetadata!.importedCss.add(this.getFileName(referenceId))
-          } else if (!config.build.ssr) {
+          } else if (this.environment.config.consumer === 'client') {
             // legacy build and inline css
 
             // Entry chunk CSS will be collected into `chunk.viteMetadata.importedCss`

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill.ts
@@ -6,8 +6,6 @@ export const modulePreloadPolyfillId = 'vite/modulepreload-polyfill'
 const resolvedModulePreloadPolyfillId = '\0' + modulePreloadPolyfillId + '.js'
 
 export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
-  // `isModernFlag` is only available during build since it is resolved by `vite:build-import-analysis`
-  const skip = config.command !== 'build' || config.build.ssr
   let polyfillString: string | undefined
 
   return {
@@ -19,7 +17,11 @@ export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
     },
     load(id) {
       if (id === resolvedModulePreloadPolyfillId) {
-        if (skip) {
+        // `isModernFlag` is only available during build since it is resolved by `vite:build-import-analysis`
+        if (
+          config.command !== 'build' ||
+          this.environment.config.consumer !== 'client'
+        ) {
           return ''
         }
         if (!polyfillString) {

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -28,7 +28,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
     name: 'vite:pre-alias',
     async resolveId(id, importer, options) {
       const { environment } = this
-      const ssr = options?.ssr === true
+      const ssr = environment.config.consumer === 'server'
       const depsOptimizer =
         environment.mode === 'dev' ? environment.depsOptimizer : undefined
       if (

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -93,7 +93,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
       code: string | Uint8Array,
     ): Promise<number | null> {
       if (
-        environment.config.build.ssr ||
+        environment.config.consumer !== 'client' ||
         !environment.config.build.reportCompressedSize
       ) {
         return null
@@ -255,7 +255,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
           hasLargeChunks &&
           environment.config.build.minify &&
           !config.build.lib &&
-          !environment.config.build.ssr
+          environment.config.consumer === 'client'
         ) {
           environment.logger.warn(
             colors.yellow(


### PR DESCRIPTION
### Description

Replaced `options?.ssr` and `config.build.ssr` with `config.consumer === 'server'`.

I didn't actually face any issues but found it while reading the code.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
