### PR TITLE
fix: handle yarn command fail when root does not exist

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -89,7 +89,7 @@ import {
 import { openBrowser as _openBrowser } from './openBrowser'
 import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
-import { searchForWorkspaceRoot } from './searchRoot'
+import { searchForPackageRoot, searchForWorkspaceRoot } from './searchRoot'
 import { warmupFiles } from './warmup'
 import type { DevEnvironment } from './environment'
 
@@ -1042,14 +1042,17 @@ export function resolveServerOptions(
   }
 
   if (process.versions.pnp) {
+    // running a command fails if cwd doesn't exist and root may not exist
+    // search for package root to find a path that exists
+    const cwd = searchForPackageRoot(root)
     try {
       const enableGlobalCache =
-        execSync('yarn config get enableGlobalCache', { cwd: root })
+        execSync('yarn config get enableGlobalCache', { cwd })
           .toString()
           .trim() === 'true'
       const yarnCacheDir = execSync(
         `yarn config get ${enableGlobalCache ? 'globalFolder' : 'cacheFolder'}`,
-        { cwd: root },
+        { cwd },
       )
         .toString()
         .trim()


### PR DESCRIPTION
### Description

Angular sets a path that doesn't exist to root.
https://github.com/angular/angular-cli/blob/ea4a125233c3ad9bc225e365b21a6b5d2d885720/packages/angular/build/src/builders/dev-server/vite-server.ts#L550-L553

That makes `execSync` to fail, because Windows requires `cwd` to exist.
https://github.com/vitejs/vite/blob/c1ed8a595a02ec7f8f5a8d23f97b2f21d3834ab1/packages/vite/src/node/server/index.ts#L1046-L1049

This PR fixes that by using `searchForPackageRoot(root)` for `cwd` instead of `root`. But I'm not sure if we want to support this case.

fixes #18136

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
