### PR TITLE
feat: support `this.environment` in `options` and `onLog` hook

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -68,7 +68,7 @@ import { mergeConfig } from './publicUtils'
 import { webWorkerPostPlugin } from './plugins/worker'
 import { getHookHandler } from './plugins'
 import { BaseEnvironment } from './baseEnvironment'
-import type { Plugin, PluginContext } from './plugin'
+import type { MinimalPluginContext, Plugin, PluginContext } from './plugin'
 import type { RollupPluginHooks } from './typeUtils'
 
 export interface BuildEnvironmentOptions {
@@ -1253,7 +1253,7 @@ function wrapEnvironmentHook<HookName extends keyof Plugin>(
   }
 }
 
-function injectEnvironmentInContext<Context extends PluginContext>(
+function injectEnvironmentInContext<Context extends MinimalPluginContext>(
   context: Context,
   environment: BuildEnvironment,
 ) {

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -8,6 +8,7 @@ const { version } = JSON.parse(
 )
 
 export const ROLLUP_HOOKS = [
+  'options',
   'buildStart',
   'buildEnd',
   'renderStart',
@@ -33,6 +34,7 @@ export const ROLLUP_HOOKS = [
   'resolveId',
   'shouldTransformCachedModule',
   'transform',
+  'onLog',
 ] satisfies RollupPluginHooks[]
 
 export const VERSION = version as string

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -3,6 +3,7 @@ import type {
   LoadResult,
   ObjectHook,
   ResolveIdResult,
+  MinimalPluginContext as RollupMinimalPluginContext,
   Plugin as RollupPlugin,
   PluginContext as RollupPluginContext,
   TransformPluginContext as RollupTransformPluginContext,
@@ -61,6 +62,10 @@ export interface HotUpdatePluginContext {
   environment: DevEnvironment
 }
 
+export interface MinimalPluginContext
+  extends RollupMinimalPluginContext,
+    PluginContextExtension {}
+
 export interface PluginContext
   extends RollupPluginContext,
     PluginContextExtension {}
@@ -75,7 +80,7 @@ export interface TransformPluginContext
 
 // Argument Rollup types to have the PluginContextExtension
 declare module 'rollup' {
-  export interface PluginContext extends PluginContextExtension {}
+  export interface MinimalPluginContext extends PluginContextExtension {}
 }
 
 /**

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -185,6 +185,7 @@ class EnvironmentPluginContainer {
       warn: noop,
       // @ts-expect-error noop
       error: noop,
+      environment,
     }
     const utils = createPluginHookUtils(plugins)
     this.getSortedPlugins = utils.getSortedPlugins

--- a/packages/vite/src/node/typeUtils.ts
+++ b/packages/vite/src/node/typeUtils.ts
@@ -1,7 +1,7 @@
 import type {
   ObjectHook,
+  MinimalPluginContext as RollupMinimalPluginContext,
   Plugin as RollupPlugin,
-  PluginContext as RollupPluginContext,
 } from 'rollup'
 
 export type NonNeverKeys<T> = {
@@ -11,7 +11,7 @@ export type NonNeverKeys<T> = {
 export type GetHookContextMap<Plugin> = {
   [K in keyof Plugin]-?: Plugin[K] extends ObjectHook<infer T, unknown>
     ? T extends (this: infer This, ...args: any[]) => any
-      ? This extends RollupPluginContext
+      ? This extends RollupMinimalPluginContext
         ? This
         : never
       : never


### PR DESCRIPTION
### Description

This PR adds `this.environment` support in `options` and `onLog` hook. Note that `onLog` hook is not called in dev (https://github.com/vitejs/vite/issues/13624).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
