### PR TITLE
fix(config): vite.config.ts can't import untranspiled ts files from other packages in the same monorepo (#5370)

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1641,6 +1641,10 @@ async function bundleConfigFile(
                 }
                 throw e
               }
+              // not nod_modules dependency, compile it #5370
+              if (idFsPath && !isInNodeModules(idFsPath)) {
+                return
+              }
               if (idFsPath && isImport) {
                 idFsPath = pathToFileURL(idFsPath).href
               }


### PR DESCRIPTION
fix(config): vite.config.ts can't import untranspiled ts files from other packages in the same monorepo (#5370)

### Description

vite.config.ts support ts files from other packages in the same monorepo

If the file path contains node_modules, the file will not be compiled. If it does not contain node_modules, it means the local path, so it will be compiled.
