### PR TITLE
fix(ssr): fix source map remapping with multiple sources

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -1,4 +1,5 @@
 import { transform } from 'esbuild'
+import { TraceMap, decodedMap, encodedMap } from '@jridgewell/trace-mapping'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { escapeRegex } from '../utils'
@@ -199,6 +200,26 @@ export async function replaceDefine(
         ? !!environment.config.build.sourcemap
         : true,
   })
+
+  // remove esbuild's <define:...> source entries
+  // since they would confuse source map remapping/collapsing which expects a single source
+  if (result.map.includes('<define:')) {
+    const originalMap = new TraceMap(result.map)
+    if (originalMap.sources.length >= 2) {
+      const sourceIndex = originalMap.sources.indexOf(id)
+      const decoded = decodedMap(originalMap)
+      decoded.sources = [id]
+      decoded.mappings = decoded.mappings.map((segments) =>
+        segments.filter((segment) => {
+          // modify and filter
+          const index = segment[1]
+          segment[1] = 0
+          return index === sourceIndex
+        }),
+      )
+      result.map = JSON.stringify(encodedMap(new TraceMap(decoded as any)))
+    }
+  }
 
   return {
     code: result.code,

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -1,5 +1,4 @@
 import { transform } from 'esbuild'
-import { TraceMap, decodedMap, encodedMap } from '@jridgewell/trace-mapping'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { escapeRegex } from '../utils'
@@ -200,26 +199,6 @@ export async function replaceDefine(
         ? !!environment.config.build.sourcemap
         : true,
   })
-
-  // remove esbuild's <define:...> source entries
-  // since they would confuse source map remapping/collapsing which expects a single source
-  if (result.map.includes('<define:')) {
-    const originalMap = new TraceMap(result.map)
-    if (originalMap.sources.length >= 2) {
-      const sourceIndex = originalMap.sources.indexOf(id)
-      const decoded = decodedMap(originalMap)
-      decoded.sources = [id]
-      decoded.mappings = decoded.mappings.map((segments) =>
-        segments.filter((segment) => {
-          // modify and filter
-          const index = segment[1]
-          segment[1] = 0
-          return index === sourceIndex
-        }),
-      )
-      result.map = JSON.stringify(encodedMap(new TraceMap(decoded as any)))
-    }
-  }
 
   return {
     code: result.code,

--- a/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/dist.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/dist.js
@@ -1,0 +1,11 @@
+// nested-directory/nested-file.js
+var nested_file_default =
+  'Nested file will trigger edge case that used to break sourcemaps'
+
+// entrypoint.js
+function entrypoint() {
+  console.log(nested_file_default)
+  throw new Error('Hello world')
+}
+export { entrypoint }
+//# sourceMappingURL=dist.js.map

--- a/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/dist.js.map
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/dist.js.map
@@ -1,0 +1,7 @@
+{
+  "version": 3,
+  "sources": ["nested-directory/nested-file.js", "entrypoint.js"],
+  "sourcesContent": ["export default 'Nested file will trigger edge case that used to break sourcemaps'\n", "/*\n * You can rebuild this with:\n * - rm -f ./dist.js ./dist.js.map\n * - npx esbuild --bundle entrypoint.js --outfile=dist.js --sourcemap --format=esm\n */\n\nimport nested from './nested-directory/nested-file'\n\nexport function entrypoint() {\n  console.log(nested)\n  throw new Error('Hello world')\n}\n"],
+  "mappings": ";AAAA,IAAO,sBAAQ;;;ACQR,SAAS,aAAa;AAC3B,UAAQ,IAAI,mBAAM;AAClB,QAAM,IAAI,MAAM,aAAa;AAC/B;",
+  "names": []
+}

--- a/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/entrypoint.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/entrypoint.js
@@ -1,0 +1,12 @@
+/*
+ * You can rebuild this with:
+ * - rm -f ./dist.js ./dist.js.map
+ * - npx esbuild --bundle entrypoint.js --outfile=dist.js --sourcemap --format=esm
+ */
+
+import nested from './nested-directory/nested-file'
+
+export function entrypoint() {
+  console.log(nested)
+  throw new Error('Hello world')
+}

--- a/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/nested-directory/nested-file.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/multi-source-sourcemaps/nested-directory/nested-file.js
@@ -1,0 +1,1 @@
+export default 'Nested file will trigger edge case that used to break sourcemaps'

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -441,6 +441,31 @@ test('sourcemap with multiple sources', async () => {
   }
 })
 
+test('sourcemap with multiple sources and nested paths', async () => {
+  const code = readFixture('dist.js')
+  const map = readFixture('dist.js.map')
+
+  const result = await ssrTransform(code, JSON.parse(map), '', code)
+  assert(result?.map)
+
+  const { sources } = result.map as SourceMap
+  expect(sources).toMatchInlineSnapshot(`
+    [
+      "nested-directory/nested-file.js",
+      "entrypoint.js",
+    ]
+  `)
+
+  function readFixture(filename: string) {
+    const url = new URL(
+      `./fixtures/multi-source-sourcemaps/${filename}`,
+      import.meta.url,
+    )
+
+    return readFileSync(fileURLToPath(url), 'utf8')
+  }
+})
+
 test('overwrite bindings', async () => {
   expect(
     await ssrTransformSimpleCode(

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -347,6 +347,10 @@ async function ssrTransformScript(
   })
 
   let map = s.generateMap({ hires: 'boundary' })
+  map.sources = [path.basename(url)]
+  // needs to use originalCode instead of code
+  // because code might be already transformed even if map is null
+  map.sourcesContent = [originalCode]
   if (
     inMap &&
     inMap.mappings &&
@@ -354,18 +358,9 @@ async function ssrTransformScript(
     inMap.sources.length > 0
   ) {
     map = combineSourcemaps(url, [
-      {
-        ...map,
-        sources: inMap.sources,
-        sourcesContent: inMap.sourcesContent,
-      } as RawSourceMap,
+      map as RawSourceMap,
       inMap as RawSourceMap,
     ]) as SourceMap
-  } else {
-    map.sources = [path.basename(url)]
-    // needs to use originalCode instead of code
-    // because code might be already transformed even if map is null
-    map.sourcesContent = [originalCode]
   }
 
   return {


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/18144

I'm not too sure, but it feels like ssr transform should pass `magic-string`'s source map directly for remapping since `combineSourcemaps` should take care merging it with original `inMap.sources`. The initial code has been there for a long time since https://github.com/vitejs/vite/commit/6cb04fa3b3a7a4ac4676a7b1c41d9d5068fae5de

This change makes `useArrayInterface = true`, so the `remapping` goes through a simplified path and the issue won't happen, but maybe there's still something wrong with `useArrayInterface = false` case.

https://github.com/vitejs/vite/blob/63a125195911259a784c4466f1429e47e649922d/packages/vite/src/node/utils.ts#L859-L875

---

For the test case, we can check the tests added in https://github.com/vitejs/vite/pull/17677 still works. I'm not sure what we can do to test `useArrayInterface = false` case though.

https://github.com/vitejs/vite/blob/63a125195911259a784c4466f1429e47e649922d/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts#L423

Here is how it looks on [evanw.github.io/source-map-visualization](https://evanw.github.io/source-map-visualization/#Njc4AGZ1bmN0aW9uIGNvdmVyZWQkMSgpIHsKICByZXR1cm4gJ0ZpcnN0Jwp9CgpmdW5jdGlvbiB1bmNvdmVyZWQkMSgpIHsKICByZXR1cm4gJ1VuY292ZXJlZCcKfQoKdmFyIGZpcnN0ID0gLyojX19QVVJFX18qLyBPYmplY3QuZnJlZXplKHsKICBfX3Byb3RvX186IG51bGwsCiAgY292ZXJlZDogY292ZXJlZCQxLAogIHVuY292ZXJlZDogdW5jb3ZlcmVkJDEsCn0pCgpmdW5jdGlvbiBjb3ZlcmVkKCkgewogIHJldHVybiAnU2Vjb25kJwp9CgpmdW5jdGlvbiB1bmNvdmVyZWQoKSB7CiAgcmV0dXJuICdVbmNvdmVyZWQnCn0KCnZhciBzZWNvbmQgPSAvKiNfX1BVUkVfXyovIE9iamVjdC5mcmVlemUoewogIF9fcHJvdG9fXzogbnVsbCwKICBjb3ZlcmVkOiBjb3ZlcmVkLAogIHVuY292ZXJlZDogdW5jb3ZlcmVkLAp9KQoKCk9iamVjdC5kZWZpbmVQcm9wZXJ0eShfX3ZpdGVfc3NyX2V4cG9ydHNfXywgImZpcnN0IiwgeyBlbnVtZXJhYmxlOiB0cnVlLCBjb25maWd1cmFibGU6IHRydWUsIGdldCgpeyByZXR1cm4gZmlyc3QgfX0pOwpPYmplY3QuZGVmaW5lUHJvcGVydHkoX192aXRlX3Nzcl9leHBvcnRzX18sICJzZWNvbmQiLCB7IGVudW1lcmFibGU6IHRydWUsIGNvbmZpZ3VyYWJsZTogdHJ1ZSwgZ2V0KCl7IHJldHVybiBzZWNvbmQgfX0pOwovLyMgc291cmNlTWFwcGluZ1VSTD1idW5kbGUuanMubWFwCjU5NAB7InZlcnNpb24iOjMsIm1hcHBpbmdzIjoiQUFBTyxTQUFTQSxTQUFPLEdBQUc7QUFDMUIsRUFBRSxPQUFPLE9BQU87QUFDaEIsQ0FBQztBQUNEO0FBQ08sU0FBU0MsV0FBUyxHQUFHO0FBQzVCLEVBQUUsT0FBTyxXQUFXO0FBQ3BCOzs7Ozs7OztBQ05PLFNBQVMsT0FBTyxHQUFHO0FBQzFCLEVBQUUsT0FBTyxRQUFRO0FBQ2pCLENBQUM7QUFDRDtBQUNPLFNBQVMsU0FBUyxHQUFHO0FBQzVCLEVBQUUsT0FBTyxXQUFXO0FBQ3BCIiwibmFtZXMiOlsiY292ZXJlZCIsInVuY292ZXJlZCJdLCJpZ25vcmVMaXN0IjpbXSwic291cmNlcyI6WyIuL2ZpcnN0LnRzIiwiLi9zZWNvbmQudHMiXSwic291cmNlc0NvbnRlbnQiOlsiZXhwb3J0IGZ1bmN0aW9uIGNvdmVyZWQoKSB7XG4gIHJldHVybiBcIkZpcnN0XCI7XG59XG5cbmV4cG9ydCBmdW5jdGlvbiB1bmNvdmVyZWQoKSB7XG4gIHJldHVybiBcIlVuY292ZXJlZFwiO1xufVxuIiwiZXhwb3J0IGZ1bmN0aW9uIGNvdmVyZWQoKSB7XG4gIHJldHVybiBcIlNlY29uZFwiO1xufVxuXG5leHBvcnQgZnVuY3Rpb24gdW5jb3ZlcmVkKCkge1xuICByZXR1cm4gXCJVbmNvdmVyZWRcIjtcbn1cbiJdLCJmaWxlIjoiIn0=) and this is same as main. 