### PR TITLE
refactor: replace `parse` with `URL`

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -371,7 +371,14 @@ async function fileToBuiltUrl(
     }
   } else {
     // emit as asset
-    const { search, hash } = new URL(id)
+    let { search, hash } = new URL(id)
+    if (!search) {
+      const hasSearchCharacter = id.includes('?')
+      if (hasSearchCharacter) {
+        // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
+        search = '?'
+      }
+    }
     const postfix = (search || '') + (hash || '')
 
     const originalFileName = normalizePath(

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -22,6 +22,7 @@ import {
   rawRE,
   removeLeadingSlash,
   removeUrlQuery,
+  urlCanParse,
   urlRE,
 } from '../utils'
 import { DEFAULT_ASSETS_INLINE_LIMIT, FS_PREFIX } from '../constants'
@@ -371,14 +372,21 @@ async function fileToBuiltUrl(
     }
   } else {
     // emit as asset
-    let { search, hash } = new URL(id)
-    if (!search) {
-      const hasSearchCharacter = id.includes('?')
-      if (hasSearchCharacter) {
-        // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
-        search = '?'
+    let search = ''
+    let hash = ''
+    if (urlCanParse(id)) {
+      const parsed = new URL(id)
+      search = parsed.search
+      hash = parsed.hash
+      if (!search) {
+        const hasSearchCharacter = id.includes('?')
+        if (hasSearchCharacter) {
+          // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
+          search = '?'
+        }
       }
     }
+
     const postfix = (search || '') + (hash || '')
 
     const originalFileName = normalizePath(

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { parse as parseUrl } from 'node:url'
+import { URL } from 'node:url'
 import fsp from 'node:fs/promises'
 import { Buffer } from 'node:buffer'
 import * as mrmime from 'mrmime'
@@ -371,7 +371,7 @@ async function fileToBuiltUrl(
     }
   } else {
     // emit as asset
-    const { search, hash } = parseUrl(id)
+    const { search, hash } = new URL(id)
     const postfix = (search || '') + (hash || '')
 
     const originalFileName = normalizePath(

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -22,7 +22,6 @@ import {
   rawRE,
   removeLeadingSlash,
   removeUrlQuery,
-  urlCanParse,
   urlRE,
 } from '../utils'
 import { DEFAULT_ASSETS_INLINE_LIMIT, FS_PREFIX } from '../constants'
@@ -374,7 +373,7 @@ async function fileToBuiltUrl(
     // emit as asset
     let search = ''
     let hash = ''
-    if (urlCanParse(id)) {
+    try {
       const parsed = new URL(id)
       search = parsed.search
       hash = parsed.hash
@@ -385,7 +384,7 @@ async function fileToBuiltUrl(
           search = '?'
         }
       }
-    }
+    } catch {}
 
     const postfix = (search || '') + (hash || '')
 

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { URL } from 'node:url'
+import { URL, parse as parseUrl } from 'node:url'
 import fsp from 'node:fs/promises'
 import { Buffer } from 'node:buffer'
 import * as mrmime from 'mrmime'
@@ -384,6 +384,10 @@ async function fileToBuiltUrl(
           search = '?'
         }
       }
+      // eslint-disable-next-line no-console
+      console.log(id, search, hash)
+      // eslint-disable-next-line no-console
+      console.log(parseUrl(id))
     } catch {}
 
     const postfix = (search || '') + (hash || '')


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
`parse` method has been deprecated.
https://nodejs.org/docs/latest/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost
