### PR TITLE
fix: treat config file as ESM in Deno

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1035,7 +1035,8 @@ export async function loadConfigFromFile(
     return null
   }
 
-  const isESM = isFilePathESM(resolvedPath)
+  const isESM =
+    typeof process.versions.deno === 'string' || isFilePathESM(resolvedPath)
 
   try {
     const bundled = await bundleConfigFile(resolvedPath, isESM)


### PR DESCRIPTION
Backports https://github.com/vitejs/vite/pull/18081 into the v5 release branch.