### PR TITLE
fix(worker): rewrite rollup `output.format` with `worker.format` on worker build error

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -707,6 +707,26 @@ test('default sharedConfigBuild true on build api', async () => {
   expect(counter).toBe(1)
 })
 
+test('adjust worker build error for worker.format', async () => {
+  try {
+    await build({
+      root: resolve(__dirname, 'fixtures/worker-dynamic'),
+      build: {
+        rollupOptions: {
+          input: {
+            index: '/main.js',
+          },
+        },
+      },
+    })
+  } catch (e) {
+    expect(e.message).toContain('worker.format')
+    expect(e.message).not.toContain('output.format')
+    return
+  }
+  expect.unreachable()
+})
+
 /**
  * for each chunks in output1, if there's a chunk in output2 with the same fileName,
  * ensure that the chunk code is the same. if not, the chunk hash should have changed.

--- a/packages/vite/src/node/__tests__/fixtures/worker-dynamic/dynamic.js
+++ b/packages/vite/src/node/__tests__/fixtures/worker-dynamic/dynamic.js
@@ -1,0 +1,1 @@
+export default 'dynamic ok'

--- a/packages/vite/src/node/__tests__/fixtures/worker-dynamic/main.js
+++ b/packages/vite/src/node/__tests__/fixtures/worker-dynamic/main.js
@@ -1,0 +1,12 @@
+document.querySelector('#app').innerHTML = `
+  <div>
+    <h1>Test worker</h1>
+    <div id="worker">???</div>
+  </div>
+`
+
+const worker = new Worker(new URL('./worker.js', import.meta.url))
+worker.onmessage = (e) => {
+  document.querySelector('#worker').textContent = e.data
+}
+worker.postMessage('hi')

--- a/packages/vite/src/node/__tests__/fixtures/worker-dynamic/worker.js
+++ b/packages/vite/src/node/__tests__/fixtures/worker-dynamic/worker.js
@@ -1,0 +1,4 @@
+self.onmessage = async () => {
+  const mod = await import('./dynamic')
+  self.postMessage('hello from worker: ' + mod.default)
+}

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import MagicString from 'magic-string'
-import type { OutputChunk } from 'rollup'
+import type { OutputChunk, RollupError } from 'rollup'
 import type { ResolvedConfig } from '../config'
 import type { Plugin } from '../plugin'
 import { ENV_ENTRY, ENV_PUBLIC_PATH } from '../constants'
@@ -126,6 +126,17 @@ async function bundleWorkerEntry(
         })
       }
     })
+  } catch (e) {
+    // adjust rollup format error
+    if (
+      e instanceof Error &&
+      e.name === 'RollupError' &&
+      (e as RollupError).code === 'INVALID_OPTION' &&
+      e.message.includes('"output.format"')
+    ) {
+      e.message = e.message.replace('output.format', 'worker.format')
+    }
+    throw e
   } finally {
     await bundle.close()
   }


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/17483
