### PR TITLE
refactor: replace `parse` with `splitFileAndPostfix`

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -373,8 +373,8 @@ async function fileToBuiltUrl(
     // emit as asset
     // On Mac or Linux platforms, the path resolution is considered an invalid URL by the new URL and an error will be thrown.
     // So it will be converted into a valid URL.
-    const _id = 'http://example.com/' + id.split('/').slice(-1)[0]
-    let { search, hash } = new URL(_id)
+    const validUrl = 'http://example.com/' + id.split('/').slice(-1)[0]
+    let { search, hash } = new URL(validUrl)
     if (!search && id.includes('?')) {
       // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
       search = '?'

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { parse as parseUrl } from 'node:url'
+import { URL } from 'node:url'
 import fsp from 'node:fs/promises'
 import { Buffer } from 'node:buffer'
 import * as mrmime from 'mrmime'
@@ -371,8 +371,15 @@ async function fileToBuiltUrl(
     }
   } else {
     // emit as asset
-    const { search, hash } = parseUrl(id)
-    const postfix = (search || '') + (hash || '')
+    // On Mac or Linux platforms, the path resolution is considered an invalid URL by the new URL and an error will be thrown.
+    // So it will be converted into a valid URL.
+    const _id = 'http://example.com/' + id.split('/').slice(-1)[0]
+    let { search, hash } = new URL(_id)
+    if (!search && id.includes('?')) {
+      // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
+      search = '?'
+    }
+    const postfix = search + hash
 
     const originalFileName = normalizePath(
       path.relative(environment.config.root, file),

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -373,7 +373,7 @@ async function fileToBuiltUrl(
     // emit as asset
     // On Mac or Linux platforms, the path resolution is considered an invalid URL by the new URL and an error will be thrown.
     // So it will be converted into a valid URL.
-    let { search, hash } = new URL(id, 'http://example.com')
+    let { search, hash } = new URL(id, 'http://vitejs.dev')
     if (!search && id.includes('?')) {
       // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
       search = '?'

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -373,8 +373,7 @@ async function fileToBuiltUrl(
     // emit as asset
     // On Mac or Linux platforms, the path resolution is considered an invalid URL by the new URL and an error will be thrown.
     // So it will be converted into a valid URL.
-    const validUrl = 'http://example.com/' + id.split('/').slice(-1)[0]
-    let { search, hash } = new URL(validUrl)
+    let { search, hash } = new URL(id, 'http://example.com')
     if (!search && id.includes('?')) {
       // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
       search = '?'

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -1,5 +1,4 @@
 import path from 'node:path'
-import { URL } from 'node:url'
 import fsp from 'node:fs/promises'
 import { Buffer } from 'node:buffer'
 import * as mrmime from 'mrmime'
@@ -25,7 +24,11 @@ import {
   urlRE,
 } from '../utils'
 import { DEFAULT_ASSETS_INLINE_LIMIT, FS_PREFIX } from '../constants'
-import { cleanUrl, withTrailingSlash } from '../../shared/utils'
+import {
+  cleanUrl,
+  splitFileAndPostfix,
+  withTrailingSlash,
+} from '../../shared/utils'
 import type { Environment } from '../environment'
 
 // referenceId is base64url but replaces - with $
@@ -351,7 +354,7 @@ async function fileToBuiltUrl(
     return cached
   }
 
-  const file = cleanUrl(id)
+  const { file, postfix } = splitFileAndPostfix(id)
   const content = await fsp.readFile(file)
 
   let url: string
@@ -371,15 +374,6 @@ async function fileToBuiltUrl(
     }
   } else {
     // emit as asset
-    // On Mac or Linux platforms, the path resolution is considered an invalid URL by the new URL and an error will be thrown.
-    // So it will be converted into a valid URL.
-    let { search, hash } = new URL(id, 'http://vitejs.dev')
-    if (!search && id.includes('?')) {
-      // When the string structure is like `woff2?#iefix`, the search value obtained by parsing the new URL is an empty string
-      search = '?'
-    }
-    const postfix = search + hash
-
     const originalFileName = normalizePath(
       path.relative(environment.config.root, file),
     )

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -53,6 +53,7 @@ import {
   cleanUrl,
   isWindows,
   slash,
+  splitFileAndPostfix,
   withTrailingSlash,
 } from '../../shared/utils'
 
@@ -587,11 +588,6 @@ function ensureVersionQuery(
     }
   }
   return resolved
-}
-
-function splitFileAndPostfix(path: string) {
-  const file = cleanUrl(path)
-  return { file, postfix: path.slice(file.length) }
 }
 
 export function tryFsResolve(

--- a/packages/vite/src/shared/utils.ts
+++ b/packages/vite/src/shared/utils.ts
@@ -33,6 +33,14 @@ export function cleanUrl(url: string): string {
   return url.replace(postfixRE, '')
 }
 
+export function splitFileAndPostfix(path: string): {
+  file: string
+  postfix: string
+} {
+  const file = cleanUrl(path)
+  return { file, postfix: path.slice(file.length) }
+}
+
 export function isPrimitive(value: unknown): boolean {
   return !value || (typeof value !== 'object' && typeof value !== 'function')
 }


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
`parse` method has been deprecated.
https://nodejs.org/docs/latest/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost
