### PR TITLE
fix: require serialization for `HMRConnection.send` on implementation side

### DIFF
--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -910,13 +910,13 @@ This keeps the HTML processing server agnostic.
 ```ts
 export interface ModuleRunnerHMRConnection {
   /**
-   * Checked before sending messages to the client.
+   * Checked before sending messages to the server.
    */
   isReady(): boolean
   /**
-   * Send a message to the client.
+   * Send a message to the server.
    */
-  send(message: string): void
+  send(payload: HotPayload): void
   /**
    * Configure how HMR is handled when this connection triggers an update.
    * This method expects that the connection will start listening for HMR updates and call this callback when it's received.

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -142,7 +142,7 @@ const hmrClient = new HMRClient(
   },
   {
     isReady: () => socket && socket.readyState === 1,
-    send: (message) => socket.send(JSON.stringify(message)),
+    send: (payload) => socket.send(JSON.stringify(payload)),
   },
   async function importUpdatedModule({
     acceptedPath,

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -142,7 +142,7 @@ const hmrClient = new HMRClient(
   },
   {
     isReady: () => socket && socket.readyState === 1,
-    send: (message) => socket.send(message),
+    send: (message) => socket.send(JSON.stringify(message)),
   },
   async function importUpdatedModule({
     acceptedPath,

--- a/packages/vite/src/node/ssr/runtime/serverHmrConnector.ts
+++ b/packages/vite/src/node/ssr/runtime/serverHmrConnector.ts
@@ -47,8 +47,8 @@ export class ServerHMRConnector implements ModuleRunnerHMRConnection {
     return this.connected
   }
 
-  send(message: HotPayload): void {
-    const payload = message as CustomPayload
+  send(payload_: HotPayload): void {
+    const payload = payload_ as CustomPayload
     this.hotChannel.api.innerEmitter.emit(
       payload.event,
       payload.data,

--- a/packages/vite/src/node/ssr/runtime/serverHmrConnector.ts
+++ b/packages/vite/src/node/ssr/runtime/serverHmrConnector.ts
@@ -47,8 +47,8 @@ export class ServerHMRConnector implements ModuleRunnerHMRConnection {
     return this.connected
   }
 
-  send(message: string): void {
-    const payload = JSON.parse(message) as CustomPayload
+  send(message: HotPayload): void {
+    const payload = message as CustomPayload
     this.hotChannel.api.innerEmitter.emit(
       payload.event,
       payload.data,

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -178,8 +178,8 @@ class HMRMessenger {
 
   private queue: HotPayload[] = []
 
-  public send(message: HotPayload): void {
-    this.queue.push(message)
+  public send(payload: HotPayload): void {
+    this.queue.push(payload)
     this.flush()
   }
 

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -1,4 +1,4 @@
-import type { Update } from 'types/hmrPayload'
+import type { HotPayload, Update } from 'types/hmrPayload'
 import type { ModuleNamespace, ViteHotContext } from 'types/hot'
 import type { InferCustomEventPayload } from 'types/customEvent'
 
@@ -28,7 +28,7 @@ export interface HMRConnection {
   /**
    * Send message to the client.
    */
-  send(messages: string): void
+  send(messages: HotPayload): void
 }
 
 export class HMRContext implements ViteHotContext {
@@ -154,9 +154,7 @@ export class HMRContext implements ViteHotContext {
   }
 
   send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void {
-    this.hmrClient.messenger.send(
-      JSON.stringify({ type: 'custom', event, data }),
-    )
+    this.hmrClient.messenger.send({ type: 'custom', event, data })
   }
 
   private acceptDeps(
@@ -178,9 +176,9 @@ export class HMRContext implements ViteHotContext {
 class HMRMessenger {
   constructor(private connection: HMRConnection) {}
 
-  private queue: string[] = []
+  private queue: HotPayload[] = []
 
-  public send(message: string): void {
+  public send(message: HotPayload): void {
     this.queue.push(message)
     this.flush()
   }


### PR DESCRIPTION
### Description

This is brought up by @jamesopstad (Also thanks for spotting the bug on my `HMRConnection` implementation!).

Currently `HMRConnection.send` and `HMRConnection.onUpdate` interfaces are unbalanced as `HMRConnection.send: (message: string) => void` receives already serialized `string` of `HotPayload`. Custom webSocket based implementation would require something like this:
https://github.com/hi-ogawa/vite-environment-examples/blob/edf04cf23fb472a9d085e1a424ae7543164b98f8/packages/workerd/src/worker.ts#L95-L107

```ts
      hmr: {
        connection: {
          isReady: () => true,
          onUpdate(callback: (payload: HotPayload) => void) {
            webSocket.addEventListener("message", (event) => {
              callback(JSON.parse(event.data));
            });
          },
          send(messages: string) {
            webSocket.send(messages);
          },
        },
      },
```

This PR changes it to `HMRConnection.send: (payload: HotPayload) => void`, so `HMRConnection` implementation will become like below:

```ts
      hmr: {
        connection: {
          ...
          send(payload: HotPayload) {
            webSocket.send(JSON.stringify(payload));
          },
        },
      },
```

I think this will make interfaces more uniform since `HotChannel` on server side also assumes (de)serialization to be taken care by implementations. Also in case of `ServerHMRConnector / ServerHotChannel`, this removes unnecessary serialization since they can pass payload object directly.