### PR TITLE
refactor: remove the need for "processSourceMap"

### DIFF
--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -715,6 +715,10 @@ export interface ModuleRunnerOptions {
 ```ts
 export interface ModuleEvaluator {
   /**
+   * Number of prefixed lines in the transformed code.
+   */
+  startOffset?: number
+  /**
    * Evaluate code that was transformed by Vite.
    * @param context Function context
    * @param code Transformed code
@@ -733,7 +737,7 @@ export interface ModuleEvaluator {
 }
 ```
 
-Vite exports `ESModulesEvaluator` that implements this interface by default. It uses `new AsyncFunction` to evaluate code, so if the code has inlined source map it should contain an [offset of 2 lines](https://tc39.es/ecma262/#sec-createdynamicfunction) to accommodate for new lines added. This is done automatically in the server node environment. If your runner implementation doesn't have this constraint, you should use `fetchModule` (exported from `vite`) directly.
+Vite exports `ESModulesEvaluator` that implements this interface by default. It uses `new AsyncFunction` to evaluate code, so if the code has inlined source map it should contain an [offset of 2 lines](https://tc39.es/ecma262/#sec-createdynamicfunction) to accommodate for new lines added. This is done automatically by the `ESModulesEvaluator`. Custom evaluators will not add additional lines.
 
 ## RunnerTransport
 

--- a/packages/vite/src/module-runner/esmEvaluator.ts
+++ b/packages/vite/src/module-runner/esmEvaluator.ts
@@ -1,4 +1,7 @@
-import { AsyncFunction } from '../shared/utils'
+import {
+  AsyncFunction,
+  asyncFunctionDeclarationPaddingLineCount,
+} from '../shared/utils'
 import {
   ssrDynamicImportKey,
   ssrExportAllKey,
@@ -9,6 +12,8 @@ import {
 import type { ModuleEvaluator, ModuleRunnerContext } from './types'
 
 export class ESModulesEvaluator implements ModuleEvaluator {
+  startOffset = asyncFunctionDeclarationPaddingLineCount
+
   async runInlinedModule(
     context: ModuleRunnerContext,
     code: string,

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -265,6 +265,7 @@ export class ModuleRunner {
           ? { externalize: url, type: 'builtin' }
           : await this.transport.fetchModule(url, importer, {
               cached: isCached,
+              startOffset: this.evaluator.startOffset,
             })
       ) as ResolvedResult
 

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -46,6 +46,9 @@ export interface ModuleRunnerContext {
 }
 
 export interface ModuleEvaluator {
+  /**
+   * Number of prefixed lines in the transformed code.
+   */
   startOffset?: number
   /**
    * Run code that was transformed by Vite.

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -46,6 +46,7 @@ export interface ModuleRunnerContext {
 }
 
 export interface ModuleEvaluator {
+  startOffset?: number
   /**
    * Run code that was transformed by Vite.
    * @param context Function context
@@ -138,6 +139,7 @@ export type FetchFunction = (
 
 export interface FetchFunctionOptions {
   cached?: boolean
+  startOffset?: number
 }
 
 export interface ModuleRunnerHmr {

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -1,7 +1,6 @@
 import type { ResolvedConfig } from '../../config'
 import type { DevEnvironmentContext } from '../environment'
 import { DevEnvironment } from '../environment'
-import { asyncFunctionDeclarationPaddingLineCount } from '../../../shared/utils'
 
 export function createNodeDevEnvironment(
   name: string,
@@ -14,17 +13,5 @@ export function createNodeDevEnvironment(
     )
   }
 
-  return new DevEnvironment(name, config, {
-    ...context,
-    runner: {
-      processSourceMap(map) {
-        // this assumes that "new AsyncFunction" is used to create the module
-        return Object.assign({}, map, {
-          mappings:
-            ';'.repeat(asyncFunctionDeclarationPaddingLineCount) + map.mappings,
-        })
-      },
-      ...context.runner,
-    },
-  })
+  return new DevEnvironment(name, config, context)
 }

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -15,7 +15,7 @@ import { normalizeResolvedIdToUrl } from '../plugins/importAnalysis'
 export interface FetchModuleOptions {
   cached?: boolean
   inlineSourceMap?: boolean
-  processSourceMap?<T extends NonNullable<TransformResult['map']>>(map: T): T
+  startOffset?: number
 }
 
 /**
@@ -126,8 +126,8 @@ export async function fetchModule(
     )
   }
 
-  if (options.inlineSourceMap !== false) {
-    result = inlineSourceMap(mod, result, options.processSourceMap)
+  if (options.startOffset != null) {
+    result = inlineSourceMap(mod, result, options.startOffset)
   }
 
   // remove shebang
@@ -150,7 +150,7 @@ const OTHER_SOURCE_MAP_REGEXP = new RegExp(
 function inlineSourceMap(
   mod: EnvironmentModuleNode,
   result: TransformResult,
-  processSourceMap?: FetchModuleOptions['processSourceMap'],
+  startOffset: number,
 ) {
   const map = result.map
   let code = result.code
@@ -167,7 +167,9 @@ function inlineSourceMap(
   if (OTHER_SOURCE_MAP_REGEXP.test(code))
     code = code.replace(OTHER_SOURCE_MAP_REGEXP, '')
 
-  const sourceMap = processSourceMap?.(map) || map
+  const sourceMap = Object.assign({}, map, {
+    mappings: ';'.repeat(startOffset) + map.mappings,
+  })
   result.code = `${code.trimEnd()}\n//# sourceURL=${
     mod.id
   }\n${MODULE_RUNNER_SOURCEMAPPING_SOURCE}\n//# ${SOURCEMAPPING_URL}=${genSourceMapUrl(sourceMap)}\n`

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -126,7 +126,7 @@ export async function fetchModule(
     )
   }
 
-  if (options.startOffset != null) {
+  if (options.inlineSourceMap !== false) {
     result = inlineSourceMap(mod, result, options.startOffset)
   }
 
@@ -150,7 +150,7 @@ const OTHER_SOURCE_MAP_REGEXP = new RegExp(
 function inlineSourceMap(
   mod: EnvironmentModuleNode,
   result: TransformResult,
-  startOffset: number,
+  startOffset: number | undefined,
 ) {
   const map = result.map
   let code = result.code
@@ -167,9 +167,11 @@ function inlineSourceMap(
   if (OTHER_SOURCE_MAP_REGEXP.test(code))
     code = code.replace(OTHER_SOURCE_MAP_REGEXP, '')
 
-  const sourceMap = Object.assign({}, map, {
-    mappings: ';'.repeat(startOffset) + map.mappings,
-  })
+  const sourceMap = startOffset
+    ? Object.assign({}, map, {
+        mappings: ';'.repeat(startOffset) + map.mappings,
+      })
+    : map
   result.code = `${code.trimEnd()}\n//# sourceURL=${
     mod.id
   }\n${MODULE_RUNNER_SOURCEMAPPING_SOURCE}\n//# ${SOURCEMAPPING_URL}=${genSourceMapUrl(sourceMap)}\n`


### PR DESCRIPTION
### Description

This PR move the logic that fixes the source maps in the module runner to the evaluator.

The evaluator is the reason why we need this change, so it makes sense that it will the one controlling it.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
