### PR TITLE
refactor: do not require "hot" option when creating a node environment

### DIFF
--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -142,7 +142,6 @@ The default SSR Node module runner is not exposed. You can use `createNodeEnviro
 ```js
 import {
   createServer,
-  createServerHotChannel,
   createServerModuleRunner,
   createNodeDevEnvironment,
 } from 'vite'
@@ -155,11 +154,8 @@ const server = await createServer({
       dev: {
         // Default Vite SSR environment can be overridden in the config, so
         // make sure you have a Node environment before the request is received.
-        createEnvironment(name, config) {
-          return createNodeDevEnvironment(name, config, {
-            hot: createServerHotChannel(),
-          })
-        },
+        // By default, "createNodeDevEnvironment" also creates an HMR channel
+        createNodeDevEnvironment,
       },
     },
   },

--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -155,7 +155,9 @@ const server = await createServer({
         // Default Vite SSR environment can be overridden in the config, so
         // make sure you have a Node environment before the request is received.
         // By default, "createNodeDevEnvironment" also creates an HMR channel
-        createNodeDevEnvironment,
+        createEnvironment(name, config) {
+          return createNodeDevEnvironment(name, config)
+        },
       },
     },
   },

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -33,7 +33,7 @@ import {
 import type { RemoteEnvironmentTransport } from './environmentTransport'
 
 export interface DevEnvironmentContext {
-  hot: false | HotChannel
+  hot?: false | HotChannel
   options?: EnvironmentOptions
   runner?: FetchModuleOptions & {
     transport?: RemoteEnvironmentTransport

--- a/packages/vite/src/node/server/environments/nodeEnvironment.ts
+++ b/packages/vite/src/node/server/environments/nodeEnvironment.ts
@@ -1,6 +1,7 @@
 import type { ResolvedConfig } from '../../config'
 import type { DevEnvironmentContext } from '../environment'
 import { DevEnvironment } from '../environment'
+import { createServerHotChannel } from '../hmr'
 
 export function createNodeDevEnvironment(
   name: string,
@@ -8,9 +9,7 @@ export function createNodeDevEnvironment(
   context: DevEnvironmentContext,
 ): DevEnvironment {
   if (context.hot == null) {
-    throw new Error(
-      '`hot` is a required option. Either explicitly opt out of HMR by setting `hot: false` or provide a hot channel.',
-    )
+    context.hot = createServerHotChannel()
   }
 
   return new DevEnvironment(name, config, context)


### PR DESCRIPTION
### Description

Requiring "hot" adds more boilerplate and requires the developer to deal with how HMR works. It might be better to hide the complexity.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
