### PR TITLE
test: misc fixes

### DIFF
--- a/playground/alias/vite.config.js
+++ b/playground/alias/vite.config.js
@@ -39,5 +39,6 @@ export default defineConfig({
   define: {
     __VUE_OPTIONS_API__: true,
     __VUE_PROD_DEVTOOLS__: true,
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
   },
 })

--- a/playground/css-lightningcss-proxy/__tests__/css-lightningcss-proxy.spec.ts
+++ b/playground/css-lightningcss-proxy/__tests__/css-lightningcss-proxy.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from 'vitest'
 import { port } from './serve'
-import { getColor, page } from '~utils'
+import { getColor, isServe, page } from '~utils'
 
 const url = `http://localhost:${port}`
 
-describe('injected inline style', () => {
+describe.runIf(isServe)('injected inline style', () => {
   test('injected inline style is present', async () => {
     await page.goto(url)
     const el = await page.$('.ssr-proxy')

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -15,7 +15,6 @@
     image
   </p>
   <p>Imported css string:</p>
-  <pre class="imported-css"></pre>
   <pre class="imported-css-glob"></pre>
   <pre class="imported-css-globEager"></pre>
 
@@ -37,7 +36,6 @@
     url starts with function call
   </p>
   <p>Imported SASS string:</p>
-  <pre class="imported-sass"></pre>
   <p class="sass-dep">
     @import dependency w/ no scss entrypoint: this should be lavender
   </p>
@@ -55,8 +53,6 @@
     contains alias
   </p>
   <p class="less-url-starts-with-variable">url starts with variable</p>
-  <p>Imported Less string:</p>
-  <pre class="imported-less"></pre>
 
   <div class="form-box-data-uri">
     tests Less's `data-uri()` function with relative image paths
@@ -87,8 +83,6 @@
     Stylus define function via vite config preprocessor options: This should be
     rgb(255, 0, 98)
   </p>
-  <p>Imported Stylus string:</p>
-  <pre class="imported-stylus"></pre>
 
   <p class="sugarss">SugarSS: This should be blue</p>
   <p class="sugarss-at-import">
@@ -98,8 +92,6 @@
     @import from SugarSS: This should be darkslateblue and have bg image which
     url contains alias
   </p>
-  <p>Imported SugarSS string:</p>
-  <pre class="imported-sugarss"></pre>
 
   <p class="modules">CSS modules: this should be turquoise</p>
   <p>Imported CSS module:</p>

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -270,7 +270,7 @@ export async function startDefaultServe(): Promise<void> {
       },
     )
     if (buildConfig.builder) {
-      const builder = await createBuilder({ root: rootDir })
+      const builder = await createBuilder(buildConfig)
       await builder.buildApp()
     } else {
       const rollupOutput = await build(buildConfig)


### PR DESCRIPTION
### Description

- set `__VUE_PROD_HYDRATION_MISMATCH_DETAILS__` to remove warning in browser: the following error was happening
  - > Feature flag __VUE_PROD_HYDRATION_MISMATCH_DETAILS__ is not explicitly defined. You are running the esm-bundler build of Vue, which expects these compile-time feature flags to be globally injected via the bundler config in order to get better tree-shaking in the production bundle.
     >
     > For more details, see https://link.vuejs.org/feature-flags.
- remove unused test code: this test was removed by #11094, #14125
- only run css-lightningcss-proxy test in dev: this test was doing the same thing in dev and build
- hide environment-react-ssr test output: hide the following log
  - https://github.com/vitejs/vite/actions/runs/11035372865/job/30651205246#step:13:230

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
