### PR TITLE
fix(mixedModuleGraph): handle undefined id in getModulesByFile

### DIFF
--- a/packages/vite/src/node/server/mixedModuleGraph.ts
+++ b/packages/vite/src/node/server/mixedModuleGraph.ts
@@ -301,7 +301,7 @@ export class ModuleGraph {
     }
     if (ssrModules) {
       for (const mod of ssrModules) {
-        if (!this._client.getModuleById(mod.id!)) {
+        if (mod.id == null || !this._client.getModuleById(mod.id)) {
           result.add(this.getBackwardCompatibleBrowserModuleNode(mod)!)
         }
       }


### PR DESCRIPTION
### Description

Handle undefined id in `getModulesByFile`. I tested it manually with Astro to verify that it fixes its e2e tests, but I've not added test (https://github.com/withastro/astro/pull/11979) 😬 
