### PR TITLE
fix: close HotChannel on environment close

### DIFF
--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -31,6 +31,7 @@ import {
   createEnvironmentPluginContainer,
 } from './pluginContainer'
 import type { RemoteEnvironmentTransport } from './environmentTransport'
+import { isWebSocketServer } from './ws'
 
 export interface DevEnvironmentContext {
   hot: false | HotChannel
@@ -213,7 +214,8 @@ export class DevEnvironment extends BaseEnvironment {
     await Promise.allSettled([
       this.pluginContainer.close(),
       this.depsOptimizer?.close(),
-      this.hot.close(),
+      // WebSocketServer is independent of HotChannel and should not be closed on environment close
+      isWebSocketServer in this.hot ? this.hot.close() : Promise.resolve(),
       (async () => {
         while (this._pendingRequests.size > 0) {
           await Promise.allSettled(

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -213,6 +213,7 @@ export class DevEnvironment extends BaseEnvironment {
     await Promise.allSettled([
       this.pluginContainer.close(),
       this.depsOptimizer?.close(),
+      this.hot.close(),
       (async () => {
         while (this._pendingRequests.size > 0) {
           await Promise.allSettled(

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -115,7 +115,7 @@ export interface HotChannel {
   /**
    * Disconnect all clients, called when server is closed or restarted.
    */
-  close(): void
+  close(): Promise<unknown> | void
 }
 /** @deprecated use `HotChannel` instead */
 export type HMRChannel = HotChannel

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -660,7 +660,7 @@ export async function _createServer(
 
       await Promise.allSettled([
         watcher.close(),
-        ws.close(),
+        ws.actualClose(),
         Promise.allSettled(
           Object.values(server.environments).map((environment) =>
             environment.close(),

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -660,7 +660,7 @@ export async function _createServer(
 
       await Promise.allSettled([
         watcher.close(),
-        ws.actualClose(),
+        ws.close(),
         Promise.allSettled(
           Object.values(server.environments).map((environment) =>
             environment.close(),

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -43,7 +43,7 @@ export interface WebSocketServer extends HotChannel {
   /**
    * Disconnect all clients and terminate the server.
    */
-  close(): Promise<void>
+  actualClose(): Promise<void>
   /**
    * Handle custom event emitted by `import.meta.hot.send`
    */
@@ -90,6 +90,9 @@ export function createWebSocketServer(
     return {
       get clients() {
         return new Set<WebSocketClient>()
+      },
+      async actualClose() {
+        // noop
       },
       async close() {
         // noop
@@ -285,6 +288,12 @@ export function createWebSocketServer(
     },
 
     close() {
+      // noop
+      // WebSocketServer is independent of HotChannel and should not be closed on environment close
+      // actualClose() will be called when needed
+    },
+
+    actualClose() {
       // should remove listener if hmr.server is set
       // otherwise the old listener swallows all WebSocket connections
       if (hmrServerWsListener && wsServer) {


### PR DESCRIPTION
### Description

HotChannel::close was not called, but I guess this should be called on environment close.

The first commit looks better but to avoid a breaking change (`ws.close` will no longer actually close wss) I made the second commit 😢

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
