### PR TITLE
fix(optimizer): re-optimize when changing config `webCompatible`

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1176,6 +1176,7 @@ function getConfigHash(environment: Environment): string {
           plugins: optimizeDeps?.esbuildOptions?.plugins?.map((p) => p.name),
         },
       },
+      webCompatible: config.webCompatible,
     },
     (_, value) => {
       if (typeof value === 'function' || value instanceof RegExp) {


### PR DESCRIPTION
### Description

When flipping `webCompatible: boolean`, it should re-optimize as it affects `import { createRequire } from 'module'` banner etc..., but it didn't as this flag wasn't included in config hash.

__additional context__

I was setting up module runner in web worker and started with forgetting to enable `webCompatible: true` https://github.com/hi-ogawa/vite-environment-examples/blob/f2d1d071bc47bf1c8e6aabc17f6d631537ddb152/examples/web-worker/vite.config.ts#L17, so optimizer injecting `import { createRequire } from 'module'` banner, which then fails on web worker.

```
module-runner.js?v=764857e6:1082 Uncaught (in promise) TypeError: Failed to resolve module specifier 'module'
    at ESModulesEvaluator.runExternalModule (module-runner.js?v=764857e6:1082:19)
```

Flipping `webCompatible` didn't re-optimize so keep getting errors. ~Also it's probably a difference issue, but running it with `--force` doesn't seem to trigger re-optimization of custom environments.~ (EDIT: it looks like `--force` only affects client, so I had to do `environments.worker.dev.optimizeDeps.force: true`)