### PR TITLE
feat: support arbitrary module namespace identifier imports from cjs deps

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/import.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/import.spec.ts
@@ -18,7 +18,7 @@ describe('transformCjsImport', () => {
   test('import specifier', () => {
     expect(
       transformCjsImport(
-        'import { useState, Component } from "react"',
+        'import { useState, Component, "👋" as fake } from "react"',
         url,
         rawUrl,
         0,
@@ -28,7 +28,8 @@ describe('transformCjsImport', () => {
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
         'const useState = __vite__cjsImport0_react["useState"]; ' +
-        'const Component = __vite__cjsImport0_react["Component"]',
+        'const Component = __vite__cjsImport0_react["Component"]; ' +
+        'const fake = __vite__cjsImport0_react["👋"]',
     )
   })
 
@@ -111,7 +112,7 @@ describe('transformCjsImport', () => {
   test('export name specifier', () => {
     expect(
       transformCjsImport(
-        'export { useState, Component } from "react"',
+        'export { useState, Component, "👋" } from "react"',
         url,
         rawUrl,
         0,
@@ -120,14 +121,15 @@ describe('transformCjsImport', () => {
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
-        'const __vite__cjsExport_useState = __vite__cjsImport0_react["useState"]; ' +
-        'const __vite__cjsExport_Component = __vite__cjsImport0_react["Component"]; ' +
-        'export { __vite__cjsExport_useState as useState, __vite__cjsExport_Component as Component }',
+        'const __vite__cjsExportI_useState = __vite__cjsImport0_react["useState"]; ' +
+        'const __vite__cjsExportI_Component = __vite__cjsImport0_react["Component"]; ' +
+        'const __vite__cjsExportL_1d0452e3 = __vite__cjsImport0_react["👋"]; ' +
+        'export { __vite__cjsExportI_useState as useState, __vite__cjsExportI_Component as Component, __vite__cjsExportL_1d0452e3 as "👋" }',
     )
 
     expect(
       transformCjsImport(
-        'export { useState as useStateAlias, Component as ComponentAlias } from "react"',
+        'export { useState as useStateAlias, Component as ComponentAlias, "👋" as "👍" } from "react"',
         url,
         rawUrl,
         0,
@@ -136,9 +138,10 @@ describe('transformCjsImport', () => {
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
-        'const __vite__cjsExport_useStateAlias = __vite__cjsImport0_react["useState"]; ' +
-        'const __vite__cjsExport_ComponentAlias = __vite__cjsImport0_react["Component"]; ' +
-        'export { __vite__cjsExport_useStateAlias as useStateAlias, __vite__cjsExport_ComponentAlias as ComponentAlias }',
+        'const __vite__cjsExportI_useStateAlias = __vite__cjsImport0_react["useState"]; ' +
+        'const __vite__cjsExportI_ComponentAlias = __vite__cjsImport0_react["Component"]; ' +
+        'const __vite__cjsExportL_5d57d39e = __vite__cjsImport0_react["👋"]; ' +
+        'export { __vite__cjsExportI_useStateAlias as useStateAlias, __vite__cjsExportI_ComponentAlias as ComponentAlias, __vite__cjsExportL_5d57d39e as "👍" }',
     )
   })
 
@@ -169,8 +172,8 @@ describe('transformCjsImport', () => {
       ),
     ).toBe(
       'import __vite__cjsImport0_react from "./node_modules/.vite/deps/react.js"; ' +
-        'const __vite__cjsExport_React = __vite__cjsImport0_react.__esModule ? __vite__cjsImport0_react.default : __vite__cjsImport0_react; ' +
-        'export { __vite__cjsExport_React as React }',
+        'const __vite__cjsExportI_React = __vite__cjsImport0_react.__esModule ? __vite__cjsImport0_react.default : __vite__cjsImport0_react; ' +
+        'export { __vite__cjsExportI_React as React }',
     )
 
     expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3318,9 +3318,6 @@ packages:
   '@types/escape-html@1.0.4':
     resolution: {integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==}
 
-  '@types/estree@1.0.5':
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
-
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -8885,8 +8882,6 @@ snapshots:
 
   '@types/escape-html@1.0.4': {}
 
-  '@types/estree@1.0.5': {}
-
   '@types/estree@1.0.6': {}
 
   '@types/etag@1.8.3':
@@ -10416,7 +10411,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
 
   esutils@2.0.3: {}
 
@@ -11758,7 +11753,7 @@ snapshots:
 
   periscopic@4.0.2:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.6
       is-reference: 3.0.2
       zimmerframe: 1.0.0
 


### PR DESCRIPTION
### Description

Adds support for arbitrary module namespace identifier imports from cjs deps.

I don't think anyone would use this 😅 but I guess it's fine to support it.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
