### PR TITLE
fix(assets): make srcset parsing HTML spec compliant (#16323)

### DIFF
--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -359,6 +359,16 @@ describe('processSrcSetSync', () => {
       processSrcSetSync('https://anydomain/image.jpg', ({ url }) => url),
     ).toBe(source)
   })
+
+  test('should not break URLs with commas in srcSet', async () => {
+    const source = `
+      \thttps://example.com/dpr_1,f_auto,fl_progressive,q_auto,w_100/v1/img   1x,
+      \thttps://example.com/dpr_2,f_auto,fl_progressive,q_auto,w_100/v1/img\t\t2x
+    `
+    const result =
+      'https://example.com/dpr_1,f_auto,fl_progressive,q_auto,w_100/v1/img 1x, https://example.com/dpr_2,f_auto,fl_progressive,q_auto,w_100/v1/img 2x'
+    expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
+  })
 })
 
 describe('flattenId', () => {

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -403,8 +403,9 @@ describe('processSrcSetSync', () => {
   })
 
   test('should parse image-set-options with resolution and type specified', async () => {
-    const source = `url("picture.png")\t1x\t type("image/jpeg")`
-    const result = 'url("picture.png") 1x type("image/jpeg")'
+    const source = `url("picture.png")\t1x\t type("image/jpeg"), url("picture.png")\t type("image/jpeg")\t2x`
+    const result =
+      'url("picture.png") 1x type("image/jpeg"), url("picture.png") type("image/jpeg") 2x'
     expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
   })
 

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -369,6 +369,44 @@ describe('processSrcSetSync', () => {
       'https://example.com/dpr_1,f_auto,fl_progressive,q_auto,w_100/v1/img 1x, https://example.com/dpr_2,f_auto,fl_progressive,q_auto,w_100/v1/img 2x'
     expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
   })
+
+  test('should not break URLs with commas in image-set-options', async () => {
+    const source = `url(https://example.com/dpr_1,f_auto,fl_progressive,q_auto,w_100/v1/img)   1x,
+      url("https://example.com/dpr_2,f_auto,fl_progressive,q_auto,w_100/v1/img")\t\t2x
+    `
+    const result =
+      'url(https://example.com/dpr_1,f_auto,fl_progressive,q_auto,w_100/v1/img) 1x, url("https://example.com/dpr_2,f_auto,fl_progressive,q_auto,w_100/v1/img") 2x'
+    expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
+  })
+
+  test('should parse image-set-options with resolution', async () => {
+    const source = ` "foo.png" 1x,
+                     "foo-2x.png" 2x,
+                     "foo-print.png" 600dpi`
+    const result = '"foo.png" 1x, "foo-2x.png" 2x, "foo-print.png" 600dpi'
+    expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
+  })
+
+  test('should parse image-set-options with type', async () => {
+    const source = ` "foo.avif" type("image/avif"),
+                     "foo.jpg" type("image/jpeg") `
+    const result = '"foo.avif" type("image/avif"), "foo.jpg" type("image/jpeg")'
+    expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
+  })
+
+  test('should parse image-set-options with linear-gradient', async () => {
+    const source = `linear-gradient(cornflowerblue, white) 1x,
+                    url("detailed-gradient.png") 3x`
+    const result =
+      'linear-gradient(cornflowerblue, white) 1x, url("detailed-gradient.png") 3x'
+    expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
+  })
+
+  test('should parse image-set-options with resolution and type specified', async () => {
+    const source = `url("picture.png")\t1x\t type("image/jpeg")`
+    const result = 'url("picture.png") 1x type("image/jpeg")'
+    expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
+  })
 })
 
 describe('flattenId', () => {

--- a/packages/vite/src/node/__tests__/utils.spec.ts
+++ b/packages/vite/src/node/__tests__/utils.spec.ts
@@ -407,6 +407,21 @@ describe('processSrcSetSync', () => {
     const result = 'url("picture.png") 1x type("image/jpeg")'
     expect(processSrcSetSync(source, ({ url }) => url)).toBe(result)
   })
+
+  test('should capture whole image set options', async () => {
+    const source = `linear-gradient(cornflowerblue, white) 1x,
+                    url("detailed-gradient.png") 3x`
+    const expected = [
+      'linear-gradient(cornflowerblue, white)',
+      'url("detailed-gradient.png")',
+    ]
+    const result: string[] = []
+    processSrcSetSync(source, ({ url }) => {
+      result.push(url)
+      return url
+    })
+    expect(result).toEqual(expected)
+  })
 })
 
 describe('flattenId', () => {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -727,10 +727,15 @@ function joinSrcset(ret: ImageCandidate[]) {
     .join(', ')
 }
 
+/*!
+ * Based on https://github.com/sindresorhus/srcset
+ * MIT License, Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ */
 /**
- This regex represents a loose rule of an “image candidate string”.
+ This regex represents a loose rule of an “image candidate string” and "image set options".
 
  @see https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
+ @see https://drafts.csswg.org/css-images-4/#image-set-notation
 
   An “image candidate string” roughly consists of the following:
   1. Zero or more whitespace characters.
@@ -752,8 +757,10 @@ export function parseSrcset(string: string): ImageCandidate[] {
     .split(imageCandidateRegex)
     .filter((_part, index) => index % 2 === 1)
     .map((part) => {
-      const [url, descriptor] = part.trim().split(/\s+/)
-      return { url, descriptor }
+      const [url, ...descriptors] = part.trim().split(/\s+/)
+      // in `image-set()` context descriptor can have `resolution` and `type` parts separated by whitespace,
+      // we need to join them back together
+      return { url, descriptor: descriptors.join(' ') }
     })
     .filter(({ url }) => !!url)
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -737,12 +737,11 @@ function joinSrcset(ret: ImageCandidate[]) {
   The `url` group can be:
   * any CSS function
   * CSS string (single or double-quoted)
-  * or URL string.
-  The `descriptor` is anything after the space and before the comma,
-  and can have optional `type(...)` for the `image-set` case.
+  * URL string (unquoted)
+  The `descriptor` is anything after the space and before the comma.
  */
 const imageCandidateRegex =
-  /(?:^|\s)(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?:\s(?<descriptor>[^,\s]+(?:\stype\([^)]*\))?)\s*)?(?:,|$)/g
+  /(?:^|\s)(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?:\s(?<descriptor>\w[^,]+))?(?:,|$)/g
 const escapedSpaceCharacters = /(?: |\\t|\\n|\\f|\\r)+/g
 
 export function parseSrcset(string: string): ImageCandidate[] {

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -727,6 +727,22 @@ function joinSrcset(ret: ImageCandidate[]) {
     .join(', ')
 }
 
+/**
+ This regex represents a loose rule of an “image candidate string” and "image set options".
+
+ @see https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
+ @see https://drafts.csswg.org/css-images-4/#image-set-notation
+
+  The Regex has named capturing groups `url` and `descriptor`.
+  The `url` group can be:
+  * any CSS function
+  * CSS string (single or double-quoted)
+  * or URL string.
+  The `descriptor` is anything after the space and before the comma,
+  and can have optional `type(...)` for the `image-set` case.
+ */
+const imageCandidateRegex =
+  /(?:^|\s)(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?:\s(?<descriptor>[^,\s]+(?:\stype\([^)]*\))?)\s*)?(?:,|$)/g
 const escapedSpaceCharacters = /(?: |\\t|\\n|\\f|\\r)+/g
 
 export function parseSrcset(string: string): ImageCandidate[] {
@@ -736,16 +752,7 @@ export function parseSrcset(string: string): ImageCandidate[] {
     .replace(/\r?\n/, '')
     .replace(/,\s+/, ', ')
     .replaceAll(/\s+/g, ' ')
-    .matchAll(
-      /**
-       This regex represents a loose rule of an “image candidate string” and "image set options".
-
-       @see https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
-       @see https://drafts.csswg.org/css-images-4/#image-set-notation
-       */
-      // eslint-disable-next-line regexp/no-super-linear-backtracking
-      /\s*(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?<descriptor>[^,]*(?:\stype\([^)]*\))?)\s*(?:,|$)/g,
-    )
+    .matchAll(imageCandidateRegex)
   return Array.from(matches, ({ groups }) => ({
     url: groups?.url?.trim() ?? '',
     descriptor: groups?.descriptor?.trim() ?? '',

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -747,8 +747,8 @@ export function parseSrcset(string: string): ImageCandidate[] {
       /\s*(?<url>[\w-]+\([^)]*\)|"[^"]*"|'[^']*'|[^,]\S*[^,])\s*(?<descriptor>[^,]*(?:\stype\([^)]*\))?)\s*(?:,|$)/g,
     )
   return Array.from(matches, ({ groups }) => ({
-    url: groups.url.trim(),
-    descriptor: groups.descriptor.trim(),
+    url: groups?.url?.trim() ?? '',
+    descriptor: groups?.descriptor?.trim() ?? '',
   })).filter(({ url }) => !!url)
 }
 


### PR DESCRIPTION
fixes #16323

### Description

Simplifies the spitting of `srcset` image candidates with descriptors, so it is compliant with spec and not driven by every edge case somebody finds out is not working.


