### PR TITLE
fix(hmr): don't try to rewrite imports for direct CSS soft invalidation

### DIFF
--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -215,8 +215,10 @@ export class EnvironmentModuleGraph {
         // to only update the import timestamps. If it's not statically imported, e.g. watched/glob file,
         // we can only soft invalidate if the current module was also soft-invalidated. A soft-invalidation
         // doesn't need to trigger a re-load and re-transform of the importer.
+        // But we exclude direct CSS files as those cannot be soft invalidated.
         const shouldSoftInvalidateImporter =
-          importer.staticImportedUrls?.has(mod.url) || softInvalidate
+          (importer.staticImportedUrls?.has(mod.url) || softInvalidate) &&
+          importer.type !== 'css'
         this.invalidateModule(
           importer,
           seen,

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -457,9 +457,8 @@ async function handleModuleSoftInvalidation(
   }
 
   let result: TransformResult
-  // For SSR or direct CSS, no transformation is needed
-  // Note that direct CSS soft invalidation happens when files included by tailwind's `content` option is updated
-  if (transformResult.ssr || mod.type === 'css') {
+  // For SSR soft-invalidation, no transformation is needed
+  if (transformResult.ssr) {
     result = transformResult
   }
   // We need to transform each imports with new timestamps if available

--- a/packages/vite/src/node/server/transformRequest.ts
+++ b/packages/vite/src/node/server/transformRequest.ts
@@ -457,8 +457,9 @@ async function handleModuleSoftInvalidation(
   }
 
   let result: TransformResult
-  // For SSR soft-invalidation, no transformation is needed
-  if (transformResult.ssr) {
+  // For SSR or direct CSS, no transformation is needed
+  // Note that direct CSS soft invalidation happens when files included by tailwind's `content` option is updated
+  if (transformResult.ssr || mod.type === 'css') {
     result = transformResult
   }
   // We need to transform each imports with new timestamps if available


### PR DESCRIPTION
### Description

When a direct CSS is soft invalidated and has a content that fails to parse by `es-module-lexer` (this only happens some times as ex-module-lexer is quite relax with invalid syntaxes), Vite failed to load that file after a refresh.

A direct CSS file is soft invalidated when the file depends on a JS file. This happens if a file included in tailwind's `content` option is updated. For example, the reproduction in the issue has `assets/custom.css` and is imported by `app.vue` and that is included by tailwind's `content` option.

fixes https://github.com/nuxt/nuxt/issues/26454

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
