### PR TITLE
test: silence sass legacy-js-api deprecation log

### DIFF
--- a/playground/backend-integration/vite.config.js
+++ b/playground/backend-integration/vite.config.js
@@ -52,4 +52,11 @@ function BackendIntegrationExample() {
 export default defineConfig({
   base: '/dev/',
   plugins: [BackendIntegrationExample()],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        silenceDeprecations: ['legacy-js-api'],
+      },
+    },
+  },
 })

--- a/playground/css-sourcemap/vite.config.js
+++ b/playground/css-sourcemap/vite.config.js
@@ -31,6 +31,9 @@ export default defineConfig({
           }
         },
       },
+      sass: {
+        silenceDeprecations: ['legacy-js-api'],
+      },
     },
   },
   build: {

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -77,6 +77,7 @@ export default defineConfig({
             return url.endsWith('.wxss') ? { contents: '' } : null
           },
         ],
+        silenceDeprecations: ['legacy-js-api'],
       },
       styl: {
         additionalData: `$injectedColor ?= orange`,

--- a/playground/multiple-entrypoints/vite.config.js
+++ b/playground/multiple-entrypoints/vite.config.js
@@ -37,4 +37,11 @@ export default defineConfig({
       },
     },
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        silenceDeprecations: ['legacy-js-api'],
+      },
+    },
+  },
 })


### PR DESCRIPTION
### Description

I just noticed this is very noisy for our tests as well. If we merge https://github.com/vitejs/vite/pull/17937 first, then we only need this in legacy test `playground/css/vite.config.js`, but I'm preparing this too as it's quick.