### PR TITLE
docs: replace AngularJS's website with Angular's website

### DIFF
--- a/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
+++ b/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
@@ -46,7 +46,7 @@ const frameworks: Framework[] = [
     name: 'Angular',
     logo: logoAngular,
     color: '#e03237',
-    url: 'https://angularjs.org/',
+    url: 'https://angular.dev/',
     visible: ref(false),
   },
   {


### PR DESCRIPTION
Use the current website of the Angular framework