### PR TITLE
fix: make it easier to configure environment runner

### DIFF
--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -15,7 +15,6 @@ import {
   createRunnableDevEnvironment,
   createServer,
   createServerHotChannel,
-  createServerModuleRunner,
 } from 'vite'
 import type { ModuleRunner } from 'vite/module-runner'
 import {
@@ -1067,8 +1066,7 @@ async function setupModuleRunner(
         dev: {
           createEnvironment(name, config) {
             return createRunnableDevEnvironment(name, config, {
-              runner: (env) =>
-                createServerModuleRunner(env, { hmr: { logger } }),
+              runnerOptions: { hmr: { logger } },
               hot: createServerHotChannel(),
             })
           },


### PR DESCRIPTION
### Description

Hide the complexity of the custom runner configuration. If you need to configure the runner, you will most likely use the `createServerModuleRunner`. It just has a single option argument, let's pass it down directly instead of requiring the user to import the function - they shouldn't even need to know it exists.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
