### PR TITLE
chore: update license copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
+Copyright (c) 2019-present, VoidZero Inc. and Vite contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/.vitepress/buildEnd.config.ts
+++ b/docs/.vitepress/buildEnd.config.ts
@@ -16,7 +16,7 @@ export const buildEnd = async (config: SiteConfig): Promise<void> => {
     language: 'en',
     image: 'https://vitejs.dev/og-image.png',
     favicon: 'https://vitejs.dev/logo.svg',
-    copyright: 'Copyright © 2019-present Evan You & Vite Contributors',
+    copyright: 'Copyright © 2019-present VoidZero Inc. & Vite Contributors',
   })
 
   const posts = await createContentLoader('blog/*.md', {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -163,8 +163,7 @@ export default defineConfig({
 
     footer: {
       message: `Released under the MIT License. (${commitRef})`,
-      copyright:
-        'Copyright © 2019-present Yuxi (Evan) You & Vite Contributors',
+      copyright: 'Copyright © 2019-present VoidZero Inc. & Vite Contributors',
     },
 
     nav: [

--- a/packages/create-vite/LICENSE
+++ b/packages/create-vite/LICENSE
@@ -3,7 +3,7 @@ create-vite is released under the MIT license:
 
 MIT License
 
-Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
+Copyright (c) 2019-present, VoidZero Inc. and Vite contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/plugin-legacy/LICENSE
+++ b/packages/plugin-legacy/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
+Copyright (c) 2019-present, VoidZero Inc. and Vite contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -3,7 +3,7 @@ Vite is released under the MIT license:
 
 MIT License
 
-Copyright (c) 2019-present, Yuxi (Evan) You and Vite contributors
+Copyright (c) 2019-present, VoidZero Inc. and Vite contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- To clarify: this change reflects that I have assigned the copyright of my code in the Vite project over to VoidZero Inc.
- Copyrights of other Vite contributors remain unaffected and governance of the project remain unchanged.