### PR TITLE
chore(docs): add margin to h4

### DIFF
--- a/docs/.vitepress/theme/components/landing/5. sponsor-section/SponsorSection.vue
+++ b/docs/.vitepress/theme/components/landing/5. sponsor-section/SponsorSection.vue
@@ -133,9 +133,10 @@ const { data } = useSponsor()
     font-weight: 400;
     line-height: 150%; /* 24px */
     letter-spacing: -0.32px;
-    width: 480px;
+    width: 520px;
     max-width: 100%;
     margin: 0 auto 40px;
+    padding: 0 20px;
   }
 
   .sponsor-grid {


### PR DESCRIPTION
### Description

The h4 in the “Free & Open Source” section of the new home page is a bit cramped on mobile. So I added a margin to it, just like the other heading elements.

before:
![image](https://github.com/user-attachments/assets/2f84915a-3a89-4366-8839-47eefc4b55cc)

after:
![image](https://github.com/user-attachments/assets/5d276776-02a1-4f83-a3ab-6a646228d7a4)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
