### PR TITLE
docs: make docsearch background darker

### DIFF
--- a/docs/.vitepress/theme/styles/vars.css
+++ b/docs/.vitepress/theme/styles/vars.css
@@ -50,6 +50,7 @@
 
 .DocSearch {
   --docsearch-primary-color: var(--vp-c-brand) !important;
+  --docsearch-container-background: rgba(0, 0, 0, 0.7);
 }
 
 /**


### PR DESCRIPTION
### Description

Small change. I noticed in the docs (especially dark mode), when you search with algolia, the popup dialog background has an odd white tint that doesn't fit the site. I updated it to be darker which seems to look nicer to me.