### PR TITLE
fix: destroy the runner when runnable environment is closed

### DIFF
--- a/packages/vite/src/node/server/environments/runnableEnvironment.ts
+++ b/packages/vite/src/node/server/environments/runnableEnvironment.ts
@@ -61,7 +61,7 @@ class RunnableDevEnvironment extends DevEnvironment {
   override async close(): Promise<void> {
     await super.close()
     if (this._runner) {
-      this._runner.destroy()
+      await this._runner.destroy()
     }
   }
 }

--- a/packages/vite/src/node/server/environments/runnableEnvironment.ts
+++ b/packages/vite/src/node/server/environments/runnableEnvironment.ts
@@ -57,6 +57,13 @@ class RunnableDevEnvironment extends DevEnvironment {
     this._runner = createServerModuleRunner(this)
     return this._runner
   }
+
+  override async close(): Promise<void> {
+    await super.close()
+    if (this._runner) {
+      this._runner.destroy()
+    }
+  }
 }
 
 export type { RunnableDevEnvironment }


### PR DESCRIPTION
### Description

Disallow importing modules in SSR after the environment has been closed (called when `server` is closed)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
