### PR TITLE
docs: change docs to include more details about public directory

### DIFF
--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -109,7 +109,6 @@ The directory defaults to `<root>/public`, but can be configured via the [`publi
 Note that:
 
 - You should always reference `public` assets using root absolute path - for example, `public/icon.png` should be referenced in source code as `/icon.png`.
-- Assets in `public` cannot be imported from JavaScript, but you can use the `fetch()` function to retrieve them.
 
 ## new URL(url, import.meta.url)
 

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -106,9 +106,7 @@ Then you can place the asset in a special `public` directory under your project 
 
 The directory defaults to `<root>/public`, but can be configured via the [`publicDir` option](/config/shared-options.md#publicdir).
 
-Note that:
-
-- You should always reference `public` assets using root absolute path - for example, `public/icon.png` should be referenced in source code as `/icon.png`.
+Note that you should always reference `public` assets using root absolute path - for example, `public/icon.png` should be referenced in source code as `/icon.png`.
 
 ## new URL(url, import.meta.url)
 

--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -109,7 +109,7 @@ The directory defaults to `<root>/public`, but can be configured via the [`publi
 Note that:
 
 - You should always reference `public` assets using root absolute path - for example, `public/icon.png` should be referenced in source code as `/icon.png`.
-- Assets in `public` cannot be imported from JavaScript.
+- Assets in `public` cannot be imported from JavaScript, but you can use the `fetch()` function to retrieve them.
 
 ## new URL(url, import.meta.url)
 


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This makes it clearer to understand how to use the `public` directory by saying how the `fetch()` function can be used instead of `import` to retrieve files from the `public` directory.

When I first started using Vite, I was confused with how to use the `public` directory, and I only found that `fetch()` could be used with it after [searching for it online](https://stackoverflow.com/questions/74344683/how-to-import-a-json-file-from-public-directory-with-vite). I hope this makes it immediately clear how to use this feature.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
