### PR TITLE
feat: log complete config in debug mode

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -31,8 +31,6 @@ if (debugIndex > 0) {
   process.env.DEBUG = `${
     process.env.DEBUG ? process.env.DEBUG + ',' : ''
   }${value}`
-  process.env.DEBUG_DEPTH = '10'
-
   if (filterIndex > 0) {
     const filter = process.argv[filterIndex + 1]
     if (filter && !filter.startsWith('-')) {

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -31,6 +31,7 @@ if (debugIndex > 0) {
   process.env.DEBUG = `${
     process.env.DEBUG ? process.env.DEBUG + ',' : ''
   }${value}`
+  process.env.DEBUG_DEPTH = '10'
 
   if (filterIndex > 0) {
     const filter = process.argv[filterIndex + 1]

--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -31,6 +31,7 @@ if (debugIndex > 0) {
   process.env.DEBUG = `${
     process.env.DEBUG ? process.env.DEBUG + ',' : ''
   }${value}`
+
   if (filterIndex > 0) {
     const filter = process.argv[filterIndex + 1]
     if (filter && !filter.startsWith('-')) {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -440,6 +440,12 @@ export interface UserConfig extends DefaultEnvironmentOptions {
    * @default 'spa'
    */
   appType?: AppType
+  /**
+   * Specifies the number of times to recurse while formatting object.
+   *
+   * https://nodejs.org/api/util.html#utilinspectobject-options
+   */
+  debugDepth?: string | undefined
 }
 
 export interface HTMLOptions {
@@ -845,6 +851,10 @@ export async function resolveConfig(
       config = mergeConfig(loadResult.config, config)
       configFile = loadResult.path
       configFileDependencies = loadResult.dependencies
+    }
+
+    if (config.debugDepth && process.env.DEBUG) {
+      process.env.DEBUG_DEPTH = config.debugDepth
     }
   }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -89,7 +89,7 @@ import { resolveSSROptions } from './ssr'
 import { PartialEnvironment } from './baseEnvironment'
 import { createIdResolver } from './idResolver'
 
-const debug = createDebugger('vite:config')
+const debug = createDebugger('vite:config', { depth: 10 })
 const promisifiedRealpath = promisify(fs.realpath)
 
 export interface ConfigEnv {
@@ -440,12 +440,6 @@ export interface UserConfig extends DefaultEnvironmentOptions {
    * @default 'spa'
    */
   appType?: AppType
-  /**
-   * Specifies the number of times to recurse while formatting object.
-   *
-   * https://nodejs.org/api/util.html#utilinspectobject-options
-   */
-  debugDepth?: string | undefined
 }
 
 export interface HTMLOptions {
@@ -851,10 +845,6 @@ export async function resolveConfig(
       config = mergeConfig(loadResult.config, config)
       configFile = loadResult.path
       configFileDependencies = loadResult.dependencies
-    }
-
-    if (config.debugDepth && process.env.DEBUG) {
-      process.env.DEBUG_DEPTH = config.debugDepth
     }
   }
 

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -176,6 +176,11 @@ export function createDebugger(
   if (enabled) {
     return (...args: [string, ...any[]]) => {
       if (!filter || args.some((a) => a?.includes?.(filter))) {
+        if (process.env.DEBUG_DEPTH) {
+          const depth = parseInt(process.env.DEBUG_DEPTH)
+          // @ts-expect-error - The log function is bound to inspectOpts, but the type is not reflected
+          log.inspectOpts.depth = depth
+        }
         log(...args)
       }
     }


### PR DESCRIPTION
### Description
When I set the debug parameters and prepare to view relevant information, I expect to be able to see some object information with a deeper nesting level more intuitively.
<table>
<tr>
<td>before</td>
<td>after</td>
</tr>
<tr>
<td>

<img width="592" alt="image" src="https://github.com/user-attachments/assets/a88e2a2b-f5ff-4caf-8bb9-33add886874f">
</td>
<td>
 
<img width="712" alt="image" src="https://github.com/user-attachments/assets/96bf6716-e9a2-45cb-b39e-86cddee0b5bc">

</td>
</tr>
</table>
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
