### PR TITLE
test: test optimized dep as ssr entry

### DIFF
--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -231,3 +231,20 @@ describe('module runner initialization', async () => {
     expect(action).toBeDefined()
   })
 })
+
+describe('optimize-deps', async () => {
+  const it = await createModuleRunnerTester({
+    cacheDir: 'node_modules/.vite-test',
+    ssr: {
+      noExternal: true,
+      optimizeDeps: {
+        include: ['@vitejs/cjs-external'],
+      },
+    },
+  })
+
+  it('optimized dep as entry', async ({ runner }) => {
+    const mod = await runner.import('@vitejs/cjs-external')
+    expect(mod.default.hello()).toMatchInlineSnapshot(`"world"`)
+  })
+})


### PR DESCRIPTION
### Description

In Vite 5, `ssrLoadModule("optimized-dep")` is failing (initially raised by Tobbe on discord and here is a repro https://github.com/hi-ogawa/reproductions/tree/main/vite-ssr-optimizeDeps-entry), but it looks like this works now. It's fairly an edge case (also has a workaround in Vite 5), but I think it's not bad to have a test.