### PR TITLE
refactor: rename runner.destroy() to runner.close()

### DIFF
--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -645,11 +645,11 @@ export class ModuleRunner {
    * Clears all caches, removes all HMR listeners, and resets source map support.
    * This method doesn't stop the HMR connection.
    */
-  public async destroy(): Promise<void>
+  public async close(): Promise<void>
   /**
-   * Returns `true` if the runner has been destroyed by calling `destroy()` method.
+   * Returns `true` if the runner has been closed by calling `close()` method.
    */
-  public isDestroyed(): boolean
+  public isClosed(): boolean
 }
 ```
 

--- a/packages/vite/src/module-runner/hmrHandler.ts
+++ b/packages/vite/src/module-runner/hmrHandler.ts
@@ -15,7 +15,7 @@ export async function handleHotPayload(
   payload: HotPayload,
 ): Promise<void> {
   const hmrClient = runner.hmrClient
-  if (!hmrClient || runner.isDestroyed()) return
+  if (!hmrClient || runner.isClosed()) return
   switch (payload.type) {
     case 'connected':
       hmrClient.logger.debug(`connected.`)

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -54,7 +54,7 @@ export class ModuleRunner {
     Promise<EvaluatedModuleNode>
   >()
 
-  private destroyed = false
+  private closed = false
 
   constructor(
     public options: ModuleRunnerOptions,
@@ -100,18 +100,18 @@ export class ModuleRunner {
    * Clears all caches, removes all HMR listeners, and resets source map support.
    * This method doesn't stop the HMR connection.
    */
-  public async destroy(): Promise<void> {
+  public async close(): Promise<void> {
     this.resetSourceMapSupport?.()
     this.clearCache()
     this.hmrClient = undefined
-    this.destroyed = true
+    this.closed = true
   }
 
   /**
-   * Returns `true` if the runtime has been destroyed by calling `destroy()` method.
+   * Returns `true` if the runtime has been closed by calling `close()` method.
    */
-  public isDestroyed(): boolean {
-    return this.destroyed
+  public isClosed(): boolean {
+    return this.closed
   }
 
   private processImport(
@@ -243,8 +243,8 @@ export class ModuleRunner {
     importer: string | undefined,
     cachedModule: EvaluatedModuleNode | undefined,
   ): Promise<EvaluatedModuleNode> {
-    if (this.destroyed) {
-      throw new Error(`Vite module runner has been destroyed.`)
+    if (this.closed) {
+      throw new Error(`Vite module runner has been closed.`)
     }
 
     this.debug?.('[module runner] fetching', url)
@@ -373,7 +373,7 @@ export class ModuleRunner {
         enumerable: true,
         get: () => {
           if (!this.hmrClient) {
-            throw new Error(`[module runner] HMR client was destroyed.`)
+            throw new Error(`[module runner] HMR client was closed.`)
           }
           this.debug?.('[module runner] creating hmr context for', mod.url)
           hotContext ||= new HMRContext(this.hmrClient, mod.url)

--- a/packages/vite/src/node/server/environments/runnableEnvironment.ts
+++ b/packages/vite/src/node/server/environments/runnableEnvironment.ts
@@ -68,7 +68,7 @@ class RunnableDevEnvironment extends DevEnvironment {
   override async close(): Promise<void> {
     await super.close()
     if (this._runner) {
-      await this._runner.destroy()
+      await this._runner.close()
     }
   }
 }

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -88,7 +88,7 @@ export async function createModuleRunnerTester(
   })
 
   afterEach<TestClient>(async (t) => {
-    await t.runner.destroy()
+    await t.runner.close()
     await t.server.close()
   })
 


### PR DESCRIPTION
### Description

Rename to be consistent with `server.close()` and other APIs.
