### PR TITLE
fix(css): dont remove JS chunk for pure CSS chunk when the export is used

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -568,7 +568,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       let chunkCSS = ''
       // the chunk is empty if it's a dynamic entry chunk that only contains a CSS import
       const isJsChunkEmpty = code === '' && !chunk.isEntry
-      let isPureCssChunk = true
+      let isPureCssChunk = chunk.exports.length === 0
       const ids = Object.keys(chunk.modules)
       for (const id of ids) {
         if (styles.has(id)) {

--- a/playground/glob-import/vite.config.ts
+++ b/playground/glob-import/vite.config.ts
@@ -24,5 +24,14 @@ export default defineConfig({
   },
   build: {
     sourcemap: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('foo.css')) {
+            return 'foo_css'
+          }
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
### Description

```js
import * as something from './foo.css'
```
When the module namespace of CSS is imported, the pure CSS chunk remover removed the JS chunk even if it should not be removed.

The import happens if `import.meta.glob` includes a CSS file.

This PR makes chunks that have exports to be marked as non-pure CSS chunk.

The alternative fix is to improve the following code, but I think it would be complicated.
https://github.com/vitejs/vite/blob/41735a72a3b0b1f8b058a4d58b5f556b420fa756/packages/vite/src/node/plugins/css.ts#L1039-L1055

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
