### PR TITLE
test(css): make "duplicate CSS" test to focus on what it's testing

### DIFF
--- a/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
+++ b/playground/css-dynamic-import/__tests__/css-dynamic-import.spec.ts
@@ -65,38 +65,9 @@ baseOptions.forEach(({ base, label }) => {
         await page.waitForSelector('.loaded', { state: 'attached' })
 
         expect(await getColor('.css-dynamic-import')).toBe('green')
-        expect(await getLinks()).toEqual([
-          {
-            pathname: expect.stringMatching(/^\/assets\/index-.+\.css$/),
-            rel: 'stylesheet',
-            as: '',
-          },
-          {
-            pathname: expect.stringMatching(/^\/assets\/dynamic-.+\.css$/),
-            rel: 'preload',
-            as: 'style',
-          },
-          {
-            pathname: expect.stringMatching(/^\/assets\/dynamic-.+\.js$/),
-            rel: 'modulepreload',
-            as: 'script',
-          },
-          {
-            pathname: expect.stringMatching(/^\/assets\/dynamic-.+\.css$/),
-            rel: 'stylesheet',
-            as: '',
-          },
-          {
-            pathname: expect.stringMatching(/^\/assets\/static-.+\.js$/),
-            rel: 'modulepreload',
-            as: 'script',
-          },
-          {
-            pathname: expect.stringMatching(/^\/assets\/index-.+\.js$/),
-            rel: 'modulepreload',
-            as: 'script',
-          },
-        ])
+        const linkUrls = (await getLinks()).map((link) => link.pathname)
+        const uniqueLinkUrls = [...new Set(linkUrls)]
+        expect(linkUrls).toStrictEqual(uniqueLinkUrls)
       })
     },
   )


### PR DESCRIPTION
### Description

This test is about whether there's a duplicate or not. I think this change would make the test to focus on what it's testing.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
