### PR TITLE
ci: add test-passed/failed job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - run: echo "Build & Test Passed or Skipped"
 
   test-failed:
-    if: !cancelled()
+    if: !cancelled() && failure()
     needs: test
     runs-on: ubuntu-latest
     name: Build & Test Failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: pnpm run test-build
 
   test-passed:
-    if: ${{ !cancelled() && !failure() }}
+    if: (!cancelled() && !failure())
     needs: test
     runs-on: ubuntu-latest
     name: Build & Test Passed or Skipped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,22 @@ jobs:
       - name: Test build
         run: pnpm run test-build
 
+  test-passed:
+    if: "!cancelled() && !failure()"
+    needs: test
+    runs-on: ubuntu-latest
+    name: Build & Test Passed or Skipped
+    steps:
+      - run: echo "Build & Test Passed or Skipped"
+
+  test-failed:
+    if: !cancelled()
+    needs: test
+    runs-on: ubuntu-latest
+    name: Build & Test Failed
+    steps:
+      - run: echo "Build & Test Failed"
+
   lint:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
       - run: echo "Build & Test Passed or Skipped"
 
   test-failed:
-    if: !cancelled() && failure()
+    if: (!cancelled() && failure())
     needs: test
     runs-on: ubuntu-latest
     name: Build & Test Failed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: pnpm run test-build
 
   test-passed:
-    if: "!cancelled() && !failure()"
+    if: ${{ !cancelled() && !failure() }}
     needs: test
     runs-on: ubuntu-latest
     name: Build & Test Passed or Skipped


### PR DESCRIPTION
### Description

#17855 changed where the skip is set, but that made the branch check not passing for PRs that only touches docs (e.g. https://github.com/vitejs/vite/pull/18316).
![image](https://github.com/user-attachments/assets/cdec159a-4bec-49b9-bead-4aea3e2b8c35)

This PR adds test-passed job so that we can set the required jobs to "test-passed" instead of possibly skipped "Build&Test" jobs. I added test-failed job just to make it easier to understand why "test-passed" was skipped.

The required jobs needs to be updated after this PR is merged.

related: https://github.com/orgs/community/discussions/13690

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
