### PR TITLE
fix(resolve): separate package cache per environment

### DIFF
--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -1,4 +1,6 @@
+import path from 'node:path'
 import { describe, expect, test } from 'vitest'
+import type { RollupOutput } from 'rollup'
 import { createServer } from '../server'
 import { defineConfig } from '../config'
 import { createBuilder } from '../build'
@@ -10,11 +12,34 @@ describe('custom environment conditions', () => {
       root: import.meta.dirname,
       logLevel: 'error',
       environments: {
+        ssr: {
+          resolve: {
+            noExternal: true,
+          },
+          build: {
+            outDir: path.join(
+              import.meta.dirname,
+              'fixtures/test-dep-conditions/dist/ssr',
+            ),
+            rollupOptions: {
+              input: { index: '@vitejs/test-dep-conditions' },
+            },
+          },
+        },
         worker: {
           webCompatible: true,
           resolve: {
             noExternal: true,
             conditions: ['worker'],
+          },
+          build: {
+            outDir: path.join(
+              import.meta.dirname,
+              'fixtures/test-dep-conditions/dist/worker',
+            ),
+            rollupOptions: {
+              input: { index: '@vitejs/test-dep-conditions' },
+            },
           },
         },
         custom1: {
@@ -23,6 +48,15 @@ describe('custom environment conditions', () => {
             noExternal: true,
             conditions: ['custom1'],
           },
+          build: {
+            outDir: path.join(
+              import.meta.dirname,
+              'fixtures/test-dep-conditions/dist/custom1',
+            ),
+            rollupOptions: {
+              input: { index: '@vitejs/test-dep-conditions' },
+            },
+          },
         },
         custom2: {
           webCompatible: false,
@@ -30,12 +64,30 @@ describe('custom environment conditions', () => {
             noExternal: true,
             conditions: ['custom2'],
           },
+          build: {
+            outDir: path.join(
+              import.meta.dirname,
+              'fixtures/test-dep-conditions/dist/custom2',
+            ),
+            rollupOptions: {
+              input: { index: '@vitejs/test-dep-conditions' },
+            },
+          },
         },
         custom3: {
           webCompatible: false,
           resolve: {
             noExternal: true,
             conditions: ['custom3'],
+          },
+          build: {
+            outDir: path.join(
+              import.meta.dirname,
+              'fixtures/test-dep-conditions/dist/custom3',
+            ),
+            rollupOptions: {
+              input: { index: '@vitejs/test-dep-conditions' },
+            },
           },
         },
       },
@@ -67,7 +119,29 @@ describe('custom environment conditions', () => {
   })
 
   test('build', async () => {
-    const builder = createBuilder(getConfig())
-    console.log(builder)
+    const builder = await createBuilder(getConfig())
+    const results: Record<string, unknown> = {}
+    for (const key of ['ssr', 'worker', 'custom1', 'custom2', 'custom3']) {
+      const output = await builder.build(builder.environments[key])
+      const chunk = (output as RollupOutput).output[0]
+      const mod = await import(
+        path.join(
+          import.meta.dirname,
+          'fixtures/test-dep-conditions/dist',
+          key,
+          chunk.fileName,
+        )
+      )
+      results[key] = mod.default
+    }
+    expect(results).toMatchInlineSnapshot(`
+      {
+        "custom1": "index.custom1.js",
+        "custom2": "index.custom2.js",
+        "custom3": "index.custom3.js",
+        "ssr": "index.default.js",
+        "worker": "index.worker.js",
+      }
+    `)
   })
 })

--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -12,6 +12,7 @@ describe('custom environment conditions', () => {
       root: import.meta.dirname,
       logLevel: 'error',
       environments: {
+        // no web / default
         ssr: {
           resolve: {
             noExternal: true,
@@ -26,6 +27,7 @@ describe('custom environment conditions', () => {
             },
           },
         },
+        // web / worker
         worker: {
           webCompatible: true,
           resolve: {
@@ -42,6 +44,7 @@ describe('custom environment conditions', () => {
             },
           },
         },
+        // web / custom1
         custom1: {
           webCompatible: true,
           resolve: {
@@ -58,6 +61,7 @@ describe('custom environment conditions', () => {
             },
           },
         },
+        // no web / custom2
         custom2: {
           webCompatible: false,
           resolve: {
@@ -74,6 +78,7 @@ describe('custom environment conditions', () => {
             },
           },
         },
+        // no web / custom3
         custom3: {
           webCompatible: false,
           resolve: {
@@ -90,6 +95,23 @@ describe('custom environment conditions', () => {
             },
           },
         },
+        // same as custom3
+        custom3_2: {
+          webCompatible: false,
+          resolve: {
+            noExternal: true,
+            conditions: ['custom3'],
+          },
+          build: {
+            outDir: path.join(
+              import.meta.dirname,
+              'fixtures/test-dep-conditions/dist/custom3_2',
+            ),
+            rollupOptions: {
+              input: { index: '@vitejs/test-dep-conditions' },
+            },
+          },
+        },
       },
     })
   }
@@ -97,7 +119,14 @@ describe('custom environment conditions', () => {
   test('dev', async () => {
     const server = await createServer(getConfig())
     const results: Record<string, unknown> = {}
-    for (const key of ['ssr', 'worker', 'custom1', 'custom2', 'custom3']) {
+    for (const key of [
+      'ssr',
+      'worker',
+      'custom1',
+      'custom2',
+      'custom3',
+      'custom3_2',
+    ]) {
       const runner = createServerModuleRunner(server.environments[key], {
         hmr: {
           logger: false,
@@ -112,6 +141,7 @@ describe('custom environment conditions', () => {
         "custom1": "index.custom1.js",
         "custom2": "index.custom2.js",
         "custom3": "index.custom3.js",
+        "custom3_2": "index.custom3.js",
         "ssr": "index.default.js",
         "worker": "index.worker.js",
       }
@@ -121,7 +151,14 @@ describe('custom environment conditions', () => {
   test('build', async () => {
     const builder = await createBuilder(getConfig())
     const results: Record<string, unknown> = {}
-    for (const key of ['ssr', 'worker', 'custom1', 'custom2', 'custom3']) {
+    for (const key of [
+      'ssr',
+      'worker',
+      'custom1',
+      'custom2',
+      'custom3',
+      'custom3_2',
+    ]) {
       const output = await builder.build(builder.environments[key])
       const chunk = (output as RollupOutput).output[0]
       const mod = await import(
@@ -139,6 +176,7 @@ describe('custom environment conditions', () => {
         "custom1": "index.custom1.js",
         "custom2": "index.custom2.js",
         "custom3": "index.custom3.js",
+        "custom3_2": "index.custom3.js",
         "ssr": "index.default.js",
         "worker": "index.worker.js",
       }

--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -10,7 +10,10 @@ describe('custom environment conditions', () => {
   function getConfig() {
     return defineConfig({
       root: import.meta.dirname,
-      logLevel: 'error',
+      logLevel: 'silent',
+      server: {
+        middlewareMode: true,
+      },
       environments: {
         // no web / default
         ssr: {
@@ -145,6 +148,23 @@ describe('custom environment conditions', () => {
         "ssr": "index.default.js",
         "worker": "index.worker.js",
       }
+    `)
+  })
+
+  test('css', async () => {
+    const server = await createServer(getConfig())
+    const modJs = await server.ssrLoadModule(
+      '/fixtures/test-dep-conditions-app/entry.js',
+    )
+    const modCss = await server.ssrLoadModule(
+      '/fixtures/test-dep-conditions-app/entry.css?inline',
+    )
+    expect([modCss.default.replace(/\s+/g, ' '), modJs.default])
+      .toMatchInlineSnapshot(`
+      [
+        ".test-css { color: orange; } ",
+        "index.default.js",
+      ]
     `)
   })
 

--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, onTestFinished, test } from 'vitest'
 import type { RollupOutput } from 'rollup'
 import { createServer } from '../server'
 import { defineConfig } from '../config'
@@ -10,7 +10,7 @@ describe('custom environment conditions', () => {
   function getConfig() {
     return defineConfig({
       root: import.meta.dirname,
-      logLevel: 'silent',
+      logLevel: 'error',
       server: {
         middlewareMode: true,
       },
@@ -121,6 +121,8 @@ describe('custom environment conditions', () => {
 
   test('dev', async () => {
     const server = await createServer(getConfig())
+    onTestFinished(() => server.close())
+
     const results: Record<string, unknown> = {}
     for (const key of [
       'ssr',
@@ -153,6 +155,8 @@ describe('custom environment conditions', () => {
 
   test('css', async () => {
     const server = await createServer(getConfig())
+    onTestFinished(() => server.close())
+
     const modJs = await server.ssrLoadModule(
       '/fixtures/test-dep-conditions-app/entry.js',
     )

--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest'
+import { createServer } from '../server'
+import { defineConfig } from '../config'
+import { createBuilder } from '../build'
+import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
+
+describe('custom environment conditions', () => {
+  function getConfig() {
+    return defineConfig({
+      root: import.meta.dirname,
+      logLevel: 'error',
+      environments: {
+        worker: {
+          webCompatible: true,
+          resolve: {
+            noExternal: true,
+            conditions: ['worker'],
+          },
+        },
+        custom1: {
+          webCompatible: true,
+          resolve: {
+            noExternal: true,
+            conditions: ['custom1'],
+          },
+        },
+        custom2: {
+          webCompatible: false,
+          resolve: {
+            noExternal: true,
+            conditions: ['custom2'],
+          },
+        },
+        custom3: {
+          webCompatible: false,
+          resolve: {
+            noExternal: true,
+            conditions: ['custom3'],
+          },
+        },
+      },
+    })
+  }
+
+  test('dev', async () => {
+    const server = await createServer(getConfig())
+    const results: Record<string, unknown> = {}
+    for (const key of ['ssr', 'worker', 'custom1', 'custom2', 'custom3']) {
+      const runner = createServerModuleRunner(server.environments[key], {
+        hmr: {
+          logger: false,
+        },
+        sourcemapInterceptor: false,
+      })
+      const mod = await runner.import('@vitejs/test-dep-conditions')
+      results[key] = mod.default
+    }
+    expect(results).toMatchInlineSnapshot(`
+      {
+        "custom1": "index.custom1.js",
+        "custom2": "index.custom2.js",
+        "custom3": "index.custom3.js",
+        "ssr": "index.default.js",
+        "worker": "index.worker.js",
+      }
+    `)
+  })
+
+  test('build', async () => {
+    const builder = createBuilder(getConfig())
+    console.log(builder)
+  })
+})

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions-app/entry.css
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions-app/entry.css
@@ -1,0 +1,1 @@
+@import '@vitejs/test-dep-conditions';

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions-app/entry.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions-app/entry.js
@@ -1,0 +1,2 @@
+import dep from '@vitejs/test-dep-conditions'
+export default dep

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.browser.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.browser.js
@@ -1,0 +1,1 @@
+export default 'index.browser.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.css
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.css
@@ -1,0 +1,3 @@
+.test-css {
+  color: orange;
+}

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.custom1.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.custom1.js
@@ -1,0 +1,1 @@
+export default 'index.custom1.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.custom2.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.custom2.js
@@ -1,0 +1,1 @@
+export default 'index.custom2.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.custom3.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.custom3.js
@@ -1,0 +1,1 @@
+export default 'index.custom3.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.default.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.default.js
@@ -1,0 +1,1 @@
+export default 'index.default.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.worker.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/index.worker.js
@@ -1,0 +1,1 @@
+export default 'index.worker.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     ".": {
+      "style": "./index.css",
       "custom1": "./index.custom1.js",
       "custom2": "./index.custom2.js",
       "custom3": "./index.custom3.js",

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@vitejs/test-dep-conditions",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "custom1": "./index.custom1.js",
+      "custom2": "./index.custom2.js",
+      "custom3": "./index.custom3.js",
+      "worker": "./index.worker.js",
+      "browser": "./index.browser.js",
+      "default": "./index.default.js"
+    }
+  }
+}

--- a/packages/vite/src/node/__tests__/package.json
+++ b/packages/vite/src/node/__tests__/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
-    "@vitejs/cjs-ssr-dep": "link:./fixtures/cjs-ssr-dep"
+    "@vitejs/cjs-ssr-dep": "link:./fixtures/cjs-ssr-dep",
+    "@vitejs/test-dep-conditions": "file:./fixtures/test-dep-conditions"
   }
 }

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -2,6 +2,7 @@ import colors from 'picocolors'
 import type { Logger } from './logger'
 import type { ResolvedConfig, ResolvedEnvironmentOptions } from './config'
 import type { Plugin } from './plugin'
+import type { PackageCache } from './packages'
 
 const environmentColors = [
   colors.blue,
@@ -64,6 +65,7 @@ export class PartialEnvironment {
     this.name = name
     this._topLevelConfig = topLevelConfig
     this._options = options
+    const packageCache: PackageCache = new Map()
     this.config = new Proxy(
       options as ResolvedConfig & ResolvedEnvironmentOptions,
       {
@@ -73,6 +75,9 @@ export class PartialEnvironment {
           }
           if (prop in target) {
             return this._options[prop as keyof ResolvedEnvironmentOptions]
+          }
+          if (prop === 'packageCache') {
+            return packageCache
           }
           return this._topLevelConfig[prop]
         },

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -827,7 +827,7 @@ export async function addManuallyIncludedOptimizeDeps(
     for (let i = 0; i < includes.length; i++) {
       const id = includes[i]
       if (glob.isDynamicPattern(id)) {
-        const globIds = expandGlobIds(id, environment.getTopLevelConfig())
+        const globIds = expandGlobIds(id, environment.config)
         includes.splice(i, 1, ...globIds)
         i += globIds.length - 1
       }

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -51,7 +51,6 @@ export function expandGlobIds(id: string, config: ResolvedConfig): string[] {
     pkgName,
     config.root,
     config.resolve.preserveSymlinks,
-    // TODO
     config.packageCache,
   )
   if (!pkgData) return []

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -51,6 +51,7 @@ export function expandGlobIds(id: string, config: ResolvedConfig): string[] {
     pkgName,
     config.root,
     config.resolve.preserveSymlinks,
+    // TODO
     config.packageCache,
   )
   if (!pkgData) return []

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -23,8 +23,6 @@ export type PackageCache = Map<string, PackageData>
 export interface PackageData {
   dir: string
   hasSideEffects: (id: string) => boolean | 'no-treeshake' | null
-  webResolvedImports: Record<string, string | undefined>
-  nodeResolvedImports: Record<string, string | undefined>
   setResolvedCache: (key: string, entry: string, targetWeb: boolean) => void
   getResolvedCache: (key: string, targetWeb: boolean) => string | undefined
   data: {
@@ -201,24 +199,24 @@ export function loadPackageData(pkgPath: string): PackageData {
     hasSideEffects = () => null
   }
 
+  const webResolvedImports: Record<string, string | undefined> = {}
+  const nodeResolvedImports: Record<string, string | undefined> = {}
   const pkg: PackageData = {
     dir: pkgDir,
     data,
     hasSideEffects,
-    webResolvedImports: {},
-    nodeResolvedImports: {},
     setResolvedCache(key: string, entry: string, targetWeb: boolean) {
       if (targetWeb) {
-        pkg.webResolvedImports[key] = entry
+        webResolvedImports[key] = entry
       } else {
-        pkg.nodeResolvedImports[key] = entry
+        nodeResolvedImports[key] = entry
       }
     },
     getResolvedCache(key: string, targetWeb: boolean) {
       if (targetWeb) {
-        return pkg.webResolvedImports[key]
+        return webResolvedImports[key]
       } else {
-        return pkg.nodeResolvedImports[key]
+        return nodeResolvedImports[key]
       }
     },
   }

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -24,8 +24,6 @@ export type PackageCache = Map<string, PackageData>
 export interface PackageData {
   dir: string
   hasSideEffects: (id: string) => boolean | 'no-treeshake' | null
-  // setResolvedCache: (key: string, entry: string, targetWeb: boolean) => void
-  // getResolvedCache: (key: string, targetWeb: boolean) => string | undefined
   setResolvedCache: (
     key: string,
     entry: string,
@@ -209,27 +207,11 @@ export function loadPackageData(pkgPath: string): PackageData {
     hasSideEffects = () => null
   }
 
-  // const webResolvedImports: Record<string, string | undefined> = {}
-  // const nodeResolvedImports: Record<string, string | undefined> = {}
   const resolvedCache: Record<string, string | undefined> = {}
   const pkg: PackageData = {
     dir: pkgDir,
     data,
     hasSideEffects,
-    // setResolvedCache(key: string, entry: string, targetWeb: boolean) {
-    //   if (targetWeb) {
-    //     webResolvedImports[key] = entry
-    //   } else {
-    //     nodeResolvedImports[key] = entry
-    //   }
-    // },
-    // getResolvedCache(key: string, targetWeb: boolean) {
-    //   if (targetWeb) {
-    //     return webResolvedImports[key]
-    //   } else {
-    //     return nodeResolvedImports[key]
-    //   }
-    // },
     setResolvedCache(key, entry, options) {
       resolvedCache[getResolveCacheKey(key, options)] = entry
     },

--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -228,12 +228,12 @@ function getResolveCacheKey(key: string, options: InternalResolveOptions) {
   // `resolvePackageEntry` or `resolveDeepImport`
   return [
     key,
-    ...options.conditions,
-    ...options.extensions,
-    ...options.mainFields,
-    !!options.webCompatible,
-    !!options.isRequire,
-  ].join('_')
+    options.webCompatible ? '1' : '0',
+    options.isRequire ? '1' : '0',
+    options.conditions.join('_'),
+    options.extensions.join('_'),
+    options.mainFields.join('_'),
+  ].join('|')
 }
 
 export function watchPackageDataPlugin(packageCache: PackageCache): Plugin {

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -38,7 +38,6 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     root: config.root,
     isProduction: config.isProduction,
     isBuild: config.command === 'build',
-    packageCache: config.packageCache,
     asSrc: true,
   }
 

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -46,7 +46,6 @@ export async function resolvePlugins(
   return [
     depOptimizationEnabled ? optimizedDepsPlugin() : null,
     isBuild ? metadataPlugin() : null,
-    // TODO
     !isWorker ? watchPackageDataPlugin() : null,
     preAliasPlugin(config),
     aliasPlugin({

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -47,7 +47,7 @@ export async function resolvePlugins(
     depOptimizationEnabled ? optimizedDepsPlugin() : null,
     isBuild ? metadataPlugin() : null,
     // TODO
-    !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
+    !isWorker ? watchPackageDataPlugin() : null,
     preAliasPlugin(config),
     aliasPlugin({
       entries: config.resolve.alias,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -46,6 +46,7 @@ export async function resolvePlugins(
   return [
     depOptimizationEnabled ? optimizedDepsPlugin() : null,
     isBuild ? metadataPlugin() : null,
+    // TODO
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     preAliasPlugin(config),
     aliasPlugin({
@@ -63,7 +64,6 @@ export async function resolvePlugins(
         root: config.root,
         isProduction: config.isProduction,
         isBuild,
-        packageCache: config.packageCache,
         asSrc: true,
         fsUtils: getFsUtils(config),
         optimizeDeps: true,

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -45,7 +45,7 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
             id,
             importer,
             config.resolve.preserveSymlinks,
-            config.packageCache,
+            environment.config.packageCache,
           )
           if (optimizedId) {
             return optimizedId // aliased dep already optimized

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1022,7 +1022,6 @@ export function resolvePackageEntry(
 ): string | undefined {
   const { file: idWithoutPostfix, postfix } = splitFileAndPostfix(id)
 
-  // const cached = getResolvedCache('.', !!options.webCompatible)
   const cached = getResolvedCache('.', options)
   if (cached) {
     return cached + postfix
@@ -1095,7 +1094,6 @@ export function resolvePackageEntry(
             resolvedEntryPoint,
           )}${postfix !== '' ? ` (postfix: ${postfix})` : ''}`,
         )
-        // setResolvedCache('.', resolvedEntryPoint, !!options.webCompatible)
         setResolvedCache('.', resolvedEntryPoint, options)
         return resolvedEntryPoint + postfix
       }
@@ -1156,7 +1154,6 @@ function resolveDeepImport(
   { setResolvedCache, getResolvedCache, dir, data }: PackageData,
   options: InternalResolveOptions,
 ): string | undefined {
-  // const cache = getResolvedCache(id, !!options.webCompatible)
   const cache = getResolvedCache(id, options)
   if (cache) {
     return cache
@@ -1197,7 +1194,6 @@ function resolveDeepImport(
     if (mapped) {
       relativeId = mapped + postfix
     } else if (mapped === false) {
-      // setResolvedCache(id, browserExternalId, !!options.webCompatible)
       setResolvedCache(id, browserExternalId, options)
       return browserExternalId
     }
@@ -1213,7 +1209,6 @@ function resolveDeepImport(
       debug?.(
         `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`,
       )
-      // setResolvedCache(id, resolved, !!options.webCompatible)
       setResolvedCache(id, resolved, options)
       return resolved
     }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1151,13 +1151,7 @@ function resolveExportsOrImports(
 
 function resolveDeepImport(
   id: string,
-  {
-    webResolvedImports,
-    setResolvedCache,
-    getResolvedCache,
-    dir,
-    data,
-  }: PackageData,
+  { setResolvedCache, getResolvedCache, dir, data }: PackageData,
   options: InternalResolveOptions,
 ): string | undefined {
   const cache = getResolvedCache(id, !!options.webCompatible)
@@ -1200,7 +1194,8 @@ function resolveDeepImport(
     if (mapped) {
       relativeId = mapped + postfix
     } else if (mapped === false) {
-      return (webResolvedImports[id] = browserExternalId)
+      setResolvedCache(id, browserExternalId, !!options.webCompatible)
+      return browserExternalId
     }
   }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1022,7 +1022,7 @@ export function resolvePackageEntry(
 ): string | undefined {
   const { file: idWithoutPostfix, postfix } = splitFileAndPostfix(id)
 
-  const cached = getResolvedCache('.', options)
+  const cached = getResolvedCache('.', !!options.webCompatible)
   if (cached) {
     return cached + postfix
   }
@@ -1094,7 +1094,7 @@ export function resolvePackageEntry(
             resolvedEntryPoint,
           )}${postfix !== '' ? ` (postfix: ${postfix})` : ''}`,
         )
-        setResolvedCache('.', resolvedEntryPoint, options)
+        setResolvedCache('.', resolvedEntryPoint, !!options.webCompatible)
         return resolvedEntryPoint + postfix
       }
     }
@@ -1151,10 +1151,16 @@ function resolveExportsOrImports(
 
 function resolveDeepImport(
   id: string,
-  { setResolvedCache, getResolvedCache, dir, data }: PackageData,
+  {
+    webResolvedImports,
+    setResolvedCache,
+    getResolvedCache,
+    dir,
+    data,
+  }: PackageData,
   options: InternalResolveOptions,
 ): string | undefined {
-  const cache = getResolvedCache(id, options)
+  const cache = getResolvedCache(id, !!options.webCompatible)
   if (cache) {
     return cache
   }
@@ -1194,8 +1200,7 @@ function resolveDeepImport(
     if (mapped) {
       relativeId = mapped + postfix
     } else if (mapped === false) {
-      setResolvedCache(id, browserExternalId, options)
-      return browserExternalId
+      return (webResolvedImports[id] = browserExternalId)
     }
   }
 
@@ -1209,7 +1214,7 @@ function resolveDeepImport(
       debug?.(
         `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`,
       )
-      setResolvedCache(id, resolved, options)
+      setResolvedCache(id, resolved, !!options.webCompatible)
       return resolved
     }
   }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1022,7 +1022,8 @@ export function resolvePackageEntry(
 ): string | undefined {
   const { file: idWithoutPostfix, postfix } = splitFileAndPostfix(id)
 
-  const cached = getResolvedCache('.', !!options.webCompatible)
+  // const cached = getResolvedCache('.', !!options.webCompatible)
+  const cached = getResolvedCache('.', options)
   if (cached) {
     return cached + postfix
   }
@@ -1094,7 +1095,8 @@ export function resolvePackageEntry(
             resolvedEntryPoint,
           )}${postfix !== '' ? ` (postfix: ${postfix})` : ''}`,
         )
-        setResolvedCache('.', resolvedEntryPoint, !!options.webCompatible)
+        // setResolvedCache('.', resolvedEntryPoint, !!options.webCompatible)
+        setResolvedCache('.', resolvedEntryPoint, options)
         return resolvedEntryPoint + postfix
       }
     }
@@ -1154,7 +1156,8 @@ function resolveDeepImport(
   { setResolvedCache, getResolvedCache, dir, data }: PackageData,
   options: InternalResolveOptions,
 ): string | undefined {
-  const cache = getResolvedCache(id, !!options.webCompatible)
+  // const cache = getResolvedCache(id, !!options.webCompatible)
+  const cache = getResolvedCache(id, options)
   if (cache) {
     return cache
   }
@@ -1194,7 +1197,8 @@ function resolveDeepImport(
     if (mapped) {
       relativeId = mapped + postfix
     } else if (mapped === false) {
-      setResolvedCache(id, browserExternalId, !!options.webCompatible)
+      // setResolvedCache(id, browserExternalId, !!options.webCompatible)
+      setResolvedCache(id, browserExternalId, options)
       return browserExternalId
     }
   }
@@ -1209,7 +1213,8 @@ function resolveDeepImport(
       debug?.(
         `[node/deep-import] ${colors.cyan(id)} -> ${colors.dim(resolved)}`,
       )
-      setResolvedCache(id, resolved, !!options.webCompatible)
+      // setResolvedCache(id, resolved, !!options.webCompatible)
+      setResolvedCache(id, resolved, options)
       return resolved
     }
   }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -243,9 +243,9 @@ export function resolvePlugin(
         isRequire,
         ...environmentResolveOptions,
         webCompatible: currentEnvironmentOptions.webCompatible,
+        packageCache: this.environment.config.packageCache,
         ...resolveOptions, // plugin options + resolve options overrides
         scan: resolveOpts?.scan ?? resolveOptions.scan,
-        packageCache: currentEnvironmentOptions.packageCache,
       }
 
       const depsOptimizerOptions = this.environment.config.dev.optimizeDeps

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -245,6 +245,7 @@ export function resolvePlugin(
         webCompatible: currentEnvironmentOptions.webCompatible,
         ...resolveOptions, // plugin options + resolve options overrides
         scan: resolveOpts?.scan ?? resolveOptions.scan,
+        packageCache: currentEnvironmentOptions.packageCache,
       }
 
       const depsOptimizerOptions = this.environment.config.dev.optimizeDeps

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -113,6 +113,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     root: config.root,
     isProduction: config.isProduction,
     isBuild: config.command === 'build',
+    // TODO
     packageCache: config.packageCache,
     asSrc: true,
   }

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -113,8 +113,6 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     root: config.root,
     isProduction: config.isProduction,
     isBuild: config.command === 'build',
-    // TODO
-    packageCache: config.packageCache,
     asSrc: true,
   }
 
@@ -158,7 +156,11 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           let file: string | undefined
           if (url[0] === '.') {
             file = path.resolve(path.dirname(id), url)
-            file = tryFsResolve(file, fsResolveOptions) ?? file
+            const resolveOptions = {
+              ...fsResolveOptions,
+              packageCache: this.environment.config.packageCache,
+            }
+            file = tryFsResolve(file, resolveOptions) ?? file
           } else {
             workerResolver ??= createBackCompatIdResolver(config, {
               extensions: [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -427,8 +427,13 @@ importers:
       '@vitejs/cjs-ssr-dep':
         specifier: link:./fixtures/cjs-ssr-dep
         version: link:fixtures/cjs-ssr-dep
+      '@vitejs/test-dep-conditions':
+        specifier: file:./fixtures/test-dep-conditions
+        version: file:packages/vite/src/node/__tests__/fixtures/test-dep-conditions
 
   packages/vite/src/node/__tests__/fixtures/cjs-ssr-dep: {}
+
+  packages/vite/src/node/__tests__/fixtures/test-dep-conditions: {}
 
   packages/vite/src/node/__tests__/packages/module: {}
 
@@ -3601,6 +3606,9 @@ packages:
 
   '@vitejs/test-dep-cjs-with-assets@file:playground/optimize-deps/dep-cjs-with-assets':
     resolution: {directory: playground/optimize-deps/dep-cjs-with-assets, type: directory}
+
+  '@vitejs/test-dep-conditions@file:packages/vite/src/node/__tests__/fixtures/test-dep-conditions':
+    resolution: {directory: packages/vite/src/node/__tests__/fixtures/test-dep-conditions, type: directory}
 
   '@vitejs/test-dep-css-require@file:playground/optimize-deps/dep-css-require':
     resolution: {directory: playground/optimize-deps/dep-css-require, type: directory}
@@ -9214,6 +9222,8 @@ snapshots:
   '@vitejs/test-dep-cjs-external-package-omit-js-suffix@file:playground/optimize-deps/dep-cjs-external-package-omit-js-suffix': {}
 
   '@vitejs/test-dep-cjs-with-assets@file:playground/optimize-deps/dep-cjs-with-assets': {}
+
+  '@vitejs/test-dep-conditions@file:packages/vite/src/node/__tests__/fixtures/test-dep-conditions': {}
 
   '@vitejs/test-dep-css-require@file:playground/optimize-deps/dep-css-require': {}
 


### PR DESCRIPTION
### Description

Alternative approach https://github.com/vitejs/vite/pull/18302#issuecomment-2404013913

This PR separates `PackageCache` per environment using `environment.config` proxy. I replaced `config.packageCache` with `environment.config.packageCache` through the code base (seems straight-forward except `watchPackageDataPlugin`).