### PR TITLE
docs: split environment frameworks guide

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -328,12 +328,16 @@ export default defineConfig({
               link: '/guide/api-environment',
             },
             {
-              text: 'Frameworks',
-              link: '/guide/api-environment-frameworks',
+              text: 'JavaScript',
+              link: '/guide/api-environment-javascript',
             },
             {
               text: 'Plugins',
               link: '/guide/api-environment-plugins',
+            },
+            {
+              text: 'Frameworks',
+              link: '/guide/api-environment-frameworks',
             },
             {
               text: 'Runtimes',

--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -13,96 +13,7 @@ Please share with us your feedback as you test the proposal.
 
 ## Environments and frameworks
 
-The available environments in a dev server can be accessed using `server.environments`:
-
-```js
-const environment = server.environments.client
-
-environment.transformRequest(url)
-
-console.log(server.environments.ssr.moduleGraph)
-```
-
-A dev environment is an instance of the `DevEnvironment` class:
-
-```ts
-class DevEnvironment {
-  /**
-   * Unique identifier for the environment in a Vite server.
-   * By default Vite exposes 'client' and 'ssr' environments.
-   */
-  name: string
-  /**
-   * Communication channel to send and receive messages from the
-   * associated module runner in the target runtime.
-   */
-  hot: HotChannel | null
-  /**
-   * Graph of module nodes, with the imported relationship between
-   * processed modules and the cached result of the processed code.
-   */
-  moduleGraph: EnvironmentModuleGraph
-  /**
-   * Resolved plugins for this environment, including the ones
-   * created using the per-environment `create` hook
-   */
-  plugins: Plugin[]
-  /**
-   * Allows to resolve, load, and transform code through the
-   * environment plugins pipeline
-   */
-  pluginContainer: EnvironmentPluginContainer
-  /**
-   * Resolved config options for this environment. Options at the server
-   * global scope are taken as defaults for all environments, and can
-   * be overridden (resolve conditions, external, optimizedDeps)
-   */
-  config: ResolvedConfig & ResolvedDevEnvironmentOptions
-
-  constructor(name, config, { hot, options }: DevEnvironmentSetup)
-
-  /**
-   * Resolve the URL to an id, load it, and process the code using the
-   * plugins pipeline. The module graph is also updated.
-   */
-  async transformRequest(url: string): TransformResult
-
-  /**
-   * Register a request to be processed with low priority. This is useful
-   * to avoid waterfalls. The Vite server has information about the imported
-   * modules by other requests, so it can warmup the module graph so the
-   * modules are already processed when they are requested.
-   */
-  async warmupRequest(url: string): void
-}
-```
-
-With `TransformResult` being:
-
-```ts
-interface TransformResult {
-  code: string
-  map: SourceMap | { mappings: '' } | null
-  etag?: string
-  deps?: string[]
-  dynamicDeps?: string[]
-}
-```
-
-:::warning
-The `runner` is evaluated eagerly when it's accessed for the first time. Beware that Vite enables source map support when the `runner` is created by calling `process.setSourceMapsEnabled` or by overriding `Error.prepareStackTrace` if it's not available.
-:::
-
-An environment instance in the Vite server lets you process a URL using the `environment.transformRequest(url)` method. This function will use the plugin pipeline to resolve the `url` to a module `id`, load it (reading the file from the file system or through a plugin that implements a virtual module), and then transform the code. While transforming the module, imports and other metadata will be recorded in the environment module graph by creating or updating the corresponding module node. When processing is done, the transform result is also stored in the module.
-
-But the environment instance can't execute the code itself, as the runtime where the module will be run could be different from the one the Vite server is running in. This is the case for the browser environment. When a html is loaded in the browser, its scripts are executed triggering the evaluation of the entire static module graph. Each imported URL generates a request to the Vite server to get the module code, which ends up handled by the Transform Middleware by calling `server.environments.client.transformRequest(url)`. The connection between the environment instance in the server and the module runner in the browser is carried out through HTTP in this case.
-
-:::info transformRequest naming
-We are using `transformRequest(url)` and `warmupRequest(url)` in the current version of this proposal so it is easier to discuss and understand for users used to Vite's current API. Before releasing, we can take the opportunity to review these names too. For example, it could be named `environment.processModule(url)` or `environment.loadModule(url)` taking a page from Rollup's `context.load(id)` in plugin hooks. For the moment, we think keeping the current names and delaying this discussion is better.
-:::
-
-Vite also exposes a `RunnableDevEnvironment`. While this is only implementable for some runtimes as it requires the runtime to be the same with the one the Vite server is running in, this works similarly with `ssrLoadModule`. You can guard any runnable environment with an `isRunnableDevEnvironment` function.
-In dev mode the default `ssr` environment is a `RunnableDevEnvironment`.
+The implicit `ssr` environment and other non-client environments use a `RunnableDevEnvironment` by default during dev. While this is only implementable for some runtimes as it requires the runtime to be the same with the one the Vite server is running in, this works similarly with `ssrLoadModule` and allows frameworks for to migrate and enable HMR during for their SSR dev story. You can guard any runnable environment with an `isRunnableDevEnvironment` function.
 
 ```ts
 export class RunnableDevEnvironment extends DevEnvironment {
@@ -125,59 +36,19 @@ if (isRunnableDevEnvironment(server.environments.ssr)) {
 }
 ```
 
-:::info
-In the v5.1 Runtime API, there were `executeUrl` and `executeEntryPoint` methods - they are now merged into a single `import` method. If you want to opt-out of the HMR support, create a runner with `hmr: false` flag.
-:::
-
-## Using custom environments
-
-A Vite dev server exposes two environments by default: a `client` environment and an `ssr` environment. The client environment is a browser environment by default and the SSR environment runs in the same Node runtime as the Vite server by default.
-
-To register a custom environment (for example to have a separate module graph for [RSC](https://react.dev/blog/2023/03/22/react-labs-what-we-have-been-working-on-march-2023#react-server-components)), you can pass a new property to the `environments` option. You can also use a plugin (See [Environment API for Plugins](./api-environment-plugins.md#registering-new-environments-using-hooks)).
-
-```ts
-import { createServer, createRunnableDevEnvironment } from 'vite'
-
-const server = await createServer({
-  /* ... */
-  environments: {
-    rsc: {
-      dev: {
-        createEnvironment(name, config) {
-          return createRunnableDevEnvironment(name, config)
-        },
-      },
-      build: {
-        outDir: '/dist/rsc',
-      },
-    },
-  },
-})
-
-// TODO: Maybe we should expose a `createNodeEnvironment` function (an environment factory for Node)?
-```
-
-Then, you can access the environment from `server.environments[environmentName]` (e.g. `server.environments.rsc`) as usual.
-
-## Using `RunnableDevEnvironment`
+## Default `RunnableDevEnvironment`
 
 Given a Vite server configured in middleware mode as described by the [SSR setup guide](/guide/ssr#setting-up-the-dev-server), let's implement the SSR middleware using the environment API. Error handling is omitted.
 
 ```js
-import { createServer, createRunnableDevEnvironment } from 'vite'
+import { createServer } from 'vite'
 
 const server = await createServer({
   server: { middlewareMode: true },
   appType: 'custom',
   environments: {
-    node: {
-      dev: {
-        // Default Vite SSR environment can be overridden in the config, so
-        // make sure you have a Node environment before the request is received.
-        createEnvironment(name, config) {
-          return createRunnableDevEnvironment(name, config)
-        },
-      },
+    server: {
+      // by default, the modules are run in the same process as the vite dev server during dev
     },
   },
 })
@@ -298,93 +169,6 @@ This keeps the HTML processing server agnostic.
 The initial proposal had a `run` method on the `DevEnvironment` class that would allow consumers to invoke an import on the runner side by using the `transport` option. During our testing we found out that the API was not universal enough to start recommending it. At the moment, we are looking for feedback on [the `FetchableDevEnvironment` proposal](https://github.com/vitejs/vite/discussions/18191).
 
 :::
-
-## Separate module graphs
-
-Each environment has an isolated module graph. All module graphs have the same signature, so generic algorithms can be implemented to crawl or query the graph without depending on the environment. `hotUpdate` is a good example. When a file is modified, the module graph of each environment will be used to discover the affected modules and perform HMR for each environment independently.
-
-::: info
-Vite v5 had a mixed Client and SSR module graph. Given an unprocessed or invalidated node, it isn't possible to know if it corresponds to the Client, SSR, or both environments. Module nodes have some properties prefixed, like `clientImportedModules` and `ssrImportedModules` (and `importedModules` that returns the union of both). `importers` contains all importers from both the Client and SSR environment for each module node. A module node also has `transformResult` and `ssrTransformResult`. A backward compatibility layer allows the ecosystem to migrate from the deprecated `server.moduleGraph`.
-:::
-
-Each module is represented by a `EnvironmentModuleNode` instance. Modules may be registered in the graph without yet being processed (`transformResult` would be `null` in that case). `importers` and `importedModules` are also updated after the module is processed.
-
-```ts
-class EnvironmentModuleNode {
-  environment: string
-
-  url: string
-  id: string | null = null
-  file: string | null = null
-
-  type: 'js' | 'css'
-
-  importers = new Set<EnvironmentModuleNode>()
-  importedModules = new Set<EnvironmentModuleNode>()
-  importedBindings: Map<string, Set<string>> | null = null
-
-  info?: ModuleInfo
-  meta?: Record<string, any>
-  transformResult: TransformResult | null = null
-
-  acceptedHmrDeps = new Set<EnvironmentModuleNode>()
-  acceptedHmrExports: Set<string> | null = null
-  isSelfAccepting?: boolean
-  lastHMRTimestamp = 0
-  lastInvalidationTimestamp = 0
-}
-```
-
-`environment.moduleGraph` is an instance of `EnvironmentModuleGraph`:
-
-```ts
-export class EnvironmentModuleGraph {
-  environment: string
-
-  urlToModuleMap = new Map<string, EnvironmentModuleNode>()
-  idToModuleMap = new Map<string, EnvironmentModuleNode>()
-  etagToModuleMap = new Map<string, EnvironmentModuleNode>()
-  fileToModulesMap = new Map<string, Set<EnvironmentModuleNode>>()
-
-  constructor(
-    environment: string,
-    resolveId: (url: string) => Promise<PartialResolvedId | null>,
-  )
-
-  async getModuleByUrl(
-    rawUrl: string,
-  ): Promise<EnvironmentModuleNode | undefined>
-
-  getModulesByFile(file: string): Set<EnvironmentModuleNode> | undefined
-
-  onFileChange(file: string): void
-
-  invalidateModule(
-    mod: EnvironmentModuleNode,
-    seen: Set<EnvironmentModuleNode> = new Set(),
-    timestamp: number = Date.now(),
-    isHmr: boolean = false,
-  ): void
-
-  invalidateAll(): void
-
-  async ensureEntryFromUrl(
-    rawUrl: string,
-    setIsSelfAccepting = true,
-  ): Promise<EnvironmentModuleNode>
-
-  createFileOnlyEntry(file: string): EnvironmentModuleNode
-
-  async resolveUrl(url: string): Promise<ResolvedUrl>
-
-  updateModuleTransformResult(
-    mod: EnvironmentModuleNode,
-    result: TransformResult | null,
-  ): void
-
-  getModuleByEtag(etag: string): EnvironmentModuleNode | undefined
-}
-```
 
 ## Environments during build
 

--- a/docs/guide/api-environment-javascript.md
+++ b/docs/guide/api-environment-javascript.md
@@ -1,0 +1,189 @@
+# Environment API for Frameworks
+
+:::warning Experimental
+Initial work for this API was introduced in Vite 5.1 with the name "Vite Runtime API". This guide describes a revised API, renamed to Environment API. This API will be released in Vite 6 as experimental. You can already test it in the latest `vite@6.0.0-beta.x` version.
+
+Resources:
+
+- [Feedback discussion](https://github.com/vitejs/vite/discussions/16358) where we are gathering feedback about the new APIs.
+- [Environment API PR](https://github.com/vitejs/vite/pull/16471) where the new API were implemented and reviewed.
+
+Please share with us your feedback as you test the proposal.
+:::
+
+## Environment JavasScript API
+
+During dev, the available environments in a dev server can be accessed using `server.environments`:
+
+```js
+const environment = server.environments.client
+
+environment.transformRequest(url)
+
+console.log(server.environments.ssr.moduleGraph)
+```
+
+A dev environment is an instance of the `DevEnvironment` class:
+
+```ts
+class DevEnvironment {
+  /**
+   * Unique identifier for the environment in a Vite server.
+   * By default Vite exposes 'client' and 'ssr' environments.
+   */
+  name: string
+  /**
+   * Communication channel to send and receive messages from the
+   * associated module runner in the target runtime.
+   */
+  hot: HotChannel | null
+  /**
+   * Graph of module nodes, with the imported relationship between
+   * processed modules and the cached result of the processed code.
+   */
+  moduleGraph: EnvironmentModuleGraph
+  /**
+   * Resolved plugins for this environment, including the ones
+   * created using the per-environment `create` hook
+   */
+  plugins: Plugin[]
+  /**
+   * Allows to resolve, load, and transform code through the
+   * environment plugins pipeline
+   */
+  pluginContainer: EnvironmentPluginContainer
+  /**
+   * Resolved config options for this environment. Options at the server
+   * global scope are taken as defaults for all environments, and can
+   * be overridden (resolve conditions, external, optimizedDeps)
+   */
+  config: ResolvedConfig & ResolvedDevEnvironmentOptions
+
+  constructor(name, config, { hot, options }: DevEnvironmentSetup)
+
+  /**
+   * Resolve the URL to an id, load it, and process the code using the
+   * plugins pipeline. The module graph is also updated.
+   */
+  async transformRequest(url: string): TransformResult
+
+  /**
+   * Register a request to be processed with low priority. This is useful
+   * to avoid waterfalls. The Vite server has information about the imported
+   * modules by other requests, so it can warmup the module graph so the
+   * modules are already processed when they are requested.
+   */
+  async warmupRequest(url: string): void
+}
+```
+
+With `TransformResult` being:
+
+```ts
+interface TransformResult {
+  code: string
+  map: SourceMap | { mappings: '' } | null
+  etag?: string
+  deps?: string[]
+  dynamicDeps?: string[]
+}
+```
+
+:::warning
+The `runner` is evaluated eagerly when it's accessed for the first time. Beware that Vite enables source map support when the `runner` is created by calling `process.setSourceMapsEnabled` or by overriding `Error.prepareStackTrace` if it's not available.
+:::
+
+An environment instance in the Vite server lets you process a URL using the `environment.transformRequest(url)` method. This function will use the plugin pipeline to resolve the `url` to a module `id`, load it (reading the file from the file system or through a plugin that implements a virtual module), and then transform the code. While transforming the module, imports and other metadata will be recorded in the environment module graph by creating or updating the corresponding module node. When processing is done, the transform result is also stored in the module.
+
+But the environment instance can't execute the code itself, as the runtime where the module will be run could be different from the one the Vite server is running in. This is the case for the browser environment. When a html is loaded in the browser, its scripts are executed triggering the evaluation of the entire static module graph. Each imported URL generates a request to the Vite server to get the module code, which ends up handled by the Transform Middleware by calling `server.environments.client.transformRequest(url)`. The connection between the environment instance in the server and the module runner in the browser is carried out through HTTP in this case.
+
+:::info transformRequest naming
+We are using `transformRequest(url)` and `warmupRequest(url)` in the current version of this proposal so it is easier to discuss and understand for users used to Vite's current API. Before releasing, we can take the opportunity to review these names too. For example, it could be named `environment.processModule(url)` or `environment.loadModule(url)` taking a page from Rollup's `context.load(id)` in plugin hooks. For the moment, we think keeping the current names and delaying this discussion is better.
+:::
+
+## Separate module graphs
+
+Each environment has an isolated module graph. All module graphs have the same signature, so generic algorithms can be implemented to crawl or query the graph without depending on the environment. `hotUpdate` is a good example. When a file is modified, the module graph of each environment will be used to discover the affected modules and perform HMR for each environment independently.
+
+::: info
+Vite v5 had a mixed Client and SSR module graph. Given an unprocessed or invalidated node, it isn't possible to know if it corresponds to the Client, SSR, or both environments. Module nodes have some properties prefixed, like `clientImportedModules` and `ssrImportedModules` (and `importedModules` that returns the union of both). `importers` contains all importers from both the Client and SSR environment for each module node. A module node also has `transformResult` and `ssrTransformResult`. A backward compatibility layer allows the ecosystem to migrate from the deprecated `server.moduleGraph`.
+:::
+
+Each module is represented by a `EnvironmentModuleNode` instance. Modules may be registered in the graph without yet being processed (`transformResult` would be `null` in that case). `importers` and `importedModules` are also updated after the module is processed.
+
+```ts
+class EnvironmentModuleNode {
+  environment: string
+
+  url: string
+  id: string | null = null
+  file: string | null = null
+
+  type: 'js' | 'css'
+
+  importers = new Set<EnvironmentModuleNode>()
+  importedModules = new Set<EnvironmentModuleNode>()
+  importedBindings: Map<string, Set<string>> | null = null
+
+  info?: ModuleInfo
+  meta?: Record<string, any>
+  transformResult: TransformResult | null = null
+
+  acceptedHmrDeps = new Set<EnvironmentModuleNode>()
+  acceptedHmrExports: Set<string> | null = null
+  isSelfAccepting?: boolean
+  lastHMRTimestamp = 0
+  lastInvalidationTimestamp = 0
+}
+```
+
+`environment.moduleGraph` is an instance of `EnvironmentModuleGraph`:
+
+```ts
+export class EnvironmentModuleGraph {
+  environment: string
+
+  urlToModuleMap = new Map<string, EnvironmentModuleNode>()
+  idToModuleMap = new Map<string, EnvironmentModuleNode>()
+  etagToModuleMap = new Map<string, EnvironmentModuleNode>()
+  fileToModulesMap = new Map<string, Set<EnvironmentModuleNode>>()
+
+  constructor(
+    environment: string,
+    resolveId: (url: string) => Promise<PartialResolvedId | null>,
+  )
+
+  async getModuleByUrl(
+    rawUrl: string,
+  ): Promise<EnvironmentModuleNode | undefined>
+
+  getModulesByFile(file: string): Set<EnvironmentModuleNode> | undefined
+
+  onFileChange(file: string): void
+
+  invalidateModule(
+    mod: EnvironmentModuleNode,
+    seen: Set<EnvironmentModuleNode> = new Set(),
+    timestamp: number = Date.now(),
+    isHmr: boolean = false,
+  ): void
+
+  invalidateAll(): void
+
+  async ensureEntryFromUrl(
+    rawUrl: string,
+    setIsSelfAccepting = true,
+  ): Promise<EnvironmentModuleNode>
+
+  createFileOnlyEntry(file: string): EnvironmentModuleNode
+
+  async resolveUrl(url: string): Promise<ResolvedUrl>
+
+  updateModuleTransformResult(
+    mod: EnvironmentModuleNode,
+    result: TransformResult | null,
+  ): void
+
+  getModuleByEtag(etag: string): EnvironmentModuleNode | undefined
+}
+```


### PR DESCRIPTION
### Description

Move Frameworks after Plugin, and split the JavaScript API into its own guide.