### PR TITLE
test: ssr external / resolveId test

### DIFF
--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -2,13 +2,14 @@ import path from 'node:path'
 import { describe, expect, onTestFinished, test } from 'vitest'
 import type { RollupOutput } from 'rollup'
 import { createServer } from '../server'
-import { defineConfig } from '../config'
+import type { InlineConfig } from '../config'
 import { createBuilder } from '../build'
 import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
 
 describe('custom environment conditions', () => {
-  function getConfig() {
-    return defineConfig({
+  function getConfig(): InlineConfig {
+    return {
+      configFile: false,
       root: import.meta.dirname,
       logLevel: 'error',
       server: {
@@ -116,7 +117,7 @@ describe('custom environment conditions', () => {
           },
         },
       },
-    })
+    }
   }
 
   test('dev', async () => {

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions-app/entry-with-module.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions-app/entry-with-module.js
@@ -1,0 +1,2 @@
+import dep from '@vitejs/test-dep-conditions/with-module'
+export default dep

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/dir/index.default.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/dir/index.default.js
@@ -1,0 +1,1 @@
+export default 'dir/index.default.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/dir/index.module.js
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/dir/index.module.js
@@ -1,0 +1,1 @@
+export default 'dir/index.module.js'

--- a/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/package.json
+++ b/packages/vite/src/node/__tests__/fixtures/test-dep-conditions/package.json
@@ -11,6 +11,10 @@
       "worker": "./index.worker.js",
       "browser": "./index.browser.js",
       "default": "./index.default.js"
+    },
+    "./with-module": {
+      "module": "./dir/index.module.js",
+      "default": "./dir/index.default.js"
     }
   }
 }

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -13,17 +13,17 @@ describe('import and resolveId', () => {
       },
     })
     onTestFinished(() => server.close())
-    return server
-  }
-
-  test('import first', async () => {
-    const server = await createTestServer()
     const runner = createServerModuleRunner(server.environments.ssr, {
       hmr: {
         logger: false,
       },
       sourcemapInterceptor: false,
     })
+    return { server, runner }
+  }
+
+  test('import first', async () => {
+    const { server, runner } = await createTestServer()
     const mod = await runner.import(
       '/fixtures/test-dep-conditions-app/entry-with-module',
     )
@@ -37,13 +37,7 @@ describe('import and resolveId', () => {
   })
 
   test('resolveId first', async () => {
-    const server = await createTestServer()
-    const runner = createServerModuleRunner(server.environments.ssr, {
-      hmr: {
-        logger: false,
-      },
-      sourcemapInterceptor: false,
-    })
+    const { server, runner } = await createTestServer()
     const resolved = await server.environments.ssr.pluginContainer.resolveId(
       '@vitejs/test-dep-conditions/with-module',
     )

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, onTestFinished, test } from 'vitest'
+import { createServer } from '../server'
+import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
+
+describe('import and resolveId', () => {
+  async function createTestServer() {
+    const server = await createServer({
+      configFile: false,
+      root: import.meta.dirname,
+      logLevel: 'error',
+      server: {
+        middlewareMode: true,
+      },
+    })
+    onTestFinished(() => server.close())
+    return server
+  }
+
+  test('import first', async () => {
+    const server = await createTestServer()
+    const runner = createServerModuleRunner(server.environments.ssr, {
+      hmr: {
+        logger: false,
+      },
+      sourcemapInterceptor: false,
+    })
+    const mod = await runner.import(
+      '/fixtures/test-dep-conditions-app/entry-with-module',
+    )
+    const resolved = await server.environments.ssr.pluginContainer.resolveId(
+      '@vitejs/test-dep-conditions/with-module',
+    )
+    expect([mod.default, resolved?.id]).toEqual([
+      'dir/index.default.js',
+      expect.stringContaining('dir/index.module.js'),
+    ])
+  })
+
+  test('resolveId first', async () => {
+    const server = await createTestServer()
+    const runner = createServerModuleRunner(server.environments.ssr, {
+      hmr: {
+        logger: false,
+      },
+      sourcemapInterceptor: false,
+    })
+    const resolved = await server.environments.ssr.pluginContainer.resolveId(
+      '@vitejs/test-dep-conditions/with-module',
+    )
+    const mod = await runner.import(
+      '/fixtures/test-dep-conditions-app/entry-with-module',
+    )
+    expect([mod.default, resolved?.id]).toEqual([
+      'dir/index.default.js',
+      expect.stringContaining('dir/index.module.js'),
+    ])
+  })
+})


### PR DESCRIPTION
### Description

Copying a test case from https://github.com/vitejs/vite/issues/16631, which is closed by https://github.com/vitejs/vite/pull/18302.
This test shows single module is resolved differently in a single environment, so it's probably worth having.