### PR TITLE
fix(resolve): fix resolve cache key for external conditions

### DIFF
--- a/packages/vite/src/node/packages.ts
+++ b/packages/vite/src/node/packages.ts
@@ -9,7 +9,7 @@ import {
   tryStatSync,
 } from './utils'
 import type { Plugin } from './plugin'
-import type { InternalResolveOptions } from './plugins/resolve'
+import type { InternalResolveOptionsWithOverrideConditions } from './plugins/resolve'
 
 let pnp: typeof import('pnpapi') | undefined
 if (process.versions.pnp) {
@@ -27,11 +27,11 @@ export interface PackageData {
   setResolvedCache: (
     key: string,
     entry: string,
-    options: InternalResolveOptions,
+    options: InternalResolveOptionsWithOverrideConditions,
   ) => void
   getResolvedCache: (
     key: string,
-    options: InternalResolveOptions,
+    options: InternalResolveOptionsWithOverrideConditions,
   ) => string | undefined
   data: {
     [field: string]: any
@@ -223,7 +223,10 @@ export function loadPackageData(pkgPath: string): PackageData {
   return pkg
 }
 
-function getResolveCacheKey(key: string, options: InternalResolveOptions) {
+function getResolveCacheKey(
+  key: string,
+  options: InternalResolveOptionsWithOverrideConditions,
+) {
   // cache key needs to include options which affect
   // `resolvePackageEntry` or `resolveDeepImport`
   return [
@@ -231,6 +234,7 @@ function getResolveCacheKey(key: string, options: InternalResolveOptions) {
     options.webCompatible ? '1' : '0',
     options.isRequire ? '1' : '0',
     options.conditions.join('_'),
+    options.overrideConditions?.join('_') || '',
     options.extensions.join('_'),
     options.mainFields.join('_'),
   ].join('|')


### PR DESCRIPTION
### Description

I realized resolve cache still conflicts for ssr external resolution as it uses `conditions: []` and `overrideConditions` instead internally. To fix this, I'm adding one more to cache key for now.

https://github.com/vitejs/vite/blob/f85aea2ad365cdce491a635816176fbd3034e82d/packages/vite/src/node/ssr/fetchModule.ts#L47-L60

My use case / experiment is to externalize `react` in both `ssr` and `rsc` environments. I found the resolve bug still exists in https://github.com/hi-ogawa/vite-environment-examples/pull/131 when testing pkg-pr-new from main.