### PR TITLE
chore(deps): update eslint-plugin-react-hooks to stable v5

### DIFF
--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -19,7 +19,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^9.12.0",
-    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.12",
     "globals": "^15.10.0",
     "typescript": "^5.5.3",

--- a/packages/create-vite/template-react/package.json
+++ b/packages/create-vite/template-react/package.json
@@ -20,7 +20,7 @@
     "@vitejs/plugin-react": "^4.3.2",
     "eslint": "^9.12.0",
     "eslint-plugin-react": "^7.37.1",
-    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.12",
     "globals": "^15.10.0",
     "vite": "^5.4.8"


### PR DESCRIPTION
The stable version should now be used instead of an rc version.

https://github.com/facebook/react/releases/tag/eslint-plugin-react-hooks%405.0.0