### PR TITLE
feat: implement fetchable runner

### DIFF
--- a/packages/vite/src/module-runner/fetchTransport.ts
+++ b/packages/vite/src/module-runner/fetchTransport.ts
@@ -1,0 +1,41 @@
+import { ENVIRONMENT_URL_PUBLIC_PATH } from '../shared/constants'
+import type { RunnerTransport } from './runnerTransport'
+import type { FetchFunctionOptions, FetchResult } from './types'
+
+export class FetchTransport implements RunnerTransport {
+  constructor(
+    private environmentName: string,
+    private serverURL: string,
+  ) {}
+
+  async fetchModule(
+    moduleUrl: string,
+    importer: string | undefined,
+    { cached, startOffset }: FetchFunctionOptions = {},
+  ): Promise<FetchResult> {
+    const serverUrl = new URL(
+      `${ENVIRONMENT_URL_PUBLIC_PATH}/${this.environmentName}`,
+      this.serverURL,
+    )
+    serverUrl.searchParams.set('moduleUrl', encodeURIComponent(moduleUrl))
+    if (importer) {
+      serverUrl.searchParams.set('importer', encodeURIComponent(importer))
+    }
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    const request = new Request(serverUrl, {
+      headers: {
+        'x-vite-cache': String(cached ?? false),
+        'x-vite-start-offset': String(startOffset ?? ''),
+      },
+    })
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    const response = await fetch(request)
+    if (response.status !== 200) {
+      // TODO: better error?
+      throw new Error(
+        `Failed to fetch module ${moduleUrl}, responded with ${response.status} (${response.statusText})`,
+      )
+    }
+    return await response.json()
+  }
+}

--- a/packages/vite/src/module-runner/fetchableRunner.ts
+++ b/packages/vite/src/module-runner/fetchableRunner.ts
@@ -1,0 +1,59 @@
+import { ENVIRONMENT_URL_PUBLIC_PATH } from '../shared/constants'
+import { ESModulesEvaluator } from './esmEvaluator'
+import { ModuleRunner } from './runner'
+import type { ModuleRunnerOptions } from './types'
+
+export interface FetchableModuleRunnerOptions
+  extends Pick<
+    ModuleRunnerOptions,
+    'sourcemapInterceptor' | 'evaluatedModules' | 'hmr'
+  > {
+  root: string
+  serverURL: string
+  environmentName: string
+}
+
+export function createFetchableModuleRunner(
+  options: FetchableModuleRunnerOptions,
+): ModuleRunner {
+  const { serverURL, environmentName } = options
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  const fetch = globalThis.fetch
+  if (!fetch) {
+    throw new TypeError('fetch is not available in this environment')
+  }
+  return new ModuleRunner(
+    {
+      root: options.root,
+      transport: {
+        async fetchModule(moduleUrl, importer, { cached, startOffset } = {}) {
+          const serverUrl = new URL(
+            `${ENVIRONMENT_URL_PUBLIC_PATH}/${environmentName}`,
+            serverURL,
+          )
+          serverUrl.searchParams.set('moduleUrl', encodeURIComponent(moduleUrl))
+          if (importer) {
+            serverUrl.searchParams.set('importer', encodeURIComponent(importer))
+          }
+          // eslint-disable-next-line n/no-unsupported-features/node-builtins
+          const request = new Request(serverUrl, {
+            headers: {
+              'x-vite-cache': String(cached ?? false),
+              'x-vite-start-offset': String(startOffset ?? ''),
+            },
+          })
+          const response = await fetch(request)
+          if (response.status !== 200) {
+            // TODO: better error?
+            throw new Error(
+              `Failed to fetch module ${moduleUrl}, responded with ${response.status} (${response.statusText})`,
+            )
+          }
+          return await response.json()
+        },
+      },
+      hmr: options.hmr,
+    },
+    new ESModulesEvaluator(),
+  )
+}

--- a/packages/vite/src/module-runner/fetchableRunner.ts
+++ b/packages/vite/src/module-runner/fetchableRunner.ts
@@ -18,8 +18,7 @@ export function createFetchableModuleRunner(
 ): ModuleRunner {
   const { serverURL, environmentName } = options
   // eslint-disable-next-line n/no-unsupported-features/node-builtins
-  const fetch = globalThis.fetch
-  if (!fetch) {
+  if (typeof fetch === 'undefined') {
     throw new TypeError('fetch is not available in this environment')
   }
   return new ModuleRunner(

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -5,6 +5,8 @@ export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 export { RemoteRunnerTransport } from './runnerTransport'
 
+export { createFetchableModuleRunner } from './fetchableRunner'
+
 export type { RunnerTransport } from './runnerTransport'
 export type { HMRLogger, HMRConnection } from '../shared/hmr'
 export type {

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -4,6 +4,7 @@ export { EvaluatedModules, type EvaluatedModuleNode } from './evaluatedModules'
 export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 export { RemoteRunnerTransport } from './runnerTransport'
+export { FetchTransport } from './fetchTransport'
 
 export { createFetchableModuleRunner } from './fetchableRunner'
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -95,6 +95,7 @@ import { transformRequest } from './transformRequest'
 import { searchForPackageRoot, searchForWorkspaceRoot } from './searchRoot'
 import { warmupFiles } from './warmup'
 import type { DevEnvironment } from './environment'
+import { environmentTransformMiddleware } from './middlewares/environmentTransform'
 
 export interface ServerOptions extends CommonServerOptions {
   /**
@@ -829,6 +830,7 @@ export async function _createServer(
   }
 
   middlewares.use(cachedTransformMiddleware(server))
+  middlewares.use(environmentTransformMiddleware(server))
 
   // proxy
   const { proxy } = serverConfig

--- a/packages/vite/src/node/server/middlewares/environmentTransform.ts
+++ b/packages/vite/src/node/server/middlewares/environmentTransform.ts
@@ -52,7 +52,7 @@ export function environmentTransformMiddleware(
     // }
 
     try {
-      const importer = searchParams.get('importer') || ''
+      const importer = searchParams.get('importer') || undefined
       const cached = req.headers['x-vite-cache'] === 'true'
       const startOffset = req.headers['x-vite-start-offset']
         ? Number(req.headers['x-vite-start-offset'])

--- a/packages/vite/src/node/server/middlewares/environmentTransform.ts
+++ b/packages/vite/src/node/server/middlewares/environmentTransform.ts
@@ -1,0 +1,77 @@
+import type { Connect } from 'dep-types/connect'
+import type { ViteDevServer } from '..'
+import {
+  ENVIRONMENT_URL_PUBLIC_PATH,
+  NULL_BYTE_PLACEHOLDER,
+} from '../../../shared/constants'
+
+export function environmentTransformMiddleware(
+  server: ViteDevServer,
+): Connect.NextHandleFunction {
+  return async function viteEnvironmentTransformMiddleware(req, res, next) {
+    if (req.method !== 'GET') {
+      return next()
+    }
+
+    let url: string
+    try {
+      url = decodeURI(req.url!).replace(NULL_BYTE_PLACEHOLDER, '\0')
+    } catch (e) {
+      return next(e)
+    }
+
+    if (!url.startsWith(ENVIRONMENT_URL_PUBLIC_PATH)) {
+      return next()
+    }
+
+    const { pathname, searchParams } = new URL(url, 'http://localhost')
+    const environmentName = pathname.slice(
+      ENVIRONMENT_URL_PUBLIC_PATH.length + 1,
+    )
+    const environment = server.environments[environmentName]
+
+    if (!environmentName || !environment) {
+      res.statusCode = 404
+      res.end()
+      return
+    }
+
+    const moduleUrl = searchParams.get('moduleUrl')
+
+    if (!moduleUrl) {
+      res.statusCode = 404
+      res.end()
+      return
+    }
+
+    // TODO: how to check consistently for all environments(?)
+    // currently ignores if the consumer is a `server`
+    // https://github.com/vitejs/vite/blob/main/packages/vite/src/node/server/transformRequest.ts:271
+    // if (!ensureServingAccess(moduleUrl, server, res, next)) {
+    //   return
+    // }
+
+    try {
+      const importer = searchParams.get('importer') || ''
+      const cached = req.headers['x-vite-cache'] === 'true'
+      const startOffset = req.headers['x-vite-start-offset']
+        ? Number(req.headers['x-vite-start-offset'])
+        : undefined
+      const moduleResult = await environment.fetchModule(moduleUrl, importer, {
+        cached,
+        startOffset,
+      })
+
+      if (res.writableEnded) {
+        return
+      }
+
+      res.setHeader('Content-Type', 'application/json')
+      res.statusCode = 200
+      res.end(JSON.stringify(moduleResult))
+      return
+    } catch (e) {
+      return next(e)
+    }
+  }
+}

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-fetchable-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-fetchable-runner.spec.ts
@@ -1,0 +1,36 @@
+import { createRunnableDevEnvironment, createServer } from 'vite'
+import { createFetchableModuleRunner } from 'vite/module-runner'
+import { expect, test } from 'vitest'
+
+test('fetchable module runner works correctly', async () => {
+  const server = await createServer({
+    root: import.meta.dirname,
+    server: {
+      port: 5010,
+      watch: null,
+      hmr: false,
+    },
+    environments: {
+      custom: {
+        dev: {
+          createEnvironment(name, config) {
+            return createRunnableDevEnvironment(name, config, {
+              hot: false,
+            })
+          },
+        },
+      },
+    },
+  })
+  await server.listen()
+
+  const runner = createFetchableModuleRunner({
+    root: server.config.root,
+    serverURL: 'http://localhost:5010',
+    environmentName: 'custom',
+    sourcemapInterceptor: false,
+  })
+
+  const mod = await runner.import('/fixtures/basic.js')
+  expect(mod.name).toBe('basic')
+})

--- a/packages/vite/src/shared/constants.ts
+++ b/packages/vite/src/shared/constants.ts
@@ -16,6 +16,8 @@ export const VALID_ID_PREFIX = `/@id/`
  */
 export const NULL_BYTE_PLACEHOLDER = `__x00__`
 
+export const ENVIRONMENT_URL_PUBLIC_PATH = '/@vite/import'
+
 export let SOURCEMAPPING_URL = 'sourceMa'
 SOURCEMAPPING_URL += 'ppingURL'
 

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -47,6 +47,7 @@ export const ports = {
   'css/dynamic-import': 5007,
   'css/lightningcss-proxy': 5008,
   'backend-integration': 5009,
+  'runner-fetchable': 5010, // not imported but used in `server-fetchable-runner.spec.ts`
 }
 export const hmrPorts = {
   'optimize-missing-deps': 24680,


### PR DESCRIPTION
### Description

Rought but working concept of a fetchable runner (related to https://github.com/vitejs/vite/discussions/18191)

Note that this is not a fetchable _environment_ (a bit confusing, is it?).

```ts
const server = await createServer()
await server.listen()

// can be initiated in a another process
const runner = createFetchableModuleRunner({
  root: process.env.VITE_CONFIG_ROOT,
  serverURL: process.env.VITE_SERVER_URL,
  environmentName: process.env.VITE_ENVIRONMENT_NAME,
})
```

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
