### PR TITLE
fix: add position to import analysis resolve exception

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -12,7 +12,7 @@ import { parseAst } from 'rollup/parseAst'
 import type { StaticImport } from 'mlly'
 import { ESM_STATIC_IMPORT_RE, parseStaticImport } from 'mlly'
 import { makeLegalIdentifier } from '@rollup/pluginutils'
-import type { PartialResolvedId } from 'rollup'
+import type { PartialResolvedId, RollupError } from 'rollup'
 import type { Identifier, Literal } from 'estree'
 import {
   CLIENT_DIR,
@@ -348,7 +348,12 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
         }
 
-        const resolved = await this.resolve(url, importerFile)
+        const resolved = await this.resolve(url, importerFile).catch((e) => {
+          if (e instanceof Error) {
+            ;(e as RollupError).pos ??= pos
+          }
+          throw e
+        })
 
         if (!resolved || resolved.meta?.['vite:alias']?.noResolved) {
           // in ssr, we should let node handle the missing modules


### PR DESCRIPTION
### Description

While improving rollup plugin errors display on Vitest https://github.com/vitest-dev/vitest/pull/6686, I noticed that the error thrown by `resolve.exports` such as `Error: Missing "./xxx" specifier in "yyy" package` doesn't have a code frame info.

I added try/catch for import analysis's `this.resolve` to add `RollupError.pos`.

<details><summary>Screenshots before and after</summary>

Example of an error when adding `import "vite/no-such-export"` to `playground/resolve`.

_before_

![Screenshot From 2024-10-12 14-20-20](https://github.com/user-attachments/assets/fb82ed24-fe30-444d-971d-438c051298a7)

_after_

![Screenshot From 2024-10-12 14-20-32](https://github.com/user-attachments/assets/3668c187-fbfa-41a1-937c-fc6b32482087)

</details>