### PR TITLE
refactor: use `verbatimModuleSyntax` instead of `importsNotUsedAsValues`

### DIFF
--- a/playground/tsconfig-json-load-error/tsconfig.json
+++ b/playground/tsconfig-json-load-error/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitReturns": true,
 
     "useDefineForClassFields": true,
-    "importsNotUsedAsValues": "preserve"
+    "verbatimModuleSyntax": true
   },
   "include": ["./src"]
 }

--- a/playground/tsconfig-json/tsconfig.json
+++ b/playground/tsconfig-json/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitReturns": true,
 
     "useDefineForClassFields": true,
-    "importsNotUsedAsValues": "preserve",
+    "verbatimModuleSyntax": true,
     "experimentalDecorators": true
   },
   "include": ["./src"]


### PR DESCRIPTION
### Description

`importsNotUsedAsValues` was removed in TS 5.5.
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#disabling-features-deprecated-in-typescript-50
This PR changes the tests to use `verbatimModuleSyntax` instead.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
