### PR TITLE
feat: allow custom `console` in `createLogger`

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -50,6 +50,7 @@ export interface LoggerOptions {
   prefix?: string
   allowClearScreen?: boolean
   customLogger?: Logger
+  console?: Console
 }
 
 // Only initialize the timeFormatter when the timestamp option is used, and
@@ -73,7 +74,11 @@ export function createLogger(
   }
 
   const loggedErrors = new WeakSet<Error | RollupError>()
-  const { prefix = '[vite]', allowClearScreen = true } = options
+  const {
+    prefix = '[vite]',
+    allowClearScreen = true,
+    console = globalThis.console,
+  } = options
   const thresh = LogLevels[level]
   const canClearScreen =
     allowClearScreen && process.stdout.isTTY && !process.env.CI


### PR DESCRIPTION
### Description

It's possible to define a console with custom stdout/stderr streams in Node.js by using the `Console` class:

```ts
const console = new Console({ stdout: myCustomStdout })
```

Vitest uses this mostly to make [testing itself easier](https://github.com/vitest-dev/vitest/blob/0a2132b38fea27afec83ca3044bc4e3a607f68ca/test/test-utils/index.ts#L34), but I don't see any harm in allowing the custom console in the logger.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
