### PR TITLE
feat: add .git to deny list by default

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -323,7 +323,7 @@ export default defineConfig({
 ## server.fs.deny
 
 - **Type:** `string[]`
-- **Default:** `['.env', '.env.*', '*.{crt,pem}']`
+- **Default:** `['.env', '.env.*', '*.{crt,pem}', '**/.git/**']`
 
 Blocklist for sensitive files being restricted to be served by Vite dev server. This will have higher priority than [`server.fs.allow`](#server-fs-allow). [picomatch patterns](https://github.com/micromatch/picomatch#globbing-features) are supported.
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1035,7 +1035,12 @@ export function resolveServerOptions(
     middlewareMode: raw?.middlewareMode || false,
   }
   let allowDirs = server.fs?.allow
-  const deny = server.fs?.deny || ['.env', '.env.*', '*.{crt,pem}']
+  const deny = server.fs?.deny || [
+    '.env',
+    '.env.*',
+    '*.{crt,pem}',
+    '**/.git/**',
+  ]
 
   if (!allowDirs) {
     allowDirs = [searchForWorkspaceRoot(root)]


### PR DESCRIPTION
### Description

Even if credentials shouldn't be committed to git, we discussed with others in the team that it makes sense to add `.git` to the default server deny list.