### PR TITLE
refactor(resolve): remove `tryEsmOnly` flag

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -7,8 +7,6 @@ import { hasESMSyntax } from 'mlly'
 import type { Plugin } from '../plugin'
 import {
   CLIENT_ENTRY,
-  DEFAULT_EXTENSIONS,
-  DEFAULT_MAIN_FIELDS,
   DEP_VERSION_RE,
   ENV_ENTRY,
   FS_PREFIX,
@@ -126,7 +124,6 @@ interface ResolvePluginOptions {
   // if the specifier requests a non-existent `.js/jsx/mjs/cjs` file,
   // should also try import from `.ts/tsx/mts/cts` source file as fallback.
   isFromTsImporter?: boolean
-  tryEsmOnly?: boolean
   // True when resolving during the scan phase to discover dependencies
   scan?: boolean
   // Appends ?__vite_skip_optimization to the resolved id if shouldn't be optimized
@@ -818,22 +815,7 @@ export function tryNodeResolve(
   const resolveId = deepMatch ? resolveDeepImport : resolvePackageEntry
   const unresolvedId = deepMatch ? '.' + id.slice(pkgId.length) : id
 
-  let resolved: string | undefined
-  try {
-    resolved = resolveId(unresolvedId, pkg, options)
-  } catch (err) {
-    if (!options.tryEsmOnly) {
-      throw err
-    }
-  }
-  if (!resolved && options.tryEsmOnly) {
-    resolved = resolveId(unresolvedId, pkg, {
-      ...options,
-      isRequire: false,
-      mainFields: DEFAULT_MAIN_FIELDS,
-      extensions: DEFAULT_EXTENSIONS,
-    })
-  }
+  let resolved = resolveId(unresolvedId, pkg, options)
   if (!resolved) {
     return
   }

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -65,7 +65,6 @@ export async function fetchModule(
         isProduction,
         root,
         packageCache: environment.config.packageCache,
-        tryEsmOnly: true,
         webCompatible: environment.config.webCompatible,
       },
       undefined,


### PR DESCRIPTION
### Description

This seems to be added by #5693.
At that time, `isRequire` was always set to `true`,
https://github.com/aleclarson/vite/blob/e3e6ed193f9cdf175071edb2f8e6d9fe35e8c9d5/packages/vite/src/node/ssr/ssrModuleLoader.ts#L112
but now we don't set that so this should be no longer needed.



<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
