### PR TITLE
feat: allow worker options via variable

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -657,7 +657,15 @@ const worker = new Worker(new URL('./worker.js', import.meta.url), {
 })
 ```
 
-The worker detection will only work if the `new URL()` constructor is used directly inside the `new Worker()` declaration. Additionally, all options parameters must be static values (i.e. string literals).
+The worker detection will only work if the `new URL()` constructor is used directly inside the `new Worker()` declaration. Additionally, all options parameters must be static values (i.e. string literals), or a variable that is defined before the `new Worker()`, as follows:
+
+```ts
+const workerOptions = { type: 'module' }
+const worker = new Worker(
+  new URL('./worker.js', import.meta.url),
+  workerOptions,
+)
+```
 
 ### Import with Query Suffixes
 

--- a/playground/worker/index.html
+++ b/playground/worker/index.html
@@ -100,6 +100,13 @@
 <code class="worker-import-meta-url-without-extension"></code>
 
 <p>
+  var workerOptions = { type: 'module' } new Worker(new URL('./url-worker.js',
+  import.meta.url), workerOptions)
+  <span class="classname">.worker-import-meta-url-via-variable</span>
+</p>
+<code class="worker-import-meta-url-via-variable"></code>
+
+<p>
   new SharedWorker(new URL('./url-shared-worker.js', import.meta.url), { type:
   'module' })
   <span class="classname">.shared-worker-import-meta-url</span>

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -135,6 +135,17 @@ wWithoutExt.addEventListener('message', (ev) =>
   text('.worker-import-meta-url-without-extension', JSON.stringify(ev.data)),
 )
 
+const myWorkerOptions = { type: 'module' }
+
+// url import worker via variable
+const wViaVariable = new Worker(
+  new URL('../url-worker', import.meta.url),
+  myWorkerOptions,
+)
+wViaVariable.addEventListener('message', (ev) =>
+  text('.worker-import-meta-url-via-variable', JSON.stringify(ev.data)),
+)
+
 const genWorkerName = () => 'module'
 const w2 = new SharedWorker(
   new URL('../url-shared-worker.js', import.meta.url),


### PR DESCRIPTION
### Description

This PR allows a variable reference in worker options of `new Worker()` as follows:

```
const myWorkerOptions = { type: 'module' }
...
new Worker(new URL(..., import.meta.url), myWorkerOptions)
```

Background: Emscripten 3.1.58 (or later) generates such a code. I thought about fixing it on the emscripten side, but it would be better if the vite could support this style. See also https://github.com/emscripten-core/emscripten/issues/22394