### PR TITLE
fix: set scripts imported by HTML moduleSideEffects=true

### DIFF
--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -349,14 +349,7 @@ export function resolvePlugin(
           res = ensureVersionQuery(res, id, options, ssr, depsOptimizer)
           debug?.(`[relative] ${colors.cyan(id)} -> ${colors.dim(res)}`)
 
-          // If this isn't a script imported from a .html file, include side effects
-          // hints so the non-used code is properly tree-shaken during build time.
-          if (
-            !options.idOnly &&
-            !options.scan &&
-            options.isBuild &&
-            !importer?.endsWith('.html')
-          ) {
+          if (!options.idOnly && !options.scan && options.isBuild) {
             const resPkg = findNearestPackageData(
               path.dirname(res),
               options.packageCache,


### PR DESCRIPTION
### Description

When setting `moduleSideEffects: false`, all scripts gets tree-shaked and the built output becomes empty. This is because we convert HTML files into a JS file just containing side effect imports that points to the `href` attr of script tags.

While the behavior is correct (the scripts do have a side-effect and setting it `false` is a lie) and kind of expected, it is more easier to configure if these scripts are marked as `moduleSideEffects: true` as in most cases you won't rely on side-effect imports. (The correct way of fixing this is to set `treeshake.moduleSideEffects: (id) => scriptsImportedByHtml.includes(id)` instead.)

fixes #16720
fixes #17911 

This PR reverts #12786 as this fix covers that one as well. (To fix that one correctly, the `sideEffects` field should include the scripts imported by the HTML file.)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
