### PR TITLE
fix(css): don't transform sass function calls with namespace

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -197,7 +197,7 @@ const commonjsProxyRE = /\?commonjs-proxy/
 const inlineRE = /[?&]inline\b/
 const inlineCSSRE = /[?&]inline-css\b/
 const styleAttrRE = /[?&]style-attr\b/
-const functionCallRE = /^[A-Z_][\w-]*\(/i
+const functionCallRE = /^[A-Z_][.\w-]*\(/i
 const transformOnlyRE = /[?&]transform-only\b/
 const nonEscapedDoubleQuoteRe = /(?<!\\)"/g
 

--- a/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
+++ b/playground/css-sourcemap/__tests__/css-sourcemap.spec.ts
@@ -145,11 +145,11 @@ describe.runIf(isServe)('serve', () => {
           "/root/imported-nested.sass",
         ],
         "sourcesContent": [
-          "@import "/imported-nested.sass"
+          "@use "/imported-nested.sass"
 
       .imported
         &-sass
-          color: $primary
+          color: imported-nested.$primary
       ",
           "$primary: red
       ",

--- a/playground/css-sourcemap/imported.sass
+++ b/playground/css-sourcemap/imported.sass
@@ -1,5 +1,5 @@
-@import "/imported-nested.sass"
+@use "/imported-nested.sass"
 
 .imported
   &-sass
-    color: $primary
+    color: imported-nested.$primary

--- a/playground/css-sourcemap/vite.config.js
+++ b/playground/css-sourcemap/vite.config.js
@@ -32,7 +32,7 @@ export default defineConfig({
         },
       },
       sass: {
-        silenceDeprecations: ['legacy-js-api'],
+        silenceDeprecations: ['legacy-js-api', 'import'],
       },
     },
   },

--- a/playground/css/nested/_index.scss
+++ b/playground/css/nested/_index.scss
@@ -20,6 +20,6 @@ $var: '/ok.png';
 
 $var2: '/OK.PNG';
 .sass-url-starts-with-function-call {
-  background: url(to-lower-case($var2));
+  background: url(string.to-lower-case($var2));
   background-position: center;
 }

--- a/playground/css/sass.scss
+++ b/playground/css/sass.scss
@@ -1,13 +1,13 @@
-@import '=/nested'; // alias + custom index resolving -> /nested/_index.scss
-@import '=/nested/partial'; // sass convention: omitting leading _ for partials
-@import '@vitejs/test-css-dep'; // package w/ sass entry points
-@import '@vitejs/test-css-dep-exports'; // package with a sass export mapping
-@import '@vitejs/test-scss-proxy-dep'; // package with a sass proxy import
-@import 'virtual-dep'; // virtual file added through importer
-@import '=/pkg-dep'; // package w/out sass field
-@import '=/weapp.wxss'; // wxss file
-@import 'virtual-file-absolute';
-@import '=/scss-dir/main.scss'; // "./dir" reference from vite custom importer
+@use '=/nested'; // alias + custom index resolving -> /nested/_index.scss
+@use '=/nested/partial'; // sass convention: omitting leading _ for partials
+@use '@vitejs/test-css-dep'; // package w/ sass entry points
+@use '@vitejs/test-css-dep-exports'; // package with a sass export mapping
+@use '@vitejs/test-scss-proxy-dep'; // package with a sass proxy import
+@use 'virtual-dep'; // virtual file added through importer
+@use '=/pkg-dep'; // package w/out sass field
+@use '=/weapp.wxss'; // wxss file
+@use 'virtual-file-absolute';
+@use '=/scss-dir/main.scss'; // "./dir" reference from vite custom importer
 
 .sass {
   /* injected via vite.config.js */

--- a/playground/css/scss-dir/main.scss
+++ b/playground/css/scss-dir/main.scss
@@ -1,1 +1,1 @@
-@import './dir';
+@use './dir';

--- a/playground/css/scss-proxy-dep/index.scss
+++ b/playground/css/scss-proxy-dep/index.scss
@@ -1,1 +1,1 @@
-@import '@vitejs/test-scss-proxy-dep-nested/index.css';
+@use '@vitejs/test-scss-proxy-dep-nested/index.css';

--- a/playground/css/vite.config-sass-modern.js
+++ b/playground/css/vite.config-sass-modern.js
@@ -34,7 +34,7 @@ export default defineConfig({
             },
             load() {
               return {
-                contents: `@import "${pathToFileURL(path.join(import.meta.dirname, 'file-absolute.scss')).href}"`,
+                contents: `@use "${pathToFileURL(path.join(import.meta.dirname, 'file-absolute.scss')).href}"`,
                 syntax: 'scss',
               }
             },

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -69,7 +69,7 @@ export default defineConfig({
           function (url) {
             return url === 'virtual-file-absolute'
               ? {
-                  contents: `@import "${pathToFileURL(path.join(import.meta.dirname, 'file-absolute.scss')).href}"`,
+                  contents: `@use "${pathToFileURL(path.join(import.meta.dirname, 'file-absolute.scss')).href}"`,
                 }
               : null
           },
@@ -77,7 +77,7 @@ export default defineConfig({
             return url.endsWith('.wxss') ? { contents: '' } : null
           },
         ],
-        silenceDeprecations: ['legacy-js-api'],
+        silenceDeprecations: ['legacy-js-api', 'import'],
       },
       styl: {
         additionalData: `$injectedColor ?= orange`,


### PR DESCRIPTION
### Description

This PR fixes `background: url(string.to-lower-case($var2));` to be not to transformed. I found this while fixing [the deprecation warnings coming from sass](https://sass-lang.com/documentation/breaking-changes/import/).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
