### PR TITLE
feat: add import.meta.DEBUG

### DIFF
--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -44,6 +44,7 @@ export function definePlugin(config: ResolvedConfig): Plugin {
     // these will be set to a proper value in `generatePattern`
     importMetaKeys['import.meta.env.SSR'] = `undefined`
     importMetaFallbackKeys['import.meta.env'] = `undefined`
+    importMetaKeys['import.meta.DEBUG'] = !config.isProduction + ''
   }
 
   const userDefine: Record<string, string> = {}
@@ -89,7 +90,11 @@ export function definePlugin(config: ResolvedConfig): Plugin {
       patternKeys.push('process.env')
     }
     if (Object.keys(importMetaKeys).length) {
-      patternKeys.push('import.meta.env', 'import.meta.hot')
+      patternKeys.push(
+        'import.meta.env',
+        'import.meta.hot',
+        'import.meta.DEBUG',
+      )
     }
     const pattern = patternKeys.length
       ? new RegExp(patternKeys.map(escapeRegex).join('|'))

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -259,6 +259,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
     async transform(source, importer) {
       const environment = this.environment as DevEnvironment
       const ssr = environment.config.consumer === 'server'
+      const isDebug = !environment.config.isProduction
       const moduleGraph = environment.moduleGraph
 
       if (canSkipImportAnalysis(importer)) {
@@ -311,6 +312,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       let hasHMR = false
       let isSelfAccepting = false
       let hasEnv = false
+      let hasDebug = false
       let needQueryInjectHelper = false
       let s: MagicString | undefined
       const str = () => s || (s = new MagicString(source))
@@ -486,6 +488,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               }
             } else if (prop === '.env') {
               hasEnv = true
+            } else if (
+              prop === '.DEB' &&
+              source.slice(end, end + 6) === '.DEBUG'
+            ) {
+              hasDebug = true
             }
             return
           } else if (templateLiteralRE.test(rawUrl)) {
@@ -715,6 +722,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       if (hasEnv && !isClassicWorker) {
         // inject import.meta.env
         str().prepend(getEnv(ssr))
+      }
+
+      if (hasDebug && !isClassicWorker) {
+        // inject import.meta.DEBUG
+        str().prepend(`import.meta.DEBUG = ${isDebug};`)
       }
 
       if (hasHMR && !ssr && !isClassicWorker) {

--- a/playground/define/__tests__/define.spec.ts
+++ b/playground/define/__tests__/define.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import viteConfig from '../vite.config'
-import { page } from '~utils'
+import { isBuild, page } from '~utils'
 
 const defines = viteConfig.define
 
@@ -91,6 +91,11 @@ test('replaces constants in template literal expressions', async () => {
       '.replaces-constants-in-template-literal-expressions .process-env-NODE_ENV',
     ),
   ).toBe('dev')
+  expect(
+    await page.textContent(
+      '.replaces-constants-in-template-literal-expressions .import-meta-DEBUG',
+    ),
+  ).toBe(isBuild ? 'false' : 'true')
 })
 
 test('replace constants on import.meta.env when it is a invalid json', async () => {

--- a/playground/define/index.html
+++ b/playground/define/index.html
@@ -58,6 +58,7 @@
     <code class="globalThis-process-env-NODE_ENV"></code>
   </p>
   <p>import.meta.hot <code class="import-meta-hot"></code></p>
+  <p>import.meta.DEBUG <code class="import-meta-DEBUG"></code></p>
 </section>
 
 <h2>Define undefined constants on import.meta.env when it's a invalid json</h2>
@@ -141,6 +142,10 @@
   text(
     '.replaces-constants-in-template-literal-expressions .process-env-NODE_ENV',
     `${process.env.NODE_ENV}`,
+  )
+  text(
+    '.replaces-constants-in-template-literal-expressions .import-meta-DEBUG',
+    `${import.meta.DEBUG}`,
   )
 
   text(


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Adds an alternative to `process.env.NODE_ENV`-based guards. It's a simple boolean and doesn't require the use of node-specific APIs in non-node code.

See: https://github.com/jkrems/md/blob/main/import-meta-debug.md
Or just skip ahead to the section that defines this new property: https://github.com/jkrems/md/blob/main/import-meta-debug.md#importmetaDEBUG.

The goal is to have this property reliably available across tools. PRs across bundlers:

* Parcel: TBD
* Rspack: TBD
* Vite: https://github.com/vitejs/vite/pull/18417
* webpack: https://github.com/webpack/webpack/pull/18876

I wouldn't be surprised if there's some bikeshedding on the name (`.DEBUG` vs `.DEV` vs `.development` vs ..?). So it's likely a good idea to hold off on landing it in any of the tools before there's a broader consensus on the name. The API itself seems simple enough that I'm not expecting a _lot_ of churn.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
