### PR TITLE
docs: center last projects row in landing

### DIFF
--- a/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
+++ b/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
@@ -284,7 +284,6 @@ const centerIndexes: ComputedRef<{ start: number; end: number }[]> = computed(
   },
 )
 
-console.log(centerIndexes.value)
 /**
  * Generate CSS transformations for each row, to gracefully slide between horizontal positions.
  */

--- a/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
+++ b/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
@@ -245,25 +245,46 @@ const numFrameworksPerRow = computed(
 )
 
 /**
- * The indexes of the blocks on each row that support framework cards.
- */
-const centerIndexes: ComputedRef<{ start: number; end: number }> = computed(
-  () => {
-    const startIndex = paddedBlocksPerSide.value
-    return {
-      start: startIndex,
-      end: numBlocksPerRow.value - paddedBlocksPerSide.value,
-    }
-  },
-)
-
-/**
  * How many rows do we need to display all the frameworks?
  */
 const numRows: ComputedRef<number> = computed(() => {
   return Math.ceil(frameworks.length / numFrameworksPerRow.value)
 })
 
+/**
+ * The indexes of the blocks on each row that support framework cards.
+ */
+const centerIndexes: ComputedRef<{ start: number; end: number }[]> = computed(
+  () => {
+    const firstRowsStartIndex = paddedBlocksPerSide.value
+    const frameworksPerFirstRows =
+      numBlocksPerRow.value - 2 * paddedBlocksPerSide.value
+    const lastRowStartIndex =
+      paddedBlocksPerSide.value +
+      Math.floor(
+        (frameworksPerFirstRows -
+          (frameworks.length % frameworksPerFirstRows)) /
+          2,
+      )
+    return new Array(numRows.value + 1).fill(0).map((_, i) => {
+      return i < numRows.value ||
+        frameworks.length % frameworksPerFirstRows === 0
+        ? {
+            start: firstRowsStartIndex,
+            end: numBlocksPerRow.value - paddedBlocksPerSide.value,
+          }
+        : {
+            start: lastRowStartIndex,
+            end:
+              lastRowStartIndex +
+              (frameworks.length % frameworksPerFirstRows) +
+              1,
+          }
+    })
+  },
+)
+
+console.log(centerIndexes.value)
 /**
  * Generate CSS transformations for each row, to gracefully slide between horizontal positions.
  */
@@ -289,8 +310,8 @@ const rowStyle: ComputedRef<{ transform: string }> = computed(() => {
           <template v-for="columnIndex in numBlocksPerRow + 2">
             <template
               v-if="
-                columnIndex - 1 >= centerIndexes.start &&
-                columnIndex - 1 < centerIndexes.end
+                columnIndex - 1 >= centerIndexes[rowIndex].start &&
+                columnIndex - 1 < centerIndexes[rowIndex].end
               "
             >
               <FrameworkCard
@@ -298,7 +319,7 @@ const rowStyle: ComputedRef<{ transform: string }> = computed(() => {
                   frameworks[
                     (rowIndex - 1) * numFrameworksPerRow +
                       (columnIndex - 1) -
-                      centerIndexes.start
+                      centerIndexes[rowIndex].start
                   ]
                 "
               />

--- a/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
+++ b/docs/.vitepress/theme/components/landing/3. frameworks-section/FrameworksSection.vue
@@ -253,6 +253,8 @@ const numRows: ComputedRef<number> = computed(() => {
 
 /**
  * The indexes of the blocks on each row that support framework cards.
+ *
+ * Note that the index of the returned array is 1-based.
  */
 const centerIndexes: ComputedRef<{ start: number; end: number }[]> = computed(
   () => {


### PR DESCRIPTION
### Description

When the last row had 1 or 2 projects, it looked unbalanced.
<img width="1424" alt="image" src="https://github.com/user-attachments/assets/74f36bd1-381b-4faf-ba5a-2059e83f510a">
