### PR TITLE
refactor: dollar sign prefixed environments

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -456,17 +456,15 @@ export default defineConfig({
         },
       }),
     ],
-    environments: {
-      client: {
-        dev: {
-          optimizeDeps: {
-            include: [
-              '@shikijs/vitepress-twoslash/client',
-              'gsap',
-              'gsap/dist/ScrollTrigger',
-              'gsap/dist/MotionPathPlugin',
-            ],
-          },
+    $client: {
+      dev: {
+        optimizeDeps: {
+          include: [
+            '@shikijs/vitepress-twoslash/client',
+            'gsap',
+            'gsap/dist/ScrollTrigger',
+            'gsap/dist/MotionPathPlugin',
+          ],
         },
       },
     },

--- a/docs/changes/this-environment-in-hooks.md
+++ b/docs/changes/this-environment-in-hooks.md
@@ -18,7 +18,7 @@ Affect scope: `Vite Plugin Authors`
 
 ## Migration Guide
 
-For the existing plugin to do a quick migration, replace the `options.ssr` argument with `this.environment.name !== 'client'` in the `resolveId`, `load` and `transform` hooks:
+For the existing plugin to do a quick migration, replace the `options.ssr` argument with `this.environment.name !== '$client'` in the `resolveId`, `load` and `transform` hooks:
 
 ```ts
 import { Plugin } from 'vite'
@@ -28,7 +28,7 @@ export function myPlugin(): Plugin {
     name: 'my-plugin',
     resolveId(id, importer, options) {
       const isSSR = options.ssr // [!code --]
-      const isSSR = this.environment.name !== 'client' // [!code ++]
+      const isSSR = this.environment.name !== '$client' // [!code ++]
 
       if (isSSR) {
         // SSR specific logic

--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -31,8 +31,8 @@ class ModuleRunner {
    */
 }
 
-if (isRunnableDevEnvironment(server.environments.ssr)) {
-  await server.environments.ssr.runner.import('/entry-point.js')
+if (isRunnableDevEnvironment(server.environments.$ssr)) {
+  await server.environments.$ssr.runner.import('/entry-point.js')
 }
 ```
 
@@ -50,16 +50,14 @@ import { createServer } from 'vite'
 const server = await createServer({
   server: { middlewareMode: true },
   appType: 'custom',
-  environments: {
-    server: {
-      // by default, the modules are run in the same process as the vite dev server during dev
-    },
+  $server: {
+    // by default, the modules are run in the same process as the vite dev server during dev
   },
 })
 
 // You might need to cast this to RunnableDevEnvironment in TypeScript or use
 // the "isRunnableDevEnvironment" function to guard the access to the runner
-const environment = server.environments.node
+const environment = server.environments.$server
 
 app.use('*', async (req, res, next) => {
   const url = req.originalUrl
@@ -109,7 +107,7 @@ For example, the following example uses the value of the user module from the co
 import { createServer } from 'vite'
 
 const server = createServer()
-const ssrEnvironment = server.environment.ssr
+const ssrEnvironment = server.environments.$ssr
 const input = {}
 
 const { createHandler } = await ssrEnvironment.runner.import('./entrypoint.js')
@@ -140,7 +138,7 @@ const server = createServer({
     },
   ],
 })
-const ssrEnvironment = server.environment.ssr
+const ssrEnvironment = server.environments.$ssr
 const input = {}
 
 // use exposed functions by each environment factories that runs the code
@@ -214,7 +212,7 @@ const server = createServer({
     },
   ],
 })
-const ssrEnvironment = server.environment.ssr
+const ssrEnvironment = server.environments.$ssr
 const input = {}
 
 // use exposed functions by each environment factories that runs the code

--- a/docs/guide/api-environment-frameworks.md
+++ b/docs/guide/api-environment-frameworks.md
@@ -31,8 +31,8 @@ class ModuleRunner {
    */
 }
 
-if (isRunnableDevEnvironment(server.environments.$ssr)) {
-  await server.environments.$ssr.runner.import('/entry-point.js')
+if (isRunnableDevEnvironment(server.$ssr)) {
+  await server.$ssr.runner.import('/entry-point.js')
 }
 ```
 
@@ -57,7 +57,7 @@ const server = await createServer({
 
 // You might need to cast this to RunnableDevEnvironment in TypeScript or use
 // the "isRunnableDevEnvironment" function to guard the access to the runner
-const environment = server.environments.$server
+const environment = server.$server
 
 app.use('*', async (req, res, next) => {
   const url = req.originalUrl
@@ -107,7 +107,7 @@ For example, the following example uses the value of the user module from the co
 import { createServer } from 'vite'
 
 const server = createServer()
-const ssrEnvironment = server.environments.$ssr
+const ssrEnvironment = server.$ssr
 const input = {}
 
 const { createHandler } = await ssrEnvironment.runner.import('./entrypoint.js')
@@ -138,7 +138,7 @@ const server = createServer({
     },
   ],
 })
-const ssrEnvironment = server.environments.$ssr
+const ssrEnvironment = server.$ssr
 const input = {}
 
 // use exposed functions by each environment factories that runs the code
@@ -212,7 +212,7 @@ const server = createServer({
     },
   ],
 })
-const ssrEnvironment = server.environments.$ssr
+const ssrEnvironment = server.$ssr
 const input = {}
 
 // use exposed functions by each environment factories that runs the code
@@ -281,4 +281,4 @@ export default {
 
 ## Environment agnostic code
 
-Most of the time, the current `environment` instance will be available as part of the context of the code being run so the need to access them through `server.environments` should be rare. For example, inside plugin hooks the environment is exposed as part of the `PluginContext`, so it can be accessed using `this.environment`. See [Environment API for Plugins](./api-environment-plugins.md) to learn about how to build environment aware plugins.
+Most of the time, the current `environment` instance will be available as part of the context of the code being run so the need to access them by name should be rare. For example, inside plugin hooks the environment is exposed as part of the `PluginContext`, so it can be accessed using `this.environment`. See [Environment API for Plugins](./api-environment-plugins.md) to learn about how to build environment aware plugins.

--- a/docs/guide/api-environment-instances.md
+++ b/docs/guide/api-environment-instances.md
@@ -13,15 +13,15 @@ Please share with us your feedback as you test the proposal.
 
 ## Accessing the environments
 
-During dev, the available environments in a dev server can be accessed using `server.environments`:
+During dev, the available environments in a dev server can be accessed using `server`:
 
 ```js
 // create the server, or get it from the configureServer hook
 const server = await createServer(/* options */)
 
-const environment = server.environments.$client
+const environment = server.$client
 environment.transformRequest(url)
-console.log(server.environments.$ssr.moduleGraph)
+console.log(server.$ssr.moduleGraph)
 ```
 
 You can also access the current environment from plugins. See the [Environment API for Plugins](./api-environment-plugins.md#accessing-the-current-environment-in-hooks) for more details.

--- a/docs/guide/api-environment-instances.md
+++ b/docs/guide/api-environment-instances.md
@@ -19,9 +19,9 @@ During dev, the available environments in a dev server can be accessed using `se
 // create the server, or get it from the configureServer hook
 const server = await createServer(/* options */)
 
-const environment = server.environments.client
+const environment = server.environments.$client
 environment.transformRequest(url)
-console.log(server.environments.ssr.moduleGraph)
+console.log(server.environments.$ssr.moduleGraph)
 ```
 
 You can also access the current environment from plugins. See the [Environment API for Plugins](./api-environment-plugins.md#accessing-the-current-environment-in-hooks) for more details.
@@ -34,7 +34,7 @@ During dev, each environment is an instance of the `DevEnvironment` class:
 class DevEnvironment {
   /**
    * Unique identifier for the environment in a Vite server.
-   * By default Vite exposes 'client' and 'ssr' environments.
+   * By default Vite exposes '$client' and '$ssr' environments.
    */
   name: string
   /**

--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -82,7 +82,7 @@ The hook can choose to:
 
   ```js
   hotUpdate({ modules, timestamp }) {
-    if (this.environment.name !== 'client')
+    if (this.environment.name !== '$client')
       return
 
     // Invalidate modules manually
@@ -104,7 +104,7 @@ The hook can choose to:
 
   ```js
   hotUpdate() {
-    if (this.environment.name !== 'client')
+    if (this.environment.name !== '$client')
       return
 
     this.environment.hot.send({

--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -33,7 +33,7 @@ Plugins can add new environments in the `config` hook (for example to have a sep
 
 ```ts
   config(config: UserConfig) {
-    config.environments.rsc ??= {}
+    config.$rsc ??= {}
   }
 ```
 
@@ -41,7 +41,7 @@ An empty object is enough to register the environment, default values from the r
 
 ## Configuring environment using hooks
 
-While the `config` hook is running, the complete list of environments isn't yet known and the environments can be affected by both the default values from the root level environment config or explicitly through the `config.environments` record.
+While the `config` hook is running, the complete list of environments isn't yet known and the environments can be affected by both the default values from the root level environment config or explicitly using `config.$environment`.
 Plugins should set default values using the `config` hook. To configure each environment, they can use the new `configEnvironment` hook. This hook is called for each environment with its partially resolved config including resolution of final defaults.
 
 ```ts

--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -66,7 +66,7 @@ export default {
 and frameworks can use an environment with the workerd runtime to do SSR using:
 
 ```js
-const ssrEnvironment = server.environments.$ssr
+const ssrEnvironment = server.$ssr
 ```
 
 ## Creating a new environment factory

--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -50,25 +50,23 @@ Then the config file can be written as:
 import { createWorkerdEnvironment } from 'vite-environment-workerd'
 
 export default {
-  environments: {
-    ssr: createWorkerdEnvironment({
-      build: {
-        outDir: '/dist/ssr',
-      },
-    }),
-    rsc: createWorkerdEnvironment({
-      build: {
-        outDir: '/dist/rsc',
-      },
-    }),
-  },
+  $ssr: createWorkerdEnvironment({
+    build: {
+      outDir: '/dist/ssr',
+    },
+  }),
+  $rsc: createWorkerdEnvironment({
+    build: {
+      outDir: '/dist/rsc',
+    },
+  }),
 }
 ```
 
 and frameworks can use an environment with the workerd runtime to do SSR using:
 
 ```js
-const ssrEnvironment = server.environments.ssr
+const ssrEnvironment = server.environments.$ssr
 ```
 
 ## Creating a new environment factory
@@ -293,11 +291,9 @@ function createWorkerEnvironment(name, config, context) {
 }
 
 await createServer({
-  environments: {
-    worker: {
-      dev: {
-        createEnvironment: createWorkerEnvironment,
-      },
+  $worker: {
+    dev: {
+      createEnvironment: createWorkerEnvironment,
     },
   },
 })

--- a/docs/guide/api-environment.md
+++ b/docs/guide/api-environment.md
@@ -31,27 +31,25 @@ Environments are explicitly configured with the `environments` config option.
 
 ```js
 export default {
-  environments: {
-    client: {
-      resolve: {
-        conditions: [], // configure the Client environment
-      },
+  $client: {
+    resolve: {
+      conditions: [], // configure the Client environment
     },
-    ssr: {
-      dev: {
-        optimizeDeps: {}, // configure the SSR environment
-      },
+  },
+  $ssr: {
+    dev: {
+      optimizeDeps: {}, // configure the SSR environment
     },
-    rsc: {
-      resolve: {
-        noExternal: true, // configure a custom environment
-      },
+  },
+  $rsc: {
+    resolve: {
+      noExternal: true, // configure a custom environment
     },
   },
 }
 ```
 
-All environment configs extend from user's root config, allowing users add defaults for all environments at the root level. This is quite useful for the common use case of configuring a Vite client only app, that can be done without going through `environments.client`.
+All environment configs extend from user's root config, allowing users add defaults for all environments at the root level. This is quite useful for the common use case of configuring a Vite client only app, that can be done without going through `environments.$client`.
 
 ```js
 export default {
@@ -70,7 +68,7 @@ interface EnvironmentOptions extends SharedEnvironmentOptions {
 }
 ```
 
-As we explained, Environment specific options defined at the root level of user config are used for the default client environment (the `UserConfig` interface extends from the `EnvironmentOptions` interface). And environments can be configured explicitly using the `environments` record. The `client` and `ssr` environments are always present during dev, even if an empty object is set to `environments`. This allows backward compatibility with `server.ssrLoadModule(url)` and `server.moduleGraph`. During build, the `client` environment is always present, and the `ssr` environment is only present if it is explicitly configured (using `environments.ssr` or for backward compatibility `build.ssr`).
+As we explained, Environment specific options defined at the root level of user config are used for the default client environment (the `UserConfig` interface extends from the `EnvironmentOptions` interface). And environments can be configured explicitly using the `environments` record. The `client` and `ssr` environments are always present during dev, even if an empty object is set to `environments`. This allows backward compatibility with `server.ssrLoadModule(url)` and `server.moduleGraph`. During build, the `client` environment is always present, and the `ssr` environment is only present if it is explicitly configured (using `environments.$ssr` or for backward compatibility `build.ssr`).
 
 ```ts
 interface UserConfig extends EnvironmentOptions {
@@ -93,18 +91,16 @@ Low level configuration APIs are available so runtime providers can provide envi
 import { createCustomEnvironment } from 'vite-environment-provider'
 
 export default {
-  environments: {
-    client: {
-      build: {
-        outDir: '/dist/client',
-      },
-    }
-    ssr: createCustomEnvironment({
-      build: {
-        outDir: '/dist/ssr',
-      },
-    }),
-  },
+  $client: {
+    build: {
+      outDir: '/dist/client',
+    },
+  }
+  $ssr: createCustomEnvironment({
+    build: {
+      outDir: '/dist/ssr',
+    },
+  }),
 }
 ```
 

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -624,7 +624,7 @@ describe('resolveBuildOutputs', () => {
         },
       },
     })
-    const result = await builder.build(builder.environments.$ssr)
+    const result = await builder.build(builder.$ssr)
     expect(result).toMatchObject({
       output: [
         {
@@ -652,7 +652,7 @@ describe('resolveBuildOutputs', () => {
         },
       },
     })
-    const result = await builder.build(builder.environments.$ssr)
+    const result = await builder.build(builder.$ssr)
     expect((result as RollupOutput).output[0].code).not.toContain('preload')
   })
 
@@ -671,7 +671,7 @@ describe('resolveBuildOutputs', () => {
         },
       },
     })
-    const result = await builder.build(builder.environments.$custom)
+    const result = await builder.build(builder.$custom)
     expect((result as RollupOutput).output[0].code).not.toContain('preload')
   })
 })

--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -612,21 +612,19 @@ describe('resolveBuildOutputs', () => {
     const builder = await createBuilder({
       root: resolve(__dirname, 'fixtures/emit-assets'),
       logLevel: 'warn',
-      environments: {
-        ssr: {
-          build: {
-            ssr: true,
-            emitAssets: true,
-            rollupOptions: {
-              input: {
-                index: '/entry',
-              },
+      $ssr: {
+        build: {
+          ssr: true,
+          emitAssets: true,
+          rollupOptions: {
+            input: {
+              index: '/entry',
             },
           },
         },
       },
     })
-    const result = await builder.build(builder.environments.ssr)
+    const result = await builder.build(builder.environments.$ssr)
     expect(result).toMatchObject({
       output: [
         {
@@ -643,20 +641,18 @@ describe('resolveBuildOutputs', () => {
     const builder = await createBuilder({
       root: resolve(__dirname, 'fixtures/dynamic-import'),
       logLevel: 'warn',
-      environments: {
-        ssr: {
-          build: {
-            ssr: true,
-            rollupOptions: {
-              input: {
-                index: '/entry',
-              },
+      $ssr: {
+        build: {
+          ssr: true,
+          rollupOptions: {
+            input: {
+              index: '/entry',
             },
           },
         },
       },
     })
-    const result = await builder.build(builder.environments.ssr)
+    const result = await builder.build(builder.environments.$ssr)
     expect((result as RollupOutput).output[0].code).not.toContain('preload')
   })
 
@@ -664,20 +660,18 @@ describe('resolveBuildOutputs', () => {
     const builder = await createBuilder({
       root: resolve(__dirname, 'fixtures/dynamic-import'),
       logLevel: 'warn',
-      environments: {
-        custom: {
-          build: {
-            ssr: true,
-            rollupOptions: {
-              input: {
-                index: '/entry',
-              },
+      $custom: {
+        build: {
+          ssr: true,
+          rollupOptions: {
+            input: {
+              index: '/entry',
             },
           },
         },
       },
     })
-    const result = await builder.build(builder.environments.custom)
+    const result = await builder.build(builder.environments.$custom)
     expect((result as RollupOutput).output[0].code).not.toContain('preload')
   })
 })

--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -20,110 +20,108 @@ describe('custom environment conditions', () => {
         middlewareMode: true,
         ws: false,
       },
-      environments: {
-        // no web / default
-        ssr: {
-          resolve: {
-            noExternal,
-          },
-          build: {
-            outDir: path.join(
-              import.meta.dirname,
-              'fixtures/test-dep-conditions/dist/ssr',
-            ),
-            rollupOptions: {
-              input: { index: '@vitejs/test-dep-conditions' },
-            },
+      // no web / default
+      $ssr: {
+        resolve: {
+          noExternal,
+        },
+        build: {
+          outDir: path.join(
+            import.meta.dirname,
+            'fixtures/test-dep-conditions/dist/ssr',
+          ),
+          rollupOptions: {
+            input: { index: '@vitejs/test-dep-conditions' },
           },
         },
-        // web / worker
-        worker: {
-          webCompatible: true,
-          resolve: {
-            noExternal,
-            conditions: ['worker'],
-            externalConditions: ['worker'],
-          },
-          build: {
-            outDir: path.join(
-              import.meta.dirname,
-              'fixtures/test-dep-conditions/dist/worker',
-            ),
-            rollupOptions: {
-              input: { index: '@vitejs/test-dep-conditions' },
-            },
+      },
+      // web / worker
+      $worker: {
+        webCompatible: true,
+        resolve: {
+          noExternal,
+          conditions: ['worker'],
+          externalConditions: ['worker'],
+        },
+        build: {
+          outDir: path.join(
+            import.meta.dirname,
+            'fixtures/test-dep-conditions/dist/worker',
+          ),
+          rollupOptions: {
+            input: { index: '@vitejs/test-dep-conditions' },
           },
         },
-        // web / custom1
-        custom1: {
-          webCompatible: true,
-          resolve: {
-            noExternal,
-            conditions: ['custom1'],
-            externalConditions: ['custom1'],
-          },
-          build: {
-            outDir: path.join(
-              import.meta.dirname,
-              'fixtures/test-dep-conditions/dist/custom1',
-            ),
-            rollupOptions: {
-              input: { index: '@vitejs/test-dep-conditions' },
-            },
+      },
+      // web / custom1
+      $custom1: {
+        webCompatible: true,
+        resolve: {
+          noExternal,
+          conditions: ['custom1'],
+          externalConditions: ['custom1'],
+        },
+        build: {
+          outDir: path.join(
+            import.meta.dirname,
+            'fixtures/test-dep-conditions/dist/custom1',
+          ),
+          rollupOptions: {
+            input: { index: '@vitejs/test-dep-conditions' },
           },
         },
-        // no web / custom2
-        custom2: {
-          webCompatible: false,
-          resolve: {
-            noExternal,
-            conditions: ['custom2'],
-            externalConditions: ['custom2'],
-          },
-          build: {
-            outDir: path.join(
-              import.meta.dirname,
-              'fixtures/test-dep-conditions/dist/custom2',
-            ),
-            rollupOptions: {
-              input: { index: '@vitejs/test-dep-conditions' },
-            },
+      },
+      // no web / custom2
+      $custom2: {
+        webCompatible: false,
+        resolve: {
+          noExternal,
+          conditions: ['custom2'],
+          externalConditions: ['custom2'],
+        },
+        build: {
+          outDir: path.join(
+            import.meta.dirname,
+            'fixtures/test-dep-conditions/dist/custom2',
+          ),
+          rollupOptions: {
+            input: { index: '@vitejs/test-dep-conditions' },
           },
         },
-        // no web / custom3
-        custom3: {
-          webCompatible: false,
-          resolve: {
-            noExternal,
-            conditions: ['custom3'],
-            externalConditions: ['custom3'],
-          },
-          build: {
-            outDir: path.join(
-              import.meta.dirname,
-              'fixtures/test-dep-conditions/dist/custom3',
-            ),
-            rollupOptions: {
-              input: { index: '@vitejs/test-dep-conditions' },
-            },
+      },
+      // no web / custom3
+      $custom3: {
+        webCompatible: false,
+        resolve: {
+          noExternal,
+          conditions: ['custom3'],
+          externalConditions: ['custom3'],
+        },
+        build: {
+          outDir: path.join(
+            import.meta.dirname,
+            'fixtures/test-dep-conditions/dist/custom3',
+          ),
+          rollupOptions: {
+            input: { index: '@vitejs/test-dep-conditions' },
           },
         },
-        // same as custom3
-        custom3_2: {
-          webCompatible: false,
-          resolve: {
-            noExternal,
-            conditions: ['custom3'],
-            externalConditions: ['custom3'],
-          },
-          build: {
-            outDir: path.join(
-              import.meta.dirname,
-              'fixtures/test-dep-conditions/dist/custom3_2',
-            ),
-            rollupOptions: {
-              input: { index: '@vitejs/test-dep-conditions' },
-            },
+      },
+      // same as custom3
+      $custom3_2: {
+        webCompatible: false,
+        resolve: {
+          noExternal,
+          conditions: ['custom3'],
+          externalConditions: ['custom3'],
+        },
+        build: {
+          outDir: path.join(
+            import.meta.dirname,
+            'fixtures/test-dep-conditions/dist/custom3_2',
+          ),
+          rollupOptions: {
+            input: { index: '@vitejs/test-dep-conditions' },
           },
         },
       },
@@ -136,12 +134,12 @@ describe('custom environment conditions', () => {
 
     const results: Record<string, unknown> = {}
     for (const key of [
-      'ssr',
-      'worker',
-      'custom1',
-      'custom2',
-      'custom3',
-      'custom3_2',
+      '$ssr',
+      '$worker',
+      '$custom1',
+      '$custom2',
+      '$custom3',
+      '$custom3_2',
     ]) {
       const runner = createServerModuleRunner(server.environments[key], {
         hmr: {
@@ -154,12 +152,12 @@ describe('custom environment conditions', () => {
     }
     expect(results).toMatchInlineSnapshot(`
       {
-        "custom1": "index.custom1.js",
-        "custom2": "index.custom2.js",
-        "custom3": "index.custom3.js",
-        "custom3_2": "index.custom3.js",
-        "ssr": "index.default.js",
-        "worker": "index.worker.js",
+        "$custom1": "index.custom1.js",
+        "$custom2": "index.custom2.js",
+        "$custom3": "index.custom3.js",
+        "$custom3_2": "index.custom3.js",
+        "$ssr": "index.default.js",
+        "$worker": "index.worker.js",
       }
     `)
   })
@@ -170,12 +168,12 @@ describe('custom environment conditions', () => {
 
     const results: Record<string, unknown> = {}
     for (const key of [
-      'ssr',
-      'worker',
-      'custom1',
-      'custom2',
-      'custom3',
-      'custom3_2',
+      '$ssr',
+      '$worker',
+      '$custom1',
+      '$custom2',
+      '$custom3',
+      '$custom3_2',
     ]) {
       const runner = createServerModuleRunner(server.environments[key], {
         hmr: {
@@ -190,12 +188,12 @@ describe('custom environment conditions', () => {
     }
     expect(results).toMatchInlineSnapshot(`
       {
-        "custom1": "index.custom1.js",
-        "custom2": "index.custom2.js",
-        "custom3": "index.custom3.js",
-        "custom3_2": "index.custom3.js",
-        "ssr": "index.default.js",
-        "worker": "index.worker.js",
+        "$custom1": "index.custom1.js",
+        "$custom2": "index.custom2.js",
+        "$custom3": "index.custom3.js",
+        "$custom3_2": "index.custom3.js",
+        "$ssr": "index.default.js",
+        "$worker": "index.worker.js",
       }
     `)
   })
@@ -223,12 +221,12 @@ describe('custom environment conditions', () => {
     const builder = await createBuilder(getConfig({ noExternal: true }))
     const results: Record<string, unknown> = {}
     for (const key of [
-      'ssr',
-      'worker',
-      'custom1',
-      'custom2',
-      'custom3',
-      'custom3_2',
+      '$ssr',
+      '$worker',
+      '$custom1',
+      '$custom2',
+      '$custom3',
+      '$custom3_2',
     ]) {
       const output = await builder.build(builder.environments[key])
       const chunk = (output as RollupOutput).output[0]
@@ -236,7 +234,7 @@ describe('custom environment conditions', () => {
         path.join(
           import.meta.dirname,
           'fixtures/test-dep-conditions/dist',
-          key,
+          key.slice(1),
           chunk.fileName,
         )
       )
@@ -244,12 +242,12 @@ describe('custom environment conditions', () => {
     }
     expect(results).toMatchInlineSnapshot(`
       {
-        "custom1": "index.custom1.js",
-        "custom2": "index.custom2.js",
-        "custom3": "index.custom3.js",
-        "custom3_2": "index.custom3.js",
-        "ssr": "index.default.js",
-        "worker": "index.worker.js",
+        "$custom1": "index.custom1.js",
+        "$custom2": "index.custom2.js",
+        "$custom3": "index.custom3.js",
+        "$custom3_2": "index.custom3.js",
+        "$ssr": "index.default.js",
+        "$worker": "index.worker.js",
       }
     `)
   })

--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -141,7 +141,7 @@ describe('custom environment conditions', () => {
       '$custom3',
       '$custom3_2',
     ]) {
-      const runner = createServerModuleRunner(server.environments[key], {
+      const runner = createServerModuleRunner(server[key], {
         hmr: {
           logger: false,
         },
@@ -175,7 +175,7 @@ describe('custom environment conditions', () => {
       '$custom3',
       '$custom3_2',
     ]) {
-      const runner = createServerModuleRunner(server.environments[key], {
+      const runner = createServerModuleRunner(server[key], {
         hmr: {
           logger: false,
         },
@@ -228,7 +228,7 @@ describe('custom environment conditions', () => {
       '$custom3',
       '$custom3_2',
     ]) {
-      const output = await builder.build(builder.environments[key])
+      const output = await builder.build(builder[key])
       const chunk = (output as RollupOutput).output[0]
       const mod = await import(
         path.join(

--- a/packages/vite/src/node/__tests__/external.spec.ts
+++ b/packages/vite/src/node/__tests__/external.spec.ts
@@ -25,6 +25,6 @@ async function createIsExternal(external?: true) {
     },
     'serve',
   )
-  const environment = new PartialEnvironment('ssr', resolvedConfig)
+  const environment = new PartialEnvironment('$ssr', resolvedConfig)
   return createIsConfiguredAsExternal(environment)
 }

--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -204,7 +204,7 @@ describe('hoist @ rules', () => {
 
 async function createCssPluginTransform(inlineConfig: InlineConfig = {}) {
   const config = await resolveConfig(inlineConfig, 'serve')
-  const environment = new PartialEnvironment('client', config)
+  const environment = new PartialEnvironment('$client', config)
 
   const { transform, buildStart } = cssPlugin(config)
 

--- a/packages/vite/src/node/__tests__/plugins/define.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/define.spec.ts
@@ -13,7 +13,7 @@ async function createDefinePluginTransform(
     build ? 'build' : 'serve',
   )
   const instance = definePlugin(config)
-  const environment = new PartialEnvironment(ssr ? 'ssr' : 'client', config)
+  const environment = new PartialEnvironment(ssr ? '$ssr' : '$client', config)
 
   return async (code: string) => {
     // @ts-expect-error transform should exist

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -13,7 +13,7 @@ describe('import and resolveId', () => {
       },
     })
     onTestFinished(() => server.close())
-    const runner = createServerModuleRunner(server.environments.$ssr, {
+    const runner = createServerModuleRunner(server.$ssr, {
       hmr: {
         logger: false,
       },
@@ -27,7 +27,7 @@ describe('import and resolveId', () => {
     const mod = await runner.import(
       '/fixtures/test-dep-conditions-app/entry-with-module',
     )
-    const resolved = await server.environments.$ssr.pluginContainer.resolveId(
+    const resolved = await server.$ssr.pluginContainer.resolveId(
       '@vitejs/test-dep-conditions/with-module',
     )
     expect([mod.default, resolved?.id]).toEqual([
@@ -38,7 +38,7 @@ describe('import and resolveId', () => {
 
   test('resolveId first', async () => {
     const { server, runner } = await createTestServer()
-    const resolved = await server.environments.$ssr.pluginContainer.resolveId(
+    const resolved = await server.$ssr.pluginContainer.resolveId(
       '@vitejs/test-dep-conditions/with-module',
     )
     const mod = await runner.import(

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -13,7 +13,7 @@ describe('import and resolveId', () => {
       },
     })
     onTestFinished(() => server.close())
-    const runner = createServerModuleRunner(server.environments.ssr, {
+    const runner = createServerModuleRunner(server.environments.$ssr, {
       hmr: {
         logger: false,
       },
@@ -27,7 +27,7 @@ describe('import and resolveId', () => {
     const mod = await runner.import(
       '/fixtures/test-dep-conditions-app/entry-with-module',
     )
-    const resolved = await server.environments.ssr.pluginContainer.resolveId(
+    const resolved = await server.environments.$ssr.pluginContainer.resolveId(
       '@vitejs/test-dep-conditions/with-module',
     )
     expect([mod.default, resolved?.id]).toEqual([
@@ -38,7 +38,7 @@ describe('import and resolveId', () => {
 
   test('resolveId first', async () => {
     const { server, runner } = await createTestServer()
-    const resolved = await server.environments.ssr.pluginContainer.resolveId(
+    const resolved = await server.environments.$ssr.pluginContainer.resolveId(
       '@vitejs/test-dep-conditions/with-module',
     )
     const mod = await runner.import(

--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -24,7 +24,7 @@ export function getDefaultResolvedEnvironmentOptions(
 }
 
 export class PartialEnvironment {
-  name: string
+  name: `$${string}`
   getTopLevelConfig(): ResolvedConfig {
     return this._topLevelConfig
   }
@@ -50,9 +50,9 @@ export class PartialEnvironment {
   _topLevelConfig: ResolvedConfig
 
   constructor(
-    name: string,
+    name: `$${string}`,
     topLevelConfig: ResolvedConfig,
-    options: ResolvedEnvironmentOptions = topLevelConfig.environments[name],
+    options: ResolvedEnvironmentOptions = topLevelConfig[name],
   ) {
     // only allow some characters so that we can use name without escaping for directory names
     // and make users easier to access with `environments.*`
@@ -140,9 +140,9 @@ export class BaseEnvironment extends PartialEnvironment {
   _initiated: boolean = false
 
   constructor(
-    name: string,
+    name: `$${string}`,
     config: ResolvedConfig,
-    options: ResolvedEnvironmentOptions = config.environments[name],
+    options: ResolvedEnvironmentOptions = config[name],
   ) {
     super(name, config, options)
   }

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -244,7 +244,7 @@ export interface BuildEnvironmentOptions {
    */
   ssrEmitAssets?: boolean
   /**
-   * Emit assets during build. Frameworks can set environments.ssr.build.emitAssets
+   * Emit assets during build. Frameworks can set environments.$ssr.build.emitAssets
    * By default, it is true for the client and false for other environments.
    */
   emitAssets?: boolean
@@ -515,7 +515,7 @@ export async function build(
     // we need to make override `config.build` for the current environment.
     // We can deprecate `config.build` in ResolvedConfig and push everyone to upgrade, and later
     // remove the default values that shouldn't be used at all once the config is resolved
-    const environmentName = resolved.build.ssr ? 'ssr' : 'client'
+    const environmentName = resolved.build.ssr ? '$ssr' : '$client'
     ;(resolved.build as ResolvedBuildOptions) = {
       ...resolved.environments[environmentName].build,
     }
@@ -530,7 +530,7 @@ export async function build(
 export async function buildWithResolvedConfig(
   config: ResolvedConfig,
 ): Promise<RollupOutput | RollupOutput[] | RollupWatcher> {
-  const environmentName = config.build.ssr ? 'ssr' : 'client'
+  const environmentName = config.build.ssr ? '$ssr' : '$client'
   const environment = await config.environments[
     environmentName
   ].build.createEnvironment(environmentName, config)

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -317,7 +317,7 @@ cli
           // we need to make override `config.build` for the current environment.
           // We can deprecate `config.build` in ResolvedConfig and push everyone to upgrade, and later
           // remove the default values that shouldn't be used at all once the config is resolved
-          const environmentName = resolved.build.ssr ? 'ssr' : 'client'
+          const environmentName = resolved.build.ssr ? '$ssr' : '$client'
           ;(resolved.build as ResolvedBuildOptions) = {
             ...resolved.environments[environmentName].build,
           }

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -319,7 +319,7 @@ cli
           // remove the default values that shouldn't be used at all once the config is resolved
           const environmentName = resolved.build.ssr ? '$ssr' : '$client'
           ;(resolved.build as ResolvedBuildOptions) = {
-            ...resolved.environments[environmentName].build,
+            ...resolved[environmentName].build,
           }
         }
         const config = await build.resolveConfigToBuild(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -179,7 +179,7 @@ export interface DevEnvironmentOptions {
    * create the Dev Environment instance
    */
   createEnvironment?: (
-    name: string,
+    name: `$${string}`,
     config: ResolvedConfig,
     context: CreateDevEnvironmentContext,
   ) => Promise<DevEnvironment> | DevEnvironment
@@ -201,7 +201,7 @@ export interface DevEnvironmentOptions {
 }
 
 function defaultCreateClientDevEnvironment(
-  name: string,
+  name: `$${string}`,
   config: ResolvedConfig,
   context: CreateDevEnvironmentContext,
 ) {
@@ -211,13 +211,16 @@ function defaultCreateClientDevEnvironment(
 }
 
 function defaultCreateSsrDevEnvironment(
-  name: string,
+  name: `$${string}`,
   config: ResolvedConfig,
 ): DevEnvironment {
   return createRunnableDevEnvironment(name, config)
 }
 
-function defaultCreateDevEnvironment(name: string, config: ResolvedConfig) {
+function defaultCreateDevEnvironment(
+  name: `$${string}`,
+  config: ResolvedConfig,
+) {
   return new DevEnvironment(name, config, {
     hot: false,
   })
@@ -576,7 +579,7 @@ export type ResolvedConfig = Readonly<
     worker: ResolvedWorkerOptions
     appType: AppType
     experimental: ExperimentalOptions
-    environments: Record<string, ResolvedEnvironmentOptions>
+    environments: Record<`$${string}`, ResolvedEnvironmentOptions>
     [key: `$${string}`]: ResolvedEnvironmentOptions
     /** @internal */
     fsDenyGlob: AnymatchFn

--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -28,8 +28,8 @@ export function createBackCompatIdResolver(
   const compatResolve = config.createResolver(options)
   let resolve: ResolveIdFn
   return async (environment, id, importer, aliasOnly) => {
-    if (environment.name === 'client' || environment.name === 'ssr') {
-      return compatResolve(id, importer, aliasOnly, environment.name === 'ssr')
+    if (environment.name === '$client' || environment.name === '$ssr') {
+      return compatResolve(id, importer, aliasOnly, environment.name === '$ssr')
     }
     resolve ??= createIdResolver(config, options)
     return resolve(environment, id, importer, aliasOnly)

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -255,7 +255,7 @@ export async function optimizeDeps(
 ): Promise<DepOptimizationMetadata> {
   const log = asCommand ? config.logger.info : debug
 
-  const environment = new ScanEnvironment('client', config)
+  const environment = new ScanEnvironment('$client', config)
   await environment.init()
 
   const cachedMetadata = await loadCachedDepOptimizationMetadata(
@@ -877,7 +877,7 @@ export function getOptimizedDepPath(
 }
 
 function getDepsCacheSuffix(environment: Environment): string {
-  return environment.name === 'client' ? '' : `_${environment.name}`
+  return environment.name === '$client' ? '' : `_${environment.name}`
 }
 
 export function getDepsCacheDir(environment: Environment): string {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1537,7 +1537,7 @@ export async function preprocessCSS(
   // cases. We should revisit in the future if there's a case to preprocess CSS based on a
   // different environment instance.
   const environment: PartialEnvironment = new PartialEnvironment(
-    'client',
+    '$client',
     config,
   )
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -227,7 +227,8 @@ export function resolvePlugin(
       const isRequire: boolean =
         resolveOpts?.custom?.['node-resolve']?.isRequire ?? false
 
-      const environmentName = this.environment.name ?? (ssr ? 'ssr' : 'client')
+      const environmentName =
+        this.environment.name ?? (ssr ? '$ssr' : '$client')
       const currentEnvironmentOptions =
         this.environment.config || environmentsOptions?.[environmentName]
       const environmentResolveOptions = currentEnvironmentOptions?.resolve

--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -75,7 +75,7 @@ async function bundleWorkerEntry(
   const { plugins, rollupOptions, format } = config.worker
   const { plugins: resolvedPlugins, config: workerConfig } =
     await plugins(newBundleChain)
-  const workerEnvironment = new BuildEnvironment('client', workerConfig) // TODO: should this be 'worker'?
+  const workerEnvironment = new BuildEnvironment('$client', workerConfig) // TODO: should this be '$worker'?
   const bundle = await rollup({
     ...rollupOptions,
     input,

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -117,8 +117,7 @@ export async function preview(
     true,
   )
 
-  const clientOutDir =
-    config.environments.client.build.outDir ?? config.build.outDir
+  const clientOutDir = config.$client.build.outDir ?? config.build.outDir
   const distDir = path.resolve(config.root, clientOutDir)
   if (
     !fs.existsSync(distDir) &&

--- a/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
+++ b/packages/vite/src/node/server/__tests__/moduleGraph.spec.ts
@@ -6,7 +6,7 @@ import { ModuleGraph } from '../mixedModuleGraph'
 describe('moduleGraph', () => {
   describe('invalidateModule', () => {
     it('removes an ssr error', async () => {
-      const moduleGraph = new EnvironmentModuleGraph('ssr', async (url) => ({
+      const moduleGraph = new EnvironmentModuleGraph('$ssr', async (url) => ({
         id: url,
       }))
       const entryUrl = '/x.js'
@@ -20,7 +20,7 @@ describe('moduleGraph', () => {
     })
 
     it('ensureEntryFromUrl should based on resolvedId', async () => {
-      const moduleGraph = new EnvironmentModuleGraph('client', async (url) => {
+      const moduleGraph = new EnvironmentModuleGraph('$client', async (url) => {
         if (url === '/xx.js') {
           return { id: '/x.js' }
         } else {
@@ -37,12 +37,15 @@ describe('moduleGraph', () => {
 
     it('ensure backward compatibility', async () => {
       const clientModuleGraph = new EnvironmentModuleGraph(
-        'client',
+        '$client',
         async (url) => ({ id: url }),
       )
-      const ssrModuleGraph = new EnvironmentModuleGraph('ssr', async (url) => ({
-        id: url,
-      }))
+      const ssrModuleGraph = new EnvironmentModuleGraph(
+        '$ssr',
+        async (url) => ({
+          id: url,
+        }),
+      )
       const moduleGraph = new ModuleGraph({
         client: () => clientModuleGraph,
         ssr: () => ssrModuleGraph,

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -226,7 +226,7 @@ async function getDevEnvironment(
   // @ts-expect-error This plugin requires a ViteDevServer instance.
   config.plugins = config.plugins.filter((p) => !p.name.includes('pre-alias'))
 
-  const environment = new DevEnvironment('client', config, { hot: false })
+  const environment = new DevEnvironment('$client', config, { hot: false })
   await environment.init()
 
   return environment

--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -97,12 +97,11 @@ export class DevEnvironment extends BaseEnvironment {
    */
   hot: HotChannel
   constructor(
-    name: string,
+    name: `$${string}`,
     config: ResolvedConfig,
     context: DevEnvironmentContext,
   ) {
-    let options =
-      config.environments[name] ?? getDefaultResolvedEnvironmentOptions(config)
+    let options = config[name] ?? getDefaultResolvedEnvironmentOptions(config)
     if (context.options) {
       options = mergeConfig(
         options,

--- a/packages/vite/src/node/server/environments/runnableEnvironment.ts
+++ b/packages/vite/src/node/server/environments/runnableEnvironment.ts
@@ -9,7 +9,7 @@ import { createServerHotChannel } from '../hmr'
 import type { Environment } from '../../environment'
 
 export function createRunnableDevEnvironment(
-  name: string,
+  name: `$${string}`,
   config: ResolvedConfig,
   context: RunnableDevEnvironmentContext = {},
 ): DevEnvironment {
@@ -47,7 +47,7 @@ class RunnableDevEnvironment extends DevEnvironment {
   private _runnerOptions: ServerModuleRunnerOptions | undefined
 
   constructor(
-    name: string,
+    name: `$${string}`,
     config: ResolvedConfig,
     context: RunnableDevEnvironmentContext,
   ) {

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -253,14 +253,14 @@ export async function handleHMRUpdate(
     modules: [...mixedMods],
   }
 
-  const clientEnvironment = server.environments.client
-  const ssrEnvironment = server.environments.ssr
+  const clientEnvironment = server.environments.$client
+  const ssrEnvironment = server.environments.$ssr
   const clientContext = { environment: clientEnvironment }
   const clientHotUpdateOptions = hotMap.get(clientEnvironment)!.options
   const ssrHotUpdateOptions = hotMap.get(ssrEnvironment)?.options
   try {
     for (const plugin of getSortedHotUpdatePlugins(
-      server.environments.client,
+      server.environments.$client,
     )) {
       if (plugin.hotUpdate) {
         const filteredModules = await getHookHandler(plugin.hotUpdate).call(
@@ -340,11 +340,11 @@ export async function handleHMRUpdate(
       }
     }
   } catch (error) {
-    hotMap.get(server.environments.client)!.error = error
+    hotMap.get(server.environments.$client)!.error = error
   }
 
   for (const environment of Object.values(server.environments)) {
-    if (environment.name === 'client') continue
+    if (environment.name === '$client') continue
     const hot = hotMap.get(environment)!
     const environmentThis = { environment }
     try {

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -253,15 +253,13 @@ export async function handleHMRUpdate(
     modules: [...mixedMods],
   }
 
-  const clientEnvironment = server.environments.$client
-  const ssrEnvironment = server.environments.$ssr
+  const clientEnvironment = server.$client
+  const ssrEnvironment = server.$ssr
   const clientContext = { environment: clientEnvironment }
   const clientHotUpdateOptions = hotMap.get(clientEnvironment)!.options
   const ssrHotUpdateOptions = hotMap.get(ssrEnvironment)?.options
   try {
-    for (const plugin of getSortedHotUpdatePlugins(
-      server.environments.$client,
-    )) {
+    for (const plugin of getSortedHotUpdatePlugins(server.$client)) {
       if (plugin.hotUpdate) {
         const filteredModules = await getHookHandler(plugin.hotUpdate).call(
           clientContext,
@@ -340,7 +338,7 @@ export async function handleHMRUpdate(
       }
     }
   } catch (error) {
-    hotMap.get(server.environments.$client)!.error = error
+    hotMap.get(server.$client)!.error = error
   }
 
   for (const environment of Object.values(server.environments)) {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -277,7 +277,7 @@ export interface ViteDevServer {
   /**
    * Module execution environments attached to the Vite server.
    */
-  environments: Record<'client' | 'ssr' | (string & {}), DevEnvironment>
+  environments: Record<'$client' | '$ssr' | (string & {}), DevEnvironment>
   /**
    * Module graph that tracks the import relationships, url to file mapping
    * and hmr state.
@@ -508,8 +508,8 @@ export async function _createServer(
   // Backward compatibility
 
   let moduleGraph = new ModuleGraph({
-    client: () => environments.client.moduleGraph,
-    ssr: () => environments.ssr.moduleGraph,
+    client: () => environments.$client.moduleGraph,
+    ssr: () => environments.$ssr.moduleGraph,
   })
   const pluginContainer = createPluginContainer(environments)
 
@@ -555,12 +555,13 @@ export async function _createServer(
         'removeServerTransformRequest',
         'server.transformRequest() is deprecated. Use environment.transformRequest() instead.',
       )
-      const environment = server.environments[options?.ssr ? 'ssr' : 'client']
+      const environment = server.environments[options?.ssr ? '$ssr' : '$client']
       return transformRequest(environment, url, options)
     },
     async warmupRequest(url, options) {
       try {
-        const environment = server.environments[options?.ssr ? 'ssr' : 'client']
+        const environment =
+          server.environments[options?.ssr ? '$ssr' : '$client']
         await transformRequest(environment, url, options)
       } catch (e) {
         if (
@@ -585,10 +586,10 @@ export async function _createServer(
       return ssrLoadModule(url, server, opts?.fixStacktrace)
     },
     ssrFixStacktrace(e) {
-      ssrFixStacktrace(e, server.environments.ssr.moduleGraph)
+      ssrFixStacktrace(e, server.environments.$ssr.moduleGraph)
     },
     ssrRewriteStacktrace(stack: string) {
-      return ssrRewriteStacktrace(stack, server.environments.ssr.moduleGraph)
+      return ssrRewriteStacktrace(stack, server.environments.$ssr.moduleGraph)
     },
     async reloadModule(module) {
       if (serverConfig.hmr !== false && module.file) {
@@ -706,7 +707,7 @@ export async function _createServer(
     },
 
     waitForRequestsIdle(ignoredId?: string): Promise<void> {
-      return environments.client.waitForRequestsIdle(ignoredId)
+      return environments.$client.waitForRequestsIdle(ignoredId)
     },
 
     _setInternalServer(_server: ViteDevServer) {
@@ -764,7 +765,7 @@ export async function _createServer(
         const path = file.slice(publicDir.length)
         publicFiles[isUnlink ? 'delete' : 'add'](path)
         if (!isUnlink) {
-          const clientModuleGraph = server.environments.client.moduleGraph
+          const clientModuleGraph = server.environments.$client.moduleGraph
           const moduleWithSamePath =
             await clientModuleGraph.getModuleByUrl(path)
           const etag = moduleWithSamePath?.transformResult?.etag
@@ -913,7 +914,7 @@ export async function _createServer(
       // For backward compatibility, we call buildStart for the client
       // environment when initing the server. For other environments
       // buildStart will be called when the first request is transformed
-      await environments.client.pluginContainer.buildStart()
+      await environments.$client.pluginContainer.buildStart()
 
       // ensure ws server started
       if (onListen || options.listen) {

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -53,7 +53,7 @@ export function logError(server: ViteDevServer, err: RollupError): void {
     error: err,
   })
 
-  server.environments.$client.hot.send({
+  server.$client.hot.send({
     type: 'error',
     err: prepareError(err),
   })

--- a/packages/vite/src/node/server/middlewares/error.ts
+++ b/packages/vite/src/node/server/middlewares/error.ts
@@ -53,7 +53,7 @@ export function logError(server: ViteDevServer, err: RollupError): void {
     error: err,
   })
 
-  server.environments.client.hot.send({
+  server.environments.$client.hot.send({
     type: 'error',
     err: prepareError(err),
   })

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -131,7 +131,8 @@ const processNodeUrl = (
   // prefix with base (dev only, base is never relative)
   const replacer = (url: string) => {
     if (server) {
-      const mod = server.environments.client.moduleGraph.urlToModuleMap.get(url)
+      const mod =
+        server.environments.$client.moduleGraph.urlToModuleMap.get(url)
       if (mod && mod.lastHMRTimestamp > 0) {
         url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
       }
@@ -250,7 +251,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     const modulePath = `${proxyModuleUrl}?html-proxy&index=${inlineModuleIndex}.${ext}`
 
     // invalidate the module so the newly cached contents will be served
-    const clientModuleGraph = server?.environments.client.moduleGraph
+    const clientModuleGraph = server?.environments.$client.moduleGraph
     const module = clientModuleGraph?.getModuleById(modulePath)
     if (module) {
       clientModuleGraph!.invalidateModule(module)
@@ -360,14 +361,14 @@ const devHtmlHook: IndexHtmlTransformHook = async (
 
       // ensure module in graph after successful load
       const mod =
-        await server!.environments.client.moduleGraph.ensureEntryFromUrl(
+        await server!.environments.$client.moduleGraph.ensureEntryFromUrl(
           url,
           false,
         )
       ensureWatchedFile(watcher, mod.file, config.root)
 
       const result = await server!.pluginContainer.transform(code, mod.id!, {
-        environment: server!.environments.client,
+        environment: server!.environments.$client,
       })
       let content = ''
       if (result) {
@@ -391,14 +392,14 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       const url = `${proxyModulePath}?html-proxy&inline-css&style-attr&index=${index}.css`
 
       const mod =
-        await server!.environments.client.moduleGraph.ensureEntryFromUrl(
+        await server!.environments.$client.moduleGraph.ensureEntryFromUrl(
           url,
           false,
         )
       ensureWatchedFile(watcher, mod.file, config.root)
 
       await server?.pluginContainer.transform(code, mod.id!, {
-        environment: server!.environments.client,
+        environment: server!.environments.$client,
       })
 
       const hash = getHash(cleanUrl(mod.id!))

--- a/packages/vite/src/node/server/middlewares/indexHtml.ts
+++ b/packages/vite/src/node/server/middlewares/indexHtml.ts
@@ -131,8 +131,7 @@ const processNodeUrl = (
   // prefix with base (dev only, base is never relative)
   const replacer = (url: string) => {
     if (server) {
-      const mod =
-        server.environments.$client.moduleGraph.urlToModuleMap.get(url)
+      const mod = server.$client.moduleGraph.urlToModuleMap.get(url)
       if (mod && mod.lastHMRTimestamp > 0) {
         url = injectQuery(url, `t=${mod.lastHMRTimestamp}`)
       }
@@ -251,7 +250,7 @@ const devHtmlHook: IndexHtmlTransformHook = async (
     const modulePath = `${proxyModuleUrl}?html-proxy&index=${inlineModuleIndex}.${ext}`
 
     // invalidate the module so the newly cached contents will be served
-    const clientModuleGraph = server?.environments.$client.moduleGraph
+    const clientModuleGraph = server?.$client.moduleGraph
     const module = clientModuleGraph?.getModuleById(modulePath)
     if (module) {
       clientModuleGraph!.invalidateModule(module)
@@ -360,15 +359,14 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       const url = `${proxyModulePath}?html-proxy&direct&index=${index}.css`
 
       // ensure module in graph after successful load
-      const mod =
-        await server!.environments.$client.moduleGraph.ensureEntryFromUrl(
-          url,
-          false,
-        )
+      const mod = await server!.$client.moduleGraph.ensureEntryFromUrl(
+        url,
+        false,
+      )
       ensureWatchedFile(watcher, mod.file, config.root)
 
       const result = await server!.pluginContainer.transform(code, mod.id!, {
-        environment: server!.environments.$client,
+        environment: server!.$client,
       })
       let content = ''
       if (result) {
@@ -391,15 +389,14 @@ const devHtmlHook: IndexHtmlTransformHook = async (
       // will transform with css plugin and cache result with css-post plugin
       const url = `${proxyModulePath}?html-proxy&inline-css&style-attr&index=${index}.css`
 
-      const mod =
-        await server!.environments.$client.moduleGraph.ensureEntryFromUrl(
-          url,
-          false,
-        )
+      const mod = await server!.$client.moduleGraph.ensureEntryFromUrl(
+        url,
+        false,
+      )
       ensureWatchedFile(watcher, mod.file, config.root)
 
       await server?.pluginContainer.transform(code, mod.id!, {
-        environment: server!.environments.$client,
+        environment: server!.$client,
       })
 
       const hash = getHash(cleanUrl(mod.id!))

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -50,7 +50,7 @@ export function cachedTransformMiddleware(
 ): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteCachedTransformMiddleware(req, res, next) {
-    const environment = server.environments.$client
+    const environment = server.$client
 
     // check if we can return 304 early
     const ifNoneMatch = req.headers['if-none-match']
@@ -87,7 +87,7 @@ export function transformMiddleware(
   const publicPath = `${publicDir.slice(root.length)}/`
 
   return async function viteTransformMiddleware(req, res, next) {
-    const environment = server.environments.$client
+    const environment = server.$client
 
     if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
       return next()

--- a/packages/vite/src/node/server/middlewares/transform.ts
+++ b/packages/vite/src/node/server/middlewares/transform.ts
@@ -50,7 +50,7 @@ export function cachedTransformMiddleware(
 ): Connect.NextHandleFunction {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteCachedTransformMiddleware(req, res, next) {
-    const environment = server.environments.client
+    const environment = server.environments.$client
 
     // check if we can return 304 early
     const ifNoneMatch = req.headers['if-none-match']
@@ -87,7 +87,7 @@ export function transformMiddleware(
   const publicPath = `${publicDir.slice(root.length)}/`
 
   return async function viteTransformMiddleware(req, res, next) {
-    const environment = server.environments.client
+    const environment = server.environments.$client
 
     if (req.method !== 'GET' || knownIgnoreList.has(req.url!)) {
       return next()

--- a/packages/vite/src/node/server/mixedModuleGraph.ts
+++ b/packages/vite/src/node/server/mixedModuleGraph.ts
@@ -322,9 +322,9 @@ export class ModuleGraph {
   /** @internal */
   _getModuleGraph(environment: string): EnvironmentModuleGraph {
     switch (environment) {
-      case 'client':
+      case '$client':
         return this._client
-      case 'ssr':
+      case '$ssr':
         return this._ssr
       default:
         throw new Error(`Invalid module node environment ${environment}`)
@@ -412,9 +412,9 @@ export class ModuleGraph {
     result: TransformResult | null,
     ssr?: boolean,
   ): void {
-    const environment = ssr ? 'ssr' : 'client'
+    const environment = ssr ? '$ssr' : '$client'
     this._getModuleGraph(environment).updateModuleTransformResult(
-      (environment === 'client' ? mod._clientModule : mod._ssrModule)!,
+      (environment === '$client' ? mod._clientModule : mod._ssrModule)!,
       result,
     )
   }
@@ -443,7 +443,7 @@ export class ModuleGraph {
   }
 
   getBackwardCompatibleModuleNode(mod: EnvironmentModuleNode): ModuleNode {
-    return mod.environment === 'client'
+    return mod.environment === '$client'
       ? this.getBackwardCompatibleBrowserModuleNode(mod)
       : this.getBackwardCompatibleServerModuleNode(mod)
   }

--- a/packages/vite/src/node/server/moduleGraph.ts
+++ b/packages/vite/src/node/server/moduleGraph.ts
@@ -429,7 +429,7 @@ export class EnvironmentModuleGraph {
     mod: EnvironmentModuleNode,
     result: TransformResult | null,
   ): void {
-    if (this.environment === 'client') {
+    if (this.environment === '$client') {
       const prevEtag = mod.transformResult?.etag
       if (prevEtag) this.etagToModuleMap.delete(prevEtag)
       if (result?.etag) this.etagToModuleMap.set(result.etag, mod)

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -318,7 +318,7 @@ class EnvironmentPluginContainer {
         (plugin) => this._getPluginContext(plugin),
         () => [this.options as NormalizedInputOptions],
         (plugin) =>
-          this.environment.name === 'client' ||
+          this.environment.name === '$client' ||
           plugin.perEnvironmentStartEndDuringDev === true,
       ),
     ) as Promise<void>
@@ -517,7 +517,7 @@ class EnvironmentPluginContainer {
       (plugin) => this._getPluginContext(plugin),
       () => [],
       (plugin) =>
-        this.environment.name === 'client' ||
+        this.environment.name === '$client' ||
         plugin.perEnvironmentStartEndDuringDev !== true,
     )
     await this.hookParallel(
@@ -949,7 +949,7 @@ class PluginContainer {
   }) {
     return options?.environment
       ? options.environment
-      : this.environments?.[options?.ssr ? 'ssr' : 'client']
+      : this.environments?.[options?.ssr ? '$ssr' : '$client']
   }
 
   private _getPluginContainer(options?: {
@@ -962,23 +962,23 @@ class PluginContainer {
   getModuleInfo(id: string): ModuleInfo | null {
     return (
       (
-        this.environments.client as DevEnvironment
+        this.environments.$client as DevEnvironment
       ).pluginContainer.getModuleInfo(id) ||
-      (this.environments.ssr as DevEnvironment).pluginContainer.getModuleInfo(
+      (this.environments.$ssr as DevEnvironment).pluginContainer.getModuleInfo(
         id,
       )
     )
   }
 
   get options(): InputOptions {
-    return (this.environments.client as DevEnvironment).pluginContainer.options
+    return (this.environments.$client as DevEnvironment).pluginContainer.options
   }
 
   // For backward compatibility, buildStart and watchChange are called only for the client environment
   // buildStart is called per environment for a plugin with the perEnvironmentStartEndDuring dev flag
 
   async buildStart(_options?: InputOptions): Promise<void> {
-    ;(this.environments.client as DevEnvironment).pluginContainer.buildStart(
+    ;(this.environments.$client as DevEnvironment).pluginContainer.buildStart(
       _options,
     )
   }
@@ -987,7 +987,7 @@ class PluginContainer {
     id: string,
     change: { event: 'create' | 'update' | 'delete' },
   ): Promise<void> {
-    ;(this.environments.client as DevEnvironment).pluginContainer.watchChange(
+    ;(this.environments.$client as DevEnvironment).pluginContainer.watchChange(
       id,
       change,
     )

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
@@ -53,7 +53,7 @@ describe('module runner initialization', async () => {
       (code) => '\n\n\n\n\n' + code + '\n',
     )
     runner.evaluatedModules.clear()
-    server.environments.ssr.moduleGraph.invalidateAll()
+    server.environments.$ssr.moduleGraph.invalidateAll()
 
     const methodErrorNew = await getError(async () => {
       const mod = await runner.import('/fixtures/throws-error-method.ts')

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts
@@ -53,7 +53,7 @@ describe('module runner initialization', async () => {
       (code) => '\n\n\n\n\n' + code + '\n',
     )
     runner.evaluatedModules.clear()
-    server.environments.$ssr.moduleGraph.invalidateAll()
+    server.$ssr.moduleGraph.invalidateAll()
 
     const methodErrorNew = await getError(async () => {
       const mod = await runner.import('/fixtures/throws-error-method.ts')

--- a/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-worker-runner.spec.ts
@@ -26,20 +26,18 @@ describe('running module runner inside a worker', () => {
           port: 9609,
         },
       },
-      environments: {
-        worker: {
-          dev: {
-            createEnvironment: (name, config) => {
-              return new DevEnvironment(name, config, {
-                remoteRunner: {
-                  transport: new RemoteEnvironmentTransport({
-                    send: (data) => worker.postMessage(data),
-                    onMessage: (handler) => worker.on('message', handler),
-                  }),
-                },
-                hot: false,
-              })
-            },
+      $worker: {
+        dev: {
+          createEnvironment: (name, config) => {
+            return new DevEnvironment(name, config, {
+              remoteRunner: {
+                transport: new RemoteEnvironmentTransport({
+                  send: (data) => worker.postMessage(data),
+                  onMessage: (handler) => worker.on('message', handler),
+                }),
+              },
+              hot: false,
+            })
           },
         },
       },

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -73,7 +73,7 @@ export async function createModuleRunnerTester(
       ],
       ...config,
     })
-    t.environment = t.server.environments.$ssr
+    t.environment = t.server.$ssr
     t.runner = createServerModuleRunner(t.environment, {
       hmr: {
         logger: false,

--- a/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/utils.ts
@@ -73,7 +73,7 @@ export async function createModuleRunnerTester(
       ],
       ...config,
     })
-    t.environment = t.server.environments.ssr
+    t.environment = t.server.environments.$ssr
     t.runner = createServerModuleRunner(t.environment, {
       hmr: {
         logger: false,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -13,7 +13,7 @@ export async function ssrLoadModule(
   server: ViteDevServer,
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
-  const environment = server.environments.$ssr
+  const environment = server.$ssr
   server._ssrCompatModuleRunner ||= new SSRCompatModuleRunner(environment)
   url = unwrapId(url)
 

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -13,7 +13,7 @@ export async function ssrLoadModule(
   server: ViteDevServer,
   fixStacktrace?: boolean,
 ): Promise<SSRModule> {
-  const environment = server.environments.ssr
+  const environment = server.environments.$ssr
   server._ssrCompatModuleRunner ||= new SSRCompatModuleRunner(environment)
   url = unwrapId(url)
 

--- a/playground/environment-react-ssr/vite.config.ts
+++ b/playground/environment-react-ssr/vite.config.ts
@@ -46,8 +46,8 @@ export default defineConfig((env) => ({
 
   builder: {
     async buildApp(builder) {
-      await builder.build(builder.environments.$client)
-      await builder.build(builder.environments.$ssr)
+      await builder.build(builder.$client)
+      await builder.build(builder.$ssr)
     },
   },
 }))
@@ -64,7 +64,7 @@ export function vitePluginSsrMiddleware({
     name: vitePluginSsrMiddleware.name,
 
     configureServer(server) {
-      const runner = createServerModuleRunner(server.environments.$ssr, {
+      const runner = createServerModuleRunner(server.$ssr, {
         hmr: { logger: false },
       })
       const handler: Connect.NextHandleFunction = async (req, res, next) => {

--- a/playground/environment-react-ssr/vite.config.ts
+++ b/playground/environment-react-ssr/vite.config.ts
@@ -21,26 +21,24 @@ export default defineConfig((env) => ({
       },
     },
   ],
-  environments: {
-    client: {
-      build: {
-        minify: false,
-        sourcemap: true,
-        outDir: 'dist/client',
-      },
+  $client: {
+    build: {
+      minify: false,
+      sourcemap: true,
+      outDir: 'dist/client',
     },
-    ssr: {
-      build: {
-        outDir: 'dist/server',
-        // [feedback]
-        // is this still meant to be used?
-        // for example, `ssr: true` seems to make `minify: false` automatically
-        // and also externalization.
-        ssr: true,
-        rollupOptions: {
-          input: {
-            index: '/src/entry-server',
-          },
+  },
+  $ssr: {
+    build: {
+      outDir: 'dist/server',
+      // [feedback]
+      // is this still meant to be used?
+      // for example, `ssr: true` seems to make `minify: false` automatically
+      // and also externalization.
+      ssr: true,
+      rollupOptions: {
+        input: {
+          index: '/src/entry-server',
         },
       },
     },
@@ -48,8 +46,8 @@ export default defineConfig((env) => ({
 
   builder: {
     async buildApp(builder) {
-      await builder.build(builder.environments.client)
-      await builder.build(builder.environments.ssr)
+      await builder.build(builder.environments.$client)
+      await builder.build(builder.environments.$ssr)
     },
   },
 }))
@@ -66,7 +64,7 @@ export function vitePluginSsrMiddleware({
     name: vitePluginSsrMiddleware.name,
 
     configureServer(server) {
-      const runner = createServerModuleRunner(server.environments.ssr, {
+      const runner = createServerModuleRunner(server.environments.$ssr, {
         hmr: { logger: false },
       })
       const handler: Connect.NextHandleFunction = async (req, res, next) => {

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -498,7 +498,7 @@ if (!isBuild) {
         beforeAll(async () => {
           clientLogs.length = 0
           // so it's in the module graph
-          const ssrEnvironment = server.environments.$ssr
+          const ssrEnvironment = server.$ssr
           await ssrEnvironment.transformRequest(testFile)
           await ssrEnvironment.transformRequest('non-tested/dep.js')
         })
@@ -1079,7 +1079,7 @@ async function setupModuleRunner(
     ...serverOptions,
   })
 
-  runner = (server.environments.$ssr as RunnableDevEnvironment).runner
+  runner = (server.$ssr as RunnableDevEnvironment).runner
 
   await waitForWatcher(server, waitForFile)
 

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -498,7 +498,7 @@ if (!isBuild) {
         beforeAll(async () => {
           clientLogs.length = 0
           // so it's in the module graph
-          const ssrEnvironment = server.environments.ssr
+          const ssrEnvironment = server.environments.$ssr
           await ssrEnvironment.transformRequest(testFile)
           await ssrEnvironment.transformRequest('non-tested/dep.js')
         })
@@ -1061,15 +1061,13 @@ async function setupModuleRunner(
       },
       preTransformRequests: false,
     },
-    environments: {
-      ssr: {
-        dev: {
-          createEnvironment(name, config) {
-            return createRunnableDevEnvironment(name, config, {
-              runnerOptions: { hmr: { logger } },
-              hot: createServerHotChannel(),
-            })
-          },
+    $ssr: {
+      dev: {
+        createEnvironment(name, config) {
+          return createRunnableDevEnvironment(name, config, {
+            runnerOptions: { hmr: { logger } },
+            hot: createServerHotChannel(),
+          })
         },
       },
     },
@@ -1081,7 +1079,7 @@ async function setupModuleRunner(
     ...serverOptions,
   })
 
-  runner = (server.environments.ssr as RunnableDevEnvironment).runner
+  runner = (server.environments.$ssr as RunnableDevEnvironment).runner
 
   await waitForWatcher(server, waitForFile)
 

--- a/playground/hmr-ssr/vite.config.ts
+++ b/playground/hmr-ssr/vite.config.ts
@@ -17,12 +17,9 @@ export default defineConfig({
         }
       },
       configureServer(server) {
-        server.environments.$ssr.hot.on(
-          'custom:remote-add',
-          ({ a, b }, client) => {
-            client.send('custom:remote-add-result', { result: a + b })
-          },
-        )
+        server.$ssr.hot.on('custom:remote-add', ({ a, b }, client) => {
+          client.send('custom:remote-add-result', { result: a + b })
+        })
       },
     },
     virtualPlugin(),
@@ -48,14 +45,12 @@ export const virtual = _virtual + '${num}';`
       }
     },
     configureServer(server) {
-      server.environments.$ssr.hot.on('virtual:increment', async () => {
+      server.$ssr.hot.on('virtual:increment', async () => {
         const mod =
-          await server.environments.$ssr.moduleGraph.getModuleByUrl(
-            '\0virtual:file',
-          )
+          await server.$ssr.moduleGraph.getModuleByUrl('\0virtual:file')
         if (mod) {
           num++
-          server.environments.$ssr.reloadModule(mod)
+          server.$ssr.reloadModule(mod)
         }
       })
     },

--- a/playground/hmr-ssr/vite.config.ts
+++ b/playground/hmr-ssr/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
         }
       },
       configureServer(server) {
-        server.environments.ssr.hot.on(
+        server.environments.$ssr.hot.on(
           'custom:remote-add',
           ({ a, b }, client) => {
             client.send('custom:remote-add-result', { result: a + b })
@@ -48,14 +48,14 @@ export const virtual = _virtual + '${num}';`
       }
     },
     configureServer(server) {
-      server.environments.ssr.hot.on('virtual:increment', async () => {
+      server.environments.$ssr.hot.on('virtual:increment', async () => {
         const mod =
-          await server.environments.ssr.moduleGraph.getModuleByUrl(
+          await server.environments.$ssr.moduleGraph.getModuleByUrl(
             '\0virtual:file',
           )
         if (mod) {
           num++
-          server.environments.ssr.reloadModule(mod)
+          server.environments.$ssr.reloadModule(mod)
         }
       })
     },

--- a/playground/hmr/vite.config.ts
+++ b/playground/hmr/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         }
       },
       configureServer(server) {
-        server.environments.client.hot.on(
+        server.environments.$client.hot.on(
           'custom:remote-add',
           ({ a, b }, client) => {
             client.send('custom:remote-add-result', { result: a + b })
@@ -50,14 +50,14 @@ export const virtual = _virtual + '${num}';`
       }
     },
     configureServer(server) {
-      server.environments.client.hot.on('virtual:increment', async () => {
+      server.environments.$client.hot.on('virtual:increment', async () => {
         const mod =
-          await server.environments.client.moduleGraph.getModuleByUrl(
+          await server.environments.$client.moduleGraph.getModuleByUrl(
             '\0virtual:file',
           )
         if (mod) {
           num++
-          server.environments.client.reloadModule(mod)
+          server.environments.$client.reloadModule(mod)
         }
       })
     },

--- a/playground/hmr/vite.config.ts
+++ b/playground/hmr/vite.config.ts
@@ -19,12 +19,9 @@ export default defineConfig({
         }
       },
       configureServer(server) {
-        server.environments.$client.hot.on(
-          'custom:remote-add',
-          ({ a, b }, client) => {
-            client.send('custom:remote-add-result', { result: a + b })
-          },
-        )
+        server.$client.hot.on('custom:remote-add', ({ a, b }, client) => {
+          client.send('custom:remote-add-result', { result: a + b })
+        })
       },
     },
     virtualPlugin(),
@@ -50,14 +47,12 @@ export const virtual = _virtual + '${num}';`
       }
     },
     configureServer(server) {
-      server.environments.$client.hot.on('virtual:increment', async () => {
+      server.$client.hot.on('virtual:increment', async () => {
         const mod =
-          await server.environments.$client.moduleGraph.getModuleByUrl(
-            '\0virtual:file',
-          )
+          await server.$client.moduleGraph.getModuleByUrl('\0virtual:file')
         if (mod) {
           num++
-          server.environments.$client.reloadModule(mod)
+          server.$client.reloadModule(mod)
         }
       })
     },

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -283,7 +283,7 @@ describe.runIf(isServe)('invalid', () => {
     await page.keyboard.press('Escape')
     await hiddenPromise
 
-    viteServer.environments.$client.hot.send({
+    viteServer.$client.hot.send({
       type: 'error',
       err: {
         message: 'someError',
@@ -395,9 +395,7 @@ describe.runIf(isServe)('warmup', () => {
     // here might take a while to load
     await withRetry(async () => {
       const mod =
-        await viteServer.environments.$client.moduleGraph.getModuleByUrl(
-          '/warmup/warm.js',
-        )
+        await viteServer.$client.moduleGraph.getModuleByUrl('/warmup/warm.js')
       expect(mod).toBeTruthy()
     })
   })

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -283,7 +283,7 @@ describe.runIf(isServe)('invalid', () => {
     await page.keyboard.press('Escape')
     await hiddenPromise
 
-    viteServer.environments.client.hot.send({
+    viteServer.environments.$client.hot.send({
       type: 'error',
       err: {
         message: 'someError',
@@ -395,7 +395,7 @@ describe.runIf(isServe)('warmup', () => {
     // here might take a while to load
     await withRetry(async () => {
       const mod =
-        await viteServer.environments.client.moduleGraph.getModuleByUrl(
+        await viteServer.environments.$client.moduleGraph.getModuleByUrl(
           '/warmup/warm.js',
         )
       expect(mod).toBeTruthy()

--- a/playground/module-graph/__tests__/module-graph.spec.ts
+++ b/playground/module-graph/__tests__/module-graph.spec.ts
@@ -4,7 +4,7 @@ import { isServe, page, viteServer } from '~utils'
 test.runIf(isServe)('importedUrls order is preserved', async () => {
   const el = page.locator('.imported-urls-order')
   expect(await el.textContent()).toBe('[success]')
-  const mod = await viteServer.environments.$client.moduleGraph.getModuleByUrl(
+  const mod = await viteServer.$client.moduleGraph.getModuleByUrl(
     '/imported-urls-order.js',
   )
   const importedModuleIds = [...mod.importedModules].map((m) => m.url)

--- a/playground/module-graph/__tests__/module-graph.spec.ts
+++ b/playground/module-graph/__tests__/module-graph.spec.ts
@@ -4,7 +4,7 @@ import { isServe, page, viteServer } from '~utils'
 test.runIf(isServe)('importedUrls order is preserved', async () => {
   const el = page.locator('.imported-urls-order')
   expect(await el.textContent()).toBe('[success]')
-  const mod = await viteServer.environments.client.moduleGraph.getModuleByUrl(
+  const mod = await viteServer.environments.$client.moduleGraph.getModuleByUrl(
     '/imported-urls-order.js',
   )
   const importedModuleIds = [...mod.importedModules].map((m) => m.url)

--- a/playground/ssr-html/test-network-imports.js
+++ b/playground/ssr-html/test-network-imports.js
@@ -12,7 +12,7 @@ async function runTest(userRunner) {
   })
   let mod
   if (userRunner) {
-    const runner = await createServerModuleRunner(server.environments.ssr, {
+    const runner = await createServerModuleRunner(server.environments.$ssr, {
       hmr: false,
     })
     mod = await runner.import('/src/network-imports.js')

--- a/playground/ssr-html/test-network-imports.js
+++ b/playground/ssr-html/test-network-imports.js
@@ -12,7 +12,7 @@ async function runTest(userRunner) {
   })
   let mod
   if (userRunner) {
-    const runner = await createServerModuleRunner(server.environments.$ssr, {
+    const runner = await createServerModuleRunner(server.$ssr, {
       hmr: false,
     })
     mod = await runner.import('/src/network-imports.js')

--- a/playground/ssr-html/test-stacktrace-runtime.js
+++ b/playground/ssr-html/test-stacktrace-runtime.js
@@ -13,7 +13,7 @@ const server = await createServer({
   },
 })
 
-const runner = await createServerModuleRunner(server.environments.$ssr, {
+const runner = await createServerModuleRunner(server.$ssr, {
   sourcemapInterceptor: 'prepareStackTrace',
 })
 

--- a/playground/ssr-html/test-stacktrace-runtime.js
+++ b/playground/ssr-html/test-stacktrace-runtime.js
@@ -13,7 +13,7 @@ const server = await createServer({
   },
 })
 
-const runner = await createServerModuleRunner(server.environments.ssr, {
+const runner = await createServerModuleRunner(server.environments.$ssr, {
   sourcemapInterceptor: 'prepareStackTrace',
 })
 


### PR DESCRIPTION
### Description

PR for reference, checkout this one instead:
- https://github.com/vitejs/vite/pull/18439

Alternative API to configure environments using top level keys prefixed by `$` instead of nesting inside `environments`.