### PR TITLE
refactor: remove `patchPlugins`

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -541,7 +541,6 @@ export async function buildWithResolvedConfig(
 export function resolveConfigToBuild(
   inlineConfig: InlineConfig = {},
   patchConfig?: (config: ResolvedConfig) => void,
-  patchPlugins?: (resolvedPlugins: Plugin[]) => void,
 ): Promise<ResolvedConfig> {
   return resolveConfig(
     inlineConfig,
@@ -550,7 +549,6 @@ export function resolveConfigToBuild(
     'production',
     false,
     patchConfig,
-    patchPlugins,
   )
 }
 
@@ -1573,8 +1571,8 @@ export async function createBuilderWithResolvedConfig(
         ;(resolved.build as ResolvedBuildOptions) = {
           ...resolved.environments[environmentName].build,
         }
-      }
-      const patchPlugins = (resolvedPlugins: Plugin[]) => {
+
+        const resolvedPlugins = resolved.plugins as Plugin[]
         // Force opt-in shared plugins
         let j = 0
         for (let i = 0; i < resolvedPlugins.length; i++) {
@@ -1593,11 +1591,7 @@ export async function createBuilderWithResolvedConfig(
           }
         }
       }
-      environmentConfig = await resolveConfigToBuild(
-        inlineConfig,
-        patchConfig,
-        patchPlugins,
-      )
+      environmentConfig = await resolveConfigToBuild(inlineConfig, patchConfig)
     }
 
     const environment = await environmentConfig.build.createEnvironment(


### PR DESCRIPTION
### Description

I simply resolved the TODO and ran the tests and it passed.
But after doing that I noticed that there's still some `config` references in our internal plugins, should we remove all of these before doing this PR?
https://github.com/vitejs/vite/blob/3778c7acf95e2dec3c18f3954ba4a52a979f45c4/packages/vite/src/node/plugins/asset.ts#L153

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
