### PR TITLE
docs: if users need the third parameter from loadEnv as '' they must set it themselves.

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -105,8 +105,9 @@ import { defineConfig, loadEnv } from 'vite'
 
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to 'APP_' to load envs with the `APP_` prefix.
   // If necessary, you can set the optional third parameter to '' to load all env regardless of the `VITE_` prefix.
-  const env = loadEnv(mode, process.cwd())
+  const env = loadEnv(mode, process.cwd(), 'APP_')
   return {
     // vite config
     define: {

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -105,8 +105,8 @@ import { defineConfig, loadEnv } from 'vite'
 
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
-  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
-  const env = loadEnv(mode, process.cwd(), '')
+  // If necessary, you can set the optional third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const env = loadEnv(mode, process.cwd())
   return {
     // vite config
     define: {


### PR DESCRIPTION
### Purpose

The idea is to improve the Vite docs so that users who copy the code sample need to make a change if their use case requires that they override the `VITE_` prefix enforcement.

### Explanation

We experienced a leak of some secret environment variables after copying this code without understanding it thoroughly. After pulling in all environment variables, we then exposed them in the js bundle by doing the following in the vite config,

```
    define: {
      'process.env': env,
    },
```

🤦 

While it is nice to be able to show how all of the parameters in loadEnv can be used, when there is just one code sample on the page, I think it may protect users from mistakenly loading more environment variables than they need if we don't set the third parameter to empty string here. 

The proposed change removes the third parameter but leaves the comment that describes how it can be used if it is needed.