### PR TITLE
fix(dev): prevent double URL encoding in server.open on macOS

### DIFF
--- a/packages/vite/src/node/server/openBrowser.ts
+++ b/packages/vite/src/node/server/openBrowser.ts
@@ -96,9 +96,7 @@ async function startBrowserProcess(
       if (openedBrowser) {
         // Try our best to reuse existing tab with AppleScript
         await execAsync(
-          `osascript openChrome.applescript "${encodeURI(
-            url,
-          )}" "${openedBrowser}"`,
+          `osascript openChrome.applescript "${url}" "${openedBrowser}"`,
           {
             cwd: join(VITE_PACKAGE_DIR, 'bin'),
           },


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Currently, when using `server.open` on `macOS`, the opened URL is double-encoded.

For example, with the following configuration:

```ts
{
  base: '/测试%23%24/',
  server: {
    open: './?key1=测试&key2=%23%24',
  },
}
```

The opened link becomes: `http://localhost:5173/%25E6%25B5%258B%25E8%25AF%2595%2523%2524/?key1=%25E6%25B5%258B%25E8%25AF%2595&key2=%2523%2524`
But the correct link should be: `http://localhost:5173/%E6%B5%8B%E8%AF%95%23%24/?key1=%E6%B5%8B%E8%AF%95&key2=%23%24`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
