### PR TITLE
fix(preview): set resolvedUrls null after close

### DIFF
--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -128,8 +128,8 @@ interface ViteDevServer {
    */
   moduleGraph: ModuleGraph
   /**
-   * The resolved urls Vite prints on the CLI. null in middleware mode or
-   * before `server.listen` is called.
+   * The resolved urls Vite prints on the CLI (URL-encoded). Returns `null`
+   * in middleware mode or if the server is not listening on any port.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**
@@ -274,8 +274,8 @@ interface PreviewServer {
    */
   httpServer: http.Server
   /**
-   * The resolved urls Vite prints on the CLI.
-   * null before server is listening.
+   * The resolved urls Vite prints on the CLI (URL-encoded). Returns `null`
+   * if the server is not listening on any port.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -84,8 +84,8 @@ export interface PreviewServer {
    */
   httpServer: HttpServer
   /**
-   * The resolved urls Vite prints on the CLI.
-   * null before server is listening.
+   * The resolved urls Vite prints on the CLI (URL-encoded). Returns `null`
+   * if the server is not listening on any port.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**
@@ -154,6 +154,7 @@ export async function preview(
     async close() {
       teardownSIGTERMListener(closeServerAndExit)
       await closeHttpServer()
+      server.resolvedUrls = null
     },
     resolvedUrls: null,
     printUrls() {

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -284,8 +284,8 @@ export interface ViteDevServer {
    */
   moduleGraph: ModuleGraph
   /**
-   * The resolved urls Vite prints on the CLI. null in middleware mode or
-   * before `server.listen` is called.
+   * The resolved urls Vite prints on the CLI (URL-encoded). Returns `null`
+   * in middleware mode or if the server is not listening on any port.
    */
   resolvedUrls: ResolvedServerUrls | null
   /**


### PR DESCRIPTION
### Description

- After the preview server is closed, `resolvedUrls` is reset to `null` (we did for the [dev server](https://github.com/vitejs/vite/blob/b80daa7c0970645dca569d572892648f66c6799c/packages/vite/src/node/server/index.ts#L683) but not for preview)
- Improve jsdoc for `resolvedUrls`, particularly I wanted to note that they're URL encoded after reviewing https://github.com/vitejs/vite/pull/18443
- Improve jsdoc to mention that `resolvedUrls` can be null if the server is "not listening", not necessarily "before listening" (which could imply that the `resolvedUrls` may retain after closing the server) 
