### PR TITLE
chore: replace deprecated `File` type with `RunnerTestFile`

### DIFF
--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -21,7 +21,7 @@ import {
 } from 'vite'
 import type { Browser, Page } from 'playwright-chromium'
 import type { RollupError, RollupWatcher, RollupWatcherEvent } from 'rollup'
-import type { File } from 'vitest'
+import type { RunnerTestFile } from 'vitest'
 import { beforeAll, inject } from 'vitest'
 
 // #region env
@@ -81,7 +81,7 @@ export function setViteUrl(url: string): void {
 // #endregion
 
 beforeAll(async (s) => {
-  const suite = s as File
+  const suite = s as RunnerTestFile
 
   testPath = suite.filepath!
   testName = slash(testPath).match(/playground\/([\w-]+)\//)?.[1]


### PR DESCRIPTION
### Description

Very minor, just addressing a deprecated type used in the playground's vitestSetup file:
![Screenshot 2024-10-24 at 10 30 49](https://github.com/user-attachments/assets/9420fc15-b91f-4afc-9f2d-e5c252160b65)


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
