### PR TITLE
fix: return the same instance of ModuleNode for the same EnvironmentModuleNode

### DIFF
--- a/packages/vite/src/node/server/mixedModuleGraph.ts
+++ b/packages/vite/src/node/server/mixedModuleGraph.ts
@@ -220,6 +220,12 @@ export class ModuleGraph {
 
   fileToModulesMap: Map<string, Set<ModuleNode>>
 
+  private moduleNodeCache = new DualWeakMap<
+    EnvironmentModuleNode,
+    EnvironmentModuleNode,
+    ModuleNode
+  >()
+
   constructor(moduleGraphs: {
     client: () => EnvironmentModuleGraph
     ssr: () => EnvironmentModuleGraph
@@ -452,8 +458,36 @@ export class ModuleGraph {
     clientModule?: EnvironmentModuleNode,
     ssrModule?: EnvironmentModuleNode,
   ): ModuleNode {
-    // ...
-    return new ModuleNode(this, clientModule, ssrModule)
+    const cached = this.moduleNodeCache.get(clientModule, ssrModule)
+    if (cached) {
+      return cached
+    }
+
+    const moduleNode = new ModuleNode(this, clientModule, ssrModule)
+    this.moduleNodeCache.set(clientModule, ssrModule, moduleNode)
+    return moduleNode
+  }
+}
+
+class DualWeakMap<K1 extends WeakKey, K2 extends WeakKey, V> {
+  private map = new WeakMap<K1 | object, WeakMap<K2 | object, V>>()
+  private undefinedKey = {}
+
+  get(key1: K1 | undefined, key2: K2 | undefined): V | undefined {
+    const k1 = key1 ?? this.undefinedKey
+    const k2 = key2 ?? this.undefinedKey
+    return this.map.get(k1)?.get(k2)
+  }
+
+  set(key1: K1 | undefined, key2: K2 | undefined, value: V): void {
+    const k1 = key1 ?? this.undefinedKey
+    const k2 = key2 ?? this.undefinedKey
+    if (!this.map.has(k1)) {
+      this.map.set(k1, new Map<K2, V>())
+    }
+
+    const m = this.map.get(k1)!
+    m.set(k2, value)
   }
 }
 


### PR DESCRIPTION
### Description

This PR should fix the vite-plugin-svelte fail (https://github.com/vitejs/vite-ecosystem-ci/actions/runs/11473350317/job/31927446107) by improving backward compat of the ModuleGraph.

It was failing because this `inline_styles` function never resolved.
https://github.com/sveltejs/kit/blob/dcbe4222a194c5f90cfc0fc020cf065f7a4e4c46/packages/kit/src/exports/vite/dev/index.js#L189-L194
This `find_deps` function was recursively called infinitely because `moduleGraph.getModuleByUrl` returned a new instance for the same ModuleNode.
https://github.com/sveltejs/kit/blob/dcbe4222a194c5f90cfc0fc020cf065f7a4e4c46/packages/kit/src/exports/vite/dev/index.js#L578-L614
This PR prevents that happening by caching the ModuleNode.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
