### PR TITLE
fix: handle warmup glob hang

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -147,7 +147,7 @@
     "source-map-support": "^0.5.21",
     "strip-ansi": "^7.1.0",
     "strip-literal": "^2.1.0",
-    "tinyglobby": "^0.2.9",
+    "tinyglobby": "^0.2.10",
     "tsconfck": "^3.1.4",
     "tslib": "^2.8.0",
     "types": "link:./types",

--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -70,10 +70,12 @@ function fileToUrl(file: string, root: string) {
   return '/' + normalizePath(url)
 }
 
-function mapFiles(files: string[], root: string) {
-  return glob(files, {
+async function mapFiles(files: string[], root: string) {
+  if (!files.length) return []
+  return await glob(files, {
     absolute: true,
     cwd: root,
     expandDirectories: false,
+    ignore: ['**/.git/**', '**/node_modules/**'],
   })
 }

--- a/playground/backend-integration/package.json
+++ b/playground/backend-integration/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "sass": "^1.80.3",
     "tailwindcss": "^3.4.14",
-    "tinyglobby": "^0.2.9"
+    "tinyglobby": "^0.2.10"
   }
 }

--- a/playground/css/package.json
+++ b/playground/css/package.json
@@ -26,7 +26,7 @@
     "sass": "^1.80.3",
     "stylus": "^0.64.0",
     "sugarss": "^4.0.1",
-    "tinyglobby": "^0.2.9"
+    "tinyglobby": "^0.2.10"
   },
   "imports": {
     "#imports": "./imports-field.css"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,8 +404,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       tinyglobby:
-        specifier: ^0.2.9
-        version: 0.2.9
+        specifier: ^0.2.10
+        version: 0.2.10
       tsconfck:
         specifier: ^3.1.4
         version: 3.1.4(typescript@5.6.2)
@@ -517,8 +517,8 @@ importers:
         specifier: ^3.4.14
         version: 3.4.14(ts-node@10.9.2(@types/node@20.16.13)(typescript@5.6.2))
       tinyglobby:
-        specifier: ^0.2.9
-        version: 0.2.9
+        specifier: ^0.2.10
+        version: 0.2.10
 
   playground/build-old: {}
 
@@ -584,8 +584,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(postcss@8.4.47)
       tinyglobby:
-        specifier: ^0.2.9
-        version: 0.2.9
+        specifier: ^0.2.10
+        version: 0.2.10
 
   playground/css-codesplit: {}
 
@@ -4772,6 +4772,14 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.4.2:
+    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   feed@4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
@@ -6736,8 +6744,8 @@ packages:
   tinyexec@0.3.0:
     resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
 
-  tinyglobby@0.2.9:
-    resolution: {integrity: sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==}
+  tinyglobby@0.2.10:
+    resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.0.0:
@@ -8523,7 +8531,7 @@ snapshots:
       astring: 1.8.6
       estree-walker: 2.0.2
       magic-string: 0.30.12
-      tinyglobby: 0.2.9
+      tinyglobby: 0.2.10
     optionalDependencies:
       rollup: 4.23.0
 
@@ -10390,6 +10398,10 @@ snapshots:
       picomatch: 4.0.2
 
   fdir@6.4.0(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
+  fdir@6.4.2(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
@@ -12509,9 +12521,9 @@ snapshots:
 
   tinyexec@0.3.0: {}
 
-  tinyglobby@0.2.9:
+  tinyglobby@0.2.10:
     dependencies:
-      fdir: 6.4.0(picomatch@4.0.2)
+      fdir: 6.4.2(picomatch@4.0.2)
       picomatch: 4.0.2
 
   tinypool@1.0.0: {}


### PR DESCRIPTION
### Description

If the warmup files is empty, we skip doing any globbing. It also works around https://github.com/SuperchupuDev/tinyglobby/pull/65 otherwise the glob hangs the process.

I also updated `tinyglobby` as it got some fixes around supporting negating absolute patterns which was relied on by Astro.

I also added `ignore` for `.git ` and `node_modules`. It's probably unlikely someone needs to warmup those files and it's better to target your own source code as the entrypoints instead. I think it helps if the glob is `./**/*.jsx` too as `tinyglobby` (or any other glob libraries) couldn't detect the glob parent to know not to crawl `.git` or `node_modules`.