### PR TITLE
fix(css): `cssCodeSplit` in `environments.xxx.build` is invalid

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -762,7 +762,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
           pureCssChunks.add(chunk)
         }
 
-        if (config.build.cssCodeSplit) {
+        if (this.environment.config.build.cssCodeSplit) {
           if (opts.format === 'es' || opts.format === 'cjs') {
             const isEntry = chunk.isEntry && isPureCssChunk
             const cssFullAssetName = ensureFileExt(chunk.name, '.css')


### PR DESCRIPTION
Fixed the problem that under environments, setting cssCodeSplit for a single environment is invalid.

``` ts
export default defineConfig({
  environments: {
    core: {
      build: {
        cssCodeSplit: false // invalid
      }
    }
  },
})
```