### PR TITLE
fix(plugins): noop if config hook returns same config reference

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1740,7 +1740,7 @@ async function runConfigHook(
     const handler = getHookHandler(hook)
     if (handler) {
       const res = await handler(conf, configEnv)
-      if (res) {
+      if (res && res !== conf) {
         conf = mergeConfig(conf, res)
       }
     }


### PR DESCRIPTION
### Description

If the `config()` hook returns the same config given, Vite currently merges it again, causing the config to merge onto itself, causing unintended behaviour like `resolve.conditions` duplicating or other array-based fields.

This PR skips the merge if so to prevent unnecessary work, which in most cases shouldn't be a breaking change. Open to discussion though if we think this is nice to have, or we can ignore it for now.

I found this footgun happening in https://github.com/withastro/astro/issues/12287. And [searching around](https://github.com/search?q=config%28config%29+return+config+vite&type=code), it seems to happen elsewhere:

- https://github.com/MikeBild/serverless-workshop-sveltekit/blob/01a0cb2cec362602e79d34ae0532d7588ae5e6ad/vite.config.js#L10-L20
- https://github.com/zwq8299174/auto-css-plugin/blob/2fe09511aa34c56ffd7caeef1b23abcd4e208037/src/vite-use.js#L9-L13