### PR TITLE
fix(resolve): Deno now uses mostly JSR

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -96,6 +96,7 @@ export const normalizeId = (id: string): string =>
 const NODE_BUILTIN_NAMESPACE = 'node:'
 // Supported by Deno
 const NPM_BUILTIN_NAMESPACE = 'npm:'
+const JSR_BUILTIN_NAMESPACE = 'jsr:'
 // Supported by Bun
 const BUN_BUILTIN_NAMESPACE = 'bun:'
 // Some runtimes like Bun injects namespaced modules here, which is not a node builtin
@@ -103,7 +104,7 @@ const nodeBuiltins = builtinModules.filter((id) => !id.includes(':'))
 
 // TODO: Use `isBuiltin` from `node:module`, but Deno doesn't support it
 export function isBuiltin(id: string): boolean {
-  if (process.versions.deno && id.startsWith(NPM_BUILTIN_NAMESPACE)) return true
+  if (process.versions.deno && (id.startsWith(NPM_BUILTIN_NAMESPACE) || id.startsWith(JSR_BUILTIN_NAMESPACE))) return true
   if (process.versions.bun && id.startsWith(BUN_BUILTIN_NAMESPACE)) return true
   return isNodeBuiltin(id)
 }


### PR DESCRIPTION
Adds support for https://jsr.io/ imports like `jsr:@db/sqlite@0.12`

This is related to a bug in Deno repository: https://github.com/denoland/deno/issues/26492