### PR TITLE
fix(module-runner): delay function eval until module runner instantiation

### DIFF
--- a/packages/vite/src/module-runner/esmEvaluator.ts
+++ b/packages/vite/src/module-runner/esmEvaluator.ts
@@ -1,6 +1,6 @@
 import {
   AsyncFunction,
-  asyncFunctionDeclarationPaddingLineCount,
+  getAsyncFunctionDeclarationPaddingLineCount,
 } from '../shared/utils'
 import {
   ssrDynamicImportKey,
@@ -12,7 +12,7 @@ import {
 import type { ModuleEvaluator, ModuleRunnerContext } from './types'
 
 export class ESModulesEvaluator implements ModuleEvaluator {
-  startOffset = asyncFunctionDeclarationPaddingLineCount
+  startOffset = getAsyncFunctionDeclarationPaddingLineCount()
 
   async runInlinedModule(
     context: ModuleRunnerContext,

--- a/packages/vite/src/shared/utils.ts
+++ b/packages/vite/src/shared/utils.ts
@@ -56,9 +56,14 @@ export function withTrailingSlash(path: string): string {
 export const AsyncFunction = async function () {}.constructor as typeof Function
 
 // https://github.com/nodejs/node/issues/43047#issuecomment-1564068099
-export const asyncFunctionDeclarationPaddingLineCount =
-  /** #__PURE__ */ (() => {
+let asyncFunctionDeclarationPaddingLineCount: number | undefined
+
+export function getAsyncFunctionDeclarationPaddingLineCount(): number {
+  if (typeof asyncFunctionDeclarationPaddingLineCount === 'undefined') {
     const body = '/*code*/'
     const source = new AsyncFunction('a', 'b', body).toString()
-    return source.slice(0, source.indexOf(body)).split('\n').length - 1
-  })()
+    asyncFunctionDeclarationPaddingLineCount =
+      source.slice(0, source.indexOf(body)).split('\n').length - 1
+  }
+  return asyncFunctionDeclarationPaddingLineCount
+}


### PR DESCRIPTION
### Description

While trying to avoid bundling `vite/module-runner` in my workerd package https://github.com/hi-ogawa/vite-environment-examples/pull/143, I found that `new AsyncFunction('a', 'b', body)` executed during import side effect causes an error since normal eval is not supported in the environment.

In https://github.com/hi-ogawa/vite-environment-examples/pull/143, I manually removed `new AsyncFunction` from the source code to make it work. Though I'm not sure we'll be recommending not bundling module runner, delaying this function eval won't probably hurt anything.

I tested with a local build and confirmed that `new AsyncFunction` removal isn't necessary after this change.