### PR TITLE
feat: implement fetch transport (POC)

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -187,7 +187,7 @@ const moduleRunnerConfig = defineConfig({
   ],
   plugins: [
     ...createSharedNodePlugins({ esbuildOptions: { minifySyntax: true } }),
-    bundleSizeLimit(53),
+    bundleSizeLimit(55),
   ],
 })
 

--- a/packages/vite/src/module-runner/fetchTransport.ts
+++ b/packages/vite/src/module-runner/fetchTransport.ts
@@ -1,0 +1,101 @@
+/* eslint-disable n/no-unsupported-features/node-builtins */
+import type { ModuleRunnerTransport } from '../shared/moduleRunnerTransport'
+
+export function createClientFetchTransport(
+  environmentName: string,
+  url: string,
+): ModuleRunnerTransport {
+  let sseClient: Awaited<ReturnType<typeof createSSEClient>>
+
+  return {
+    async connect(handlers) {
+      sseClient = await createSSEClient(
+        environmentName,
+        url + '/@vite/transport',
+        handlers,
+      )
+    },
+    async disconnect() {
+      // TODO
+    },
+    async send(payload) {
+      if (!sseClient) throw new Error('not connected')
+      sseClient.send(payload)
+    },
+  }
+}
+
+async function createSSEClient(
+  environmentName: string,
+  url: string,
+  handlers: {
+    onMessage: (payload: any) => void
+    onDisconnection: () => void
+  },
+) {
+  const response = await fetch(url, {
+    headers: {
+      'x-vite-environment': environmentName,
+    },
+  })
+  if (!response.ok) throw new Error('failed to connect')
+
+  const clientId = response.headers.get('x-client-id')
+  if (!clientId) throw new Error('invalid connect response')
+  if (!response.body) throw new Error('invalid connect response')
+
+  response.body
+    .pipeThrough(new TextDecoderStream())
+    .pipeThrough(splitTransform('\n\n'))
+    .pipeTo(
+      new WritableStream({
+        write(chunk) {
+          if (chunk.startsWith('data: ')) {
+            const payload = JSON.parse(chunk.slice('data: '.length))
+            handlers.onMessage(payload)
+          }
+        },
+        close() {
+          handlers.onDisconnection()
+        },
+      }),
+    )
+    // TODO
+    .catch(() => {})
+
+  return {
+    send: async (payload: unknown) => {
+      const response = await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        headers: {
+          'x-vite-environment': environmentName,
+          'x-client-id': clientId,
+        },
+      })
+      if (!response.ok) throw new Error('invalid send response')
+      const result = await response.json()
+      return result
+    },
+  }
+}
+
+function splitTransform(sep: string): TransformStream<string, string> {
+  let pending = ''
+  return new TransformStream({
+    transform(chunk, controller) {
+      while (true) {
+        const i = chunk.indexOf(sep)
+        if (i >= 0) {
+          pending += chunk.slice(0, i)
+          controller.enqueue(pending)
+          pending = ''
+          chunk = chunk.slice(i + sep.length)
+          continue
+        }
+        pending += chunk
+        break
+      }
+    },
+  })
+}

--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -5,6 +5,7 @@ export { ModuleRunner } from './runner'
 export { ESModulesEvaluator } from './esmEvaluator'
 
 export { createWebSocketModuleRunnerTransport } from '../shared/moduleRunnerTransport'
+export { createClientFetchTransport } from './fetchTransport'
 
 export type { FetchFunctionOptions, FetchResult } from '../shared/invokeMethods'
 export type {

--- a/packages/vite/src/node/index.ts
+++ b/packages/vite/src/node/index.ts
@@ -36,6 +36,7 @@ export { createServerModuleRunner } from './ssr/runtime/serverModuleRunner'
 export { createServerHotChannel } from './server/hmr'
 export { ssrTransform as moduleRunnerTransform } from './ssr/ssrTransform'
 export type { ModuleRunnerTransformOptions } from './ssr/ssrTransform'
+export { createServerFetchTransport } from './server/fetchTransport'
 
 export * from './publicUtils'
 

--- a/packages/vite/src/node/server/fetchTransport.ts
+++ b/packages/vite/src/node/server/fetchTransport.ts
@@ -1,0 +1,167 @@
+/* eslint-disable n/no-unsupported-features/node-builtins */
+import assert from 'node:assert'
+import { Readable } from 'node:stream'
+import type { HotPayload } from 'types/hmrPayload'
+import type { Connect, ViteDevServer } from '..'
+import type { HotChannel, HotChannelListener } from './hmr'
+
+export function fetchTransportMiddleware(
+  server: ViteDevServer,
+): Connect.NextHandleFunction {
+  return async function viteFetchTransportMiddleware(req, res, next) {
+    // TODO: protect endpoint
+    if (req.url !== '/@vite/transport') {
+      return next()
+    }
+    const environmentName = req.headers['x-vite-environment']
+    if (typeof environmentName !== 'string') {
+      res.statusCode = 400
+      res.end(JSON.stringify({ message: 'missing environment' }))
+      return
+    }
+    const environment = server.environments[environmentName]
+    if (!environment) {
+      res.statusCode = 400
+      res.end(
+        JSON.stringify({ message: `unknown environment '${environmentName}'` }),
+      )
+      return
+    }
+    const api = environment.hot.api
+    if (!(api instanceof ServerFetchTransport)) {
+      res.statusCode = 400
+      res.end(
+        JSON.stringify({ message: `invalid environment '${environmentName}'` }),
+      )
+      return
+    }
+    try {
+      await api.handler(req, res)
+    } catch (e) {
+      next(e)
+    }
+  }
+}
+
+export function createServerFetchTransport(): HotChannel {
+  return new ServerFetchTransport()
+}
+
+interface SSEClientProxy {
+  send(payload: HotPayload): void
+  close(): void
+}
+
+class ServerFetchTransport implements HotChannel {
+  private clientMap = new Map<string, SSEClientProxy>()
+  private listenerManager = createListenerManager()
+
+  on = this.listenerManager.on
+  off = this.listenerManager.off
+  send: HotChannel['send'] = (payload) => {
+    for (const client of this.clientMap.values()) {
+      client.send(payload)
+    }
+  }
+  close() {
+    for (const client of this.clientMap.values()) {
+      client.close()
+    }
+  }
+
+  // expose hot.api.handler
+  api = this
+
+  handler: Connect.SimpleHandleFunction = async (req, res) => {
+    // handle 'send'
+    if (req.method === 'POST') {
+      const senderId = req.headers['x-client-id']
+      assert(typeof senderId === 'string')
+      const client = this.clientMap.get(senderId)
+      assert(client)
+      const payload = JSON.parse(await readReq(req))
+      this.listenerManager.dispatch(payload, client)
+      res.end(JSON.stringify({ ok: true }))
+      return
+    }
+    // handle 'connect'
+    assert(req.method === 'GET')
+    let controller: ReadableStreamDefaultController<string>
+    const stream = new ReadableStream<string>({
+      start: (controller_) => {
+        controller = controller_
+        controller.enqueue(`:ping\n\n`)
+      },
+      cancel: () => {
+        this.clientMap.delete(clientId)
+      },
+    })
+    const pingInterval = setInterval(() => {
+      controller.enqueue(`:ping\n\n`)
+    }, 10_000)
+    const clientId = Math.random().toString(36).slice(2)
+    const client: SSEClientProxy = {
+      send(payload) {
+        controller.enqueue(`data: ${JSON.stringify(payload)}\n\n`)
+      },
+      close() {
+        clearInterval(pingInterval)
+        controller.close()
+      },
+    }
+    this.clientMap.set(clientId, client)
+    res.setHeader('x-client-id', clientId)
+    res.setHeader('content-type', 'text/event-stream')
+    res.setHeader('cache-control', 'no-cache')
+    res.setHeader('connection', 'keep-alive')
+    Readable.fromWeb(stream as any).pipe(res)
+  }
+}
+
+function readReq(req: Readable): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let payload = ''
+    req.on('data', (chunk) => {
+      payload += chunk.toString()
+    })
+    req.on('end', () => {
+      resolve(payload)
+    })
+    req.on('error', (error) => {
+      reject(error)
+    })
+  })
+}
+
+// wrapper to simplify listener management
+function createListenerManager(): Pick<HotChannel, 'on' | 'off'> & {
+  dispatch: (
+    payload: HotPayload,
+    client: { send: (payload: HotPayload) => void },
+  ) => void
+} {
+  const listerMap: Record<string, Set<HotChannelListener>> = {}
+  const getListerMap = (e: string) => (listerMap[e] ??= new Set())
+
+  return {
+    on(event: string, listener: HotChannelListener) {
+      if (event === 'connection') {
+        return
+      }
+      getListerMap(event).add(listener)
+    },
+    off(event, listener: any) {
+      if (event === 'connection') {
+        return
+      }
+      getListerMap(event).delete(listener)
+    },
+    dispatch(payload, client) {
+      if (payload.type === 'custom') {
+        for (const lister of getListerMap(payload.event)) {
+          lister(payload.data, client)
+        }
+      }
+    },
+  }
+}

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -93,6 +93,7 @@ import type { TransformOptions, TransformResult } from './transformRequest'
 import { transformRequest } from './transformRequest'
 import { searchForPackageRoot, searchForWorkspaceRoot } from './searchRoot'
 import type { DevEnvironment } from './environment'
+import { fetchTransportMiddleware } from './fetchTransport'
 
 export interface ServerOptions extends CommonServerOptions {
   /**
@@ -835,6 +836,7 @@ export async function _createServer(
   }
 
   middlewares.use(cachedTransformMiddleware(server))
+  middlewares.use(fetchTransportMiddleware(server))
 
   // proxy
   const { proxy } = serverConfig

--- a/packages/vite/src/node/ssr/runtime/__tests__/fetch-transport.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/fetch-transport.spec.ts
@@ -1,0 +1,78 @@
+import { assert, expect, test } from 'vitest'
+import type { ViteHotContext } from 'types/hot'
+import { createServer } from '../../../server'
+import { DevEnvironment } from '../../../server/environment'
+import { createServerFetchTransport } from '../../../server/fetchTransport'
+import { ESModulesEvaluator, ModuleRunner } from '../../../../module-runner'
+import { createClientFetchTransport } from '../../../../module-runner/fetchTransport'
+
+test('fetch transport', async () => {
+  const server = await createServer({
+    root: import.meta.dirname,
+    server: {
+      port: 5010,
+      watch: null,
+      hmr: false,
+    },
+    environments: {
+      custom: {
+        dev: {
+          createEnvironment(name, config) {
+            return new DevEnvironment(name, config, {
+              transport: createServerFetchTransport(),
+            })
+          },
+        },
+      },
+    },
+  })
+  await server.listen()
+
+  const runner = new ModuleRunner(
+    {
+      root: server.config.root,
+      sourcemapInterceptor: false,
+      hmr: true,
+      transport: createClientFetchTransport('custom', 'http://localhost:5010'),
+    },
+    new ESModulesEvaluator(),
+  )
+
+  const mod = await runner.import('/fixtures/basic.js')
+  expect(mod.name).toBe('basic')
+
+  // hot api
+  const { hmr: importMetaHot } = (await runner.import('/fixtures/hmr.js')) as {
+    hmr: ViteHotContext
+  }
+  assert(importMetaHot)
+
+  const serverToClient = await new Promise((resolve) => {
+    importMetaHot.on('test-event-server', (payload) => {
+      resolve(payload)
+    })
+    server.environments['custom'].hot.send('test-event-server', 'ok')
+  })
+  expect(serverToClient).toEqual('ok')
+
+  const clientToServer = await new Promise((resolve) => {
+    server.environments['custom'].hot.on('test-event-client', (payload) => {
+      resolve(payload)
+    })
+    importMetaHot.send('test-event-client', 'ok')
+  })
+  expect(clientToServer).toEqual('ok')
+
+  // multiple runners
+  const runner2 = new ModuleRunner(
+    {
+      root: server.config.root,
+      sourcemapInterceptor: false,
+      hmr: true,
+      transport: createClientFetchTransport('custom', 'http://localhost:5010'),
+    },
+    new ESModulesEvaluator(),
+  )
+  const mod2 = await runner2.import('/fixtures/basic.js')
+  expect(mod2.name).toBe('basic')
+})


### PR DESCRIPTION
### Description

base branch: https://github.com/vitejs/vite/pull/18362
diff: https://github.com/vitejs/vite/compare/sapphi-red:refactor/single-transport...hi-ogawa:feat-fetch-transport

On top of https://github.com/vitejs/vite/pull/18362 and with a same spirit as https://github.com/vitejs/vite/pull/18338, this PR adds a primitives for server and client transports with builtin server middleware. I had initial implementation in https://github.com/hi-ogawa/vite-environment-examples/pull/140 and mostly copied it here. Currently the diff is only the last commit of this PR.

Example (see fetch-transport.spec.ts)

```ts
// environment
import { createServerFetchTransport } from "vite"
new DevEnvironment(name, config, {
  hot: true,
  transport: createServerFetchTransport(),
})

// runner
import { createClientFetchTransport } from "vite/module-runner"
const runner = new ModuleRunner(
  {
    root: server.config.root,
    sourcemapInterceptor: false,
    hmr: true,
    transport: createClientFetchTransport('custom', 'http://localhost:5010'),
  },
  new ESModulesEvaluator(),
)
```

TBD
- it has the same concern as https://github.com/vitejs/vite/pull/18338 regarding:
  - how to bootstrap runner (e.g. how to pass server url `http://localhost:5010`, need wait for server listen, etc...),
  - how to protect `/@vite/transport` request which can expose arbitrary `fetchModule`
