### PR TITLE
fix(css): `cssCodeSplit` uses the current environment configuration

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -868,7 +868,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       }
 
       // extract as single css bundle if no codesplit
-      if (!config.build.cssCodeSplit && !hasEmitted) {
+      if (!this.environment.config.build.cssCodeSplit && !hasEmitted) {
         let extractedCss = ''
         const collected = new Set<OutputChunk>()
         // will be populated in order they are used by entry points


### PR DESCRIPTION
### Description

In the `cssPostPlugin.generateBundle` hook function, the top-level `build.config.cssCodeSplit` is used, and then the setting of `cssCodeSplit` in the current environment is invalid.

`config.build.cssCodeSplit` => `this.environment.config.build.cssCodeSplit`

refs #18464
