### PR TITLE
fix(build): apply resolve.external/noExternal to server environments

### DIFF
--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -67,7 +67,7 @@ export async function resolvePlugins(
         asSrc: true,
         fsUtils: getFsUtils(config),
         optimizeDeps: true,
-        externalize: isBuild && !!config.build.ssr, // TODO: should we do this for all environments?
+        externalize: true,
       },
       config.environments,
     ),

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -85,12 +85,18 @@ export interface EnvironmentResolveOptions {
    */
   extensions?: string[]
   dedupe?: string[]
+  // TODO: better abstraction that works for the client environment too?
   /**
-   * external/noExternal logic, this only works for certain environments
-   * Previously this was ssr.external/ssr.noExternal
-   * TODO: better abstraction that works for the client environment too?
+   * Prevent listed dependencies from being externalized and will get bundled in build.
+   * Only works in server environments for now. Previously this was `ssr.noExternal`.
+   * @experimental
    */
   noExternal?: string | RegExp | (string | RegExp)[] | true
+  /**
+   * Externalize the given dependencies and their transitive dependencies.
+   * Only works in server environments for now. Previously this was `ssr.external`.
+   * @experimental
+   */
   external?: string[] | true
 }
 
@@ -135,7 +141,8 @@ interface ResolvePluginOptions {
   optimizeDeps?: boolean
 
   /**
-   * externalize using external/noExternal, defaults to false // TODO: Review default
+   * Externalize using `resolve.external` and `resolve.noExternal` when running a build in
+   * a server environment. Defaults to false (only for createResolver)
    * @internal
    */
   externalize?: boolean
@@ -398,6 +405,8 @@ export function resolvePlugin(
       if (bareImportRE.test(id)) {
         const external =
           options.externalize &&
+          options.isBuild &&
+          currentEnvironmentOptions.consumer === 'server' &&
           shouldExternalize(this.environment, id, importer)
         if (
           !external &&


### PR DESCRIPTION
### Description

Apply resolve.external/noExternal to server environments during build. Previously it only applied if `config.build.ssr` is set, and I'm not sure if that's intentional. Perhaps it's related to this: https://github.com/vitejs/vite/blob/dee60ba0932e4be63835523073aa6f1adcf504f1/playground/environment-react-ssr/vite.config.ts#L41-L45