### PR TITLE
fix: allow nested dependency selector to be used for `optimizeDeps.include` for SSR

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -13,7 +13,6 @@ import {
   createDebugger,
   flattenId,
   getHash,
-  isOptimizable,
   lookupFile,
   normalizeId,
   normalizePath,
@@ -841,10 +840,8 @@ export async function addManuallyIncludedOptimizeDeps(
       if (!deps[normalizedId]) {
         const entry = await resolve(id)
         if (entry) {
-          if (isOptimizable(entry, optimizeDeps)) {
-            if (!entry.endsWith('?__vite_skip_optimization')) {
-              deps[normalizedId] = entry
-            }
+          if (entry.optimizable) {
+            deps[normalizedId] = entry.id
           } else {
             unableToOptimize(id, 'Cannot optimize dependency')
           }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -13,6 +13,7 @@ import {
   createDebugger,
   flattenId,
   getHash,
+  isOptimizable,
   lookupFile,
   normalizeId,
   normalizePath,
@@ -840,8 +841,8 @@ export async function addManuallyIncludedOptimizeDeps(
       if (!deps[normalizedId]) {
         const entry = await resolve(id)
         if (entry) {
-          if (entry.optimizable) {
-            deps[normalizedId] = entry.id
+          if (isOptimizable(entry, optimizeDeps)) {
+            deps[normalizedId] = entry
           } else {
             unableToOptimize(id, 'Cannot optimize dependency')
           }

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -13,7 +13,7 @@ import { resolvePackageData } from '../packages'
 import { cleanUrl, slash } from '../../shared/utils'
 import type { Environment } from '../environment'
 import { createBackCompatIdResolver } from '../idResolver'
-import { OPTIMIZABLE_ENTRY_RE, SPECIAL_QUERY_RE } from '../constants'
+import { SPECIAL_QUERY_RE } from '../constants'
 
 export function createOptimizeDepsIncludeResolver(
   environment: Environment,
@@ -40,18 +40,16 @@ export function createOptimizeDepsIncludeResolver(
     const deepMatch = deepImportRE.exec(id)
     const pkgId = deepMatch ? deepMatch[1] || deepMatch[2] : cleanUrl(id)
 
-    const isJsType = OPTIMIZABLE_ENTRY_RE.test(resolvedId)
-
-    const exclude = environment.config.optimizeDeps?.exclude
+    const exclude = environment.config.optimizeDeps.exclude
 
     const skipOptimization =
-      !isJsType ||
+      !optimizable ||
       (importer && isInNodeModules(importer)) ||
       exclude?.includes(pkgId) ||
       exclude?.includes(id) ||
       SPECIAL_QUERY_RE.test(resolvedId)
 
-    return { id: resolvedId, optimizable: optimizable && !skipOptimization }
+    return { id: resolvedId, optimizable: !skipOptimization }
   }
 
   return async (id: string) => {

--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -2,18 +2,11 @@ import path from 'node:path'
 import micromatch from 'micromatch'
 import { globSync } from 'tinyglobby'
 import type { ResolvedConfig } from '../config'
-import {
-  deepImportRE,
-  escapeRegex,
-  getNpmPackageName,
-  isInNodeModules,
-  isOptimizable,
-} from '../utils'
+import { escapeRegex, getNpmPackageName, isOptimizable } from '../utils'
 import { resolvePackageData } from '../packages'
-import { cleanUrl, slash } from '../../shared/utils'
+import { slash } from '../../shared/utils'
 import type { Environment } from '../environment'
 import { createBackCompatIdResolver } from '../idResolver'
-import { SPECIAL_QUERY_RE } from '../constants'
 
 export function createOptimizeDepsIncludeResolver(
   environment: Environment,
@@ -33,23 +26,7 @@ export function createOptimizeDepsIncludeResolver(
       environment.config.optimizeDeps,
     )
 
-    if (environment.config.consumer !== 'server') {
-      return { id: resolvedId, optimizable }
-    }
-
-    const deepMatch = deepImportRE.exec(id)
-    const pkgId = deepMatch ? deepMatch[1] || deepMatch[2] : cleanUrl(id)
-
-    const exclude = environment.config.optimizeDeps.exclude
-
-    const skipOptimization =
-      !optimizable ||
-      (importer && isInNodeModules(importer)) ||
-      exclude?.includes(pkgId) ||
-      exclude?.includes(id) ||
-      SPECIAL_QUERY_RE.test(resolvedId)
-
-    return { id: resolvedId, optimizable: !skipOptimization }
+    return { id: resolvedId, optimizable }
   }
 
   return async (id: string) => {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -878,11 +878,9 @@ export function tryNodeResolve(
     // can cache it without re-validation, but only do so for known js types.
     // otherwise we may introduce duplicated modules for externalized files
     // from pre-bundled deps.
-    if (!isBuild) {
-      const versionHash = depsOptimizer.metadata.browserHash
-      if (versionHash && isJsType) {
-        resolved = injectQuery(resolved, `v=${versionHash}`)
-      }
+    const versionHash = depsOptimizer.metadata.browserHash
+    if (versionHash && isJsType) {
+      resolved = injectQuery(resolved, `v=${versionHash}`)
     }
   } else {
     // this is a missing import, queue optimize-deps re-run and
@@ -891,16 +889,7 @@ export function tryNodeResolve(
     resolved = depsOptimizer.getOptimizedDepId(optimizedInfo)
   }
 
-  if (!options.idOnly && isBuild) {
-    // Resolve package side effects for build so that rollup can better
-    // perform tree-shaking
-    return {
-      id: resolved,
-      moduleSideEffects: pkg.hasSideEffects(resolved),
-    }
-  } else {
-    return { id: resolved }
-  }
+  return { id: resolved }
 }
 
 export async function tryOptimizedResolve(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -843,10 +843,7 @@ export function tryNodeResolve(
     return { ...resolved, id: resolvedId, external: true }
   }
 
-  if (
-    !options.idOnly &&
-    ((!options.scan && isBuild && !depsOptimizer) || externalize)
-  ) {
+  if (!options.idOnly && ((!options.scan && isBuild) || externalize)) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return processResult({
@@ -894,7 +891,7 @@ export function tryNodeResolve(
     resolved = depsOptimizer.getOptimizedDepId(optimizedInfo)
   }
 
-  if (!options.idOnly && !options.scan && isBuild) {
+  if (!options.idOnly && isBuild) {
     // Resolve package side effects for build so that rollup can better
     // perform tree-shaking
     return {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -11,7 +11,6 @@ import {
   DEP_VERSION_RE,
   ENV_ENTRY,
   FS_PREFIX,
-  OPTIMIZABLE_ENTRY_RE,
   SPECIAL_QUERY_RE,
 } from '../constants'
 import {
@@ -865,14 +864,11 @@ export function tryNodeResolve(
   }
 
   // if we reach here, it's a valid dep import that hasn't been optimized.
-  const isJsType = depsOptimizer
-    ? isOptimizable(resolved, depsOptimizer.options)
-    : OPTIMIZABLE_ENTRY_RE.test(resolved)
-
-  const exclude = depsOptimizer?.options.exclude
+  const isJsType = isOptimizable(resolved, depsOptimizer.options)
+  const exclude = depsOptimizer.options.exclude
 
   const skipOptimization =
-    depsOptimizer?.options.noDiscovery ||
+    depsOptimizer.options.noDiscovery ||
     !isJsType ||
     (importer && isInNodeModules(importer)) ||
     exclude?.includes(pkgId) ||
@@ -886,7 +882,7 @@ export function tryNodeResolve(
     // otherwise we may introduce duplicated modules for externalized files
     // from pre-bundled deps.
     if (!isBuild) {
-      const versionHash = depsOptimizer!.metadata.browserHash
+      const versionHash = depsOptimizer.metadata.browserHash
       if (versionHash && isJsType) {
         resolved = injectQuery(resolved, `v=${versionHash}`)
       }
@@ -894,8 +890,8 @@ export function tryNodeResolve(
   } else {
     // this is a missing import, queue optimize-deps re-run and
     // get a resolved its optimized info
-    const optimizedInfo = depsOptimizer!.registerMissingImport(id, resolved)
-    resolved = depsOptimizer!.getOptimizedDepId(optimizedInfo)
+    const optimizedInfo = depsOptimizer.registerMissingImport(id, resolved)
+    resolved = depsOptimizer.getOptimizedDepId(optimizedInfo)
   }
 
   if (!options.idOnly && !options.scan && isBuild) {
@@ -906,7 +902,7 @@ export function tryNodeResolve(
       moduleSideEffects: pkg.hasSideEffects(resolved),
     }
   } else {
-    return { id: resolved! }
+    return { id: resolved }
   }
 }
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -926,9 +926,7 @@ export function tryNodeResolve(
   }
 
   // if we reach here, it's a valid dep import that hasn't been optimized.
-  const isJsType = depsOptimizer
-    ? isOptimizable(resolved, depsOptimizer.options)
-    : OPTIMIZABLE_ENTRY_RE.test(resolved)
+  const isJsType = OPTIMIZABLE_ENTRY_RE.test(resolved)
 
   const exclude = depsOptimizerOptions?.exclude
 


### PR DESCRIPTION
### Description

I started this PR as a refactor but turned out that I can fix a bug that will simplify the code more.

The bug is that `optimizeDeps.include: ['foo > bar']` was not working only for SSR.
`ssrOptimizeCheck` is set at this line.
https://github.com/vitejs/vite/blob/2c10f9a452d181ce0612f62491211befad6e8a9e/packages/vite/src/node/optimizer/resolve.ts#L18
That makes this condition to be used and
https://github.com/vitejs/vite/blob/2c10f9a452d181ce0612f62491211befad6e8a9e/packages/vite/src/node/plugins/resolve.ts#L896
because we pass the `absolute/path/to/foo/package.json` as a importer
https://github.com/vitejs/vite/blob/2c10f9a452d181ce0612f62491211befad6e8a9e/packages/vite/src/node/optimizer/resolve.ts#L38
that condition is always `true` for nested selectors.
So all dependencies specified with nested selectors in `optimizeDeps.include` will be skipped.
The purpose of using `skipOptimization` for SSR seems to be to only optimize CJS deps (https://github.com/vitejs/vite/pull/8932). But this is not the case anymore since #18358 and probably can be removed.

---

Commits in this PR other than 817640e0840a3b85eef67cf00bd03fccca8bf52d should not change any behavior.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
