### PR TITLE
fix(scss): improve error logs

### DIFF
--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -201,7 +201,7 @@ const createTemplate = () =>
   )
 
 const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
-const codeframeRE = /^(?:>?\s*\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
+const codeframeRE = /^(?:>?\s*\d+\s+[|│╷╵].*|\s+[|│╷╵]\s*\^.*|\s*[|│╷╵])\r?\n/gm
 
 // Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
 // `HTMLElement` was not originally defined.

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -201,7 +201,7 @@ const createTemplate = () =>
   )
 
 const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g
-const codeframeRE = /^(?:>?\s*\d+\s+[|│╷╵].*|\s+[|│╷╵]\s*\^.*|\s*[|│╷╵])\r?\n/gm
+const codeframeRE = /^(?:>?\s*\d+\s+\|.*|\s+\|\s*\^.*)\r?\n/gm
 
 // Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
 // `HTMLElement` was not originally defined.

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2539,6 +2539,12 @@ const scssProcessor = (
         e.message = `[sass] ${e.message}`
         e.id = e.file
         e.frame = e.formatted
+        // modern api lacks `line` and `column` property. extract from `span`.
+        // NOTE: the values are 0-based so +1 is required.
+        if (e.span?.start) {
+          e.line = e.span.start.line + 1
+          e.column = e.span.start.column + 1
+        }
         return { code: '', error: e, deps: [] }
       }
     },

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2536,19 +2536,18 @@ const scssProcessor = (
         }
       } catch (e) {
         // normalize SASS error
-        // extract the part before the trace as we'll manually generate it ourselves
-        const messageFrameStart = e.message.indexOf('╷')
-        e.message = `[sass] ${
-          messageFrameStart > 0
-            ? e.message.slice(0, messageFrameStart).trim()
-            : e.message
-        }`
+        e.message = `[sass] ${e.message}`
         e.id = e.file
-        // modern api lacks `line` and `column` property. extract from `span`.
+        e.frame = e.formatted
+        // modern api lacks `line` and `column` property. extract from `e.span`.
         // NOTE: the values are 0-based so +1 is required.
         if (e.span?.start) {
           e.line = e.span.start.line + 1
           e.column = e.span.start.column + 1
+          // it also lacks `e.formatted`, so we shim with the message here since
+          // sass error messages have the frame already in them and we don't want
+          // to re-generate a new frame (same as legavy api)
+          e.frame = e.message
         }
         return { code: '', error: e, deps: [] }
       }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2536,9 +2536,14 @@ const scssProcessor = (
         }
       } catch (e) {
         // normalize SASS error
-        e.message = `[sass] ${e.message}`
+        // extract the part before the trace as we'll manually generate it ourselves
+        const messageFrameStart = e.message.indexOf('╷')
+        e.message = `[sass] ${
+          messageFrameStart > 0
+            ? e.message.slice(0, messageFrameStart).trim()
+            : e.message
+        }`
         e.id = e.file
-        e.frame = e.formatted
         // modern api lacks `line` and `column` property. extract from `span`.
         // NOTE: the values are 0-based so +1 is required.
         if (e.span?.start) {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2563,7 +2563,7 @@ const scssProcessor = (
           e.column = e.span.start.column + 1
           // it also lacks `e.formatted`, so we shim with the message here since
           // sass error messages have the frame already in them and we don't want
-          // to re-generate a new frame (same as legavy api)
+          // to re-generate a new frame (same as legacy api)
           e.frame = e.message
         }
         return { code: '', error: e, deps: [] }


### PR DESCRIPTION
### Description

There's 3 commits in this PR:

1. Add `e.line` and `e.column` to error object when compiler with scss modern api. It's missing by default which makes the file name open-in-editor not have the line/col. (Astro had a test that expected the positional info to exist. I don't think this is a breaking change, but figured nice to fix anyway)
2. (and 3) I fiddled with making the error overlay look better because with no1, modern api error will cause Vite to regenerate a code frame, causing two code frames to appear. At the end, I shimmed `e.frame = e.message` to prevent it (mimicking same behaviour as legacy api for now)

I think the error messages could be a little better for css preprocessors, but it's a bit subjective so i didn't want to make a too drastic change for now.

<details>
<summary>Before (legacy)</summary>

<img width="913" alt="image" src="https://github.com/user-attachments/assets/912b8a75-4e10-4c6d-9f4d-a7e63ea8f7c9">



</details>

<details>
<summary>Before (modern)</summary>

<img width="912" alt="image" src="https://github.com/user-attachments/assets/432d9749-eda4-439b-808c-38b1e9a3decb">


</details>

<details>
<summary>After (legacy)</summary>

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/bf4faeda-df72-44d8-a7e4-c9a3e2bd995e">



</details>

<details>
<summary>After (modern)</summary>

<img width="1015" alt="image" src="https://github.com/user-attachments/assets/3ec914a8-4115-4489-8154-43719af93043">




</details>