### PR TITLE
refactor: client-only top-level warmup

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -966,15 +966,16 @@ export async function resolveConfig(
   // Merge default environment config values
   const defaultEnvironmentOptions = getDefaultEnvironmentOptions(config)
   // Some top level options only apply to the client environment
-  const defaultClientEnvironmentOptions = {
+  const defaultClientEnvironmentOptions: UserConfig = {
     ...defaultEnvironmentOptions,
     optimizeDeps: config.optimizeDeps,
   }
-  const defaultNonClientEnvironmentOptions = {
+  const defaultNonClientEnvironmentOptions: UserConfig = {
     ...defaultEnvironmentOptions,
     dev: {
       ...defaultEnvironmentOptions.dev,
       createEnvironment: undefined,
+      warmup: undefined,
     },
     build: {
       ...defaultEnvironmentOptions.build,


### PR DESCRIPTION
### Description

I think this is the last one, once we merge the `resolve.conditions` PR (if that has `mainFields` too).

Reference https://github.com/vitejs/vite/pull/18465