### PR TITLE
chore(plugin-legacy): add type module in package.json

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vitejs/plugin-legacy",
   "version": "5.4.3",
+  "type": "module",
   "license": "MIT",
   "author": "Evan You",
   "files": [


### PR DESCRIPTION
### Description

publint warns when the `type` isn't set. It's also safe for us to set `"type": "module"` here as we're publishing files with strict extensions like `.mjs` and `.cjs`.