### PR TITLE
docs: optimize home page styles

### DIFF
--- a/docs/.vitepress/theme/styles/landing.css
+++ b/docs/.vitepress/theme/styles/landing.css
@@ -4,11 +4,14 @@
 
 html:has(.landing) {
   background-color: #101010;
-  --vp-c-bg: #101010;
 
   body {
     background-color: #101010;
   }
+}
+
+html.dark:has(.landing) {
+  --vp-c-bg: #101010;
 }
 
 .landing {
@@ -37,7 +40,12 @@ html:has(.landing) {
 
     .content-body {
       background: none !important;
+      transition: none;
     }
+  }
+
+  .VPNavBar *:not(.wrapper *) {
+    transition: none;
   }
 
   .VPFooter {
@@ -55,6 +63,10 @@ html:has(.landing) {
   /* /////////////// */
 
   .VPNavBarAppearance {
+    display: none;
+  }
+
+  .VPMenu .translations + .group {
     display: none;
   }
 


### PR DESCRIPTION
#### The reasons for the change are as follows (Will not affect other codes):

- Please expand for before and after comparison

<details>
  <summary>1、Non-dark mode display abnormality</summary>

#### before
![image](https://github.com/user-attachments/assets/82fe3cf8-5ce9-497d-b2fa-ca2ab484149d)
#### after
![image](https://github.com/user-attachments/assets/039c746b-a08a-4990-bb78-878c37adb85c)

</details>

```css
html.dark:has(.landing) {
  --vp-c-bg: #101010;
}
```


<details>
  <summary>2、Switching to the home page, the transition animation of the header is stiff</summary>

#### before
![screenshots](https://github.com/user-attachments/assets/9e1b972a-78c0-4e6c-9641-658812f64fd0)
#### after
![screenshots](https://github.com/user-attachments/assets/867bb72d-ae24-45e6-bc37-5d2af26edc81)

</details>

```css
transition: none;

.VPNavBar *:not(.wrapper *) {
  transition: none;
}
```


<details>
  <summary>3、Appearance Small screen display is meaningless</summary>

#### before
![image](https://github.com/user-attachments/assets/c5b5b45d-77df-423d-8185-ee4c85931d77)
#### after
![image](https://github.com/user-attachments/assets/f7e39dbc-5a9e-4523-b964-104384408263)

</details>

```css
.VPMenu .translations + .group {
  display: none;
}
```
