### PR TITLE
fix(json): don't `json.stringify` arrays

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/json.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/json.spec.ts
@@ -35,6 +35,22 @@ describe('transform', () => {
     return (plugin.transform! as Function)(input, 'test.json').code
   }
 
+  test("namedExports: true, stringify: 'auto' should not transformed an array input", () => {
+    const actualSmall = transform(
+      '[{"a":1,"b":2}]',
+      { namedExports: true, stringify: 'auto' },
+      false,
+    )
+    expect(actualSmall).toMatchInlineSnapshot(`
+"export default [
+	{
+		a: 1,
+		b: 2
+	}
+];"
+    `)
+  })
+
   test('namedExports: true, stringify: false', () => {
     const actual = transform(
       '{"a":1,\n"🫠": "",\n"const": false}',

--- a/packages/vite/src/node/__tests__/plugins/json.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/json.spec.ts
@@ -51,6 +51,17 @@ describe('transform', () => {
     `)
   })
 
+  test('namedExports: true, stringify: true should not transformed an array input', () => {
+    const actualSmall = transform(
+      '[{"a":1,"b":2}]',
+      { namedExports: true, stringify: true },
+      false,
+    )
+    expect(actualSmall).toMatchInlineSnapshot(
+      `"export default JSON.parse("[{\\"a\\":1,\\"b\\":2}]")"`,
+    )
+  })
+
   test('namedExports: true, stringify: false', () => {
     const actual = transform(
       '{"a":1,\n"🫠": "",\n"const": false}',

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -29,6 +29,8 @@ export interface JsonOptions {
 // Custom json filter for vite
 const jsonExtRE = /\.json(?:$|\?)(?!commonjs-(?:proxy|external))/
 
+const jsonObjRE = /^\s*\{/
+
 const jsonLangs = `\\.(?:json|json5)(?:$|\\?)`
 const jsonLangRE = new RegExp(jsonLangs)
 export const isJSONRequest = (request: string): boolean =>
@@ -49,7 +51,7 @@ export function jsonPlugin(
 
       try {
         if (options.stringify !== false) {
-          if (options.namedExports && /^\s*\{/.test(json)) {
+          if (options.namedExports && jsonObjRE.test(json)) {
             const parsed = JSON.parse(json)
             const keys = Object.keys(parsed)
 

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -48,8 +48,8 @@ export function jsonPlugin(
       json = stripBomTag(json)
 
       try {
-        if (options.stringify !== false && /^\s*\{/.test(json)) {
-          if (options.namedExports) {
+        if (options.stringify !== false) {
+          if (options.namedExports && /^\s*\{/.test(json)) {
             const parsed = JSON.parse(json)
             if (typeof parsed === 'object' && parsed != null) {
               const keys = Object.keys(parsed)

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -51,26 +51,24 @@ export function jsonPlugin(
         if (options.stringify !== false) {
           if (options.namedExports && /^\s*\{/.test(json)) {
             const parsed = JSON.parse(json)
-            if (typeof parsed === 'object' && parsed != null) {
-              const keys = Object.keys(parsed)
+            const keys = Object.keys(parsed)
 
-              let code = ''
-              let defaultObjectCode = '{\n'
-              for (const key of keys) {
-                if (key === makeLegalIdentifier(key)) {
-                  code += `export const ${key} = ${serializeValue(parsed[key])};\n`
-                  defaultObjectCode += `  ${key},\n`
-                } else {
-                  defaultObjectCode += `  ${JSON.stringify(key)}: ${serializeValue(parsed[key])},\n`
-                }
+            let code = ''
+            let defaultObjectCode = '{\n'
+            for (const key of keys) {
+              if (key === makeLegalIdentifier(key)) {
+                code += `export const ${key} = ${serializeValue(parsed[key])};\n`
+                defaultObjectCode += `  ${key},\n`
+              } else {
+                defaultObjectCode += `  ${JSON.stringify(key)}: ${serializeValue(parsed[key])},\n`
               }
-              defaultObjectCode += '}'
+            }
+            defaultObjectCode += '}'
 
-              code += `export default ${defaultObjectCode};\n`
-              return {
-                code,
-                map: { mappings: '' },
-              }
+            code += `export default ${defaultObjectCode};\n`
+            return {
+              code,
+              map: { mappings: '' },
             }
           }
 

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -51,7 +51,11 @@ export function jsonPlugin(
         if (options.stringify !== false) {
           if (options.namedExports) {
             const parsed = JSON.parse(json)
-            if (typeof parsed === 'object' && parsed != null && !Array.isArray(parsed)) {
+            if (
+              typeof parsed === 'object' &&
+              parsed != null &&
+              !Array.isArray(parsed)
+            ) {
               const keys = Object.keys(parsed)
 
               let code = ''

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -48,14 +48,10 @@ export function jsonPlugin(
       json = stripBomTag(json)
 
       try {
-        if (options.stringify !== false) {
+        if (options.stringify !== false && /^\s*\{/.test(json)) {
           if (options.namedExports) {
             const parsed = JSON.parse(json)
-            if (
-              typeof parsed === 'object' &&
-              parsed != null &&
-              !Array.isArray(parsed)
-            ) {
+            if (typeof parsed === 'object' && parsed != null) {
               const keys = Object.keys(parsed)
 
               let code = ''

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -51,7 +51,7 @@ export function jsonPlugin(
         if (options.stringify !== false) {
           if (options.namedExports) {
             const parsed = JSON.parse(json)
-            if (typeof parsed === 'object' && parsed != null) {
+            if (typeof parsed === 'object' && parsed != null && !Array.isArray(parsed)) {
               const keys = Object.keys(parsed)
 
               let code = ''


### PR DESCRIPTION
### Description

fixes #18533

importing an array from a JSON file shouldn't be converted to object and we shouldn't need to stringify them

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
