### PR TITLE
fix(client): detect ws close correctly

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -91,9 +91,19 @@ function setupWebSocket(
     handleMessage(JSON.parse(data))
   })
 
+  let willUnload = false
+  window.addEventListener(
+    'beforeunload',
+    () => {
+      willUnload = true
+    },
+    { once: true },
+  )
+
   // ping server
-  socket.addEventListener('close', async ({ wasClean }) => {
-    if (wasClean) return
+  socket.addEventListener('close', async () => {
+    // ignore close caused by top-level navigation
+    if (willUnload) return
 
     if (!isOpened && onCloseWithoutOpen) {
       onCloseWithoutOpen()


### PR DESCRIPTION
### Description

The client was checking [`wasClean` property](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent/wasClean) of the close event to detect WebSocket disconnection on top-level navigation (#1872). But `wasClean: true` can happen for other reasons.

I changed that condition to use a variable set by `beforeUnload` event.

Applying this patch makes https://github.com/sapphi-red/vite-setup-catalogue/pull/13 pass (https://github.com/sapphi-red/vite-setup-catalogue/pull/13/commits/3fa0baa51f50cda1ac216d206933c09445cb5bdc).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
