### PR TITLE
fix: use `server.perEnvironmentStartEndDuringDev`

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -283,7 +283,7 @@ class EnvironmentPluginContainer {
     hookName: H,
     context: (plugin: Plugin) => ThisType<FunctionPluginHooks[H]>,
     args: (plugin: Plugin) => Parameters<FunctionPluginHooks[H]>,
-    condition?: (plugin: Plugin) => boolean,
+    condition?: (plugin: Plugin) => boolean | undefined,
   ): Promise<void> {
     const parallelPromises: Promise<unknown>[] = []
     for (const plugin of this.getSortedPlugins(hookName)) {
@@ -321,7 +321,7 @@ class EnvironmentPluginContainer {
         (plugin) =>
           this.environment.name === 'client' ||
           config.server.perEnvironmentStartEndDuringDev ||
-          plugin.perEnvironmentStartEndDuringDev === true,
+          plugin.perEnvironmentStartEndDuringDev,
       ),
     ) as Promise<void>
     await this._buildStartPromise
@@ -522,7 +522,7 @@ class EnvironmentPluginContainer {
       (plugin) =>
         this.environment.name === 'client' ||
         config.server.perEnvironmentStartEndDuringDev ||
-        plugin.perEnvironmentStartEndDuringDev === true,
+        plugin.perEnvironmentStartEndDuringDev,
     )
     await this.hookParallel(
       'closeBundle',

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -312,6 +312,7 @@ class EnvironmentPluginContainer {
       return
     }
     this._started = true
+    const config = this.environment.getTopLevelConfig()
     this._buildStartPromise = this.handleHookPromise(
       this.hookParallel(
         'buildStart',
@@ -319,6 +320,7 @@ class EnvironmentPluginContainer {
         () => [this.options as NormalizedInputOptions],
         (plugin) =>
           this.environment.name === 'client' ||
+          config.server.perEnvironmentStartEndDuringDev ||
           plugin.perEnvironmentStartEndDuringDev === true,
       ),
     ) as Promise<void>
@@ -512,13 +514,15 @@ class EnvironmentPluginContainer {
     if (this._closed) return
     this._closed = true
     await Promise.allSettled(Array.from(this._processesing))
+    const config = this.environment.getTopLevelConfig()
     await this.hookParallel(
       'buildEnd',
       (plugin) => this._getPluginContext(plugin),
       () => [],
       (plugin) =>
         this.environment.name === 'client' ||
-        plugin.perEnvironmentStartEndDuringDev !== true,
+        config.server.perEnvironmentStartEndDuringDev ||
+        plugin.perEnvironmentStartEndDuringDev === true,
     )
     await this.hookParallel(
       'closeBundle',


### PR DESCRIPTION
### Description

`server.perEnvironmentStartEndDuringDev` was not used anywhere.

refs https://github.com/vitejs/vite/pull/18491#discussion_r1819975103

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
