### PR TITLE
docs: add bluesky profiles

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -141,8 +141,9 @@ export default defineConfig({
     },
 
     socialLinks: [
+      { icon: 'bluesky', link: 'https://bsky.app/profile/vite.dev' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@vite' },
-      { icon: 'twitter', link: 'https://twitter.com/vite_js' },
+      { icon: 'x', link: 'https://x.com/vite_js' },
       { icon: 'discord', link: 'https://chat.vite.dev' },
       { icon: 'github', link: 'https://github.com/vitejs/vite' },
     ],
@@ -179,12 +180,16 @@ export default defineConfig({
           {
             items: [
               {
+                text: 'Bluesky',
+                link: 'https://bsky.app/profile/vite.dev',
+              },
+              {
                 text: 'Mastodon',
                 link: 'https://elk.zone/m.webtoo.ls/@vite',
               },
               {
-                text: 'Twitter',
-                link: 'https://twitter.com/vite_js',
+                text: 'X',
+                link: 'https://x.com/vite_js',
               },
               {
                 text: 'Discord Chat',

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -8,7 +8,8 @@ export const core = [
     desc: 'Independent open source developer, creator of Vue.js and Vite.',
     links: [
       { icon: 'github', link: 'https://github.com/yyx990803' },
-      { icon: 'twitter', link: 'https://twitter.com/youyuxi' },
+      { icon: 'x', link: 'https://x.com/youyuxi' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/evanyou.me' },
     ],
     sponsor: 'https://github.com/sponsors/yyx990803',
   },
@@ -21,8 +22,9 @@ export const core = [
     desc: 'Core team member of Vite. Team member of Vue.',
     links: [
       { icon: 'github', link: 'https://github.com/patak-dev' },
-      { icon: 'twitter', link: 'https://twitter.com/patak_dev' },
+      { icon: 'x', link: 'https://x.com/patak_dev' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@patak' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/patak.dev' },
     ],
     sponsor: 'https://github.com/sponsors/patak-dev',
   },
@@ -35,8 +37,9 @@ export const core = [
     desc: 'Core team member of Vite & Vue. Working at NuxtLabs.',
     links: [
       { icon: 'github', link: 'https://github.com/antfu' },
-      { icon: 'twitter', link: 'https://twitter.com/antfu7' },
+      { icon: 'x', link: 'https://x.com/antfu7' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@antfu' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/antfu.me' },
     ],
     sponsor: 'https://github.com/sponsors/antfu',
   },
@@ -47,8 +50,9 @@ export const core = [
     desc: 'Astro core residency. Svelte and Vite core team member.',
     links: [
       { icon: 'github', link: 'https://github.com/bluwy' },
-      { icon: 'twitter', link: 'https://twitter.com/bluwyoo' },
+      { icon: 'x', link: 'https://x.com/bluwyoo' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@bluwy' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },
     ],
     sponsor: 'https://bjornlu.com/sponsor',
   },
@@ -59,7 +63,7 @@ export const core = [
     desc: 'Vite core team member. Call me sapphi or green or midori ;)',
     links: [
       { icon: 'github', link: 'https://github.com/sapphi-red' },
-      { icon: 'twitter', link: 'https://twitter.com/sapphi_red' },
+      { icon: 'x', link: 'https://x.com/sapphi_red' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@sapphi_red' },
     ],
     sponsor: 'https://github.com/sponsors/sapphi-red',
@@ -71,8 +75,12 @@ export const core = [
     desc: 'Passionate by tooling around TypeScript and React.',
     links: [
       { icon: 'github', link: 'https://github.com/ArnaudBarre' },
-      { icon: 'twitter', link: 'https://twitter.com/_ArnaudBarre' },
+      { icon: 'x', link: 'https://x.com/_ArnaudBarre' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@ArnaudBarre' },
+      {
+        icon: 'bluesky',
+        link: 'https://bsky.app/profile/arnaud-barre.bsky.social',
+      },
     ],
     sponsor: 'https://github.com/sponsors/ArnaudBarre',
   },
@@ -94,8 +102,8 @@ export const core = [
     desc: 'An open source fullstack developer',
     links: [
       { icon: 'github', link: 'https://github.com/sheremet-va' },
+      { icon: 'x', link: 'https://x.com/sheremet_va' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@sheremet_va' },
-      { icon: 'twitter', link: 'https://twitter.com/sheremet_va' },
     ],
     sponsor: 'https://github.com/sponsors/sheremet-va',
   },
@@ -106,7 +114,7 @@ export const core = [
     desc: 'Open source enthusiast',
     links: [
       { icon: 'github', link: 'https://github.com/hi-ogawa' },
-      { icon: 'twitter', link: 'https://twitter.com/hiroshi_18181' },
+      { icon: 'x', link: 'https://x.com/hiroshi_18181' },
     ],
     sponsor: 'https://github.com/sponsors/hi-ogawa',
   },
@@ -120,7 +128,11 @@ export const emeriti = [
     desc: 'Dabbling in social ecommerce, meta frameworks, and board games',
     links: [
       { icon: 'github', link: 'https://github.com/aleclarson' },
-      { icon: 'twitter', link: 'https://twitter.com/retropragma' },
+      { icon: 'x', link: 'https://x.com/retropragma' },
+      {
+        icon: 'bluesky',
+        link: 'https://bsky.app/profile/retropragma.bsky.social',
+      },
     ],
   },
   {
@@ -130,7 +142,7 @@ export const emeriti = [
     desc: 'Frontend. Vite team member.',
     links: [
       { icon: 'github', link: 'https://github.com/poyoho' },
-      { icon: 'twitter', link: 'https://twitter.com/yoho_po' },
+      { icon: 'x', link: 'https://x.com/yoho_po' },
     ],
   },
   {
@@ -140,7 +152,7 @@ export const emeriti = [
     desc: 'Web Developer. Vue & Vite team member',
     links: [
       { icon: 'github', link: 'https://github.com/ygj6' },
-      { icon: 'twitter', link: 'https://twitter.com/ygj_66' },
+      { icon: 'x', link: 'https://x.com/ygj_66' },
     ],
   },
   {
@@ -151,7 +163,8 @@ export const emeriti = [
     desc: 'weeb/javascript lover.',
     links: [
       { icon: 'github', link: 'https://github.com/Niputi' },
-      { icon: 'twitter', link: 'https://twitter.com/Niputi_' },
+      { icon: 'x', link: 'https://x.com/Niputi_' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/niputi.bsky.social' },
     ],
   },
   {
@@ -164,7 +177,10 @@ export const emeriti = [
     avatar: 'https://github.com/GrygrFlzr.png',
     name: 'GrygrFlzr',
     title: 'Developer',
-    links: [{ icon: 'github', link: 'https://github.com/GrygrFlzr' }],
+    links: [
+      { icon: 'github', link: 'https://github.com/GrygrFlzr' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/bsky.cybeast.dev' },
+    ],
   },
   {
     avatar: 'https://github.com/nihalgonsalves.png',
@@ -193,8 +209,9 @@ export const emeriti = [
     desc: 'Vue/Vite team member. Full-time open sourcerer.',
     links: [
       { icon: 'github', link: 'https://github.com/sodatea' },
-      { icon: 'twitter', link: 'https://twitter.com/haoqunjiang' },
+      { icon: 'x', link: 'https://x.com/haoqunjiang' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@haoqun' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/haoqun.dev' },
     ],
     sponsor: 'https://github.com/sponsors/sodatea',
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "@shikijs/vitepress-twoslash": "^1.22.2",
     "@types/express": "^4.17.21",
     "feed": "^4.2.2",
-    "vitepress": "1.4.5",
+    "vitepress": "^1.5.0",
     "vitepress-plugin-group-icons": "^1.3.0",
     "vue": "^3.5.12"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2
       vitepress:
-        specifier: 1.4.5
-        version: 1.4.5(@algolia/client-search@4.20.0)(@types/react@18.3.12)(axios@1.7.7)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)
+        specifier: ^1.5.0
+        version: 1.5.0(@algolia/client-search@4.20.0)(@types/react@18.3.12)(axios@1.7.7)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)
       vitepress-plugin-group-icons:
         specifier: ^1.3.0
         version: 1.3.0
@@ -2622,6 +2622,9 @@ packages:
 
   '@iconify-json/logos@1.2.3':
     resolution: {integrity: sha512-JLHS5hgZP1b55EONAWNeqBUuriRfRNKWXK4cqYx0PpVaJfIIMiiMxFfvoQiX/bkE9XgkLhcKmDUqL3LXPdXPwQ==}
+
+  '@iconify-json/simple-icons@1.2.10':
+    resolution: {integrity: sha512-9OK1dsSjXlH36lhu5n+BlSoXuqFjHUErGLtNdzHpq0vHq4YFBuGYWtZ+vZTHLreRQ8ijPRv/6EsgkV+nf6AReQ==}
 
   '@iconify-json/vscode-icons@1.2.2':
     resolution: {integrity: sha512-bTpT0HJDRqGkxQv8oiETNHLEnBZpnA1QaRD35CQyO7M7qgWVLx2xwn/lK6e4waojmlPC3ckMBx3WFIUUn0/Jdg==}
@@ -6858,8 +6861,8 @@ packages:
   vitepress-plugin-group-icons@1.3.0:
     resolution: {integrity: sha512-E6Up5HyWh0gxmy2v1v1VVzQpL9UOZuHgoqOmSNBMTRv2rSwg6nk8MeIiJD0tJ0xtWrY5dwG69ENZPyFoD+fVoA==}
 
-  vitepress@1.4.5:
-    resolution: {integrity: sha512-9K0k8kvdEbeowVCpKF/x0AySSq0Pr9pM8xufLgQcKMjsifwxtDjXJjcFhZv4LYw2dcpdYiBq2j7PnWi0tCaMCg==}
+  vitepress@1.5.0:
+    resolution: {integrity: sha512-q4Q/G2zjvynvizdB3/bupdYkCJe2umSAMv9Ju4d92E6/NXJ59z70xB0q5p/4lpRyAwflDsbwy1mLV9Q5+nlB+g==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -8069,6 +8072,10 @@ snapshots:
   '@hutson/parse-repository-url@5.0.0': {}
 
   '@iconify-json/logos@1.2.3':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/simple-icons@1.2.10':
     dependencies:
       '@iconify/types': 2.0.0
 
@@ -12603,10 +12610,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.4.5(@algolia/client-search@4.20.0)(@types/react@18.3.12)(axios@1.7.7)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2):
+  vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/react@18.3.12)(axios@1.7.7)(postcss@8.4.47)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2):
     dependencies:
       '@docsearch/css': 3.6.2
       '@docsearch/js': 3.6.2(@algolia/client-search@4.20.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@iconify-json/simple-icons': 1.2.10
       '@shikijs/core': 1.22.2
       '@shikijs/transformers': 1.22.2
       '@shikijs/types': 1.22.2


### PR DESCRIPTION
### Description

Adds Bluesky profiles of vite and team members to docs and renames twitter to x 🫠

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/c6d88ac1-31d3-474c-b12b-b1bf8c3905a8">

\
I wasn't able to find everyone's profile on bsky. Please add if someone is there but not updated on the list.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
