### PR TITLE
fix: browser field should not be included by default for `consumer: 'server'`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -754,6 +754,12 @@ function resolveEnvironmentResolveOptions(
   // Backward compatibility
   isSsrTargetWebworkerEnvironment?: boolean,
 ): ResolvedAllResolveOptions {
+  let mainFields = resolve?.mainFields
+  mainFields ??=
+    consumer === 'client' || isSsrTargetWebworkerEnvironment
+      ? DEFAULT_MAIN_FIELDS
+      : DEFAULT_MAIN_FIELDS.filter((f) => f !== 'browser')
+
   let conditions = resolve?.conditions
   conditions ??=
     consumer === 'client' || isSsrTargetWebworkerEnvironment
@@ -761,7 +767,7 @@ function resolveEnvironmentResolveOptions(
       : DEFAULT_CONDITIONS.filter((c) => c !== 'browser')
 
   const resolvedResolve: ResolvedAllResolveOptions = {
-    mainFields: resolve?.mainFields ?? DEFAULT_MAIN_FIELDS,
+    mainFields,
     conditions,
     externalConditions:
       resolve?.externalConditions ?? DEFAULT_EXTERNAL_CONDITIONS,


### PR DESCRIPTION
### Description

This should have been done in #18395.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
