### PR TITLE
feat: add the `builtins` environment `resolve`

### DIFF
--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -59,7 +59,6 @@ describe('custom environment conditions', () => {
             noExternal,
             conditions: ['custom1'],
             externalConditions: ['custom1'],
-            builtins: ['my-env:custom-builtin'],
           },
           build: {
             outDir: path.join(
@@ -77,7 +76,6 @@ describe('custom environment conditions', () => {
             noExternal,
             conditions: ['custom1'],
             externalConditions: ['custom1'],
-            builtins: ['my-env:custom-builtin'],
           },
           build: {
             outDir: path.join(
@@ -141,27 +139,6 @@ describe('custom environment conditions', () => {
         "custom1_2": "index.custom1.js",
         "ssr": "index.default.js",
         "worker": "index.worker.js",
-      }
-    `)
-  })
-
-  test('dev builtins', async () => {
-    const server = await createServer(getConfig({ noExternal: true }))
-    onTestFinished(() => server.close())
-
-    const results: Record<string, unknown> = {}
-    for (const key of ['ssr', 'worker', 'custom1', 'custom1_2']) {
-      const resolved = await server.environments[key].pluginContainer.resolveId(
-        'my-env:custom-builtin',
-      )
-      results[key] = JSON.stringify(resolved)
-    }
-    expect(results).toMatchInlineSnapshot(`
-      {
-        "custom1": "{"id":"my-env:custom-builtin","external":true,"moduleSideEffects":false}",
-        "custom1_2": "{"id":"my-env:custom-builtin","external":true,"moduleSideEffects":false}",
-        "ssr": "null",
-        "worker": "null",
       }
     `)
   })

--- a/packages/vite/src/node/__tests__/environment.spec.ts
+++ b/packages/vite/src/node/__tests__/environment.spec.ts
@@ -59,6 +59,7 @@ describe('custom environment conditions', () => {
             noExternal,
             conditions: ['custom1'],
             externalConditions: ['custom1'],
+            builtins: ['my-env:custom-builtin'],
           },
           build: {
             outDir: path.join(
@@ -76,6 +77,7 @@ describe('custom environment conditions', () => {
             noExternal,
             conditions: ['custom1'],
             externalConditions: ['custom1'],
+            builtins: ['my-env:custom-builtin'],
           },
           build: {
             outDir: path.join(
@@ -139,6 +141,27 @@ describe('custom environment conditions', () => {
         "custom1_2": "index.custom1.js",
         "ssr": "index.default.js",
         "worker": "index.worker.js",
+      }
+    `)
+  })
+
+  test('dev builtins', async () => {
+    const server = await createServer(getConfig({ noExternal: true }))
+    onTestFinished(() => server.close())
+
+    const results: Record<string, unknown> = {}
+    for (const key of ['ssr', 'worker', 'custom1', 'custom1_2']) {
+      const resolved = await server.environments[key].pluginContainer.resolveId(
+        'my-env:custom-builtin',
+      )
+      results[key] = JSON.stringify(resolved)
+    }
+    expect(results).toMatchInlineSnapshot(`
+      {
+        "custom1": "{"id":"my-env:custom-builtin","external":true,"moduleSideEffects":false}",
+        "custom1_2": "{"id":"my-env:custom-builtin","external":true,"moduleSideEffects":false}",
+        "ssr": "null",
+        "worker": "null",
       }
     `)
   })

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -140,7 +140,7 @@ describe('file url', () => {
     async function run(
       customEnvBuiltins: NonNullable<EnvironmentOptions['resolve']>['builtins'],
       idToResolve: string,
-      envName = 'custom',
+      envName: 'client' | 'ssr' | string = 'custom',
     ) {
       const server = await createServer(getConfig(customEnvBuiltins))
       onTestFinished(() => server.close())
@@ -177,6 +177,16 @@ describe('file url', () => {
     test('default to node-like builtins', async () => {
       const resolved = await run(undefined, 'node:fs')
       expect(resolved?.external).toBe(true)
+    })
+
+    test('default to node-like builtins for ssr environment', async () => {
+      const resolved = await run(undefined, 'node:fs', 'ssr')
+      expect(resolved?.external).toBe(true)
+    })
+
+    test('no default to node-like builtins for client environment', async () => {
+      const resolved = await run(undefined, 'node:fs', 'client')
+      expect(resolved?.id).toEqual('__vite-browser-external:node:fs')
     })
 
     test('declared node builtin', async () => {

--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -119,7 +119,7 @@ describe('file url', () => {
   describe('environment builtins', () => {
     function getConfig(
       targetEnv: 'client' | 'ssr' | string,
-      customEnvBuiltins: NonNullable<EnvironmentOptions['resolve']>['builtins'],
+      builtins: NonNullable<EnvironmentOptions['resolve']>['builtins'],
     ): InlineConfig {
       return {
         configFile: false,
@@ -131,7 +131,7 @@ describe('file url', () => {
         environments: {
           [targetEnv]: {
             resolve: {
-              builtins: customEnvBuiltins,
+              builtins,
             },
           },
         },

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -882,14 +882,11 @@ function resolveEnvironmentResolveOptions(
         consumer === 'client' || isSsrTargetWebworkerEnvironment
           ? DEFAULT_CLIENT_CONDITIONS
           : DEFAULT_SERVER_CONDITIONS.filter((c) => c !== 'browser'),
-      enableBuiltinNoExternalCheck: !!isSsrTargetWebworkerEnvironment,
       builtins:
         resolve?.builtins ??
-        (consumer === 'server'
+        (consumer === 'server' && !isSsrTargetWebworkerEnvironment
           ? nodeLikeBuiltins
-          : [
-              // there are not built-in modules in the browser
-            ]),
+          : []),
     },
     resolve ?? {},
   )

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -71,6 +71,7 @@ import {
   mergeAlias,
   mergeConfig,
   mergeWithDefaults,
+  nodeLikeBuiltins,
   normalizeAlias,
   normalizePath,
 } from './utils'
@@ -283,7 +284,6 @@ export type ResolvedEnvironmentOptions = {
   optimizeDeps: DepOptimizationOptions
   dev: ResolvedDevEnvironmentOptions
   build: ResolvedBuildEnvironmentOptions
-  isBuiltin?: (id: string) => boolean
 }
 
 export type DefaultEnvironmentOptions = Omit<
@@ -773,7 +773,6 @@ function resolveEnvironmentOptions(
       resolve.preserveSymlinks,
       consumer,
     ),
-    isBuiltin: resolve.isBuiltin,
     dev: resolveDevEnvironmentOptions(
       options.dev,
       environmentName,
@@ -884,12 +883,13 @@ function resolveEnvironmentResolveOptions(
           ? DEFAULT_CLIENT_CONDITIONS
           : DEFAULT_SERVER_CONDITIONS.filter((c) => c !== 'browser'),
       enableBuiltinNoExternalCheck: !!isSsrTargetWebworkerEnvironment,
-      isBuiltin:
-        resolve?.isBuiltin ??
+      builtins:
+        resolve?.builtins ??
         (consumer === 'server'
-          ? isNodeLikeBuiltin
-          : // there are not built-in modules in the browser
-            () => false),
+          ? nodeLikeBuiltins
+          : [
+              // there are not built-in modules in the browser
+            ]),
     },
     resolve ?? {},
   )
@@ -1761,7 +1761,7 @@ async function bundleConfigFile(
               preserveSymlinks: false,
               packageCache,
               isRequire,
-              isBuiltin: isNodeLikeBuiltin,
+              builtins: nodeLikeBuiltins,
             })?.id
           }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -260,6 +260,11 @@ export interface SharedEnvironmentOptions {
    * Optimize deps config
    */
   optimizeDeps?: DepOptimizationOptions
+  /**
+   * Function to specify when modules should be considered built-in for the environment.
+   * (If not provided the node built-in modules are the only ones assumed as such)
+   */
+  isBuiltin?: (id: string) => boolean
 }
 
 export interface EnvironmentOptions extends SharedEnvironmentOptions {
@@ -283,6 +288,7 @@ export type ResolvedEnvironmentOptions = {
   optimizeDeps: DepOptimizationOptions
   dev: ResolvedDevEnvironmentOptions
   build: ResolvedBuildEnvironmentOptions
+  isBuiltin?: (id: string) => boolean
 }
 
 export type DefaultEnvironmentOptions = Omit<
@@ -772,6 +778,7 @@ function resolveEnvironmentOptions(
       resolve.preserveSymlinks,
       consumer,
     ),
+    isBuiltin: options.isBuiltin,
     dev: resolveDevEnvironmentOptions(
       options.dev,
       environmentName,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -885,9 +885,11 @@ function resolveEnvironmentResolveOptions(
           : DEFAULT_SERVER_CONDITIONS.filter((c) => c !== 'browser'),
       enableBuiltinNoExternalCheck: !!isSsrTargetWebworkerEnvironment,
       isBuiltin:
-        // Note: even client environments get the node-like isBuiltin
-        //       utility since that is necessary for prerendering
-        resolve?.isBuiltin ?? isNodeLikeBuiltin,
+        resolve?.isBuiltin ??
+        (consumer === 'server'
+          ? isNodeLikeBuiltin
+          : // there are not built-in modules in the browser
+            () => false),
     },
     resolve ?? {},
   )

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -6,6 +6,7 @@ import {
   createDebugger,
   createFilter,
   getNpmPackageName,
+  isBuiltin,
   isInNodeModules,
 } from './utils'
 import type { Environment } from './environment'
@@ -156,7 +157,7 @@ function createIsExternal(
     let isExternal = false
     if (id[0] !== '.' && !path.isAbsolute(id)) {
       isExternal =
-        environment.config.resolve.isBuiltin(id) ||
+        isBuiltin(environment.config.resolve.builtins, id) ||
         isConfiguredAsExternal(id, importer)
     }
     processedIds.set(id, isExternal)

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -88,6 +88,7 @@ export function createIsConfiguredAsExternal(
         resolveOptions,
         undefined,
         false,
+        environment.config,
       )
       if (!resolved) {
         return false
@@ -155,7 +156,9 @@ function createIsExternal(
     }
     let isExternal = false
     if (id[0] !== '.' && !path.isAbsolute(id)) {
-      isExternal = isBuiltin(id) || isConfiguredAsExternal(id, importer)
+      isExternal =
+        isBuiltin(id, environment.config) ||
+        isConfiguredAsExternal(id, importer)
     }
     processedIds.set(id, isExternal)
     return isExternal

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -88,7 +88,6 @@ export function createIsConfiguredAsExternal(
         resolveOptions,
         undefined,
         false,
-        environment.config,
       )
       if (!resolved) {
         return false

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -6,7 +6,6 @@ import {
   createDebugger,
   createFilter,
   getNpmPackageName,
-  isBuiltin,
   isInNodeModules,
 } from './utils'
 import type { Environment } from './environment'
@@ -157,7 +156,7 @@ function createIsExternal(
     let isExternal = false
     if (id[0] !== '.' && !path.isAbsolute(id)) {
       isExternal =
-        isBuiltin(id, environment.config) ||
+        environment.config.resolve.isBuiltin(id) ||
         isConfiguredAsExternal(id, importer)
     }
     processedIds.set(id, isExternal)

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -115,7 +115,10 @@ export function esbuildDepPlugin(
         namespace: 'optional-peer-dep',
       }
     }
-    if (environment.config.consumer === 'server' && isBuiltin(resolved)) {
+    if (
+      environment.config.consumer === 'server' &&
+      isBuiltin(resolved, environment.config)
+    ) {
       return
     }
     if (isExternalUrl(resolved)) {

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -5,6 +5,7 @@ import type { PackageCache } from '../packages'
 import {
   escapeRegex,
   flattenId,
+  isBuiltin,
   isExternalUrl,
   moduleListContains,
   normalizePath,
@@ -114,7 +115,7 @@ export function esbuildDepPlugin(
         namespace: 'optional-peer-dep',
       }
     }
-    if (environment.config.resolve.isBuiltin(resolved)) {
+    if (isBuiltin(environment.config.resolve.builtins, resolved)) {
       return
     }
     if (isExternalUrl(resolved)) {

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -5,7 +5,6 @@ import type { PackageCache } from '../packages'
 import {
   escapeRegex,
   flattenId,
-  isBuiltin,
   isExternalUrl,
   moduleListContains,
   normalizePath,
@@ -117,7 +116,7 @@ export function esbuildDepPlugin(
     }
     if (
       environment.config.consumer === 'server' &&
-      isBuiltin(resolved, environment.config)
+      environment.config.resolve.isBuiltin(resolved)
     ) {
       return
     }

--- a/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
+++ b/packages/vite/src/node/optimizer/esbuildDepPlugin.ts
@@ -114,10 +114,7 @@ export function esbuildDepPlugin(
         namespace: 'optional-peer-dep',
       }
     }
-    if (
-      environment.config.consumer === 'server' &&
-      environment.config.resolve.isBuiltin(resolved)
-    ) {
+    if (environment.config.resolve.isBuiltin(resolved)) {
       return
     }
     if (isExternalUrl(resolved)) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -519,7 +519,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               if (shouldExternalize(environment, specifier, importer)) {
                 return
               }
-              if (isBuiltin(specifier)) {
+              if (isBuiltin(specifier, environment.config)) {
                 return
               }
             }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -35,7 +35,6 @@ import {
   generateCodeFrame,
   getHash,
   injectQuery,
-  isBuiltin,
   isDataUrl,
   isDefined,
   isExternalUrl,
@@ -519,7 +518,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               if (shouldExternalize(environment, specifier, importer)) {
                 return
               }
-              if (isBuiltin(specifier, environment.config)) {
+              if (environment.config.resolve.isBuiltin(specifier)) {
                 return
               }
             }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -35,6 +35,7 @@ import {
   generateCodeFrame,
   getHash,
   injectQuery,
+  isBuiltin,
   isDataUrl,
   isDefined,
   isExternalUrl,
@@ -518,7 +519,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
               if (shouldExternalize(environment, specifier, importer)) {
                 return
               }
-              if (environment.config.resolve.isBuiltin(specifier)) {
+              if (isBuiltin(environment.config.resolve.builtins, specifier)) {
                 return
               }
             }

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -456,6 +456,26 @@ export function resolvePlugin(
             ? id
             : { id, external: true, moduleSideEffects: false }
         } else if (
+          currentEnvironmentOptions.consumer === 'server' &&
+          isNodeLikeBuiltin(id)
+        ) {
+          if (
+            options.noExternal === true &&
+            // if both noExternal and external are true, noExternal will take the higher priority and bundle it.
+            // only if the id is explicitly listed in external, we will externalize it and skip this error.
+            (options.external === true || !options.external.includes(id))
+          ) {
+            let message = `Cannot bundle node built-in module "${id}"`
+            if (importer) {
+              message += ` imported from "${path.relative(
+                process.cwd(),
+                importer,
+              )}"`
+            }
+            message += `. Consider disabling environments.${this.environment.name}.noExternal or remove the built-in dependency.`
+            this.error(message)
+          }
+        } if (
           currentEnvironmentOptions.consumer === 'client' &&
           isNodeLikeBuiltin(id)
         ) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -475,7 +475,7 @@ export function resolvePlugin(
             message += `. Consider disabling environments.${this.environment.name}.noExternal or remove the built-in dependency.`
             this.error(message)
           }
-        } if (
+        } else if (
           currentEnvironmentOptions.consumer === 'client' &&
           isNodeLikeBuiltin(id)
         ) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -756,7 +756,7 @@ export function tryNodeResolve(
   }
 
   const isModuleBuiltin = (id: string) =>
-    isBuiltin(options?.builtins ?? nodeLikeBuiltins, id)
+    isBuiltin(options.builtins, id)
 
   let selfPkg = null
   if (!isModuleBuiltin(id) && !id.includes('\0') && bareImportRE.test(id)) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -433,22 +433,6 @@ export function resolvePlugin(
           currentEnvironmentOptions.consumer === 'server' &&
           isNodeLikeBuiltin(id)
         ) {
-          if (
-            options.noExternal === true &&
-            // if both noExternal and external are true, noExternal will take the higher priority and bundle it.
-            // only if the id is explicitly listed in external, we will externalize it and skip this error.
-            (options.external === true || !options.external.includes(id))
-          ) {
-            let message = `Cannot bundle node built-in module "${id}"`
-            if (importer) {
-              message += ` imported from "${path.relative(
-                process.cwd(),
-                importer,
-              )}"`
-            }
-            message += `. Consider disabling environments.${this.environment.name}.noExternal or remove the built-in dependency.`
-            this.error(message)
-          }
           if (!(options.external === true || options.external.includes(id))) {
             let message = `Automatically externalized node built-in module "${id}"`
             if (importer) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -30,7 +30,6 @@ import {
   isObject,
   isOptimizable,
   isTsRequest,
-  nodeLikeBuiltins,
   normalizePath,
   safeRealpathSync,
   tryStatSync,
@@ -461,7 +460,7 @@ export function resolvePlugin(
             message += `. Consider adding it to environments.${this.environment.name}.external if it is intended.`
             this.error(message)
           }
-          
+
           return options.idOnly
             ? id
             : { id, external: true, moduleSideEffects: false }
@@ -755,8 +754,7 @@ export function tryNodeResolve(
     basedir = root
   }
 
-  const isModuleBuiltin = (id: string) =>
-    isBuiltin(options.builtins, id)
+  const isModuleBuiltin = (id: string) => isBuiltin(options.builtins, id)
 
   let selfPkg = null
   if (!isModuleBuiltin(id) && !id.includes('\0') && bareImportRE.test(id)) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -450,6 +450,21 @@ export function resolvePlugin(
             message += `. Consider disabling environments.${this.environment.name}.noExternal or remove the built-in dependency.`
             this.error(message)
           }
+          if (!(options.external === true || options.external.includes(id))) {
+            let message = `Automatically externalized node built-in module "${id}"`
+            if (importer) {
+              message += ` imported from "${path.relative(
+                process.cwd(),
+                importer,
+              )}"`
+            }
+            message += `. Consider adding it to environments.${this.environment.name}.external if it is intended.`
+            this.error(message)
+          }
+          
+          return options.idOnly
+            ? id
+            : { id, external: true, moduleSideEffects: false }
         } else if (
           currentEnvironmentOptions.consumer === 'client' &&
           isNodeLikeBuiltin(id)

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -101,7 +101,7 @@ export interface EnvironmentResolveOptions {
    */
   enableBuiltinNoExternalCheck?: boolean
   /**
-   * Function to specify when modules should be considered built-in for the environment.
+   * Function to discern when a module should be considered as built-in for the environment.
    * (If not provided the node built-in modules are the only ones assumed as such)
    */
   isBuiltin?: (id: string) => boolean

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -28,8 +28,7 @@ export async function fetchModule(
   importer?: string,
   options: FetchModuleOptions = {},
 ): Promise<FetchResult> {
-  // builtins should always be externalized
-  if (url.startsWith('data:') || isBuiltin(url)) {
+  if (url.startsWith('data:') || isBuiltin(url, environment.config)) {
     return { externalize: url, type: 'builtin' }
   }
 

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from 'node:url'
 import type { FetchResult } from 'vite/module-runner'
 import type { EnvironmentModuleNode, TransformResult } from '..'
 import { tryNodeResolve } from '../plugins/resolve'
-import { isBuiltin, isExternalUrl, isFilePathESM } from '../utils'
+import { isExternalUrl, isFilePathESM } from '../utils'
 import { unwrapId } from '../../shared/utils'
 import {
   MODULE_RUNNER_SOURCEMAPPING_SOURCE,
@@ -28,7 +28,7 @@ export async function fetchModule(
   importer?: string,
   options: FetchModuleOptions = {},
 ): Promise<FetchResult> {
-  if (url.startsWith('data:') || isBuiltin(url, environment.config)) {
+  if (url.startsWith('data:') || environment.config.resolve.isBuiltin(url)) {
     return { externalize: url, type: 'builtin' }
   }
 
@@ -56,6 +56,7 @@ export async function fetchModule(
       isProduction,
       root,
       packageCache: environment.config.packageCache,
+      isBuiltin: environment.config.resolve.isBuiltin,
     })
     if (!resolved) {
       const err: any = new Error(

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from 'node:url'
 import type { FetchResult } from 'vite/module-runner'
 import type { EnvironmentModuleNode, TransformResult } from '..'
 import { tryNodeResolve } from '../plugins/resolve'
-import { isExternalUrl, isFilePathESM } from '../utils'
+import { isBuiltin, isExternalUrl, isFilePathESM } from '../utils'
 import { unwrapId } from '../../shared/utils'
 import {
   MODULE_RUNNER_SOURCEMAPPING_SOURCE,
@@ -28,7 +28,10 @@ export async function fetchModule(
   importer?: string,
   options: FetchModuleOptions = {},
 ): Promise<FetchResult> {
-  if (url.startsWith('data:') || environment.config.resolve.isBuiltin(url)) {
+  if (
+    url.startsWith('data:') ||
+    isBuiltin(environment.config.resolve.builtins, url)
+  ) {
     return { externalize: url, type: 'builtin' }
   }
 
@@ -56,7 +59,7 @@ export async function fetchModule(
       isProduction,
       root,
       packageCache: environment.config.packageCache,
-      isBuiltin: environment.config.resolve.isBuiltin,
+      builtins: environment.config.resolve.builtins,
     })
     if (!resolved) {
       const err: any = new Error(

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -102,16 +102,16 @@ const BUN_BUILTIN_NAMESPACE = 'bun:'
 // Some runtimes like Bun injects namespaced modules here, which is not a node builtin
 const nodeBuiltins = builtinModules.filter((id) => !id.includes(':'))
 
-const isConfiguredAsExternalCache = new WeakMap<
+const isBuiltinCache = new WeakMap<
   (string | RegExp)[],
   (id: string, importer?: string) => boolean
 >()
 
 export function isBuiltin(builtins: (string | RegExp)[], id: string): boolean {
-  let isBuiltin = isConfiguredAsExternalCache.get(builtins)
+  let isBuiltin = isBuiltinCache.get(builtins)
   if (!isBuiltin) {
     isBuiltin = createIsBuiltin(builtins)
-    isConfiguredAsExternalCache.set(builtins, isBuiltin)
+    isBuiltinCache.set(builtins, isBuiltin)
   }
   return isBuiltin(id)
 }

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -102,8 +102,7 @@ const BUN_BUILTIN_NAMESPACE = 'bun:'
 // Some runtimes like Bun injects namespaced modules here, which is not a node builtin
 const nodeBuiltins = builtinModules.filter((id) => !id.includes(':'))
 
-// TODO: For the default node implementation use `isBuiltin` from `node:module`.
-//       Note that Deno doesn't support it.
+// TODO: Use `isBuiltin` from `node:module`, but Deno doesn't support it
 export function isNodeLikeBuiltin(id: string): boolean {
   if (process.versions.deno && id.startsWith(NPM_BUILTIN_NAMESPACE)) return true
   if (process.versions.bun && id.startsWith(BUN_BUILTIN_NAMESPACE)) return true

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -46,7 +46,7 @@ import {
   findNearestPackageData,
   resolvePackageData,
 } from './packages'
-import type { CommonServerOptions, EnvironmentOptions } from '.'
+import type { CommonServerOptions } from '.'
 
 /**
  * Inlined to keep `@rollup/pluginutils` in devDependencies
@@ -104,16 +104,7 @@ const nodeBuiltins = builtinModules.filter((id) => !id.includes(':'))
 
 // TODO: For the default node implementation use `isBuiltin` from `node:module`.
 //       Note that Deno doesn't support it.
-export function isBuiltin(
-  id: string,
-  environmentOptions?: EnvironmentOptions,
-): boolean {
-  if (environmentOptions?.isBuiltin) {
-    return environmentOptions.isBuiltin(id)
-  }
-
-  // TODO: Deprecate/remove the following ifs and let the environment
-  // tell vite what builtins it has (via the `isBuiltin` option)
+export function isNodeLikeBuiltin(id: string): boolean {
   if (process.versions.deno && id.startsWith(NPM_BUILTIN_NAMESPACE)) return true
   if (process.versions.bun && id.startsWith(BUN_BUILTIN_NAMESPACE)) return true
   return isNodeBuiltin(id)

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -46,7 +46,7 @@ import {
   findNearestPackageData,
   resolvePackageData,
 } from './packages'
-import type { CommonServerOptions } from '.'
+import type { CommonServerOptions, EnvironmentOptions } from '.'
 
 /**
  * Inlined to keep `@rollup/pluginutils` in devDependencies
@@ -102,8 +102,18 @@ const BUN_BUILTIN_NAMESPACE = 'bun:'
 // Some runtimes like Bun injects namespaced modules here, which is not a node builtin
 const nodeBuiltins = builtinModules.filter((id) => !id.includes(':'))
 
-// TODO: Use `isBuiltin` from `node:module`, but Deno doesn't support it
-export function isBuiltin(id: string): boolean {
+// TODO: For the default node implementation use `isBuiltin` from `node:module`.
+//       Note that Deno doesn't support it.
+export function isBuiltin(
+  id: string,
+  environmentOptions?: EnvironmentOptions,
+): boolean {
+  if (environmentOptions?.isBuiltin) {
+    return environmentOptions.isBuiltin(id)
+  }
+
+  // TODO: Deprecate/remove the following ifs and let the environment
+  // tell vite what builtins it has (via the `isBuiltin` option)
   if (process.versions.deno && id.startsWith(NPM_BUILTIN_NAMESPACE)) return true
   if (process.versions.bun && id.startsWith(BUN_BUILTIN_NAMESPACE)) return true
   return isNodeBuiltin(id)


### PR DESCRIPTION
### Description

The issue this PR is addressing that the current `isBuiltin` methods seems to be hardcoded for node: https://github.com/vitejs/vite/blob/ce0eec91c9b5a91c52bf5b9bae6173d35f6e1649/packages/vite/src/node/utils.ts#L105-L109

This doesn't fully seems right to me given the new environment API, since different environments can have different builtins.

For example Cloudflare's workerd runtime has the following builtins:
- `cloudflare:email`
- `cloudflare:sockets`
- `cloudflare:workers`

It can also include the node builtins based on the user's configuration.

So I think that it would be nice if environment authors could declare what builtin modules their environment has.

___

One final note, without this option it is pretty easy to workaround the hardcoded node `isBuiltin` method, in dev environments could implement their `fetchModule` to externalize all their builtins ([example](https://github.com/flarelabs-net/vite-plugin-cloudflare/blob/4bdc0a8d0d5dc0961fbb8417a524855780eaae7a/packages/vite-plugin-cloudflare/src/miniflare-options.ts#L230-L236)) and for build those could be marked as external ([example](https://github.com/flarelabs-net/vite-plugin-cloudflare/blob/4bdc0a8d0d5dc0961fbb8417a524855780eaae7a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts#L178)). There are also a few other places where these might need to be set like in `optimizeDeps.exclude` ([example](https://github.com/flarelabs-net/vite-plugin-cloudflare/blob/4bdc0a8d0d5dc0961fbb8417a524855780eaae7a/packages/vite-plugin-cloudflare/src/cloudflare-environment.ts#L147)). So this option I'm proposing is probably something not absolutely necessary but just something to avoiding having to specify such modules all over the place (but there might also be other benefits in letting `isBuiltin` know how to distinguish environment specific builtins 🤷 ).
