### PR TITLE
fix: vite build now works with broken symlink in public

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -598,6 +598,10 @@ export function copyDir(srcDir: string, destDir: string): void {
       continue
     }
     const destFile = path.resolve(destDir, file)
+    // This may occur if the source directory is a symlink that points to a non-existent directory
+    if (!fs.existsSync(destFile)) {
+      return
+    }
     const stat = fs.statSync(srcFile)
     if (stat.isDirectory()) {
       copyDir(srcFile, destFile)


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR solves the problem of breaking `vite build` when having a broken symlink inside of the `public` folder.

This occurs because `stat` treats symlinks as `isDirectory() === true` and breaks with a "Not found" error when it attempts to copy

A reproduction of this issue can be found here:

https://github.com/crutchcorn/broken-symblink-copy-demo

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
