### PR TITLE
test: update filename regex

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -602,7 +602,7 @@ describe('resolveBuildOutputs', () => {
           fileName: 'index.mjs',
         },
         {
-          fileName: expect.stringMatching(/assets\/index-\w*\.css/),
+          fileName: expect.stringMatching(/assets\/index-[-\w]{8}\.css/),
         },
       ],
     })
@@ -633,7 +633,7 @@ describe('resolveBuildOutputs', () => {
           fileName: 'index.mjs',
         },
         {
-          fileName: expect.stringMatching(/assets\/index-\w*\.css/),
+          fileName: expect.stringMatching(/assets\/index-[-\w]{8}\.css/),
         },
       ],
     })


### PR DESCRIPTION
### Description

This PR improves the robustness of the test. The previous regex might fail if the hash contains `-`. It happened to contain `-` when I tried rolldown.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
