### PR TITLE
docs: remove X links in team page

### DIFF
--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -49,9 +49,8 @@ export const core = [
     links: [
       { icon: 'github', link: 'https://github.com/bluwy' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },
-      { icon: 'x', link: 'https://x.com/bluwyoo' },
+      { icon: 'twitter', link: 'https://twitter.com/bluwyoo' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@bluwy' },
-      { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },
     ],
     sponsor: 'https://bjornlu.com/sponsor',
   },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -45,7 +45,7 @@ export const core = [
     avatar: 'https://github.com/bluwy.png',
     name: 'Bjorn Lu',
     title: 'Open Source Developer',
-    desc: 'Astro core residency. Svelte and Vite core team member.',
+    desc: 'Vite, Astro, and Svelte core team.',
     links: [
       { icon: 'github', link: 'https://github.com/bluwy' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -74,12 +74,11 @@ export const core = [
     desc: 'Passionate by tooling around TypeScript and React.',
     links: [
       { icon: 'github', link: 'https://github.com/ArnaudBarre' },
-      { icon: 'x', link: 'https://x.com/_ArnaudBarre' },
-      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@ArnaudBarre' },
       {
         icon: 'bluesky',
         link: 'https://bsky.app/profile/arnaud-barre.bsky.social',
       },
+      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@ArnaudBarre' },
     ],
     sponsor: 'https://github.com/sponsors/ArnaudBarre',
   },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -22,9 +22,8 @@ export const core = [
     desc: 'Core team member of Vite. Team member of Vue.',
     links: [
       { icon: 'github', link: 'https://github.com/patak-dev' },
-      { icon: 'x', link: 'https://x.com/patak_dev' },
-      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@patak' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/patak.dev' },
+      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@patak' },
     ],
     sponsor: 'https://github.com/sponsors/patak-dev',
   },
@@ -37,9 +36,8 @@ export const core = [
     desc: 'Core team member of Vite & Vue. Working at NuxtLabs.',
     links: [
       { icon: 'github', link: 'https://github.com/antfu' },
-      { icon: 'x', link: 'https://x.com/antfu7' },
-      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@antfu' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/antfu.me' },
+      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@antfu' },
     ],
     sponsor: 'https://github.com/sponsors/antfu',
   },
@@ -50,6 +48,7 @@ export const core = [
     desc: 'Astro core residency. Svelte and Vite core team member.',
     links: [
       { icon: 'github', link: 'https://github.com/bluwy' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },
       { icon: 'x', link: 'https://x.com/bluwyoo' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@bluwy' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },
@@ -63,6 +62,7 @@ export const core = [
     desc: 'Vite core team member. Call me sapphi or green or midori ;)',
     links: [
       { icon: 'github', link: 'https://github.com/sapphi-red' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/sapphi.red' },
       { icon: 'x', link: 'https://x.com/sapphi_red' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@sapphi_red' },
     ],
@@ -102,9 +102,8 @@ export const core = [
     desc: 'An open source fullstack developer',
     links: [
       { icon: 'github', link: 'https://github.com/sheremet-va' },
-      { icon: 'x', link: 'https://x.com/sheremet_va' },
-      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@sheremet_va' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/erus.dev' },
+      { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@sheremet_va' },
     ],
     sponsor: 'https://github.com/sponsors/sheremet-va',
   },
@@ -115,7 +114,7 @@ export const core = [
     desc: 'Open source enthusiast',
     links: [
       { icon: 'github', link: 'https://github.com/hi-ogawa' },
-      { icon: 'x', link: 'https://x.com/hiroshi_18181' },
+      { icon: 'bluesky', link: 'https://bsky.app/profile/hiogawa.bsky.social' },
     ],
     sponsor: 'https://github.com/sponsors/hi-ogawa',
   },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -45,7 +45,7 @@ export const core = [
     avatar: 'https://github.com/bluwy.png',
     name: 'Bjorn Lu',
     title: 'Open Source Developer',
-    desc: 'Vite, Astro, and Svelte core team.',
+    desc: 'Vite, Astro, and Svelte core team member.',
     links: [
       { icon: 'github', link: 'https://github.com/bluwy' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/bluwy.me' },

--- a/docs/_data/team.js
+++ b/docs/_data/team.js
@@ -62,7 +62,7 @@ export const core = [
     links: [
       { icon: 'github', link: 'https://github.com/sapphi-red' },
       { icon: 'bluesky', link: 'https://bsky.app/profile/sapphi.red' },
-      { icon: 'x', link: 'https://x.com/sapphi_red' },
+      { icon: 'twitter', link: 'https://twitter.com/sapphi_red' },
       { icon: 'mastodon', link: 'https://elk.zone/m.webtoo.ls/@sapphi_red' },
     ],
     sponsor: 'https://github.com/sponsors/sapphi-red',


### PR DESCRIPTION
### Description

We discussed between the vitest team and decided that it is better for the project to use its Bluesky account as the main updates feed. We removed links to X in the docs, GitHub, and in the team page:
- https://github.com/vitest-dev/vitest/pull/6868
- [Post in X](https://x.com/vitest_dev/status/1854198573384056864)
- [Post in Bluesky](https://bsky.app/profile/vitest.dev/post/3lac6mixagw2x)

For now, this PR removes the X links for the Vite team members that are also Vitest team members. Please comment here or send a commit to remove yours if you'd like, so we do a single batch for all the changes.