### PR TITLE
fix(html): externalize `rollup.external` scripts correctly

### DIFF
--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -117,12 +117,24 @@ describe('main', () => {
       expect(serverLogs).not.toEqual(
         expect.arrayContaining([
           expect.stringMatching(
-            'can\'t be bundled without type="module" attribute',
+            /"\/external-path\.js".*can't be bundled without type="module" attribute/,
           ),
         ]),
       )
     }
   })
+
+  test.runIf(isBuild)(
+    'external paths by rollupOptions.external works',
+    async () => {
+      expect(await page.textContent('.external-path-by-rollup-options')).toBe(
+        'works',
+      )
+      expect(serverLogs).not.toEqual(
+        expect.arrayContaining([expect.stringContaining('Could not load')]),
+      )
+    },
+  )
 })
 
 describe('nested', () => {

--- a/playground/html/index.html
+++ b/playground/html/index.html
@@ -13,3 +13,7 @@
 <div>External path: <span class="external-path"></span></div>
 <script type="module" src="/external-path.js" vite-ignore></script>
 <link rel="stylesheet" href="/external-path.css" vite-ignore />
+<div>
+  External path by rollupOptions.external (build only):
+  <span class="external-path-by-rollup-options"></span>
+</div>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -40,6 +40,7 @@ export default defineConfig({
           resolve(__dirname, 'relative-input.html'),
         ),
       },
+      external: ['/external-path-by-rollup-options.js'],
     },
   },
 
@@ -228,6 +229,26 @@ ${
         },
       },
     },
+    {
+      name: 'append-external-path-by-rollup-options',
+      apply: 'build', // this does not work in serve
+      transformIndexHtml: {
+        order: 'pre',
+        handler(_, ctx) {
+          if (!ctx.filename.endsWith('html/index.html')) return
+          return [
+            {
+              tag: 'script',
+              attrs: {
+                type: 'module',
+                src: '/external-path-by-rollup-options.js',
+              },
+              injectTo: 'body',
+            },
+          ]
+        },
+      },
+    },
     serveExternalPathPlugin(),
   ],
 })
@@ -241,6 +262,11 @@ function serveExternalPathPlugin() {
     } else if (req.url === '/external-path.css') {
       res.setHeader('Content-Type', 'text/css')
       res.end('.external-path{color:red}')
+    } else if (req.url === '/external-path-by-rollup-options.js') {
+      res.setHeader('Content-Type', 'application/javascript')
+      res.end(
+        'document.querySelector(".external-path-by-rollup-options").textContent = "works"',
+      )
     } else {
       next()
     }


### PR DESCRIPTION
### Description

This PR fixes two bugs:

- `<script type="module">` with the src externalized by `rollupOptions.external` was throwing an error (it didn't error before #18411)
  - this fix should fix storybook in ecosystem-ci
- `<script type="module">` with the src externalized by `rollupOptions.external` was not preserved in the output HTML
  - I found this when I wrote the test

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
