### PR TITLE
feat: add `isSsrTargetWebWorker` flag to `configEnvironment` hook

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -618,13 +618,13 @@ function resolveEnvironmentOptions(
   environmentName: string,
   // Backward compatibility
   skipSsrTransform?: boolean,
-  ssrTargetWebworker?: boolean,
+  isSsrTargetWebworkerSet?: boolean,
 ): ResolvedEnvironmentOptions {
   const isClientEnvironment = environmentName === 'client'
   const consumer =
     options.consumer ?? (isClientEnvironment ? 'client' : 'server')
   const isSsrTargetWebworkerEnvironment =
-    ssrTargetWebworker && environmentName === 'ssr'
+    isSsrTargetWebworkerSet && environmentName === 'ssr'
   const resolve = resolveEnvironmentResolveOptions(
     options.resolve,
     alias,
@@ -1025,7 +1025,12 @@ export async function resolveConfig(
     )
   }
 
-  await runConfigEnvironmentHook(config.environments, userPlugins, configEnv)
+  await runConfigEnvironmentHook(
+    config.environments,
+    userPlugins,
+    configEnv,
+    config.ssr?.target === 'webworker',
+  )
 
   const resolvedDefaultResolve = resolveResolveOptions(config.resolve, logger)
 
@@ -1793,6 +1798,7 @@ async function runConfigEnvironmentHook(
   environments: Record<string, EnvironmentOptions>,
   plugins: Plugin[],
   configEnv: ConfigEnv,
+  isSsrTargetWebworkerSet: boolean,
 ): Promise<void> {
   const environmentNames = Object.keys(environments)
   for (const p of getSortedPluginsByHook('configEnvironment', plugins)) {
@@ -1800,7 +1806,10 @@ async function runConfigEnvironmentHook(
     const handler = getHookHandler(hook)
     if (handler) {
       for (const name of environmentNames) {
-        const res = await handler(name, environments[name], configEnv)
+        const res = await handler(name, environments[name], {
+          ...configEnv,
+          isSsrTargetWebworker: isSsrTargetWebworkerSet && name === 'ssr',
+        })
         if (res) {
           environments[name] = mergeConfig(environments[name], res)
         }

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -239,7 +239,13 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
       this: void,
       name: string,
       config: EnvironmentOptions,
-      env: ConfigEnv,
+      env: ConfigEnv & {
+        /**
+         * Whether this environment is SSR environment and `ssr.target` is set to `'webworker'`.
+         * Only intended to be used for backward compatibility.
+         */
+        isSsrTargetWebworker?: boolean
+      },
     ) =>
       | EnvironmentOptions
       | null


### PR DESCRIPTION
### Description

This PR adds `isSsrTargetWebWorker` flag to `configEnvironment` hook so that plugins can support `ssr.target: 'webworker'` correctly.
For example, this `configEnvironment` hook from https://github.com/sveltejs/vite-plugin-svelte/pull/1020 needs to know if `ssr.target: 'webworker'` is set.
https://github.com/sveltejs/vite-plugin-svelte/blob/dcec9afa2a9b1bfd5fe8f0767cc871a2b144a9d6/packages/vite-plugin-svelte/src/index.js#L71-L81

https://discord.com/channels/804011606160703521/1304311237332697098/1304350474085859338

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
