### PR TITLE
fix(ssr): format ssrTransform parse error

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 packages/*/CHANGELOG.md
 packages/vite/src/node/ssr/runtime/__tests__/fixtures
+packages/vite/src/node/ssr/__tests__/fixtures/errors
 playground-temp/
 dist/
 temp/

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -213,6 +213,7 @@ export const normalizeHotChannel = (
           name: error.name,
           message: error.message,
           stack: error.stack,
+          ...error, // preserve enumerable properties such as RollupError.loc, frame, plugin
         },
       }
     }

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parse error 1`] = `
+{
+  "frame": "
+Expected ";" but found "code"
+1  |  invalid code
+   |          ^
+2  |  
+",
+  "id": "<root>/fixtures/errors/syntax-error.ts",
+  "loc": {
+    "column": 8,
+    "file": "<root>/fixtures/errors/syntax-error.ts",
+    "line": 1,
+  },
+  "message": "Transform failed with 1 error:
+<root>/fixtures/errors/syntax-error.ts:1:8: ERROR: Expected ";" but found "code"",
+}
+`;
+
+exports[`parse error 2`] = `
+{
+  "frame": "",
+  "id": "",
+  "loc": undefined,
+  "message": "Expected ';', '}' or <eof>",
+}
+`;
+
+exports[`parse error 3`] = `
+{
+  "frame": "
+Expected ";" but found "code"
+1  |  invalid code
+   |          ^
+2  |  
+",
+  "id": "<root>/fixtures/errors/syntax-error.ts",
+  "loc": {
+    "column": 8,
+    "file": "<root>/fixtures/errors/syntax-error.ts",
+    "line": 1,
+  },
+  "message": "Transform failed with 1 error:
+<root>/fixtures/errors/syntax-error.ts:1:8: ERROR: Expected ";" but found "code"",
+}
+`;
+
+exports[`parse error 4`] = `
+{
+  "frame": "",
+  "id": "",
+  "loc": undefined,
+  "message": "Expected ';', '}' or <eof>",
+}
+`;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -21,9 +21,15 @@ Expected ";" but found "code"
 
 exports[`parse error 2`] = `
 {
-  "frame": "",
+  "frame": "1  |  invalid code
+   |          ^
+2  |  ",
   "id": "",
-  "loc": undefined,
+  "loc": {
+    "column": 9,
+    "file": "/fixtures/errors/syntax-error.js",
+    "line": 1,
+  },
   "message": "Expected ';', '}' or <eof>",
 }
 `;
@@ -49,9 +55,15 @@ Expected ";" but found "code"
 
 exports[`parse error 4`] = `
 {
-  "frame": "",
+  "frame": "1  |  invalid code
+   |          ^
+2  |  ",
   "id": "",
-  "loc": undefined,
+  "loc": {
+    "column": 9,
+    "file": "/fixtures/errors/syntax-error.js",
+    "line": 1,
+  },
   "message": "Expected ';', '}' or <eof>",
 }
 `;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`parse error 2`] = `
   "frame": "1  |  invalid code
    |          ^
 2  |  ",
-  "id": "",
+  "id": "/fixtures/errors/syntax-error.js",
   "loc": {
     "column": 9,
     "file": "/fixtures/errors/syntax-error.js",
@@ -58,7 +58,7 @@ exports[`parse error 4`] = `
   "frame": "1  |  invalid code
    |          ^
 2  |  ",
-  "id": "",
+  "id": "/fixtures/errors/syntax-error.js",
   "loc": {
     "column": 9,
     "file": "/fixtures/errors/syntax-error.js",

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.js
@@ -1,0 +1,1 @@
+import './syntax-error.js'

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.ts
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.ts
@@ -1,0 +1,1 @@
+import './syntax-error.ts'

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.js
@@ -1,0 +1,1 @@
+invalid code

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.ts
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.ts
@@ -1,0 +1,1 @@
+invalid code

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -1205,3 +1205,25 @@ console.log(bar)
       "
   `)
 })
+
+test('parse error', async () => {
+  try {
+    await ssrTransform(`some bad code`, null, '/file.js', '')
+    expect.unreachable()
+  } catch (e) {
+    expect(e).toMatchInlineSnapshot(`[RollupError: Expected ';', '}' or <eof>]`)
+    expect({ ...e }).toMatchInlineSnapshot(`
+      {
+        "code": "PARSE_ERROR",
+        "frame": "1  |  some bad code
+         |       ^",
+        "loc": {
+          "column": 6,
+          "file": "/file.js",
+          "line": 1,
+        },
+        "pos": 5,
+      }
+    `)
+  }
+})

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -1205,25 +1205,3 @@ console.log(bar)
       "
   `)
 })
-
-test('parse error', async () => {
-  try {
-    await ssrTransform(`some bad code`, null, '/file.js', '')
-    expect.unreachable()
-  } catch (e) {
-    expect(e).toMatchInlineSnapshot(`[RollupError: Expected ';', '}' or <eof>]`)
-    expect({ ...e }).toMatchInlineSnapshot(`
-      {
-        "code": "PARSE_ERROR",
-        "frame": "1  |  some bad code
-         |       ^",
-        "loc": {
-          "column": 6,
-          "file": "/file.js",
-          "line": 1,
-        },
-        "pos": 5,
-      }
-    `)
-  }
-})

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -87,6 +87,7 @@ async function ssrTransformScript(
     ast = await rollupParseAstAsync(code)
   } catch (err) {
     if (err.code === 'PARSE_ERROR' && typeof err.pos === 'number') {
+      err.id = url
       err.loc = numberToPos(code, err.pos)
       err.loc.file = url
       err.frame = generateCodeFrame(code, err.pos)

--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -32,6 +32,10 @@ type InvokeableModuleRunnerTransport = Omit<ModuleRunnerTransport, 'invoke'> & {
   ): Promise<ReturnType<Awaited<InvokeMethods[T]>>>
 }
 
+function reviveInvokeError(e: any) {
+  return Object.assign(new Error(e.message || 'Unknown invoke error'), e)
+}
+
 const createInvokeableTransport = (
   transport: ModuleRunnerTransport,
 ): InvokeableModuleRunnerTransport => {
@@ -49,7 +53,7 @@ const createInvokeableTransport = (
           } satisfies InvokeSendData,
         } satisfies CustomPayload)
         if ('e' in result) {
-          throw result.e
+          throw reviveInvokeError(result.e)
         }
         return result.r
       },
@@ -90,7 +94,7 @@ const createInvokeableTransport = (
 
               const { e, r } = data.data
               if (e) {
-                promise.reject(e)
+                promise.reject(reviveInvokeError(e))
               } else {
                 promise.resolve(r)
               }


### PR DESCRIPTION
### Description

- closes https://github.com/vitest-dev/vitest/issues/6882
- on top of https://github.com/vitejs/vite/pull/18626 and diff https://github.com/hi-ogawa/vite/compare/fix-runner-fetchModule-rollup-error...fix-format-ssr-transform-parse-error

It looks like this parse error handling code is obsolete and does nothing for current rollup parse error. For non-js file, esbuild transform in plugin pipeline normally catches a syntax error, but for js file, `ssrTransform` needs to throw an error. Since `ssrTransform` is outside of transform plugin pipeline, `Error.pos` doesn't get prettified automatically, so I added a error processing inside the try/catch.

reproduction: https://stackblitz.com/edit/vitest-dev-vitest-wpj5mg?file=vite.config.ts

<details><summary>Screenshots</summary>

- v5

![image](https://github.com/user-attachments/assets/8b069d9d-f021-40c2-912d-ba13bf3b1871)

- this PR

![image](https://github.com/user-attachments/assets/95bb571f-1f1b-49a2-a7d8-371205ea7dde)

</details>
