### PR TITLE
fix(ssr): preserve fetchModule error details

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 packages/*/CHANGELOG.md
 packages/vite/src/node/ssr/runtime/__tests__/fixtures
+packages/vite/src/node/ssr/__tests__/fixtures/errors
 playground-temp/
 dist/
 temp/

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -213,6 +213,7 @@ export const normalizeHotChannel = (
           name: error.name,
           message: error.message,
           stack: error.stack,
+          ...error, // preserve enumerable properties such as RollupError.loc, frame, plugin
         },
       }
     }

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`parse error 1`] = `
+{
+  "frame": "
+Expected ";" but found "code"
+1  |  invalid code
+   |          ^
+2  |  
+",
+  "id": "<root>/fixtures/errors/syntax-error.ts",
+  "loc": {
+    "column": 8,
+    "file": "<root>/fixtures/errors/syntax-error.ts",
+    "line": 1,
+  },
+  "message": "Transform failed with 1 error:
+<root>/fixtures/errors/syntax-error.ts:1:8: ERROR: Expected ";" but found "code"",
+}
+`;
+
+exports[`parse error 2`] = `
+{
+  "frame": "",
+  "id": "",
+  "loc": undefined,
+  "message": "Expected ';', '}' or <eof>",
+}
+`;
+
+exports[`parse error 3`] = `
+{
+  "frame": "
+Expected ";" but found "code"
+1  |  invalid code
+   |          ^
+2  |  
+",
+  "id": "<root>/fixtures/errors/syntax-error.ts",
+  "loc": {
+    "column": 8,
+    "file": "<root>/fixtures/errors/syntax-error.ts",
+    "line": 1,
+  },
+  "message": "Transform failed with 1 error:
+<root>/fixtures/errors/syntax-error.ts:1:8: ERROR: Expected ";" but found "code"",
+}
+`;
+
+exports[`parse error 4`] = `
+{
+  "frame": "",
+  "id": "",
+  "loc": undefined,
+  "message": "Expected ';', '}' or <eof>",
+}
+`;

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.js
@@ -1,0 +1,1 @@
+import './syntax-error.js'

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.ts
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error-dep.ts
@@ -1,0 +1,1 @@
+import './syntax-error.ts'

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.js
@@ -1,0 +1,1 @@
+invalid code

--- a/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.ts
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/errors/syntax-error.ts
@@ -1,0 +1,1 @@
+invalid code

--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -32,6 +32,10 @@ type InvokeableModuleRunnerTransport = Omit<ModuleRunnerTransport, 'invoke'> & {
   ): Promise<ReturnType<Awaited<InvokeMethods[T]>>>
 }
 
+function reviveInvokeError(e: any) {
+  return Object.assign(new Error(e.message || 'Unknown invoke error'), e)
+}
+
 const createInvokeableTransport = (
   transport: ModuleRunnerTransport,
 ): InvokeableModuleRunnerTransport => {
@@ -49,7 +53,7 @@ const createInvokeableTransport = (
           } satisfies InvokeSendData,
         } satisfies CustomPayload)
         if ('e' in result) {
-          throw result.e
+          throw reviveInvokeError(result.e)
         }
         return result.r
       },
@@ -90,7 +94,7 @@ const createInvokeableTransport = (
 
               const { e, r } = data.data
               if (e) {
-                promise.reject(e)
+                promise.reject(reviveInvokeError(e))
               } else {
                 promise.resolve(r)
               }


### PR DESCRIPTION
### Description

While investigating the other fix https://github.com/vitejs/vite/pull/18621, I realized new transport (introduced in https://github.com/vitejs/vite/pull/18362) is not preserving some error properties such as `RollupError.loc, frame`, which is useful for error overlay.

<details><summary>Error overlay screenshots</summary>

- main: https://stackblitz.com/edit/vitest-dev-vitest-ankaav?file=vite.config.ts

![image](https://github.com/user-attachments/assets/e3c59349-dd97-4d86-a0cc-55220e3abe84)

- this PR: https://stackblitz.com/edit/vitest-dev-vitest-xtwqzr?file=vite.config.ts

![image](https://github.com/user-attachments/assets/3d59bc6c-5248-48c0-a128-e267162f51b7)

</details>