### PR TITLE
docs: fix attribute in example

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -177,7 +177,7 @@ Assets referenced by HTML elements such as `<script type="module" src>` and `<li
 - `<img src>` and `<img srcset>`
 - `<image src>`
 - `<input src>`
-- `<link href>` and `<link imagesrcet>`
+- `<link href>` and `<link imagesrcset>`
 - `<object data>`
 - `<script type="module" src>`
 - `<source src>` and `<source srcset>`


### PR DESCRIPTION
### Description

This PR just fixes a typo in an html example in the feature page, that I have noticed while reviewing a different PR.
