### PR TITLE
docs: fix mobile menu background on light mode landing page

### DIFF
--- a/docs/.vitepress/theme/styles/landing.css
+++ b/docs/.vitepress/theme/styles/landing.css
@@ -3,15 +3,13 @@
 /* /////////////////////// */
 
 html:has(.landing) {
+  --vp-c-bg: #101010;
+
   background-color: #101010;
 
   body {
     background-color: #101010;
   }
-}
-
-html.dark:has(.landing) {
-  --vp-c-bg: #101010;
 }
 
 .landing {


### PR DESCRIPTION
### Description

Mobile menu on light mode landing page was white, but probably it was intended to be gray.

**Before**
![image](https://github.com/user-attachments/assets/d7e6eb1f-7797-4a62-81f5-6d680bf2fdc1)
**After**
![image](https://github.com/user-attachments/assets/87f64dc5-b6bc-4e33-bdfe-050bfed05ad1)

fixes #18631

#### Reproduction steps
1. Open other page than the landing page.
2. Toggle dark mode.
3. Navigate to the landing page.
4. Open the mobile menu.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
