### PR TITLE
fix: allow bare imports of ts packages in a monorepo

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -22,6 +22,7 @@ import {
   DEFAULT_MAIN_FIELDS,
   ENV_ENTRY,
   FS_PREFIX,
+  VITE_PACKAGE_DIR,
 } from './constants'
 import type {
   HookHandler,
@@ -1628,7 +1629,7 @@ async function bundleConfigFile(
           // externalize bare imports
           build.onResolve(
             { filter: /^[^.].*/ },
-            async ({ path: id, importer, kind }) => {
+            ({ path: id, importer, kind }) => {
               if (
                 kind === 'entry-point' ||
                 path.isAbsolute(id) ||
@@ -1668,12 +1669,16 @@ async function bundleConfigFile(
                 }
                 throw e
               }
-              if (idFsPath && isImport) {
+              const isExternal =
+                !idFsPath ||
+                idFsPath.includes('node_modules') ||
+                idFsPath.startsWith(VITE_PACKAGE_DIR)
+              if (idFsPath && isImport && isExternal) {
                 idFsPath = pathToFileURL(idFsPath).href
               }
               return {
                 path: idFsPath,
-                external: true,
+                external: isExternal,
               }
             },
           )


### PR DESCRIPTION
### Description

This PR adds support for bare imports of packages that export a TS entry point:

```ts
import pkg from '@monorepo/ts' // <-- exports .ts file
export default defineConfig({
  ...pkg.sharedConfig,
})
```

Currently, vite resolves the `.ts` file but keeps it external which breaks in Node:

```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /react-monorepo-ts/packages/components/src/test.ts
```

TODO
- [ ] Tests
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
