### PR TITLE
fix: `loadEnv` can return a object with `undefined` values

### DIFF
--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -18,7 +18,7 @@ export function loadEnv(
   mode: string,
   envDir: string,
   prefixes: string | string[] = 'VITE_',
-): Record<string, string> {
+): Record<string, string | undefined> {
   if (mode === 'local') {
     throw new Error(
       `"local" cannot be used as a mode name because it conflicts with ` +
@@ -26,7 +26,7 @@ export function loadEnv(
     )
   }
   prefixes = arraify(prefixes)
-  const env: Record<string, string> = {}
+  const env: Record<string, string | undefined> = {}
   const envFiles = getEnvFilesForMode(mode, envDir)
 
   const parsed = Object.fromEntries(


### PR DESCRIPTION
Corrects the return typing of the `loadEnv` function because it may return `undefined` values in the object values.
