### PR TITLE
fix(ssr): format `ssrTransform` parse error 

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -30,7 +30,9 @@ exports[`parse error 2`] = `
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
-  "message": "Parse Failure: Expected ';', '}' or <eof>",
+  "message": "Parse Failure: Expected ';', '}' or <eof>
+At file: /fixtures/errors/syntax-error.js:1:9
+Contents of line: invalid code",
 }
 `;
 
@@ -64,6 +66,8 @@ exports[`parse error 4`] = `
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
-  "message": "Parse Failure: Expected ';', '}' or <eof>",
+  "message": "Parse Failure: Expected ';', '}' or <eof>
+At file: /fixtures/errors/syntax-error.js:1:9
+Contents of line: invalid code",
 }
 `;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`parse error 2`] = `
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
-  "message": "Expected ';', '}' or <eof>",
+  "message": "Parse Failure: Expected ';', '}' or <eof>",
 }
 `;
 
@@ -64,6 +64,6 @@ exports[`parse error 4`] = `
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
-  "message": "Expected ';', '}' or <eof>",
+  "message": "Parse Failure: Expected ';', '}' or <eof>",
 }
 `;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -31,8 +31,7 @@ exports[`parse error 2`] = `
     "line": 1,
   },
   "message": "Parse Failure: Expected ';', '}' or <eof>
-At file: /fixtures/errors/syntax-error.js:1:9
-Contents of line: invalid code",
+At file: /fixtures/errors/syntax-error.js:1:9",
 }
 `;
 
@@ -67,7 +66,6 @@ exports[`parse error 4`] = `
     "line": 1,
   },
   "message": "Parse Failure: Expected ';', '}' or <eof>
-At file: /fixtures/errors/syntax-error.js:1:9
-Contents of line: invalid code",
+At file: /fixtures/errors/syntax-error.js:1:9",
 }
 `;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -21,9 +21,15 @@ Expected ";" but found "code"
 
 exports[`parse error 2`] = `
 {
-  "frame": "",
+  "frame": "1  |  invalid code
+   |          ^
+2  |  ",
   "id": "",
-  "loc": undefined,
+  "loc": {
+    "column": 9,
+    "file": "/fixtures/errors/syntax-error.js",
+    "line": 1,
+  },
   "message": "Expected ';', '}' or <eof>",
 }
 `;
@@ -49,9 +55,15 @@ Expected ";" but found "code"
 
 exports[`parse error 4`] = `
 {
-  "frame": "",
+  "frame": "1  |  invalid code
+   |          ^
+2  |  ",
   "id": "",
-  "loc": undefined,
+  "loc": {
+    "column": 9,
+    "file": "/fixtures/errors/syntax-error.js",
+    "line": 1,
+  },
   "message": "Expected ';', '}' or <eof>",
 }
 `;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`parse error 2`] = `
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
-  "message": "Parse Failure: Expected ';', '}' or <eof>
+  "message": "Parse failure: Expected ';', '}' or <eof>
 At file: /fixtures/errors/syntax-error.js:1:9",
 }
 `;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -65,7 +65,7 @@ exports[`parse error 4`] = `
     "file": "/fixtures/errors/syntax-error.js",
     "line": 1,
   },
-  "message": "Parse Failure: Expected ';', '}' or <eof>
+  "message": "Parse failure: Expected ';', '}' or <eof>
 At file: /fixtures/errors/syntax-error.js:1:9",
 }
 `;

--- a/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
+++ b/packages/vite/src/node/ssr/__tests__/__snapshots__/ssrLoadModule.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`parse error 2`] = `
   "frame": "1  |  invalid code
    |          ^
 2  |  ",
-  "id": "",
+  "id": "/fixtures/errors/syntax-error.js",
   "loc": {
     "column": 9,
     "file": "/fixtures/errors/syntax-error.js",
@@ -58,7 +58,7 @@ exports[`parse error 4`] = `
   "frame": "1  |  invalid code
    |          ^
 2  |  ",
-  "id": "",
+  "id": "/fixtures/errors/syntax-error.js",
   "loc": {
     "column": 9,
     "file": "/fixtures/errors/syntax-error.js",

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -1205,3 +1205,25 @@ console.log(bar)
       "
   `)
 })
+
+test('parse error', async () => {
+  try {
+    await ssrTransform(`some bad code`, null, '/file.js', '')
+    expect.unreachable()
+  } catch (e) {
+    expect(e).toMatchInlineSnapshot(`[RollupError: Expected ';', '}' or <eof>]`)
+    expect({ ...e }).toMatchInlineSnapshot(`
+      {
+        "code": "PARSE_ERROR",
+        "frame": "1  |  some bad code
+         |       ^",
+        "loc": {
+          "column": 6,
+          "file": "/file.js",
+          "line": 1,
+        },
+        "pos": 5,
+      }
+    `)
+  }
+})

--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -1205,25 +1205,3 @@ console.log(bar)
       "
   `)
 })
-
-test('parse error', async () => {
-  try {
-    await ssrTransform(`some bad code`, null, '/file.js', '')
-    expect.unreachable()
-  } catch (e) {
-    expect(e).toMatchInlineSnapshot(`[RollupError: Expected ';', '}' or <eof>]`)
-    expect({ ...e }).toMatchInlineSnapshot(`
-      {
-        "code": "PARSE_ERROR",
-        "frame": "1  |  some bad code
-         |       ^",
-        "loc": {
-          "column": 6,
-          "file": "/file.js",
-          "line": 1,
-        },
-        "pos": 5,
-      }
-    `)
-  }
-})

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -87,6 +87,7 @@ async function ssrTransformScript(
     ast = await rollupParseAstAsync(code)
   } catch (err) {
     if (err.code === 'PARSE_ERROR' && typeof err.pos === 'number') {
+      err.id = url
       err.loc = numberToPos(code, err.pos)
       err.loc.file = url
       err.frame = generateCodeFrame(code, err.pos)

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -95,8 +95,7 @@ async function ssrTransformScript(
         err.loc = numberToPos(code, err.pos)
         err.loc.file = url
         err.frame = generateCodeFrame(code, err.pos)
-        const { line, column } = err.loc
-        err.message += `At file: ${url}:${line}:${column}\nContents of line: ${code.split('\n')[line - 1]}`
+        err.message += `At file: ${url}:${err.loc.line}:${err.loc.column}`
       } else {
         err.message += `At file: ${url}`
       }

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -89,7 +89,7 @@ async function ssrTransformScript(
     // enhance known rollup errors
     // https://github.com/rollup/rollup/blob/42e587e0e37bc0661aa39fe7ad6f1d7fd33f825c/src/utils/bufferToAst.ts#L17-L22
     if (err.code === 'PARSE_ERROR') {
-      err.message = `Parse Failure: ${err.message}\n`
+      err.message = `Parse failure: ${err.message}\n`
       err.id = url
       if (typeof err.pos === 'number') {
         err.loc = numberToPos(code, err.pos)

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -87,6 +87,7 @@ async function ssrTransformScript(
     ast = await rollupParseAstAsync(code)
   } catch (err) {
     if (err.code === 'PARSE_ERROR' && typeof err.pos === 'number') {
+      err.message = `Parse Failure: ${err.message}`
       err.id = url
       err.loc = numberToPos(code, err.pos)
       err.loc.file = url


### PR DESCRIPTION
### Description

(Recreated https://github.com/vitejs/vite/pull/18621 as I force-pushed the branch and Github won't let me reopen it)

- closes https://github.com/vitest-dev/vitest/issues/6882


It looks like this parse error handling code is obsolete and does nothing for current rollup parse error. For non-js file, esbuild transform in plugin pipeline normally catches a syntax error, but for js file, `ssrTransform` needs to throw an error. Since `ssrTransform` is outside of transform plugin pipeline, `Error.pos` doesn't get prettified automatically, so I added a error processing inside the try/catch.

reproduction: https://stackblitz.com/edit/vitest-dev-vitest-wpj5mg?file=vite.config.ts

<details><summary>Screenshots</summary>

- v5

![image](https://github.com/user-attachments/assets/8b069d9d-f021-40c2-912d-ba13bf3b1871)

- this PR

![image](https://github.com/user-attachments/assets/95bb571f-1f1b-49a2-a7d8-371205ea7dde)

</details>

