### PR TITLE
feat: add `ssr.resolve.mainFields` option

### DIFF
--- a/docs/config/ssr-options.md
+++ b/docs/config/ssr-options.md
@@ -53,3 +53,10 @@ When using this option, make sure to run Node with [`--conditions` flag](https:/
 For example, when setting `['node', 'custom']`, you should run `NODE_OPTIONS='--conditions custom' vite` in dev and `NODE_OPTIONS="--conditions custom" node ./dist/server.js` after build.
 
 :::
+
+### ssr.resolve.mainFields
+
+- **Type:** `string[]`
+- **Default:** `['module', 'jsnext:main', 'jsnext']`
+
+List of fields in `package.json` to try when resolving a package's entry point. Note this takes lower precedence than conditional exports resolved from the `exports` field: if an entry point is successfully resolved from `exports`, the main field will be ignored. This setting only affect non-externalized dependencies.

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -93,6 +93,8 @@ There are other breaking changes which only affect few users.
     - If you are specifying a CommonJS file as an entry point, you may need additional steps. Read [the commonjs plugin documentation](https://github.com/rollup/plugins/blob/master/packages/commonjs/README.md#using-commonjs-files-as-entry-points) for more details.
 - [[#18243] chore(deps)!: migrate `fast-glob` to `tinyglobby`](https://github.com/vitejs/vite/pull/18243)
   - Range braces (`{01..03}` ⇒ `['01', '02', '03']`) and incremental braces (`{2..8..2}` ⇒ `['2', '4', '6', '8']`) are no longer supported in globs.
+- [[#18395] feat(resolve)!: allow removing conditions](https://github.com/vitejs/vite/pull/18395)
+  - This PR not only introduces a breaking change mentioned above as "Default value for `resolve.conditions`", but also makes `resolve.mainFields` to not be used for no-externalized dependencies in SSR. If you were using `resolve.mainFields` and want to apply that to no-externalized dependencies in SSR, you can use [`ssr.resolve.mainFields`](/config/ssr-options#ssr-resolve-mainfields).
 - [[#18493] refactor!: remove fs.cachedChecks option](https://github.com/vitejs/vite/pull/18493)
   - This opt-in optimization was removed due to edge cases when writing a file in a cached folder and immediately importing it.
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -974,6 +974,7 @@ export async function resolveConfig(
     configEnvironmentsSsr.resolve.conditions ??= config.ssr?.resolve?.conditions
     configEnvironmentsSsr.resolve.externalConditions ??=
       config.ssr?.resolve?.externalConditions
+    configEnvironmentsSsr.resolve.mainFields ??= config.ssr?.resolve?.mainFields
     configEnvironmentsSsr.resolve.external ??= config.ssr?.external
     configEnvironmentsSsr.resolve.noExternal ??= config.ssr?.noExternal
   }

--- a/packages/vite/src/node/ssr/index.ts
+++ b/packages/vite/src/node/ssr/index.ts
@@ -42,6 +42,8 @@ export interface SSROptions {
      * @default []
      */
     externalConditions?: string[]
+
+    mainFields?: string[]
   }
 }
 


### PR DESCRIPTION
### Description

In #18395, we made `resolve.mainFields` not to be used for no-externalized dependencies in SSR. To achieve that behavior, users now have to reach out to the Environment API (`environments.ssr.resolve.mainFields`).

To avoid that happening, this PR adds `ssr.resolve.mainFields` option that is similar to `ssr.resolve.conditions`.

refs https://github.com/vitest-dev/vitest/pull/6896


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
