### PR TITLE
fix(client): overlay not appearing when multiple vite clients were loaded

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -6,11 +6,7 @@ import {
   createWebSocketModuleRunnerTransport,
   normalizeModuleRunnerTransport,
 } from '../shared/moduleRunnerTransport'
-import {
-  type ErrorOverlay,
-  getErrorOverlayConstructor,
-  overlayId,
-} from './overlay'
+import { ErrorOverlay, overlayId } from './overlay'
 import '@vite/env'
 
 // injected by the hmr plugin when served
@@ -311,7 +307,14 @@ const enableOverlay = __HMR_ENABLE_OVERLAY__
 const hasDocument = 'document' in globalThis
 
 function createErrorOverlay(err: ErrorPayload['err']) {
-  const ErrorOverlayConstructor = getErrorOverlayConstructor()
+  const { customElements } = globalThis
+  let ErrorOverlayConstructor
+  if (customElements) {
+    ErrorOverlayConstructor = customElements.get(overlayId)
+  }
+  if (!ErrorOverlayConstructor) {
+    ErrorOverlayConstructor = ErrorOverlay
+  }
   clearErrorOverlay()
   document.body.appendChild(new ErrorOverlayConstructor(err))
 }

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -307,16 +307,12 @@ const enableOverlay = __HMR_ENABLE_OVERLAY__
 const hasDocument = 'document' in globalThis
 
 function createErrorOverlay(err: ErrorPayload['err']) {
-  const { customElements } = globalThis
-  let ErrorOverlayConstructor
-  if (customElements) {
-    ErrorOverlayConstructor = customElements.get(overlayId)
-  }
-  if (!ErrorOverlayConstructor) {
-    ErrorOverlayConstructor = ErrorOverlay
-  }
   clearErrorOverlay()
-  document.body.appendChild(new ErrorOverlayConstructor(err))
+  const { customElements } = globalThis
+  if (customElements) {
+    const ErrorOverlayConstructor = customElements.get(overlayId)!
+    document.body.appendChild(new ErrorOverlayConstructor(err))
+  }
 }
 
 function clearErrorOverlay() {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -6,7 +6,11 @@ import {
   createWebSocketModuleRunnerTransport,
   normalizeModuleRunnerTransport,
 } from '../shared/moduleRunnerTransport'
-import { ErrorOverlay, overlayId } from './overlay'
+import {
+  type ErrorOverlay,
+  getErrorOverlayConstructor,
+  overlayId,
+} from './overlay'
 import '@vite/env'
 
 // injected by the hmr plugin when served
@@ -307,8 +311,9 @@ const enableOverlay = __HMR_ENABLE_OVERLAY__
 const hasDocument = 'document' in globalThis
 
 function createErrorOverlay(err: ErrorPayload['err']) {
+  const ErrorOverlayConstructor = getErrorOverlayConstructor()
   clearErrorOverlay()
-  document.body.appendChild(new ErrorOverlay(err))
+  document.body.appendChild(new ErrorOverlayConstructor(err))
 }
 
 function clearErrorOverlay() {

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -295,3 +295,16 @@ const { customElements } = globalThis // Ensure `customElements` is defined befo
 if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay)
 }
+
+type Constructor<T, Args extends unknown[] = any[]> = new (...args: Args) => T
+
+export function getErrorOverlayConstructor(): Constructor<ErrorOverlay> {
+  const { customElements } = globalThis
+  if (customElements) {
+    const ElementConstructor = customElements.get(overlayId)
+    if (ElementConstructor) {
+      return ElementConstructor as Constructor<ErrorOverlay>
+    }
+  }
+  return ErrorOverlay
+}

--- a/packages/vite/src/client/overlay.ts
+++ b/packages/vite/src/client/overlay.ts
@@ -295,16 +295,3 @@ const { customElements } = globalThis // Ensure `customElements` is defined befo
 if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay)
 }
-
-type Constructor<T, Args extends unknown[] = any[]> = new (...args: Args) => T
-
-export function getErrorOverlayConstructor(): Constructor<ErrorOverlay> {
-  const { customElements } = globalThis
-  if (customElements) {
-    const ElementConstructor = customElements.get(overlayId)
-    if (ElementConstructor) {
-      return ElementConstructor as Constructor<ErrorOverlay>
-    }
-  }
-  return ErrorOverlay
-}


### PR DESCRIPTION
### Description

Vite is creating a custom elemtn with `<vite-error-overlay>` to display error overlay.

If the vite client is loaded multiple times (e.g. in the case of Micro-Frontend architecture), there is an issue while creating error overlay from second vite client because creating custom element without defining into custom elements registry causes error. (below screenshot is error from chrome browser)

<img width="738" alt="screenshot" src="https://github.com/user-attachments/assets/55da79c7-340a-48b3-aa47-2f1df692ff28">

**src/client/overlay.ts:**
```ts
export const overlayId = 'vite-error-overlay'
const { customElements } = globalThis // Ensure `customElements` is defined before the next line.
if (customElements && !customElements.get(overlayId)) {
  customElements.define(overlayId, ErrorOverlay)
}
```

Fix this by get the constructor of `ErrorOverlay` from custom element registry if already defined.

Although it may not be the expected behavior for the vite client to be loaded multiple times, this PR will be helpful as there are cases where the `ErrorOverlay` singleton cannot be guaranteed.