### PR TITLE
feat: show error when accessing variables not exposed in CJS build

### DIFF
--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -29,7 +29,7 @@ asyncFunctions.forEach((name) => {
 
 // variables and sync functions that cannot be used from cjs build
 const disallowedVariables = [
-  // was not exposed in cjs from the beggining
+  // was not exposed in cjs from the beginning
   'parseAst',
   'buildErrorMessage',
   'sortUserPlugins',

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -31,6 +31,7 @@ asyncFunctions.forEach((name) => {
 const disallowedVariables = [
   // was not exposed in cjs from the beginning
   'parseAst',
+  'parseAstAsync',
   'buildErrorMessage',
   'sortUserPlugins',
   // Environment API related variables that are too big to include in the cjs build

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -1,3 +1,6 @@
+const description =
+  ' See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.'
+
 warnCjsUsage()
 
 // type utils
@@ -17,10 +20,40 @@ const asyncFunctions = [
   'formatPostcssSourceMap',
   'loadConfigFromFile',
   'preprocessCSS',
+  'createBuilder',
 ]
 asyncFunctions.forEach((name) => {
   module.exports[name] = (...args) =>
     import('./dist/node/index.js').then((i) => i[name](...args))
+})
+
+// variables and sync functions that cannot be used from cjs build
+const disallowedVariables = [
+  // was not exposed in cjs from the beggining
+  'parseAst',
+  'buildErrorMessage',
+  'sortUserPlugins',
+  // Environment API related variables that are too big to include in the cjs build
+  'DevEnvironment',
+  'BuildEnvironment',
+  'createIdResolver',
+  'createRunnableDevEnvironment',
+  // can be redirected from ESM, but doesn't make sense as it's Environment API related
+  'fetchModule',
+  'moduleRunnerTransform',
+  // can be exposed, but doesn't make sense as it's Environment API related
+  'createServerHotChannel',
+  'createServerModuleRunner',
+  'isRunnableDevEnvironment',
+]
+disallowedVariables.forEach((name) => {
+  Object.defineProperty(module.exports, name, {
+    get() {
+      throw new Error(
+        `${name} is not available in the CJS build. ` + description,
+      )
+    },
+  })
 })
 
 function warnCjsUsage() {
@@ -39,9 +72,7 @@ function warnCjsUsage() {
   }
   const yellow = (str) => `\u001b[33m${str}\u001b[39m`
   console.warn(
-    yellow(
-      `The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.`,
-    ),
+    yellow("The CJS build of Vite's Node API is deprecated." + description),
   )
   if (process.env.VITE_CJS_TRACE) {
     const e = {}

--- a/packages/vite/index.cjs
+++ b/packages/vite/index.cjs
@@ -50,7 +50,7 @@ disallowedVariables.forEach((name) => {
   Object.defineProperty(module.exports, name, {
     get() {
       throw new Error(
-        `${name} is not available in the CJS build. ` + description,
+        `${name} is not available in the CJS build of Vite.` + description,
       )
     },
   })


### PR DESCRIPTION
### Description

No error happened when accessing variables not exposed in CJS build. This PR adds an error for that, so the user can know what is needed to do.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
