### PR TITLE
feat: support `module-sync` condition when loading config if enabled

### DIFF
--- a/packages/vite/misc/false.d.ts
+++ b/packages/vite/misc/false.d.ts
@@ -1,0 +1,2 @@
+declare const result: boolean
+export default result

--- a/packages/vite/misc/false.js
+++ b/packages/vite/misc/false.js
@@ -1,0 +1,1 @@
+export default false

--- a/packages/vite/misc/true.d.ts
+++ b/packages/vite/misc/true.d.ts
@@ -1,0 +1,2 @@
+declare const result: boolean
+export default result

--- a/packages/vite/misc/true.js
+++ b/packages/vite/misc/true.js
@@ -1,0 +1,1 @@
+export default true

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -27,9 +27,7 @@
     "./client": {
       "types": "./client.d.ts"
     },
-    "./module-runner": {
-      "import": "./dist/node/module-runner.js"
-    },
+    "./module-runner": "./dist/node/module-runner.js",
     "./dist/client/*": "./dist/client/*",
     "./types/*": {
       "types": "./types/*"

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -20,20 +20,14 @@
   "types": "./dist/node/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/node/index.d.ts",
-        "default": "./dist/node/index.js"
-      },
-      "require": {
-        "types": "./index.d.cts",
-        "default": "./index.cjs"
-      }
+      "module-sync": "./dist/node/index.js",
+      "import": "./dist/node/index.js",
+      "require": "./index.cjs"
     },
     "./client": {
       "types": "./client.d.ts"
     },
     "./module-runner": {
-      "types": "./dist/node/module-runner.d.ts",
       "import": "./dist/node/module-runner.js"
     },
     "./dist/client/*": "./dist/client/*",
@@ -50,9 +44,16 @@
       ]
     }
   },
+  "imports": {
+    "#module-sync-enabled": {
+      "module-sync": "./misc/true.js",
+      "default": "./misc/false.js"
+    }
+  },
   "files": [
     "bin",
     "dist",
+    "misc/**/*.js",
     "client.d.ts",
     "index.cjs",
     "index.d.cts",

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -111,6 +111,7 @@ const nodeConfig = defineConfig({
     /^vite\//,
     'rollup/parseAst',
     /^tsx\//,
+    /^#/,
     ...Object.keys(pkg.dependencies),
     ...Object.keys(pkg.peerDependencies),
   ],

--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -24,8 +24,8 @@ const external = [
 
 export default defineConfig({
   input: {
-    index: './temp/node/index.d.ts',
-    'module-runner': './temp/module-runner/index.d.ts',
+    index: './temp/src/node/index.d.ts',
+    'module-runner': './temp/src/module-runner/index.d.ts',
   },
   output: {
     dir: './dist/node',

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1697,7 +1697,8 @@ async function bundleConfigFile(
   fileName: string,
   isESM: boolean,
 ): Promise<{ code: string; dependencies: string[] }> {
-  const isModuleSyncConditionEnabled = await import('#module-sync-enabled')
+  const isModuleSyncConditionEnabled = (await import('#module-sync-enabled'))
+    .default
 
   const dirnameVarName = '__vite_injected_original_dirname'
   const filenameVarName = '__vite_injected_original_filename'

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1697,6 +1697,8 @@ async function bundleConfigFile(
   fileName: string,
   isESM: boolean,
 ): Promise<{ code: string; dependencies: string[] }> {
+  const isModuleSyncConditionEnabled = await import('#module-sync-enabled')
+
   const dirnameVarName = '__vite_injected_original_dirname'
   const filenameVarName = '__vite_injected_original_filename'
   const importMetaUrlVarName = '__vite_injected_original_import_meta_url'
@@ -1735,7 +1737,10 @@ async function bundleConfigFile(
               preferRelative: false,
               tryIndex: true,
               mainFields: [],
-              conditions: ['node'],
+              conditions: [
+                'node',
+                ...(isModuleSyncConditionEnabled ? ['module-sync'] : []),
+              ],
               externalConditions: [],
               external: [],
               noExternal: [],

--- a/packages/vite/tsconfig.base.json
+++ b/packages/vite/tsconfig.base.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "rootDir": ".",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
### Description

With this PR, users can now import variables not exposed in CJS build by `require`. It requires the users to enable `require(esm)` by setting `--experimental-require-module` or using Node 23+.

related #18649

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
