### PR TITLE
chore(create-vite): add @types/node as devDependency in *-ts

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -512,6 +512,11 @@ async function init() {
 
   pkg.name = packageName || getProjectName()
 
+  if(template.endsWith('-ts')){
+    if(!pkg.devDependencies) pkg.devDependencies = {}
+    pkg.devDependencies["@types/node"] = `^${process.versions.node}`
+  }
+
   write('package.json', JSON.stringify(pkg, null, 2) + '\n')
 
   if (isReactSwc) {

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -381,8 +381,8 @@ async function init() {
           message:
             typeof argTemplate === 'string' && !TEMPLATES.includes(argTemplate)
               ? reset(
-                  `"${argTemplate}" isn't a valid template. Please choose from below: `,
-                )
+                `"${argTemplate}" isn't a valid template. Please choose from below: `,
+              )
               : reset('Select a framework:'),
           initial: 0,
           choices: FRAMEWORKS.map((framework) => {
@@ -443,7 +443,7 @@ async function init() {
   const isYarn1 = pkgManager === 'yarn' && pkgInfo?.version.startsWith('1.')
 
   const { customCommand } =
-    FRAMEWORKS.flatMap((f) => f.variants).find((v) => v.name === template) ?? {}
+  FRAMEWORKS.flatMap((f) => f.variants).find((v) => v.name === template) ?? {}
 
   if (customCommand) {
     const fullCustomCommand = customCommand
@@ -512,12 +512,12 @@ async function init() {
 
   pkg.name = packageName || getProjectName()
 
-  if(template.endsWith('-ts')){
-    if(!pkg.devDependencies) pkg.devDependencies = {}
-    pkg.devDependencies["@types/node"] = `^${process.versions.node}`
+  if (template.endsWith('-ts')) {
+    if (!pkg.devDependencies) pkg.devDependencies = {}
+    pkg.devDependencies['@types/node'] = `^${process.versions.node}`
   }
 
-  write('package.json', JSON.stringify(pkg, null, 2) + '\n')
+  write('package.json', JSON.stringify(pkg, sortKeys, 2) + '\n')
 
   if (isReactSwc) {
     setupReactSwc(root, template.endsWith('-ts'))
@@ -628,6 +628,24 @@ function editFile(file: string, callback: (content: string) => string) {
   const content = fs.readFileSync(file, 'utf-8')
   fs.writeFileSync(file, callback(content), 'utf-8')
 }
+
+function sortKeys(key: string, value: any) {
+  if (
+    (key === 'dependencies' || key === 'devDependencies') &&
+    typeof value === 'object' &&
+    value != null
+  ) {
+    const sortedObject: { [key: string]: any } = {}
+    Object.keys(value)
+      .sort()
+      .forEach((it) => {
+        sortedObject[it] = value[it]
+      })
+    return sortedObject
+  }
+  return value
+}
+
 
 init().catch((e) => {
   console.error(e)

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -381,8 +381,8 @@ async function init() {
           message:
             typeof argTemplate === 'string' && !TEMPLATES.includes(argTemplate)
               ? reset(
-                `"${argTemplate}" isn't a valid template. Please choose from below: `,
-              )
+                  `"${argTemplate}" isn't a valid template. Please choose from below: `,
+                )
               : reset('Select a framework:'),
           initial: 0,
           choices: FRAMEWORKS.map((framework) => {
@@ -443,7 +443,7 @@ async function init() {
   const isYarn1 = pkgManager === 'yarn' && pkgInfo?.version.startsWith('1.')
 
   const { customCommand } =
-  FRAMEWORKS.flatMap((f) => f.variants).find((v) => v.name === template) ?? {}
+    FRAMEWORKS.flatMap((f) => f.variants).find((v) => v.name === template) ?? {}
 
   if (customCommand) {
     const fullCustomCommand = customCommand
@@ -645,7 +645,6 @@ function sortKeys(key: string, value: any) {
   }
   return value
 }
-
 
 init().catch((e) => {
   console.error(e)

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -635,7 +635,7 @@ function sortKeys(key: string, value: any) {
     typeof value === 'object' &&
     value != null
   ) {
-    const sortedObject: { [key: string]: any } = {}
+    const sortedObject: Record<string, any> = {}
     Object.keys(value)
       .sort()
       .forEach((it) => {

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -513,8 +513,11 @@ async function init() {
   pkg.name = packageName || getProjectName()
 
   if (template.endsWith('-ts')) {
-    if (!pkg.devDependencies) pkg.devDependencies = {}
-    pkg.devDependencies['@types/node'] = `^${process.versions.node}`
+    const major = parseInt(process.versions.node.split('.')[0])
+    if ((major === 18 || major >= 20) && (major & 1) === 0) {
+      if (!pkg.devDependencies) pkg.devDependencies = {}
+      pkg.devDependencies['@types/node'] = `^${process.versions.node}`
+    }
   }
 
   write('package.json', JSON.stringify(pkg, sortKeys, 2) + '\n')


### PR DESCRIPTION
fix(#18600): use user’s Node version for @types/node version instead of fixed version

This PR resolves the issue #18600 and improves upon the previous PR #18642:
- It uses the user's current Node.js version to dynamically determine the version of `@types/node`, instead of using a fixed version. This improvement ensures that the `@types/node` version matches the Node.js version the user is actually using, avoiding potential compatibility issues.
- This approach is more flexible than using a fixed version, reducing the hassle of manually updating dependencies and improving the maintainability and stability of the project.
