### PR TITLE
build: ignore cjs warning

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -352,6 +352,8 @@ function exportCheck(): Plugin {
     async writeBundle() {
       // escape import so that it's not bundled while config load
       const dynImport = (id: string) => import(id)
+      // ignore warning from CJS entrypoint to avoid misleading logs
+      process.env.VITE_CJS_IGNORE_WARNING = 'true'
 
       const esmNamespace = await dynImport('./dist/node/index.js')
       const cjsModuleExports = (await dynImport('./index.cjs')).default


### PR DESCRIPTION
### Description

Otherwise the build may log this:

```bash
/Users/bjorn/Work/oss/vite/packages/vite/src/node/publicUtils.ts → ./dist...
The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.
created ./dist in 188ms
```
