### PR TITLE
refactor: applyToEnvironment -> perEnvironment hook

### DIFF
--- a/docs/guide/api-environment-plugins.md
+++ b/docs/guide/api-environment-plugins.md
@@ -128,7 +128,7 @@ The hook can choose to:
 
 ## Per-environment Plugins
 
-A plugin can define what are the environments it should apply to with the `applyToEnvironment` function.
+A plugin can define what are the environments it should apply to with the `perEnvironment` function.
 
 ```js
 const UnoCssPlugin = () => {
@@ -141,7 +141,7 @@ const UnoCssPlugin = () => {
     configureServer() {
       // use global hooks normally
     },
-    applyToEnvironment(environment) {
+    perEnvironment(environment) {
       // return true if this plugin should be active in this environment,
       // or return a new plugin to replace it.
       // if the hook is not used, the plugin is active in all environments
@@ -153,7 +153,7 @@ const UnoCssPlugin = () => {
 }
 ```
 
-If a plugin isn't environment aware and has state that isn't keyed on the current environment, the `applyToEnvironment` hook allows to easily make it per-environment.
+If a plugin isn't environment aware and has state that isn't keyed on the current environment, the `perEnvironment` hook allows to easily make it per-environment.
 
 ```js
 import { nonShareablePlugin } from 'non-shareable-plugin'
@@ -162,7 +162,7 @@ export default defineConfig({
   plugins: [
     {
       name: 'per-environment-plugin',
-      applyToEnvironment(environment) {
+      perEnvironment(environment) {
         return nonShareablePlugin({ outputName: environment.name })
       },
     },

--- a/packages/vite/src/node/plugin.ts
+++ b/packages/vite/src/node/plugin.ts
@@ -207,7 +207,7 @@ export interface Plugin<A = any> extends RollupPlugin<A> {
    * By default, the plugin is active in all environments
    * @experimental
    */
-  applyToEnvironment?: (
+  perEnvironment?: (
     environment: PartialEnvironment,
   ) => boolean | Promise<boolean> | PluginOption
   /**
@@ -334,8 +334,8 @@ export async function resolveEnvironmentPlugins(
 ): Promise<Plugin[]> {
   const environmentPlugins: Plugin[] = []
   for (const plugin of environment.getTopLevelConfig().plugins) {
-    if (plugin.applyToEnvironment) {
-      const applied = await plugin.applyToEnvironment(environment)
+    if (plugin.perEnvironment) {
+      const applied = await plugin.perEnvironment(environment)
       if (!applied) {
         continue
       }
@@ -358,12 +358,12 @@ export async function resolveEnvironmentPlugins(
  */
 export function perEnvironmentPlugin(
   name: string,
-  applyToEnvironment: (
+  perEnvironment: (
     environment: PartialEnvironment,
   ) => boolean | Promise<boolean> | PluginOption,
 ): Plugin {
   return {
     name,
-    applyToEnvironment,
+    perEnvironment,
   }
 }

--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -42,7 +42,7 @@ export function manifestPlugin(): Plugin {
 
     perEnvironmentStartEndDuringDev: true,
 
-    applyToEnvironment(environment) {
+    perEnvironment(environment) {
       return !!environment.config.build.manifest
     },
 

--- a/packages/vite/src/node/plugins/terser.ts
+++ b/packages/vite/src/node/plugins/terser.ts
@@ -59,7 +59,7 @@ export function terserPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:terser',
 
-    applyToEnvironment(environment) {
+    perEnvironment(environment) {
       // We also need the plugin even if minify isn't 'terser' as we force
       // terser in plugin-legacy
       return !!environment.config.build.minify

--- a/packages/vite/src/node/ssr/ssrManifestPlugin.ts
+++ b/packages/vite/src/node/ssr/ssrManifestPlugin.ts
@@ -25,7 +25,7 @@ export function ssrManifestPlugin(): Plugin {
   return {
     name: 'vite:ssr-manifest',
 
-    applyToEnvironment(environment) {
+    perEnvironment(environment) {
       return !!environment.config.build.ssrManifest
     },
 


### PR DESCRIPTION
### Description

Start from https://github.com/vitejs/vite/pull/18544 for reference.

This PR renames the `applyToEnvironment` hook to `perEnvironment`. I think it is a good idea to find a shorter name, and this one will match the set:

- `plugin.perEnvironment: env => PluginOptionOrBoolean`
- `perEnvironmentPlugin(name, env => PluginOptionOrBoolean)`
- `perEnvironmentState`