### PR TITLE
fix(optimizer): workaround firefox's false warning for no sources source map

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -677,7 +677,7 @@ export function runOptimizeDeps(
             // workaround Firefox warning by removing blank source map reference
             // https://github.com/evanw/esbuild/issues/3945
             const output = meta.outputs[o]
-            // filter by exact bytes
+            // filter by exact bytes of an empty source map
             if (output.bytes === 93) {
               const jsMapPath = path.resolve(
                 processingCacheDirOutputPath,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -679,10 +679,7 @@ export function runOptimizeDeps(
             const output = meta.outputs[o]
             // filter by exact bytes of an empty source map
             if (output.bytes === 93) {
-              const jsMapPath = path.resolve(
-                processingCacheDirOutputPath,
-                path.relative(processingCacheDirOutputPath, o),
-              )
+              const jsMapPath = path.resolve(o)
               const jsPath = jsMapPath.slice(0, -4)
               if (fs.existsSync(jsPath) && fs.existsSync(jsMapPath)) {
                 const map = JSON.parse(fs.readFileSync(jsMapPath, 'utf-8'))

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -673,6 +673,28 @@ export function runOptimizeDeps(
                 browserHash: metadata.browserHash,
               })
             }
+          } else {
+            // workaround Firefox warning by removing blank source map reference
+            // https://github.com/evanw/esbuild/issues/3945
+            const output = meta.outputs[o]
+            // filter by exact bytes
+            if (output.bytes === 93) {
+              const jsMapPath = path.resolve(
+                processingCacheDirOutputPath,
+                path.relative(processingCacheDirOutputPath, o),
+              )
+              const jsPath = jsMapPath.slice(0, -4)
+              if (fs.existsSync(jsPath) && fs.existsSync(jsMapPath)) {
+                const map = JSON.parse(fs.readFileSync(jsMapPath, 'utf-8'))
+                if (map.sources.length === 0) {
+                  const js = fs.readFileSync(jsPath, 'utf-8')
+                  fs.writeFileSync(
+                    jsPath,
+                    js.slice(0, js.lastIndexOf('//# sourceMappingURL=')),
+                  )
+                }
+              }
+            }
           }
         }
 

--- a/playground/optimize-deps/dep-source-map-no-sources/all.js
+++ b/playground/optimize-deps/dep-source-map-no-sources/all.js
@@ -1,0 +1,2 @@
+export const all = 'all'
+export { sub } from './sub.js'

--- a/playground/optimize-deps/dep-source-map-no-sources/package.json
+++ b/playground/optimize-deps/dep-source-map-no-sources/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@vitejs/test-dep-source-map-no-sources",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "./*": "./*"
+  }
+}

--- a/playground/optimize-deps/dep-source-map-no-sources/sub.js
+++ b/playground/optimize-deps/dep-source-map-no-sources/sub.js
@@ -1,0 +1,1 @@
+export const sub = 'sub'

--- a/playground/optimize-deps/index.html
+++ b/playground/optimize-deps/index.html
@@ -299,3 +299,9 @@
   text('.dep-with-asset-ext-prebundled', isPreBundled)
   text('.dep-with-asset-ext-no-dual-package', original === reexport)
 </script>
+
+<script type="module">
+  // manually check Firefox doesn't show warning in devtool debugger
+  import * as sub from '@vitejs/test-dep-source-map-no-sources/sub.js'
+  import * as all from '@vitejs/test-dep-source-map-no-sources/all.js'
+</script>

--- a/playground/optimize-deps/package.json
+++ b/playground/optimize-deps/package.json
@@ -29,6 +29,7 @@
     "@vitejs/test-dep-optimize-exports-with-root-glob": "file:./dep-optimize-exports-with-root-glob",
     "@vitejs/test-dep-optimize-with-glob": "file:./dep-optimize-with-glob",
     "@vitejs/test-dep-relative-to-main": "file:./dep-relative-to-main",
+    "@vitejs/test-dep-source-map-no-sources": "file:./dep-source-map-no-sources",
     "@vitejs/test-dep-with-asset-ext1.pdf": "file:./dep-with-asset-ext/dep1",
     "@vitejs/test-dep-with-asset-ext2.pdf": "file:./dep-with-asset-ext/dep2",
     "@vitejs/test-dep-with-builtin-module-cjs": "file:./dep-with-builtin-module-cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,6 +960,9 @@ importers:
       '@vitejs/test-dep-relative-to-main':
         specifier: file:./dep-relative-to-main
         version: file:playground/optimize-deps/dep-relative-to-main
+      '@vitejs/test-dep-source-map-no-sources':
+        specifier: file:./dep-source-map-no-sources
+        version: file:playground/optimize-deps/dep-source-map-no-sources
       '@vitejs/test-dep-with-asset-ext1.pdf':
         specifier: file:./dep-with-asset-ext/dep1
         version: file:playground/optimize-deps/dep-with-asset-ext/dep1
@@ -1084,6 +1087,8 @@ importers:
   playground/optimize-deps/dep-optimize-with-glob: {}
 
   playground/optimize-deps/dep-relative-to-main: {}
+
+  playground/optimize-deps/dep-source-map-no-sources: {}
 
   playground/optimize-deps/dep-with-asset-ext/dep1: {}
 
@@ -3292,6 +3297,9 @@ packages:
 
   '@vitejs/test-dep-self-reference-url-worker@file:playground/worker/dep-self-reference-url-worker':
     resolution: {directory: playground/worker/dep-self-reference-url-worker, type: directory}
+
+  '@vitejs/test-dep-source-map-no-sources@file:playground/optimize-deps/dep-source-map-no-sources':
+    resolution: {directory: playground/optimize-deps/dep-source-map-no-sources, type: directory}
 
   '@vitejs/test-dep-that-imports@file:playground/external/dep-that-imports':
     resolution: {directory: playground/external/dep-that-imports, type: directory}
@@ -8850,6 +8858,8 @@ snapshots:
   '@vitejs/test-dep-relative-to-main@file:playground/optimize-deps/dep-relative-to-main': {}
 
   '@vitejs/test-dep-self-reference-url-worker@file:playground/worker/dep-self-reference-url-worker': {}
+
+  '@vitejs/test-dep-source-map-no-sources@file:playground/optimize-deps/dep-source-map-no-sources': {}
 
   '@vitejs/test-dep-that-imports@file:playground/external/dep-that-imports(typescript@5.6.3)':
     dependencies:


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/17474

I reported the issue to esbuild https://github.com/evanw/esbuild/issues/3945, but Vite side workaround seems reasonably simple, so I made a PR here. Note that Rolldown doesn't create a source map for this case, so this won't be an issue with rolldown-based optimizer in the future.

_How to verify_

- `pnpm -C playground/optimize-deps dev --force`
- open a page on Firefox (I tested on 132.0)
- open devtool debugger tab
- on main, it shows "Source map error: No sources are declared in this source map." in devtool console
- on this PR, there's no warning.

(there were already a warning from an existing test dependencies, but I added a probably simplest one to see it easily)