### PR TITLE
perf: reduce bundle size for `Object.keys(import.meta.glob(...))` / `Object.values(import.meta.glob(...))`

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -594,8 +594,8 @@ const modules = import.meta.glob('./dir/*.js', {
 ```ts
 // code produced by vite:
 const modules = {
-  './dir/foo.svg': '',
-  './dir/bar.svg': '',
+  './dir/foo.js': '',
+  './dir/bar.js': '',
 }
 ```
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -581,6 +581,24 @@ const modules = import.meta.glob('./dir/*.js', {
 })
 ```
 
+If you just want to get the filename, You can provide query `?nocontent`:
+
+```ts twoslash
+import 'vite/client'
+// ---cut---
+const modules = import.meta.glob('./dir/*.js', {
+  query: '?nocontent',
+})
+```
+
+```ts
+// code produced by vite:
+const modules = {
+  './dir/foo.svg': '',
+  './dir/bar.svg': '',
+}
+```
+
 ### Glob Import Caveats
 
 Note that:

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -581,24 +581,6 @@ const modules = import.meta.glob('./dir/*.js', {
 })
 ```
 
-If you just want to get the filename, You can provide query `?nocontent`:
-
-```ts twoslash
-import 'vite/client'
-// ---cut---
-const modules = import.meta.glob('./dir/*.js', {
-  query: '?nocontent',
-})
-```
-
-```ts
-// code produced by vite:
-const modules = {
-  './dir/foo.js': '',
-  './dir/bar.js': '',
-}
-```
-
 ### Glob Import Caveats
 
 Note that:

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -1,20 +1,40 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`fixture > transform 1`] = `
-"import * as __vite_glob_1_0 from "./modules/a.ts";import * as __vite_glob_1_1 from "./modules/b.ts";import * as __vite_glob_1_2 from "./modules/index.ts";import { name as __vite_glob_3_0 } from "./modules/a.ts";import { name as __vite_glob_3_1 } from "./modules/b.ts";import { name as __vite_glob_3_2 } from "./modules/index.ts";import { default as __vite_glob_5_0 } from "./modules/a.ts?raw";import { default as __vite_glob_5_1 } from "./modules/b.ts?raw";import "types/importMeta";
+"import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_1_0,"./modules/b.ts": __vite_glob_1_1,"./modules/index.ts": __vite_glob_1_2
+export const basicWithObjectKeys = Object.keys(/* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''}));
+export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
 
 });
+export const basicEagerWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+
+})
+);
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
-export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
+export const ignoreWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": ''})
+);
+export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_6_0,"./modules/b.ts": __vite_glob_6_1,"./modules/index.ts": __vite_glob_6_2
 
 
 });
+export const namedEagerWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+
+
+})
+);
 export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
-export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_5_0,"./modules/b.ts": __vite_glob_5_1
+export const namedDefaultWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+
+})
+);
+export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_10_0,"./modules/b.ts": __vite_glob_10_1
 
 
 });
@@ -56,20 +76,40 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({"./modules/a.ts": () =>
 `;
 
 exports[`fixture > transform with restoreQueryExtension 1`] = `
-"import * as __vite_glob_1_0 from "./modules/a.ts";import * as __vite_glob_1_1 from "./modules/b.ts";import * as __vite_glob_1_2 from "./modules/index.ts";import { name as __vite_glob_3_0 } from "./modules/a.ts";import { name as __vite_glob_3_1 } from "./modules/b.ts";import { name as __vite_glob_3_2 } from "./modules/index.ts";import { default as __vite_glob_5_0 } from "./modules/a.ts?raw";import { default as __vite_glob_5_1 } from "./modules/b.ts?raw";import "types/importMeta";
+"import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_1_0,"./modules/b.ts": __vite_glob_1_1,"./modules/index.ts": __vite_glob_1_2
+export const basicWithObjectKeys = Object.keys(/* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''}));
+export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
 
 });
+export const basicEagerWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+
+})
+);
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
-export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
+export const ignoreWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": ''})
+);
+export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_6_0,"./modules/b.ts": __vite_glob_6_1,"./modules/index.ts": __vite_glob_6_2
 
 
 });
+export const namedEagerWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+
+
+})
+);
 export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
-export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_5_0,"./modules/b.ts": __vite_glob_5_1
+export const namedDefaultWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+
+})
+);
+export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_10_0,"./modules/b.ts": __vite_glob_10_1
 
 
 });

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -3,13 +3,13 @@
 exports[`fixture > transform 1`] = `
 "import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicWithObjectKeys = Object.keys({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''});
+export const basicWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
 export const basicWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts"),() => import("./modules/index.ts")]);
 export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
 
 });
 export const basicEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
 }
 );
@@ -20,7 +20,7 @@ export const basicEagerWithObjectValues = Object.values(
 );
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
 export const ignoreWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": ''}
+  {"./modules/a.ts": 0,"./modules/b.ts": 0}
 );
 export const ignoreWithObjectValues = Object.values(
   [() => import("./modules/a.ts"),() => import("./modules/b.ts")]
@@ -30,7 +30,7 @@ export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vit
 
 });
 export const namedEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
 
 }
@@ -45,7 +45,7 @@ export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () 
 
 });
 export const namedDefaultWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
 }
 );
@@ -98,13 +98,13 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({"./modules/a.ts": () =>
 exports[`fixture > transform with restoreQueryExtension 1`] = `
 "import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicWithObjectKeys = Object.keys({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''});
+export const basicWithObjectKeys = Object.keys({"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0});
 export const basicWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts"),() => import("./modules/index.ts")]);
 export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
 
 });
 export const basicEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
 }
 );
@@ -115,7 +115,7 @@ export const basicEagerWithObjectValues = Object.values(
 );
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
 export const ignoreWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": ''}
+  {"./modules/a.ts": 0,"./modules/b.ts": 0}
 );
 export const ignoreWithObjectValues = Object.values(
   [() => import("./modules/a.ts"),() => import("./modules/b.ts")]
@@ -125,7 +125,7 @@ export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vit
 
 });
 export const namedEagerWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
 
 }
@@ -140,7 +140,7 @@ export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () 
 
 });
 export const namedDefaultWithObjectKeys = Object.keys(
-  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": 0,"./modules/b.ts": 0,"./modules/index.ts": 0
 
 }
 );

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -3,38 +3,36 @@
 exports[`fixture > transform 1`] = `
 "import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''})
-);
+export const basicWithObjectKeys = Object.keys({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''});
 export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
 
 });
 export const basicEagerWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
 
-})
+}
 );
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
 export const ignoreWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": ''})
+  {"./modules/a.ts": '',"./modules/b.ts": ''}
 );
 export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_6_0,"./modules/b.ts": __vite_glob_6_1,"./modules/index.ts": __vite_glob_6_2
 
 
 });
 export const namedEagerWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
 
 
-})
+}
 );
 export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
 export const namedDefaultWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
 
-})
+}
 );
 export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_10_0,"./modules/b.ts": __vite_glob_10_1
 
@@ -80,38 +78,36 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({"./modules/a.ts": () =>
 exports[`fixture > transform with restoreQueryExtension 1`] = `
 "import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''})
-);
+export const basicWithObjectKeys = Object.keys({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''});
 export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
 
 });
 export const basicEagerWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
 
-})
+}
 );
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
 export const ignoreWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": ''})
+  {"./modules/a.ts": '',"./modules/b.ts": ''}
 );
 export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_6_0,"./modules/b.ts": __vite_glob_6_1,"./modules/index.ts": __vite_glob_6_2
 
 
 });
 export const namedEagerWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
 
 
-})
+}
 );
 export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
 export const namedDefaultWithObjectKeys = Object.keys(
-  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
+  {"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''
 
-})
+}
 );
 export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_10_0,"./modules/b.ts": __vite_glob_10_1
 

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -1,10 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`fixture > transform 1`] = `
-"import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
+"import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
 export const basicWithObjectKeys = Object.keys({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''});
-export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
+export const basicWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts"),() => import("./modules/index.ts")]);
+export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
 
 });
 export const basicEagerWithObjectKeys = Object.keys(
@@ -12,11 +13,19 @@ export const basicEagerWithObjectKeys = Object.keys(
 
 }
 );
+export const basicEagerWithObjectValues = Object.values(
+  [__vite_glob_5_0,__vite_glob_5_1,__vite_glob_5_2
+
+]
+);
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
 export const ignoreWithObjectKeys = Object.keys(
   {"./modules/a.ts": '',"./modules/b.ts": ''}
 );
-export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_6_0,"./modules/b.ts": __vite_glob_6_1,"./modules/index.ts": __vite_glob_6_2
+export const ignoreWithObjectValues = Object.values(
+  [() => import("./modules/a.ts"),() => import("./modules/b.ts")]
+);
+export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_9_0,"./modules/b.ts": __vite_glob_9_1,"./modules/index.ts": __vite_glob_9_2
 
 
 });
@@ -26,6 +35,12 @@ export const namedEagerWithObjectKeys = Object.keys(
 
 }
 );
+export const namedEagerWithObjectValues = Object.values(
+  [__vite_glob_11_0,__vite_glob_11_1,__vite_glob_11_2
+
+
+]
+);
 export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
@@ -34,7 +49,12 @@ export const namedDefaultWithObjectKeys = Object.keys(
 
 }
 );
-export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_10_0,"./modules/b.ts": __vite_glob_10_1
+export const namedDefaultWithObjectValues = Object.values(
+  [() => import("./modules/a.ts").then(m => m["default"]),() => import("./modules/b.ts").then(m => m["default"]),() => import("./modules/index.ts").then(m => m["default"])
+
+]
+);
+export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_15_0,"./modules/b.ts": __vite_glob_15_1
 
 
 });
@@ -76,10 +96,11 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({"./modules/a.ts": () =>
 `;
 
 exports[`fixture > transform with restoreQueryExtension 1`] = `
-"import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
+"import * as __vite_glob_3_0 from "./modules/a.ts";import * as __vite_glob_3_1 from "./modules/b.ts";import * as __vite_glob_3_2 from "./modules/index.ts";import * as __vite_glob_5_0 from "./modules/a.ts";import * as __vite_glob_5_1 from "./modules/b.ts";import * as __vite_glob_5_2 from "./modules/index.ts";import { name as __vite_glob_9_0 } from "./modules/a.ts";import { name as __vite_glob_9_1 } from "./modules/b.ts";import { name as __vite_glob_9_2 } from "./modules/index.ts";import { name as __vite_glob_11_0 } from "./modules/a.ts";import { name as __vite_glob_11_1 } from "./modules/b.ts";import { name as __vite_glob_11_2 } from "./modules/index.ts";import { default as __vite_glob_15_0 } from "./modules/a.ts?raw";import { default as __vite_glob_15_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
 export const basicWithObjectKeys = Object.keys({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''});
-export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
+export const basicWithObjectValues = Object.values([() => import("./modules/a.ts"),() => import("./modules/b.ts"),() => import("./modules/index.ts")]);
+export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_3_0,"./modules/b.ts": __vite_glob_3_1,"./modules/index.ts": __vite_glob_3_2
 
 });
 export const basicEagerWithObjectKeys = Object.keys(
@@ -87,11 +108,19 @@ export const basicEagerWithObjectKeys = Object.keys(
 
 }
 );
+export const basicEagerWithObjectValues = Object.values(
+  [__vite_glob_5_0,__vite_glob_5_1,__vite_glob_5_2
+
+]
+);
 export const ignore = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts")});
 export const ignoreWithObjectKeys = Object.keys(
   {"./modules/a.ts": '',"./modules/b.ts": ''}
 );
-export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_6_0,"./modules/b.ts": __vite_glob_6_1,"./modules/index.ts": __vite_glob_6_2
+export const ignoreWithObjectValues = Object.values(
+  [() => import("./modules/a.ts"),() => import("./modules/b.ts")]
+);
+export const namedEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_9_0,"./modules/b.ts": __vite_glob_9_1,"./modules/index.ts": __vite_glob_9_2
 
 
 });
@@ -101,6 +130,12 @@ export const namedEagerWithObjectKeys = Object.keys(
 
 }
 );
+export const namedEagerWithObjectValues = Object.values(
+  [__vite_glob_11_0,__vite_glob_11_1,__vite_glob_11_2
+
+
+]
+);
 export const namedDefault = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts").then(m => m["default"]),"./modules/b.ts": () => import("./modules/b.ts").then(m => m["default"]),"./modules/index.ts": () => import("./modules/index.ts").then(m => m["default"])
 
 });
@@ -109,7 +144,12 @@ export const namedDefaultWithObjectKeys = Object.keys(
 
 }
 );
-export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_10_0,"./modules/b.ts": __vite_glob_10_1
+export const namedDefaultWithObjectValues = Object.values(
+  [() => import("./modules/a.ts").then(m => m["default"]),() => import("./modules/b.ts").then(m => m["default"]),() => import("./modules/index.ts").then(m => m["default"])
+
+]
+);
+export const eagerAs = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_15_0,"./modules/b.ts": __vite_glob_15_1
 
 
 });

--- a/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/__snapshots__/fixture.spec.ts.snap
@@ -3,7 +3,9 @@
 exports[`fixture > transform 1`] = `
 "import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicWithObjectKeys = Object.keys(/* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''}));
+export const basicWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''})
+);
 export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
 
 });
@@ -78,7 +80,9 @@ export const cleverCwd2 = /* #__PURE__ */ Object.assign({"./modules/a.ts": () =>
 exports[`fixture > transform with restoreQueryExtension 1`] = `
 "import * as __vite_glob_2_0 from "./modules/a.ts";import * as __vite_glob_2_1 from "./modules/b.ts";import * as __vite_glob_2_2 from "./modules/index.ts";import { name as __vite_glob_6_0 } from "./modules/a.ts";import { name as __vite_glob_6_1 } from "./modules/b.ts";import { name as __vite_glob_6_2 } from "./modules/index.ts";import { default as __vite_glob_10_0 } from "./modules/a.ts?raw";import { default as __vite_glob_10_1 } from "./modules/b.ts?raw";import "types/importMeta";
 export const basic = /* #__PURE__ */ Object.assign({"./modules/a.ts": () => import("./modules/a.ts"),"./modules/b.ts": () => import("./modules/b.ts"),"./modules/index.ts": () => import("./modules/index.ts")});
-export const basicWithObjectKeys = Object.keys(/* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''}));
+export const basicWithObjectKeys = Object.keys(
+  /* #__PURE__ */ Object.assign({"./modules/a.ts": '',"./modules/b.ts": '',"./modules/index.ts": ''})
+);
 export const basicEager = /* #__PURE__ */ Object.assign({"./modules/a.ts": __vite_glob_2_0,"./modules/b.ts": __vite_glob_2_1,"./modules/index.ts": __vite_glob_2_2
 
 });

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
@@ -7,6 +7,8 @@ export interface ModuleType {
 export const basic = import.meta.glob<ModuleType>('./modules/*.ts')
 // prettier-ignore
 export const basicWithObjectKeys = Object.keys(import.meta.glob<ModuleType>('./modules/*.ts'))
+// prettier-ignore
+export const basicWithObjectValues = Object.values(import.meta.glob<ModuleType>('./modules/*.ts'))
 
 export const basicEager = import.meta.glob<ModuleType>('./modules/*.ts', {
   eager: true,
@@ -16,9 +18,17 @@ export const basicEagerWithObjectKeys = Object.keys(
     eager: true,
   }),
 )
+export const basicEagerWithObjectValues = Object.values(
+  import.meta.glob<ModuleType>('./modules/*.ts', {
+    eager: true,
+  }),
+)
 
 export const ignore = import.meta.glob(['./modules/*.ts', '!**/index.ts'])
 export const ignoreWithObjectKeys = Object.keys(
+  import.meta.glob(['./modules/*.ts', '!**/index.ts']),
+)
+export const ignoreWithObjectValues = Object.values(
   import.meta.glob(['./modules/*.ts', '!**/index.ts']),
 )
 
@@ -32,11 +42,22 @@ export const namedEagerWithObjectKeys = Object.keys(
     import: 'name',
   }),
 )
+export const namedEagerWithObjectValues = Object.values(
+  import.meta.glob<string>('./modules/*.ts', {
+    eager: true,
+    import: 'name',
+  }),
+)
 
 export const namedDefault = import.meta.glob<string>('./modules/*.ts', {
   import: 'default',
 })
 export const namedDefaultWithObjectKeys = Object.keys(
+  import.meta.glob<string>('./modules/*.ts', {
+    import: 'default',
+  }),
+)
+export const namedDefaultWithObjectValues = Object.values(
   import.meta.glob<string>('./modules/*.ts', {
     import: 'default',
   }),

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
@@ -5,9 +5,8 @@ export interface ModuleType {
 }
 
 export const basic = import.meta.glob<ModuleType>('./modules/*.ts')
-export const basicWithObjectKeys = Object.keys(
-  import.meta.glob<ModuleType>('./modules/*.ts'),
-)
+// prettier-ignore
+export const basicWithObjectKeys = Object.keys(import.meta.glob<ModuleType>('./modules/*.ts'))
 
 export const basicEager = import.meta.glob<ModuleType>('./modules/*.ts', {
   eager: true,

--- a/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
+++ b/packages/vite/src/node/__tests__/plugins/importGlob/fixture-a/index.ts
@@ -5,21 +5,43 @@ export interface ModuleType {
 }
 
 export const basic = import.meta.glob<ModuleType>('./modules/*.ts')
+export const basicWithObjectKeys = Object.keys(
+  import.meta.glob<ModuleType>('./modules/*.ts'),
+)
 
 export const basicEager = import.meta.glob<ModuleType>('./modules/*.ts', {
   eager: true,
 })
+export const basicEagerWithObjectKeys = Object.keys(
+  import.meta.glob<ModuleType>('./modules/*.ts', {
+    eager: true,
+  }),
+)
 
 export const ignore = import.meta.glob(['./modules/*.ts', '!**/index.ts'])
+export const ignoreWithObjectKeys = Object.keys(
+  import.meta.glob(['./modules/*.ts', '!**/index.ts']),
+)
 
 export const namedEager = import.meta.glob<string>('./modules/*.ts', {
   eager: true,
   import: 'name',
 })
+export const namedEagerWithObjectKeys = Object.keys(
+  import.meta.glob<string>('./modules/*.ts', {
+    eager: true,
+    import: 'name',
+  }),
+)
 
 export const namedDefault = import.meta.glob<string>('./modules/*.ts', {
   import: 'default',
 })
+export const namedDefaultWithObjectKeys = Object.keys(
+  import.meta.glob<string>('./modules/*.ts', {
+    import: 'default',
+  }),
+)
 
 export const eagerAs = import.meta.glob<ModuleType>(
   ['./modules/*.ts', '!**/index.ts'],

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -108,7 +108,7 @@ export function importGlobPlugin(config: ResolvedConfig): Plugin {
 }
 
 const importGlobRE = /\bimport\.meta\.glob(?:<\w+>)?\s*\(/g
-const objectKeysRE = /Object\.keys\(\s*$/
+const objectKeysRE = /\bObject\.keys\(\s*$/
 
 const knownOptions = {
   as: ['string'],
@@ -494,10 +494,11 @@ export async function transformGlobImport(
             originalLineBreakCount > 0
               ? '\n'.repeat(originalLineBreakCount)
               : ''
-
-          const replacement = `/* #__PURE__ */ Object.assign({${objectProps.join(
-            ',',
-          )}${lineBreaks}})`
+          const replacement = onlyKeys
+            ? `{${objectProps.join(',')}${lineBreaks}}`
+            : `/* #__PURE__ */ Object.assign({${objectProps.join(
+                ',',
+              )}${lineBreaks}})`
           s.overwrite(start, end, replacement)
 
           return staticImports

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -437,7 +437,7 @@ export async function transformGlobImport(
             let importPath = paths.importPath
             let importQuery = options.query ?? ''
 
-            if (importQuery && importQuery === '?nocontnet') {
+            if (importQuery && importQuery === '?nocontent') {
               objectProps.push(`${JSON.stringify(filePath)}: ''`)
               return
             }

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -459,7 +459,7 @@ export async function transformGlobImport(
             let importQuery = options.query ?? ''
 
             if (onlyKeys) {
-              objectProps.push(`${JSON.stringify(filePath)}: ''`)
+              objectProps.push(`${JSON.stringify(filePath)}: 0`)
               return
             }
 

--- a/packages/vite/src/node/plugins/importMetaGlob.ts
+++ b/packages/vite/src/node/plugins/importMetaGlob.ts
@@ -437,6 +437,11 @@ export async function transformGlobImport(
             let importPath = paths.importPath
             let importQuery = options.query ?? ''
 
+            if (importQuery && importQuery === '?nocontnet') {
+              objectProps.push(`${JSON.stringify(filePath)}: ''`)
+              return
+            }
+
             if (importQuery && importQuery !== '?raw') {
               const fileExtension = basename(file).split('.').slice(-1)[0]
               if (fileExtension && restoreQueryExtension)


### PR DESCRIPTION
### Description
close #18662
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
