### PR TITLE
refactor(resolve): remove `allowLinkedExternal` parameter from `tryNodeResolve`

### DIFF
--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -88,13 +88,12 @@ export function createIsConfiguredAsExternal(
         resolveOptions,
         undefined,
         false,
-        // Allow linked packages to be externalized if they are explicitly
-        // configured as external
-        !!configuredAsExternal,
       )
       if (!resolved) {
         return false
       }
+      // Allow linked packages to be externalized if they are explicitly
+      // configured as external
       return canExternalizeFile(resolved.id, !!configuredAsExternal)
     } catch {
       debug?.(

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -92,9 +92,12 @@ export function createIsConfiguredAsExternal(
       if (!resolved) {
         return false
       }
-      // Allow linked packages to be externalized if they are explicitly
-      // configured as external
-      return canExternalizeFile(resolved.id, !!configuredAsExternal)
+      // Only allow linked packages to be externalized
+      // if they are explicitly configured as external
+      if (!configuredAsExternal && !isInNodeModules(resolved.id)) {
+        return false
+      }
+      return canExternalizeFile(resolved.id)
     } catch {
       debug?.(
         `Failed to node resolve "${id}". Skipping externalizing it by default.`,
@@ -159,14 +162,7 @@ function createIsExternal(
   }
 }
 
-export function canExternalizeFile(
-  filePath: string,
-  allowLinkedExternal: boolean,
-): boolean {
-  // don't external symlink packages
-  if (!allowLinkedExternal && !isInNodeModules(filePath)) {
-    return false
-  }
+export function canExternalizeFile(filePath: string): boolean {
   const ext = path.extname(filePath)
   // only external js imports
   return !ext || ext === '.js' || ext === '.mjs' || ext === '.cjs'

--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -16,14 +16,14 @@ const debug = createDebugger('vite:external')
 
 const isExternalCache = new WeakMap<
   Environment,
-  (id: string, importer?: string) => boolean | undefined
+  (id: string, importer?: string) => boolean
 >()
 
 export function shouldExternalize(
   environment: Environment,
   id: string,
   importer: string | undefined,
-): boolean | undefined {
+): boolean {
   let isExternal = isExternalCache.get(environment)
   if (!isExternal) {
     isExternal = createIsExternal(environment)
@@ -73,8 +73,8 @@ export function createIsConfiguredAsExternal(
 
   const isExternalizable = (
     id: string,
-    importer?: string,
-    configuredAsExternal?: boolean,
+    importer: string | undefined,
+    configuredAsExternal: boolean,
   ): boolean => {
     if (!bareImportRE.test(id) || id.includes('\0')) {
       return false
@@ -120,7 +120,7 @@ export function createIsConfiguredAsExternal(
     }
     const pkgName = getNpmPackageName(id)
     if (!pkgName) {
-      return isExternalizable(id, importer)
+      return isExternalizable(id, importer, false)
     }
     if (
       // A package name in ssr.external externalizes every
@@ -144,14 +144,14 @@ export function createIsConfiguredAsExternal(
 
 function createIsExternal(
   environment: Environment,
-): (id: string, importer?: string) => boolean | undefined {
-  const processedIds = new Map<string, boolean | undefined>()
+): (id: string, importer?: string) => boolean {
+  const processedIds = new Map<string, boolean>()
 
   const isConfiguredAsExternal = createIsConfiguredAsExternal(environment)
 
   return (id: string, importer?: string) => {
     if (processedIds.has(id)) {
-      return processedIds.get(id)
+      return processedIds.get(id)!
     }
     let isExternal = false
     if (id[0] !== '.' && !path.isAbsolute(id)) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -410,14 +410,7 @@ export function resolvePlugin(
         }
 
         if (
-          (res = tryNodeResolve(
-            id,
-            importer,
-            options,
-            depsOptimizer,
-            external,
-            undefined,
-          ))
+          (res = tryNodeResolve(id, importer, options, depsOptimizer, external))
         ) {
           return res
         }
@@ -696,7 +689,6 @@ export function tryNodeResolve(
   options: InternalResolveOptions,
   depsOptimizer?: DepsOptimizer,
   externalize?: boolean,
-  allowLinkedExternal: boolean = true,
 ): PartialResolvedId | undefined {
   const { root, dedupe, isBuild, preserveSymlinks, packageCache } = options
 
@@ -771,7 +763,7 @@ export function tryNodeResolve(
     if (!externalize) {
       return resolved
     }
-    if (!canExternalizeFile(resolved.id, allowLinkedExternal)) {
+    if (!canExternalizeFile(resolved.id, true)) {
       return resolved
     }
 
@@ -1098,7 +1090,6 @@ function tryResolveBrowserMapping(
               browserMappedPath,
               importer,
               options,
-              undefined,
               undefined,
               undefined,
             )?.id

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -763,7 +763,7 @@ export function tryNodeResolve(
     if (!externalize) {
       return resolved
     }
-    if (!canExternalizeFile(resolved.id, true)) {
+    if (!canExternalizeFile(resolved.id)) {
       return resolved
     }
 


### PR DESCRIPTION
### Description

`allowLinkedExternal` was only used for `createIsConfiguredAsExternal` so I moved that logic to there and remove it from `tryNodeResolve`.

Also removed some `| undefined` to make the types more simple.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
