### PR TITLE
fix: `createRunnableDevEnvironment` returns `RunnableDevEnvironment`, not `DevEnvironment`

### DIFF
--- a/packages/vite/src/node/server/environments/runnableEnvironment.ts
+++ b/packages/vite/src/node/server/environments/runnableEnvironment.ts
@@ -11,7 +11,7 @@ export function createRunnableDevEnvironment(
   name: string,
   config: ResolvedConfig,
   context: RunnableDevEnvironmentContext = {},
-): DevEnvironment {
+): RunnableDevEnvironment {
   if (context.transport == null) {
     context.transport = createServerHotChannel()
   }


### PR DESCRIPTION
### Description

`createRunnableDevEnvironment` was returning incorrect type. `DevEnvironment` doesn't have a `runner` property 😄 
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
