### PR TITLE
fix(html): fix inline proxy modules invalidation

### DIFF
--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -510,3 +510,12 @@ test('escape html attribute', async () => {
   const el = await page.$('.unescape-div')
   expect(el).toBeNull()
 })
+
+test('invalidate inline proxy module on reload', async () => {
+  await page.goto(`${viteTestUrl}/transform-inline-js`)
+  await expect.poll(() => page.textContent('.test')).toContain('ok')
+  await page.reload()
+  await expect.poll(() => page.textContent('.test')).toContain('ok')
+  await page.reload()
+  await expect.poll(() => page.textContent('.test')).toContain('ok')
+})

--- a/playground/html/__tests__/html.spec.ts
+++ b/playground/html/__tests__/html.spec.ts
@@ -513,9 +513,9 @@ test('escape html attribute', async () => {
 
 test('invalidate inline proxy module on reload', async () => {
   await page.goto(`${viteTestUrl}/transform-inline-js`)
-  await expect.poll(() => page.textContent('.test')).toContain('ok')
+  expect(await page.textContent('.test')).toContain('ok')
   await page.reload()
-  await expect.poll(() => page.textContent('.test')).toContain('ok')
+  expect(await page.textContent('.test')).toContain('ok')
   await page.reload()
-  await expect.poll(() => page.textContent('.test')).toContain('ok')
+  expect(await page.textContent('.test')).toContain('ok')
 })

--- a/playground/html/transform-inline-js.html
+++ b/playground/html/transform-inline-js.html
@@ -1,0 +1,5 @@
+<div>id: {{ id }}</div>
+<div class="test">test: <span id="{{ id }}">???</span></div>
+<script type="module">
+  document.getElementById('{{ id }}').textContent = 'ok'
+</script>

--- a/playground/html/vite.config.js
+++ b/playground/html/vite.config.js
@@ -35,6 +35,7 @@ export default defineConfig({
         serveBothFile: resolve(__dirname, 'serve/both.html'),
         serveBothFolder: resolve(__dirname, 'serve/both/index.html'),
         write: resolve(__dirname, 'write.html'),
+        'transform-inline-js': resolve(__dirname, 'transform-inline-js.html'),
         relativeInput: relative(
           process.cwd(),
           resolve(__dirname, 'relative-input.html'),
@@ -246,6 +247,19 @@ ${
               injectTo: 'body',
             },
           ]
+        },
+      },
+    },
+    {
+      name: 'transform-inline-js',
+      transformIndexHtml: {
+        order: 'pre',
+        handler(html, ctx) {
+          if (!ctx.filename.endsWith('html/transform-inline-js.html')) return
+          return html.replaceAll(
+            '{{ id }}',
+            Math.random().toString(36).slice(2),
+          )
         },
       },
     },


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/discussions/18685#discussioncomment-11283654

For the reproduction in the discussion, `moduleGraph.getModuleById(modulePath)` is always `null` because `modulePath` is `/index.html?html-proxy...` but actual module id is `/abs-path-to/index.html?html-proxy...`.

I replaced `getModuleById` with `getModuleByUrl`, but this is async, so I moved the invalidation after sync `traverseHtml`.