### PR TITLE
test: remove `runInBuild` flag from `withRetry`

### DIFF
--- a/playground/cli/__tests__/cli.spec.ts
+++ b/playground/cli/__tests__/cli.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port, streams } from './serve'
-import { editFile, page, withRetry } from '~utils'
+import { editFile, isServe, page, withRetry } from '~utils'
 
 test('cli should work', async () => {
   // this test uses a custom serve implementation, so regular helpers for browserLogs and goto don't work
@@ -20,7 +20,7 @@ test('cli should work', async () => {
   }
 })
 
-test('should restart', async () => {
+test.runIf(isServe)('should restart', async () => {
   const logsLengthBeforeEdit = streams.server.out.length
   editFile('./vite.config.js', (content) => content)
   await withRetry(async () => {

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -528,13 +528,13 @@ test('async css order', async () => {
   await withRetry(async () => {
     expect(await getColor('.async-green')).toMatchInlineSnapshot('"green"')
     expect(await getColor('.async-blue')).toMatchInlineSnapshot('"blue"')
-  }, true)
+  })
 })
 
 test('async css order with css modules', async () => {
   await withRetry(async () => {
     expect(await getColor('.modules-pink')).toMatchInlineSnapshot('"pink"')
-  }, true)
+  })
 })
 
 test('@import scss', async () => {

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -87,15 +87,15 @@ test('should work', async () => {
   await withRetry(async () => {
     const actual = await page.textContent('.result')
     expect(JSON.parse(actual)).toStrictEqual(allResult)
-  }, true)
+  })
   await withRetry(async () => {
     const actualEager = await page.textContent('.result-eager')
     expect(JSON.parse(actualEager)).toStrictEqual(allResult)
-  }, true)
+  })
   await withRetry(async () => {
     const actualNodeModules = await page.textContent('.result-node_modules')
     expect(JSON.parse(actualNodeModules)).toStrictEqual(nodeModulesResult)
-  }, true)
+  })
 })
 
 test('import glob raw', async () => {

--- a/playground/ssr-conditions/__tests__/ssr-conditions.spec.ts
+++ b/playground/ssr-conditions/__tests__/ssr-conditions.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port } from './serve'
-import { page, withRetry } from '~utils'
+import { isServe, page, withRetry } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -16,16 +16,19 @@ test('ssr.resolve.externalConditions affect externalized imports during ssr', as
   expect(await page.textContent('.external-react-server')).toMatch('edge.js')
 })
 
-test('ssr.resolve settings do not affect non-ssr imports', async () => {
-  await page.goto(url)
-  await withRetry(async () => {
-    expect(await page.textContent('.browser-no-external-react-server')).toMatch(
-      'default.js',
-    )
-  })
-  await withRetry(async () => {
-    expect(await page.textContent('.browser-external-react-server')).toMatch(
-      'default.js',
-    )
-  })
-})
+test.runIf(isServe)(
+  'ssr.resolve settings do not affect non-ssr imports',
+  async () => {
+    await page.goto(url)
+    await withRetry(async () => {
+      expect(
+        await page.textContent('.browser-no-external-react-server'),
+      ).toMatch('default.js')
+    })
+    await withRetry(async () => {
+      expect(await page.textContent('.browser-external-react-server')).toMatch(
+        'default.js',
+      )
+    })
+  },
+)

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -45,7 +45,7 @@ test.runIf(isServe)('html proxy is encoded', async () => {
 })
 
 // run this at the end to reduce flakiness
-test('should restart ssr', async () => {
+test.runIf(isServe)('should restart ssr', async () => {
   editFile('./vite.config.ts', (content) => content)
   await withRetry(async () => {
     expect(serverLogs).toEqual(

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -241,11 +241,7 @@ export async function untilUpdated(
 /**
  * Retry `func` until it does not throw error.
  */
-export async function withRetry(
-  func: () => Promise<void>,
-  runInBuild = false,
-): Promise<void> {
-  if (isBuild && !runInBuild) return
+export async function withRetry(func: () => Promise<void>): Promise<void> {
   const maxTries = process.env.CI ? 200 : 50
   for (let tries = 0; tries < maxTries; tries++) {
     try {
@@ -263,10 +259,7 @@ export const expectWithRetry = <T>(getActual: () => Promise<T>) => {
     {
       get(_target, key) {
         return async (...args) => {
-          await withRetry(
-            async () => expect(await getActual())[key](...args),
-            true,
-          )
+          await withRetry(async () => expect(await getActual())[key](...args))
         }
       },
     },


### PR DESCRIPTION
### Description

`withRetry` gets me confused from time to time as it skips assertions on build by default. From the current usage, I couldn't tell the benefit of this behavior, so I replaced it with adding `runIf(isServe)` at dev only tests.