### PR TITLE
test: remove `runInBuild` flag from `withRetry` and `untilUpdated` helpers

### DIFF
--- a/playground/alias/__tests__/alias.spec.ts
+++ b/playground/alias/__tests__/alias.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { editFile, getColor, page, untilUpdated } from '~utils'
+import { editFile, getColor, isBuild, page, untilUpdated } from '~utils'
 
 test('fs', async () => {
   expect(await page.textContent('.fs')).toMatch('[success] alias to fs path')
@@ -29,6 +29,7 @@ test('js via script src', async () => {
 
 test('css via link', async () => {
   expect(await getColor('body')).toBe('grey')
+  if (isBuild) return
   editFile('dir/test.css', (code) => code.replace('grey', 'red'))
   await untilUpdated(() => getColor('body'), 'red')
 })

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -552,7 +552,7 @@ test.runIf(isBuild)('manifest', async () => {
 
 describe.runIf(isBuild)('css and assets in css in build watch', () => {
   test('css will not be lost and css does not contain undefined', async () => {
-    editFile('index.html', (code) => code.replace('Assets', 'assets'), true)
+    editFile('index.html', (code) => code.replace('Assets', 'assets'))
     await notifyRebuildComplete(watcher)
     const cssFile = findAssetFile(/index-[-\w]+\.css$/, 'foo')
     expect(cssFile).not.toBe('')
@@ -561,7 +561,7 @@ describe.runIf(isBuild)('css and assets in css in build watch', () => {
 
   test('import module.css', async () => {
     expect(await getColor('#foo')).toBe('red')
-    editFile('css/foo.module.css', (code) => code.replace('red', 'blue'), true)
+    editFile('css/foo.module.css', (code) => code.replace('red', 'blue'))
     await notifyRebuildComplete(watcher)
     await page.reload()
     expect(await getColor('#foo')).toBe('blue')
@@ -569,7 +569,7 @@ describe.runIf(isBuild)('css and assets in css in build watch', () => {
 
   test('import with raw query', async () => {
     expect(await page.textContent('.raw-query')).toBe('foo')
-    editFile('static/foo.txt', (code) => code.replace('foo', 'zoo'), true)
+    editFile('static/foo.txt', (code) => code.replace('foo', 'zoo'))
     await notifyRebuildComplete(watcher)
     await page.reload()
     expect(await page.textContent('.raw-query')).toBe('zoo')
@@ -585,11 +585,7 @@ if (!isBuild) {
   test('@import in html style tag hmr', async () => {
     await untilUpdated(() => getColor('.import-css'), 'rgb(0, 136, 255)')
     const loadPromise = page.waitForEvent('load')
-    editFile(
-      './css/import.css',
-      (code) => code.replace('#0088ff', '#00ff88'),
-      true,
-    )
+    editFile('./css/import.css', (code) => code.replace('#0088ff', '#00ff88'))
     await loadPromise
     await untilUpdated(() => getColor('.import-css'), 'rgb(0, 255, 136)')
   })

--- a/playground/cli/__tests__/cli.spec.ts
+++ b/playground/cli/__tests__/cli.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port, streams } from './serve'
-import { editFile, page, withRetry } from '~utils'
+import { editFile, isServe, page, withRetry } from '~utils'
 
 test('cli should work', async () => {
   // this test uses a custom serve implementation, so regular helpers for browserLogs and goto don't work
@@ -20,7 +20,7 @@ test('cli should work', async () => {
   }
 })
 
-test('should restart', async () => {
+test.runIf(isServe)('should restart', async () => {
   const logsLengthBeforeEdit = streams.server.out.length
   editFile('./vite.config.js', (content) => content)
   await withRetry(async () => {

--- a/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
+++ b/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
@@ -19,6 +19,7 @@ test('linked css', async () => {
   expect(await getColor(linked)).toBe('blue')
   expect(await getColor(atImport)).toBe('red')
 
+  if (isBuild) return
   editFile('linked.css', (code) => code.replace('color: blue', 'color: red'))
   await untilUpdated(() => getColor(linked), 'red')
 
@@ -35,6 +36,7 @@ test('css import from js', async () => {
   expect(await getColor(imported)).toBe('green')
   expect(await getColor(atImport)).toBe('purple')
 
+  if (isBuild) return
   editFile('imported.css', (code) => code.replace('color: green', 'color: red'))
   await untilUpdated(() => getColor(imported), 'red')
 
@@ -50,6 +52,7 @@ test('css modules', async () => {
 
   expect(await imported.getAttribute('class')).toMatch(/\w{6}_apply-color/)
 
+  if (isBuild) return
   editFile('mod.module.css', (code) =>
     code.replace('color: turquoise', 'color: red'),
   )

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -528,13 +528,13 @@ test('async css order', async () => {
   await withRetry(async () => {
     expect(await getColor('.async-green')).toMatchInlineSnapshot('"green"')
     expect(await getColor('.async-blue')).toMatchInlineSnapshot('"blue"')
-  }, true)
+  })
 })
 
 test('async css order with css modules', async () => {
   await withRetry(async () => {
     expect(await getColor('.modules-pink')).toMatchInlineSnapshot('"pink"')
-  }, true)
+  })
 })
 
 test('@import scss', async () => {

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -30,6 +30,8 @@ test('linked css', async () => {
   expect(await getColor(linked)).toBe('blue')
   expect(await getColor(atImport)).toBe('red')
 
+  if (isBuild) return
+
   editFile('linked.css', (code) => code.replace('color: blue', 'color: red'))
   await untilUpdated(() => getColor(linked), 'red')
 
@@ -45,6 +47,8 @@ test('css import from js', async () => {
 
   expect(await getColor(imported)).toBe('green')
   expect(await getColor(atImport)).toBe('purple')
+
+  if (isBuild) return
 
   editFile('imported.css', (code) => code.replace('color: green', 'color: red'))
   await untilUpdated(() => getColor(imported), 'red')
@@ -64,6 +68,8 @@ test('css import asset with space', async () => {
 test('postcss config', async () => {
   const imported = await page.$('.postcss .nesting')
   expect(await getColor(imported)).toBe('pink')
+
+  if (isBuild) return
 
   editFile('imported.css', (code) => code.replace('color: pink', 'color: red'))
   await untilUpdated(() => getColor(imported), 'red')
@@ -95,6 +101,8 @@ test('sass', async () => {
   expect(await getColor(partialImport)).toBe('orchid')
   expect(await getColor(await page.$('.sass-file-absolute'))).toBe('orange')
   expect(await getColor(await page.$('.sass-dir-index'))).toBe('orange')
+
+  if (isBuild) return
 
   editFile('sass.scss', (code) =>
     code.replace('color: $injectedColor', 'color: red'),
@@ -131,6 +139,8 @@ test('less', async () => {
     isBuild ? /ok-[-\w]+\.png/ : `${viteTestUrl}/ok.png`,
   )
 
+  if (isBuild) return
+
   editFile('less.less', (code) => code.replace('@color: blue', '@color: red'))
   await untilUpdated(() => getColor(imported), 'red')
 
@@ -162,6 +172,8 @@ test('stylus', async () => {
   expect(await getColor(optionsDefineVar)).toBe('rgb(51, 197, 255)')
   expect(await getColor(optionsDefineFunc)).toBe('rgb(255, 0, 98)')
 
+  if (isBuild) return
+
   editFile('stylus.styl', (code) =>
     code.replace('$color ?= blue', '$color ?= red'),
   )
@@ -182,6 +194,8 @@ test('css modules', async () => {
   expect(await imported.getAttribute('class')).toMatch(
     /.mod-module__apply-color___[\w-]{5}/,
   )
+
+  if (isBuild) return
 
   editFile('mod.module.css', (code) =>
     code.replace('color: turquoise', 'color: red'),
@@ -258,6 +272,8 @@ test('css modules w/ sass', async () => {
   expect(await imported.getAttribute('class')).toMatch(
     /.mod-module__apply-color___[\w-]{5}/,
   )
+
+  if (isBuild) return
 
   editFile('mod.module.scss', (code) =>
     code.replace('color: orangered', 'color: blue'),
@@ -513,6 +529,8 @@ test('sugarss', async () => {
   expect(await getBg(atImportAlias)).toMatch(
     isBuild ? /base64/ : '/nested/icon.png',
   )
+
+  if (isBuild) return
 
   editFile('sugarss.sss', (code) => code.replace('color: blue', 'color: coral'))
   await untilUpdated(() => getColor(imported), 'coral')

--- a/playground/dynamic-import/__tests__/dynamic-import.spec.ts
+++ b/playground/dynamic-import/__tests__/dynamic-import.spec.ts
@@ -11,12 +11,12 @@ import {
 
 test('should load literal dynamic import', async () => {
   await page.click('.baz')
-  await untilUpdated(() => page.textContent('.view'), 'Baz view', true)
+  await untilUpdated(() => page.textContent('.view'), 'Baz view')
 })
 
 test('should load full dynamic import from public', async () => {
   await page.click('.qux')
-  await untilUpdated(() => page.textContent('.view'), 'Qux view', true)
+  await untilUpdated(() => page.textContent('.view'), 'Qux view')
   // No warning should be logged as we are using @vite-ignore
   expect(
     serverLogs.some((log) => log.includes('cannot be analyzed by vite')),
@@ -25,38 +25,38 @@ test('should load full dynamic import from public', async () => {
 
 test('should load data URL of `blob:`', async () => {
   await page.click('.issue-2658-1')
-  await untilUpdated(() => page.textContent('.view'), 'blob', true)
+  await untilUpdated(() => page.textContent('.view'), 'blob')
 })
 
 test('should load data URL of `data:`', async () => {
   await page.click('.issue-2658-2')
-  await untilUpdated(() => page.textContent('.view'), 'data', true)
+  await untilUpdated(() => page.textContent('.view'), 'data')
 })
 
 test('should have same reference on static and dynamic js import, .mxd', async () => {
   await page.click('.mxd')
-  await untilUpdated(() => page.textContent('.view'), 'true', true)
+  await untilUpdated(() => page.textContent('.view'), 'true')
 })
 
 // in this case, it is not possible to detect the correct module
 test('should have same reference on static and dynamic js import, .mxd2', async () => {
   await page.click('.mxd2')
-  await untilUpdated(() => page.textContent('.view'), 'false', true)
+  await untilUpdated(() => page.textContent('.view'), 'false')
 })
 
 test('should have same reference on static and dynamic js import, .mxdjson', async () => {
   await page.click('.mxdjson')
-  await untilUpdated(() => page.textContent('.view'), 'true', true)
+  await untilUpdated(() => page.textContent('.view'), 'true')
 })
 
 // since this test has a timeout, it should be put last so that it
 // does not bleed on the last
 test('should load dynamic import with vars', async () => {
   await page.click('.foo')
-  await untilUpdated(() => page.textContent('.view'), 'Foo view', true)
+  await untilUpdated(() => page.textContent('.view'), 'Foo view')
 
   await page.click('.bar')
-  await untilUpdated(() => page.textContent('.view'), 'Bar view', true)
+  await untilUpdated(() => page.textContent('.view'), 'Bar view')
 })
 
 // dynamic import css
@@ -65,7 +65,6 @@ test('should load dynamic import with css', async () => {
   await untilUpdated(
     () => page.$eval('.view', (node) => window.getComputedStyle(node).color),
     'rgb(255, 0, 0)',
-    true,
   )
 })
 
@@ -73,7 +72,6 @@ test('should load dynamic import with vars', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars'),
     'hello',
-    true,
   )
 })
 
@@ -81,7 +79,6 @@ test('should load dynamic import with vars ignored', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-ignored'),
     'hello',
-    true,
   )
   // No warning should be logged as we are using @vite-ignore
   expect(
@@ -95,7 +92,6 @@ test('should load dynamic import with double slash ignored', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-double-slash-ignored'),
     'hello',
-    true,
   )
 })
 
@@ -103,7 +99,6 @@ test('should load dynamic import with vars multiline', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-multiline'),
     'hello',
-    true,
   )
 })
 
@@ -111,7 +106,6 @@ test('should load dynamic import with vars alias', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-alias'),
     'hi',
-    true,
   )
 })
 
@@ -119,7 +113,6 @@ test('should load dynamic import with vars raw', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-raw'),
     'export function hello()',
-    true,
   )
 })
 
@@ -127,7 +120,6 @@ test('should load dynamic import with vars url', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-url'),
     isBuild ? 'data:text/javascript' : '/alias/url.js',
-    true,
   )
 })
 
@@ -135,20 +127,18 @@ test('should load dynamic import with vars worker', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-worker'),
     'load worker',
-    true,
   )
 })
 
 test('should load dynamic import with css in package', async () => {
   await page.click('.pkg-css')
-  await untilUpdated(() => getColor('.pkg-css'), 'blue', true)
+  await untilUpdated(() => getColor('.pkg-css'), 'blue')
 })
 
 test('should work with load ../ and itself directory', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-self'),
     'dynamic-import-self-content',
-    true,
   )
 })
 
@@ -156,7 +146,6 @@ test('should work with load ../ and contain itself directory', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-nested-self'),
     'dynamic-import-nested-self-content',
-    true,
   )
 })
 
@@ -164,7 +153,6 @@ test('should work a load path that contains parentheses.', async () => {
   await untilUpdated(
     () => page.textContent('.dynamic-import-with-vars-contains-parenthesis'),
     'dynamic-import-with-vars-contains-parenthesis',
-    true,
   )
 })
 

--- a/playground/glob-import/__tests__/glob-import.spec.ts
+++ b/playground/glob-import/__tests__/glob-import.spec.ts
@@ -87,15 +87,15 @@ test('should work', async () => {
   await withRetry(async () => {
     const actual = await page.textContent('.result')
     expect(JSON.parse(actual)).toStrictEqual(allResult)
-  }, true)
+  })
   await withRetry(async () => {
     const actualEager = await page.textContent('.result-eager')
     expect(JSON.parse(actualEager)).toStrictEqual(allResult)
-  }, true)
+  })
   await withRetry(async () => {
     const actualNodeModules = await page.textContent('.result-node_modules')
     expect(JSON.parse(actualNodeModules)).toStrictEqual(nodeModulesResult)
-  }, true)
+  })
 })
 
 test('import glob raw', async () => {

--- a/playground/json/server.js
+++ b/playground/json/server.js
@@ -4,8 +4,6 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import express from 'express'
 
-// TODO: this can be probably unit test?
-
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const isTest = process.env.VITEST
 

--- a/playground/json/server.js
+++ b/playground/json/server.js
@@ -4,6 +4,8 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import express from 'express'
 
+// TODO: this can be probably unit test?
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const isTest = process.env.VITEST
 

--- a/playground/legacy/__tests__/legacy.spec.ts
+++ b/playground/legacy/__tests__/legacy.spec.ts
@@ -10,40 +10,31 @@ import {
 } from '~utils'
 
 test('should load the worker', async () => {
-  await untilUpdated(() => page.textContent('.worker-message'), 'module', true)
+  await untilUpdated(() => page.textContent('.worker-message'), 'module')
 })
 
 test('should work', async () => {
-  await untilUpdated(() => page.textContent('#app'), 'Hello', true)
+  await untilUpdated(() => page.textContent('#app'), 'Hello')
 })
 
 test('import.meta.env.LEGACY', async () => {
-  await untilUpdated(
-    () => page.textContent('#env'),
-    isBuild ? 'true' : 'false',
-    true,
-  )
-  await untilUpdated(() => page.textContent('#env-equal'), 'true', true)
+  await untilUpdated(() => page.textContent('#env'), isBuild ? 'true' : 'false')
+  await untilUpdated(() => page.textContent('#env-equal'), 'true')
 })
 
 // https://github.com/vitejs/vite/issues/3400
 test('transpiles down iterators correctly', async () => {
-  await untilUpdated(() => page.textContent('#iterators'), 'hello', true)
+  await untilUpdated(() => page.textContent('#iterators'), 'hello')
 })
 
 test('async generator', async () => {
-  await untilUpdated(
-    () => page.textContent('#async-generator'),
-    '[0,1,2]',
-    true,
-  )
+  await untilUpdated(() => page.textContent('#async-generator'), '[0,1,2]')
 })
 
 test('wraps with iife', async () => {
   await untilUpdated(
     () => page.textContent('#babel-helpers'),
     'exposed babel helpers: false',
-    true,
   )
 })
 
@@ -69,7 +60,6 @@ test('generates assets', async () => {
           'immutable-chunk-legacy: text/html',
           'polyfills-legacy: text/html',
         ].join('\n'),
-    true,
   )
 })
 
@@ -80,7 +70,7 @@ test('correctly emits styles', async () => {
 // dynamic import css
 test('should load dynamic import with css', async () => {
   await page.click('#dynamic-css-button')
-  await untilUpdated(() => getColor('#dynamic-css'), 'red', true)
+  await untilUpdated(() => getColor('#dynamic-css'), 'red')
 })
 
 test('asset url', async () => {

--- a/playground/legacy/__tests__/no-polyfills-no-systemjs/legacy-no-polyfills-no-systemjs.spec.ts
+++ b/playground/legacy/__tests__/no-polyfills-no-systemjs/legacy-no-polyfills-no-systemjs.spec.ts
@@ -7,7 +7,6 @@ test.runIf(isBuild)('includes only a single script tag', async () => {
   await untilUpdated(
     () => page.getAttribute('#vite-legacy-entry', 'data-src'),
     /.\/assets\/index-legacy-(.+)\.js/,
-    true,
   )
 
   expect(await page.locator('script').count()).toBe(1)

--- a/playground/legacy/__tests__/no-polyfills/legacy-no-polyfills.spec.ts
+++ b/playground/legacy/__tests__/no-polyfills/legacy-no-polyfills.spec.ts
@@ -3,18 +3,16 @@ import { isBuild, page, untilUpdated, viteTestUrl } from '~utils'
 
 test('should load and execute the JS file', async () => {
   await page.goto(viteTestUrl + '/no-polyfills.html')
-  await untilUpdated(() => page.textContent('main'), '👋', true)
+  await untilUpdated(() => page.textContent('main'), '👋')
 })
 
 test.runIf(isBuild)('includes a script tag for SystemJS', async () => {
   await untilUpdated(
     () => page.getAttribute('#vite-legacy-polyfill', 'src'),
     /.\/assets\/polyfills-legacy-(.+)\.js/,
-    true,
   )
   await untilUpdated(
     () => page.getAttribute('#vite-legacy-entry', 'data-src'),
     /.\/assets\/index-legacy-(.+)\.js/,
-    true,
   )
 })

--- a/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
+++ b/playground/legacy/__tests__/watch/legacy-styles-only-entry-watch.spec.ts
@@ -19,10 +19,8 @@ test.runIf(isBuild)('rebuilds styles only entry on change', async () => {
   const numberOfManifestEntries = Object.keys(readManifest('watch')).length
   expect(numberOfManifestEntries).toBe(3)
 
-  editFile(
-    'style-only-entry.css',
-    (originalContents) => originalContents.replace('#ff69b4', '#ffb6c1'),
-    true,
+  editFile('style-only-entry.css', (originalContents) =>
+    originalContents.replace('#ff69b4', '#ffb6c1'),
   )
   await notifyRebuildComplete(watcher)
 

--- a/playground/lib/index.dist.html
+++ b/playground/lib/index.dist.html
@@ -20,7 +20,7 @@
 </script>
 
 <script type="module">
-  import message from './lib/dynamic-import-message.js'
+  import message from './lib/dynamic-import-message.es.mjs'
 
   message('.dynamic-import-message')
 </script>

--- a/playground/multiple-entrypoints/__tests__/multiple-entrypoints.spec.ts
+++ b/playground/multiple-entrypoints/__tests__/multiple-entrypoints.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from 'vitest'
 import { getColor, page, untilUpdated } from '~utils'
 
 test('should have css applied on second dynamic import', async () => {
-  await untilUpdated(() => page.textContent('.content'), 'Initial', true)
+  await untilUpdated(() => page.textContent('.content'), 'Initial')
   await page.click('.b')
 
-  await untilUpdated(() => page.textContent('.content'), 'Reference', true)
+  await untilUpdated(() => page.textContent('.content'), 'Reference')
   expect(await getColor('.content')).toBe('red')
 })

--- a/playground/optimize-missing-deps/__test__/optimize-missing-deps.spec.ts
+++ b/playground/optimize-missing-deps/__test__/optimize-missing-deps.spec.ts
@@ -1,11 +1,11 @@
 import fetch from 'node-fetch'
 import { expect, test } from 'vitest'
 import { port } from './serve'
-import { page, untilUpdated } from '~utils'
+import { isBuild, page, untilUpdated } from '~utils'
 
 const url = `http://localhost:${port}/`
 
-test('optimize', async () => {
+test.runIf(!isBuild)('optimize', async () => {
   await page.goto(url)
   // reload page to get optimized missing deps
   await page.reload()

--- a/playground/proxy-hmr/__tests__/proxy-hmr.spec.ts
+++ b/playground/proxy-hmr/__tests__/proxy-hmr.spec.ts
@@ -1,13 +1,14 @@
 import { test } from 'vitest'
 import {
   editFile,
+  isBuild,
   page,
   untilBrowserLogAfter,
   untilUpdated,
   viteTestUrl,
 } from '~utils'
 
-test('proxy-hmr', async () => {
+test.runIf(!isBuild)('proxy-hmr', async () => {
   await untilBrowserLogAfter(
     () => page.goto(viteTestUrl),
     // wait for both main and sub app HMR connection

--- a/playground/ssr-conditions/__tests__/ssr-conditions.spec.ts
+++ b/playground/ssr-conditions/__tests__/ssr-conditions.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 import { port } from './serve'
-import { page, withRetry } from '~utils'
+import { isServe, page, withRetry } from '~utils'
 
 const url = `http://localhost:${port}`
 
@@ -16,16 +16,19 @@ test('ssr.resolve.externalConditions affect externalized imports during ssr', as
   expect(await page.textContent('.external-react-server')).toMatch('edge.js')
 })
 
-test('ssr.resolve settings do not affect non-ssr imports', async () => {
-  await page.goto(url)
-  await withRetry(async () => {
-    expect(await page.textContent('.browser-no-external-react-server')).toMatch(
-      'default.js',
-    )
-  })
-  await withRetry(async () => {
-    expect(await page.textContent('.browser-external-react-server')).toMatch(
-      'default.js',
-    )
-  })
-})
+test.runIf(isServe)(
+  'ssr.resolve settings do not affect non-ssr imports',
+  async () => {
+    await page.goto(url)
+    await withRetry(async () => {
+      expect(
+        await page.textContent('.browser-no-external-react-server'),
+      ).toMatch('default.js')
+    })
+    await withRetry(async () => {
+      expect(await page.textContent('.browser-external-react-server')).toMatch(
+        'default.js',
+      )
+    })
+  },
+)

--- a/playground/ssr/__tests__/ssr.spec.ts
+++ b/playground/ssr/__tests__/ssr.spec.ts
@@ -45,7 +45,7 @@ test.runIf(isServe)('html proxy is encoded', async () => {
 })
 
 // run this at the end to reduce flakiness
-test('should restart ssr', async () => {
+test.runIf(isServe)('should restart ssr', async () => {
   editFile('./vite.config.ts', (content) => content)
   await withRetry(async () => {
     expect(serverLogs).toEqual(

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -241,11 +241,7 @@ export async function untilUpdated(
 /**
  * Retry `func` until it does not throw error.
  */
-export async function withRetry(
-  func: () => Promise<void>,
-  runInBuild = false,
-): Promise<void> {
-  if (isBuild && !runInBuild) return
+export async function withRetry(func: () => Promise<void>): Promise<void> {
   const maxTries = process.env.CI ? 200 : 50
   for (let tries = 0; tries < maxTries; tries++) {
     try {
@@ -263,10 +259,7 @@ export const expectWithRetry = <T>(getActual: () => Promise<T>) => {
     {
       get(_target, key) {
         return async (...args) => {
-          await withRetry(
-            async () => expect(await getActual())[key](...args),
-            true,
-          )
+          await withRetry(async () => expect(await getActual())[key](...args))
         }
       },
     },

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -137,9 +137,7 @@ export function readFile(filename: string): string {
 export function editFile(
   filename: string,
   replacer: (str: string) => string,
-  runInBuild: boolean = false,
 ): void {
-  if (isBuild && !runInBuild) return
   filename = path.resolve(testDir, filename)
   const content = fs.readFileSync(filename, 'utf-8')
   const modified = replacer(content)
@@ -218,9 +216,7 @@ export function readDepOptimizationMetadata(): DepOptimizationMetadata {
 export async function untilUpdated(
   poll: () => string | Promise<string>,
   expected: string | RegExp,
-  runInBuild = false,
 ): Promise<void> {
-  if (isBuild && !runInBuild) return
   const maxTries = process.env.CI ? 200 : 50
   for (let tries = 0; tries < maxTries; tries++) {
     const actual = (await poll()) ?? ''

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -15,7 +15,7 @@ import { fromComment } from 'convert-source-map'
 import type { Assertion } from 'vitest'
 import { expect } from 'vitest'
 import type { ResultPromise as ExecaResultPromise } from 'execa'
-import { isBuild, isWindows, page, testDir } from './vitestSetup'
+import { isWindows, page, testDir } from './vitestSetup'
 
 export * from './vitestSetup'
 

--- a/playground/transform-plugin/__tests__/transform-plugin.spec.ts
+++ b/playground/transform-plugin/__tests__/transform-plugin.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from 'vitest'
-import { editFile, page, untilUpdated } from '~utils'
+import { editFile, isBuild, page, untilUpdated } from '~utils'
 
 test('should re-run transform when dependencies are edited', async () => {
   expect(await page.textContent('#transform-count')).toBe('1')
 
+  if (isBuild) return
   editFile('plugin-dep.js', (str) => str)
   await untilUpdated(() => page.textContent('#transform-count'), '2')
 

--- a/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
+++ b/playground/tsconfig-json-load-error/__tests__/tsconfig-json-load-error.spec.ts
@@ -50,7 +50,7 @@ describe.runIf(isServe)('server', () => {
   })
 
   test('should reload when tsconfig is changed', async () => {
-    await editFile('has-error/tsconfig.json', (content) => {
+    editFile('has-error/tsconfig.json', (content) => {
       return content.replace('"compilerOptions":', '"compilerOptions":{}')
     })
     await untilUpdated(() => {

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -4,41 +4,34 @@ import { describe, expect, test } from 'vitest'
 import { expectWithRetry, isBuild, page, testDir, untilUpdated } from '~utils'
 
 test('normal', async () => {
-  await untilUpdated(() => page.textContent('.pong'), 'pong', true)
-  await untilUpdated(
-    () => page.textContent('.mode'),
-    process.env.NODE_ENV,
-    true,
-  )
+  await untilUpdated(() => page.textContent('.pong'), 'pong')
+  await untilUpdated(() => page.textContent('.mode'), process.env.NODE_ENV)
   await untilUpdated(
     () => page.textContent('.bundle-with-plugin'),
     'worker bundle with plugin success!',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
     isBuild ? '/es/assets/worker_asset-vite.svg' : '/es/vite.svg',
-    true,
   )
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker', true)
+  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker')
 })
 
 test('TS output', async () => {
-  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong', true)
+  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong')
 })
 
 test('inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline'), 'pong', true)
+  await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
 })
 
 test('named inlined', async () => {
   await untilUpdated(
     () => page.textContent('.pong-inline-named'),
     'namedInlineWorker',
-    true,
   )
 })
 
@@ -46,24 +39,19 @@ test('import meta url', async () => {
   await untilUpdated(
     () => page.textContent('.pong-inline-url'),
     /^(blob|http):/,
-    true,
   )
 })
 
 test('unicode inlined', async () => {
-  await untilUpdated(
-    () => page.textContent('.pong-inline-unicode'),
-    '•pong•',
-    true,
-  )
+  await untilUpdated(() => page.textContent('.pong-inline-unicode'), '•pong•')
 })
 
 test('shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count'), 'pong', true)
+  await untilUpdated(() => page.textContent('.tick-count'), 'pong')
 })
 
 test('named shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong', true)
+  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong')
 })
 
 test('inline shared worker', async () => {
@@ -74,17 +62,14 @@ test('worker emitted and import.meta.url in nested worker (serve)', async () => 
   await untilUpdated(
     () => page.textContent('.nested-worker'),
     'worker-nested-worker',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.nested-worker-module'),
     'sub-worker',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.nested-worker-constructor'),
     '"type":"constructor"',
-    true,
   )
 })
 
@@ -92,17 +77,14 @@ test('deeply nested workers', async () => {
   await untilUpdated(
     async () => page.textContent('.deeply-nested-worker'),
     /Hello\sfrom\sroot.*\/es\/.+deeply-nested-worker\.js/,
-    true,
   )
   await untilUpdated(
     async () => page.textContent('.deeply-nested-second-worker'),
     /Hello\sfrom\ssecond.*\/es\/.+second-worker\.js/,
-    true,
   )
   await untilUpdated(
     async () => page.textContent('.deeply-nested-third-worker'),
     /Hello\sfrom\sthird.*\/es\/.+third-worker\.js/,
-    true,
   )
 })
 
@@ -142,12 +124,10 @@ describe.runIf(isBuild)('build', () => {
     await untilUpdated(
       () => page.textContent('.nested-worker-module'),
       '"type":"module"',
-      true,
     )
     await untilUpdated(
       () => page.textContent('.nested-worker-constructor'),
       '"type":"constructor"',
-      true,
     )
   })
 })
@@ -156,31 +136,23 @@ test('module worker', async () => {
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url'),
     'A string',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-resolve'),
     'A string',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-without-extension'),
     'A string',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
-    true,
   )
 })
 
 test('classic worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.classic-worker'),
-    'A classic',
-    true,
-  )
+  await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
   await untilUpdated(
     () => page.textContent('.classic-worker-import'),
     '[success] classic-esm',
@@ -188,7 +160,6 @@ test('classic worker', async () => {
   await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',
-    true,
   )
 })
 
@@ -196,12 +167,10 @@ test('emit chunk', async () => {
   await untilUpdated(
     () => page.textContent('.emit-chunk-worker'),
     '["A string",{"type":"emit-chunk-sub-worker","data":"A string"},{"type":"module-and-worker:worker","data":"A string"},{"type":"module-and-worker:module","data":"module and worker"},{"type":"emit-chunk-sub-worker","data":{"module":"module and worker","msg1":"module1","msg2":"module2","msg3":"module3"}}]',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.emit-chunk-dynamic-import-worker'),
     '"A stringmodule1/es/"',
-    true,
   )
 })
 
@@ -209,23 +178,17 @@ test('url query worker', async () => {
   await untilUpdated(
     () => page.textContent('.simple-worker-url'),
     'Hello from simple worker!',
-    true,
   )
 })
 
 test('import.meta.glob in worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.importMetaGlob-worker'),
-    '["',
-    true,
-  )
+  await untilUpdated(() => page.textContent('.importMetaGlob-worker'), '["')
 })
 
 test('import.meta.glob with eager in worker', async () => {
   await untilUpdated(
     () => page.textContent('.importMetaGlobEager-worker'),
     '["',
-    true,
   )
 })
 

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -153,11 +153,12 @@ test('module worker', async () => {
 
 test('classic worker', async () => {
   await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
-  if (isBuild) return
-  await untilUpdated(
-    () => page.textContent('.classic-worker-import'),
-    '[success] classic-esm',
-  )
+  if (!isBuild) {
+    await untilUpdated(
+      () => page.textContent('.classic-worker-import'),
+      '[success] classic-esm',
+    )
+  }
   await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',

--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -153,6 +153,7 @@ test('module worker', async () => {
 
 test('classic worker', async () => {
   await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
+  if (isBuild) return
   await untilUpdated(
     () => page.textContent('.classic-worker-import'),
     '[success] classic-esm',

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -56,17 +56,23 @@ test('inline shared worker', async () => {
   await untilUpdated(() => page.textContent('.pong-shared-inline'), 'pong')
 })
 
-test('worker emitted and import.meta.url in nested worker (serve)', async () => {
-  await untilUpdated(() => page.textContent('.nested-worker'), '/worker-nested')
-  await untilUpdated(
-    () => page.textContent('.nested-worker-module'),
-    '/sub-worker',
-  )
-  await untilUpdated(
-    () => page.textContent('.nested-worker-constructor'),
-    '"type":"constructor"',
-  )
-})
+test.runIf(!isBuild)(
+  'worker emitted and import.meta.url in nested worker (serve)',
+  async () => {
+    await untilUpdated(
+      () => page.textContent('.nested-worker'),
+      '/worker-nested',
+    )
+    await untilUpdated(
+      () => page.textContent('.nested-worker-module'),
+      '/sub-worker',
+    )
+    await untilUpdated(
+      () => page.textContent('.nested-worker-constructor'),
+      '"type":"constructor"',
+    )
+  },
+)
 
 describe.runIf(isBuild)('build', () => {
   // assert correct files
@@ -131,6 +137,7 @@ test('module worker', async () => {
 
 test('classic worker', async () => {
   await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
+  if (isBuild) return
   await untilUpdated(
     () => page.textContent('.classic-worker-import'),
     '[success] classic-esm',

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -137,11 +137,12 @@ test('module worker', async () => {
 
 test('classic worker', async () => {
   await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
-  if (isBuild) return
-  await untilUpdated(
-    () => page.textContent('.classic-worker-import'),
-    '[success] classic-esm',
-  )
+  if (!isBuild) {
+    await untilUpdated(
+      () => page.textContent('.classic-worker-import'),
+      '[success] classic-esm',
+    )
+  }
   await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',

--- a/playground/worker/__tests__/iife/worker-iife.spec.ts
+++ b/playground/worker/__tests__/iife/worker-iife.spec.ts
@@ -22,12 +22,11 @@ test('normal', async () => {
   await untilUpdated(
     () => page.textContent('.asset-url'),
     isBuild ? '/iife/assets/worker_asset-vite.svg' : '/iife/vite.svg',
-    true,
   )
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker', true)
+  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker')
 })
 
 test('TS output', async () => {
@@ -42,7 +41,6 @@ test('named inlined', async () => {
   await untilUpdated(
     () => page.textContent('.pong-inline-named'),
     'namedInlineWorker',
-    true,
   )
 })
 
@@ -51,7 +49,7 @@ test('shared worker', async () => {
 })
 
 test('named shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong', true)
+  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong')
 })
 
 test('inline shared worker', async () => {
@@ -116,22 +114,18 @@ test('module worker', async () => {
   await untilUpdated(
     async () => page.textContent('.worker-import-meta-url'),
     /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
-    true,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-resolve'),
     /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
-    true,
   )
   await untilUpdated(
     () => page.textContent('.worker-import-meta-url-without-extension'),
     /A\sstring.*\/iife\/.+url-worker\.js.+url-worker\.js/,
-    true,
   )
   await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
-    true,
   )
 })
 

--- a/playground/worker/__tests__/relative-base-iife/worker-relative-base-iife.spec.ts
+++ b/playground/worker/__tests__/relative-base-iife/worker-relative-base-iife.spec.ts
@@ -5,6 +5,5 @@ test('asset url', async () => {
   await untilUpdated(
     () => page.textContent('.asset-url'),
     isBuild ? '/worker-assets/worker_asset-vite' : '/vite.svg',
-    true,
   )
 })

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -4,43 +4,37 @@ import { describe, expect, test } from 'vitest'
 import { expectWithRetry, isBuild, page, testDir, untilUpdated } from '~utils'
 
 test('normal', async () => {
-  await untilUpdated(() => page.textContent('.pong'), 'pong', true)
-  await untilUpdated(
-    () => page.textContent('.mode'),
-    process.env.NODE_ENV,
-    true,
-  )
+  await untilUpdated(() => page.textContent('.pong'), 'pong')
+  await untilUpdated(() => page.textContent('.mode'), process.env.NODE_ENV)
   await untilUpdated(
     () => page.textContent('.bundle-with-plugin'),
     'worker bundle with plugin success!',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.asset-url'),
     isBuild ? '/worker-assets/worker_asset-vite' : '/vite.svg',
-    true,
   )
 })
 
 test('named', async () => {
-  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker', true)
+  await untilUpdated(() => page.textContent('.pong-named'), 'namedWorker')
 })
 
 test('TS output', async () => {
-  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong', true)
+  await untilUpdated(() => page.textContent('.pong-ts-output'), 'pong')
 })
 
 // TODO: inline worker should inline assets
 test.skip('inlined', async () => {
-  await untilUpdated(() => page.textContent('.pong-inline'), 'pong', true)
+  await untilUpdated(() => page.textContent('.pong-inline'), 'pong')
 })
 
 test('shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count'), 'pong', true)
+  await untilUpdated(() => page.textContent('.tick-count'), 'pong')
 })
 
 test('named shared worker', async () => {
-  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong', true)
+  await untilUpdated(() => page.textContent('.tick-count-named'), 'pong')
 })
 
 test('inline shared worker', async () => {
@@ -51,17 +45,14 @@ test('worker emitted and import.meta.url in nested worker (serve)', async () => 
   await untilUpdated(
     () => page.textContent('.nested-worker'),
     'worker-nested-worker',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.nested-worker-module'),
     'sub-worker',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.nested-worker-constructor'),
     '"type":"constructor"',
-    true,
   )
 })
 
@@ -98,12 +89,10 @@ describe.runIf(isBuild)('build', () => {
     await untilUpdated(
       () => page.textContent('.nested-worker-module'),
       '"type":"module"',
-      true,
     )
     await untilUpdated(
       () => page.textContent('.nested-worker-constructor'),
       '"type":"constructor"',
-      true,
     )
   })
 })
@@ -112,16 +101,11 @@ test('module worker', async () => {
   await untilUpdated(
     () => page.textContent('.shared-worker-import-meta-url'),
     'A string',
-    true,
   )
 })
 
 test.runIf(isBuild)('classic worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.classic-worker'),
-    'A classic',
-    true,
-  )
+  await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
   await untilUpdated(
     () => page.textContent('.classic-worker-import'),
     '[success] classic-esm',
@@ -129,7 +113,6 @@ test.runIf(isBuild)('classic worker', async () => {
   await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',
-    true,
   )
 })
 
@@ -137,28 +120,21 @@ test.runIf(isBuild)('emit chunk', async () => {
   await untilUpdated(
     () => page.textContent('.emit-chunk-worker'),
     '["A string",{"type":"emit-chunk-sub-worker","data":"A string"},{"type":"module-and-worker:worker","data":"A string"},{"type":"module-and-worker:module","data":"module and worker"},{"type":"emit-chunk-sub-worker","data":{"module":"module and worker","msg1":"module1","msg2":"module2","msg3":"module3"}}]',
-    true,
   )
   await untilUpdated(
     () => page.textContent('.emit-chunk-dynamic-import-worker'),
     '"A stringmodule1./"',
-    true,
   )
 })
 
 test('import.meta.glob in worker', async () => {
-  await untilUpdated(
-    () => page.textContent('.importMetaGlob-worker'),
-    '["',
-    true,
-  )
+  await untilUpdated(() => page.textContent('.importMetaGlob-worker'), '["')
 })
 
 test('import.meta.glob with eager in worker', async () => {
   await untilUpdated(
     () => page.textContent('.importMetaGlobEager-worker'),
     '["',
-    true,
   )
 })
 

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -106,11 +106,12 @@ test('module worker', async () => {
 
 test('classic worker', async () => {
   await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
-  if (isBuild) return
-  await untilUpdated(
-    () => page.textContent('.classic-worker-import'),
-    '[success] classic-esm',
-  )
+  if (!isBuild) {
+    await untilUpdated(
+      () => page.textContent('.classic-worker-import'),
+      '[success] classic-esm',
+    )
+  }
   await untilUpdated(
     () => page.textContent('.classic-shared-worker'),
     'A classic',

--- a/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
+++ b/playground/worker/__tests__/relative-base/worker-relative-base.spec.ts
@@ -104,8 +104,9 @@ test('module worker', async () => {
   )
 })
 
-test.runIf(isBuild)('classic worker', async () => {
+test('classic worker', async () => {
   await untilUpdated(() => page.textContent('.classic-worker'), 'A classic')
+  if (isBuild) return
   await untilUpdated(
     () => page.textContent('.classic-worker-import'),
     '[success] classic-esm',


### PR DESCRIPTION
### Description

Continuing on https://github.com/vitejs/vite/pull/18698, it looks like there are a few unintentionally skipped assertions on build and broken tests due to `untilUpdated`.