### PR TITLE
fix(create-vite): change create-app prompt to not remove existing files by default

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -344,12 +344,12 @@ async function init() {
           initial: 0,
           choices: [
             {
-              title: 'Remove existing files and continue',
-              value: 'yes',
-            },
-            {
               title: 'Cancel operation',
               value: 'no',
+            },
+            {
+              title: 'Remove existing files and continue',
+              value: 'yes',
             },
             {
               title: 'Ignore files and continue',


### PR DESCRIPTION
### Description
If the create app script was run in a directory with files (say ~), the default option is to delete all files and install the app.

This seems like a dangerously destructive option to have as the default. I switched the default to be cancel.

