### PR TITLE
feat: show more info on server start

### DIFF
--- a/docs/.vitepress/theme/components/landing/2. feature-section/FeatureTypedAPI.vue
+++ b/docs/.vitepress/theme/components/landing/2. feature-section/FeatureTypedAPI.vue
@@ -45,7 +45,7 @@ const { isCardActive, startAnimation } = useCardAnimation(
             >listen</span
           >()<br />
           <span class="code--extra"
-            >server.<span class="code--purple">printUrls</span>()</span
+            >server.<span class="code--purple">printInfo</span>()</span
           >
         </span>
       </div>

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -279,9 +279,9 @@ interface PreviewServer {
    */
   resolvedUrls: ResolvedServerUrls | null
   /**
-   * Print server urls
+   * Print server info
    */
-  printUrls(): void
+  printInfo(): void
   /**
    * Bind CLI shortcuts
    */

--- a/docs/guide/api-javascript.md
+++ b/docs/guide/api-javascript.md
@@ -28,7 +28,7 @@ const server = await createServer({
 })
 await server.listen()
 
-server.printUrls()
+server.printInfo()
 server.bindCLIShortcuts({ print: true })
 ```
 
@@ -248,7 +248,7 @@ const previewServer = await preview({
   },
 })
 
-previewServer.printUrls()
+previewServer.printInfo()
 previewServer.bindCLIShortcuts({ print: true })
 ```
 

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -192,7 +192,7 @@ cli
         },
       )
 
-      server.printUrls()
+      server.printInfo()
       const customShortcuts: CLIShortcut<typeof server>[] = []
       if (profileSession) {
         customShortcuts.push({
@@ -360,7 +360,7 @@ cli
             open: options.open,
           },
         })
-        server.printUrls()
+        server.printInfo()
         server.bindCLIShortcuts({ print: true })
       } catch (e) {
         createLogger(options.logLevel).error(

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -5,13 +5,25 @@ import { type DotenvPopulateInput, expand } from 'dotenv-expand'
 import { arraify, normalizePath, tryStatSync } from './utils'
 import type { UserConfig } from './config'
 
-export function getEnvFilesForMode(mode: string, envDir: string): string[] {
+function getEnvFileNamesForMode(mode: string): string[] {
   return [
     /** default file */ `.env`,
     /** local file */ `.env.local`,
     /** mode file */ `.env.${mode}`,
     /** mode local file */ `.env.${mode}.local`,
-  ].map((file) => normalizePath(path.join(envDir, file)))
+  ]
+}
+
+export function getEnvFilesForMode(mode: string, envDir: string): string[] {
+  return getEnvFileNamesForMode(mode).map((fileName) =>
+    normalizePath(path.join(envDir, fileName)),
+  )
+}
+
+export function getLoadedEnvFiles(mode: string, envDir: string): string[] {
+  return getEnvFileNamesForMode(mode).filter((fileName) =>
+    tryStatSync(normalizePath(path.join(envDir, fileName)))?.isFile(),
+  )
 }
 
 export function loadEnv(

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -20,7 +20,10 @@ export function getEnvFilesForMode(mode: string, envDir: string): string[] {
   )
 }
 
-export function getLoadedEnvFiles(mode: string, envDir: string): string[] {
+export function getLoadedEnvFileNamesForMode(
+  mode: string,
+  envDir: string,
+): string[] {
   return getEnvFileNamesForMode(mode).filter((fileName) =>
     tryStatSync(normalizePath(path.join(envDir, fileName)))?.isFile(),
   )

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -4,7 +4,7 @@ import readline from 'node:readline'
 import colors from 'picocolors'
 import type { RollupError } from 'rollup'
 import type { ResolvedServerUrls } from './server'
-import { getLoadedEnvFiles } from './env'
+import { getLoadedEnvFileNamesForMode } from './env'
 
 export type LogType = 'error' | 'warn' | 'info'
 export type LogLevel = LogType | 'silent'
@@ -180,7 +180,7 @@ export function printServerInfo(
     )
   }
   info(`  ${colors.green('➜')}  ${colors.bold('Mode')}:    ${mode}`)
-  const envFiles = getLoadedEnvFiles(mode, envDir)
+  const envFiles = getLoadedEnvFileNamesForMode(mode, envDir)
   info(
     `  ${colors.green('➜')}  ${colors.bold('Env')}:     ${envFiles.length ? envFiles.join(' ') : 'no env files loaded'}`,
   )

--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -4,6 +4,7 @@ import readline from 'node:readline'
 import colors from 'picocolors'
 import type { RollupError } from 'rollup'
 import type { ResolvedServerUrls } from './server'
+import { getLoadedEnvFiles } from './env'
 
 export type LogType = 'error' | 'warn' | 'info'
 export type LogLevel = LogType | 'silent'
@@ -158,19 +159,31 @@ export function createLogger(
   return logger
 }
 
-export function printServerUrls(
+export function printServerInfo(
   urls: ResolvedServerUrls,
   optionsHost: string | boolean | undefined,
+  mode: string,
+  envDir: string,
   info: Logger['info'],
 ): void {
-  const colorUrl = (url: string) =>
-    colors.cyan(url.replace(/:(\d+)\//, (_, port) => `:${colors.bold(port)}/`))
+  const formatUrl = (url: string) =>
+    url.replace(/:(\d+)\//, (_, port) => `:${colors.bold(port)}/`)
+
   for (const url of urls.local) {
-    info(`  ${colors.green('➜')}  ${colors.bold('Local')}:   ${colorUrl(url)}`)
+    info(
+      `  ${colors.green('➜')}  ${colors.bold('Local')}:   ${colors.cyan(formatUrl(url))}`,
+    )
   }
   for (const url of urls.network) {
-    info(`  ${colors.green('➜')}  ${colors.bold('Network')}: ${colorUrl(url)}`)
+    info(
+      `  ${colors.green('➜')}  ${colors.bold('Network')}: ${colors.cyan(formatUrl(url))}`,
+    )
   }
+  info(`  ${colors.green('➜')}  ${colors.bold('Mode')}:    ${mode}`)
+  const envFiles = getLoadedEnvFiles(mode, envDir)
+  info(
+    `  ${colors.green('➜')}  ${colors.bold('Env')}:     ${envFiles.length ? envFiles.join(' ') : 'no env files loaded'}`,
+  )
   if (urls.network.length === 0 && optionsHost === undefined) {
     info(
       colors.dim(`  ${colors.green('➜')}  ${colors.bold('Network')}: use `) +

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -32,7 +32,7 @@ import {
   shouldServeFile,
   teardownSIGTERMListener,
 } from './utils'
-import { printServerUrls } from './logger'
+import { printServerInfo } from './logger'
 import { bindCLIShortcuts } from './shortcuts'
 import type { BindCLIShortcutsOptions } from './shortcuts'
 import { resolveConfig } from './config'
@@ -89,9 +89,9 @@ export interface PreviewServer {
    */
   resolvedUrls: ResolvedServerUrls | null
   /**
-   * Print server urls
+   * Print server info
    */
-  printUrls(): void
+  printInfo(): void
   /**
    * Bind CLI shortcuts
    */
@@ -154,11 +154,17 @@ export async function preview(
       await closeHttpServer()
     },
     resolvedUrls: null,
-    printUrls() {
+    printInfo() {
       if (server.resolvedUrls) {
-        printServerUrls(server.resolvedUrls, options.host, logger.info)
+        printServerInfo(
+          server.resolvedUrls,
+          options.host,
+          config.mode,
+          config.envDir,
+          logger.info,
+        )
       } else {
-        throw new Error('cannot print server URLs before server is listening.')
+        throw new Error('cannot print server info before server is listening.')
       }
     },
     bindCLIShortcuts(options) {

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -89,6 +89,11 @@ export interface PreviewServer {
    */
   resolvedUrls: ResolvedServerUrls | null
   /**
+   * Print server urls
+   * @deprecated use `printInfo` instead
+   */
+  printUrls(): void
+  /**
    * Print server info
    */
   printInfo(): void
@@ -154,6 +159,9 @@ export async function preview(
       await closeHttpServer()
     },
     resolvedUrls: null,
+    printUrls() {
+      return this.printInfo()
+    },
     printInfo() {
       if (server.resolvedUrls) {
         printServerInfo(

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -48,7 +48,7 @@ import { bindCLIShortcuts } from '../shortcuts'
 import type { BindCLIShortcutsOptions } from '../shortcuts'
 import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
 import type { Logger } from '../logger'
-import { printServerUrls } from '../logger'
+import { printServerInfo } from '../logger'
 import {
   createNoopWatcher,
   getResolvedOutDirs,
@@ -338,9 +338,9 @@ export interface ViteDevServer {
    */
   close(): Promise<void>
   /**
-   * Print server urls
+   * Print server info
    */
-  printUrls(): void
+  printInfo(): void
   /**
    * Bind CLI shortcuts
    */
@@ -664,18 +664,20 @@ export async function _createServer(
       }
       server.resolvedUrls = null
     },
-    printUrls() {
+    printInfo() {
       if (server.resolvedUrls) {
-        printServerUrls(
+        printServerInfo(
           server.resolvedUrls,
           serverConfig.host,
+          config.mode,
+          config.envDir,
           config.logger.info,
         )
       } else if (middlewareMode) {
-        throw new Error('cannot print server URLs in middleware mode.')
+        throw new Error('cannot print server info in middleware mode.')
       } else {
         throw new Error(
-          'cannot print server URLs before server.listen is called.',
+          'cannot print server info before server.listen is called.',
         )
       }
     },
@@ -1201,7 +1203,7 @@ export async function restartServerWithUrls(
     diffDnsOrderChange(prevUrls, server.resolvedUrls)
   ) {
     logger.info('')
-    server.printUrls()
+    server.printInfo()
   }
 }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -338,6 +338,11 @@ export interface ViteDevServer {
    */
   close(): Promise<void>
   /**
+   * Print server urls
+   * @deprecated use `printInfo` instead
+   */
+  printUrls(): void
+  /**
    * Print server info
    */
   printInfo(): void
@@ -663,6 +668,9 @@ export async function _createServer(
         )
       }
       server.resolvedUrls = null
+    },
+    printUrls() {
+      return this.printInfo()
     },
     printInfo() {
       if (server.resolvedUrls) {

--- a/packages/vite/src/node/shortcuts.ts
+++ b/packages/vite/src/node/shortcuts.ts
@@ -102,10 +102,10 @@ const BASE_DEV_SHORTCUTS: CLIShortcut<ViteDevServer>[] = [
   },
   {
     key: 'u',
-    description: 'show server url',
+    description: 'show server info',
     action(server) {
       server.config.logger.info('')
-      server.printUrls()
+      server.printInfo()
     },
   },
   {

--- a/playground/cli/__tests__/cli.spec.ts
+++ b/playground/cli/__tests__/cli.spec.ts
@@ -28,7 +28,7 @@ test('should restart', async () => {
     expect(logs).toEqual(
       expect.arrayContaining([expect.stringMatching('server restarted')]),
     )
-    // Don't reprint the server URLs as they are the same
+    // Don't reprint the server info as they are the same
     expect(logs).not.toEqual(
       expect.arrayContaining([expect.stringMatching('http://localhost')]),
     )


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Resolves #18719

- Deprecate `DevServer.printUrls` and `PreviewServer.printUrls`.
- Add `DevServer.printInfo` and `PreviewServer.printInfo`
- Make the new methods print `mode` and loaded env file names on server start

I created this PR for `v5` branch, but technically it can be applied to `main` branch too.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
