### PR TITLE
test: change assets-runtime-base outDir to different one

### DIFF
--- a/playground/assets/__tests__/runtime-base/assets-runtime-base.spec.ts
+++ b/playground/assets/__tests__/runtime-base/assets-runtime-base.spec.ts
@@ -137,7 +137,7 @@ describe('css url() references', () => {
 describe.runIf(isBuild)('index.css URLs', () => {
   let css: string
   beforeAll(() => {
-    css = findAssetFile(/index-[-\w]{8}\.css$/, '', 'other-assets')
+    css = findAssetFile(/index-[-\w]{8}\.css$/, 'runtime-base', 'other-assets')
   })
 
   test('relative asset URL', () => {

--- a/playground/assets/vite.config-runtime-base.js
+++ b/playground/assets/vite.config-runtime-base.js
@@ -11,7 +11,7 @@ export default defineConfig({
   base: './', // overwrite the original base: '/foo/'
   build: {
     ...baseConfig.build,
-    outDir: 'dist',
+    outDir: 'dist/runtime-base',
     watch: null,
     minify: false,
     assetsInlineLimit: 0,


### PR DESCRIPTION
### Description

so that the build does not clear out other output by other vite configs.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
