### PR TITLE
fix(optimizer): trigger onCrawlEnd after manual included deps are registered

### DIFF
--- a/packages/vite/src/node/optimizer/optimizer.ts
+++ b/packages/vite/src/node/optimizer/optimizer.ts
@@ -162,7 +162,6 @@ export function createDepsOptimizer(
       cachedMetadata || initDepsOptimizerMetadata(environment, sessionTimestamp)
 
     if (!cachedMetadata) {
-      environment.waitForRequestsIdle().then(onCrawlEnd)
       waitingForCrawlEnd = true
 
       // Enter processing state until crawl of static imports ends
@@ -186,6 +185,8 @@ export function createDepsOptimizer(
         })
         newDepsDiscovered = true
       }
+
+      environment.waitForRequestsIdle().then(onCrawlEnd)
 
       if (noDiscovery) {
         // We don't need to scan for dependencies or wait for the static crawl to end


### PR DESCRIPTION
### Description

When the optimizer runs before manual included deps are registered, Vite indefinitely stalled the request to optimized files.

I guess this rarely happens.
It happens when `runOptimizer` in this `onCrawlEnd` is called while the promise of `addManuallyIncludedOptimizeDeps(environment, manuallyIncludedDeps)` is pending.
https://github.com/vitejs/vite/blob/a384d8fd39162190675abcfea31ba657383a3d03/packages/vite/src/node/optimizer/optimizer.ts#L165
https://github.com/vitejs/vite/blob/a384d8fd39162190675abcfea31ba657383a3d03/packages/vite/src/node/optimizer/optimizer.ts#L174

Changing the code like below would make it constantly reproduce the problem with react template of create-vite.
```diff
-      environment.waitForRequestsIdle().then(onCrawlEnd)
+      // environment.waitForRequestsIdle().then(onCrawlEnd)
      waitingForCrawlEnd = true

      // Enter processing state until crawl of static imports ends
      currentlyProcessing = true

      // Initialize discovered deps with manually added optimizeDeps.include info

      const manuallyIncludedDeps: Record<string, string> = {}
      await addManuallyIncludedOptimizeDeps(environment, manuallyIncludedDeps)

+      startNextDiscoveredBatch()
+      await runOptimizer()

      const manuallyIncludedDepsInfo = toDiscoveredDependencies(
        environment,
        manuallyIncludedDeps,
        sessionTimestamp,
      )
```


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
