### PR TITLE
fix: allow enabling esbuild.minifyWhitespace for es format in lib mode (fix #6555)

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -230,7 +230,7 @@ During the SSR build, static assets aren't emitted as it is assumed they would b
 
 Set to `false` to disable minification, or specify the minifier to use. The default is [esbuild](https://github.com/evanw/esbuild) which is 20 ~ 40x faster than terser and only 1 ~ 2% worse compression. [Benchmarks](https://github.com/privatenumber/minification-benchmarks)
 
-Note the `build.minify` option does not minify whitespaces when using the `'es'` format in lib mode, as it removes pure annotations and breaks tree-shaking.
+Note the `build.minify` option does not minify whitespaces when using the `'es'` format in lib mode, as it removes pure annotations and breaks tree-shaking. To force whitespace minification for `'es'` format in lib mode, explicitly set `esbuild.minifyWhitespace` to `true`.
 
 Terser must be installed when it is set to `'terser'`.
 

--- a/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/esbuild.spec.ts
@@ -201,7 +201,7 @@ describe('resolveEsbuildTranspileOptions', () => {
       minify: false,
       minifyIdentifiers: true,
       minifySyntax: true,
-      minifyWhitespace: false,
+      minifyWhitespace: true,
       treeShaking: true,
       supported: {
         'dynamic-import': true,

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -426,7 +426,7 @@ export function resolveEsbuildTranspileOptions(
         minify: false,
         minifyIdentifiers: options.minifyIdentifiers ?? true,
         minifySyntax: options.minifySyntax ?? true,
-        minifyWhitespace: false,
+        minifyWhitespace: options.minifyWhitespace ?? false,
         treeShaking: true,
       }
     } else {


### PR DESCRIPTION
### Description

To produce `es` bundles that can be tree-shaken, lib mode disables `minifyWhitespace` by default when using the `es` format. But there are cases where we want an `es` bundle that is as small as possible and that does not need to be tree-shakable. This change allows` esbuild.minifyWhitespace` to be re-enabled if the user so desires.

fixes #6555


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
