### PR TITLE
feat: enable HMR by default on ModuleRunner side

### DIFF
--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -190,15 +190,10 @@ export interface ModuleRunnerOptions {
     | InterceptorOptions
   /**
    * Disable HMR or configure HMR options.
+   *
+   * @default true
    */
-  hmr?:
-    | false
-    | {
-        /**
-         * Configure HMR logger.
-         */
-        logger?: false | HMRLogger
-      }
+  hmr?: boolean | ModuleRunnerHmr
   /**
    * Custom module cache. If not provided, it creates a separate module
    * cache for each module runner instance.
@@ -356,6 +351,7 @@ export const runner = new ModuleRunner(
         return response.json()
       },
     },
+    hmr: false, // disable HMR as HMR requires transport.connect
   },
   new ESModulesEvaluator(),
 )

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -194,7 +194,7 @@ const moduleRunnerConfig = defineConfig({
   ],
   plugins: [
     ...createSharedNodePlugins({ esbuildOptions: { minifySyntax: true } }),
-    bundleSizeLimit(53),
+    bundleSizeLimit(54),
   ],
 })
 

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -69,13 +69,14 @@ export class ModuleRunner {
     this.root = root[root.length - 1] === '/' ? root : `${root}/`
     this.evaluatedModules = options.evaluatedModules ?? new EvaluatedModules()
     this.transport = normalizeModuleRunnerTransport(options.transport)
-    if (options.hmr) {
+    if (options.hmr !== false) {
+      const optionsHmr = options.hmr ?? true
       const resolvedHmrLogger: HMRLogger =
-        options.hmr === true || options.hmr.logger === undefined
+        optionsHmr === true || optionsHmr.logger === undefined
           ? hmrLogger
-          : options.hmr.logger === false
+          : optionsHmr.logger === false
             ? silentConsole
-            : options.hmr.logger
+            : optionsHmr.logger
       this.hmrClient = new HMRClient(
         resolvedHmrLogger,
         this.transport,

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -103,6 +103,8 @@ export interface ModuleRunnerOptions {
     | InterceptorOptions
   /**
    * Disable HMR or configure HMR options.
+   *
+   * @default true
    */
   hmr?: boolean | ModuleRunnerHmr
   /**


### PR DESCRIPTION
### Description

I guess we can set `true` for the ModuleRunner so that HMR works unless the transport doesn't support it and is disabled explicitly.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
