### PR TITLE
feat!: make `import.meta.hot.send` async

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -40,7 +40,10 @@ interface ViteHotContext {
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
   ): void
-  send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void
+  send<T extends string>(
+    event: T,
+    data?: InferCustomEventPayload<T>,
+  ): Promise<void>
 }
 ```
 

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -194,7 +194,7 @@ const moduleRunnerConfig = defineConfig({
   ],
   plugins: [
     ...createSharedNodePlugins({ esbuildOptions: { minifySyntax: true } }),
-    bundleSizeLimit(53),
+    bundleSizeLimit(54),
   ],
 })
 

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -143,8 +143,11 @@ export class HMRContext implements ViteHotContext {
     removeFromMap(this.newListeners)
   }
 
-  send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void {
-    this.hmrClient.send({ type: 'custom', event, data })
+  async send<T extends string>(
+    event: T,
+    data?: InferCustomEventPayload<T>,
+  ): Promise<void> {
+    await this.hmrClient.send({ type: 'custom', event, data })
   }
 
   private acceptDeps(
@@ -189,8 +192,8 @@ export class HMRClient {
     }
   }
 
-  public send(payload: HotPayload): void {
-    this.transport.send(payload)
+  public async send(payload: HotPayload): Promise<void> {
+    await this.transport.send(payload)
   }
 
   public clear(): void {

--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -179,7 +179,7 @@ const createInvokeableTransport = (
 export interface NormalizedModuleRunnerTransport {
   connect?(onMessage?: (data: HotPayload) => void): Promise<void> | void
   disconnect?(): Promise<void> | void
-  send(data: HotPayload): void
+  send(data: HotPayload): Promise<void>
   invoke<T extends keyof InvokeMethods>(
     name: T,
     data: Parameters<InvokeMethods[T]>,

--- a/packages/vite/types/hot.d.ts
+++ b/packages/vite/types/hot.d.ts
@@ -32,5 +32,8 @@ export interface ViteHotContext {
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
   ): void
-  send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void
+  send<T extends string>(
+    event: T,
+    data?: InferCustomEventPayload<T>,
+  ): Promise<void>
 }


### PR DESCRIPTION
### Description

The error that happened inside `send` method of `ModuleRunnerTransport` was not able to handle.

This PR fixes that by `await`ing on the `send` method. This requires the `import.meta.hot.send` to be also `await`ed (thus a breaking change). This `await` was not required in Vite 5 because we only used WS and WS's send is sync. In #18362, I made the ModuleRunnerTransport to allow async `send` just because I thought there may be a place that require async and didn't find any breaking change by doing so.

Alternative way to solve this is #18751.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
