### PR TITLE
perf(worker): inline worker without base64

### DIFF
--- a/playground/worker/__tests__/es/worker-es.spec.ts
+++ b/playground/worker/__tests__/es/worker-es.spec.ts
@@ -116,7 +116,7 @@ describe.runIf(isBuild)('build', () => {
     )
     // inlined shared worker
     expect(content).toMatch(
-      `return new SharedWorker("data:text/javascript;base64,"+`,
+      `return new SharedWorker("data:text/javascript;charset=utf-8,"+`,
     )
   })
 

--- a/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
+++ b/playground/worker/__tests__/sourcemap-hidden/worker-sourcemap-hidden.spec.ts
@@ -94,7 +94,7 @@ describe.runIf(isBuild)('build', () => {
     expect(content).toMatch(
       `new Worker("/iife-sourcemap-hidden/assets/my-worker`,
     )
-    expect(content).toMatch(`new Worker("data:text/javascript;base64`)
+    expect(content).toMatch(`new Worker("data:text/javascript;charset=utf-8,"+`)
     expect(content).toMatch(
       `new Worker("/iife-sourcemap-hidden/assets/possible-ts-output-worker`,
     )

--- a/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
+++ b/playground/worker/__tests__/sourcemap-inline/worker-sourcemap-inline.spec.ts
@@ -75,7 +75,7 @@ describe.runIf(isBuild)('build', () => {
     expect(content).toMatch(
       `new Worker("/iife-sourcemap-inline/assets/my-worker`,
     )
-    expect(content).toMatch(`new Worker("data:text/javascript;base64`)
+    expect(content).toMatch(`new Worker("data:text/javascript;charset=utf-8,"+`)
     expect(content).toMatch(
       `new Worker("/iife-sourcemap-inline/assets/possible-ts-output-worker`,
     )

--- a/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
+++ b/playground/worker/__tests__/sourcemap/worker-sourcemap.spec.ts
@@ -95,7 +95,7 @@ describe.runIf(isBuild)('build', () => {
 
     // chunk
     expect(content).toMatch(`new Worker("/iife-sourcemap/assets/my-worker`)
-    expect(content).toMatch(`new Worker("data:text/javascript;base64`)
+    expect(content).toMatch(`new Worker("data:text/javascript;charset=utf-8,"+`)
     expect(content).toMatch(
       `new Worker("/iife-sourcemap/assets/possible-ts-output-worker`,
     )
@@ -117,8 +117,9 @@ describe.runIf(isBuild)('build', () => {
 })
 
 function getSourceMapUrl(code: string): string {
-  const regex = /\/\/[#@]\ssource(?:Mapping)?URL=\s*(\S+)/
-  const results = regex.exec(code)
+  const regex = /\/\/[#@]\ssource(?:Mapping)?URL=\s*(\S+)/g
+  const matches = [...code.matchAll(regex)]
+  const results = matches.at(-1)
 
   if (results && results.length >= 2) {
     return results[1]


### PR DESCRIPTION
### Description

This PR changes the inline worker to be inlined as a normal string. IIUC there was no need to embed the inlined worker code as base64. This would reduce the bundle size of the inlined worker by ~25%.

refs https://github.com/vitejs/vite/commit/a9fe3e7de7e871400b1df6cce80cb52d1f5c0a94#diff-3b7bb11b5633d82f82c069037789e105005d657667b1da1e96c18fcf3eb622adR54
fixes https://github.com/vitejs/vite/issues/18336 (this PR does not add the proposed feature which I don't think it will improve the size transmitted over the network, but would make the bundle size smaller)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
