### PR TITLE
fix: log error when send in module runner failed

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -194,7 +194,7 @@ const moduleRunnerConfig = defineConfig({
   ],
   plugins: [
     ...createSharedNodePlugins({ esbuildOptions: { minifySyntax: true } }),
-    bundleSizeLimit(53),
+    bundleSizeLimit(54),
   ],
 })
 

--- a/packages/vite/src/shared/hmr.ts
+++ b/packages/vite/src/shared/hmr.ts
@@ -190,7 +190,9 @@ export class HMRClient {
   }
 
   public send(payload: HotPayload): void {
-    this.transport.send(payload)
+    this.transport.send(payload).catch((err) => {
+      this.logger.error(err)
+    })
   }
 
   public clear(): void {

--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -179,7 +179,7 @@ const createInvokeableTransport = (
 export interface NormalizedModuleRunnerTransport {
   connect?(onMessage?: (data: HotPayload) => void): Promise<void> | void
   disconnect?(): Promise<void> | void
-  send(data: HotPayload): void
+  send(data: HotPayload): Promise<void>
   invoke<T extends keyof InvokeMethods>(
     name: T,
     data: Parameters<InvokeMethods[T]>,


### PR DESCRIPTION
### Description

Instead of giving the user (the one that calls `import.meta.hot.send`) the ability to handle the errors, this PR logs the error on Vite's side. This means `import.meta.hot.send` will never error. Also the message might be sent after `import.meta.hot.send` is finished. I guess that's fine though.

Alternative to #18750, #18751.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
