### PR TITLE
fix: display pre-transform error details

### DIFF
--- a/packages/vite/src/node/server/environment.ts
+++ b/packages/vite/src/node/server/environment.ts
@@ -35,6 +35,7 @@ import {
 } from './pluginContainer'
 import { type WebSocketServer, isWebSocketServer } from './ws'
 import { warmupFiles } from './warmup'
+import { buildErrorMessage } from './middlewares/error'
 
 export interface DevEnvironmentContext {
   hot: boolean
@@ -220,10 +221,13 @@ export class DevEnvironment extends BaseEnvironment {
         return
       }
       // Unexpected error, log the issue but avoid an unhandled exception
-      this.logger.error(`Pre-transform error: ${e.message}`, {
-        error: e,
-        timestamp: true,
-      })
+      this.logger.error(
+        buildErrorMessage(e, [`Pre-transform error: ${e.message}`], false),
+        {
+          error: e,
+          timestamp: true,
+        },
+      )
     }
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -80,7 +80,7 @@ import { timeMiddleware } from './middlewares/time'
 import { ModuleGraph } from './mixedModuleGraph'
 import type { ModuleNode } from './mixedModuleGraph'
 import { notFoundMiddleware } from './middlewares/notFound'
-import { errorMiddleware } from './middlewares/error'
+import { buildErrorMessage, errorMiddleware } from './middlewares/error'
 import type { HmrOptions, HotBroadcaster } from './hmr'
 import {
   createDeprecatedHotBroadcaster,
@@ -569,10 +569,13 @@ export async function _createServer(
           return
         }
         // Unexpected error, log the issue but avoid an unhandled exception
-        server.config.logger.error(`Pre-transform error: ${e.message}`, {
-          error: e,
-          timestamp: true,
-        })
+        server.config.logger.error(
+          buildErrorMessage(e, [`Pre-transform error: ${e.message}`], false),
+          {
+            error: e,
+            timestamp: true,
+          },
+        )
       }
     },
     transformIndexHtml(url, html, originalUrl) {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/18754

I wrapped a pre transform error with already available `buildErrorMessage` utility. This looks like a quick DX improvement.

__how to verify__

- add `<div>foo</div>` to `playground/html/warmup/warm.js`
- run `pnpm -C playground/html dev`

```
$ pnpm -C playground/html dev

> @vitejs/test-html@0.0.0 dev /home/hiroshi/code/others/vite/playground/html
> vite


  VITE v6.0.0-beta.10  ready in 139 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  press h + enter to show help
10:55:40 AM [vite] (client) Pre-transform error: Failed to parse source for import analysis because the content contains invalid JS syntax. If you are using JSX, make sure to name the file with the .jsx or .tsx extension.
  Plugin: vite:import-analysis
  File: /home/hiroshi/code/others/vite/playground/html/warmup/warm.js:2:16
  1  |  console.log('From warm.js')
  2  |  <div>fooo</div>
     |                 ^
  3  |  
```
