### PR TITLE
docs: clarify .env loading precedence / behavior

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -29,7 +29,7 @@ Vite uses [dotenv](https://github.com/motdotla/dotenv) to load additional enviro
 
 An env file for a specific mode (e.g. `.env.production`) will take higher priority than a generic one (e.g. `.env`).
 
-⚠️ When running with a mode specified, Vite will load _both_ `.env` and `.env.[mode]` files. If the same variable is defined in both files, the value in `.env.[mode]` will take precedence. Variables defined only in `.env` will also be passed into the environment unless explicitly overridden in `.env.[mode]`.
+Vite will always load `.env` and `.env.local` in addition to the mode-specific `.env.[mode]` file. Variables declared in mode-specific files will take precedence over those in generic files, but variables defined only in `.env` or `.env.local` will still be available in the environment.
 
 In addition, environment variables that already exist when Vite is executed have the highest priority and will not be overwritten by `.env` files. For example, when running `VITE_SOME_KEY=123 vite build`.
 

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -29,6 +29,8 @@ Vite uses [dotenv](https://github.com/motdotla/dotenv) to load additional enviro
 
 An env file for a specific mode (e.g. `.env.production`) will take higher priority than a generic one (e.g. `.env`).
 
+⚠️ When running with a mode specified, Vite will load _both_ `.env` and `.env.[mode]` files. If the same variable is defined in both files, the value in `.env.[mode]` will take precedence. Variables defined only in `.env` will also be passed into the environment unless explicitly overridden in `.env.[mode]`.
+
 In addition, environment variables that already exist when Vite is executed have the highest priority and will not be overwritten by `.env` files. For example, when running `VITE_SOME_KEY=123 vite build`.
 
 `.env` files are loaded at the start of Vite. Restart the server after making changes.


### PR DESCRIPTION
### Description
The current documentation under "Env Variables and Modes" contains a statement that may lead to misunderstandings:

> An env file for a specific mode (e.g. .env.production) will take higher priority than a generic one (e.g. .env).

The current phrasing implies that when running with a mode specified, Vite will exclusively use `.env.[mode]` over `.env`. However, Vite actually loads _both_ `.env` and `.env.[mode]`. 
Furthermore, if a variable exists in `.env` but is not defined in `.env.[mode]`, the variable from `.env` will still be passed into the environment. This implicit behavior can cause issues at deployment time.

### Example
The following will unexpectedly load the `VITE_SKIP_2FA` variable into the environment when running `yarn build --mode prod`
```sh
# .env
VITE_API=https://my.api.local
VITE_SKIP_2FA=true   # local dev use only

# .env.prod
VITE_API=https://my.api.com
```

### Proposed Update
I guess the above is the intended behavior of Vite and will not be changed, so I propose a note is added to the docs to make this behavior clear.

> ⚠️ When running with a mode specified, Vite will load *both* `.env` and `.env.[mode]` files. If the same variable is defined in both files, the value in `.env.[mode]` will take precedence. Variables defined only in `.env` will also be passed into the environment unless explicitly overridden in `.env.[mode]`.


This clarification ensures users understand the relationship between `.env` and `.env.[mode]`, avoiding potential confusion about variable precedence and availability.
