### PR TITLE
fix: expose missing `InterceptorOptions` type

### DIFF
--- a/packages/vite/src/module-runner/index.ts
+++ b/packages/vite/src/module-runner/index.ts
@@ -29,3 +29,4 @@ export {
   ssrImportMetaKey,
   ssrModuleExportsKey,
 } from './constants'
+export type { InterceptorOptions } from './sourcemap/interceptor'


### PR DESCRIPTION
### Description

This type was used in `ModuleRunnerOptions.sourcemapInterceptor` but was not exposed.
https://main.vite.dev/guide/api-environment-runtimes.html#modulerunneroptions

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
