### PR TITLE
chore(legacy): bump terser peer dep to ^5.16

### DIFF
--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -52,7 +52,7 @@
     "systemjs": "^6.15.1"
   },
   "peerDependencies": {
-    "terser": "^5.4.0",
+    "terser": "^5.16.0",
     "vite": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

Since Vite requires `^5.16.0` this change does not change any behavior.
https://github.com/vitejs/vite/blob/63c62b3059b589a51d1673bfdcefdb0b4e87c089/packages/vite/package.json#L164
But updated it to make it less confusing.


<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
