### PR TITLE
fix(server): recover `server.ws.clients.send` API changes for back compatibility

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -9,9 +9,9 @@ import colors from 'picocolors'
 import type { WebSocket as WebSocketRaw } from 'ws'
 import { WebSocketServer as WebSocketServerRaw_ } from 'ws'
 import type { WebSocket as WebSocketTypes } from 'dep-types/ws'
-import type { ErrorPayload, HotPayload } from 'types/hmrPayload'
+import type { CustomPayload, ErrorPayload, HotPayload } from 'types/hmrPayload'
 import type { InferCustomEventPayload } from 'types/customEvent'
-import type { ResolvedConfig } from '..'
+import type { HotChannelClient, ResolvedConfig } from '..'
 import { isObject } from '../utils'
 import { type NormalizedHotChannel, normalizeHotChannel } from './hmr'
 import type { HttpServer } from '.'
@@ -66,7 +66,16 @@ export interface WebSocketServer extends NormalizedHotChannel {
   clients: Set<WebSocketClient>
 }
 
-export interface WebSocketClient extends NormalizedHotChannel {
+export interface WebSocketClient extends HotChannelClient {
+  /**
+   * Send event to the client
+   */
+  send(payload: HotPayload): void
+  // support this signature for backward compatibility
+  /**
+   * Send custom event
+   */
+  send(event: string, payload?: CustomPayload['data']): void
   /**
    * The raw WebSocket instance
    * @advanced
@@ -269,7 +278,7 @@ export function createWebSocketServer(
           socket.send(JSON.stringify(payload))
         },
         socket,
-      } as WebSocketClient)
+      })
     }
     return clientsMap.get(socket)!
   }


### PR DESCRIPTION
During refactoring of Environment API, I think we mistakenly change the `send` signature on `WebSocketClient`, causing a breaking regression:

Vite 5:

https://github.com/vitejs/vite/blob/81e6c0406ac2cef790cbcae18de839d901566c39/packages/vite/src/node/server/ws.ts#L65-L72

Vite v6.0.0 (WebSocketClient extends HotChannelClient):

https://github.com/vitejs/vite/blob/c7b330832675ee6385ee1a8750762e496c8e18e6/packages/vite/src/node/server/hmr.ts#L78-L80
