### PR TITLE
fix(server): close _ssrCompatModuleRunner on server close

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -674,6 +674,7 @@ export async function _createServer(
           ),
         ),
         closeHttpServer(),
+        server._ssrCompatModuleRunner?.close(),
       ])
       server.resolvedUrls = null
     },


### PR DESCRIPTION
### Description

Not doing this seems to be causing odd errors happening in Astro side. After its temporary Vite server is teardown, some memory state or cache aren't properly cleaned up and it impacted unrelated promises runs happening in Astro side. [Promises simply abruptly stopped and the process exited](https://github.com/withastro/astro/actions/runs/12033033351/job/33546308033?pr=12524#step:8:2227).

It looks like the cleanup wasn't done since the Environment API was introduced, but strangely it still worked, until https://github.com/vitejs/vite/pull/18362 was merged. Maybe that PR broke the camel's back but it's unclear to me what ultimately triggered it.

Anyways with this proper cleanup, Vite should free the memory if the server called `ssrLoadModule` and was closed later.