### PR TITLE
fix: default empty server `proxy` prevents starting http2 server

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1022,7 +1022,7 @@ export const serverConfigDefaults = Object.freeze({
   host: 'localhost',
   https: undefined,
   open: false,
-  // proxy
+  proxy: undefined,
   cors: true,
   headers: {},
   // hmr

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1022,6 +1022,7 @@ export const serverConfigDefaults = Object.freeze({
   host: 'localhost',
   https: undefined,
   open: false,
+  // proxy
   cors: true,
   headers: {},
   // hmr

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1022,7 +1022,6 @@ export const serverConfigDefaults = Object.freeze({
   host: 'localhost',
   https: undefined,
   open: false,
-  proxy: {},
   cors: true,
   headers: {},
   // hmr


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Configuring `proxy` from user land has other meaning and so we cannot check if the `proxy` has no entries to downgrade to HTTP/1, this PR just removes the empty `proxy` object from the default server configuration options.

fixes #18786

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
