### PR TITLE
docs: link correctly to vite 5/6 docs versions

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -39,6 +39,10 @@ const additionalTitle = ((): string => {
 const versionLinks = ((): DefaultTheme.NavItemWithLink[] => {
   const oldVersions: DefaultTheme.NavItemWithLink[] = [
     {
+      text: 'Vite 5 Docs',
+      link: 'https://v5.vite.dev',
+    },
+    {
       text: 'Vite 4 Docs',
       link: 'https://v4.vite.dev',
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -61,7 +61,7 @@ const versionLinks = ((): DefaultTheme.NavItemWithLink[] => {
     case 'local':
       return [
         {
-          text: 'Vite 5 Docs (release)',
+          text: 'Vite 6 Docs (release)',
           link: 'https://vite.dev',
         },
         ...oldVersions,


### PR DESCRIPTION
### Description

cc @bluwy 

- Closes #18794 


Before
<img width="261" alt="Screenshot 2024-11-27 at 03 51 14" src="https://github.com/user-attachments/assets/b104c748-ec93-4cb1-a972-ac99944036b4">




After:

<img width="274" alt="Screenshot 2024-11-27 at 03 50 33" src="https://github.com/user-attachments/assets/b0be7389-6985-45e4-8912-b65d4138f653">




<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
