### PR TITLE
refactor: make properties of ResolvedServerOptions and ResolvedPreviewOptions required

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -259,7 +259,7 @@ describe('preview config', () => {
     expect(await resolveConfig(config, 'serve')).toMatchObject({
       preview: {
         ...serverConfig(),
-        port: undefined,
+        port: 4173,
       },
     })
   })

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -34,7 +34,7 @@ import {
 import { printServerUrls } from './logger'
 import { bindCLIShortcuts } from './shortcuts'
 import type { BindCLIShortcutsOptions } from './shortcuts'
-import { configDefaults, resolveConfig } from './config'
+import { resolveConfig } from './config'
 import type { InlineConfig, ResolvedConfig } from './config'
 import { DEFAULT_PREVIEW_PORT } from './constants'
 import type { RequiredExceptFor } from './typeUtils'
@@ -246,10 +246,9 @@ export async function preview(
   }
 
   const hostname = await resolveHostname(options.host)
-  const port = options.port ?? configDefaults.preview.port
 
   await httpServerStart(httpServer, {
-    port,
+    port: options.port,
     strictPort: options.strictPort,
     host: hostname.host,
     logger,

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -36,10 +36,13 @@ import { bindCLIShortcuts } from './shortcuts'
 import type { BindCLIShortcutsOptions } from './shortcuts'
 import { configDefaults, resolveConfig } from './config'
 import type { InlineConfig, ResolvedConfig } from './config'
+import { DEFAULT_PREVIEW_PORT } from './constants'
+import type { RequiredExceptFor } from './typeUtils'
 
 export interface PreviewOptions extends CommonServerOptions {}
 
-export interface ResolvedPreviewOptions extends PreviewOptions {}
+export interface ResolvedPreviewOptions
+  extends RequiredExceptFor<PreviewOptions, 'host' | 'https' | 'proxy'> {}
 
 export function resolvePreviewOptions(
   preview: PreviewOptions | undefined,
@@ -49,7 +52,7 @@ export function resolvePreviewOptions(
   // except for the port to enable having both the dev and preview servers running
   // at the same time without extra configuration
   return {
-    port: preview?.port,
+    port: preview?.port ?? DEFAULT_PREVIEW_PORT,
     strictPort: preview?.strictPort ?? server.strictPort,
     host: preview?.host ?? server.host,
     https: preview?.https ?? server.https,

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -56,6 +56,7 @@ import {
 } from '../watch'
 import { initPublicFiles } from '../publicDir'
 import { getEnvFilesForMode } from '../env'
+import type { RequiredExceptFor } from '../typeUtils'
 import type { PluginContainer } from './pluginContainer'
 import { ERR_CLOSED_SERVER, createPluginContainer } from './pluginContainer'
 import type { WebSocketServer } from './ws'
@@ -180,7 +181,20 @@ export interface ServerOptions extends CommonServerOptions {
 }
 
 export interface ResolvedServerOptions
-  extends Omit<ServerOptions, 'fs' | 'middlewareMode' | 'sourcemapIgnoreList'> {
+  extends Omit<
+    RequiredExceptFor<
+      ServerOptions,
+      | 'host'
+      | 'https'
+      | 'proxy'
+      | 'hmr'
+      | 'ws'
+      | 'watch'
+      | 'origin'
+      | 'hotUpdateEnvironments'
+    >,
+    'fs' | 'middlewareMode' | 'sourcemapIgnoreList'
+  > {
   fs: Required<FileSystemServeOptions>
   middlewareMode: NonNullable<ServerOptions['middlewareMode']>
   sourcemapIgnoreList: Exclude<

--- a/packages/vite/src/node/typeUtils.ts
+++ b/packages/vite/src/node/typeUtils.ts
@@ -20,3 +20,6 @@ export type GetHookContextMap<Plugin> = {
 
 type RollupPluginHooksContext = GetHookContextMap<RollupPlugin>
 export type RollupPluginHooks = NonNeverKeys<RollupPluginHooksContext>
+
+export type RequiredExceptFor<T, K extends keyof T> = Pick<T, K> &
+  Required<Omit<T, K>>


### PR DESCRIPTION
### Description

This PR makes properties of `ResolvedServerOptions` and `ResolvedPreviewOptions` required.

If we had the properties of ResolvedServerOptions not-optional and enabled `no-unnecessary-condition` rule from typescript-eslint, we can catch things like #18788 happening.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
