### PR TITLE
docs: show old document warning

### DIFF
--- a/docs/.vitepress/theme/components/OldDocument.vue
+++ b/docs/.vitepress/theme/components/OldDocument.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="old-document">
+    <p>
+      This documentation describes <b>the old</b> Vite version. For the latest
+      version, see
+      <a href="https://vite.dev/" class="new-document-link"
+        >the latest document</a
+      >.
+    </p>
+  </div>
+</template>
+
+<style>
+:root {
+  --vp-layout-top-height: 96px;
+  @media (min-width: 455px) {
+    --vp-layout-top-height: 64px;
+  }
+  @media (min-width: 960px) {
+    --vp-layout-top-height: 32px;
+  }
+}
+
+.old-document {
+  position: fixed;
+  display: flex;
+  height: var(--vp-layout-top-height);
+  width: 100%;
+  padding: 4px 32px;
+  justify-content: center;
+  align-items: center;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-danger-3);
+  z-index: var(--vp-z-index-nav);
+
+  .new-document-link {
+    text-decoration: underline;
+    color: var(--vp-c-text-1);
+    &:hover {
+      color: var(--vp-c-text-2);
+    }
+  }
+}
+</style>

--- a/docs/.vitepress/theme/components/OldDocument.vue
+++ b/docs/.vitepress/theme/components/OldDocument.vue
@@ -29,7 +29,7 @@
   align-items: center;
   color: var(--vp-c-text-1);
   background: var(--vp-c-brand-lightest);
-  z-index: var(--vp-z-index-nav);
+  z-index: var(--vp-z-index-layout-top);
 
   .new-document-link {
     text-decoration: underline;

--- a/docs/.vitepress/theme/components/OldDocument.vue
+++ b/docs/.vitepress/theme/components/OldDocument.vue
@@ -1,11 +1,9 @@
 <template>
   <div class="old-document">
     <p>
-      This documentation covers Vite 5 <strong>(old version)</strong>. For the latest
-      version, see
-      <a href="https://vite.dev" class="new-document-link"
-        >https://vite.dev</a
-      >.
+      This documentation covers Vite 5 <strong>(old version)</strong>. For the
+      latest version, see
+      <a href="https://vite.dev" class="new-document-link">https://vite.dev</a>.
     </p>
   </div>
 </template>
@@ -30,7 +28,7 @@
   justify-content: center;
   align-items: center;
   color: var(--vp-c-text-1);
-  background: var(--vp-c-danger-3);
+  background: var(--vp-c-brand-lightest);
   z-index: var(--vp-z-index-nav);
 
   .new-document-link {
@@ -39,6 +37,11 @@
     &:hover {
       color: var(--vp-c-text-2);
     }
+  }
+}
+.dark {
+  .old-document {
+    background: var(--vp-c-brand-darker);
   }
 }
 </style>

--- a/docs/.vitepress/theme/components/OldDocument.vue
+++ b/docs/.vitepress/theme/components/OldDocument.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="old-document">
     <p>
-      This documentation describes <b>the old</b> Vite version. For the latest
+      This documentation covers Vite 5 <strong>(old version)</strong>. For the latest
       version, see
-      <a href="https://vite.dev/" class="new-document-link"
-        >the latest document</a
+      <a href="https://vite.dev" class="new-document-link"
+        >https://vite.dev</a
       >.
     </p>
   </div>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -7,12 +7,14 @@ import './styles/vars.css'
 import './styles/landing.css'
 import AsideSponsors from './components/AsideSponsors.vue'
 import SvgImage from './components/SvgImage.vue'
+import OldDocument from './components/OldDocument.vue'
 
 export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
       'aside-ads-before': () => h(AsideSponsors),
+      'layout-top': () => h(OldDocument),
     })
   },
   enhanceApp({ app }) {


### PR DESCRIPTION
### Description

![image](https://github.com/user-attachments/assets/6f33e216-3766-464e-9b24-6072677d4004)
![image](https://github.com/user-attachments/assets/f4edc533-321a-4399-8f0f-a6b75568782f)
![image](https://github.com/user-attachments/assets/a746c610-6b9b-4828-b881-3f937f6d5274)

<details>
<summary>old design</summary>

![image](https://github.com/user-attachments/assets/953e3ea0-8532-4099-ba18-7777f0625fda)
![image](https://github.com/user-attachments/assets/2411508a-84a6-414b-9b86-a14418d78221)

</details>

If the design looks good, I'll make a PR to v2,3,4 as well.

fixes #18420

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
