### PR TITLE
fix(css): referencing aliased svg asset with lightningcss enabled errored

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3177,7 +3177,6 @@ async function compileLightningCSS(
           css = css.replace(dep.placeholder, () => dep.url)
           break
         }
-        deps.add(dep.url)
         if (urlReplacer) {
           const replaceUrl = await urlReplacer(
             dep.url,

--- a/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
+++ b/playground/css-lightningcss/__tests__/css-lightningcss.spec.ts
@@ -82,3 +82,8 @@ test('nested css with relative asset', async () => {
     isBuild ? /ok-[-\w]+\.png/ : `${viteTestUrl}/ok.png`,
   )
 })
+
+test('aliased asset', async () => {
+  const bg = await getBg('.css-url-aliased')
+  expect(bg).toMatch('data:image/svg+xml,')
+})

--- a/playground/css-lightningcss/css-url.css
+++ b/playground/css-lightningcss/css-url.css
@@ -1,0 +1,4 @@
+.css-url-aliased {
+  background: url('@/fragment.svg');
+  background-size: 10px;
+}

--- a/playground/css-lightningcss/index.html
+++ b/playground/css-lightningcss/index.html
@@ -29,6 +29,10 @@
 
   <p>Assets relative to nested CSS</p>
   <div class="nested-css-relative-asset"></div>
+
+  <div class="css-url-aliased">
+    <span style="background: #fff">CSS background (aliased)</span>
+  </div>
 </div>
 
 <script type="module" src="./main.js"></script>

--- a/playground/css-lightningcss/main.js
+++ b/playground/css-lightningcss/main.js
@@ -2,6 +2,7 @@ import './minify.css'
 import './imported.css'
 import mod from './mod.module.css'
 import './external-url.css'
+import './css-url.css'
 
 document.querySelector('.modules').classList.add(mod['apply-color'])
 text('.modules-code', JSON.stringify(mod, null, 2))

--- a/playground/css-lightningcss/nested/fragment.svg
+++ b/playground/css-lightningcss/nested/fragment.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 96" enable-background="new 0 0 32 96" xml:space="preserve">
+
+<view id="icon-clock-view" viewBox="0 0 32 32" />
+<view id="icon-heart-view" viewBox="0 32 32 32" />
+<view id="icon-arrow-right-view" viewBox="0 64 32 32" />
+
+<g id="icon-clock">
+	<path d="M20.6,23.3L14,16.7V7.9h4v7.2l5.4,5.4L20.6,23.3z M16-0.1c-8.8,0-16,7.2-16,16s7.2,16,16,16s16-7.2,16-16S24.8-0.1,16-0.1z
+		 M16,27.9c-6.6,0-12-5.4-12-12s5.4-12,12-12s12,5.4,12,12S22.6,27.9,16,27.9z"/>
+</g>
+<g id="icon-heart">
+	<path d="M32,43.2c0,2.7-1.2,5.1-3,6.8l0,0l-10,10c-1,1-2,2-3,2s-2-1-3-2l-10-10c-1.9-1.7-3-4.1-3-6.8c0-5.1,4.1-9.2,9.2-9.2
+		c2.7,0,5.1,1.2,6.8,3c1.7-1.9,4.1-3,6.8-3C27.9,33.9,32,38.1,32,43.2z"/>
+</g>
+<g id="icon-arrow-right">
+	<path d="M32,80.1l-16-16v10H0v12h16v10L32,80.1z"/>
+</g>
+</svg>

--- a/playground/css-lightningcss/vite.config.js
+++ b/playground/css-lightningcss/vite.config.js
@@ -1,8 +1,14 @@
+import path from 'node:path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
   css: {
     transformer: 'lightningcss',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'nested'),
+    },
   },
   build: {
     cssTarget: ['chrome61'],


### PR DESCRIPTION
### Description

fixes #18806

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
