### PR TITLE
fix(resolve): don't set builtinModules to `external` by default

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 import { performance } from 'node:perf_hooks'
-import { builtinModules, createRequire } from 'node:module'
+import { createRequire } from 'node:module'
 import colors from 'picocolors'
 import type { Alias, AliasOptions } from 'dep-types/alias'
 import { build } from 'esbuild'
@@ -621,7 +621,7 @@ export const configDefaults = Object.freeze({
     dedupe: [],
     /** @experimental */
     noExternal: [],
-    // external
+    external: [],
     preserveSymlinks: false,
     alias: [],
   },
@@ -882,10 +882,6 @@ function resolveEnvironmentResolveOptions(
         consumer === 'client' || isSsrTargetWebworkerEnvironment
           ? DEFAULT_CLIENT_CONDITIONS
           : DEFAULT_SERVER_CONDITIONS.filter((c) => c !== 'browser'),
-      external:
-        consumer === 'server' && !isSsrTargetWebworkerEnvironment
-          ? builtinModules
-          : [],
     },
     resolve ?? {},
   )

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -882,6 +882,7 @@ function resolveEnvironmentResolveOptions(
         consumer === 'client' || isSsrTargetWebworkerEnvironment
           ? DEFAULT_CLIENT_CONDITIONS
           : DEFAULT_SERVER_CONDITIONS.filter((c) => c !== 'browser'),
+      enableBuiltinNoExternalCheck: !!isSsrTargetWebworkerEnvironment,
     },
     resolve ?? {},
   )

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -96,6 +96,10 @@ export interface EnvironmentResolveOptions {
    * @experimental
    */
   external?: string[] | true
+  /**
+   * @internal
+   */
+  enableBuiltinNoExternalCheck?: boolean
 }
 
 export interface ResolveOptions extends EnvironmentResolveOptions {
@@ -420,6 +424,7 @@ export function resolvePlugin(
         if (isBuiltin(id)) {
           if (currentEnvironmentOptions.consumer === 'server') {
             if (
+              options.enableBuiltinNoExternalCheck &&
               options.noExternal === true &&
               // if both noExternal and external are true, noExternal will take the higher priority and bundle it.
               // only if the id is explicitly listed in external, we will externalize it and skip this error.

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -173,8 +173,11 @@ interface ResolvePluginOptions {
 }
 
 export interface InternalResolveOptions
-  extends Required<ResolveOptions>,
-    ResolvePluginOptions {}
+  extends Required<Omit<ResolveOptions, 'enableBuiltinNoExternalCheck'>>,
+    ResolvePluginOptions {
+  /** @internal this is always optional for backward compat */
+  enableBuiltinNoExternalCheck?: boolean
+}
 
 // Defined ResolveOptions are used to overwrite the values for all environments
 // It is used when creating custom resolvers (for CSS, scanning, etc)


### PR DESCRIPTION
### Description

~~I didn't intend to include this diff, but got included mistakenly.~~
https://github.com/vitejs/vite/commit/d002e7d05a0f23110f9185b39222819bcdfffc16#diff-11e17761d4ecfee8f8fde15c6d79b7bc0260176396a30dfd8e6f6bbaf5af4745L743-R772
No, it was for https://github.com/vitejs/vite/commit/d002e7d05a0f23110f9185b39222819bcdfffc16#diff-9b81bb364c02eab9494a7d27a5effc400cacbffd3b8f349c192f890c37bfc83fL450.
But now that I think we should not set, `builtinModules` to `resolve.external` because if a user set `external: ['foo']` then, the builtin modules will go away. I think we do need `resolve.builtins`.

I'll focus on fixing the issue in this PR, let's do the `resolve.builtins` thing separately.



fixes #18810

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
