### PR TITLE
fix: don't store temporary vite config file in `node_modules` if deno

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1859,18 +1859,20 @@ async function loadConfigFromBundledFile(
   // write it to disk, load it with native Node ESM, then delete the file.
   if (isESM) {
     const nodeModulesDir = findNearestNodeModules(path.dirname(fileName))
-    if (nodeModulesDir) {
+    const isDeno = !!(globalThis as any).Deno
+    if (nodeModulesDir && !isDeno) {
       await fsp.mkdir(path.resolve(nodeModulesDir, '.vite-temp/'), {
         recursive: true,
       })
     }
     const hash = `timestamp-${Date.now()}-${Math.random().toString(16).slice(2)}`
-    const tempFileName = nodeModulesDir
-      ? path.resolve(
-          nodeModulesDir,
-          `.vite-temp/${path.basename(fileName)}.${hash}.mjs`,
-        )
-      : `${fileName}.${hash}.mjs`
+    const tempFileName =
+      nodeModulesDir && !isDeno
+        ? path.resolve(
+            nodeModulesDir,
+            `.vite-temp/${path.basename(fileName)}.${hash}.mjs`,
+          )
+        : `${fileName}.${hash}.mjs`
     await fsp.writeFile(tempFileName, bundledCode)
     try {
       return (await import(pathToFileURL(tempFileName).href)).default

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1858,6 +1858,9 @@ async function loadConfigFromBundledFile(
   // with --experimental-loader themselves, we have to do a hack here:
   // write it to disk, load it with native Node ESM, then delete the file.
   if (isESM) {
+    // Storing the bundled file in node_modules/ is avoided for Deno
+    // because Deno only supports Node.js style modules under node_modules/
+    // and configs with `npm:` import statements will fail when executed.
     const nodeModulesDir =
       typeof process.versions.deno === 'string'
         ? undefined


### PR DESCRIPTION
### Description

fixes #18822

This fixes an issue where Vite v6 does not work on Deno when import statements with the specifier `npm:` is used in the config file.

Vite will create a bundled version of `vite.config.ts` under `node_modules/.vite-temp` if `node_modules/` exits. Import statements like the following will be kept in the generated output.

```typescript
import { defineConfig } from 'npm:vite@6'
```  

When this generated file is `import()` ed by Vite running on Deno, Deno will throw an error `TypeError: [ERR_UNSUPPORTED_ESM_URL_SCHEME]`.  This is because Deno assumes that modules under `node_modules/` is a valid file for executing with Node.js and considers the `npm:` prefix invalid.

This patch will check if the the environment is Deno and will prevent from storing the temp file under `node_modules/` if its Deno.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
