### PR TITLE
fix(module-runner): decode uri for file url passed to import

### DIFF
--- a/packages/vite/src/module-runner/utils.ts
+++ b/packages/vite/src/module-runner/utils.ts
@@ -7,7 +7,7 @@ export function normalizeAbsoluteUrl(url: string, root: string): string {
   // file:///C:/root/id.js -> C:/root/id.js
   if (url.startsWith('file://')) {
     // 8 is the length of "file:///"
-    url = url.slice(isWindows ? 8 : 7)
+    url = decodeURI(url.slice(isWindows ? 8 : 7))
   }
 
   // strip root from the URL because fetchModule prefers a public served url path

--- a/packages/vite/src/node/ssr/__tests__/fixtures/file-url/test space.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/file-url/test space.js
@@ -1,0 +1,1 @@
+export const msg = 'works'

--- a/packages/vite/src/node/ssr/__tests__/fixtures/file-url/test.js
+++ b/packages/vite/src/node/ssr/__tests__/fixtures/file-url/test.js
@@ -1,0 +1,1 @@
+export const msg = 'works'

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -237,3 +237,17 @@ test('json', async () => {
   )
   expect(json?.code.length).toMatchInlineSnapshot(`61`)
 })
+
+test('file url', async () => {
+  const server = await createDevServer()
+
+  const mod = await server.ssrLoadModule(
+    new URL('./fixtures/file-url/test.js', import.meta.url).href,
+  )
+  expect(mod.msg).toBe('works')
+
+  const modWithSpace = await server.ssrLoadModule(
+    new URL('./fixtures/file-url/test space.js', import.meta.url).href,
+  )
+  expect(modWithSpace.msg).toBe('works')
+})


### PR DESCRIPTION
### Description

fix https://github.com/withastro/astro/issues/12556

The `normalizeAbsoluteUrl` function should call `decodeURI` when normalizing `file://` urls as raw fs paths.