### PR TITLE
fix: correctly resolve hmr dep ids and fallback to url 

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -411,7 +411,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           // check if the dep has been hmr updated. If yes, we need to attach
           // its last updated timestamp to force the browser to fetch the most
           // up-to-date version of this module.
-          if (environment.config.consumer === 'client' && depModule.lastHMRTimestamp > 0) {
+          if (
+            environment.config.consumer === 'client' &&
+            depModule.lastHMRTimestamp > 0
+          ) {
             url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)
           }
         } catch (e: any) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -753,9 +753,20 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // normalize and rewrite accepted urls
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
-        const [normalized] = await moduleGraph.resolveUrl(toAbsoluteUrl(url))
+        let normalized
+        if (url.startsWith('.')) {
+          const [resolved] = await moduleGraph.resolveUrl(toAbsoluteUrl(url))
+          normalized = resolved
+        } else {
+          const resolved = await this.resolve(
+            url,
+            importerModule.id || undefined,
+          )
+          normalized = resolved?.id || url
+        }
         normalizedAcceptedUrls.add(normalized)
-        str().overwrite(start, end, JSON.stringify(normalized), {
+        const hmrAccept = normalizeHmrUrl(normalized)
+        str().overwrite(start, end, JSON.stringify(hmrAccept), {
           contentOnly: true,
         })
       }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -324,7 +324,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         url: string,
         pos: number,
         forceSkipImportAnalysis: boolean = false,
-      ): Promise<[string, string]> => {
+      ): Promise<[string, string | null]> => {
         url = stripBase(url, base)
 
         let importerFile = importer
@@ -357,7 +357,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         if (!resolved || resolved.meta?.['vite:alias']?.noResolved) {
           // in ssr, we should let node handle the missing modules
           if (ssr) {
-            return [url, url]
+            return [url, null]
           }
           // fix#9534, prevent the importerModuleNode being stopped from propagating updates
           importerModule.isSelfAccepting = false
@@ -552,7 +552,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             }
 
             // normalize
-            const [url, resolvedId] = await normalizeUrl(specifier, start)
+            let [url, resolvedId] = await normalizeUrl(specifier, start)
+            resolvedId = resolvedId || url
 
             // record as safe modules
             // safeModulesPath should not include the base prefix.

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -754,15 +754,14 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
         let normalized
-        if (url.startsWith('.')) {
+        const resolved = await this.resolve(url, importerModule.id || undefined)
+        if (resolved?.id) {
+          const mod = moduleGraph.getModuleById(resolved.id)
+          normalized = mod?.url
+        }
+        if (!normalized) {
           const [resolved] = await moduleGraph.resolveUrl(toAbsoluteUrl(url))
           normalized = resolved
-        } else {
-          const resolved = await this.resolve(
-            url,
-            importerModule.id || undefined,
-          )
-          normalized = resolved?.id || url
         }
         normalizedAcceptedUrls.add(normalized)
         const hmrAccept = normalizeHmrUrl(normalized)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -400,9 +400,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           }
         }
 
-        // check if the dep has been hmr updated. If yes, we need to attach
-        // its last updated timestamp to force the browser to fetch the most
-        // up-to-date version of this module.
         try {
           // delay setting `isSelfAccepting` until the file is actually used (#7870)
           // We use an internal function to avoid resolving the url again
@@ -411,7 +408,10 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
             canSkipImportAnalysis(url) || forceSkipImportAnalysis,
             resolved,
           )
-          if (depModule.lastHMRTimestamp > 0) {
+          // check if the dep has been hmr updated. If yes, we need to attach
+          // its last updated timestamp to force the browser to fetch the most
+          // up-to-date version of this module.
+          if (environment.config.consumer === 'client' && depModule.lastHMRTimestamp > 0) {
             url = injectQuery(url, `t=${depModule.lastHMRTimestamp}`)
           }
         } catch (e: any) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -757,7 +757,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       // normalize and rewrite accepted urls
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
-        let [normalized, resolvedId] = await normalizeUrl(url, start)
+        let [normalized, resolvedId] = await normalizeUrl(url, start).catch(
+          () => [],
+        )
         if (resolvedId) {
           const mod = moduleGraph.getModuleById(resolvedId)
           if (!mod) {

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -769,7 +769,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
           normalized = mod.url
         } else {
           try {
+            // this fallback is for backward compat and will be removed in Vite 7
             const [resolved] = await moduleGraph.resolveUrl(toAbsoluteUrl(url))
+            normalized = resolved
             if (resolved) {
               this.warn({
                 message:
@@ -777,11 +779,11 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
                   ' An id should be written. Did you pass a URL?',
                 pos: start,
               })
-              continue
             }
-          } catch {}
-          this.error(`Failed to resolve ${JSON.stringify(url)}`, start)
-          return
+          } catch {
+            this.error(`Failed to resolve ${JSON.stringify(url)}`, start)
+            return
+          }
         }
         normalizedAcceptedUrls.add(normalized)
         const hmrAccept = normalizeHmrUrl(normalized)

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -754,7 +754,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const normalizedAcceptedUrls = new Set<string>()
       for (const { url, start, end } of acceptedUrls) {
         let normalized
-        const resolved = await this.resolve(url, importerModule.id || undefined)
+        const resolved = await this.resolve(url, importer)
         if (resolved?.id) {
           const mod = moduleGraph.getModuleById(resolved.id)
           normalized = mod?.url

--- a/playground/hmr/__tests__/hmr.spec.ts
+++ b/playground/hmr/__tests__/hmr.spec.ts
@@ -779,6 +779,29 @@ if (!isBuild) {
     }, '[wow]1')
   })
 
+  test('handle virtual module accept updates', async () => {
+    await page.goto(viteTestUrl)
+    const el = await page.$('.virtual-dep')
+    expect(await el.textContent()).toBe('0')
+    editFile('importedVirtual.js', (code) => code.replace('[success]', '[wow]'))
+    await untilUpdated(async () => {
+      const el = await page.$('.virtual-dep')
+      return await el.textContent()
+    }, '[wow]')
+  })
+
+  test('invalidate virtual module and accept', async () => {
+    await page.goto(viteTestUrl)
+    const el = await page.$('.virtual-dep')
+    expect(await el.textContent()).toBe('0')
+    const btn = await page.$('.virtual-update-dep')
+    btn.click()
+    await untilUpdated(async () => {
+      const el = await page.$('.virtual-dep')
+      return await el.textContent()
+    }, '[wow]2')
+  })
+
   test('keep hmr reload after missing import on server startup', async () => {
     const file = 'missing-import/a.js'
     const importCode = "import 'missing-modules'"

--- a/playground/hmr/hmr.ts
+++ b/playground/hmr/hmr.ts
@@ -1,4 +1,5 @@
 import { virtual } from 'virtual:file'
+import { virtual as virtualDep } from 'virtual:file-dep'
 import { foo as depFoo, nestedFoo } from './hmrDep'
 import './importing-updated'
 import './file-delete-restore'
@@ -14,14 +15,26 @@ text('.app', foo)
 text('.dep', depFoo)
 text('.nested', nestedFoo)
 text('.virtual', virtual)
+text('.virtual-dep', virtualDep)
 text('.soft-invalidation', softInvalidationMsg)
 setImgSrc('#logo', logo)
 setImgSrc('#logo-no-inline', logoNoInline)
+
+text('.virtual-dep', 0)
 
 const btn = document.querySelector('.virtual-update') as HTMLButtonElement
 btn.onclick = () => {
   if (import.meta.hot) {
     import.meta.hot.send('virtual:increment')
+  }
+}
+
+const btnDep = document.querySelector(
+  '.virtual-update-dep',
+) as HTMLButtonElement
+btnDep.onclick = () => {
+  if (import.meta.hot) {
+    import.meta.hot.send('virtual:increment', '-dep')
   }
 }
 
@@ -53,6 +66,10 @@ if (import.meta.hot) {
 
   import.meta.hot.accept('./hmrDep', ({ foo, nestedFoo }) => {
     handleDep('single dep', foo, nestedFoo)
+  })
+
+  import.meta.hot.accept('virtual:file-dep', ({ virtual }) => {
+    text('.virtual-dep', virtual)
   })
 
   import.meta.hot.accept(['./hmrDep'], ([{ foo, nestedFoo }]) => {

--- a/playground/hmr/index.html
+++ b/playground/hmr/index.html
@@ -6,6 +6,7 @@
   />
 </div>
 <button class="virtual-update">update virtual module</button>
+<button class="virtual-update-dep">update virtual module via accept</button>
 
 <script type="module" src="./invalidation/root.js"></script>
 <script type="module" src="./hmr.ts"></script>
@@ -24,6 +25,7 @@
 <div class="custom"></div>
 <div class="toRemove"></div>
 <div class="virtual"></div>
+<div class="virtual-dep"></div>
 <div class="soft-invalidation"></div>
 <div class="invalidation-parent"></div>
 <div class="invalidation-root"></div>

--- a/playground/hmr/modules.d.ts
+++ b/playground/hmr/modules.d.ts
@@ -1,3 +1,7 @@
 declare module 'virtual:file' {
   export const virtual: string
 }
+
+declare module 'virtual:file-dep' {
+  export const virtual: string
+}

--- a/playground/hmr/vite.config.ts
+++ b/playground/hmr/vite.config.ts
@@ -45,23 +45,22 @@ function virtualPlugin(): Plugin {
   return {
     name: 'virtual-file',
     resolveId(id) {
-      if (id === 'virtual:file') {
-        return '\0virtual:file'
+      if (id.startsWith('virtual:file')) {
+        return '\0' + id
       }
     },
     load(id) {
-      if (id === '\0virtual:file') {
+      if (id.startsWith('\0virtual:file')) {
         return `\
 import { virtual as _virtual } from "/importedVirtual.js";
 export const virtual = _virtual + '${num}';`
       }
     },
     configureServer(server) {
-      server.environments.client.hot.on('virtual:increment', async () => {
-        const mod =
-          await server.environments.client.moduleGraph.getModuleByUrl(
-            '\0virtual:file',
-          )
+      server.environments.client.hot.on('virtual:increment', async (suffix) => {
+        const mod = await server.environments.client.moduleGraph.getModuleById(
+          '\0virtual:file' + (suffix || ''),
+        )
         if (mod) {
           num++
           server.environments.client.reloadModule(mod)


### PR DESCRIPTION
### Description

fixes #12912 
fixes #16375

this is the most basic to get it working. There are more issues regarding this, like having multiple modules in the module graph. one for `0virtual:file` and another for `/@id/__00__/virtual:file`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
