### PR TITLE
docs(assets): update static asset URL transformation in dev

### DIFF
--- a/docs/guide/assets.md
+++ b/docs/guide/assets.md
@@ -14,7 +14,7 @@ import imgUrl from './img.png'
 document.getElementById('hero-img').src = imgUrl
 ```
 
-For example, `imgUrl` will be `/img.png` during development, and become `/assets/img.2d8efhg.png` in the production build.
+For example, `imgUrl` will be `/src/img.png` during development, and become `/assets/img.2d8efhg.png` in the production build.
 
 The behavior is similar to webpack's `file-loader`. The difference is that the import can be either using absolute public paths (based on project root during dev) or relative paths.
 


### PR DESCRIPTION
TL;DR: `imgUrl` will be `/src/img.png` during development instead of `/img.png`, because said image is NOT a public asset.

Longer description:

Regarding this code snippet from the text:
```
import imgUrl from './img.png'
document.getElementById('hero-img').src = imgUrl
```

If the reader reasonably supposes this was extracted from the file `<root>/src/main.js`, then `img.png` must be located at the same directory: `<root>/src`, which makes `img.png` NOT a public asset (i.e., an asset in the `<root>/<publicDir>` directory (e.g., `/public/img.png`)).

Therefore, the import statement's URL `./img.png` would NOT be changed to `/img.png` by the Dev Server as the text currently states, but to ` /src/img.png` instead.

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
