### PR TITLE
docs(migration): add assets names array hint to avoid breaking the build when manifest enabled

### DIFF
--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -82,7 +82,7 @@ If you prefer to stick with `style.css` like in Vite 5, you can set `build.lib.c
 There are other breaking changes which only affect few users.
 
 - [[#18240] refactor: use `originalFileNames/names`](https://github.com/vitejs/vite/pull/18240):
-  - any plugin that emits assets with type `asset` must include the `names` array in the asset to avoid breaking the build when the manifest is enabled. Older versions of Vite use the `name` file to check whether the asset should be included in the manifest.
+  - any plugin that emits assets with type `asset` must include the `names` array in the asset to avoid breaking the build when the manifest is enabled. Older versions of Vite use the `name` field to check whether the asset should be included in the manifest.
 - [[#17922] fix(css)!: remove default import in ssr dev](https://github.com/vitejs/vite/pull/17922)
   - Support for default import of CSS files was [deprecated in Vite 4](https://v4.vite.dev/guide/migration.html#importing-css-as-a-string) and removed in Vite 5, but it was still unintentionally supported in SSR dev mode. This support is now removed.
 - [[#15637] fix!: default `build.cssMinify` to `'esbuild'` for SSR](https://github.com/vitejs/vite/pull/15637)

--- a/docs/guide/migration.md
+++ b/docs/guide/migration.md
@@ -81,6 +81,8 @@ If you prefer to stick with `style.css` like in Vite 5, you can set `build.lib.c
 
 There are other breaking changes which only affect few users.
 
+- [[#18240] refactor: use `originalFileNames/names`](https://github.com/vitejs/vite/pull/18240):
+  - any plugin that emits assets with type `asset` must include the `names` array in the asset to avoid breaking the build when the manifest is enabled. Older versions of Vite use the `name` file to check whether the asset should be included in the manifest.
 - [[#17922] fix(css)!: remove default import in ssr dev](https://github.com/vitejs/vite/pull/17922)
   - Support for default import of CSS files was [deprecated in Vite 4](https://v4.vite.dev/guide/migration.html#importing-css-as-a-string) and removed in Vite 5, but it was still unintentionally supported in SSR dev mode. This support is now removed.
 - [[#15637] fix!: default `build.cssMinify` to `'esbuild'` for SSR](https://github.com/vitejs/vite/pull/15637)


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->
Changes included in #18240 can break the build when the manifest is enabled and missing names if some plugin emit any asset  without the entry (with `type='asset'`).

Vite <6 using `name` entry to  check whether the asset should be included in the manifest (`name` is deprecated, not sure when was deprecated in Rollup).

For example, vite-plugin-pwa emits 2 assets (not registered in the manifest): https://github.com/vite-pwa/vite-plugin-pwa/pull/797/commits/58553f85a3d5e21db4e846ebe3c8b3c9e10e7e09

![image](https://github.com/user-attachments/assets/2950f889-1146-497d-ab90-9a2f499bf59a)


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
