### PR TITLE
fix: make result interfaces for `ModuleRunnerTransport#invoke` more explicit

### DIFF
--- a/docs/guide/api-environment-runtimes.md
+++ b/docs/guide/api-environment-runtimes.md
@@ -265,9 +265,7 @@ interface ModuleRunnerTransport {
   connect?(handlers: ModuleRunnerTransportHandlers): Promise<void> | void
   disconnect?(): Promise<void> | void
   send?(data: HotPayload): Promise<void> | void
-  invoke?(
-    data: HotPayload,
-  ): Promise<{ /** result */ r: any } | { /** error */ e: any }>
+  invoke?(data: HotPayload): Promise<{ result: any } | { error: any }>
   timeout?: number
 }
 ```

--- a/packages/vite/src/shared/moduleRunnerTransport.ts
+++ b/packages/vite/src/shared/moduleRunnerTransport.ts
@@ -19,9 +19,7 @@ export interface ModuleRunnerTransport {
   connect?(handlers: ModuleRunnerTransportHandlers): Promise<void> | void
   disconnect?(): Promise<void> | void
   send?(data: HotPayload): Promise<void> | void
-  invoke?(
-    data: HotPayload,
-  ): Promise<{ /** result */ r: any } | { /** error */ e: any }>
+  invoke?(data: HotPayload): Promise<{ result: any } | { error: any }>
   timeout?: number
 }
 
@@ -58,10 +56,10 @@ const createInvokeableTransport = (
             data,
           } satisfies InvokeSendData,
         } satisfies CustomPayload)
-        if ('e' in result) {
-          throw reviveInvokeError(result.e)
+        if ('error' in result) {
+          throw reviveInvokeError(result.error)
         }
-        return result.r
+        return result.result
       },
     }
   }


### PR DESCRIPTION
currently the `invoke` method of `ModuleRunnerTransport` can return an object with either an `r` or `e` field, where the former stands for `result` and the latter for `error`, the changes here simply rename `r` to `result` and `e` to `error` providing a more clear environment authoring experience

___

> [!Note]
> I appreciate that this change might be subjective, but I do personally think that more explicit fields here would benefit the DX/Authoring experience of environment authors.

___

> [!Note]
> It's a bit unsettling that the fields rename didn't break/force me to update any tests 🥲
> I think ideally this API should be tested, if everyone agrees I am happy to look into adding some
> tests either in this PR or in a followup one

___

> [!Note]
> This is a breaking change, hopefully this is fine since the API is still experimental, if this is a problem I could update this to be non-breaking as in still accepting `r` and `e` alongside the new fields. although I am not sure if such change would be still worth it 😅

___

[Discord thread](https://discord.com/channels/804011606160703521/1305708398582431754)