### PR TITLE
fix(html): allow unexpected question mark in tag name

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -302,6 +302,7 @@ function handleParseError(
       return
     case 'unexpected-question-mark-instead-of-tag-name':
       // Allow <?xml> declaration and <?> empty elements
+      // lit generates <?>: https://github.com/lit/lit/issues/2470
       return
   }
   const parseError = formatParseError(parserError, filePath, html)

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -300,6 +300,9 @@ function handleParseError(
     case 'non-void-html-element-start-tag-with-trailing-solidus':
       // Allow self closing on non-void elements #10439
       return
+    case 'unexpected-question-mark-instead-of-tag-name':
+      // Allow <?xml> declaration and <?> empty elements
+      return
   }
   const parseError = formatParseError(parserError, filePath, html)
   throw new Error(


### PR DESCRIPTION
Allow question marks at the start of tag names, see [the html spec](https://html.spec.whatwg.org/multipage/parsing.html#parse-error-unexpected-question-mark-instead-of-tag-name).This is so the`<?xml>` tag and (why this pull request exists) empty [lit](https://lit.dev/) templates (see [this issue](https://github.com/lit/lit/issues/2470)) get turned into comments and don't crash vite.

Parse5 already turns the tag into a comment and continues parsing. This is the default behaviour on browsers and HTML-Parsers, granted it's a bit weird that a parser can throw an error and continue.

This is not the first pull request of this kind as error ignoring logic has already been implemented and this is just adds the `'unexpected-question-mark-instead-of-tag-name'` to those ignored errors.
