### PR TITLE
fix: make handleInvoke interface compatible with invoke

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -105,7 +105,7 @@ export function createWebSocketServer(
       off: noop as any as WebSocketServer['off'],
       setInvokeHandler: noop,
       handleInvoke: async () => ({
-        e: {
+        error: {
           name: 'TransportError',
           message: 'handleInvoke not implemented',
           stack: new Error().stack,


### PR DESCRIPTION
### Description

This change was missing from #18851

Without this change, this example doesn't work.
https://vite.dev/guide/api-environment-runtimes.html#modulerunnertransport:~:text=In%20this%20case%2C%20the%20handleInvoke%20method%20in%20the%20NormalizedHotChannel%20can%20be%20used%3A

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
