### PR TITLE
feat(create-vite): minimal One.js option to create-vite react templates

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -144,6 +144,12 @@ const FRAMEWORKS: Framework[] = [
         color: cyan,
         customCommand: 'npm create react-router@latest TARGET_DIR',
       },
+      {
+        name: 'react-one',
+        display: 'One',
+        color: yellow,
+        customCommand: 'npx one@latest TARGET_DIR --template Minimal'
+      }
     ],
   },
   {


### PR DESCRIPTION
### Description

As discussed with @patak-dev this should add a minimal template for One for easy testing with Vite and for bugs.

One thing I'm not sure of - we expect TARGET_DIR to be just a name like "app-name", we don't accept a path. I can make the changes in the cli easily though to accept a path, but didn't see clearly if this was expected or not here.