### PR TITLE
refactor: simplify manifest plugin code

### DIFF
--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -59,7 +59,7 @@ export function manifestPlugin(): Plugin {
       function getChunkName(chunk: OutputChunk) {
         return (
           getChunkOriginalFileName(chunk, root, format) ??
-          `_` + path.basename(chunk.fileName)
+          `_${path.basename(chunk.fileName)}`
         )
       }
 
@@ -142,8 +142,6 @@ export function manifestPlugin(): Plugin {
         }
       }
 
-      const fileNameToAsset = new Map<string, ManifestChunk>()
-
       for (const file in bundle) {
         const chunk = bundle[file]
         if (chunk.type === 'chunk') {
@@ -153,7 +151,7 @@ export function manifestPlugin(): Plugin {
           const src =
             chunk.originalFileNames.length > 0
               ? chunk.originalFileNames[0]
-              : '_' + path.basename(chunk.fileName)
+              : `_${path.basename(chunk.fileName)}`
           const isEntry = entryCssAssetFileNames.has(chunk.fileName)
           const asset = createAsset(chunk, src, isEntry)
 
@@ -162,7 +160,6 @@ export function manifestPlugin(): Plugin {
           const file = manifest[src]?.file
           if (!(file && endsWithJSRE.test(file))) {
             manifest[src] = asset
-            fileNameToAsset.set(chunk.fileName, asset)
           }
 
           for (const originalFileName of chunk.originalFileNames.slice(1)) {
@@ -201,7 +198,7 @@ export function getChunkOriginalFileName(
     if (format === 'system' && !chunk.name.includes('-legacy')) {
       const ext = path.extname(name)
       const endPos = ext.length !== 0 ? -ext.length : undefined
-      name = name.slice(0, endPos) + `-legacy` + ext
+      name = `${name.slice(0, endPos)}-legacy${ext}`
     }
     return name.replace(/\0/g, '')
   }


### PR DESCRIPTION
### Description

Encountered this issue while improving the built-in `manifest` plugin in `rolldown`.

- remove unnecessary variable `fileNameToAsset`
- use template literals