### PR TITLE
fix: merge client and ssr values for `pluginContainer.getModuleInfo`

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -960,14 +960,41 @@ class PluginContainer {
   }
 
   getModuleInfo(id: string): ModuleInfo | null {
-    return (
-      (
-        this.environments.client as DevEnvironment
-      ).pluginContainer.getModuleInfo(id) ||
-      (this.environments.ssr as DevEnvironment).pluginContainer.getModuleInfo(
-        id,
-      )
-    )
+    const clientModuleInfo = (
+      this.environments.client as DevEnvironment
+    ).pluginContainer.getModuleInfo(id)
+    const ssrModuleInfo = (
+      this.environments.ssr as DevEnvironment
+    ).pluginContainer.getModuleInfo(id)
+
+    if (clientModuleInfo == null && ssrModuleInfo == null) return null
+
+    return new Proxy({} as any, {
+      get: (_, key: string) => {
+        // `meta` refers to `ModuleInfo.meta` so we refer to `this.meta` to
+        // handle the object union between client and ssr
+        if (key === 'meta') {
+          const meta: Record<string, any> = {}
+          if (ssrModuleInfo) {
+            Object.assign(meta, ssrModuleInfo.meta)
+          }
+          if (clientModuleInfo) {
+            Object.assign(meta, clientModuleInfo.meta)
+          }
+          return meta
+        }
+        if (clientModuleInfo) {
+          if (key in clientModuleInfo) {
+            return clientModuleInfo[key as keyof ModuleInfo]
+          }
+        }
+        if (ssrModuleInfo) {
+          if (key in ssrModuleInfo) {
+            return ssrModuleInfo[key as keyof ModuleInfo]
+          }
+        }
+      },
+    })
   }
 
   get options(): InputOptions {

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -971,8 +971,8 @@ class PluginContainer {
 
     return new Proxy({} as any, {
       get: (_, key: string) => {
-        // `meta` refers to `ModuleInfo.meta` so we refer to `this.meta` to
-        // handle the object union between client and ssr
+        // `meta` refers to `ModuleInfo.meta` of both environments, so we also
+        // need to merge it here
         if (key === 'meta') {
           const meta: Record<string, any> = {}
           if (ssrModuleInfo) {


### PR DESCRIPTION
### Description

fix https://github.com/withastro/astro/issues/12635

When calling `server.pluginContainer.getModuleInfo()`, if both client and ssr modules exists, the `info` is merged instead of only having the client module take precedence. This is done via proxy the same way as `EnvironmentPluginContainer.getModuleInfo` is implemented so we don't break the proxy behaviour.

This PR also fixes accessing (mixed) `ModuleNode`'s `info` and `meta` properties to also merged them for client and ssr moudules instead of having the client module take precedence. This fix isn't needed for the linked issue above, but I did it anyways since I initially thought I needed the fix here.