### PR TITLE
test: test output hash changes

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -57,6 +57,17 @@ describe('build', () => {
       buildProject('red'),
       buildProject('blue'),
     ])
+    expect(getOutputHashChanges(result[0], result[1])).toMatchInlineSnapshot(`
+      {
+        "changed": [
+          "index",
+          "_subentry.css",
+        ],
+        "unchanged": [
+          "undefined",
+        ],
+      }
+    `)
     assertOutputHashContentChange(result[0], result[1])
   })
 
@@ -105,6 +116,21 @@ describe('build', () => {
       buildProject('yellow'),
       buildProject('blue'),
     ])
+    expect(getOutputHashChanges(result[0], result[1])).toMatchInlineSnapshot(`
+      {
+        "changed": [
+          "index",
+          "_foo",
+          "_bar",
+          "_baz.css",
+        ],
+        "unchanged": [
+          "_foo.css",
+          "_bar.css",
+          "undefined",
+        ],
+      }
+    `)
     assertOutputHashContentChange(result[0], result[1])
   })
 
@@ -748,5 +774,19 @@ function assertOutputHashContentChange(
         ).toEqual(chunk2.code)
       }
     }
+  }
+}
+
+function getOutputHashChanges(output1: RollupOutput, output2: RollupOutput) {
+  const map1 = Object.fromEntries(
+    output1.output.map((o) => [o.name, o.fileName]),
+  )
+  const map2 = Object.fromEntries(
+    output2.output.map((o) => [o.name, o.fileName]),
+  )
+  const names = Object.keys(map1).filter(Boolean)
+  return {
+    changed: names.filter((name) => map1[name] !== map2[name]),
+    unchanged: names.filter((name) => map1[name] === map2[name]),
   }
 }


### PR DESCRIPTION
### Description

`assertOutputHashContentChange` wasn't explicitly asserting the hash change, so I added more direct assertion `getOutputHashChanges` to dump what changed and not.

For the context, I had an odd test failure on rolldown due to https://github.com/rolldown/rolldown/issues/3049 and I was a bit confused about the expectation of this test.