### PR TITLE
fix(optimizer): keep NODE_ENV as-is when keepProcessEnv is `true`

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -775,9 +775,11 @@ async function prepareEsbuildOptimizerRun(
   if (optimizerContext.cancelled) return { context: undefined, idToExports }
 
   const define = {
-    'process.env.NODE_ENV': JSON.stringify(
-      process.env.NODE_ENV || environment.config.mode,
-    ),
+    'process.env.NODE_ENV': environment.config.keepProcessEnv
+      ? // define process.env.NODE_ENV even for keepProcessEnv === true
+        // as esbuild will replace it automatically when `platform` is `'browser'`
+        'process.env.NODE_ENV'
+      : JSON.stringify(process.env.NODE_ENV || environment.config.mode),
   }
 
   const platform =
@@ -1210,7 +1212,9 @@ function getConfigHash(environment: Environment): string {
   const { optimizeDeps } = config
   const content = JSON.stringify(
     {
-      mode: process.env.NODE_ENV || config.mode,
+      define: config.keepProcessEnv
+        ? process.env.NODE_ENV || config.mode
+        : null,
       root: config.root,
       resolve: config.resolve,
       assetsInclude: config.assetsInclude,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1212,7 +1212,7 @@ function getConfigHash(environment: Environment): string {
   const { optimizeDeps } = config
   const content = JSON.stringify(
     {
-      define: config.keepProcessEnv
+      define: !config.keepProcessEnv
         ? process.env.NODE_ENV || config.mode
         : null,
       root: config.root,

--- a/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
+++ b/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
@@ -48,7 +48,7 @@ describe.runIf(!isBuild)('pre-bundling', () => {
       })
       .filter((file) => file.isFile() && file.name.endsWith('.js'))
       .map((file) => path.join(file.parentPath, file.name))
-    const depsFileHasProcessEnvNodeEnvLeft = depsFiles
+    const depsFilesWithProcessEnvNodeEnv = depsFiles
       .filter((file) =>
         fs.readFileSync(file, 'utf-8').includes('process.env.NODE_ENV'),
       )
@@ -58,7 +58,7 @@ describe.runIf(!isBuild)('pre-bundling', () => {
           file,
         ),
       )
-    expect(depsFileHasProcessEnvNodeEnvLeft.length).toBeGreaterThan(0)
+    expect(depsFilesWithProcessEnvNodeEnv.length).toBeGreaterThan(0)
   })
 
   test('deps reload', async () => {

--- a/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
+++ b/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
@@ -40,6 +40,25 @@ describe.runIf(!isBuild)('pre-bundling', () => {
     expect(metaJson.optimized['react/jsx-dev-runtime']).toBeTruthy()
 
     expect(metaJson.optimized['react-dom/client']).toBeFalsy()
+
+    // process.env.NODE_ENV should be kept as keepProcessEnv is true
+    const depsFiles = fs
+      .readdirSync(path.resolve(testDir, 'node_modules/.vite/deps_ssr'), {
+        withFileTypes: true,
+      })
+      .filter((file) => file.isFile() && file.name.endsWith('.js'))
+      .map((file) => path.join(file.parentPath, file.name))
+    const depsFileHasProcessEnvNodeEnvLeft = depsFiles
+      .filter((file) =>
+        fs.readFileSync(file, 'utf-8').includes('process.env.NODE_ENV'),
+      )
+      .map((file) =>
+        path.relative(
+          path.resolve(testDir, 'node_modules/.vite/deps_ssr'),
+          file,
+        ),
+      )
+    expect(depsFileHasProcessEnvNodeEnvLeft.length).toBeGreaterThan(0)
   })
 
   test('deps reload', async () => {

--- a/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
+++ b/playground/environment-react-ssr/__tests__/environment-react-ssr.spec.ts
@@ -48,16 +48,10 @@ describe.runIf(!isBuild)('pre-bundling', () => {
       })
       .filter((file) => file.isFile() && file.name.endsWith('.js'))
       .map((file) => path.join(file.parentPath, file.name))
-    const depsFilesWithProcessEnvNodeEnv = depsFiles
-      .filter((file) =>
-        fs.readFileSync(file, 'utf-8').includes('process.env.NODE_ENV'),
-      )
-      .map((file) =>
-        path.relative(
-          path.resolve(testDir, 'node_modules/.vite/deps_ssr'),
-          file,
-        ),
-      )
+    const depsFilesWithProcessEnvNodeEnv = depsFiles.filter((file) =>
+      fs.readFileSync(file, 'utf-8').includes('process.env.NODE_ENV'),
+    )
+
     expect(depsFilesWithProcessEnvNodeEnv.length).toBeGreaterThan(0)
   })
 


### PR DESCRIPTION
### Description

`process.env.NODE_ENV` was replaced by the optimizer even if `keepProcessEnv` was set to `true`. But the optimizer should respect `keepProcessEnv` to make it consistent with build.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
