### PR TITLE
fix: make `--force` work for all environments

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -182,8 +182,8 @@ cli
         configFile: options.config,
         logLevel: options.logLevel,
         clearScreen: options.clearScreen,
-        optimizeDeps: { force: options.force },
         server: cleanGlobalCLIOptions(options),
+        forceOptimization: options.force,
       })
 
       if (!server.httpServer) {

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -183,7 +183,7 @@ cli
         logLevel: options.logLevel,
         clearScreen: options.clearScreen,
         server: cleanGlobalCLIOptions(options),
-        forceOptimization: options.force,
+        forceOptimizeDeps: options.force,
       })
 
       if (!server.httpServer) {

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -743,7 +743,7 @@ function resolveEnvironmentOptions(
   options: EnvironmentOptions,
   alias: Alias[],
   preserveSymlinks: boolean,
-  optimizeDepsForce: boolean | undefined,
+  forceOptimizeDeps: boolean | undefined,
   logger: Logger,
   environmentName: string,
   // Backward compatibility
@@ -773,7 +773,7 @@ function resolveEnvironmentOptions(
     optimizeDeps: resolveDepOptimizationOptions(
       options.optimizeDeps,
       resolve.preserveSymlinks,
-      optimizeDepsForce,
+      forceOptimizeDeps,
       consumer,
     ),
     dev: resolveDevEnvironmentOptions(
@@ -941,7 +941,7 @@ function resolveResolveOptions(
 function resolveDepOptimizationOptions(
   optimizeDeps: DepOptimizationOptions | undefined,
   preserveSymlinks: boolean,
-  optimizeDepsForce: boolean | undefined,
+  forceOptimizeDeps: boolean | undefined,
   consumer: 'client' | 'server' | undefined,
 ): DepOptimizationOptions {
   return mergeWithDefaults(
@@ -952,7 +952,7 @@ function resolveDepOptimizationOptions(
       esbuildOptions: {
         preserveSymlinks,
       },
-      force: optimizeDepsForce ?? configDefaults.optimizeDeps.force,
+      force: forceOptimizeDeps ?? configDefaults.optimizeDeps.force,
     },
     optimizeDeps ?? {},
   )

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -530,7 +530,7 @@ export interface ResolvedWorkerOptions {
 export interface InlineConfig extends UserConfig {
   configFile?: string | false
   envFile?: false
-  forceOptimization?: boolean
+  forceOptimizeDeps?: boolean
 }
 
 export type ResolvedConfig = Readonly<
@@ -1164,7 +1164,7 @@ export async function resolveConfig(
       config.environments[environmentName],
       resolvedDefaultResolve.alias,
       resolvedDefaultResolve.preserveSymlinks,
-      inlineConfig.forceOptimization,
+      inlineConfig.forceOptimizeDeps,
       logger,
       environmentName,
       config.experimental?.skipSsrTransform,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -742,6 +742,7 @@ function resolveEnvironmentOptions(
   options: EnvironmentOptions,
   alias: Alias[],
   preserveSymlinks: boolean,
+  optimizeDepsForce: boolean | undefined,
   logger: Logger,
   environmentName: string,
   // Backward compatibility
@@ -771,6 +772,7 @@ function resolveEnvironmentOptions(
     optimizeDeps: resolveDepOptimizationOptions(
       options.optimizeDeps,
       resolve.preserveSymlinks,
+      optimizeDepsForce,
       consumer,
     ),
     dev: resolveDevEnvironmentOptions(
@@ -938,6 +940,7 @@ function resolveResolveOptions(
 function resolveDepOptimizationOptions(
   optimizeDeps: DepOptimizationOptions | undefined,
   preserveSymlinks: boolean,
+  optimizeDepsForce: boolean | undefined,
   consumer: 'client' | 'server' | undefined,
 ): DepOptimizationOptions {
   return mergeWithDefaults(
@@ -948,6 +951,7 @@ function resolveDepOptimizationOptions(
       esbuildOptions: {
         preserveSymlinks,
       },
+      force: optimizeDepsForce ?? configDefaults.optimizeDeps.force,
     },
     optimizeDeps ?? {},
   )
@@ -1159,6 +1163,7 @@ export async function resolveConfig(
       config.environments[environmentName],
       resolvedDefaultResolve.alias,
       resolvedDefaultResolve.preserveSymlinks,
+      config.optimizeDeps?.force,
       logger,
       environmentName,
       config.experimental?.skipSsrTransform,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -530,6 +530,7 @@ export interface ResolvedWorkerOptions {
 export interface InlineConfig extends UserConfig {
   configFile?: string | false
   envFile?: false
+  forceOptimization?: boolean
 }
 
 export type ResolvedConfig = Readonly<
@@ -1163,7 +1164,7 @@ export async function resolveConfig(
       config.environments[environmentName],
       resolvedDefaultResolve.alias,
       resolvedDefaultResolve.preserveSymlinks,
-      config.optimizeDeps?.force,
+      inlineConfig.forceOptimization,
       logger,
       environmentName,
       config.experimental?.skipSsrTransform,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -373,24 +373,36 @@ export async function loadCachedDepOptimizationMetadata(
       if (cachedMetadata.lockfileHash !== getLockfileHash(environment)) {
         environment.logger.info(
           'Re-optimizing dependencies because lockfile has changed',
+          {
+            timestamp: true,
+          },
         )
       } else if (cachedMetadata.configHash !== getConfigHash(environment)) {
         environment.logger.info(
           'Re-optimizing dependencies because vite config has changed',
+          {
+            timestamp: true,
+          },
         )
       } else {
-        log?.('Hash is consistent. Skipping. Use --force to override.')
+        log?.(
+          `(${environment.name}) Hash is consistent. Skipping. Use --force to override.`,
+        )
         // Nothing to commit or cancel as we are using the cache, we only
         // need to resolve the processing promise so requests can move on
         return cachedMetadata
       }
     }
   } else {
-    environment.logger.info('Forced re-optimization of dependencies')
+    environment.logger.info('Forced re-optimization of dependencies', {
+      timestamp: true,
+    })
   }
 
   // Start with a fresh cache
-  debug?.(colors.green(`removing old cache dir ${depsCacheDir}`))
+  debug?.(
+    `(${environment.name}) ${colors.green(`removing old cache dir ${depsCacheDir}`)}`,
+  )
   await fsp.rm(depsCacheDir, { recursive: true, force: true })
 }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1141,9 +1141,7 @@ async function restartServer(server: ViteDevServer) {
   let inlineConfig = server.config.inlineConfig
   if (server._forceOptimizeOnRestart) {
     inlineConfig = mergeConfig(inlineConfig, {
-      optimizeDeps: {
-        force: true,
-      },
+      forceOptimization: true,
     })
   }
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1141,7 +1141,7 @@ async function restartServer(server: ViteDevServer) {
   let inlineConfig = server.config.inlineConfig
   if (server._forceOptimizeOnRestart) {
     inlineConfig = mergeConfig(inlineConfig, {
-      forceOptimization: true,
+      forceOptimizeDeps: true,
     })
   }
 


### PR DESCRIPTION
### Description

`--force` only applied to the client environment. I think passing it should apply to other environments too.
Probably the behavior change was caused by https://github.com/vitejs/vite/pull/18465

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
