### PR TITLE
docs: display file name in a better way

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -8,8 +8,7 @@ When running `vite` from the command line, Vite will automatically try to resolv
 
 The most basic config file looks like this:
 
-```js
-// vite.config.js
+```js [vite.config.js]
 export default {
   // config options
 }


### PR DESCRIPTION
### Description

use a better way to display the file name

![image](https://github.com/user-attachments/assets/1e03e8cb-e791-44a6-9b99-1f4d91b87dfa)

vs

![image](https://github.com/user-attachments/assets/67c45472-033a-4666-bb57-4a2b8c3c720a)
