### PR TITLE
refactor: replace <div> with <main> as root.

### DIFF
--- a/packages/create-vite/template-react-ts/index.html
+++ b/packages/create-vite/template-react-ts/index.html
@@ -7,7 +7,7 @@
     <title>Vite + React + TS</title>
   </head>
   <body>
-    <div id="root"></div>
+    <main id="root"></main>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/create-vite/template-react/index.html
+++ b/packages/create-vite/template-react/index.html
@@ -7,7 +7,7 @@
     <title>Vite + React</title>
   </head>
   <body>
-    <div id="root"></div>
+    <main id="root"></main>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
### Description
I recently noticed that a `<div>` tag was being used as the root within the `<body>` tag. I researched a bit and I am confident that using `<main>` tag instead of `<div>` is better because it promotes semantic structure and better accessibility. In some cases, this can positively impact SEO in some cases.