### PR TITLE
ci: fix checkout pr in ecosystem ci 

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -188,6 +188,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ fromJSON(steps.get-pr-data.outputs.result).num }}/head
           fetch-depth: 0
 
       # This step can be removed on May 26 2025


### PR DESCRIPTION
As discussed in discord, right now the git ambiguity check always fails because the pr commits are yet to exist in the main history.

in this fix, we checkout to the pull request history and have a look there.