### PR TITLE
test: don't use `__dirname` in tailwind config

### DIFF
--- a/playground/backend-integration/tailwind.config.js
+++ b/playground/backend-integration/tailwind.config.js
@@ -1,5 +1,10 @@
-/** @type {import('tailwindcss').Config} */
+import { fileURLToPath } from 'node:url'
+import { dirname } from 'node:path'
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+/** @type {import('tailwindcss').Config} */
 export default {
   content: [__dirname + '/frontend/**/*.{css,html,ts,js}'],
   theme: {


### PR DESCRIPTION
### Description

`require(esm)` is now enabled by default from Node 22.12.0.
Before node 22.12.0, the tailwind config was loaded by jiti and that allowed users to use `__dirname` in ESM tailwind configs.
But after node 22.12.0, `require(esm)` is supported by Node and that is used instead of jiti and thus `__dirname` is not declared and errors.

https://github.com/tailwindlabs/tailwindcss/blob/f875ab9706cae8262e15e5b382580fc8e2d4197f/src/lib/load-config.ts#L34-L51

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
