### PR TITLE
fix(css): skip non css in custom sass importer

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ playground/html/valid.html
 playground/external/public/slash@3.0.0.js
 playground/ssr-html/public/slash@3.0.0.js
 playground/worker/classic-worker.js
+playground/css/weapp.wxss

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2376,6 +2376,11 @@ const makeModernScssWorker = (
             const resolved = await internalCanonicalize(url, importer)
             if (
               resolved &&
+              // only limit to these extensions because:
+              // - for the `@import`/`@use`s written in file loaded by `load` function,
+              //   the `canonicalize` function of that `importer` is called first
+              // - the `load` function of an importer is only called for the importer
+              //   that returned a non-null result from its `canonicalize` function
               (resolved.endsWith('.css') ||
                 resolved.endsWith('.scss') ||
                 resolved.endsWith('.sass'))

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2374,7 +2374,15 @@ const makeModernScssWorker = (
               ? fileURLToPath(context.containingUrl)
               : options.filename
             const resolved = await internalCanonicalize(url, importer)
-            return resolved ? pathToFileURL(resolved) : null
+            if (
+              resolved &&
+              (resolved.endsWith('.css') ||
+                resolved.endsWith('.scss') ||
+                resolved.endsWith('.sass'))
+            ) {
+              return pathToFileURL(resolved)
+            }
+            return null
           },
           async load(canonicalUrl) {
             const ext = path.extname(canonicalUrl.pathname)
@@ -2463,7 +2471,15 @@ const makeModernCompilerScssWorker = (
             url,
             cleanScssBugUrl(importer),
           )
-          return resolved ? pathToFileURL(resolved) : null
+          if (
+            resolved &&
+            (resolved.endsWith('.css') ||
+              resolved.endsWith('.scss') ||
+              resolved.endsWith('.sass'))
+          ) {
+            return pathToFileURL(resolved)
+          }
+          return null
         },
         async load(canonicalUrl) {
           const ext = path.extname(canonicalUrl.pathname)

--- a/playground/css/nested/_index.scss
+++ b/playground/css/nested/_index.scss
@@ -1,4 +1,5 @@
 @use 'sass:string';
+@use '../weapp.wxss'; // test user's custom importer in a file loaded by vite's custom importer
 
 @import './css-in-scss.css';
 

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -65,7 +65,7 @@ export default defineConfig({
         importers: [
           {
             canonicalize(url) {
-              return url === 'virtual-dep'
+              return url === 'virtual-dep' || url.endsWith('.wxss')
                 ? new URL('custom-importer:virtual-dep')
                 : null
             },

--- a/playground/css/weapp.wxss
+++ b/playground/css/weapp.wxss
@@ -1,0 +1,1 @@
+this is not css


### PR DESCRIPTION
### Description

- closes https://github.com/vitejs/vite/issues/18961

_todo_

- [x] double check sass spec if this is necessary
- [x] check how webpack deals with this
  - they also restrict the extension https://github.com/webpack-contrib/sass-loader/blob/1c98038a2647230a7a00cdf7b148395b4e687d03/src/utils.js#L502

---

https://sass-lang.com/documentation/js-api/interfaces/options/#importers

> Loads are resolved by trying, in order:
> - The importer that was used to load the current stylesheet, with the loaded URL resolved relative to the current stylesheet's canonical URL.
> - Each [Importer](https://sass-lang.com/documentation/js-api/interfaces/Importer), [FileImporter](https://sass-lang.com/documentation/js-api/interfaces/FileImporter), or [NodePackageImporter](https://sass-lang.com/documentation/js-api/classes/NodePackageImporter) in [importers](https://sass-lang.com/documentation/js-api/interfaces/Options#importers), in order.
> - ...

As per the documentation above, Vite's importer `canonicalize` runs before user's custom importer when Vite's importer `load` the style. To allow users to always intercept non css file import, Vite needs to ignore them from own `canonicalize` even if file exists. This sounds like technically a breaking change, but I'm not sure there's other way without asking sass side change.

For the tests, I re-purposed `.wxss` file added in https://github.com/vitejs/vite/pull/10101.