### PR TITLE
fix(hmr): reload CSS when inlined SVG is changed

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -184,6 +184,11 @@ export function assetPlugin(config: ResolvedConfig): Plugin {
       id = removeUrlQuery(id)
       let url = await fileToUrl(this, id)
 
+      if (id.endsWith('.css')) {
+        // .css?url depends on .css?direct
+        this.addWatchFile(id + '?direct')
+      }
+
       // Inherit HMR timestamp if this asset was invalidated
       if (!url.startsWith('data:') && this.environment.mode === 'dev') {
         const mod = this.environment.moduleGraph.getModuleById(id)

--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -793,6 +793,7 @@ function propagateUpdate(
     // #3716, #3913
     // For a non-CSS file, if all of its importers are CSS files (registered via
     // PostCSS plugins) it should be considered a dead end and force full reload.
+    // TODO
     if (
       !isCSSRequest(node.url) &&
       [...node.importers].every((i) => isCSSRequest(i.url))

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -303,6 +303,20 @@ describe('css url() references', () => {
   test('image-set() with svg', async () => {
     expect(await getBg('.css-image-set-svg')).toMatch(/data:image\/svg\+xml,.+/)
   })
+
+  test('url() with svg in .css?url', async () => {
+    const bg = await getBg('.css-url-svg-in-url')
+    expect(bg).toMatch(/data:image\/svg\+xml,.+/)
+    expect(bg).toContain('blue')
+    expect(bg).not.toContain('red')
+
+    if (isServe) {
+      editFile('nested/fragment-bg-hmr2.svg', (code) =>
+        code.replace('fill="blue"', 'fill="red"'),
+      )
+      await untilUpdated(() => getBg('.css-url-svg'), 'red')
+    }
+  })
 })
 
 describe('image', () => {

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -287,7 +287,17 @@ describe('css url() references', () => {
   })
 
   test('url() with svg', async () => {
-    expect(await getBg('.css-url-svg')).toMatch(/data:image\/svg\+xml,.+/)
+    const bg = await getBg('.css-url-svg')
+    expect(bg).toMatch(/data:image\/svg\+xml,.+/)
+    expect(bg).toContain('blue')
+    expect(bg).not.toContain('red')
+
+    if (isServe) {
+      editFile('nested/fragment-bg-hmr.svg', (code) =>
+        code.replace('fill="blue"', 'fill="red"'),
+      )
+      await untilUpdated(() => getBg('.css-url-svg'), 'red')
+    }
   })
 
   test('image-set() with svg', async () => {

--- a/playground/assets/css/css-url-url.css
+++ b/playground/assets/css/css-url-url.css
@@ -1,0 +1,4 @@
+.css-url-svg-in-url {
+  background: url(../nested/fragment-bg-hmr2.svg);
+  background-size: 10px;
+}

--- a/playground/assets/css/css-url.css
+++ b/playground/assets/css/css-url.css
@@ -114,7 +114,7 @@ urls inside comments should be ignored
 */
 
 .css-url-svg {
-  background: url(../nested/fragment-bg.svg);
+  background: url(../nested/fragment-bg-hmr.svg);
   background-size: 10px;
 }
 

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -148,6 +148,9 @@
 <div class="css-url-svg">
   <span style="background: #fff">CSS SVG background</span>
 </div>
+<div class="css-url-svg-in-url">
+  <span style="background: #fff">CSS (?url) SVG background</span>
+</div>
 
 <div class="css-image-set-svg">
   <span style="background: #fff">CSS SVG background with image-set</span>
@@ -527,6 +530,12 @@
 
   import cssUrl from './css/icons.css?url'
   text('.url-css', cssUrl)
+
+  import cssUrlUrl from './css/css-url-url.css?url'
+  const linkTag = document.createElement('link')
+  linkTag.href = cssUrlUrl
+  linkTag.rel = 'stylesheet'
+  document.body.appendChild(linkTag)
 
   // const url = new URL('non_existent_file.png', import.meta.url)
   const metaUrl = new URL('./nested/asset.png', import.meta.url)

--- a/playground/assets/nested/fragment-bg-hmr.svg
+++ b/playground/assets/nested/fragment-bg-hmr.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32" height="32" viewBox="0 0 32 96" enable-background="new 0 0 32 96" xml:space="preserve">
+
+<view id="icon-clock-view" viewBox="0 0 32 32" />
+<view id="icon-heart-view" viewBox="0 32 32 32" />
+<view id="icon-arrow-right-view" viewBox="0 64 32 32" />
+
+<g id="icon-clock">
+	<path d="M20.6,23.3L14,16.7V7.9h4v7.2l5.4,5.4L20.6,23.3z M16-0.1c-8.8,0-16,7.2-16,16s7.2,16,16,16s16-7.2,16-16S24.8-0.1,16-0.1z
+		 M16,27.9c-6.6,0-12-5.4-12-12s5.4-12,12-12s12,5.4,12,12S22.6,27.9,16,27.9z" fill="blue"/>
+</g>
+<g id="icon-heart">
+	<path d="M32,43.2c0,2.7-1.2,5.1-3,6.8l0,0l-10,10c-1,1-2,2-3,2s-2-1-3-2l-10-10c-1.9-1.7-3-4.1-3-6.8c0-5.1,4.1-9.2,9.2-9.2
+		c2.7,0,5.1,1.2,6.8,3c1.7-1.9,4.1-3,6.8-3C27.9,33.9,32,38.1,32,43.2z"/>
+</g>
+<g id="icon-arrow-right">
+	<path d="M32,80.1l-16-16v10H0v12h16v10L32,80.1z"/>
+</g>
+</svg>

--- a/playground/assets/nested/fragment-bg-hmr2.svg
+++ b/playground/assets/nested/fragment-bg-hmr2.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32" height="32" viewBox="0 0 32 96" enable-background="new 0 0 32 96" xml:space="preserve">
+
+<view id="icon-clock-view" viewBox="0 0 32 32" />
+<view id="icon-heart-view" viewBox="0 32 32 32" />
+<view id="icon-arrow-right-view" viewBox="0 64 32 32" />
+
+<g id="icon-clock">
+	<path d="M20.6,23.3L14,16.7V7.9h4v7.2l5.4,5.4L20.6,23.3z M16-0.1c-8.8,0-16,7.2-16,16s7.2,16,16,16s16-7.2,16-16S24.8-0.1,16-0.1z
+		 M16,27.9c-6.6,0-12-5.4-12-12s5.4-12,12-12s12,5.4,12,12S22.6,27.9,16,27.9z" fill="blue"/>
+</g>
+<g id="icon-heart">
+	<path d="M32,43.2c0,2.7-1.2,5.1-3,6.8l0,0l-10,10c-1,1-2,2-3,2s-2-1-3-2l-10-10c-1.9-1.7-3-4.1-3-6.8c0-5.1,4.1-9.2,9.2-9.2
+		c2.7,0,5.1,1.2,6.8,3c1.7-1.9,4.1-3,6.8-3C27.9,33.9,32,38.1,32,43.2z"/>
+</g>
+<g id="icon-arrow-right">
+	<path d="M32,80.1l-16-16v10H0v12h16v10L32,80.1z"/>
+</g>
+</svg>


### PR DESCRIPTION
### Description

fixes #18963

This PR fixes #18963 by registering all referenced assets as a dependency of CSS files.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
