### PR TITLE
fix: normalize html path in `transformIndexHtml()`

### DIFF
--- a/packages/vite/src/node/server/__tests__/transformIndexHtml.spec.ts
+++ b/packages/vite/src/node/server/__tests__/transformIndexHtml.spec.ts
@@ -1,0 +1,80 @@
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { normalizePath } from '../../utils'
+import { type ViteDevServer, createServer } from '../index'
+
+describe('transformIndexHtml', () => {
+  const root = join(__dirname, 'fixtures/transformIndexHtml')
+  let server: ViteDevServer | undefined
+
+  let resolveResult: { path: string; filename: string } | undefined
+
+  beforeEach(async () => {
+    server = await createServer({
+      root,
+      plugins: [
+        {
+          name: 'transformIndexHtml-record-result',
+          transformIndexHtml: {
+            order: 'pre',
+            handler: (html, ctx) => {
+              expect(html).toBe('')
+              expect(resolveResult).toBe(undefined)
+              resolveResult = { path: ctx.path, filename: ctx.filename }
+            },
+          },
+        },
+      ],
+    })
+  })
+  afterEach(async () => {
+    if (server) {
+      await server.close()
+      server = undefined
+    }
+  })
+
+  async function test(url: string, expPath: string, expFilename: string) {
+    resolveResult = undefined
+    await server!.transformIndexHtml(url, '')
+    expect(resolveResult).toEqual({
+      path: expPath,
+      filename: normalizePath(expFilename),
+    })
+  }
+
+  const p = join(root, 'a', 'b')
+
+  it('handles root url', async () => {
+    await test('/', '/index.html', join(root, 'index.html'))
+  })
+
+  it('handles filename in a subdirectory', async () => {
+    await test('/a/b/index.html', '/a/b/index.html', join(p, 'index.html'))
+  })
+  it('handles no filename in a subdirectory', async () => {
+    await test('/a/b/', '/a/b/index.html', join(p, 'index.html'))
+  })
+  it('handles filename without an extension', async () => {
+    await test('/a/b/index', '/a/b/index.html', join(p, 'index.html'))
+  })
+
+  it('handles filename other than index.html without extension', async () => {
+    await test('/a/b/other', '/a/b/other.html', join(p, 'other.html'))
+  })
+  it('handles unicode in the path', async () => {
+    await test(
+      '/%F0%9F%90%B1/',
+      '/%F0%9F%90%B1/index.html',
+      join(root, '🐱', 'index.html'),
+    )
+  })
+
+  it('handles search parameters', async () => {
+    await test('/a/b/?c=d', '/a/b/index.html', join(p, 'index.html'))
+  })
+
+  it('handles hash', async () => {
+    await test('/a/b/#c', '/a/b/index.html', join(p, 'index.html'))
+  })
+})


### PR DESCRIPTION
### Problem

Currently, the `url` accepted by `transformIndexHtml()` [is passed unaltered](https://github.com/vitejs/vite/blob/ccd1a4c4145ee1069d7baea56981a0322e7be864/packages/vite/src/node/server/middlewares/indexHtml.ts#L83) to `applyHtmlTransforms()`.This causes issues if the url
1. doesn't refer to a file (see #18964), or
2. contains search parameters or hash (`/index.html?a=b` or `index.html#id`).

This is different from how default vite server and build behave; they use urls that refer to a file. (The server modifies urls in [`htmlFallbackMiddleware()`](https://github.com/vitejs/vite/blob/ccd1a4c4145ee1069d7baea56981a0322e7be864/packages/vite/src/node/server/middlewares/htmlFallback.ts#L9)).

### Solution

I extracted html path normalization from `htmlFallbackMiddleware()` and used it in `createDevHtmlTransformFn()`.

Fixes #18964 