### PR TITLE
fix: fallback terser to main thread when function options are used

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -145,6 +145,7 @@
     "sirv": "^3.0.0",
     "source-map-support": "^0.5.21",
     "strip-literal": "^2.1.1",
+    "terser": "^5.37.0",
     "tinyglobby": "^0.2.10",
     "tsconfck": "^3.1.4",
     "tslib": "^2.8.1",

--- a/packages/vite/src/node/__tests__/plugins/terser.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/terser.spec.ts
@@ -1,0 +1,55 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+import { build } from 'vite'
+import type { RollupOutput } from 'rollup'
+import type { TerserOptions } from '../../plugins/terser'
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..')
+
+describe('terser', () => {
+  const run = async (terserOptions: TerserOptions) => {
+    const result = (await build({
+      root: resolve(__dirname, '../packages/build-project'),
+      logLevel: 'silent',
+      build: {
+        write: false,
+        minify: 'terser',
+        terserOptions,
+      },
+      plugins: [
+        {
+          name: 'test',
+          resolveId(id) {
+            if (id === 'entry.js') {
+              return '\0' + id
+            }
+          },
+          load(id) {
+            if (id === '\0entry.js') {
+              return `const foo = 1;console.log(foo)`
+            }
+          },
+        },
+      ],
+    })) as RollupOutput
+    return result.output[0].code
+  }
+
+  test('basic', async () => {
+    await run({})
+  })
+
+  test('nth', async () => {
+    const resultCode = await run({
+      mangle: {
+        nth_identifier: {
+          get: (n) => {
+            return 'prefix_' + n.toString()
+          },
+        },
+      },
+    })
+    expect(resultCode).toContain('prefix_')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
       strip-literal:
         specifier: ^2.1.1
         version: 2.1.1
+      terser:
+        specifier: ^5.37.0
+        version: 5.37.0
       tinyglobby:
         specifier: ^0.2.10
         version: 0.2.10


### PR DESCRIPTION
### Description

This PR makes terser to run in the main thread when function options are used.
I also tested out calling functions on the main thread side from the workers, but it was slower than simply running in the main thread.

<details>
<summary>the way I tested and the results</summary>

I ran the script below with each implementation.
```js
import { resolve } from 'node:path'
import { fileURLToPath } from 'node:url'
import { build } from 'vite'

const __dirname = resolve(fileURLToPath(import.meta.url), '..')

const result = (await build({
  root: resolve(__dirname, '../../../../../../playground/resolve'), // or css
  logLevel: 'silent',
  build: {
    write: false,
    minify: 'terser',
    terserOptions: {
      mangle: {
        nth_identifier: {
          get: (n) => {
            return 'prefix_' + n.toString()
          },
        },
      },
    },
  },
}))
```

The results was:

 - `resolve` playground
   - call main thread: 2.76s
   - fallback: 2.48s
 - `css` playground
   - call main thread: 2.76s
   - fallback: 2.66s

It is expected that "call main thread" is slower for the `resolve` playground because it only has a single chunk. `css` playground generates multiple chunks but it's still slower than "fallback".

</details>

We can improve this by detecting if the passed function is serializable (i.e. does not use variables outside the function) and serializing the function in that case. But I think we can first merge this PR as it's better than nothing.

fixes #17409
refs #17589

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
