### PR TITLE
feat: export default config

### DIFF
--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -10,6 +10,7 @@ export {
   DEFAULT_SERVER_CONDITIONS as defaultServerConditions,
   DEFAULT_SERVER_MAIN_FIELDS as defaultServerMainFields,
 } from './constants'
+export { configDefaults } from './config'
 export { version as esbuildVersion } from 'esbuild'
 export {
   splitVendorChunkPlugin,


### PR DESCRIPTION
### Description

Makes the default config consumable by the user.

### Use case

I'm developing a plugin that needs to access the `build.outDir` variable:

```typescript
config: (conf) => {
    return {
      build: {
        rollupOptions: {
          plugins: [
            AnotherPlugin({
              outDir: conf.build.outDir,
            })
          ]
        }
      }
    };
```

However, `conf.build.outDir` variable is only defined if the user has provided that option in their own configuration file. If not, it will only be accessible on the ``configResolved`` hook, which makes our use case useless.

With this PR, we can make a graceful fallback:

```typescript
config: (conf) => {
    return {
      build: {
        rollupOptions: {
          plugins: [
            AnotherPlugin({
              outDir: conf.build.outDir ?? configDefaults.build.outDir,
            })
          ]
        }
      }
    };
```
