### PR TITLE
feat(worker): support dynamic worker option fields

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -71,6 +71,38 @@ describe('workerImportMetaUrlPlugin', async () => {
     )
   })
 
+  test('with parenthesis inside of worker options', async () => {
+    expect(
+      await transform(
+        'const worker = new Worker(new URL("./worker.js", import.meta.url), { name: genName(), type: "module"})',
+      ),
+    ).toMatchInlineSnapshot(
+      `"const worker = new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { name: genName(), type: "module"})"`,
+    )
+  })
+
+  test('with multi-line code and worker options', async () => {
+    expect(
+      await transform(`
+const worker = new Worker(new URL("./worker.js", import.meta.url), {
+    name: genName(),
+    type: "module",
+  },
+)
+
+worker.addEventListener('message', (ev) => text('.simple-worker-url', JSON.stringify(ev.data)))
+`),
+    ).toMatchInlineSnapshot(`"
+const worker = new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), {
+    name: genName(),
+    type: "module",
+  },
+)
+
+worker.addEventListener('message', (ev) => text('.simple-worker-url', JSON.stringify(ev.data)))
+"`)
+  })
+
   test('throws an error when non-static worker options are provided', async () => {
     await expect(
       transform(

--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'vitest'
+import { parseAst } from 'rollup/parseAst'
+import { workerImportMetaUrlPlugin } from '../../plugins/workerImportMetaUrl'
+import { resolveConfig } from '../../config'
+import { PartialEnvironment } from '../../baseEnvironment'
+
+async function createWorkerImportMetaUrlPluginTransform() {
+  const config = await resolveConfig({ configFile: false }, 'serve')
+  const instance = workerImportMetaUrlPlugin(config)
+  const environment = new PartialEnvironment('client', config)
+
+  return async (code: string) => {
+    // @ts-expect-error transform should exist
+    const result = await instance.transform.call(
+      { environment, parse: parseAst },
+      code,
+      'foo.ts',
+    )
+    return result?.code || result
+  }
+}
+
+describe('workerImportMetaUrlPlugin', async () => {
+  const transform = await createWorkerImportMetaUrlPluginTransform()
+
+  test('without worker options', async () => {
+    expect(
+      await transform('new Worker(new URL(`./worker.js`, import.meta.url))'),
+    ).toMatchInlineSnapshot(
+      `"new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=classic", import.meta.url))"`,
+    )
+  })
+
+  test('with shared worker', async () => {
+    expect(
+      await transform(
+        'new SharedWorker(new URL(`./worker.js`, import.meta.url))',
+      ),
+    ).toMatchInlineSnapshot(
+      `"new SharedWorker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=classic", import.meta.url))"`,
+    )
+  })
+
+  test('with static worker options', async () => {
+    expect(
+      await transform(
+        'new Worker(new URL(`./worker.js`, import.meta.url), { type: "module", name: "worker1" })',
+      ),
+    ).toMatchInlineSnapshot(
+      `"new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { type: "module", name: "worker1" })"`,
+    )
+  })
+
+  test('with dynamic name field in worker options', async () => {
+    expect(
+      await transform(
+        'const id = 1; new Worker(new URL(`./worker.js`, import.meta.url), { name: "worker" + id })',
+      ),
+    ).toMatchInlineSnapshot(
+      `"const id = 1; new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=classic", import.meta.url), { name: "worker" + id })"`,
+    )
+  })
+
+  test('with dynamic name field and static type in worker options', async () => {
+    expect(
+      await transform(
+        'const id = 1; new Worker(new URL(`./worker.js`, import.meta.url), { name: "worker" + id, type: "module" })',
+      ),
+    ).toMatchInlineSnapshot(
+      `"const id = 1; new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { name: "worker" + id, type: "module" })"`,
+    )
+  })
+
+  test('throws an error when non-static worker options are provided', async () => {
+    await expect(
+      transform(
+        'new Worker(new URL(`./worker.js`, import.meta.url), myWorkerOptions)',
+      ),
+    ).rejects.toThrow(
+      'Vite is unable to parse the worker options as the value is not static. To ignore this error, please use /* @vite-ignore */ in the worker options.',
+    )
+  })
+
+  test('throws an error when worker options are not an object', async () => {
+    await expect(
+      transform(
+        'new Worker(new URL(`./worker.js`, import.meta.url), "notAnObject")',
+      ),
+    ).rejects.toThrow('Expected worker options to be an object, got string')
+  })
+
+  test('throws an error when non-literal type field in worker options', async () => {
+    await expect(
+      transform(
+        'const type = "module"; new Worker(new URL(`./worker.js`, import.meta.url), { type })',
+      ),
+    ).rejects.toThrow(
+      'Expected worker options type property to be a literal value.',
+    )
+  })
+
+  test('throws an error when spread operator used without the type field', async () => {
+    await expect(
+      transform(
+        'const options = { name: "worker1" }; new Worker(new URL(`./worker.js`, import.meta.url), { ...options })',
+      ),
+    ).rejects.toThrow(
+      'Expected object spread to be used before the definition of the type property. Vite needs a static value for the type property to correctly infer it.',
+    )
+  })
+
+  test('throws an error when spread operator used after definition of type field', async () => {
+    await expect(
+      transform(
+        'const options = { name: "worker1" }; new Worker(new URL(`./worker.js`, import.meta.url), { type: "module", ...options })',
+      ),
+    ).rejects.toThrow(
+      'Expected object spread to be used before the definition of the type property. Vite needs a static value for the type property to correctly infer it.',
+    )
+  })
+})

--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -25,7 +25,7 @@ describe('workerImportMetaUrlPlugin', async () => {
 
   test('without worker options', async () => {
     expect(
-      await transform('new Worker(new URL(`./worker.js`, import.meta.url))'),
+      await transform('new Worker(new URL("./worker.js", import.meta.url))'),
     ).toMatchInlineSnapshot(
       `"new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=classic", import.meta.url))"`,
     )
@@ -34,7 +34,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('with shared worker', async () => {
     expect(
       await transform(
-        'new SharedWorker(new URL(`./worker.js`, import.meta.url))',
+        'new SharedWorker(new URL("./worker.js", import.meta.url))',
       ),
     ).toMatchInlineSnapshot(
       `"new SharedWorker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=classic", import.meta.url))"`,
@@ -44,7 +44,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('with static worker options', async () => {
     expect(
       await transform(
-        'new Worker(new URL(`./worker.js`, import.meta.url), { type: "module", name: "worker1" })',
+        'new Worker(new URL("./worker.js", import.meta.url), { type: "module", name: "worker1" })',
       ),
     ).toMatchInlineSnapshot(
       `"new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { type: "module", name: "worker1" })"`,
@@ -54,7 +54,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('with dynamic name field in worker options', async () => {
     expect(
       await transform(
-        'const id = 1; new Worker(new URL(`./worker.js`, import.meta.url), { name: "worker" + id })',
+        'const id = 1; new Worker(new URL("./worker.js", import.meta.url), { name: "worker" + id })',
       ),
     ).toMatchInlineSnapshot(
       `"const id = 1; new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=classic", import.meta.url), { name: "worker" + id })"`,
@@ -64,7 +64,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('with dynamic name field and static type in worker options', async () => {
     expect(
       await transform(
-        'const id = 1; new Worker(new URL(`./worker.js`, import.meta.url), { name: "worker" + id, type: "module" })',
+        'const id = 1; new Worker(new URL("./worker.js", import.meta.url), { name: "worker" + id, type: "module" })',
       ),
     ).toMatchInlineSnapshot(
       `"const id = 1; new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { name: "worker" + id, type: "module" })"`,
@@ -74,7 +74,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('throws an error when non-static worker options are provided', async () => {
     await expect(
       transform(
-        'new Worker(new URL(`./worker.js`, import.meta.url), myWorkerOptions)',
+        'new Worker(new URL("./worker.js", import.meta.url), myWorkerOptions)',
       ),
     ).rejects.toThrow(
       'Vite is unable to parse the worker options as the value is not static. To ignore this error, please use /* @vite-ignore */ in the worker options.',
@@ -84,7 +84,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('throws an error when worker options are not an object', async () => {
     await expect(
       transform(
-        'new Worker(new URL(`./worker.js`, import.meta.url), "notAnObject")',
+        'new Worker(new URL("./worker.js", import.meta.url), "notAnObject")',
       ),
     ).rejects.toThrow('Expected worker options to be an object, got string')
   })
@@ -92,7 +92,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('throws an error when non-literal type field in worker options', async () => {
     await expect(
       transform(
-        'const type = "module"; new Worker(new URL(`./worker.js`, import.meta.url), { type })',
+        'const type = "module"; new Worker(new URL("./worker.js", import.meta.url), { type })',
       ),
     ).rejects.toThrow(
       'Expected worker options type property to be a literal value.',
@@ -102,7 +102,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('throws an error when spread operator used without the type field', async () => {
     await expect(
       transform(
-        'const options = { name: "worker1" }; new Worker(new URL(`./worker.js`, import.meta.url), { ...options })',
+        'const options = { name: "worker1" }; new Worker(new URL("./worker.js", import.meta.url), { ...options })',
       ),
     ).rejects.toThrow(
       'Expected object spread to be used before the definition of the type property. Vite needs a static value for the type property to correctly infer it.',
@@ -112,7 +112,7 @@ describe('workerImportMetaUrlPlugin', async () => {
   test('throws an error when spread operator used after definition of type field', async () => {
     await expect(
       transform(
-        'const options = { name: "worker1" }; new Worker(new URL(`./worker.js`, import.meta.url), { type: "module", ...options })',
+        'const options = { name: "worker1" }; new Worker(new URL("./worker.js", import.meta.url), { type: "module", ...options })',
       ),
     ).rejects.toThrow(
       'Expected object spread to be used before the definition of the type property. Vite needs a static value for the type property to correctly infer it.',

--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -41,13 +41,23 @@ describe('workerImportMetaUrlPlugin', async () => {
     )
   })
 
-  test('with static worker options', async () => {
+  test('with static worker options and identifier properties', async () => {
     expect(
       await transform(
         'new Worker(new URL("./worker.js", import.meta.url), { type: "module", name: "worker1" })',
       ),
     ).toMatchInlineSnapshot(
       `"new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { type: "module", name: "worker1" })"`,
+    )
+  })
+
+  test('with static worker options and literal properties', async () => {
+    expect(
+      await transform(
+        'new Worker(new URL("./worker.js", import.meta.url), { "type": "module", "name": "worker1" })',
+      ),
+    ).toMatchInlineSnapshot(
+      `"new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { "type": "module", "name": "worker1" })"`,
     )
   })
 

--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -5,8 +5,14 @@ import { workerImportMetaUrlPlugin } from '../../plugins/workerImportMetaUrl'
 import { resolveConfig } from '../../config'
 import { PartialEnvironment } from '../../baseEnvironment'
 
+// @Note copied from packages/vite/src/shared/utils.ts
+const windowsSlashRE = /\\/g
+function slash(p: string): string {
+  return p.replace(windowsSlashRE, '/')
+}
+
 async function createWorkerImportMetaUrlPluginTransform() {
-  const root = path.join(import.meta.dirname, 'fixtures/worker')
+  const root = slash(path.join(import.meta.dirname, 'fixtures/worker'))
   const config = await resolveConfig({ configFile: false, root }, 'serve')
   const instance = workerImportMetaUrlPlugin(config)
   const environment = new PartialEnvironment('client', config)

--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { parseAst } from 'rollup/parseAst'
 import { workerImportMetaUrlPlugin } from '../../plugins/workerImportMetaUrl'
@@ -5,7 +6,8 @@ import { resolveConfig } from '../../config'
 import { PartialEnvironment } from '../../baseEnvironment'
 
 async function createWorkerImportMetaUrlPluginTransform() {
-  const config = await resolveConfig({ configFile: false }, 'serve')
+  const root = path.join(import.meta.dirname, 'fixtures/worker')
+  const config = await resolveConfig({ configFile: false, root }, 'serve')
   const instance = workerImportMetaUrlPlugin(config)
   const environment = new PartialEnvironment('client', config)
 
@@ -14,7 +16,7 @@ async function createWorkerImportMetaUrlPluginTransform() {
     const result = await instance.transform.call(
       { environment, parse: parseAst },
       code,
-      'foo.ts',
+      path.join(root, 'foo.ts'),
     )
     return result?.code || result
   }

--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -1,19 +1,11 @@
-import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import { parseAst } from 'rollup/parseAst'
 import { workerImportMetaUrlPlugin } from '../../plugins/workerImportMetaUrl'
 import { resolveConfig } from '../../config'
 import { PartialEnvironment } from '../../baseEnvironment'
 
-// @Note copied from packages/vite/src/shared/utils.ts
-const windowsSlashRE = /\\/g
-function slash(p: string): string {
-  return p.replace(windowsSlashRE, '/')
-}
-
 async function createWorkerImportMetaUrlPluginTransform() {
-  const root = slash(path.join(import.meta.dirname, 'fixtures/worker'))
-  const config = await resolveConfig({ configFile: false, root }, 'serve')
+  const config = await resolveConfig({ configFile: false }, 'serve')
   const instance = workerImportMetaUrlPlugin(config)
   const environment = new PartialEnvironment('client', config)
 
@@ -22,7 +14,7 @@ async function createWorkerImportMetaUrlPluginTransform() {
     const result = await instance.transform.call(
       { environment, parse: parseAst },
       code,
-      path.join(root, 'foo.ts'),
+      'foo.ts',
     )
     return result?.code || result
   }

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -232,7 +232,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
           let file: string | undefined
           if (url[0] === '.') {
             file = path.resolve(path.dirname(id), url)
-            file = tryFsResolve(file, fsResolveOptions) ?? file
+            file = slash(tryFsResolve(file, fsResolveOptions) ?? file)
           } else {
             workerResolver ??= createBackCompatIdResolver(config, {
               extensions: [],

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -25,6 +25,18 @@ function err(e: string, pos: number) {
   return error
 }
 
+function findClosingParen(input: string, fromIndex: number) {
+  let count = 1
+
+  for (let i = fromIndex + 1; i < input.length; i++) {
+    if (input[i] === '(') count++
+    if (input[i] === ')') count--
+    if (count === 0) return i
+  }
+
+  return -1
+}
+
 function extractWorkerTypeFromAst(
   astNode: any,
   optsStartIndex: number,
@@ -122,7 +134,7 @@ async function getWorkerType(
   if (commaIndex === -1) {
     return 'classic'
   }
-  const endIndex = clean.indexOf(')', i)
+  const endIndex = findClosingParen(clean, i)
 
   // case: ') ... ,' mean no worker options params
   if (commaIndex > endIndex) {

--- a/playground/worker/worker/main-module.js
+++ b/playground/worker/worker/main-module.js
@@ -140,7 +140,6 @@ const genWorkerName = () => 'module'
 const w2 = new SharedWorker(
   new URL('../url-shared-worker.js', import.meta.url),
   {
-    /* @vite-ignore */
     name: genWorkerName(),
     type: 'module',
   },


### PR DESCRIPTION
### Description

**The Problem**

Vite has a hard requirement that worker options are defined statically or it throws an error. This prevents some legitimate use cases, such as when a dynamic name is used to differentiate workers. As seen in the Emscripten project ([code reference](https://github.com/emscripten-core/emscripten/blob/1171adaa21048ba8dc82169b9d79952e8754b201/src/library_pthread.js#L409))
```js
worker = new Worker(new URL('target.js', import.meta.url), {
  'type': 'module',
  'name': 'em-pthread-' + PThread.nextWorkerID,
})
```

This is causing some issues in trying to update Emscripten to support Vite when workers are in use.

**Solution**

Vite only needs to ensure that the `type` value is statically defined. Other fields could be dynamically computed with no effect on the Vite bundling process.

A side discussion was started in https://github.com/vitejs/vite/pull/18396#issuecomment-2538226748 about relaxing the usage of some worker option fields to support this.

This PR hopes to solve this issue in a backwards compatible way that still ensures that Vite can have high confidence in asserting the worker type at compile time.