### PR TITLE
refactor(create-vite): remove tslib from svelte-ts template

### DIFF
--- a/packages/create-vite/template-svelte-ts/package.json
+++ b/packages/create-vite/template-svelte-ts/package.json
@@ -14,7 +14,6 @@
     "@tsconfig/svelte": "^5.0.4",
     "svelte": "^5.14.3",
     "svelte-check": "^4.1.1",
-    "tslib": "^2.8.1",
     "typescript": "~5.6.2",
     "vite": "^6.0.3"
   }


### PR DESCRIPTION
### Description

Vite does not use `tslib` and `importHelpers` is not enabled in tsconfig so I guess it's not used.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
