### PR TITLE
fix: skip the plugin if it has been called before with the same id and importer

### DIFF
--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -258,6 +258,30 @@ describe('plugin container', () => {
         const result = await environment.pluginContainer.resolveId('foo')
         expect(result).toStrictEqual({ id: 'success' })
       })
+
+      it('should skip the plugin if it has been called before with the same id and importer', async () => {
+        const p1: Plugin = {
+          name: 'p1',
+          async resolveId(id, importer) {
+            return (
+              (await this.resolve(id.replace(/\/modified$/, ''), importer, {
+                skipSelf: true,
+              })) ?? 'success'
+            )
+          },
+        }
+        const p2: Plugin = {
+          name: 'p2',
+          async resolveId(id, importer) {
+            return await this.resolve(id + '/modified', importer, {
+              skipSelf: true,
+            })
+          },
+        }
+        const environment = await getDevEnvironment({ plugins: [p1, p2] })
+        const result = await environment.pluginContainer.resolveId('foo')
+        expect(result).toStrictEqual({ id: 'success' })
+      })
     })
   })
 })

--- a/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
+++ b/packages/vite/src/node/server/__tests__/pluginContainer.spec.ts
@@ -259,7 +259,7 @@ describe('plugin container', () => {
         expect(result).toStrictEqual({ id: 'success' })
       })
 
-      it('should skip the plugin if it has been called before with the same id and importer', async () => {
+      it('should skip the plugin if it has been called before with the same id and importer (1)', async () => {
         const p1: Plugin = {
           name: 'p1',
           async resolveId(id, importer) {
@@ -279,6 +279,39 @@ describe('plugin container', () => {
           },
         }
         const environment = await getDevEnvironment({ plugins: [p1, p2] })
+        const result = await environment.pluginContainer.resolveId('foo')
+        expect(result).toStrictEqual({ id: 'success' })
+      })
+
+      it('should skip the plugin if it has been called before with the same id and importer (2)', async () => {
+        const p1: Plugin = {
+          name: 'p1',
+          async resolveId(id, importer) {
+            return (
+              (await this.resolve(id.replace(/\/modified$/, ''), importer, {
+                skipSelf: true,
+              })) ?? 'failure1'
+            )
+          },
+        }
+        const p2: Plugin = {
+          name: 'p2',
+          async resolveId(id, importer) {
+            return await this.resolve(id + '/modified', importer, {
+              skipSelf: true,
+            })
+          },
+        }
+        const p3: Plugin = {
+          name: 'p3',
+          resolveId(id) {
+            if (id.endsWith('/modified')) {
+              return 'success'
+            }
+            return 'failure2'
+          },
+        }
+        const environment = await getDevEnvironment({ plugins: [p1, p2, p3] })
         const result = await environment.pluginContainer.resolveId('foo')
         expect(result).toStrictEqual({ id: 'success' })
       })


### PR DESCRIPTION
### Description

#18903 changed the `skipSelf` behavior to align with rollup.
In Nuxt + Vitest scenario, a recursive call happened because of that change (it happens with rollup: https://github.com/rollup/rollup/issues/5768).

Nuxt has [`nuxt:resolve-bare-imports` plugin that calls `this.resolve(id, nuxtRoot)`](https://github.com/nuxt/nuxt/blob/f86d749077f438f5aafd7cbaab2e96d1e326d7ba/packages/nuxt/src/core/plugins/resolve-deep-imports.ts#L27-L30) and Vitest has [`vitest:resolve-core` plugin that calls `this.resolve(id, viteIndexHtml)`](https://github.com/vitest-dev/vitest/blob/78b62ffe1dc078d3e48573b3517f19bbeb898726/packages/vitest/src/node/plugins/vitestResolver.ts#L35-L37).
These plugins were calling each other after #18903.
This didn't happen before #18903 because the plugins were skipped even if the `importer` is different.

In this PR, `this.resolve(id, importer)` with the same id and importer will be skipped when it's called inside the same `id` and `importer` even if it's called inside a different `this.resolve`.
For example, `this.resolve('foo', 'bar')` -> `this.resolve('foo', 'bar')` was skipped before this PR. `this.resolve('foo', 'bar')` -> `this.resolve('foo', 'bar2')` -> `this.resolve('foo', 'bar')` was not skipped before this PR, but now this case is also skipped.

fixes this CI failure in nuxt: https://github.com/nuxt/nuxt/actions/runs/12418711683/job/34672477920?pr=30306
refs #18903

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
