### PR TITLE
fix: esbuild regression (pin to 0.24.0)

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -85,7 +85,7 @@
   },
   "//": "READ CONTRIBUTING.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
-    "esbuild": "^0.24.0",
+    "esbuild": "0.24.0",
     "postcss": "^8.4.49",
     "rollup": "^4.23.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,7 +224,7 @@ importers:
   packages/vite:
     dependencies:
       esbuild:
-        specifier: ^0.24.0
+        specifier: 0.24.0
         version: 0.24.0
       postcss:
         specifier: ^8.4.49


### PR DESCRIPTION
### Description

Pin to esbuild 0.24.0 until @sapphi-red's fix to esbuild is merged and released:
- https://github.com/evanw/esbuild/pull/4013

Reference:
- https://github.com/evanw/esbuild/issues/4010
- https://github.com/vitejs/vite/issues/19018