### PR TITLE
chore: use node v22 on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
   # don't need playwright for docs build
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"
 [build]


### PR DESCRIPTION
Since node version 22 is stable now, may be we may use node 22 on netlify.