### PR TITLE
test(ssr): test virtual module with query

### DIFF
--- a/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
+++ b/packages/vite/src/node/ssr/runtime/__tests__/server-runtime.spec.ts
@@ -28,6 +28,19 @@ describe('module runner initialization', async () => {
   it('can load virtual modules as an entry point', async ({ runner }) => {
     const mod = await runner.import('virtual:test')
     expect(mod.msg).toBe('virtual')
+
+    // virtual module query is not supported out of the box
+    // (`?t=...` was working on Vite 5 ssrLoadModule as `transformRequest` strips off timestamp query)
+    await expect(() =>
+      runner.import(`virtual:test?t=${Date.now()}`),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('cannot find entry point module'),
+    })
+    await expect(() =>
+      runner.import('virtual:test?abcd=1234'),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('cannot find entry point module'),
+    })
   })
 
   it('css is loaded correctly', async ({ runner }) => {


### PR DESCRIPTION
### Description

- related https://github.com/vitejs/vite/issues/18223#issuecomment-2558541504

There's a slight regression on how `?t=` works with virtual module, so I added test cases related to this. Current behavior seems more consistent, so probably we don't need to make it work like before unless users provide a concrete use cases.