### PR TITLE
ci: add additionalAllowedUsers to `ecosystem-ci-trigger` workflow

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -17,6 +17,8 @@ jobs:
             const user = context.payload.sender.login
             console.log(`Validate user: ${user}`)
 
+            const additionalAllowedUsers = ['lukastaegert']
+
             let hasTriagePermission = false
             try {
               const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
@@ -29,7 +31,7 @@ jobs:
               console.warn(e)
             }
 
-            if (hasTriagePermission) {
+            if (hasTriagePermission || additionalAllowedUsers.includes(user)) {
               console.log('User is allowed. Adding +1 reaction.')
               await github.rest.reactions.createForIssueComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
### Description

Added `additionalAllowedUsers` to allow additional users that doesn't have triage permission in this repo ([lukastaegert](https://github.com/lukastaegert)) to trigger ecosystem-ci.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
