### PR TITLE
fix(css): show correct error when unknown placeholder is used for CSS modules pattern in lightningcss

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3221,10 +3221,12 @@ async function compileLightningCSS(
         })
   } catch (e) {
     e.message = `[lightningcss] ${e.message}`
-    e.loc = {
-      file: e.fileName.replace(NULL_BYTE_PLACEHOLDER, '\0'),
-      line: e.loc.line,
-      column: e.loc.column - 1, // 1-based
+    if (e.loc) {
+      e.loc = {
+        file: e.fileName.replace(NULL_BYTE_PLACEHOLDER, '\0'),
+        line: e.loc.line,
+        column: e.loc.column - 1, // 1-based
+      }
     }
     throw e
   }


### PR DESCRIPTION
### Description

When `css.lightningcss.cssModules.pattern: '[local]__[hash:base64:5]'` is set, the following error happened:

> [vite] Internal server error: Cannot read properties of undefined (reading 'replace')
  Plugin: vite:css
  File: /path/to/root/foo.module.css

With this PR, the error becomes:

> [vite] Internal server error: [lightningcss] Error parsing CSS modules pattern: unknown placeholder "[hash:base64:5]" at index 9
  Plugin: vite:css
  File: /path/to/root/foo.module.css

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
