### PR TITLE
feat(types): make ImportMetaEnv strictly available

### DIFF
--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -86,7 +86,8 @@ To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augm
 ```typescript [vite-env.d.ts]
 /// <reference types="vite/client" />
 
-// By adding this line, you can make the type of ImportMetaEnv strict.
+// By adding this line, you can make the type of ImportMetaEnv strict
+// to disallow unknown keys.
 type ViteStrictImportMetaEnv = true
 
 interface ImportMetaEnv {

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -86,9 +86,11 @@ To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augm
 ```typescript [vite-env.d.ts]
 /// <reference types="vite/client" />
 
-// By adding this line, you can make the type of ImportMetaEnv strict
-// to disallow unknown keys.
-type ViteStrictImportMetaEnv = true
+interface ViteTypeOptions {
+  // By adding this line, you can make the type of ImportMetaEnv strict
+  // to disallow unknown keys.
+  // strictImportMetaEnv: unknown
+}
 
 interface ImportMetaEnv {
   readonly VITE_APP_TITLE: string

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -87,7 +87,7 @@ To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augm
 /// <reference types="vite/client" />
 
 // By adding this line, you can make the type of ImportMetaEnv strict.
-declare type ViteStrictImportMetaEnv = true
+type ViteStrictImportMetaEnv = true
 
 interface ImportMetaEnv {
   readonly VITE_APP_TITLE: string

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -86,6 +86,9 @@ To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augm
 ```typescript [vite-env.d.ts]
 /// <reference types="vite/client" />
 
+// By adding this line, you can make the type of ImportMetaEnv strict.
+declare type ViteStrictImportMetaEnv = true;
+
 interface ImportMetaEnv {
   readonly VITE_APP_TITLE: string
   // more env variables...

--- a/docs/guide/env-and-mode.md
+++ b/docs/guide/env-and-mode.md
@@ -87,7 +87,7 @@ To achieve this, you can create an `vite-env.d.ts` in `src` directory, then augm
 /// <reference types="vite/client" />
 
 // By adding this line, you can make the type of ImportMetaEnv strict.
-declare type ViteStrictImportMetaEnv = true;
+declare type ViteStrictImportMetaEnv = true
 
 interface ImportMetaEnv {
   readonly VITE_APP_TITLE: string

--- a/packages/vite/src/node/__tests_dts__/typeOptions.ts
+++ b/packages/vite/src/node/__tests_dts__/typeOptions.ts
@@ -1,0 +1,21 @@
+// This file tests `ViteTypeOptions` in `packages/vite/types/importMeta.d.ts`
+import type { ExpectFalse, ExpectTrue } from '@type-challenges/utils'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface TypeOptions1 {}
+interface TypeOptions2 {
+  strictImportMetaEnv: unknown
+}
+interface TypeOptions3 {
+  unknownKey: unknown
+}
+
+type IsEnabled<Opts, Key extends string> = Key extends keyof Opts ? true : false
+
+export type cases = [
+  ExpectFalse<IsEnabled<TypeOptions1, 'strictImportMetaEnv'>>,
+  ExpectTrue<IsEnabled<TypeOptions2, 'strictImportMetaEnv'>>,
+  ExpectFalse<IsEnabled<TypeOptions3, 'strictImportMetaEnv'>>,
+]
+
+export {}

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -2,12 +2,17 @@
 // Thus cannot contain any top-level imports
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore ViteStrictImportMetaEnv may or may not be declared by users
-type ImportMetaKey = ViteStrictImportMetaEnv extends true ? never : string
+// This is tested in `packages/vite/src/node/__tests_dts__/typeOptions.ts`
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- to allow extending by users
+interface ViteTypeOptions {
+  // strictImportMetaEnv: unknown
+}
+
+type ImportMetaEnvFallbackKey =
+  'strictImportMetaEnv' extends keyof ViteTypeOptions ? never : string
 
 interface ImportMetaEnv {
-  [key: ImportMetaKey]: any
+  [key: ImportMetaEnvFallbackKey]: any
   BASE_URL: string
   MODE: string
   DEV: boolean

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -2,7 +2,11 @@
 // Thus cannot contain any top-level imports
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
+// @ts-ignore
+type ImportMetaKey = ViteStrictImportMetaEnv extends true ? never : string
+
 interface ImportMetaEnv {
+  [key: ImportMetaKey]: any
   BASE_URL: string
   MODE: string
   DEV: boolean

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -3,7 +3,6 @@
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
 interface ImportMetaEnv {
-  [key: string]: any
   BASE_URL: string
   MODE: string
   DEV: boolean

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -2,7 +2,6 @@
 // Thus cannot contain any top-level imports
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
-// @ts-expect-error
 type ImportMetaKey = ViteStrictImportMetaEnv extends true ? never : string
 
 interface ImportMetaEnv {

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -2,7 +2,7 @@
 // Thus cannot contain any top-level imports
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
-// @ts-ignore
+// @ts-expect-error
 type ImportMetaKey = ViteStrictImportMetaEnv extends true ? never : string
 
 interface ImportMetaEnv {

--- a/packages/vite/types/importMeta.d.ts
+++ b/packages/vite/types/importMeta.d.ts
@@ -2,6 +2,8 @@
 // Thus cannot contain any top-level imports
 // <https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation>
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore ViteStrictImportMetaEnv may or may not be declared by users
 type ImportMetaKey = ViteStrictImportMetaEnv extends true ? never : string
 
 interface ImportMetaEnv {


### PR DESCRIPTION
### Description
Even if you want to make the type of `ImportMetaEnv` strict, you can't because `[key: string]: any` is specified. However, users should be able to choose whether to make the type strict or not.


```ts
/** vite-env.d.ts */

/// <reference types="vite/client" />

interface ImportMetaEnv {
  [key: string]: any // If you want to handle ImportMetaEnv ambiguously, add this by yourself.
  readonly MY_ENV: string;
{
```

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
