### PR TITLE
feat(plugin-legacy): allow excluding polyfills

### DIFF
--- a/packages/plugin-legacy/README.md
+++ b/packages/plugin-legacy/README.md
@@ -74,11 +74,23 @@ npm add -D terser
 
   Add custom imports to the legacy polyfills chunk. Since the usage-based polyfill detection only covers ES language features, it may be necessary to manually specify additional DOM API polyfills using this option.
 
+### `excludeLegacyPolyfills`
+
+- **Type:** `string[]`
+
+  Exclude imports from legacy polyfills. Can be used to exclude polyfills from being included although detected by `@babel/preset-env`.
+
 ### `additionalModernPolyfills`
 
 - **Type:** `string[]`
 
   Add custom imports to the modern polyfills chunk. Since the usage-based polyfill detection only covers ES language features, it may be necessary to manually specify additional DOM API polyfills using this option.
+
+### `excludeModernPolyfills`
+
+- **Type:** `string[]`
+
+  Exclude imports from modern polyfills. Can be used to exclude polyfills from being included although detected by `@babel/preset-env`.
 
 ### `modernPolyfills`
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -295,6 +295,12 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         for (const { modern } of chunkFileNameToPolyfills.values()) {
           modern.forEach((p) => modernPolyfills.add(p))
         }
+        // Remove explicitly excluded polyfills
+        if (Array.isArray(options.excludeModernPolyfills)) {
+          options.excludeModernPolyfills.forEach((p) =>
+            modernPolyfills.delete(p),
+          )
+        }
         if (!modernPolyfills.size) {
           return
         }
@@ -336,6 +342,11 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           targets,
           legacyPolyfills,
         )
+      }
+
+      // Remove explicitly excluded polyfills
+      if (Array.isArray(options.excludeLegacyPolyfills)) {
+        options.excludeLegacyPolyfills.forEach((p) => legacyPolyfills.delete(p))
       }
 
       if (legacyPolyfills.size || !options.externalSystemJS) {

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -12,7 +12,9 @@ export interface Options {
    */
   polyfills?: boolean | string[]
   additionalLegacyPolyfills?: string[]
+  excludeLegacyPolyfills?: string[]
   additionalModernPolyfills?: string[]
+  excludeModernPolyfills?: string[]
   /**
    * default: false
    */


### PR DESCRIPTION
fixes #19074 .

Two new options `excludeLegacyPolyfills` and `excludeModernPolyfills` have been added, allowing to exclude specific polyfills from being imported by `@vitejs/plugin-legacy`.