### PR TITLE
docs: fix canonical links

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -442,7 +442,7 @@ export default defineConfig({
   transformPageData(pageData) {
     const canonicalUrl = `${ogUrl}/${pageData.relativePath}`
       .replace(/\/index\.md$/, '/')
-      .replace(/\.md$/, '/')
+      .replace(/\.md$/, '')
     pageData.frontmatter.head ??= []
     pageData.frontmatter.head.unshift(
       ['link', { rel: 'canonical', href: canonicalUrl }],


### PR DESCRIPTION
### Description

Fixes https://github.com/vitejs/vite/pull/15984#issuecomment-1956300045

> * `dist/guide/index.html` should have the canonical url as `https://vitejs.dev/guide/`
> * `dist/guide/features.html` should have the canonical url as `https://vitejs.dev/guide/features`
> * `dist/index.html` should have the canonical url as `https://vitejs.dev` (special case where root `index.html` has no trailing slash)

This PR points `dist/index.html` to `https://vitejs.dev/`, but this should be fine as `https://vitejs.dev/` and `https://vitejs.dev` are the same page.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
