### PR TITLE
feat(reporter): add `wasm` to the compressible assets regex

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -24,7 +24,7 @@ type LogEntry = {
   mapSize: number | null
 }
 
-const COMPRESSIBLE_ASSETS_RE = /\.(?:html|json|svg|txt|xml|xhtml)$/
+const COMPRESSIBLE_ASSETS_RE = /\.(?:html|json|svg|txt|xml|xhtml|wasm)$/
 
 export function buildReporterPlugin(config: ResolvedConfig): Plugin {
   const compress = promisify(gzip)


### PR DESCRIPTION
Wasm files are often highly compressible. It would be nice to show their compressed size in Vite builds. This PR is a one-line change that should show their compressed size after the build is complete.

I found an earlier PR (https://github.com/vitejs/vite/pull/12485) that made this change for some other asset types, and it had a [comment](https://github.com/vitejs/vite/pull/12485#issuecomment-1763361804) that sounded open to the addition of wasm to the list:

> Feel free to add wasm to `COMPRESSIBLE_ASSETS_RE` [here](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/plugins/reporter.ts#L27).

### Description

Allows `.wasm` files to show their compressed size in the Vite build results

