### PR TITLE
fix: add --watchStdin option to exit when stdin ends

### DIFF
--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -169,6 +169,7 @@ cli
     '--force',
     `[boolean] force the optimizer to ignore the cache and re-bundle`,
   )
+  .option('--watchStdin', `[boolean] watch stdin and exit on EOF`)
   .action(async (root: string, options: ServerOptions & GlobalCLIOptions) => {
     filterDuplicateOptions(options)
     // output structure is preserved even after bundling so require()
@@ -364,6 +365,7 @@ cli
   .option('--strictPort', `[boolean] exit if specified port is already in use`)
   .option('--open [path]', `[boolean | string] open browser on startup`)
   .option('--outDir <dir>', `[string] output directory (default: dist)`)
+  .option('--watchStdin', `[boolean] watch stdin and exit on EOF`)
   .action(
     async (
       root: string,
@@ -373,6 +375,7 @@ cli
         open?: boolean | string
         strictPort?: boolean
         outDir?: string
+        watchStdin?: boolean
       } & GlobalCLIOptions,
     ) => {
       filterDuplicateOptions(options)
@@ -392,6 +395,7 @@ cli
             strictPort: options.strictPort,
             host: options.host,
             open: options.open,
+            watchStdin: options.watchStdin,
           },
         })
         server.printUrls()

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -169,7 +169,9 @@ cli
     '--force',
     `[boolean] force the optimizer to ignore the cache and re-bundle`,
   )
-  .option('--watchStdin', `[boolean] watch stdin and exit on EOF`)
+  .option('--watchStdin', `[boolean] watch stdin and exit on EOF`, {
+    default: !process.stdin.isTTY,
+  })
   .action(async (root: string, options: ServerOptions & GlobalCLIOptions) => {
     filterDuplicateOptions(options)
     // output structure is preserved even after bundling so require()
@@ -365,7 +367,9 @@ cli
   .option('--strictPort', `[boolean] exit if specified port is already in use`)
   .option('--open [path]', `[boolean | string] open browser on startup`)
   .option('--outDir <dir>', `[string] output directory (default: dist)`)
-  .option('--watchStdin', `[boolean] watch stdin and exit on EOF`)
+  .option('--watchStdin', `[boolean] watch stdin and exit on EOF`, {
+    default: !process.stdin.isTTY,
+  })
   .action(
     async (
       root: string,

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -67,6 +67,10 @@ export interface CommonServerOptions {
    * Specify server response headers.
    */
   headers?: HttpServerHeaders
+  /**
+   * Watch stdin and exit on EOF
+   */
+  watchStdin?: boolean
 }
 
 /**

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -60,6 +60,7 @@ export function resolvePreviewOptions(
     proxy: preview?.proxy ?? server.proxy,
     cors: preview?.cors ?? server.cors,
     headers: preview?.headers ?? server.headers,
+    watchStdin: preview?.watchStdin ?? server.watchStdin,
   }
 }
 
@@ -151,7 +152,7 @@ export async function preview(
   // Promise used by `server.close()` to ensure `closeServer()` is only called once
   let closeServerPromise: Promise<void> | undefined
   const closeServer = async () => {
-    teardownSIGTERMListener(closeServerAndExit)
+    teardownSIGTERMListener(config.preview.watchStdin, closeServerAndExit)
     await closeHttpServer()
     server.resolvedUrls = null
   }
@@ -188,7 +189,7 @@ export async function preview(
     }
   }
 
-  setupSIGTERMListener(closeServerAndExit)
+  setupSIGTERMListener(config.preview.watchStdin, closeServerAndExit)
 
   // apply server hooks from plugins
   const postHooks: ((() => void) | void)[] = []

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -527,7 +527,7 @@ export async function _createServer(
   let closeServerPromise: Promise<void> | undefined
   const closeServer = async () => {
     if (!middlewareMode) {
-      teardownSIGTERMListener(closeServerAndExit)
+      teardownSIGTERMListener(config.server.watchStdin, closeServerAndExit)
     }
 
     await Promise.allSettled([
@@ -766,7 +766,7 @@ export async function _createServer(
   }
 
   if (!middlewareMode) {
-    setupSIGTERMListener(closeServerAndExit)
+    setupSIGTERMListener(config.server.watchStdin, closeServerAndExit)
   }
 
   const onHMRUpdate = async (
@@ -1045,6 +1045,7 @@ export const serverConfigDefaults = Object.freeze({
   host: 'localhost',
   https: undefined,
   open: false,
+  watchStdin: false,
   proxy: undefined,
   cors: true,
   headers: {},

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1544,24 +1544,28 @@ const parentSigtermCallback: SigtermCallback = async (signal, exitCode) => {
 }
 
 export const setupSIGTERMListener = (
+  watchStdin: boolean,
   callback: (signal?: 'SIGTERM', exitCode?: number) => Promise<void>,
 ): void => {
   if (sigtermCallbacks.size === 0) {
     process.once('SIGTERM', parentSigtermCallback)
-    if (process.env.CI !== 'true') {
+    if (watchStdin) {
       process.stdin.on('end', parentSigtermCallback)
+      // resume stdin to allow the server to exit on EOF
+      process.stdin.resume()
     }
   }
   sigtermCallbacks.add(callback)
 }
 
 export const teardownSIGTERMListener = (
-  callback: Parameters<typeof setupSIGTERMListener>[0],
+  watchStdin: boolean,
+  callback: Parameters<typeof setupSIGTERMListener>[1],
 ): void => {
   sigtermCallbacks.delete(callback)
   if (sigtermCallbacks.size === 0) {
     process.off('SIGTERM', parentSigtermCallback)
-    if (process.env.CI !== 'true') {
+    if (watchStdin) {
       process.stdin.off('end', parentSigtermCallback)
     }
   }


### PR DESCRIPTION
### Description

Fixes #19091

Adds an optional `--watchStdin` flag and config. Defaults to `!process.stdin.tty` (true when stdin is a pipe) when running via the CLI. Defaults to false when starting programmatically.

If a new flag isn't desirable, it could be removed if the `watchStdin` prop is set to `!process.stdin.tty` when running from the CLI. This would still solve the linked issue, and remove the ability to override it with CLI args.