### PR TITLE
fix(plugin-legacy): avoid emitting the asset when renderLegacyChunks …

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -532,11 +532,13 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
       // entirely.
       opts.__vite_force_terser__ = true
 
-      // @ts-expect-error In the `generateBundle` hook,
-      // we'll delete the assets from the legacy bundle to avoid emitting duplicate assets.
-      // But that's still a waste of computing resource.
-      // So we add this flag to avoid emitting the asset in the first place whenever possible.
-      opts.__vite_skip_asset_emit__ = true
+      if (genModern) {
+        // @ts-expect-error In the `generateBundle` hook,
+        // we'll delete the assets from the legacy bundle to avoid emitting duplicate assets.
+        // But that's still a waste of computing resource.
+        // So we add this flag to avoid emitting the asset in the first place whenever possible.
+        opts.__vite_skip_asset_emit__ = true
+      }
 
       // avoid emitting assets for legacy bundle
       const needPolyfills =


### PR DESCRIPTION
…and renderModernChunk are both true (#18558)

closes #18558 

When creating a pure legacy build only, the configuration is legacy_plugin instead of assets/[name]-legacy-[hash].js, so the workmap is empty and no files are generated

![CleanShot 2024-12-29 at 13 30 43@2x](https://github.com/user-attachments/assets/d2d6ef0e-b89c-405e-a160-37837260f5f1)

