### PR TITLE
perf: skip globbing for static path in warmup

### DIFF
--- a/packages/vite/src/node/server/warmup.ts
+++ b/packages/vite/src/node/server/warmup.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import colors from 'picocolors'
-import { glob } from 'tinyglobby'
+import { glob, isDynamicPattern } from 'tinyglobby'
 import { FS_PREFIX } from '../constants'
 import { normalizePath } from '../utils'
 import type { ViteDevServer } from '../index'
@@ -72,10 +72,29 @@ function fileToUrl(file: string, root: string) {
 
 async function mapFiles(files: string[], root: string) {
   if (!files.length) return []
-  return await glob(files, {
-    absolute: true,
-    cwd: root,
-    expandDirectories: false,
-    ignore: ['**/.git/**', '**/node_modules/**'],
-  })
+
+  const result: string[] = []
+  const globs: string[] = []
+  for (const file of files) {
+    if (isDynamicPattern(file)) {
+      globs.push(file)
+    } else {
+      if (path.isAbsolute(file)) {
+        result.push(file)
+      } else {
+        result.push(path.resolve(root, file))
+      }
+    }
+  }
+  if (globs.length) {
+    result.push(
+      ...(await glob(globs, {
+        absolute: true,
+        cwd: root,
+        expandDirectories: false,
+        ignore: ['**/.git/**', '**/node_modules/**'],
+      })),
+    )
+  }
+  return result
 }


### PR DESCRIPTION
Context: https://github.com/nuxt/nuxt/pull/30407#issuecomment-2566210613

Fix https://github.com/nuxt/nuxt/pull/30407

In Nuxt, the entry we passed to warm up is an absolute path inside `node_modules`.

I injected into `tinyglobby` and this is what passed to `tinyglobby`:

```ts
{ 
  absolute: true,                                                                                                  
  cwd: '/Users/antfu/i/nuxt-i18n/playground/app',
  expandDirectories: false,
  ignore: [ '**/.git/**', '**/node_modules/**' ],
  patterns: [ '/Users/antfu/i/nuxt-i18n/node_modules/.pnpm/nuxt@3.15.0_@parcel+watcher@2.4.1_@types+node@20.14.9_db0@0.2.1_encoding@0.1.13_eslint@9.5.0__365piwb2r26wv7nx7oqnj3cmpa/node_modules/nuxt/dist/app/entry.js' ]
}
```

This caused `tinyglobby` to glob every file inside `node_modules`. Consider this could be a bug of `tinyglobby`, it's also something can be optimized on the Vite side by excluding non-glob inputs.