### PR TITLE
fix: build time display 7m 60s

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1501,11 +1501,17 @@ export function displayTime(time: number): string {
     return `${time.toFixed(2)}s`
   }
 
-  const mins = parseInt((time / 60).toString())
-  const seconds = time % 60
+  // Calculate total minutes and remaining seconds
+  const mins = Math.floor(time / 60)
+  const seconds = Math.round(time % 60)
+
+  // Handle case where seconds rounds to 60
+  if (seconds === 60) {
+    return `${mins + 1}m`
+  }
 
   // display: {X}m {Y}s
-  return `${mins}m${seconds < 1 ? '' : ` ${seconds.toFixed(0)}s`}`
+  return `${mins}m${seconds < 1 ? '' : ` ${seconds}s`}`
 }
 
 /**


### PR DESCRIPTION
### Description

This PR solves the problem of abnormal packaging time display. For example, '7m 60s' should be displayed as' 8m'.

happy new year
![screenshot_2024-12-31_18-22-45](https://github.com/user-attachments/assets/3ea0dc8d-8155-4bda-a478-4bb47bd1e984)

