### PR TITLE
fix(optimizer): use correct default install state path for yarn PnP

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1182,8 +1182,14 @@ const lockfileFormats = [
     manager: 'yarn',
   },
   {
-    // Yarn PnP
-    path: '.yarn/install-state.gz',
+    // Yarn v3+ PnP
+    path: '.pnp.cjs',
+    checkPatches: false,
+    manager: 'yarn',
+  },
+  {
+    // Yarn v2 PnP
+    path: '.pnp.js',
     checkPatches: false,
     manager: 'yarn',
   },

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1183,7 +1183,7 @@ const lockfileFormats = [
   },
   {
     // Yarn PnP
-    path: '.yarn/install-state',
+    path: '.yarn/install-state.gz',
     checkPatches: false,
     manager: 'yarn',
   },

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1259,7 +1259,7 @@ function getLockfileHash(environment: Environment): string {
     if (lockfileFormat.checkPatchesDir) {
       // Default of https://github.com/ds300/patch-package
       const baseDir = lockfilePath.slice(0, -lockfileFormat.path.length)
-      const fullPath = path.join(baseDir, lockfileFormat.checkPatchesDir)
+      const fullPath = path.join(baseDir, lockfileFormat.checkPatchesDir as string)
       const stat = tryStatSync(fullPath)
       if (stat?.isDirectory()) {
         content += stat.mtimeMs.toString()

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1205,7 +1205,12 @@ const lockfileFormats = [
     checkPatchesDir: false,
     manager: 'pnpm',
   },
-  { name: 'bun.lockb', path: 'bun.lockb', checkPatchesDir: 'patches', manager: 'bun' },
+  {
+    name: 'bun.lockb',
+    path: 'bun.lockb',
+    checkPatchesDir: 'patches',
+    manager: 'bun',
+  },
 ].sort((_, { manager }) => {
   return process.env.npm_config_user_agent?.startsWith(manager) ? 1 : -1
 })

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1172,40 +1172,40 @@ function isSingleDefaultExport(exports: readonly string[]) {
 const lockfileFormats = [
   {
     path: 'node_modules/.package-lock.json',
-    checkPatches: true,
+    checkPatchesDir: 'patches',
     manager: 'npm',
   },
   {
     // Yarn non-PnP
     path: 'node_modules/.yarn-state.yml',
-    checkPatches: false,
+    checkPatchesDir: false,
     manager: 'yarn',
   },
   {
     // Yarn v3+ PnP
     path: '.pnp.cjs',
-    checkPatches: true,
+    checkPatchesDir: '.yarn/patches',
     manager: 'yarn',
   },
   {
     // Yarn v2 PnP
     path: '.pnp.js',
-    checkPatches: true,
+    checkPatchesDir: '.yarn/patches',
     manager: 'yarn',
   },
   {
     // yarn 1
     path: 'node_modules/.yarn-integrity',
-    checkPatches: true,
+    checkPatchesDir: 'patches',
     manager: 'yarn',
   },
   {
     path: 'node_modules/.pnpm/lock.yaml',
     // Included in lockfile
-    checkPatches: false,
+    checkPatchesDir: false,
     manager: 'pnpm',
   },
-  { name: 'bun.lockb', path: 'bun.lockb', checkPatches: true, manager: 'bun' },
+  { name: 'bun.lockb', path: 'bun.lockb', checkPatchesDir: 'patches', manager: 'bun' },
 ].sort((_, { manager }) => {
   return process.env.npm_config_user_agent?.startsWith(manager) ? 1 : -1
 })
@@ -1256,10 +1256,10 @@ function getLockfileHash(environment: Environment): string {
     const lockfileFormat = lockfileFormats.find((f) =>
       normalizedLockfilePath.endsWith(f.path),
     )!
-    if (lockfileFormat.checkPatches) {
+    if (lockfileFormat.checkPatchesDir) {
       // Default of https://github.com/ds300/patch-package
       const baseDir = lockfilePath.slice(0, -lockfileFormat.path.length)
-      const fullPath = path.join(baseDir, 'patches')
+      const fullPath = path.join(baseDir, lockfileFormat.checkPatchesDir)
       const stat = tryStatSync(fullPath)
       if (stat?.isDirectory()) {
         content += stat.mtimeMs.toString()

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1184,13 +1184,13 @@ const lockfileFormats = [
   {
     // Yarn v3+ PnP
     path: '.pnp.cjs',
-    checkPatches: false,
+    checkPatches: true,
     manager: 'yarn',
   },
   {
     // Yarn v2 PnP
     path: '.pnp.js',
-    checkPatches: false,
+    checkPatches: true,
     manager: 'yarn',
   },
   {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import path from 'node:path'
-import { execSync } from 'node:child_process'
 import { promisify } from 'node:util'
 import { performance } from 'node:perf_hooks'
 import colors from 'picocolors'
@@ -1170,15 +1169,6 @@ function isSingleDefaultExport(exports: readonly string[]) {
   return exports.length === 1 && exports[0] === 'default'
 }
 
-let yarnInstallStatePath
-try {
-  yarnInstallStatePath = execSync('yarn config get installStatePath')
-    .toString()
-    .trim()
-} catch {
-  yarnInstallStatePath = '.yarn/install-state.gz'
-}
-
 const lockfileFormats = [
   {
     path: 'node_modules/.package-lock.json',
@@ -1186,8 +1176,20 @@ const lockfileFormats = [
     manager: 'npm',
   },
   {
-    // yarn 2+
-    path: yarnInstallStatePath,
+    // Yarn non-PnP
+    path: 'node_modules/.yarn-state.yml',
+    checkPatches: false,
+    manager: 'yarn',
+  },
+  {
+    // Yarn v3+ PnP
+    path: '.pnp.cjs',
+    checkPatches: false,
+    manager: 'yarn',
+  },
+  {
+    // Yarn v2 PnP
+    path: '.pnp.js',
     checkPatches: false,
     manager: 'yarn',
   },

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import path from 'node:path'
+import { execSync } from 'node:child_process'
 import { promisify } from 'node:util'
 import { performance } from 'node:perf_hooks'
 import colors from 'picocolors'

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1170,9 +1170,11 @@ function isSingleDefaultExport(exports: readonly string[]) {
   return exports.length === 1 && exports[0] === 'default'
 }
 
-let yarnInstallStatePath;
+let yarnInstallStatePath
 try {
-  yarnInstallStatePath = execSync('yarn config get installStatePath').toString().trim()
+  yarnInstallStatePath = execSync('yarn config get installStatePath')
+    .toString()
+    .trim()
 } catch {
   yarnInstallStatePath = '.yarn/install-state.gz'
 }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1259,7 +1259,10 @@ function getLockfileHash(environment: Environment): string {
     if (lockfileFormat.checkPatchesDir) {
       // Default of https://github.com/ds300/patch-package
       const baseDir = lockfilePath.slice(0, -lockfileFormat.path.length)
-      const fullPath = path.join(baseDir, lockfileFormat.checkPatchesDir as string)
+      const fullPath = path.join(
+        baseDir,
+        lockfileFormat.checkPatchesDir as string
+      )
       const stat = tryStatSync(fullPath)
       if (stat?.isDirectory()) {
         content += stat.mtimeMs.toString()

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1169,6 +1169,13 @@ function isSingleDefaultExport(exports: readonly string[]) {
   return exports.length === 1 && exports[0] === 'default'
 }
 
+let yarnInstallStatePath;
+try {
+  yarnInstallStatePath = execSync('yarn config get installStatePath').toString().trim()
+} catch {
+  yarnInstallStatePath = '.yarn/install-state.gz'
+}
+
 const lockfileFormats = [
   {
     path: 'node_modules/.package-lock.json',
@@ -1176,20 +1183,8 @@ const lockfileFormats = [
     manager: 'npm',
   },
   {
-    // Yarn non-PnP
-    path: 'node_modules/.yarn-state.yml',
-    checkPatches: false,
-    manager: 'yarn',
-  },
-  {
-    // Yarn v3+ PnP
-    path: '.pnp.cjs',
-    checkPatches: false,
-    manager: 'yarn',
-  },
-  {
-    // Yarn v2 PnP
-    path: '.pnp.js',
+    // yarn 2+
+    path: yarnInstallStatePath,
     checkPatches: false,
     manager: 'yarn',
   },

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1261,7 +1261,7 @@ function getLockfileHash(environment: Environment): string {
       const baseDir = lockfilePath.slice(0, -lockfileFormat.path.length)
       const fullPath = path.join(
         baseDir,
-        lockfileFormat.checkPatchesDir as string
+        lockfileFormat.checkPatchesDir as string,
       )
       const stat = tryStatSync(fullPath)
       if (stat?.isDirectory()) {


### PR DESCRIPTION
Fix https://github.com/vitejs/vite/issues/19118 for the yarn's default config. Main reason is if it can't find the file, it will use empty string to generate the hash, causing the result to be the same every time.

For yarn's custom config https://yarnpkg.com/configuration/yarnrc#installStatePath we probably need a different PR.

Also are we still going to support yarn 2.4 for optimize deps? Do we have a compatibility chart for vite version vs different package manger's version?
https://github.com/yarnpkg/berry/blob/93a56643ba3c813a87920dcf75c644eaf3b38e6f/CHANGELOG.md?plain=1#L392
