### PR TITLE
fix(html): fix css disorder when building multiple entry html

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -717,7 +717,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
     },
 
     async generateBundle(options, bundle) {
-      const analyzedChunk = new Map<OutputChunk, Set<string>>()
+      const analyzedImportedCssFiles = new Map<OutputChunk, string[]>()
       const inlineEntryChunk = new Set<string>()
       const getImportedChunks = (
         chunk: OutputChunk,
@@ -777,67 +777,61 @@ export function buildHtmlPlugin(config: ResolvedConfig): Plugin {
         },
       })
 
+      const toStyleSheetLinkTag = (
+        file: string,
+        toOutputPath: (filename: string) => string,
+      ): HtmlTagDescriptor => ({
+        tag: 'link',
+        attrs: {
+          rel: 'stylesheet',
+          crossorigin: true,
+          href: toOutputPath(file),
+        },
+      })
+
+      const getCssFilesForChunk = (
+        chunk: OutputChunk,
+        seenChunks: Set<string> = new Set(),
+        seenCss: Set<string> = new Set(),
+      ): string[] => {
+        if (seenChunks.has(chunk.fileName)) {
+          return []
+        }
+        seenChunks.add(chunk.fileName)
+
+        if (analyzedImportedCssFiles.has(chunk)) {
+          const files = analyzedImportedCssFiles.get(chunk)!
+          const additionals = files.filter((file) => !seenCss.has(file))
+          additionals.forEach((file) => seenCss.add(file))
+          return additionals
+        }
+
+        const files: string[] = []
+        chunk.imports.forEach((file) => {
+          const importee = bundle[file]
+          if (importee?.type === 'chunk') {
+            files.push(...getCssFilesForChunk(importee, seenChunks, seenCss))
+          }
+        })
+        analyzedImportedCssFiles.set(chunk, files)
+
+        chunk.viteMetadata!.importedCss.forEach((file) => {
+          if (!seenCss.has(file)) {
+            seenCss.add(file)
+            files.push(file)
+          }
+        })
+
+        return files
+      }
+
       const getCssTagsForChunk = (
         chunk: OutputChunk,
         toOutputPath: (filename: string) => string,
-        seen: Set<string> = new Set(),
-        parentImports?: Set<string>,
-        circle: Set<OutputChunk> = new Set(),
-      ): HtmlTagDescriptor[] => {
-        const tags: HtmlTagDescriptor[] = []
-        if (circle.has(chunk)) {
-          return tags
-        }
-        circle.add(chunk)
-        let analyzedChunkImportCss: Set<string>
-        const processImportedCss = (files: Set<string>): void => {
-          files.forEach((file) => {
-            if (parentImports) {
-              parentImports.add(file)
-            }
-            if (!seen.has(file)) {
-              seen.add(file)
-              tags.push({
-                tag: 'link',
-                attrs: {
-                  rel: 'stylesheet',
-                  crossorigin: true,
-                  href: toOutputPath(file),
-                },
-              })
-            }
-          })
-        }
-        if (!analyzedChunk.has(chunk)) {
-          analyzedChunkImportCss = new Set()
-          chunk.imports.forEach((file) => {
-            const importee = bundle[file]
-            if (importee?.type === 'chunk') {
-              tags.push(
-                ...getCssTagsForChunk(
-                  importee,
-                  toOutputPath,
-                  seen,
-                  analyzedChunkImportCss,
-                  circle,
-                ),
-              )
-            }
-          })
-          analyzedChunk.set(chunk, analyzedChunkImportCss)
-          if (parentImports) {
-            analyzedChunkImportCss.forEach((file) => {
-              parentImports.add(file)
-            })
-          }
-        } else {
-          analyzedChunkImportCss = analyzedChunk.get(chunk)!
-          processImportedCss(analyzedChunkImportCss)
-        }
-
-        processImportedCss(chunk.viteMetadata!.importedCss)
-        return tags
-      }
+      ) =>
+        getCssFilesForChunk(chunk).map((file) =>
+          toStyleSheetLinkTag(file, toOutputPath),
+        )
 
       for (const [normalizedId, html] of processedHtml(this)) {
         const relativeUrlPath = normalizePath(


### PR DESCRIPTION
### Description

When Vite collects css tags, it will cache the analyzed css chunk. But when collecting css tags for the second time, since the css chunk has been cached, Vite will no longer analyze the deep import, which will ignore the results of the previous import, causing the css to be out of order.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
