### PR TITLE
fix(legacy): import babel once

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -38,12 +38,9 @@ import {
 } from './snippets'
 
 // lazy load babel since it's not used during dev
-let babel: typeof import('@babel/core') | undefined
+let babel: Promise<typeof import('@babel/core')> | undefined
 async function loadBabel() {
-  if (!babel) {
-    babel = await import('@babel/core')
-  }
-  return babel
+  return (babel ??= import('@babel/core'))
 }
 
 // The requested module 'browserslist' is a CommonJS module


### PR DESCRIPTION
### Description

`import('@babel/core')` call is not deduped properly due to `await` and `renderChunk` is called in parallel for all chunks. Then weirdly, such duplicated `import` calls seem to be causing some issues with unbuild stub's interop and I was seeing a following error on main:

```js
$ pnpm -C packages/plugin-legacy/ dev

$ pnpm -C playground/legacy build
...
x Build failed in 467ms
error during build:
[vite:legacy-post-process] babel.transform is not a function
    at Object.renderChunk (/home/hiroshi/code/others/vite/packages/plugin-legacy/src/index.ts:552:28)
    at transformChunk (file:///home/hiroshi/code/others/vite/node_modules/.pnpm/rollup@4.28.1/node_modules/rollup/dist/es/shared/node-entry.js:18853:16)
    at file:///home/hiroshi/code/others/vite/node_modules/.pnpm/rollup@4.28.1/node_modules/rollup/dist/es/shared/node-entry.js:18927:17
    at async Promise.all (index 8)
    at transformChunksAndGenerateContentHashes (file:///home/hiroshi/code/others/vite/node_modules/.pnpm/rollup@4.28.1/node_modules/rollup/dist/es/shared/node-entry.js:18922:5)
...
```

~I'll try a reproduction on unbuild/jiti later.~ I couldn't get to the bottom of the issue, but I guess it's okay to have this change regardless. It would be nice if others can reproduce the same issue locally on main.