### PR TITLE
fix: resolve.conditions in ResolvedConfig was `defaultServerConditions`

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -481,3 +481,35 @@ test('config compat 2', async () => {
     ]
   `)
 })
+
+test('config compat 3', async () => {
+  const config = await resolveConfig({}, 'serve')
+  expect(config.resolve.conditions).toMatchInlineSnapshot(`
+    [
+      "module",
+      "browser",
+      "development|production",
+    ]
+  `)
+  expect(config.environments.client.resolve.conditions).toMatchInlineSnapshot(`
+    [
+      "module",
+      "browser",
+      "development|production",
+    ]
+  `)
+  expect(config.ssr.resolve?.conditions).toMatchInlineSnapshot(`
+    [
+      "module",
+      "node",
+      "development|production",
+    ]
+  `)
+  expect(config.environments.ssr.resolve?.conditions).toMatchInlineSnapshot(`
+    [
+      "module",
+      "node",
+      "development|production",
+    ]
+  `)
+})

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -867,6 +867,7 @@ function resolveEnvironmentResolveOptions(
   alias: Alias[],
   preserveSymlinks: boolean,
   logger: Logger,
+  /** undefined when resolving the top-level resolve options */
   consumer: 'client' | 'server' | undefined,
   // Backward compatibility
   isSsrTargetWebworkerEnvironment?: boolean,
@@ -875,11 +876,15 @@ function resolveEnvironmentResolveOptions(
     {
       ...configDefaults.resolve,
       mainFields:
-        consumer === 'client' || isSsrTargetWebworkerEnvironment
+        consumer === undefined ||
+        consumer === 'client' ||
+        isSsrTargetWebworkerEnvironment
           ? DEFAULT_CLIENT_MAIN_FIELDS
           : DEFAULT_SERVER_MAIN_FIELDS,
       conditions:
-        consumer === 'client' || isSsrTargetWebworkerEnvironment
+        consumer === undefined ||
+        consumer === 'client' ||
+        isSsrTargetWebworkerEnvironment
           ? DEFAULT_CLIENT_CONDITIONS
           : DEFAULT_SERVER_CONDITIONS.filter((c) => c !== 'browser'),
       enableBuiltinNoExternalCheck: !!isSsrTargetWebworkerEnvironment,


### PR DESCRIPTION
### Description

Since we treat `resolve.conditions` to be the same with `environments.client.resolve.conditions`, it should have the same value in ResolveConfig.

fixes #19087

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
