### PR TITLE
fix(css): workaround tsx esModule interop of sass-embedded import

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2480,8 +2480,10 @@ const makeModernCompilerScssWorker = (
     async run(sassPath, data, options) {
       // need pathToFileURL for windows since import("D:...") fails
       // https://github.com/nodejs/node/issues/31710
-      const sass: typeof Sass = (await import(pathToFileURL(sassPath).href))
-        .default
+      const sass_ = await import(pathToFileURL(sassPath).href)
+      // fallback for `default` to workaround tsx's __esModule interop
+      // https://github.com/privatenumber/tsx/issues/627
+      const sass: typeof Sass = sass_.default ?? sass_
       compilerPromise ??= sass.initAsyncCompiler()
       const compiler = await compilerPromise
 


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19052
- Supersedes https://github.com/vitejs/vite/pull/19053
- Related https://github.com/privatenumber/tsx/issues/627

As seen in  https://github.com/privatenumber/tsx/issues/627, tsx unwraps named exports for `__esModule` and thus strips off `default` export. The issue seems to be acknowledged as node inconsistency bug, but I'm not sure about the plan. Vite side fallback is simple, so probably it's worth having it.

From my quick read through, tsx transforms `import(xxx)` to unwrap `default` for `__esModule` automatically ([transform-dynamic-import.ts](https://github.com/privatenumber/tsx/blob/28a3e7d2b8fd72b683aab8a98dd1fcee4624e4cb/src/utils/transform/transform-dynamic-import.ts )). This seems to happen for all esm code loaded via tsx ([load.ts](https://github.com/privatenumber/tsx/blob/28a3e7d2b8fd72b683aab8a98dd1fcee4624e4cb/src/esm/hook/load.ts#L139-L144)).

I tested four combinations locally based on https://github.com/hi-ogawa/reproductions/tree/main/vite-19182-sass-tsx
- node + sass-embedded
- node + sass
- tsx + sass-embedded (this was failing before)
- tsx + sass