### PR TITLE
fix: avoid SSR HMR for HTML files

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -579,7 +579,7 @@ export async function handleHMRUpdate(
       }
       if (!options.modules.length) {
         // html file cannot be hot updated
-        if (file.endsWith('.html')) {
+        if (file.endsWith('.html') && environment.name === 'client') {
           environment.logger.info(
             colors.green(`page reload `) + colors.dim(shortFile),
             {


### PR DESCRIPTION
fixes #19185

### Description

Align with v5 behavior, we don't need the log and a full-reload for the SSR environment.

I think we still need to find a way to avoid the SSR environment lingering around for SPA, but it is hard to avoid it while maintainer backward compatibility. We may need to wait for the next major for further cleanups.