### PR TITLE
docs(ssr): remove link to Discord channel

### DIFF
--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -13,7 +13,8 @@ Currently, Vite is working on an improved SSR API with the [Environment API](htt
 :::
 
 :::tip Help
-If you have questions, the community is usually helpful at [Vite Discord's #ssr channel](https://discord.gg/PkbxgzPhJv).
+If you have questions, the community is usually helpful at [Vite Discord's #collaborate channel](https://discord.com/channels/804011606160703521/1201533611468398612).
+
 :::
 
 ## Example Projects

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -13,7 +13,7 @@ Currently, Vite is working on an improved SSR API with the [Environment API](htt
 :::
 
 :::tip Help
-If you have questions, the community is usually helpful at [Vite Discord's #collaborate channel](https://discord.com/channels/804011606160703521/1201533611468398612).
+If you have questions, the community is usually helpful at [Vite Discord's #collaborate channel](https://discord.gg/zZfRUcb5).
 
 :::
 

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -14,7 +14,6 @@ Currently, Vite is working on an improved SSR API with the [Environment API](htt
 
 :::tip Help
 If you have questions, the community is usually helpful at [Vite Discord's #collaborate channel](https://discord.gg/zZfRUcb5).
-
 :::
 
 ## Example Projects

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -12,10 +12,6 @@ This is a low-level API meant for library and framework authors. If your goal is
 Currently, Vite is working on an improved SSR API with the [Environment API](https://github.com/vitejs/vite/discussions/16358). Check out the link for more details.
 :::
 
-:::tip Help
-If you have questions, the community is usually helpful at [Vite Discord's #collaborate channel](https://discord.gg/zZfRUcb5).
-:::
-
 ## Example Projects
 
 Vite provides built-in support for server-side rendering (SSR). [`create-vite-extra`](https://github.com/bluwy/create-vite-extra) contains example SSR setups you can use as references for this guide:


### PR DESCRIPTION
### Description

Remove link from an old archived SSR channel, the channel has been combined into a general collaboration channel. The link was added when there was a particular need to raise SSR related questions. This is no-longer the case.

As per [patak's comment](https://discord.com/channels/804011606160703521/804061937029218334/1201538888439713842) the channels have been combined into a central collaborate channel.

> Hey! We're simplifying a bit the channels structure. Let's use the ⁠collaborate channel from now on. With threads we can all hangout together there and mix and match the topics we used to discuss here 👋 
The history of this channel will still be searchable.
