### PR TITLE
fix: use shared sigterm callback

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1535,20 +1535,34 @@ export function partialEncodeURIPath(uri: string): string {
   return filePath.replaceAll('%', '%25') + postfix
 }
 
+type SigtermCallback = (signal?: 'SIGTERM', exitCode?: number) => Promise<void>
+
+// Use a shared callback when attaching sigterm listeners to avoid `MaxListenersExceededWarning`
+const sigtermCallbacks = new Set<SigtermCallback>()
+const parentSigtermCallback: SigtermCallback = async (signal, exitCode) => {
+  await Promise.all([...sigtermCallbacks].map((cb) => cb(signal, exitCode)))
+}
+
 export const setupSIGTERMListener = (
   callback: (signal?: 'SIGTERM', exitCode?: number) => Promise<void>,
 ): void => {
-  process.once('SIGTERM', callback)
-  if (process.env.CI !== 'true') {
-    process.stdin.on('end', callback)
+  if (sigtermCallbacks.size === 0) {
+    process.once('SIGTERM', parentSigtermCallback)
+    if (process.env.CI !== 'true') {
+      process.stdin.on('end', parentSigtermCallback)
+    }
   }
+  sigtermCallbacks.add(callback)
 }
 
 export const teardownSIGTERMListener = (
   callback: Parameters<typeof setupSIGTERMListener>[0],
 ): void => {
-  process.off('SIGTERM', callback)
-  if (process.env.CI !== 'true') {
-    process.stdin.off('end', callback)
+  sigtermCallbacks.delete(callback)
+  if (sigtermCallbacks.size === 0) {
+    process.off('SIGTERM', parentSigtermCallback)
+    if (process.env.CI !== 'true') {
+      process.stdin.off('end', parentSigtermCallback)
+    }
   }
 }


### PR DESCRIPTION
### Description

@sheremet-va mentioned on discord before that attaching multiple sigterm callbacks, e.g. in vitest where many vite servers are created, can cause node to log

> MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 end listeners added to [ReadStream]. Use emitter.setMaxListeners() to increase limit

This PR refactors to use a shared callback instead. While this seems a bit of a workaround for the warning, it does allow end-users to focus an actual dangling listeners that they attach themselves.