### PR TITLE
fix: environments might be an empty object

### DIFF
--- a/packages/vite/src/node/baseEnvironment.ts
+++ b/packages/vite/src/node/baseEnvironment.ts
@@ -52,7 +52,7 @@ export class PartialEnvironment {
   constructor(
     name: string,
     topLevelConfig: ResolvedConfig,
-    options: ResolvedEnvironmentOptions = topLevelConfig.environments[name],
+    options: ResolvedEnvironmentOptions = topLevelConfig.environments?.[name] ?? {},
   ) {
     // only allow some characters so that we can use name without escaping for directory names
     // and make users easier to access with `environments.*`


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Hey! Small fix needed after Vite v6: `topLevelConfig.environments` might be an empty object, as there are no default environment anymore.

This will probably be needed as long as some environments are hardcoded:

https://github.com/vitejs/vite/blob/3400a5e258a597499c0f0808c8fca4d92eeabc17/packages/vite/src/node/plugins/css.ts#L1586-L1589

I can try to provide some test cases, but I'm not sure how to do so. Please bear with me!

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
