### PR TITLE
feat: print `port` in the logged error message after failed WS connection with `EADDRINUSE`

### DIFF
--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -191,10 +191,12 @@ export function createWebSocketServer(
         wss.emit('connection', ws, req)
       })
     })
-    wsHttpServer.on('error', (e: Error & { code: string }) => {
+    wsHttpServer.on('error', (e: Error & { code: string; port: number }) => {
       if (e.code === 'EADDRINUSE') {
         config.logger.error(
-          colors.red(`WebSocket server error: Port is already in use`),
+          colors.red(
+            `WebSocket server error: Port ${e.port} is already in use`,
+          ),
           { error: e },
         )
       } else {
@@ -237,10 +239,10 @@ export function createWebSocketServer(
     }
   })
 
-  wss.on('error', (e: Error & { code: string }) => {
+  wss.on('error', (e: Error & { code: string; port: number }) => {
     if (e.code === 'EADDRINUSE') {
       config.logger.error(
-        colors.red(`WebSocket server error: Port is already in use`),
+        colors.red(`WebSocket server error: Port ${e.port} is already in use`),
         { error: e },
       )
     } else {


### PR DESCRIPTION
### Description

This is just a small QoL improvement, following the same error message as the one reported here:
https://github.com/vitejs/vite/blob/4f5845a3182fc950eb9cd76d7161698383113b18/packages/vite/src/node/http.ts#L160