### PR TITLE
fix: use loc.file from rollup errors if available

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -635,7 +635,12 @@ async function buildEnvironment(
     const stackOnly = extractStack(e)
 
     let msg = colors.red((e.plugin ? `[${e.plugin}] ` : '') + e.message)
-    if (e.id) {
+    if (e.loc && e.loc.file && e.loc.file !== e.id) {
+      msg += `\nfile: ${colors.cyan(
+        `${e.loc.file}:${e.loc.line}:${e.loc.column}` +
+          (e.id ? ` (${e.id})` : ''),
+      )}`
+    } else if (e.id) {
       msg += `\nfile: ${colors.cyan(
         e.id + (e.loc ? `:${e.loc.line}:${e.loc.column}` : ''),
       )}`


### PR DESCRIPTION
### Description

Currently, Rollup errors output a filename that is actually the module name rather than the file where the error occurred. In the case of less, which supports imports, this can mean that the incorrect filename is output. Also note that the line and column numbers output are, in this case, not from the outputted file (confusing!).

This PR adds detection of `loc.file` and uses that in preference to the module id (although I've also included it for completeness).

### Example

Here is an example of the error message prior to this PR. The file identified is the module / entrypoint rather than the actual file:

```
[vite:css] [less] Could not parse call arguments or missing ')'
file: /src/web/src/main/frontend/less/screen.less:257:51
    at process (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:49569:33)
    at async compileCSSPreprocessors (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:48437:28)
    at async compileCSS (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:48495:32)
    at async Object.transform (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:47862:11)
    at async transform (file:///src/web/src/main/frontend/node_modules/.pnpm/rollup@4.30.1/node_modules/rollup/dist/es/shared/node-entry.js:19787:16)
    at async ModuleLoader.addModuleSource (file:///src/web/src/main/frontend/node_modules/.pnpm/rollup@4.30.1/node_modules/rollup/dist/es/shared/node-entry.js:20004:23)
```

Here is an example of the error message with this PR, note that the correct filename is identified:

```
[vite:css] [less] Could not parse call arguments or missing ')'
file: /src/web/src/main/frontend/less/components/site-header.less:257:51 (/src/web/src/main/frontend/less/screen.less)
    at process (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:49569:33)
    at async compileCSSPreprocessors (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:48437:28)
    at async compileCSS (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:48495:32)
    at async Object.transform (file:///src/web/src/main/frontend/node_modules/.pnpm/vite@6.0.7_@types+node@22.10.7_jiti@1.21.6_less@4.2.1_terser@5.31.1/node_modules/vite/dist/node/chunks/dep-BJP6rrE_.js:47862:11)
    at async transform (file:///src/web/src/main/frontend/node_modules/.pnpm/rollup@4.30.1/node_modules/rollup/dist/es/shared/node-entry.js:19787:16)
    at async ModuleLoader.addModuleSource (file:///src/web/src/main/frontend/node_modules/.pnpm/rollup@4.30.1/node_modules/rollup/dist/es/shared/node-entry.js:20004:23)
```