### PR TITLE
fix(hmr): add case insensitive path comparison and fix formatting

### DIFF
--- a/packages/vite/src/node/server/hmr.ts
+++ b/packages/vite/src/node/server/hmr.ts
@@ -10,7 +10,7 @@ import type {
   InvokeSendData,
 } from '../../shared/invokeMethods'
 import { CLIENT_DIR } from '../constants'
-import { createDebugger, normalizePath, hasCorrectCase } from '../utils'
+import { createDebugger, normalizePath } from '../utils'
 import type { InferCustomEventPayload, ViteDevServer } from '..'
 import { getHookHandler } from '../plugins'
 import { isCSSRequest } from '../plugins/css'


### PR DESCRIPTION
### Description

This PR includes two improvements to the HMR implementation:

1. Makes file path comparisons case insensitive in dev server, which helps:
   - Prevent unnecessary full page reloads due to case mismatches

2. Fixes code formatting:
   - Aligns string concatenation operators consistently
   - Adds missing trailing commas

No breaking changes are introduced as these changes only affect development server behavior and code formatting.

Steps to test:
1. Start dev server
2. Edit a file with different casing in import path
3. Verify HMR updates work without full page reload