### PR TITLE
fix(ssr): combine empty source mappings

### DIFF
--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -419,21 +419,26 @@ async function ssrTransformScript(
     },
   })
 
-  let map = s.generateMap({ hires: 'boundary' })
-  map.sources = [path.basename(url)]
-  // needs to use originalCode instead of code
-  // because code might be already transformed even if map is null
-  map.sourcesContent = [originalCode]
-  if (
-    inMap &&
-    inMap.mappings &&
-    'sources' in inMap &&
-    inMap.sources.length > 0
-  ) {
-    map = combineSourcemaps(url, [
-      map as RawSourceMap,
-      inMap as RawSourceMap,
-    ]) as SourceMap
+  let map: TransformResult['map']
+  if (inMap?.mappings === '') {
+    map = inMap
+  } else {
+    map = s.generateMap({ hires: 'boundary' })
+    map.sources = [path.basename(url)]
+    // needs to use originalCode instead of code
+    // because code might be already transformed even if map is null
+    map.sourcesContent = [originalCode]
+    if (
+      inMap &&
+      inMap.mappings &&
+      'sources' in inMap &&
+      inMap.sources.length > 0
+    ) {
+      map = combineSourcemaps(url, [
+        map as RawSourceMap,
+        inMap as RawSourceMap,
+      ]) as SourceMap
+    }
   }
 
   return {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19218

Current SSR transform skips collapsing `map: { mappings: '' }` and uses magic-string generated map as is. However this is incorrect since empty mappings should get collapsed to empty mappings. Additionally, magic-string source map generation is unnecessary, so it can be skipped in this case.

This change fixes a perf hit when plugin returns a large code from `load` or `transform` with explicit empty mappping `map: { mappings: '' }` as par rollup convention https://rollupjs.org/plugin-development/#source-code-transformations.