### PR TITLE
fix: `crypto.getRandomValues` is not available in old Node versions

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -767,7 +767,7 @@ export async function resolveConfig(
     // at least 64bits is recommended
     // https://owasp.org/www-community/vulnerabilities/Insufficient_Session-ID_Length
     webSocketToken: Buffer.from(
-      crypto.getRandomValues(new Uint8Array(9)),
+      crypto.randomFillSync(new Uint8Array(9)),
     ).toString('base64url'),
     additionalAllowedHosts: getAdditionalAllowedHosts(server, preview),
     getSortedPlugins: undefined!,


### PR DESCRIPTION
### Description

```js
import crypto from 'node:crypto';

console.log(crypto.getRandomValues) // undefined on Node 16.20.1
```

refs #19236

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
