### PR TITLE
fix: try parse `server.origin` URL

### DIFF
--- a/packages/vite/src/node/server/middlewares/hostCheck.ts
+++ b/packages/vite/src/node/server/middlewares/hostCheck.ts
@@ -37,8 +37,12 @@ export function getAdditionalAllowedHosts(
   // allow server origin by default as that indicates that the user is
   // expecting Vite to respond on that host
   if (resolvedServerOptions.origin) {
-    const serverOriginUrl = new URL(resolvedServerOptions.origin)
-    list.push(serverOriginUrl.hostname)
+    // some frameworks may pass the origin as a placeholder, so it's not
+    // possible to parse as URL, so use a try-catch here as a best effort
+    try {
+      const serverOriginUrl = new URL(resolvedServerOptions.origin)
+      list.push(serverOriginUrl.hostname)
+    } catch {}
   }
 
   return list


### PR DESCRIPTION
### Description

fix #19239

This line is causing the latest version to fail: https://github.com/laravel/vite-plugin/blob/e57a940c22f90e72002380d3dad1a2c6f1921983/src/index.ts#L154

I don't think we really expect frameworks to configure the option this way, but they have an [interesting usecase](https://github.com/laravel/vite-plugin/blob/e57a940c22f90e72002380d3dad1a2c6f1921983/src/index.ts#L193) that indeed make it seem like we could improve the `server.origin` option a bit, but maybe later in the future.
