### PR TITLE
fix: `preview.allowedHosts` with specific values was not respected

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -208,7 +208,7 @@ export async function preview(
   const { allowedHosts } = config.preview
   // no need to check for HTTPS as HTTPS is not vulnerable to DNS rebinding attacks
   if (allowedHosts !== true && !config.preview.https) {
-    app.use(hostCheckMiddleware(config))
+    app.use(hostCheckMiddleware(config, true))
   }
 
   // proxy

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -862,7 +862,7 @@ export async function _createServer(
   const { allowedHosts } = serverConfig
   // no need to check for HTTPS as HTTPS is not vulnerable to DNS rebinding attacks
   if (allowedHosts !== true && !serverConfig.https) {
-    middlewares.use(hostCheckMiddleware(config))
+    middlewares.use(hostCheckMiddleware(config, false))
   }
 
   middlewares.use(cachedTransformMiddleware(server))

--- a/packages/vite/src/node/server/ws.ts
+++ b/packages/vite/src/node/server/ws.ts
@@ -167,7 +167,7 @@ export function createWebSocketServer(
     if (protocol === 'vite-ping') return true
 
     const hostHeader = req.headers.host
-    if (!hostHeader || !isHostAllowed(config, hostHeader)) {
+    if (!hostHeader || !isHostAllowed(config, false, hostHeader)) {
       return false
     }
 


### PR DESCRIPTION
### Description

Setting `preview.allowedHosts: ['example.com']` was not respected. The workaround would be to set it to `server.allowedHosts` instead.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
