### PR TITLE
fix(utils): clone `RegExp` values with `new RegExp` instead of `structuredClone` (fix #19245, fix #18875)

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1093,7 +1093,7 @@ function deepClone<T>(value: T): DeepWritable<T> {
     return value as DeepWritable<T>
   }
   if (value instanceof RegExp) {
-    return structuredClone(value) as DeepWritable<T>
+    return new RegExp(value) as DeepWritable<T>
   }
   if (typeof value === 'object' && value != null) {
     throw new Error('Cannot deep clone non-plain object')


### PR DESCRIPTION
Fixes #19245. Fixes #18875.

### Description

[Jest appears to provide its own global `structuredClone`](https://github.com/jestjs/jest/issues/2549) that modifies `RegExp`s in such a way that they fail `instanceof RegExp` checks, causing an error in a rollup plugin used by `vite` (and likely other errors elsewhere). [As suggested](https://github.com/vitejs/vite/issues/19245#issuecomment-2603468590), `new RegExp` seems to correctly clone `RegExp`s in Jest.

I thought about writing a test that modified the `structuredClone` global but decided against it as that's more like testing jest implementation detail rather than regexp cloning behaviour (which is already tested).

