### PR TITLE
feat: add `test`/`.test` to `server.allowedHosts`/`server.cors.origin` by default

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -161,7 +161,7 @@ export default defineConfig({
 ## server.cors
 
 - **Type:** `boolean | CorsOptions`
-- **Default:** `false`
+- **Default:** `{ origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/ }` (allows localhost, `127.0.0.1` and `::1`)
 
 Configure CORS for the dev server. Pass an [options object](https://github.com/expressjs/cors#configuration-options) to fine tune the behavior or `true` to allow any origin.
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -48,7 +48,7 @@ See [the WSL document](https://learn.microsoft.com/en-us/windows/wsl/networking#
 - **Default:** `[]`
 
 The hostnames that Vite is allowed to respond to.
-`localhost` and domains under `.localhost` and all IP addresses are allowed by default.
+`localhost`/`test` and domains under `.localhost`/`.test` and all IP addresses are allowed by default.
 When using HTTPS, this check is skipped.
 
 If a string starts with `.`, it will allow that hostname without the `.` and all subdomains under the hostname. For example, `.example.com` will allow `example.com`, `foo.example.com`, and `foo.bar.example.com`.

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -161,7 +161,7 @@ export default defineConfig({
 ## server.cors
 
 - **Type:** `boolean | CorsOptions`
-- **Default:** `{ origin: /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/ }` (allows localhost, `127.0.0.1` and `::1`)
+- **Default:** `{ origin: /^https?:\/\/(?:(?:[^:]+\.)?(?:localhost|test)|127\.0\.0\.1|\[::1\])(?::\d+)?$/ }` (allows localhost, `127.0.0.1` and `::1`)
 
 Configure CORS for the dev server. Pass an [options object](https://github.com/expressjs/cors#configuration-options) to fine tune the behavior or `true` to allow any origin.
 

--- a/packages/vite/src/node/__tests__/constants.spec.ts
+++ b/packages/vite/src/node/__tests__/constants.spec.ts
@@ -5,6 +5,7 @@ test('defaultAllowedOrigins', () => {
   const allowed = [
     'http://localhost',
     'http://foo.localhost',
+    'http://foo.test',
     'http://localhost:3000',
     'https://localhost:3000',
     'http://127.0.0.1',

--- a/packages/vite/src/node/__tests__/constants.spec.ts
+++ b/packages/vite/src/node/__tests__/constants.spec.ts
@@ -16,6 +16,8 @@ test('defaultAllowedOrigins', () => {
     'http://localhost.example.com',
     'http://foo.example.com:localhost',
     'http://',
+    'http://192.0.2',
+    'http://[2001:db8::1]',
     'http://vite',
     'http://vite:3000',
   ]

--- a/packages/vite/src/node/__tests__/constants.spec.ts
+++ b/packages/vite/src/node/__tests__/constants.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from 'vitest'
+import { defaultAllowedOrigins } from '../constants'
+
+test('defaultAllowedOrigins', () => {
+  const allowed = [
+    'http://localhost',
+    'http://foo.localhost',
+    'http://localhost:3000',
+    'https://localhost:3000',
+    'http://127.0.0.1',
+    'http://[::1]',
+    'http://[::1]:3000',
+  ]
+  const denied = [
+    'file:///foo',
+    'http://localhost.example.com',
+    'http://foo.example.com:localhost',
+    'http://',
+    'http://vite',
+    'http://vite:3000',
+  ]
+
+  for (const origin of allowed) {
+    expect(defaultAllowedOrigins.test(origin), origin).toBe(true)
+  }
+
+  for (const origin of denied) {
+    expect(defaultAllowedOrigins.test(origin), origin).toBe(false)
+  }
+})

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -183,6 +183,9 @@ export const DEFAULT_PREVIEW_PORT = 4173
 
 export const DEFAULT_ASSETS_INLINE_LIMIT = 4096
 
+export const defaultAllowedOrigins =
+  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/
+
 export const METADATA_FILENAME = '_metadata.json'
 
 export const ERR_OPTIMIZE_DEPS_PROCESSING_ERROR =

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -183,6 +183,10 @@ export const DEFAULT_PREVIEW_PORT = 4173
 
 export const DEFAULT_ASSETS_INLINE_LIMIT = 4096
 
+// the regex to allow loopback address origins:
+// - localhost domains (which will always resolve to the loopback address by RFC 6761 section 6.3)
+// - 127.0.0.1
+// - ::1
 export const defaultAllowedOrigins =
   /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/
 

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -185,10 +185,11 @@ export const DEFAULT_ASSETS_INLINE_LIMIT = 4096
 
 // the regex to allow loopback address origins:
 // - localhost domains (which will always resolve to the loopback address by RFC 6761 section 6.3)
+// - test domains (which will never be registered by RFC 6761 section 6.2)
 // - 127.0.0.1
 // - ::1
 export const defaultAllowedOrigins =
-  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/
+  /^https?:\/\/(?:(?:[^:]+\.)?(?:localhost|test)|127\.0\.0\.1|\[::1\])(?::\d+)?$/
 
 export const METADATA_FILENAME = '_metadata.json'
 

--- a/packages/vite/src/node/http.ts
+++ b/packages/vite/src/node/http.ts
@@ -26,7 +26,7 @@ export interface CommonServerOptions {
   host?: string | boolean
   /**
    * The hostnames that Vite is allowed to respond to.
-   * `localhost` and subdomains under `.localhost` and all IP addresses are allowed by default.
+   * `localhost`/`test` and domains under `.localhost`/`.test` and all IP addresses are allowed by default.
    * When using HTTPS, this check is skipped.
    *
    * If a string starts with `.`, it will allow that hostname without the `.` and all subdomains under the hostname.

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -44,7 +44,11 @@ import { reloadOnTsconfigChange } from '../plugins/esbuild'
 import { bindCLIShortcuts } from '../shortcuts'
 import type { BindCLIShortcutsOptions } from '../shortcuts'
 import { ERR_OUTDATED_OPTIMIZED_DEP } from '../../shared/constants'
-import { CLIENT_DIR, DEFAULT_DEV_PORT } from '../constants'
+import {
+  CLIENT_DIR,
+  DEFAULT_DEV_PORT,
+  defaultAllowedOrigins,
+} from '../constants'
 import type { Logger } from '../logger'
 import { printServerUrls } from '../logger'
 import { warnFutureDeprecation } from '../deprecations'
@@ -1055,7 +1059,7 @@ export const serverConfigDefaults = Object.freeze({
   https: undefined,
   open: false,
   proxy: undefined,
-  cors: false,
+  cors: { origin: defaultAllowedOrigins },
   headers: {},
   // hmr
   // ws

--- a/packages/vite/src/node/server/middlewares/hostCheck.ts
+++ b/packages/vite/src/node/server/middlewares/hostCheck.ts
@@ -91,6 +91,11 @@ export function isHostAllowedWithoutCache(
   if (hostname === 'localhost' || hostname.endsWith('.localhost')) {
     return true
   }
+  // allow test and .test by default as they will never be registered
+  // https://datatracker.ietf.org/doc/html/rfc6761#section-6.2
+  if (hostname === 'test' || hostname.endsWith('.test')) {
+    return true
+  }
 
   for (const additionalAllowedHost of additionalAllowedHosts) {
     if (additionalAllowedHost === hostname) {


### PR DESCRIPTION
### Description

Built on top of #19249

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
