### PR TITLE
docs: clarify browser compatibility

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -4,14 +4,19 @@ When it is time to deploy your app for production, simply run the `vite build` c
 
 ## Browser Compatibility
 
-The production bundle assumes support for modern JavaScript. By default, Vite targets browsers which support the [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta):
+By default, the production bundle assumes support for modern JavaScript, including [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta). The default browser support range is:
 
 - Chrome >=87
 - Firefox >=78
 - Safari >=14
 - Edge >=88
 
-You can specify custom targets via the [`build.target` config option](/config/build-options.md#build-target), where the lowest target is `es2015`.
+You can specify custom targets via the [`build.target` config option](/config/build-options.md#build-target), where the lowest target is `es2015`. For custom `build.target`, the support range will be lower than the default list but higher than browsers supporting `es2015` as Vite still requires [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import) and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta). The browser support range when setting target `es2015` is:
+
+- Chrome >=64
+- Firefox >=67
+- Safari >=11.1
+- Edge >=79
 
 Note that by default, Vite only handles syntax transforms and **does not cover polyfills**. You can check out https://cdnjs.cloudflare.com/polyfill/ which automatically generates polyfill bundles based on the user's browser UserAgent string.
 

--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -11,7 +11,7 @@ By default, the production bundle assumes support for modern JavaScript, includi
 - Safari >=14
 - Edge >=88
 
-You can specify custom targets via the [`build.target` config option](/config/build-options.md#build-target), where the lowest target is `es2015`. For custom `build.target`, the support range will be lower than the default list but higher than browsers supporting `es2015` as Vite still requires [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import) and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta). The browser support range when setting target `es2015` is:
+You can specify custom targets via the [`build.target` config option](/config/build-options.md#build-target), where the lowest target is `es2015`. If a lower target is set, Vite will still require these minimum browser support ranges as it relies on [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import) and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta):
 
 - Chrome >=64
 - Firefox >=67


### PR DESCRIPTION
### Description

Explicit list of minimal browser support and hopefully better wording. List from [1](https://browsersl.ist/#q=supports+es6-module+and+supports+es6-module-dynamic-import) and [2](https://caniuse.com/?search=import.meta). I may be missing some other features we require here, so good to have more eyes on the minimum list.