### PR TITLE
feat: export `defaultAllowedOrigins` for user-land config and 3rd party plugins

### DIFF
--- a/packages/vite/src/node/publicUtils.ts
+++ b/packages/vite/src/node/publicUtils.ts
@@ -9,6 +9,7 @@ export {
   DEFAULT_CLIENT_MAIN_FIELDS as defaultClientMainFields,
   DEFAULT_SERVER_CONDITIONS as defaultServerConditions,
   DEFAULT_SERVER_MAIN_FIELDS as defaultServerMainFields,
+  defaultAllowedOrigins,
 } from './constants'
 export { version as esbuildVersion } from 'esbuild'
 export {


### PR DESCRIPTION
### Description

It is not currently possible to widen the shipped allowed origins. A user or plugin must completely replace them defaults. The current value could be copy and pasted from core, but could then get out of sync.

This PR allows both user-land applications and 3rd-party plugins to augment the default allowed origins that ship with Vite without worrying about drift.

```js
import { defineConfig, defaultAllowedOrigins } from 'vite';

export default defineConfig({
    server: {
        cors: {
            origin: [
                defaultAllowedOrigins,
                'my-app.com',
            ],
        }
    }
});
```

## Future proofing question

Should we make the `defaultAllowedOrigins` constant an array? I can imagine that this might slowly get more things added to the regex and it could become to maintain as a single regex expression. Having it as an array from the outset might help future proof if you ever want to split the pattern into diffe.

```
origin: [
    ...defaultAllowedOrigins,
    'my-app.com',
],
```