### PR TITLE
fix(css): less `@plugin` imports of JS files treated as CSS and rebased (fix #19268)

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -2761,14 +2761,10 @@ const makeLessWorker = (
     )
     if (!resolved) return undefined
 
+    // don't rebase URLs in JavaScript plugins
     if (mime === 'application/javascript') {
-      // loading a JavaScript plugin, so don't attempt to rebase urls; just load the contents
       const file = path.resolve(resolved) // ensure os-specific flashes
-      const contents = await fsp.readFile(file, 'utf-8')
-      return {
-        resolved,
-        contents,
-      }
+      return { resolved: file }
     }
 
     const result = await rebaseUrls(

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -108,6 +108,13 @@ test('less', async () => {
   await untilUpdated(() => getColor(atImport), 'blue')
 })
 
+test('less-plugin', async () => {
+  const body = await page.$('body')
+  expect(await getBg(body)).toBe(
+    'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgEBAFPIhPsAAAAASUVORK5CYII=")',
+  )
+})
+
 test('stylus', async () => {
   const imported = await page.$('.stylus')
   const additionalData = await page.$('.stylus-additional-data')

--- a/playground/css/less-plugin.less
+++ b/playground/css/less-plugin.less
@@ -1,0 +1,5 @@
+@plugin "less-plugin/test.js";
+
+body {
+  background-image: test();
+}

--- a/playground/css/less-plugin/test.js
+++ b/playground/css/less-plugin/test.js
@@ -1,0 +1,5 @@
+functions.add('test', function test() {
+  const transparentPng =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgEBAFPIhPsAAAAASUVORK5CYII='
+  return `url(${transparentPng})`
+})

--- a/playground/css/main.js
+++ b/playground/css/main.js
@@ -3,6 +3,7 @@ import './imported.css'
 import './sugarss.sss'
 import './sass.scss'
 import './less.less'
+import './less-plugin.less'
 import './stylus.styl'
 import './manual-chunk.css'
 


### PR DESCRIPTION
### Description

Fixes #19268:

Less files can contain `@plugin "plugin.js";` style imports, which reference JavaScript files. When Vite runs on a `.less` file that contains a `@plugin` import the `makeLessWorker` function calls `viteLessResolve` with the `plugin.js` file (in this example), which then calls `rebaseUrls`, which is expecting to have received a CSS file and runs a bunch of regex including rebasing `url(...)`s, which is breaking my JavaScript file which contains that string!

This PR resolves the issue by using the `mime` value that comes from less and indicates that it's loading a JavaScript file. For `.less` files this `mime` value is `undefined`, so checking explicitly for `application/javascript` seems like a good option. There is no doubt another option for detecting this situation (when we shouldn't treat the file as CSS and rebase it).

I have added a test case based on the example...

### Example

I have setup a basic example of this bug at https://github.com/karlvr/vite-less-plugin-bug:

* The `src/main.less` file imports the `src/plugins/test.js` plugin and then uses it in the `background-image` attribute.
* The `src/plugins/test.js` includes the string `url(` to demonstrate the bug, as `rebaseUrls` mistakenly transforms it, thinking the file is CSS
* The output `dist/assets/index-CWZCrLGA.css` demonstrates the output; the `url(...)`, which should just contain the data uri, is prefixed with the base of the `src/plugins/test.js` file: `url(plugins/data:image/png;base64...`
