### PR TITLE
fix: respect top-level `server.preTransformRequests`

### DIFF
--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -513,3 +513,97 @@ test('config compat 3', async () => {
     ]
   `)
 })
+
+test('preTransformRequests', async () => {
+  async function testConfig(inlineConfig: InlineConfig) {
+    return Object.fromEntries(
+      Object.entries(
+        (await resolveConfig(inlineConfig, 'serve')).environments,
+      ).map(([name, e]) => [name, e.dev.preTransformRequests]),
+    )
+  }
+
+  expect(
+    await testConfig({
+      environments: {
+        custom: {},
+        customTrue: {
+          dev: {
+            preTransformRequests: true,
+          },
+        },
+        customFalse: {
+          dev: {
+            preTransformRequests: false,
+          },
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "client": true,
+      "custom": false,
+      "customFalse": false,
+      "customTrue": true,
+      "ssr": false,
+    }
+  `)
+
+  expect(
+    await testConfig({
+      server: {
+        preTransformRequests: true,
+      },
+      environments: {
+        custom: {},
+        customTrue: {
+          dev: {
+            preTransformRequests: true,
+          },
+        },
+        customFalse: {
+          dev: {
+            preTransformRequests: false,
+          },
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "client": true,
+      "custom": true,
+      "customFalse": false,
+      "customTrue": true,
+      "ssr": true,
+    }
+  `)
+
+  expect(
+    await testConfig({
+      server: {
+        preTransformRequests: false,
+      },
+      environments: {
+        custom: {},
+        customTrue: {
+          dev: {
+            preTransformRequests: true,
+          },
+        },
+        customFalse: {
+          dev: {
+            preTransformRequests: false,
+          },
+        },
+      },
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "client": false,
+      "custom": false,
+      "customFalse": false,
+      "customTrue": true,
+      "ssr": false,
+    }
+  `)
+})

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -739,12 +739,13 @@ export function resolveDevEnvironmentOptions(
   consumer: 'client' | 'server' | undefined,
   // Backward compatibility
   skipSsrTransform?: boolean,
+  preTransformRequest?: boolean,
 ): ResolvedDevEnvironmentOptions {
   const resolved = mergeWithDefaults(
     {
       ...configDefaults.dev,
       sourcemapIgnoreList: isInNodeModules,
-      preTransformRequests: consumer === 'client',
+      preTransformRequests: preTransformRequest ?? consumer === 'client',
       createEnvironment:
         environmentName === 'client'
           ? defaultCreateClientDevEnvironment
@@ -775,6 +776,7 @@ function resolveEnvironmentOptions(
   // Backward compatibility
   skipSsrTransform?: boolean,
   isSsrTargetWebworkerSet?: boolean,
+  preTransformRequests?: boolean,
 ): ResolvedEnvironmentOptions {
   const isClientEnvironment = environmentName === 'client'
   const consumer =
@@ -806,6 +808,7 @@ function resolveEnvironmentOptions(
       environmentName,
       consumer,
       skipSsrTransform,
+      preTransformRequests,
     ),
     build: resolveBuildEnvironmentOptions(
       options.build ?? {},
@@ -1206,6 +1209,7 @@ export async function resolveConfig(
       environmentName,
       config.experimental?.skipSsrTransform,
       config.ssr?.target === 'webworker',
+      config.server?.preTransformRequests,
     )
   }
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1113,16 +1113,6 @@ export async function resolveConfig(
     configEnvironmentsSsr.dev.warmup = warmupOptions.ssrFiles
   }
 
-  // Backward compatibility: server.preTransformRequests -> environment.dev.preTransformRequests
-  if (typeof config.server?.preTransformRequests !== 'undefined') {
-    configEnvironmentsClient.dev.preTransformRequests =
-      config.server?.preTransformRequests
-    configEnvironmentsSsr ??= {}
-    configEnvironmentsSsr.dev ??= {}
-    configEnvironmentsSsr.dev.preTransformRequests ??=
-      config.server?.preTransformRequests
-  }
-
   // Backward compatibility: merge ssr into environments.ssr.config as defaults
   if (configEnvironmentsSsr) {
     configEnvironmentsSsr.optimizeDeps = mergeConfig(

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1110,6 +1110,16 @@ export async function resolveConfig(
     configEnvironmentsSsr.dev.warmup = warmupOptions.ssrFiles
   }
 
+  // Backward compatibility: server.preTransformRequests -> environment.dev.preTransformRequests
+  if (typeof config.server?.preTransformRequests !== 'undefined') {
+    configEnvironmentsClient.dev.preTransformRequests =
+      config.server?.preTransformRequests
+    configEnvironmentsSsr ??= {}
+    configEnvironmentsSsr.dev ??= {}
+    configEnvironmentsSsr.dev.preTransformRequests ??=
+      config.server?.preTransformRequests
+  }
+
   // Backward compatibility: merge ssr into environments.ssr.config as defaults
   if (configEnvironmentsSsr) {
     configEnvironmentsSsr.optimizeDeps = mergeConfig(


### PR DESCRIPTION
### Description

- Closes https://github.com/vitest-dev/vitest/issues/7345

It looks like there were two changes related to `preTransformRequests` on Vite 6, namely:
- `server.preTransformRequests` has no effect on `environment.dev.preTransformRequests`.
- while `server.preTransformRequests: true` by default both on client and ssr on Vite 5, now only client environment `dev.preTransformRequests: true` and ssr does not pre transform by default.

I made a reproduction in https://github.com/hi-ogawa/reproductions/tree/main/vitest-7345-preTransformRequests-false.

I assume the first one is a bug since currently `server.preTransformRequests` is no-op and we should either deprecate/remove or use it as a default. This is what this PR addresses and I confirmed this fixed Vitest's issue https://stackblitz.com/edit/bolt-vue-7wha3d5d?file=package.json. There are also some usages in the wild https://github.com/search?q=preTransformRequests&type=code.

For the 2nd one, I wasn't aware of this change and I'm not sure if it's intended. I'll leave this part out of the PR for now.