### PR TITLE
chore: unneeded name in lockfileFormats

### DIFF
--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -1206,7 +1206,6 @@ const lockfileFormats = [
     manager: 'pnpm',
   },
   {
-    name: 'bun.lockb',
     path: 'bun.lockb',
     checkPatchesDir: 'patches',
     manager: 'bun',


### PR DESCRIPTION
### Description

Seems we forgot to remove this one in the last refactoring