### PR TITLE
fix: ensure local files mapped to yarn virtuals are watched

### DIFF
--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -742,7 +742,8 @@ export function ensureWatchedFile(
   if (
     file &&
     // only need to watch if out of root
-    !file.startsWith(withTrailingSlash(root)) &&
+    (!file.startsWith(withTrailingSlash(root)) ||
+      file.includes('/.yarn/__virtual__/')) &&
     // some rollup plugins use null bytes for private resolved Ids
     !file.includes('\0') &&
     fs.existsSync(file)


### PR DESCRIPTION
### Description

- Fixes #15809, but probably not in the best way

There's a somewhat minimal repro here: https://github.com/mrginglymus/vitest-pnp though the focus of that is worrying about the coverage reporting on vitest.

The specific problem is this:

1. Using Yarn PnP
2. With a workspace package with peer dependencies
3. With source files in that workspace package
4. Imported from files via package name from the root package

Then files are reported as being in `<cwd>/.yarn/__virtual__/my-package...`.

I've failed to exactly follow how files are added to the watcher, but what I can see is that `ensureWatchedFile` bails if the file considered 'out of root', as presumably it would otherwise be watched.

However, these virtual files are not watched; I don't know how the initial watchlist is populated, but I could envisage it either having an exclusion of directories with a leading `.`, or scanning the on-disk filesystem (which would not include the virtual files).

Either way, what 'fixes' this for me locally is to either change the root (to trick `ensureWatchedFile`) or apply this fix which considers virtual files to be out of root.
