### PR TITLE
feat(create-vite): default to metaframeworks

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -91,16 +91,16 @@ const FRAMEWORKS: Framework[] = [
     color: green,
     variants: [
       {
-        name: 'custom-nuxt',
-        display: 'Nuxt ↗',
-        color: greenBright,
-        customCommand: 'npm exec nuxi init TARGET_DIR',
-      },
-      {
         name: 'custom-create-vue',
         display: 'Customize with create-vue ↗',
         color: green,
         customCommand: 'npm create vue@latest TARGET_DIR',
+      },
+      {
+        name: 'custom-nuxt',
+        display: 'Nuxt ↗',
+        color: greenBright,
+        customCommand: 'npm exec nuxi init TARGET_DIR',
       },
       {
         name: 'vue-ts',

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -91,6 +91,18 @@ const FRAMEWORKS: Framework[] = [
     color: green,
     variants: [
       {
+        name: 'custom-nuxt',
+        display: 'Nuxt ↗',
+        color: greenBright,
+        customCommand: 'npm exec nuxi init TARGET_DIR',
+      },
+      {
+        name: 'custom-create-vue',
+        display: 'Customize with create-vue ↗',
+        color: green,
+        customCommand: 'npm create vue@latest TARGET_DIR',
+      },
+      {
         name: 'vue-ts',
         display: 'TypeScript',
         color: blue,
@@ -100,18 +112,6 @@ const FRAMEWORKS: Framework[] = [
         display: 'JavaScript',
         color: yellow,
       },
-      {
-        name: 'custom-create-vue',
-        display: 'Customize with create-vue ↗',
-        color: green,
-        customCommand: 'npm create vue@latest TARGET_DIR',
-      },
-      {
-        name: 'custom-nuxt',
-        display: 'Nuxt ↗',
-        color: greenBright,
-        customCommand: 'npm exec nuxi init TARGET_DIR',
-      },
     ],
   },
   {
@@ -119,6 +119,12 @@ const FRAMEWORKS: Framework[] = [
     display: 'React',
     color: cyan,
     variants: [
+      {
+        name: 'custom-react-router',
+        display: 'React Router v7 ↗',
+        color: cyan,
+        customCommand: 'npm create react-router@latest TARGET_DIR',
+      },
       {
         name: 'react-ts',
         display: 'TypeScript',
@@ -139,12 +145,6 @@ const FRAMEWORKS: Framework[] = [
         display: 'JavaScript + SWC',
         color: yellow,
       },
-      {
-        name: 'custom-react-router',
-        display: 'React Router v7 ↗',
-        color: cyan,
-        customCommand: 'npm create react-router@latest TARGET_DIR',
-      },
     ],
   },
   {
@@ -152,6 +152,12 @@ const FRAMEWORKS: Framework[] = [
     display: 'Preact',
     color: magenta,
     variants: [
+      {
+        name: 'custom-create-preact',
+        display: 'Customize with create-preact ↗',
+        color: magenta,
+        customCommand: 'npm create preact@latest TARGET_DIR',
+      },
       {
         name: 'preact-ts',
         display: 'TypeScript',
@@ -161,12 +167,6 @@ const FRAMEWORKS: Framework[] = [
         name: 'preact',
         display: 'JavaScript',
         color: yellow,
-      },
-      {
-        name: 'custom-create-preact',
-        display: 'Customize with create-preact ↗',
-        color: magenta,
-        customCommand: 'npm create preact@latest TARGET_DIR',
       },
     ],
   },
@@ -193,6 +193,12 @@ const FRAMEWORKS: Framework[] = [
     color: red,
     variants: [
       {
+        name: 'custom-svelte-kit',
+        display: 'SvelteKit ↗',
+        color: red,
+        customCommand: 'npm exec sv create TARGET_DIR',
+      },
+      {
         name: 'svelte-ts',
         display: 'TypeScript',
         color: blue,
@@ -201,12 +207,6 @@ const FRAMEWORKS: Framework[] = [
         name: 'svelte',
         display: 'JavaScript',
         color: yellow,
-      },
-      {
-        name: 'custom-svelte-kit',
-        display: 'SvelteKit ↗',
-        color: red,
-        customCommand: 'npm exec sv create TARGET_DIR',
       },
     ],
   },
@@ -233,6 +233,12 @@ const FRAMEWORKS: Framework[] = [
     color: blueBright,
     variants: [
       {
+        name: 'custom-qwik-city',
+        display: 'QwikCity ↗',
+        color: blueBright,
+        customCommand: 'npm create qwik@latest basic TARGET_DIR',
+      },
+      {
         name: 'qwik-ts',
         display: 'TypeScript',
         color: blueBright,
@@ -241,12 +247,6 @@ const FRAMEWORKS: Framework[] = [
         name: 'qwik',
         display: 'JavaScript',
         color: yellow,
-      },
-      {
-        name: 'custom-qwik-city',
-        display: 'QwikCity ↗',
-        color: blueBright,
-        customCommand: 'npm create qwik@latest basic TARGET_DIR',
       },
     ],
   },


### PR DESCRIPTION
### Description

create-vite was initially a tool to scaffold barebones templates to try out vite with your preferred framework. We dodn't even have linting in templates. We only added eslint to React after discussing with @gaearon. And we pushed users to use other tools to start a production project, for example, in the Vue ecosystem, [create-vue](https://github.com/vuejs/create-vue) has a CLI with options to add testing and a lot of other features you would expect in a proper scaffolding tool.

Now that several framework options have metaframeworks, and they have reached stable versions using vite, if create-vite is going to be used mainly by people looking to start their next application and not a bug reproduction, then it makes sense to push the metaframeworks up as the first option so they are taken by default by users. This PR implements this idea, proposed by @gaearon [here](https://bsky.app/profile/danabra.mov/post/3lggtzxbm222w).

Note: the React Router v7 default template needs to be a bit leaner, as right now it includes files for docker and bun that may confuse new users. @markdalgleish said they are working on this, it is just part of the transition from Remix.
