### PR TITLE
chore: remove outdated code comment about `scanImports` not being used in ssr

### DIFF
--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -127,8 +127,6 @@ export function scanImports(environment: ScanEnvironment): {
     missing: Record<string, string>
   }>
 } {
-  // Only used to scan non-ssr code
-
   const start = performance.now()
   const deps: Record<string, string> = {}
   const missing: Record<string, string> = {}


### PR DESCRIPTION
Just removing a code comment I noticed which I am sure is no longer valid (since https://github.com/vitejs/vite/pull/18358)