### PR TITLE
docs: rephrase browser range and features relation

### DIFF
--- a/docs/guide/build.md
+++ b/docs/guide/build.md
@@ -4,14 +4,18 @@ When it is time to deploy your app for production, simply run the `vite build` c
 
 ## Browser Compatibility
 
-By default, the production bundle assumes support for modern JavaScript, including [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta). The default browser support range is:
+By default, the production bundle assumes support for modern JavaScript, such as [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta), [nullish coalescing](https://caniuse.com/mdn-javascript_operators_nullish_coalescing), and [BigInt](https://caniuse.com/bigint). The default browser support range is:
+
+<!-- Search for the `ESBUILD_MODULES_TARGET` constant for more information -->
 
 - Chrome >=87
 - Firefox >=78
 - Safari >=14
 - Edge >=88
 
-You can specify custom targets via the [`build.target` config option](/config/build-options.md#build-target), where the lowest target is `es2015`. If a lower target is set, Vite will still require these minimum browser support ranges as it relies on [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import) and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta):
+You can specify custom targets via the [`build.target` config option](/config/build-options.md#build-target), where the lowest target is `es2015`. If a lower target is set, Vite will still require these minimum browser support ranges as it relies on [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta):
+
+<!-- Search for the `defaultEsbuildSupported` constant for more information -->
 
 - Chrome >=64
 - Firefox >=67

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -22,7 +22,7 @@ You can learn more about the rationale behind the project in the [Why Vite](./wh
 
 During development, Vite sets [`esnext` as the transform target](https://esbuild.github.io/api/#target), because we assume a modern browser is used and it supports all of the latest JavaScript and CSS features. This prevents syntax lowering, letting Vite serve modules as close as possible to the original source code.
 
-For the production build, by default Vite targets browsers that support [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta). Legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
+For the production build, by default Vite targets browsers that support modern JavaScript, such as [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), [`import.meta`](https://caniuse.com/mdn-javascript_operators_import_meta), [nullish coalescing](https://caniuse.com/mdn-javascript_operators_nullish_coalescing), and [BigInt](https://caniuse.com/bigint). Legacy browsers can be supported via the official [@vitejs/plugin-legacy](https://github.com/vitejs/vite/tree/main/packages/plugin-legacy). See the [Building for Production](./build) section for more details.
 
 ## Trying Vite Online
 

--- a/packages/vite/src/node/constants.ts
+++ b/packages/vite/src/node/constants.ts
@@ -64,11 +64,20 @@ export const DEFAULT_SERVER_CONDITIONS = Object.freeze(
   DEFAULT_CONDITIONS.filter((c) => c !== 'browser'),
 )
 
-// Baseline support browserslist
-// "defaults and supports es6-module and supports es6-module-dynamic-import"
-// Higher browser versions may be needed for extra features.
+// Baseline support for:
+// - es2020 (covers most of following features)
+// - modules via script tag
+// - dynamic imports
+// - import.meta
+// - nullish coalescing (??)
+// - bigint
+//
+// Use this link to check for browser support (excludes es2020):
+// https://caniuse.com/es6-module,es6-module-dynamic-import,mdn-javascript_operators_import_meta,mdn-javascript_operators_nullish_coalescing,bigint#:~:text=Feature%20summary
+// NOTE: Browser versions may be slightly off as previously the browserslist special `"defaults"` query
+// was used around May 2021, which targeted browsers with >0.5% usage at the time.
 export const ESBUILD_MODULES_TARGET = [
-  'es2020', // support import.meta.url
+  'es2020',
   'edge88',
   'firefox78',
   'chrome87',

--- a/packages/vite/src/node/plugins/esbuild.ts
+++ b/packages/vite/src/node/plugins/esbuild.ts
@@ -37,6 +37,7 @@ const jsxExtensionsRE = /\.(?:j|t)sx\b/
 // the final build should always support dynamic import and import.meta.
 // if they need to be polyfilled, plugin-legacy should be used.
 // plugin-legacy detects these two features when checking for modern code.
+// Browser support: https://caniuse.com/es6-module-dynamic-import,mdn-javascript_operators_import_meta#:~:text=Feature%20summary
 export const defaultEsbuildSupported = {
   'dynamic-import': true,
   'import-meta': true,


### PR DESCRIPTION
### Description

I was discussing with @btea about the wording of this:

https://vite.dev/guide/build.html#browser-compatibility

> The production bundle assumes support for modern JavaScript. By default, Vite targets browsers which support the [native ES Modules](https://caniuse.com/es6-module), [native ESM dynamic import](https://caniuse.com/es6-module-dynamic-import), and [import.meta](https://caniuse.com/mdn-javascript_operators_import_meta):
> - Chrome >=87
> - Firefox >=78
> - Safari >=14
> - Edge >=88

The documented features don't match with the browser ranges, and few users have brought this up from time to time. And the reason is mostly that we're bumping to support features like nullish coalescing and bigint so they're not unnecessarily transpiled in modern browsers. However, this wasn't clearly explained in the docs.

---

This PR rephrases the paragraph, so instead of `targets browsers which support`, it's `targets browsers that support modern JS, such as ...`. This way we're not implying that the browser ranges strictly follow the feature set mentioned.

Ideally we could strictly follow the feature set mentioned, however the browserslist query we used is outdated and can't be reproduced anymore, so I've updated it to use caniuse. Maybe in the next major we can bump up the browser ranges again to match the JS features we intend to follow.

I remember we've brought up to update the browser ranges to be "last 2 years" in the past for every major, but I don't think we've done that. Maybe it's also something we can revisit if we want to do this.
