### PR TITLE
fix(ssr): pretty print plugin error in `ssrLoadModule`

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import fs from 'node:fs'
 import { stripVTControlCharacters } from 'node:util'
-import { expect, test } from 'vitest'
+import { expect, onTestFinished, test, vi } from 'vitest'
 import { createServer } from '../../server'
 import { normalizePath } from '../../utils'
 
@@ -250,4 +250,46 @@ test('file url', async () => {
     new URL('./fixtures/file-url/test space.js', import.meta.url).href,
   )
   expect(modWithSpace.msg).toBe('works')
+})
+
+test('plugin error', async () => {
+  const server = await createServer({
+    configFile: false,
+    root,
+    logLevel: 'error',
+    plugins: [
+      {
+        name: 'test-plugin',
+        resolveId(source) {
+          if (source === 'virtual:test') {
+            return '\0' + source
+          }
+        },
+        load(id) {
+          if (id === '\0virtual:test') {
+            return this.error('test-error')
+          }
+        },
+      },
+    ],
+  })
+  onTestFinished(() => server.close())
+
+  const spy = vi
+    .spyOn(server.config.logger, 'error')
+    .mockImplementation(() => {})
+  try {
+    await server.ssrLoadModule('virtual:test')
+    expect.unreachable()
+  } catch {}
+  expect(
+    stripVTControlCharacters(spy.mock.lastCall![0])
+      .replace('\0', '_0_')
+      .split('\n')
+      .slice(0, 2)
+      .join('\n'),
+  ).toMatchInlineSnapshot(`
+    "Error when evaluating SSR module virtual:test: test-error
+      Plugin: test-plugin"
+  `)
 })

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -284,7 +284,6 @@ test('plugin error', async () => {
   } catch {}
   expect(
     stripVTControlCharacters(spy.mock.lastCall![0])
-      .replace('\0', '_0_')
       .split('\n')
       .slice(0, 2)
       .join('\n'),

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -49,7 +49,7 @@ async function instantiateModule(
 
     environment.logger.error(
       buildErrorMessage(e, [
-        colors.red(`Error when evaluating SSR module ${url}`),
+        colors.red(`Error when evaluating SSR module ${url}: ${e.message}`),
       ]),
       {
         timestamp: true,

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -5,6 +5,7 @@ import type { ViteDevServer } from '../server'
 import { unwrapId } from '../../shared/utils'
 import type { DevEnvironment } from '../server/environment'
 import type { NormalizedServerHotChannel } from '../server/hmr'
+import { buildErrorMessage } from '../server/middlewares/error'
 import { ssrFixStacktrace } from './ssrStacktrace'
 import { createServerModuleRunnerTransport } from './runtime/serverModuleRunner'
 
@@ -47,7 +48,9 @@ async function instantiateModule(
     }
 
     environment.logger.error(
-      colors.red(`Error when evaluating SSR module ${url}:\n|- ${e.stack}\n`),
+      buildErrorMessage(e, [
+        colors.red(`Error when evaluating SSR module ${url}`),
+      ]),
       {
         timestamp: true,
         clear: environment.config.clearScreen,


### PR DESCRIPTION
### Description

- Related https://github.com/sveltejs/vite-plugin-svelte/issues/1069

Though this might look like a regression from the before/after screenshots below, this error was never pretty-printed. What's happening in sveltekit's repro is that, a plugin error of `ssrLoadModule` entry transform was outside this `try/catch`, so sveltekit were able to `try/catch` and pretty print on their own with "Internal server error" on Vite 5. Since Vite 6, entry level transform also goes through runner, so any plugin error will be caught through "Error when evaluating SSR module" message. 

Currently this automatic logging is fairly verbose and no error pretty printing. I'm not sure what to do with an extra `runnerError` (maybe make it non-enumerable?), but for now, doing pretty print probably helps the situation a bit and that's what I did it in this PR.

<details><summary>Screenshots</summary>

#### before (vite 5)

https://www.sveltelab.dev/wwj9l72l4etmdhg

![image](https://github.com/user-attachments/assets/269c666a-b1b4-4ad7-a4b5-511788366875)

#### before (vite 6)

https://www.sveltelab.dev/o2e6wq4d900igtk

![image](https://github.com/user-attachments/assets/70b64beb-ac0f-4d11-8286-6e64b9d7a5c8)

#### after (this pr)

https://www.sveltelab.dev/r04dodmlt1ekx5n

![image](https://github.com/user-attachments/assets/c80af428-d8ab-43a9-a161-0f4764a45be6)

</details>