### PR TITLE
docs: update static deployment guide

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -128,25 +128,24 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 2. Create a file called `.gitlab-ci.yml` in the root of your project with the content below. This will build and deploy your site whenever you make changes to your content:
 
    ```yaml [.gitlab-ci.yml]
-   image: node:16.5.0
-   pages:
-     stage: deploy
-     cache:
-       key:
-         files:
-           - package-lock.json
-         prefix: npm
-       paths:
-         - node_modules/
-     script:
-       - npm install
-       - npm run build
-       - cp -a dist/. public/
-     artifacts:
-       paths:
-         - public
-     rules:
-       - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    image: node:18.16.0
+
+    pages:
+      stage: deploy
+      cache:
+        key: npm-cache
+        paths:
+          - node_modules/
+      script:
+        - npm install
+        - npm run build
+        - mkdir -p public
+        - cp -r dist/* public
+      artifacts:
+        paths:
+          - public
+      rules:
+        - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
    ```
 
 ## Netlify


### PR DESCRIPTION
### Summary
The previous **.gitlab-ci.yml** used _node:16.5.0_, which caused deployment to fail during the build step due to compatibility issues with vite build.

This PR updates the Node.js version to _node:18.16.0_, resolving the issue and ensuring the pipeline runs successfully.

### Key Changes

- Updated Docker image from node:16.5.0 to node:18.16.0. 

- Ensured the public/ directory is created explicitly during the build process. 

### Why

The old Node.js version did not support `crypto.getRandomValues`, which is required for vite build. The new version ensures compatibility and resolves the deployment failure.