### PR TITLE
docs: update static deployment guide

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -128,20 +128,19 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 2. Create a file called `.gitlab-ci.yml` in the root of your project with the content below. This will build and deploy your site whenever you make changes to your content:
 
    ```yaml [.gitlab-ci.yml]
-   image: node:16.5.0
+   image: node:18.16.0
+
    pages:
      stage: deploy
      cache:
-       key:
-         files:
-           - package-lock.json
-         prefix: npm
+       key: npm-cache
        paths:
          - node_modules/
      script:
        - npm install
        - npm run build
-       - cp -a dist/. public/
+       - mkdir -p public
+       - cp -r dist/* public
      artifacts:
        paths:
          - public


### PR DESCRIPTION
### **Summary**

The previous `.gitlab-ci.yml` used `node:16.5.0`, which caused deployment to fail during the build step due to compatibility issues with `vite build`.

This PR updates the Node.js version to `node:18.16.0`, resolving the issue and ensuring the pipeline runs successfully.

### **Key Changes**

1. Updated Docker image from `node:16.5.0` to `node:18.16.0`.
2. Ensured the `public/` directory is created explicitly during the build process.

### **Why**

The old Node.js version did not support `crypto.getRandomValues`, which is required for `vite build`. The new version ensures compatibility and resolves the deployment failure.