### PR TITLE
fix(resolve): warn if node-like builtin was imported when `resolve.builtin` is empty

### DIFF
--- a/packages/vite/src/node/__tests__/resolve.spec.ts
+++ b/packages/vite/src/node/__tests__/resolve.spec.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path'
-import { describe, expect, onTestFinished, test } from 'vitest'
+import { describe, expect, onTestFinished, test, vi } from 'vitest'
 import { createServer } from '../server'
 import { createServerModuleRunner } from '../ssr/runtime/serverModuleRunner'
 import type { EnvironmentOptions, InlineConfig } from '../config'
@@ -150,6 +150,11 @@ describe('file url', () => {
       idToResolve: string
     }) {
       const server = await createServer(getConfig(targetEnv, builtins))
+      vi.spyOn(server.config.logger, 'warn').mockImplementationOnce(
+        (message) => {
+          throw new Error(message)
+        },
+      )
       onTestFinished(() => server.close())
 
       return server.environments[testEnv]?.pluginContainer.resolveId(
@@ -192,7 +197,7 @@ describe('file url', () => {
           idToResolve: 'node:fs',
         }),
       ).rejects.toThrowError(
-        /Automatically externalized node built-in module "node:fs"/,
+        /warning: Automatically externalized node built-in module "node:fs"/,
       )
     })
 

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -426,7 +426,7 @@ export function resolvePlugin(
               )}"`
             }
             message += `. Consider adding it to environments.${this.environment.name}.external if it is intended.`
-            this.error(message)
+            this.warn(message)
           }
 
           return options.idOnly


### PR DESCRIPTION
### Description

The message says "it's automatically externalized" so it should call `this.warn` instead of `this.error`.

refs #18584

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
