### PR TITLE
fix: use `nodeLikeBuiltins` for `ssr.target: 'webworker'` without `noExternal: true`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -925,8 +925,10 @@ function resolveEnvironmentResolveOptions(
           : DEFAULT_SERVER_CONDITIONS.filter((c) => c !== 'browser'),
       builtins:
         resolve?.builtins ??
-        (consumer === 'server' && !isSsrTargetWebworkerEnvironment
-          ? nodeLikeBuiltins
+        (consumer === 'server'
+          ? isSsrTargetWebworkerEnvironment && resolve?.noExternal === true
+            ? []
+            : nodeLikeBuiltins
           : []),
     },
     resolve ?? {},


### PR DESCRIPTION
### Description

Previously the `Cannot bundle Node.js built-in` error was only shown when `noExternal: true` is set.
https://github.com/vitejs/vite/pull/18584/files#diff-9b81bb364c02eab9494a7d27a5effc400cacbffd3b8f349c192f890c37bfc83fL429-L445
To align with that, this PR sets `nodeLikeBuiltins` by default for `ssr.target: 'webworker'` without `noExternal: true`.

This should fix the ecosystem-ci failure of waku: https://github.com/vitejs/vite-ecosystem-ci/actions/runs/13024909071/job/36332279608

refs #18584

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
