### PR TITLE
fix: don't call next middleware if user sent response in proxy.bypass

### DIFF
--- a/packages/vite/src/node/server/middlewares/proxy.ts
+++ b/packages/vite/src/node/server/middlewares/proxy.ts
@@ -225,6 +225,9 @@ export function proxyMiddleware(
             if (typeof bypassResult === 'string') {
               debug?.(`bypass: ${req.url} -> ${bypassResult}`)
               req.url = bypassResult
+              if (res.writableEnded) {
+                return
+              }
               return next()
             }
             if (bypassResult === false) {


### PR DESCRIPTION
### Description

This PR fixes this error that is happening when running the tests.
https://github.com/vitejs/vite/actions/runs/12984018538/job/36206191497#step:13:107

refs #18940

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
