### PR TITLE
test: handle proxy error message

### DIFF
--- a/playground/proxy-bypass/__tests__/proxy-bypass.spec.ts
+++ b/playground/proxy-bypass/__tests__/proxy-bypass.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { browserLogs, isServe, page, serverLogs } from '~utils'
+import { browserLogs, page, serverLogs } from '~utils'
 
 test('proxy-bypass', async () => {
   await vi.waitFor(() => {
@@ -12,7 +12,7 @@ test('async-proxy-bypass', async () => {
   expect(content).toContain('Hello after 4 ms (async timeout)')
 })
 
-test.runIf(isServe)('async-proxy-bypass-with-error', async () => {
+test('async-proxy-bypass-with-error', async () => {
   await vi.waitFor(() => {
     expect(serverLogs.join('\n')).toContain('bypass error')
   })

--- a/playground/proxy-bypass/vite.config.js
+++ b/playground/proxy-bypass/vite.config.js
@@ -30,4 +30,18 @@ export default defineConfig({
       },
     },
   },
+  plugins: [
+    {
+      name: 'handle-error-in-preview',
+      configurePreviewServer({ config, middlewares }) {
+        return () => {
+          middlewares.use((err, _req, res, _next) => {
+            config.logger.error(err.message, { error: err })
+            res.statusCode = 500
+            res.end()
+          })
+        }
+      },
+    },
+  ],
 })


### PR DESCRIPTION
### Description

This PR makes this error message not to be shown when running the tests.
https://github.com/vitejs/vite/actions/runs/12984018538/job/36206191497#step:13:120
It also makes the test to pass in `test-build`.

refs https://github.com/vitejs/vite/pull/18940

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
