### PR TITLE
fix: avoid packageJson without name in `resolveLibCssFilename`

### DIFF
--- a/packages/vite/src/node/__tests__/build.spec.ts
+++ b/packages/vite/src/node/__tests__/build.spec.ts
@@ -410,16 +410,15 @@ describe('resolveLibFilename', () => {
   })
 
   test('missing filename', () => {
-    expect(() => {
-      resolveLibFilename(
-        {
-          entry: 'mylib.js',
-        },
-        'es',
-        'myLib',
-        resolve(__dirname, 'packages/noname'),
-      )
-    }).toThrow()
+    const filename = resolveLibFilename(
+      {
+        entry: 'mylib.js',
+      },
+      'es',
+      'myLib',
+      resolve(__dirname, 'packages/noname'),
+    )
+    expect(filename).toBe('named-testing-package.mjs')
   })
 
   test('commonjs package extensions', () => {

--- a/packages/vite/src/node/__tests__/packages/module/package.json
+++ b/packages/vite/src/node/__tests__/packages/module/package.json
@@ -1,3 +1,4 @@
 {
+  "name": "mylib",
   "type": "module"
 }

--- a/packages/vite/src/node/__tests__/packages/package.json
+++ b/packages/vite/src/node/__tests__/packages/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "named-testing-package"
+}

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -60,7 +60,7 @@ import { dataURIPlugin } from './plugins/dataUri'
 import { buildImportAnalysisPlugin } from './plugins/importAnalysisBuild'
 import { ssrManifestPlugin } from './ssr/ssrManifestPlugin'
 import { buildLoadFallbackPlugin } from './plugins/loadFallback'
-import { findNearestPackageData } from './packages'
+import { findNearestMainPackageData, findNearestPackageData } from './packages'
 import type { PackageCache } from './packages'
 import {
   getResolvedOutDirs,
@@ -919,7 +919,7 @@ export function resolveLibFilename(
     return libOptions.fileName(format, entryName)
   }
 
-  const packageJson = findNearestPackageData(root, packageCache)?.data
+  const packageJson = findNearestMainPackageData(root, packageCache)?.data
   const name =
     libOptions.fileName ||
     (packageJson && typeof libOptions.entry === 'string'

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -91,7 +91,7 @@ import type { TransformPluginContext } from '../server/pluginContainer'
 import { searchForWorkspaceRoot } from '../server/searchRoot'
 import { type DevEnvironment } from '..'
 import type { PackageCache } from '../packages'
-import { findNearestPackageData } from '../packages'
+import { findNearestMainPackageData } from '../packages'
 import { addToHTMLProxyTransformResult } from './html'
 import {
   assetUrlRE,
@@ -3462,9 +3462,8 @@ export function resolveLibCssFilename(
     return `${libOptions.fileName}.css`
   }
 
-  const packageJson = findNearestPackageData(root, packageCache)?.data
-  const name =
-    packageJson && packageJson.name ? getPkgName(packageJson.name) : undefined
+  const packageJson = findNearestMainPackageData(root, packageCache)?.data
+  const name = packageJson ? getPkgName(packageJson.name) : undefined
 
   if (!name)
     throw new Error(

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3463,7 +3463,7 @@ export function resolveLibCssFilename(
   }
 
   const packageJson = findNearestPackageData(root, packageCache)?.data
-  const name = packageJson ? getPkgName(packageJson.name) : undefined
+  const name = (packageJson && packageJson.name) ? getPkgName(packageJson.name) : undefined
 
   if (!name)
     throw new Error(

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3463,7 +3463,8 @@ export function resolveLibCssFilename(
   }
 
   const packageJson = findNearestPackageData(root, packageCache)?.data
-  const name = (packageJson && packageJson.name) ? getPkgName(packageJson.name) : undefined
+  const name =
+    packageJson && packageJson.name ? getPkgName(packageJson.name) : undefined
 
   if (!name)
     throw new Error(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -433,6 +433,8 @@ importers:
 
   packages/vite/src/node/__tests__/fixtures/test-dep-conditions: {}
 
+  packages/vite/src/node/__tests__/packages: {}
+
   packages/vite/src/node/__tests__/packages/child: {}
 
   packages/vite/src/node/__tests__/packages/module: {}


### PR DESCRIPTION
### Description

Fix the issue when there is no package name in package.json.

which causes errors like below:

```
[vite:css-post] Cannot read properties of undefined (reading '0')
[vite:css-post] Cannot read properties of undefined (reading '0')
    at getPkgName (/.../node_modules/vite/dist/node/chunks/dep-M1IYMR16.js:10488:14)
    at resolveLibCssFilename (/.../node_modules/vite/dist/node/chunks/dep-M1IYMR16.js:50127:30)
```