### PR TITLE
feat: support for env var for defining allowed hosts

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -56,6 +56,10 @@ If a string starts with `.`, it will allow that hostname without the `.` and all
 If set to `true`, the server is allowed to respond to requests for any hosts.
 This is not recommended as it will be vulnerable to DNS rebinding attacks.
 
+::: details Configure via environment variable
+You can set the environment variable `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` to add an additional allowed host.
+:::
+
 ## server.port
 
 - **Type:** `number`

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1158,11 +1158,8 @@ export function resolveServerOptions(
     process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS &&
     Array.isArray(server.allowedHosts)
   ) {
-    const additionalHosts = process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
-      .split(',')
-      .map((h) => h.trim())
-
-    server.allowedHosts = [...server.allowedHosts, ...additionalHosts]
+    const additionalHost = process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
+    server.allowedHosts = [...server.allowedHosts, additionalHost]
   }
 
   return server

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1154,6 +1154,17 @@ export function resolveServerOptions(
     )
   }
 
+  if (
+    process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS &&
+    Array.isArray(server.allowedHosts)
+  ) {
+    const additionalHosts = process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
+      .split(',')
+      .map((h) => h.trim())
+
+    server.allowedHosts = [...server.allowedHosts, ...additionalHosts]
+  }
+
   return server
 }
 


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

Fixes #19273. This allows for users to define allowed hosts using environment variables, this is specifically useful for online sandbox environments like CodeSandbox that host the http dev server behind an https proxy.

Two questions:

1. Is this the right place to add this check?
2. Should I also add documentation for this? Not sure if this is something that you want to explicitly expose.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
