### PR TITLE
fix(ssr): fix transform error due to export all id scope

### DIFF
--- a/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrTransform.spec.ts
@@ -126,6 +126,44 @@ test('export * as from', async () => {
     `)
 })
 
+test('re-export by imported name', async () => {
+  expect(
+    await ssrTransformSimpleCode(`\
+import * as foo from 'foo'
+export * as foo from 'foo'
+`),
+  ).toMatchInlineSnapshot(`
+    "const __vite_ssr_import_0__ = await __vite_ssr_import__("foo");
+    const __vite_ssr_import_1__ = await __vite_ssr_import__("foo");
+    Object.defineProperty(__vite_ssr_exports__, "foo", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_1__ }});
+    "
+  `)
+
+  expect(
+    await ssrTransformSimpleCode(`\
+import { foo } from 'foo'
+export { foo } from 'foo'
+`),
+  ).toMatchInlineSnapshot(`
+      "const __vite_ssr_import_0__ = await __vite_ssr_import__("foo", {"importedNames":["foo"]});
+      const __vite_ssr_import_1__ = await __vite_ssr_import__("foo", {"importedNames":["foo"]});
+      Object.defineProperty(__vite_ssr_exports__, "foo", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_1__.foo }});
+      "
+    `)
+
+  expect(
+    await ssrTransformSimpleCode(`\
+import { foo } from 'foo'
+export { foo as foo } from 'foo'
+`),
+  ).toMatchInlineSnapshot(`
+      "const __vite_ssr_import_0__ = await __vite_ssr_import__("foo", {"importedNames":["foo"]});
+      const __vite_ssr_import_1__ = await __vite_ssr_import__("foo", {"importedNames":["foo"]});
+      Object.defineProperty(__vite_ssr_exports__, "foo", { enumerable: true, configurable: true, get(){ return __vite_ssr_import_1__.foo }});
+      "
+    `)
+})
+
 test('export * as from arbitrary module namespace identifier', async () => {
   expect(
     await ssrTransformSimpleCode(`export * as "arbitrary string" from 'vue'`),

--- a/packages/vite/src/node/ssr/ssrTransform.ts
+++ b/packages/vite/src/node/ssr/ssrTransform.ts
@@ -714,7 +714,12 @@ function isRefIdentifier(id: Identifier, parent: _Node, parentStack: _Node[]) {
     return false
   }
 
-  if (parent.type === 'ExportSpecifier') {
+  // export { id } from "lib"
+  // export * as id from "lib"
+  if (
+    parent.type === 'ExportSpecifier' ||
+    parent.type === 'ExportAllDeclaration'
+  ) {
     return false
   }
 


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19329
- Closes https://github.com/vitest-dev/vitest/issues/7394

Even on Vite 5, SSR transform wasn't properly handling the identifier from `export * as id from ".."` as seen by the same repro https://stackblitz.com/edit/github-pnyojxdr-mena4fdt?file=repro-vite.js

```js
const __vite_ssr_import_0__ = await __vite_ssr_import__('x');

const __vite_ssr_import_1__ = await __vite_ssr_import__('x');

Object.defineProperty(__vite_ssr_exports__, 'x', {
  enumerable: true,
  configurable: true,
  get() {
    return __vite_ssr_import_1__;
  },
});
__vite_ssr_import_0__; /// <-- what's this?
```

I haven't investigated why this now causes magic-string error, but this can be fixed by fixing `isRefIdentifier` to skip identifiers inside `export * ...`.