### PR TITLE
refactor: deprecate `vite optimize` command

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -79,6 +79,8 @@ vite build [root]
 
 Pre-bundle dependencies.
 
+**Deprecated**: the pre-bundle process runs automatically and does not need to be called.
+
 #### Usage
 
 ```bash

--- a/packages/vite/src/node/cli.ts
+++ b/packages/vite/src/node/cli.ts
@@ -333,7 +333,10 @@ cli
 
 // optimize
 cli
-  .command('optimize [root]', 'pre-bundle dependencies')
+  .command(
+    'optimize [root]',
+    'pre-bundle dependencies (deprecated, the pre-bundle process runs automatically and does not need to be called)',
+  )
   .option(
     '--force',
     `[boolean] force the optimizer to ignore the cache and re-bundle`,

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -246,6 +246,8 @@ export interface DepOptimizationMetadata {
 /**
  * Scan and optimize dependencies within a project.
  * Used by Vite CLI when running `vite optimize`.
+ *
+ * @deprecated the optimization process runs automatically and does not need to be called
  */
 
 export async function optimizeDeps(
@@ -254,6 +256,12 @@ export async function optimizeDeps(
   asCommand = false,
 ): Promise<DepOptimizationMetadata> {
   const log = asCommand ? config.logger.info : debug
+
+  config.logger.warn(
+    colors.yellow(
+      'manually calling optimizeDeps is deprecated. This is done automatically and does not need to be called manually.',
+    ),
+  )
 
   const environment = new ScanEnvironment('client', config)
   await environment.init()


### PR DESCRIPTION
### Description

The pre-bundle process runs automatically and does not need to be called manually. This command made sense when the optimizer didn't run automatically (I guess?) and took time to complete (as it was using rollup), but now none of those applies.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
