### PR TITLE
feat: expose version at ConfigEnv

### DIFF
--- a/packages/vite/src/node/__tests__/runnerImport.spec.ts
+++ b/packages/vite/src/node/__tests__/runnerImport.spec.ts
@@ -54,7 +54,7 @@ describe('importing files using inlined environment', () => {
     await expect(async () => {
       const root = resolve(import.meta.dirname, './fixtures/runner-import')
       await loadConfigFromFile(
-        { mode: 'production', command: 'serve' },
+        { mode: 'production', command: 'serve', version: '6.6.6' },
         resolve(root, './vite.config.outside-pkg-import.mts'),
         root,
         'silent',

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_SERVER_MAIN_FIELDS,
   ENV_ENTRY,
   FS_PREFIX,
+  VERSION,
 } from './constants'
 import type {
   FalsyPlugin,
@@ -116,6 +117,7 @@ export interface ConfigEnv {
   mode: string
   isSsrBuild?: boolean
   isPreview?: boolean
+  version: string
 }
 
 /**
@@ -1033,6 +1035,7 @@ export async function resolveConfig(
     command,
     isSsrBuild: command === 'build' && !!config.build?.ssr,
     isPreview,
+    version: VERSION,
   }
 
   let { configFile } = config

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1035,6 +1035,7 @@ export async function resolveConfig(
     command,
     isSsrBuild: command === 'build' && !!config.build?.ssr,
     isPreview,
+    // https://github.com/vitejs/vite/pull/19355
     version: VERSION,
   }
 

--- a/playground/vitestSetup.ts
+++ b/playground/vitestSetup.ts
@@ -247,7 +247,11 @@ export async function startDefaultServe(): Promise<void> {
 
   if (!isBuild) {
     process.env.VITE_INLINE = 'inline-serve'
-    const config = await loadConfig({ command: 'serve', mode: 'development' })
+    const config = await loadConfig({
+      command: 'serve',
+      mode: 'development',
+      version: '6.6.6',
+    })
     viteServer = server = await (await createServer(config)).listen()
     viteTestUrl = server.resolvedUrls.local[0]
     if (server.config.base === '/') {
@@ -264,7 +268,11 @@ export async function startDefaultServe(): Promise<void> {
       },
     })
     const buildConfig = mergeConfig(
-      await loadConfig({ command: 'build', mode: 'production' }),
+      await loadConfig({
+        command: 'build',
+        mode: 'production',
+        version: '6.6.6',
+      }),
       {
         plugins: [resolvedPlugin()],
       },
@@ -289,6 +297,7 @@ export async function startDefaultServe(): Promise<void> {
       command: 'serve',
       mode: 'development',
       isPreview: true,
+      version: '6.6.6',
     })
     const _nodeEnv = process.env.NODE_ENV
     const previewServer = await preview(previewConfig)


### PR DESCRIPTION
### Description

`import { version } from 'vite'` isn't reliable: because, with monorepos, it oftens returns the "wrong version" (it returns the version of the locally resolved `vite`, but not the version of `vite` that is actually running).

This PR adds `ConfigEnv['version']` so that meta frameworks can check whether the user is using a supported Vite version.

For example Vike ensures that the user is using a supported Vite version and shows a helpful error message if the user doesn't:
- https://github.com/vikejs/vike/blob/13745b05e33cd8b22b8d1a58fc54e4775fb04e90/vike/node/plugin/onLoad.ts#L14
- https://github.com/vikejs/vike/blob/13745b05e33cd8b22b8d1a58fc54e4775fb04e90/vike/utils/assertVersion.ts#L15

The only reliable solution I can think of is for Vite to expose its version to Vite plugins.

The earlier the version is exposed the better. For example, exposing the version as `ResolvedConfig['version']` would be too late: at that point Vike already uses functionalities of later Vite versions. Exposing the version over `ConfigEnv` has the advantage that the it's accessible early.

Related PR: https://github.com/vitejs/vite/pull/8456.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
