### PR TITLE
fix: avoid builtStart during vite optimize

### DIFF
--- a/packages/vite/src/node/idResolver.ts
+++ b/packages/vite/src/node/idResolver.ts
@@ -72,6 +72,8 @@ export function createIdResolver(
             idOnly: true,
           }),
         ],
+        undefined,
+        false,
       )
       pluginContainerMap.set(environment, pluginContainer)
     }
@@ -92,6 +94,8 @@ export function createIdResolver(
       pluginContainer = await createEnvironmentPluginContainer(
         environment as Environment,
         [aliasPlugin({ entries: environment.config.resolve.alias })],
+        undefined,
+        false,
       )
       aliasOnlyPluginContainerMap.set(environment, pluginContainer)
     }

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -67,6 +67,8 @@ export class ScanEnvironment extends BaseEnvironment {
     this._pluginContainer = await createEnvironmentPluginContainer(
       this,
       this.plugins,
+      undefined,
+      false,
     )
   }
 }

--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -136,11 +136,13 @@ export async function createEnvironmentPluginContainer(
   environment: Environment,
   plugins: Plugin[],
   watcher?: FSWatcher,
+  autoStart = true,
 ): Promise<EnvironmentPluginContainer> {
   const container = new EnvironmentPluginContainer(
     environment,
     plugins,
     watcher,
+    autoStart,
   )
   await container.resolveRollupOptions()
   return container
@@ -183,7 +185,9 @@ class EnvironmentPluginContainer {
     public environment: Environment,
     public plugins: Plugin[],
     public watcher?: FSWatcher,
+    autoStart = true,
   ) {
+    this._started = !autoStart
     this.minimalContext = new MinimalPluginContext(
       { rollupVersion, watchMode: true },
       environment,


### PR DESCRIPTION
fix #19316

### Description

Continuation from #19347. We started auto calling `builtStart` on `resolveId` in Vite 6, so #19347 didn't have any effect.

The PR is also disabling calling `buildStart` for the custom resolvers. This doesn't change anything, given that we only have two plugins (alias and resolve plugins) that don't have a `buildStart` hook. Given that we also needs the resolve plugin during optimize, probably a good idea to force disabling autoStart for these too.

I think we should deprecate `vite optimize` as we wanted and remove the new `autoStart` param later on.