### PR TITLE
test: isolate less js plugin test

### DIFF
--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -109,9 +109,9 @@ test('less', async () => {
 })
 
 test('less-plugin', async () => {
-  const body = await page.$('body')
+  const body = await page.$('.less-js-plugin')
   expect(await getBg(body)).toBe(
-    'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgEBAFPIhPsAAAAASUVORK5CYII=")',
+    'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjYGD4/x8AAwIB/8myre4AAAAASUVORK5CYII=")',
   )
 })
 

--- a/playground/css/index.html
+++ b/playground/css/index.html
@@ -63,6 +63,10 @@
   <div class="form-box-data-uri">
     tests Less's `data-uri()` function with relative image paths
   </div>
+  <div>
+    url in Less's JS plugin: This should have a blue square below
+    <div class="less-js-plugin"></div>
+  </div>
 
   <p class="stylus">Stylus: This should be blue</p>
   <p class="stylus-additional-data">

--- a/playground/css/less-plugin.less
+++ b/playground/css/less-plugin.less
@@ -1,5 +1,7 @@
 @plugin "less-plugin/test.js";
 
-body {
+.less-js-plugin {
+  height: 1em;
+  width: 1em;
   background-image: test();
 }

--- a/playground/css/less-plugin/test.js
+++ b/playground/css/less-plugin/test.js
@@ -1,5 +1,5 @@
 functions.add('test', function test() {
   const transparentPng =
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgEBAFPIhPsAAAAASUVORK5CYII='
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAAXNSR0IArs4c6QAAAA1JREFUGFdjYGD4/x8AAwIB/8myre4AAAAASUVORK5CYII='
   return `url(${transparentPng})`
 })


### PR DESCRIPTION
### Description

When I opened the CSS playground, this was shown.
![image](https://github.com/user-attachments/assets/4a365fde-8c6a-40f0-bab0-4ae9feac343a)
This was caused because the test case added in #19269 was adding a background to `body`. I updated that test to add the background style to a newly added `div`.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
