### PR TITLE
feat: track dependencies when loading config with native

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -46,7 +46,8 @@
     "#module-sync-enabled": {
       "module-sync": "./misc/true.js",
       "default": "./misc/false.js"
-    }
+    },
+    "#deps-tracker": "./dist/node/deps-tracker.js"
   },
   "files": [
     "bin",

--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -199,6 +199,14 @@ const moduleRunnerConfig = defineConfig({
   ],
 })
 
+const depsTrackerConfig = defineConfig({
+  ...sharedNodeOptions,
+  input: {
+    'deps-tracker': path.resolve(__dirname, 'src/deps-tracker/index.ts'),
+  },
+  plugins: [...createSharedNodePlugins({}), bundleSizeLimit(2)],
+})
+
 const cjsConfig = defineConfig({
   ...sharedNodeOptions,
   input: {
@@ -223,6 +231,7 @@ export default defineConfig([
   clientConfig,
   nodeConfig,
   moduleRunnerConfig,
+  depsTrackerConfig,
   cjsConfig,
 ])
 

--- a/packages/vite/src/deps-tracker/index.ts
+++ b/packages/vite/src/deps-tracker/index.ts
@@ -1,0 +1,52 @@
+import type { MessagePort } from 'node:worker_threads'
+import type { InitializeHook, ResolveHook } from 'node:module'
+
+const tQueryRE = /(?:\?|&)t=(\d+)(?:&|$)/
+const relativeImportRE = /^\.{1,2}(?:\/|\\)/
+
+let port: MessagePort
+let enabled = false
+
+export const initialize: InitializeHook = async ({
+  port: _port,
+  time: _time,
+}: {
+  port: MessagePort
+  time: string
+}) => {
+  port = _port
+  port.on('message', (_enabled) => {
+    enabled = _enabled
+  })
+}
+
+export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
+  const isRelativeImport = relativeImportRE.test(specifier)
+  const result = await nextResolve(specifier, context)
+  if (result.format === 'builtin' || !isRelativeImport) return result
+
+  if (
+    // when tracking is not enabled
+    !enabled ||
+    // when parent does not exist (it is not a dependency of config file)
+    !context.parentURL ||
+    // if the t query is already present, do not add it
+    tQueryRE.test(result.url) ||
+    // if it's not a file url, no need to add the t query
+    !result.url.startsWith('file:')
+  )
+    return result
+
+  // propergate the t query
+  const m = tQueryRE.exec(context.parentURL)
+  if (m) {
+    // all dependencies from the config should have the t query
+    port.postMessage(result.url)
+
+    result.url = result.url.replace(
+      /(\?)|$/,
+      (_n, n1) => `?t=${m[1]}${n1 === '?' ? '&' : ''}`,
+    )
+  }
+  return result
+}

--- a/packages/vite/src/deps-tracker/index.ts
+++ b/packages/vite/src/deps-tracker/index.ts
@@ -1,11 +1,10 @@
 import type { MessagePort } from 'node:worker_threads'
 import type { InitializeHook, ResolveHook } from 'node:module'
 
-const tQueryRE = /(?:\?|&)t=(\d+)(?:&|$)/
+const tQueryRE = /(?:\?|&)t=(\d+),([^&]+)(?:&|$)/
 const relativeImportRE = /^\.{1,2}(?:\/|\\)/
 
 let port: MessagePort
-let enabled = false
 
 export const initialize: InitializeHook = async ({
   port: _port,
@@ -15,9 +14,6 @@ export const initialize: InitializeHook = async ({
   time: string
 }) => {
   port = _port
-  port.on('message', (_enabled) => {
-    enabled = _enabled
-  })
 }
 
 export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
@@ -26,8 +22,6 @@ export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
   if (result.format === 'builtin' || !isRelativeImport) return result
 
   if (
-    // when tracking is not enabled
-    !enabled ||
     // when parent does not exist (it is not a dependency of config file)
     !context.parentURL ||
     // if the t query is already present, do not add it
@@ -40,12 +34,13 @@ export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
   // propergate the t query
   const m = tQueryRE.exec(context.parentURL)
   if (m) {
+    const [, time, contextFile] = m
     // all dependencies from the config should have the t query
-    port.postMessage(result.url)
+    port.postMessage({ context: contextFile, url: result.url })
 
     result.url = result.url.replace(
       /(\?)|$/,
-      (_n, n1) => `?t=${m[1]}${n1 === '?' ? '&' : ''}`,
+      (_n, n1) => `?t=${time},${contextFile}${n1 === '?' ? '&' : ''}`,
     )
   }
   return result

--- a/packages/vite/src/deps-tracker/tsconfig.json
+++ b/packages/vite/src/deps-tracker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["./"],
+  "compilerOptions": {
+    // https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-18
+    "lib": ["ES2023"],
+    "target": "ES2022",
+    "skipLibCheck": true, // lib check is done on final types
+    "stripInternal": true
+  }
+}

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1777,7 +1777,7 @@ export async function loadConfigFromFile(
   }
 }
 
-export async function nativeImportConfigFile(
+async function nativeImportConfigFile(
   resolvedPath: string,
 ): Promise<{ configExport: any; dependencies: string[] }> {
   depsTracker ??= createDepsTracker()


### PR DESCRIPTION
### Description

reopen of #19350

Adds support for restarting the server when the dependency of the config file is edited.

I haven't wrote the tests yet.

refs #19178

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
