### PR TITLE
ci: update react-swc plugin version in create-vite by renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["\\.[mc]?[tj]sx?$"],
+      "fileMatch": ["packages\/create-vite\/src\/index\\.ts$"],
       "matchStrings": [
         "\/\/\\s*renovate:\\s+datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+(?:var|let|const)\\s+\\S+\\s*=\\s*[\"'](?<currentValue>[^\"']+)[\"']",
       ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,4 +28,13 @@
     // breaking changes
     "kill-port", // `kill-port:^2.0.0 has perf issues (#8392)
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["\\.[mc]?[tj]sx?$"],
+      "matchStrings": [
+        "\/\/\\s*renovate:\\s+datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s+(?:var|let|const)\\s+\\S+\\s*=\\s*[\"'](?<currentValue>[^\"']+)[\"']",
+      ],
+    },
+  ],
 }

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -593,10 +593,13 @@ function pkgFromUserAgent(userAgent: string | undefined): PkgInfo | undefined {
 }
 
 function setupReactSwc(root: string, isTs: boolean) {
+  // renovate: datasource=npm depName=@vitejs/plugin-react-swc
+  const reactSwcPluginVersion = '3.7.2'
+
   editFile(path.resolve(root, 'package.json'), (content) => {
     return content.replace(
       /"@vitejs\/plugin-react": ".+?"/,
-      `"@vitejs/plugin-react-swc": "^3.7.2"`,
+      `"@vitejs/plugin-react-swc": "^${reactSwcPluginVersion}"`,
     )
   })
   editFile(


### PR DESCRIPTION
### Description

By using custom manager feature, it should be possible to auto update react-swc plugin version in the source code as well.
https://docs.renovatebot.com/modules/manager/regex/

refs #19384

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
