### PR TITLE
docs: extract introduction section

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -232,16 +232,25 @@ export default defineConfig({
     sidebar: {
       '/guide/': [
         {
-          text: 'Guide',
+          text: 'Introduction',
           items: [
-            {
-              text: 'Why Vite',
-              link: '/guide/why',
-            },
             {
               text: 'Getting Started',
               link: '/guide/',
             },
+            {
+              text: 'Philosophy',
+              link: '/guide/philosophy',
+            },
+            {
+              text: 'Why Vite',
+              link: '/guide/why',
+            },
+          ],
+        },
+        {
+          text: 'Guide',
+          items: [
             {
               text: 'Features',
               link: '/guide/features',
@@ -293,10 +302,6 @@ export default defineConfig({
             {
               text: 'Performance',
               link: '/guide/performance',
-            },
-            {
-              text: 'Philosophy',
-              link: '/guide/philosophy',
             },
             {
               text: 'Migration from v5',


### PR DESCRIPTION
### Description

Made a new introduction section in the sidebar and moved some pages into that (idea from Vitest's docs).
Also changed the order so the page that users likely to see are listed first.

![image](https://github.com/user-attachments/assets/72b95ee5-a6e3-455c-aa23-59f22657cd9d)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
