### PR TITLE
feat: use host url to open browser

### DIFF
--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -659,14 +659,14 @@ export async function _createServer(
     openBrowser() {
       const options = server.config.server
       const host = options.host
-      let url = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+      let url: string | undefined
       if (typeof host === 'string') {
-        url =
-          [
-            ...(server.resolvedUrls?.local ?? []),
-            ...(server.resolvedUrls?.network ?? []),
-          ].find((url) => url.includes(host)) || url
+        url = [
+          ...(server.resolvedUrls?.local ?? []),
+          ...(server.resolvedUrls?.network ?? []),
+        ].find((url) => url.includes(host))
       }
+      url ??= server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
       if (url) {
         const path =
           typeof options.open === 'string'

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -658,8 +658,15 @@ export async function _createServer(
     },
     openBrowser() {
       const options = server.config.server
-      const url =
-        server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+      const host = options.host
+      let url = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+      if (typeof host === 'string') {
+        url =
+          [
+            ...(server.resolvedUrls?.local ?? []),
+            ...(server.resolvedUrls?.network ?? []),
+          ].find((url) => url.includes(host)) || url
+      }
       if (url) {
         const path =
           typeof options.open === 'string'


### PR DESCRIPTION
### Description

When I use `vite-plugin-mkcert`, this issue occurs，this change will have an expression different from the previous version.
``` vite.conf.mts
server: {
    host: 'dev.aaaa.com',
    open: true
  }
```
Here, the host is configured as `dev.aaaa.com`. In previous versions, starting `vite` would automatically open `https://dev.aaaa.com:5137/`.
In the new version, it will open `https://localhost:5173/`.

To maintain consistency with the previous version, need to modify `server.open` in `vite.conf.mts` to `https://dev.aaaa.com:5173/`.


Can it be opened using the domain name of `serve.host` instead of `https://localhost:5173/`?

Related: https://github.com/vitejs/vite/pull/19317#issuecomment-2650457444

---
It seems to be the first domain automatically opened.

https://github.com/vitejs/vite/blob/051370a332df99d107365ed6beab418ef017eff6/packages/vite/src/node/server/index.ts#L661-L662