### PR TITLE
docs: use "constants" instead of "constant variables"

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -137,7 +137,7 @@ Alternatively, you can add `vite/client` to `compilerOptions.types` inside `tsco
 This will provide the following type shims:
 
 - Asset imports (e.g. importing an `.svg` file)
-- Types for the Vite-injected [constant variables](./env-and-mode#env-variables) on `import.meta.env`
+- Types for the Vite-injected [constants](./env-and-mode#env-variables) on `import.meta.env`
 - Types for the [HMR API](./api-hmr) on `import.meta.hot`
 
 ::: tip


### PR DESCRIPTION
### Description

This is another follow up PR for #18941, just adjusting one phrase. The original change is here: https://github.com/vitejs/vite/pull/18941/files#diff-f4ae8101ad2153be3871b70afa9dda69e0e4c90036614e1d713fff85b1993348R140

I assume the original PR intends to replace "env variable" with "constants" to avoid confusion so we want to use only "constants" here too (but I'm not fully confident as I don't know what the actual type shims is here in my limited knowledge).

/cc @sapphi-red 