### PR TITLE
feat: add support for unsetEnv config option

### DIFF
--- a/docs/config/shared-options.md
+++ b/docs/config/shared-options.md
@@ -486,6 +486,23 @@ define: {
 
 :::
 
+## unsetEnv
+
+- **Type:** `'error' | 'warn' | 'off'`
+- **Default:** `'off'`
+
+Controls the behaviour when an unset environment variable is encountered during build.
+
+- `'error'` - throw an error and abort the build
+- `'warn'` - write a warning and continue
+- `'off'` - disable this check
+
+:::warning WARNING
+
+If set to `'warn'` or `'off'` any unset environment variables will be replaced with `undefined`.
+
+:::
+
 ## appType
 
 - **Type:** `'spa' | 'mpa' | 'custom'`

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -415,6 +415,11 @@ export interface UserConfig extends DefaultEnvironmentOptions {
    */
   envPrefix?: string | string[]
   /**
+   * What to do with unset environment variables during build. Available options: 'error', 'warn' and 'off'
+   * @default 'off'
+   */
+  unsetEnv?: 'error' | 'warn' | 'off'
+  /**
    * Worker bundle options
    */
   worker?: {

--- a/packages/vite/src/node/plugins/define.ts
+++ b/packages/vite/src/node/plugins/define.ts
@@ -161,7 +161,22 @@ export function definePlugin(config: ResolvedConfig): Plugin {
         // Replace `import.meta.env.*` with undefined
         result.code = result.code.replaceAll(
           getImportMetaEnvKeyRe(marker),
-          (m) => 'undefined'.padEnd(m.length),
+          (m) => {
+            if (config.unsetEnv && config.unsetEnv !== 'off') {
+              // Add 1 to account for the dot after the marker
+              const variableName = m.slice(marker.length + 1)
+
+              const message = `Environment variable ${variableName} is unset. Referenced in ${id}`
+
+              if (config.unsetEnv === 'error') {
+                throw new Error(message)
+              } else if (config.unsetEnv === 'warn') {
+                config.logger.warnOnce(message)
+              }
+            }
+
+            return 'undefined'.padEnd(m.length)
+          },
         )
 
         // If there's bare `import.meta.env` references, prepend the banner


### PR DESCRIPTION
### Description

This adds a new config option `unsetEnv` which controls how the `vite build` command behaves when an unset environment variable is encountered.

This aims to protect against missing variables when performing a production build. These issues could be caught by a schema validation approach but only at runtime after the new version has been deployed. If `unsetEnv` would be set to `error` this would fail the build and the whole pipeline preventing the deployment.

This is backwards compatible, as the default value is `off` and doesn't alter the build process if left unchanged.

I'm aware of the argument made by @bluwy in https://github.com/vitejs/vite/issues/8021 but I believe this isn't a concern here because:
1. This is `off` by default
2. If not `off`, it can be disabled in the config.
3. Keeping it enabled and adding an intentionally `undefined` variable would be caught at build time without risk of any production issues.
4. If keeping it enabled is preferable but the developer still wants to have a deliberately `undefined` env variable they can designate a special string value to the variable (such as `'undefined'`) and cast it to `undefined` in code.
As a side note, I believe deliberately omitting an env variable isn't the best practice as it suggests a mistake in the configuration rather than an intentional action.

### Dev build

While this PR adds unset env variable check in production build it does nothing during development. If you feel like extending this behaviour to the dev build is desired I can add it to the PR. I briefly tested the `Proxy` approach mentioned by @bluwy in https://github.com/vitejs/vite/issues/8021 and it can be done although it has two limitations:
1. It cannot fail the build, at most throw an error or write a `console.error` in the browser.
2. ~~The file using the missing env variable has to be loaded for it to catch the issue.~~ The missing env variable has to be accessed for it to catch the issue.

### Further considerations

- Set it to `warn` by default? Still maintains BC with regard to output files and success/failure of the build but changes the build console output.
- Add a sentence explaining how to disable the error/warning in the error/warning message itself?