### PR TITLE
fix(worker): fix web worker type detection

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -160,4 +160,21 @@ worker.addEventListener('message', (ev) => text('.simple-worker-url', JSON.strin
       'Expected object spread to be used before the definition of the type property. Vite needs a static value for the type property to correctly infer it.',
     )
   })
+
+  test('find closing parenthesis correctly', async () => {
+    expect(
+      await transform(
+        `(() => { new Worker(new URL('./worker', import.meta.url)); repro({ test: "foo", }); })();`,
+      ),
+    ).toMatchInlineSnapshot(
+      `"(() => { new Worker(new URL(/* @vite-ignore */ "/worker?worker_file&type=classic", import.meta.url)); repro({ test: "foo", }); })();"`,
+    )
+    expect(
+      await transform(
+        `repro(new Worker(new URL('./worker', import.meta.url)), { type: "module" })`,
+      ),
+    ).toMatchInlineSnapshot(
+      `"repro(new Worker(new URL(/* @vite-ignore */ "/worker?worker_file&type=classic", import.meta.url)), { type: "module" })"`,
+    )
+  })
 })

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -30,7 +30,7 @@ function err(e: string, pos: number) {
 function findClosingParen(input: string, fromIndex: number) {
   let count = 1
 
-  for (let i = fromIndex + 1; i < input.length; i++) {
+  for (let i = fromIndex; i < input.length; i++) {
     if (input[i] === '(') count++
     if (input[i] === ')') count--
     if (count === 0) return i


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19458

`findClosingParen` was failing to find an immediate `)` due to an extra `+ 1`.