### PR TITLE
feat(module-runner): expose `evaluatedModules` on `import.meta.hot`

### DIFF
--- a/packages/vite/src/module-runner/hmrContext.ts
+++ b/packages/vite/src/module-runner/hmrContext.ts
@@ -1,0 +1,17 @@
+import { HMRContext } from '../shared/hmr'
+import type { EvaluatedModules } from './evaluatedModules'
+import type { ModuleRunner } from './runner'
+
+export class ModuleRunnerHMRContext extends HMRContext {
+  public evaluatedModules: EvaluatedModules
+
+  constructor(moduleRunner: ModuleRunner, url: string) {
+    if (!moduleRunner.hmrClient) {
+      throw new TypeError(
+        `Expected moduleRunner to have an HMR client. This is an error in Vite.`,
+      )
+    }
+    super(moduleRunner.hmrClient, url)
+    this.evaluatedModules = moduleRunner.evaluatedModules
+  }
+}

--- a/packages/vite/src/module-runner/types.ts
+++ b/packages/vite/src/module-runner/types.ts
@@ -1,4 +1,3 @@
-import type { ViteHotContext } from 'types/hot'
 import type { HMRLogger } from '../shared/hmr'
 import type {
   DefineImportMetadata,
@@ -20,13 +19,14 @@ import type {
   ssrModuleExportsKey,
 } from './constants'
 import type { InterceptorOptions } from './sourcemap/interceptor'
+import type { ModuleRunnerHMRContext } from './hmrContext'
 
 export type { DefineImportMetadata, SSRImportMetadata }
 
 export interface ModuleRunnerImportMeta extends ImportMeta {
   url: string
   env: ImportMetaEnv
-  hot?: ViteHotContext
+  hot?: ModuleRunnerHMRContext
   [key: string]: any
 }
 


### PR DESCRIPTION
### Description

This PR exposes `evaluatedModules` on `import.meta.hot` if the module is running by the module runner.

This is a continuation of https://github.com/vitejs/vite/pull/18092
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
