### PR TITLE
test: normalize debugId in snapshot

### DIFF
--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -141,7 +141,7 @@ describe.runIf(isBuild)('build tests', () => {
     const map = findAssetFile(/after-preload-dynamic-[-\w]{8}\.js\.map/)
     expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
       {
-        "debugId": "b4f4ae40-1415-414c-8350-c7286c81a413",
+        "debugId": "00000000-0000-0000-0000-000000000000",
         "ignoreList": [],
         "mappings": ";+8BAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
         "sources": [
@@ -180,7 +180,7 @@ describe.runIf(isBuild)('build tests', () => {
     const map = findAssetFile(/with-define-object.*\.js\.map/)
     expect(formatSourcemapForSnapshot(JSON.parse(map))).toMatchInlineSnapshot(`
       {
-        "debugId": "bd3962fc-edb5-4a6d-a5da-f27a1e5f3268",
+        "debugId": "00000000-0000-0000-0000-000000000000",
         "mappings": "qBAEA,SAASA,GAAO,CACJC,EAAA,CACZ,CAEA,SAASA,GAAY,CAEX,QAAA,MAAM,qBAAsBC,CAAkB,CACxD,CAEAF,EAAK",
         "sources": [
           "../../with-define-object.ts",

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -370,6 +370,9 @@ export const formatSourcemapForSnapshot = (map: any): any => {
   const m = { ...map }
   delete m.file
   delete m.names
+  if (m.debugId) {
+    m.debugId = '00000000-0000-0000-0000-000000000000'
+  }
   m.sources = m.sources.map((source) => source.replace(root, '/root'))
   if (m.sourceRoot) {
     m.sourceRoot = m.sourceRoot.replace(root, '/root')


### PR DESCRIPTION
### Description

We don't care about the value of `debugId` in our tests, so I added a code to normalize the value to `00000000-0000-0000-0000-000000000000` so that we don't need to update the snapshots frequently.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
