### PR TITLE
fix(worker): string interpolation in dynamic worker options

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -133,6 +133,26 @@ worker.addEventListener('message', (ev) => text('.simple-worker-url', JSON.strin
 "`)
   })
 
+  test('trailing comma', async () => {
+    expect(
+      await transform(`
+new Worker(
+  new URL('./worker.js', import.meta.url),
+  {
+    type: 'module'
+  }, // },
+)
+`),
+    ).toMatchInlineSnapshot(`"
+new Worker(
+  new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url),
+  {
+    type: 'module'
+  }, // },
+)
+"`)
+  })
+
   test('throws an error when non-static worker options are provided', async () => {
     await expect(
       transform(

--- a/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts
@@ -71,6 +71,16 @@ describe('workerImportMetaUrlPlugin', async () => {
     )
   })
 
+  test('with interpolated dynamic name field in worker options', async () => {
+    expect(
+      await transform(
+        'const id = 1; new Worker(new URL("./worker.js", import.meta.url), { name: `worker-${id}` })',
+      ),
+    ).toMatchInlineSnapshot(
+      `"const id = 1; new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=classic", import.meta.url), { name: \`worker-\${id}\` })"`,
+    )
+  })
+
   test('with dynamic name field and static type in worker options', async () => {
     expect(
       await transform(
@@ -78,6 +88,16 @@ describe('workerImportMetaUrlPlugin', async () => {
       ),
     ).toMatchInlineSnapshot(
       `"const id = 1; new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { name: "worker" + id, type: "module" })"`,
+    )
+  })
+
+  test('with interpolated dynamic name field and static type in worker options', async () => {
+    expect(
+      await transform(
+        'const id = 1; new Worker(new URL("./worker.js", import.meta.url), { name: `worker-${id}`, type: "module" })',
+      ),
+    ).toMatchInlineSnapshot(
+      `"const id = 1; new Worker(new URL(/* @vite-ignore */ "/worker.js?worker_file&type=module", import.meta.url), { name: \`worker-\${id}\`, type: "module" })"`,
     )
   })
 

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -149,9 +149,12 @@ async function getWorkerType(
   }
 
   // need to find in comment code
-  const workerOptString = raw
-    .substring(commaIndex + 1, endIndex)
-    .replace(/\}[\s\S]*,/g, '}') // strip trailing comma for parsing
+  let workerOptString = raw.substring(commaIndex + 1, endIndex).trim()
+
+  // strip trailing comma for parsing
+  if (workerOptString.endsWith(',')) {
+    workerOptString = workerOptString.slice(0, -1)
+  }
 
   const hasViteIgnore = hasViteIgnoreRE.test(workerOptString)
   if (hasViteIgnore) {

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -149,22 +149,25 @@ async function getWorkerType(
   }
 
   // need to find in comment code
-  let workerOptString = raw.substring(commaIndex + 1, endIndex).trim()
-
-  // strip trailing comma for parsing
-  if (workerOptString.endsWith(',')) {
-    workerOptString = workerOptString.slice(0, -1)
-  }
-
+  let workerOptString = raw.substring(commaIndex + 1, endIndex)
   const hasViteIgnore = hasViteIgnoreRE.test(workerOptString)
   if (hasViteIgnore) {
     return 'ignore'
   }
 
   // need to find in no comment code
-  const cleanWorkerOptString = clean.substring(commaIndex + 1, endIndex).trim()
-  if (!cleanWorkerOptString.length) {
+  const cleanWorkerOptString = clean.substring(commaIndex + 1, endIndex)
+  const trimmedCleanWorkerOptString = cleanWorkerOptString.trim()
+  if (!trimmedCleanWorkerOptString.length) {
     return 'classic'
+  }
+
+  // strip trailing comma for parsing
+  if (trimmedCleanWorkerOptString.endsWith(',')) {
+    workerOptString = workerOptString.slice(
+      0,
+      cleanWorkerOptString.lastIndexOf(','),
+    )
   }
 
   const workerOpts = await parseWorkerOptions(workerOptString, commaIndex + 1)

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -162,7 +162,7 @@ async function getWorkerType(
     return 'classic'
   }
 
-  // strip trailing comma for parsing
+  // strip trailing comma for evalValue
   if (trimmedCleanWorkerOptString.endsWith(',')) {
     workerOptString = workerOptString.slice(
       0,


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? --> 

Fixes a bug that unintentionally removes the backtick and comma at the end of a template literal in dynamic worker options.

Test failure without fix:

```
 FAIL  packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts > workerImportMetaUrlPlugin > with interpolated dynamic name field and static type in worker options
RollupError: Unexpected eof
 ❯ getRollupError node_modules/.pnpm/rollup@4.30.1/node_modules/rollup/dist/es/shared/parseAst.js:396:41
 ❯ convertProgram node_modules/.pnpm/rollup@4.30.1/node_modules/rollup/dist/es/shared/parseAst.js:1084:26
 ❯ parseAstAsync node_modules/.pnpm/rollup@4.30.1/node_modules/rollup/dist/es/shared/parseAst.js:2070:106
 ❯ parseWorkerOptions packages/vite/src/node/plugins/workerImportMetaUrl.ts:105:8
    103|   } catch {
    104|     const optsNode = (
    105|       (await parseAstAsync(`(${rawOpts})`))
       |        ^
    106|         .body[0] as RollupAstNode<ExpressionStatement>
    107|     ).expression
 ❯ getWorkerType packages/vite/src/node/plugins/workerImportMetaUrl.ts:169:22
 ❯ Object.transform packages/vite/src/node/plugins/workerImportMetaUrl.ts:239:30
 ❯ packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts:14:20
 ❯ packages/vite/src/node/__tests__/plugins/workerImportMetaUrl.spec.ts:96:7
```

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
