### PR TITLE
fix(css): temporary add `?.` after `this.getModuleInfo` in `vite:css-post`

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -645,11 +645,15 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
       // build CSS handling ----------------------------------------------------
 
-      const cssScopeTo = (
-        this.getModuleInfo(id)?.meta?.vite as
-          | CustomPluginOptionsVite
-          | undefined
-      )?.cssScopeTo
+      const cssScopeTo =
+        // NOTE: `this.getModuleInfo` can be undefined when the plugin is called directly
+        //       adding `?.` temporary to avoid unocss from breaking
+        // TODO: remove `?.` after `this.getModuleInfo` in Vite 7
+        (
+          this.getModuleInfo?.(id)?.meta?.vite as
+            | CustomPluginOptionsVite
+            | undefined
+        )?.cssScopeTo
 
       // record css
       if (!inlined) {


### PR DESCRIPTION
### Description

unocss passes `{}` as the pluginContext and `this.getModuleInfo` is `undefined` in that case.
https://github.com/unocss/unocss/blob/355558bd779997f61aab798b2a1912426064b216/packages-integrations/vite/src/modes/global/build.ts#L183-L187
#19418 added a `this.getModuleInfo` call and broke unocss.
This is technically a bug in unocss, but since the patch on our side is small and can avoid breakage on their side, I think we can add this `?.` for now. Let's remove it in Vite 7.

See https://discord.com/channels/804011606160703521/1342361424370077818/1342395667598938202

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
