### PR TITLE
fix(css): stabilize css module hashes with lightningcss in dev mode

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/css.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/css.spec.ts
@@ -114,6 +114,25 @@ composes: bar from '@/css/bar.module.css';
     const result2 = await transform(css, '/foo.module.css?direct') // client
     expect(result1.code).toBe(result2.code)
   })
+
+  test('custom generateScopedName with lightningcss', async () => {
+    const { transform } = await createCssPluginTransform({
+      configFile: false,
+      css: {
+        modules: {
+          generateScopedName: 'custom__[hash:base64:5]',
+        },
+        transformer: 'lightningcss',
+      },
+    })
+    const css = `\
+.foo {
+  color: red;
+}`
+    const result1 = await transform(css, '/foo.module.css') // server
+    const result2 = await transform(css, '/foo.module.css?direct') // client
+    expect(result1.code).toBe(result2.code)
+  })
 })
 
 describe('hoist @ rules', () => {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3297,7 +3297,8 @@ async function compileLightningCSS(
   const deps = new Set<string>()
   // replace null byte as lightningcss treats that as a string terminator
   // https://github.com/parcel-bundler/lightningcss/issues/874
-  const filename = id.replace('\0', NULL_BYTE_PLACEHOLDER)
+  const normalizedId = id.includes('?') ? id.split('?')[0] : id
+  const filename = normalizedId.replace('\0', NULL_BYTE_PLACEHOLDER)
 
   let res: LightningCssTransformAttributeResult | LightningCssTransformResult
   try {

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -3297,8 +3297,7 @@ async function compileLightningCSS(
   const deps = new Set<string>()
   // replace null byte as lightningcss treats that as a string terminator
   // https://github.com/parcel-bundler/lightningcss/issues/874
-  const normalizedId = id.includes('?') ? id.split('?')[0] : id
-  const filename = normalizedId.replace('\0', NULL_BYTE_PLACEHOLDER)
+  const filename = removeDirectQuery(id).replace('\0', NULL_BYTE_PLACEHOLDER)
 
   let res: LightningCssTransformAttributeResult | LightningCssTransformResult
   try {


### PR DESCRIPTION
### Description

Hello!

After upgrading Vite from version 6.0.5 to version 6.0.6 and above, I ran into an issue with hash mismatches in CSS class names in CSS files and in markup.

I found out that the problem is related to this change:
https://github.com/vitejs/vite/pull/19001

This PR fixes an issue where CSS module hashes were inconsistent between HTML markup and compiled CSS in development mode when using LightningCSS.

The problem occurred because query parameters (like `?direct`) in file IDs were affecting hash generation in LightningCSS. This was particularly noticeable in frameworks like Qwik that use query parameters for direct imports in dev mode.

Fix:
- Normalize file IDs by removing query parameters before passing to LightningCSS
- Maintain null byte placeholder replacement for HTML proxy cases

Before the fix:
- CSS module hashes in HTML could be different from the ones in compiled CSS
- This caused styling mismatches in development mode
- The issue was particularly visible with frameworks that use query parameters for imports

After the fix:
- CSS module hashes are stable and consistent
- Works correctly with frameworks' development mode imports
- Maintains compatibility with HTML proxy handling

This fix works for me fine.

If you want to reproduce the problem, you can do the following:

1. Clone [this repo](https://github.com/azat-io/eyecons) and install deps
2. Install Vite v6.0.6 or higher
3. Start dev server with `pnpm docs:dev`
4. The site's styles look weird
5. To fix problem downgrade Vite with `pnpm add --save-dev vite@6.0.5` and restart dev server


refs #10514
