### PR TITLE
chore(deps): unbundle tinyglobby

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -1799,35 +1799,6 @@ Repository: alexeyraspopov/picocolors
 
 ---------------------------------------
 
-## picomatch
-License: MIT
-By: Jon Schlinkert
-Repository: micromatch/picomatch
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2017-present, Jon Schlinkert.
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
 ## postcss-import
 License: MIT
 By: Maxime Thirouin
@@ -2199,35 +2170,6 @@ Repository: git+https://github.com/antfu/strip-literal.git
 > MIT License
 > 
 > Copyright (c) 2022 Anthony Fu <https://github.com/antfu>
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in all
-> copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-> SOFTWARE.
-
----------------------------------------
-
-## tinyglobby
-License: MIT
-By: Superchupu
-Repository: git+https://github.com/SuperchupuDev/tinyglobby.git
-
-> MIT License
-> 
-> Copyright (c) 2024 Madeline Gurriarán
 > 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -86,8 +86,10 @@
   "//": "READ CONTRIBUTING.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
     "esbuild": "^0.25.0",
+    "picomatch": "^4.0.2",
     "postcss": "^8.5.3",
-    "rollup": "^4.30.1"
+    "rollup": "^4.30.1",
+    "tinyglobby": "^0.2.12"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.3"
@@ -132,7 +134,6 @@
     "pathe": "^2.0.3",
     "periscopic": "^4.0.2",
     "picocolors": "^1.1.1",
-    "picomatch": "^4.0.2",
     "postcss-import": "^16.1.0",
     "postcss-load-config": "^6.0.1",
     "postcss-modules": "^6.0.1",
@@ -146,7 +147,6 @@
     "source-map-support": "^0.5.21",
     "strip-literal": "^3.0.0",
     "terser": "^5.39.0",
-    "tinyglobby": "^0.2.12",
     "tsconfck": "^3.1.5",
     "tslib": "^2.8.1",
     "types": "link:./types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,12 +229,18 @@ importers:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.0
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.2
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
       rollup:
         specifier: ^4.30.1
         version: 4.34.8
+      tinyglobby:
+        specifier: ^0.2.12
+        version: 0.2.12
     devDependencies:
       '@ampproject/remapping':
         specifier: ^2.3.0
@@ -353,9 +359,6 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      picomatch:
-        specifier: ^4.0.2
-        version: 4.0.2
       postcss-import:
         specifier: ^16.1.0
         version: 16.1.0(postcss@8.5.3)
@@ -395,9 +398,6 @@ importers:
       terser:
         specifier: ^5.39.0
         version: 5.39.0
-      tinyglobby:
-        specifier: ^0.2.12
-        version: 0.2.12
       tsconfck:
         specifier: ^3.1.5
         version: 3.1.5(typescript@5.7.3)


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->

As discussed on Discord, there may be some benefit to very selectively unbundling some of Vite's dependencies. The time to download Vite can actually be reduced by unbundling if the dependency is also used by the framework or tools being setup alongside vite as it means we only download the copy from npm rather than both the copy from npm and bundled copy.

tinyglobby is used by vitest, solidstart, astro, vitepress, nx, vike, nuxt, unimport (used by tanstack start), vite-plugin-checker, and vite-plugin-pwa. svelte doesn't use tinyglobby yet, but may soon and we do use both of its dependencies already. Other libraries adjacent to the ecosystem like eslint-import-resolver-typescript, tsup, and unocss use it as well.