### PR TITLE
chore(html): remove unnecessary value check

### DIFF
--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -216,7 +216,7 @@ export function getScriptInfo(node: DefaultTreeAdapterMap['element']): {
         src = p
         srcSourceCodeLocation = node.sourceCodeLocation?.attrs!['src']
       }
-    } else if (p.name === 'type' && p.value && p.value === 'module') {
+    } else if (p.name === 'type' && p.value === 'module') {
       isModule = true
     } else if (p.name === 'async') {
       isAsync = true


### PR DESCRIPTION
### Description

Even if the `p.value` is `null | undefined | ''`, it can still be directly compared with 'module'.