### PR TITLE
chore(css): move environment destructuring after condition check

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -363,7 +363,6 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(raw, id) {
-      const { environment } = this
       if (
         !isCSSRequest(id) ||
         commonjsProxyRE.test(id) ||
@@ -371,6 +370,8 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
       ) {
         return
       }
+
+      const { environment } = this
       const resolveUrl = (url: string, importer?: string) =>
         idResolver(environment, url, importer)
 


### PR DESCRIPTION
The function may return early, so there's no need to read the `environment` first.