### PR TITLE
fix(assets): ensure ?no-inline is not included in the asset url in the production environment

### DIFF
--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -381,7 +381,7 @@ async function fileToBuiltUrl(
     return cached
   }
 
-  const { file, postfix } = splitFileAndPostfix(id)
+  let { file, postfix } = splitFileAndPostfix(id)
   const content = await fsp.readFile(file)
 
   let url: string
@@ -401,6 +401,14 @@ async function fileToBuiltUrl(
       originalFileName,
       source: content,
     })
+
+    if (environment.config.command === 'build' && noInlineRE.test(postfix)) {
+      postfix = postfix.replace(noInlineRE, '')
+      if (postfix.startsWith('&')) {
+        postfix = postfix.replace(/^&/, '?')
+      }
+    }
+
     url = `__VITE_ASSET__${referenceId}__${postfix ? `$_${postfix}__` : ``}`
   }
 

--- a/packages/vite/src/node/plugins/asset.ts
+++ b/packages/vite/src/node/plugins/asset.ts
@@ -403,10 +403,7 @@ async function fileToBuiltUrl(
     })
 
     if (environment.config.command === 'build' && noInlineRE.test(postfix)) {
-      postfix = postfix.replace(noInlineRE, '')
-      if (postfix.startsWith('&')) {
-        postfix = postfix.replace(/^&/, '?')
-      }
+      postfix = postfix.replace(noInlineRE, '').replace(/^&/, '?')
     }
 
     url = `__VITE_ASSET__${referenceId}__${postfix ? `$_${postfix}__` : ``}`

--- a/playground/assets/__tests__/assets.spec.ts
+++ b/playground/assets/__tests__/assets.spec.ts
@@ -473,8 +473,16 @@ test('?raw import', async () => {
 test('?no-inline svg import', async () => {
   expect(await page.textContent('.no-inline-svg')).toMatch(
     isBuild
-      ? /\/foo\/bar\/assets\/fragment-[-\w]{8}\.svg\?no-inline/
+      ? /\/foo\/bar\/assets\/fragment-[-\w]{8}\.svg/
       : '/foo/bar/nested/fragment.svg?no-inline',
+  )
+})
+
+test('?no-inline svg import -- multiple postfix', async () => {
+  expect(await page.textContent('.no-inline-svg-mp')).toMatch(
+    isBuild
+      ? /\/foo\/bar\/assets\/fragment-[-\w]{8}\.svg\?foo=bar/
+      : '/foo/bar/nested/fragment.svg?no-inline&foo=bar',
   )
 })
 

--- a/playground/assets/index.html
+++ b/playground/assets/index.html
@@ -269,6 +269,9 @@
 <h2>?no-inline svg import</h2>
 <code class="no-inline-svg"></code>
 
+<h2>?no-inline svg import -- multiple postfix</h2>
+<code class="no-inline-svg-mp"></code>
+
 <h2>?inline png import</h2>
 <code class="inline-png"></code>
 
@@ -545,6 +548,9 @@
 
   import noInlineSvg from './nested/fragment.svg?no-inline'
   text('.no-inline-svg', noInlineSvg)
+
+  import noInlineSvgMP from './nested/fragment.svg?no-inline&foo=bar'
+  text('.no-inline-svg-mp', noInlineSvgMP)
 
   import inlinePng from './nested/asset.png?inline'
   text('.inline-png', inlinePng)


### PR DESCRIPTION
### Description

close #19490.

It would be better not to retain `?no-inline` in the production environment, while keeping it unchanged in the development environment.
