### PR TITLE
chore: use unicode cross icon instead of x

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -836,7 +836,7 @@ async function buildEnvironment(
     clearLine()
     if (startTime) {
       logger.error(
-        `${colors.red('x')} Build failed in ${displayTime(Date.now() - startTime)}`,
+        `${colors.red('✗')} Build failed in ${displayTime(Date.now() - startTime)}`,
       )
       startTime = undefined
     }


### PR DESCRIPTION
### Description

Use `✗` (`&cross;`) instead of `x` to better align with `✓` (`&check;`) in terminal logs. Depending on the terminal font it's rendered like this:

<img width="35" alt="image" src="https://github.com/user-attachments/assets/3bb3d0ee-5f80-47ab-bd67-28ca1402c5b4" />
