### PR TITLE
[SECURITY] [DOC] - Vite environment variables in defineConfig()

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -105,6 +105,12 @@ Environmental Variables can be obtained from `process.env` as usual.
 
 Note that Vite doesn't load `.env` files by default as the files to load can only be determined after evaluating the Vite config, for example, the `root` and `envDir` options affect the loading behaviour. However, you can use the exported `loadEnv` helper to load the specific `.env` file if needed.
 
+::: danger
+
+If the `third` parameter of the `loadEnv()` function is an empty string : `''`, the `env` variable will contain **all the environment variables** of the application. If this variable is returned, **sensitive keys** could leak in the application's JavaScript code.
+
+:::
+
 ```js twoslash
 import { defineConfig, loadEnv } from 'vite'
 
@@ -112,7 +118,7 @@ export default defineConfig(({ mode }) => {
   // Load env file based on `mode` in the current working directory.
   // Set the third parameter to '' to load all env regardless of the
   // `VITE_` prefix.
-  const env = loadEnv(mode, process.cwd(), '')
+  const env = loadEnv(mode, process.cwd(), ['VITE_', 'APP_'])
   return {
     // vite config
     define: {


### PR DESCRIPTION
### Description

Hello,

As a security auditor (pentester), I have repeatedly encountered cases where client applications expose **all environment variables** directly in the application's JavaScript code. This often leads to a **complete compromise of the application** and even its underlying infrastructure.

A common thread in these incidents is that all of these applications use `Vite` to build their code. After conducting some research in the [official documentation](https://vite.dev/config/), I realized that the code example provided in the `defineConfig()` code snippet could be misleading and potentially lead to this critical security issue.

Here's an example of vulnerable code:

```js
import { defineConfig, loadEnv } from 'vite'

export default defineConfig(({ mode }) => {
  const env = loadEnv(mode, process.cwd(), '')
  return {
    // Vite configuration
    define: {
      'process.env': env
    },
  }
})
```

By default, the documentation suggests using an empty string (`''`) as the `third argument` of the `loadEnv()` function, which results in **loading all environment variables**.

To improve the documentation and security, I suggest a small but impactful change to the documentation snippet: by default, only variables with a **specific prefix** (`VITE_` and `APP_`) should be included (rather than all environment variables). Additionally, a `warning` should be added about the risks of passing the env variable directly in the return statement of the function when using `''` as the `third` argument.

<img width="766" alt="image" src="https://github.com/user-attachments/assets/5f3b2e57-4db2-4488-a19b-b1cac29ec93a" />
