### PR TITLE
feat: warn if `define['process.env']` contains `path` key with a value

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -790,6 +790,27 @@ function resolveEnvironmentOptions(
     options.consumer ?? (isClientEnvironment ? 'client' : 'server')
   const isSsrTargetWebworkerEnvironment =
     isSsrTargetWebworkerSet && environmentName === 'ssr'
+
+  if (options.define?.['process.env']) {
+    const processEnvDefine = options.define['process.env']
+    if (typeof processEnvDefine === 'object') {
+      const pathKey = Object.entries(processEnvDefine).find(
+        // check with toLowerCase() to match with `Path` / `PATH` (Windows uses `Path`)
+        ([key, value]) => key.toLowerCase() === 'path' && !!value,
+      )?.[0]
+      if (pathKey) {
+        logger.warnOnce(
+          colors.yellow(
+            `The \`define\` option contains an object with ${JSON.stringify(pathKey)} for "process.env" key. ` +
+              'It looks like you may have passed the entire `process.env` object to `define`, ' +
+              'which can unintentionally expose all environment variables. ' +
+              'This poses a security risk and is discouraged.',
+          ),
+        )
+      }
+    }
+  }
+
   const resolve = resolveEnvironmentResolveOptions(
     options.resolve,
     alias,


### PR DESCRIPTION
### Description

Added a warning if `define['process.env']` contains `path: "some value"`.

There are a lot of people passing `'process.env': process.env` ([search](https://github.com/search?q=%2F%27process.env%27%3A%5Cs*%5Cw%2F+%28path%3Avite.config.ts+OR+path%3Avite.config.js%29&type=code&p=1)). This shouldn't be done because it may expose all the env vars, which may contain access tokens.

There were some PRs / issues that suggests to update the docs (https://github.com/vitejs/vite/issues/16686, https://github.com/vitejs/vite/pull/18441, https://github.com/vitejs/vite/pull/19510), but I don't think that can prevent people from doing it because the reason they did was because they didn't read the docs.

This PR adds a warning so that they can notice even without reading the docs.

The warning is output based on the following assumption:

- env var `Path` / `PATH` / `path` is declared on the machine and has a non-empty value: I believe this holds true in most cases
- `process.env.path` is not expected to be replaced: in this case the added warning will be output even if they only have `path: "intended-value"`. But I don't think this will likely to happen and they can workaround by setting `'process.env.path': 'value'` instead of `'process.env': { path: 'value' }`.

close #18441
close #19510

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
