### PR TITLE
docs(create-vite): recommend eslint-react for linting

### DIFF
--- a/packages/create-vite/template-react-ts/README.md
+++ b/packages/create-vite/template-react-ts/README.md
@@ -31,24 +31,24 @@ export default tseslint.config({
 })
 ```
 
-You can also install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) for React-specific lint rules:
+You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import react from 'eslint-plugin-react'
+import reactX from 'eslint-plugin-react-x'
+import reactDom from 'eslint-plugin-react-dom'
 
 export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '19.0' } },
   plugins: {
-    // Add the react plugin
-    react,
+    // Add the react-x and react-dom plugins
+    'react-x': reactX,
+    'react-dom': reactDom,
   },
   rules: {
     // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
+    // Enable its recommended typescript rules
+    ...reactX.configs['recommended-typescript'].rules,
+    ...reactDom.configs.recommended.rules,
   },
 })
 ```


### PR DESCRIPTION
### Description

Followup of #19514.

I made the simplest change possible in this PR, but alternatively we can also:
1. Use `extends: [reactX.configs['recommended-typescript'], reactDom.configs.recommended]`
2. Or simply link to https://eslint-react.xyz/docs/getting-started/typescript but it explains using `@eslint-react/eslint-plugin` as a whole.

I don't know if there's a best practice here, but personally for me I think it's easiest with no2 and let users setup as documented themselves. We can also link the type-aware setup above to https://typescript-eslint.io/getting-started/typed-linting so we don't have to maintain instructions anymore.

Also, I've tested the setup locally and it works.