### PR TITLE
docs: remove $ prefix from create-vite terminal commands in README

### DIFF
--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -8,25 +8,25 @@
 With NPM:
 
 ```bash
-$ npm create vite@latest
+npm create vite@latest
 ```
 
 With Yarn:
 
 ```bash
-$ yarn create vite
+yarn create vite
 ```
 
 With PNPM:
 
 ```bash
-$ pnpm create vite
+pnpm create vite
 ```
 
 With Bun:
 
 ```bash
-$ bun create vite
+bun create vite
 ```
 
 Then follow the prompts!


### PR DESCRIPTION
### Description

Removed the $ prefix from the terminal command examples in create-vite README.md

### Reason

Because Github automatically adds a "copy to clipboard" button next to these code examples, trying to copy paste them into terminal causes the $ symbol to be included and it needs to be manually removed or the command fails.

![CleanShot 2025-02-27 at 22 28 08@2x](https://github.com/user-attachments/assets/853b5310-28ec-49ad-b489-b30215300f46)
