### PR TITLE
perf: flush compile cache after 10s

### DIFF
--- a/packages/vite/bin/vite.js
+++ b/packages/vite/bin/vite.js
@@ -49,6 +49,15 @@ function start() {
   try {
     // eslint-disable-next-line n/no-unsupported-features/node-builtins -- it is supported in Node 22.8.0+ and only called if it exists
     module.enableCompileCache?.()
+    // flush the cache after 10s because the cache is not flushed until process end
+    // for dev server, the cache is never flushed unless manually flushed because the process.exit is called
+    // also flushing the cache in SIGINT handler seems to cause the process to hang
+    setTimeout(() => {
+      try {
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins -- it is supported in Node 22.12.0+ and only called if it exists
+        module.flushCompileCache?.()
+      } catch {}
+    }, 10 * 1000).unref()
   } catch {}
   return import('../dist/node/cli.js')
 }


### PR DESCRIPTION
### Description

It seems Node does not flush the compile cache until process exit (https://github.com/nodejs/node/pull/54971) and given that we call `process.exit` when exiting the dev server (or Ctrl + C causes SIGINT and then probably process.exit is called), the compile cache was not flushed for `vite dev`.
I made [`module.flushCompileCache()`](https://nodejs.org/docs/latest-v22.x/api/module.html#moduleflushcompilecache) to be called after 10 seconds (assuming all scripts are loaded in 10 seconds and users will open the cli for at least 10 seconds at least once).

I thought about calling it in `SIGINT` handler, but that seemed to cause the process to hang.

close #19529

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
