### PR TITLE
feat(utils): add createDurationTimer utility function

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -3,7 +3,6 @@ import path from 'node:path'
 import fsp from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
-import { performance } from 'node:perf_hooks'
 import { createRequire } from 'node:module'
 import crypto from 'node:crypto'
 import colors from 'picocolors'
@@ -12,7 +11,7 @@ import type { RollupOptions } from 'rollup'
 import picomatch from 'picomatch'
 import { build } from 'esbuild'
 import type { AnymatchFn } from '../types/anymatch'
-import { withTrailingSlash } from '../shared/utils'
+import { createDurationTimer, withTrailingSlash } from '../shared/utils'
 import {
   CLIENT_ENTRY,
   DEFAULT_ASSETS_RE,
@@ -1718,8 +1717,7 @@ export async function loadConfigFromFile(
     )
   }
 
-  const start = performance.now()
-  const getTime = () => `${(performance.now() - start).toFixed(2)}ms`
+  const getDurationTime = createDurationTimer()
 
   let resolvedPath: string | undefined
 
@@ -1751,7 +1749,7 @@ export async function loadConfigFromFile(
           ? runnerImportConfigFile
           : nativeImportConfigFile
     const { configExport, dependencies } = await resolver(resolvedPath)
-    debug?.(`config file loaded in ${getTime()}`)
+    debug?.(`config file loaded in ${getDurationTime()}`)
 
     const config = await (typeof configExport === 'function'
       ? configExport(configEnv)

--- a/packages/vite/src/node/env.ts
+++ b/packages/vite/src/node/env.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { parse } from 'dotenv'
 import { type DotenvPopulateInput, expand } from 'dotenv-expand'
+import { createDurationTimer } from '../shared/utils'
 import { arraify, createDebugger, normalizePath, tryStatSync } from './utils'
 import type { UserConfig } from './config'
 
@@ -21,8 +22,7 @@ export function loadEnv(
   envDir: string,
   prefixes: string | string[] = 'VITE_',
 ): Record<string, string> {
-  const start = performance.now()
-  const getTime = () => `${(performance.now() - start).toFixed(2)}ms`
+  const getDurationTime = createDurationTimer()
 
   if (mode === 'local') {
     throw new Error(
@@ -44,7 +44,7 @@ export function loadEnv(
     }),
   )
 
-  debug?.(`env files loaded in ${getTime()}`)
+  debug?.(`env files loaded in ${getDurationTime()}`)
 
   // test NODE_ENV override before expand as otherwise process.env.NODE_ENV would override this
   if (parsed.NODE_ENV && process.env.VITE_USER_NODE_ENV === undefined) {

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import path from 'node:path'
 import { promisify } from 'node:util'
-import { performance } from 'node:perf_hooks'
 import colors from 'picocolors'
 import type { BuildContext, BuildOptions as EsbuildBuildOptions } from 'esbuild'
 import esbuild, { build } from 'esbuild'
@@ -26,7 +25,7 @@ import {
   transformWithEsbuild,
 } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET, METADATA_FILENAME } from '../constants'
-import { isWindows } from '../../shared/utils'
+import { createDurationTimer, isWindows } from '../../shared/utils'
 import type { Environment } from '../environment'
 import { esbuildCjsExternalPlugin, esbuildDepPlugin } from './esbuildDepPlugin'
 import { ScanEnvironment, scanImports } from './scan'
@@ -612,7 +611,7 @@ export function runOptimizeDeps(
     cancel: cleanUp,
   }
 
-  const start = performance.now()
+  const getDurationTime = createDurationTimer()
 
   const preparedRun = prepareEsbuildOptimizerRun(
     environment,
@@ -715,9 +714,7 @@ export function runOptimizeDeps(
           }
         }
 
-        debug?.(
-          `Dependencies bundled in ${(performance.now() - start).toFixed(2)}ms`,
-        )
+        debug?.(`Dependencies bundled in ${getDurationTime()}`)
 
         return successfulResult
       })

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import fsp from 'node:fs/promises'
 import path from 'node:path'
-import { performance } from 'node:perf_hooks'
 import type {
   BuildContext,
   Loader,
@@ -40,7 +39,7 @@ import { createEnvironmentPluginContainer } from '../server/pluginContainer'
 import { BaseEnvironment } from '../baseEnvironment'
 import type { DevEnvironment } from '../server/environment'
 import { transformGlobImport } from '../plugins/importMetaGlob'
-import { cleanUrl } from '../../shared/utils'
+import { cleanUrl, createDurationTimer } from '../../shared/utils'
 import { loadTsconfigJsonForFile } from '../plugins/esbuild'
 
 export class ScanEnvironment extends BaseEnvironment {
@@ -128,7 +127,7 @@ export function scanImports(environment: ScanEnvironment): {
     missing: Record<string, string>
   }>
 } {
-  const start = performance.now()
+  const getDurationTime = createDurationTimer()
   const deps: Record<string, string> = {}
   const missing: Record<string, string> = {}
   let entries: string[]
@@ -219,13 +218,12 @@ export function scanImports(environment: ScanEnvironment): {
     })
     .finally(() => {
       if (debug) {
-        const duration = (performance.now() - start).toFixed(2)
         const depsStr =
           Object.keys(orderedDependencies(deps))
             .sort()
             .map((id) => `\n  ${colors.cyan(id)} -> ${colors.dim(deps[id])}`)
             .join('') || colors.dim('no dependencies found')
-        debug(`Scan completed in ${duration}ms: ${depsStr}`)
+        debug(`Scan completed in ${getDurationTime()}: ${depsStr}`)
       }
     })
 

--- a/packages/vite/src/shared/utils.ts
+++ b/packages/vite/src/shared/utils.ts
@@ -1,4 +1,3 @@
-import { performance } from 'node:perf_hooks'
 import { NULL_BYTE_PLACEHOLDER, VALID_ID_PREFIX } from './constants'
 
 export const isWindows =

--- a/packages/vite/src/shared/utils.ts
+++ b/packages/vite/src/shared/utils.ts
@@ -1,3 +1,4 @@
+import { performance } from 'node:perf_hooks'
 import { NULL_BYTE_PLACEHOLDER, VALID_ID_PREFIX } from './constants'
 
 export const isWindows =
@@ -81,4 +82,9 @@ export function promiseWithResolvers<T>(): PromiseWithResolvers<T> {
     reject = _reject
   })
   return { promise, resolve, reject }
+}
+
+export function createDurationTimer() {
+  const start = performance.now()
+  return (): string => `${(performance.now() - start).toFixed(2)}ms`
 }


### PR DESCRIPTION
### Description

Regarding the statistics of execution time, it can be encapsulated into a function.

Starting from `Node.js v16`, there is no longer a need to manually import `node:perf_hooks`.

https://nodejs.org/docs/latest-v16.x/api/globals.html#performance
