### PR TITLE
build(deps): bump stylus version to "^0.55.0"

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -160,7 +160,7 @@
     "lightningcss": "^1.21.0",
     "sass": "*",
     "sass-embedded": "*",
-    "stylus": "*",
+    "stylus": "^0.55.0",
     "sugarss": "*",
     "terser": "^5.16.0",
     "tsx": "^4.8.1",


### PR DESCRIPTION
package managers are resolving to `stylus@0.51.0`, side effecting `CVE-2022-3517`
`stylus@0.51.0` -> `glob@3.2.11` -> `minimatch@0.3.0`

I take deep view of first stylus with glob version fixing the vulnerability due to dependency tree update