### PR TITLE
perf(importAnalysis): skip merging accepted urls

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -708,8 +708,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
       const staticImportedUrls = new Set(
         _orderedImportedUrls.map((url) => removeTimestampQuery(url)),
       )
-      const acceptedUrls = mergeAcceptedUrls(orderedAcceptedUrls)
-      const acceptedExports = mergeAcceptedUrls(orderedAcceptedExports)
+      const acceptedUrls = mergeAcceptedUrls(orderedAcceptedUrls, hasHMR)
+      const acceptedExports = mergeAcceptedUrls(orderedAcceptedExports, hasHMR)
 
       // While we always expect to work with ESM, a classic worker is the only
       // case where it's not ESM and we need to avoid injecting ESM-specific code
@@ -856,12 +856,19 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
-function mergeAcceptedUrls<T>(orderedUrls: Array<Set<T> | undefined>) {
+function mergeAcceptedUrls<T>(
+  orderedUrls: Array<Set<T> | undefined>,
+  hasHMR: boolean,
+) {
   const acceptedUrls = new Set<T>()
-  for (const urls of orderedUrls) {
-    if (!urls) continue
-    for (const url of urls) acceptedUrls.add(url)
+
+  if (hasHMR) {
+    for (const urls of orderedUrls) {
+      if (!urls) continue
+      for (const url of urls) acceptedUrls.add(url)
+    }
   }
+
   return acceptedUrls
 }
 


### PR DESCRIPTION
### Description

Some modules do not have `HMR`. If the execution of `mergeAcceptedUrls` is not skipped, it will cause `2 * imports.length` unnecessary loops.

https://github.com/vitejs/vite/blob/f612e0fdf6810317b61fcca1ded125755f261d78/packages/vite/src/node/plugins/importAnalysis.ts#L432-L437