### PR TITLE
fix(reporter): fix incorrect bundle size calculation with non-ASCII characters

### DIFF
--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -148,10 +148,10 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                     return {
                       name: chunk.fileName,
                       group: 'JS',
-                      size: Buffer.from(chunk.code).length,
+                      size: Buffer.byteLength(chunk.code),
                       compressedSize: await getCompressedSize(chunk.code),
                       mapSize: chunk.map
-                        ? Buffer.from(chunk.map.toString()).length
+                        ? Buffer.byteLength(chunk.map.toString())
                         : null,
                     }
                   } else {
@@ -162,7 +162,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                     return {
                       name: chunk.fileName,
                       group: isCSS ? 'CSS' : 'Assets',
-                      size: Buffer.from(chunk.source).length,
+                      size: Buffer.byteLength(chunk.source),
                       mapSize: null, // Rollup doesn't support CSS maps?
                       compressedSize: isCompressible
                         ? await getCompressedSize(chunk.source)

--- a/packages/vite/src/node/plugins/reporter.ts
+++ b/packages/vite/src/node/plugins/reporter.ts
@@ -148,9 +148,11 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                     return {
                       name: chunk.fileName,
                       group: 'JS',
-                      size: chunk.code.length,
+                      size: Buffer.from(chunk.code).length,
                       compressedSize: await getCompressedSize(chunk.code),
-                      mapSize: chunk.map ? chunk.map.toString().length : null,
+                      mapSize: chunk.map
+                        ? Buffer.from(chunk.map.toString()).length
+                        : null,
                     }
                   } else {
                     if (chunk.fileName.endsWith('.map')) return null
@@ -160,7 +162,7 @@ export function buildReporterPlugin(config: ResolvedConfig): Plugin {
                     return {
                       name: chunk.fileName,
                       group: isCSS ? 'CSS' : 'Assets',
-                      size: chunk.source.length,
+                      size: Buffer.from(chunk.source).length,
                       mapSize: null, // Rollup doesn't support CSS maps?
                       compressedSize: isCompressible
                         ? await getCompressedSize(chunk.source)


### PR DESCRIPTION
### Description

Fix inaccurate bundle size calculation with non-ASCII characters.

When built assets contain non-ASCII characters, the current size calculation produces incorrect results due to character encoding differences:

```typescript
// String length vs actual byte length
console.log('测试'.length)                            // Outputs '2' (character count)
console.log(Buffer.from('测试').length)     // Outputs '6' (actual bytes)
```

Files containing CJK characters (or other multi-byte characters) will report significantly smaller sized than their actual byte length. The attached screenshot demonstrates this issue with a file containing repeated CJK characters:

![c72174b0f0a524c56235b1197534e5f9](https://github.com/user-attachments/assets/a203ef44-78b6-413c-a3c9-81a8156dc4e8)

> Note: On macOS, parameters of the `wc` command, used in this example, differ from Linux.