### PR TITLE
feat: add ember starter

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -38,6 +38,7 @@ The supported template presets are:
 |  [preact](https://vite.new/preact)  |  [preact-ts](https://vite.new/preact-ts)  |
 |     [lit](https://vite.new/lit)     |     [lit-ts](https://vite.new/lit-ts)     |
 |  [svelte](https://vite.new/svelte)  |  [svelte-ts](https://vite.new/svelte-ts)  |
+|   [ember](https://vite.new/ember)   |   [ember-ts](https://vite.new/ember-ts)   |
 |   [solid](https://vite.new/solid)   |   [solid-ts](https://vite.new/solid-ts)   |
 |    [qwik](https://vite.new/qwik)    |    [qwik-ts](https://vite.new/qwik-ts)    |
 
@@ -102,7 +103,7 @@ $ deno init --npm vite my-vue-app --template vue
 
 :::
 
-See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
+See [create-vite](https://github.com/vitejs/vite/tree/main/packages/create-vite) for more details on each supported template: `vanilla`, `vanilla-ts`, `vue`, `vue-ts`, `react`, `react-ts`, `react-swc`, `react-swc-ts`, `preact`, `preact-ts`, `lit`, `lit-ts`, `svelte`, `svelte-ts`, `ember`, `ember-ts`, `solid`, `solid-ts`, `qwik`, `qwik-ts`.
 
 You can use `.` for the project name to scaffold in the current directory.
 

--- a/packages/create-vite/README.md
+++ b/packages/create-vite/README.md
@@ -72,6 +72,8 @@ Currently supported template presets include:
 - `lit-ts`
 - `svelte`
 - `svelte-ts`
+- `ember`
+- `ember-ts`
 - `solid`
 - `solid-ts`
 - `qwik`

--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -55,6 +55,7 @@ ${magenta   ('preact-ts           preact'        )}
 ${redBright ('lit-ts              lit'           )}
 ${red       ('svelte-ts           svelte'        )}
 ${blue      ('solid-ts            solid'         )}
+${redBright ('ember-ts            ember'         )}
 ${blueBright('qwik-ts             qwik'          )}`
 
 type ColorFunc = (str: string | number) => string
@@ -283,6 +284,30 @@ const FRAMEWORKS: Framework[] = [
         display: 'Vike ↗',
         color: cyan,
         customCommand: 'npm create -- vike@latest --solid TARGET_DIR',
+      },
+    ],
+  },
+  {
+    name: 'ember',
+    display: 'Ember',
+    color: redBright,
+    variants: [
+      {
+        name: 'ember-ts',
+        display: 'TypeScript',
+        color: blue,
+      },
+      {
+        name: 'ember',
+        display: 'JavaScript',
+        color: yellow,
+      },
+      {
+        name: 'ember app',
+        display: 'Production-ready App',
+        color: redBright,
+        customCommand:
+          'npx ember-cli@latest new TARGET_DIR --blueprint @embroider/app-blueprint --interactive --lang en',
       },
     ],
   },

--- a/packages/create-vite/template-ember-ts/_gitignore
+++ b/packages/create-vite/template-ember-ts/_gitignore
@@ -1,0 +1,26 @@
+# compiled output
+/dist/
+
+# dependencies
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/connect.lock
+/.eslintcache
+/coverage/
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/packages/create-vite/template-ember-ts/babel.config.cjs
+++ b/packages/create-vite/template-ember-ts/babel.config.cjs
@@ -1,0 +1,44 @@
+const { buildMacros } = require('@embroider/macros/babel')
+
+const macros = buildMacros()
+
+module.exports = {
+  plugins: [
+    [
+      '@babel/plugin-transform-typescript',
+      {
+        allExtensions: true,
+        onlyRemoveTypeImports: true,
+        allowDeclareFields: true,
+      },
+    ],
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        compilerPath: 'ember-source/dist/ember-template-compiler.js',
+        transforms: [...macros.templateMacros],
+      },
+    ],
+    [
+      'module:decorator-transforms',
+      {
+        runtime: {
+          import: require.resolve('decorator-transforms/runtime-esm'),
+        },
+      },
+    ],
+    [
+      '@babel/plugin-transform-runtime',
+      {
+        absoluteRuntime: __dirname,
+        useESModules: true,
+        regenerator: false,
+      },
+    ],
+    ...macros.babelMacros,
+  ],
+
+  generatorOpts: {
+    compact: false,
+  },
+}

--- a/packages/create-vite/template-ember-ts/index.html
+++ b/packages/create-vite/template-ember-ts/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Vite Ember Starter</title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <link rel="stylesheet" href="./src/styles/app.css" />
+  </head>
+
+  <body>
+    <script type="module">
+      import Application from './src/app'
+      import environment from './src/config'
+
+      Application.create(environment.APP)
+    </script>
+  </body>
+</html>

--- a/packages/create-vite/template-ember-ts/package.json
+++ b/packages/create-vite/template-ember-ts/package.json
@@ -29,7 +29,7 @@
     "@glimmer/component": "^2.0.0",
     "@glint/ember-tsc": "^1.0.4",
     "@glint/template": "^1.6.2",
-    "@glint/tsserver-plugin": "^2.0.4"
+    "@glint/tsserver-plugin": "^2.0.4",
     "@rollup/plugin-babel": "^5.3.1",
     "@types/rsvp": "^4.0.9",
     "babel-plugin-ember-template-compilation": "^2.3.0",

--- a/packages/create-vite/template-ember-ts/package.json
+++ b/packages/create-vite/template-ember-ts/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "vite-ember-ts-starter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#src/*": "./src/*",
+    "#config": "./src/config.ts",
+    "#components/*": "./src/components/*"
+  },
+  "exports": {
+    "./*": "./src/*"
+  },
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.19.3",
+    "@babel/plugin-transform-typescript": "^7.26.8",
+    "@babel/plugin-transform-runtime": "^7.25.4",
+    "@babel/runtime": "^7.25.6",
+    "@ember/app-tsconfig": "^1.0.1",
+    "@embroider/core": "^4.0.1",
+    "@embroider/macros": "^1.17.1'",
+    "@embroider/vite": "^1.0.2",
+    "@glimmer/component": "^2.0.0",
+    "@glint/ember-tsc": "^1.0.4",
+    "@glint/template": "^1.6.2",
+    "@glint/tsserver-plugin": "^2.0.4"
+    "@rollup/plugin-babel": "^5.3.1",
+    "@types/rsvp": "^4.0.9",
+    "babel-plugin-ember-template-compilation": "^2.3.0",
+    "decorator-transforms": "^2.0.0",
+    "ember-modifier": "^4.1.0",
+    "ember-resolver": "^13.1.0",
+    "ember-source": "^6.3.0",
+    "typescript": "~5.8.2",
+    "vite": "^6.2.0"
+  },
+  "engines": {
+    "node": ">= 18"
+  },
+  "ember": {
+    "edition": "octane"
+  }
+}

--- a/packages/create-vite/template-ember-ts/src/app.ts
+++ b/packages/create-vite/template-ember-ts/src/app.ts
@@ -1,0 +1,10 @@
+import Application from '@ember/application'
+import Resolver from 'ember-resolver'
+import config from '#config'
+
+import { registry } from './registry.ts'
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix
+  Resolver = Resolver.withModules(registry)
+}

--- a/packages/create-vite/template-ember-ts/src/config.ts
+++ b/packages/create-vite/template-ember-ts/src/config.ts
@@ -1,0 +1,12 @@
+const ENV = {
+  modulePrefix: 'vite-ember-ts-starter',
+  environment: import.meta.env.DEV ? 'development' : 'production',
+  rootURL: '/',
+  locationType: 'history',
+  APP: {
+    // Here you can pass flags/options to your application instance
+    // when it is created
+  } as any,
+}
+
+export default ENV

--- a/packages/create-vite/template-ember-ts/src/registry.ts
+++ b/packages/create-vite/template-ember-ts/src/registry.ts
@@ -1,0 +1,37 @@
+import Router from './router.js'
+//import PageTitleService from 'ember-page-title/services/page-title'
+import config from './config.js'
+
+const appName = config.modulePrefix
+
+function formatAsResolverEntries(imports: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(imports).map(([k, v]) => [
+      k.replace(/\.g?(j|t)s$/, '').replace(/^\.\//, `${appName}/`),
+      v,
+    ]),
+  )
+}
+
+/**
+ * A global registry is needed until:
+ * - Services can be referenced via import paths (rather than strings)
+ * - we design a new routing system
+ */
+const resolverRegistry = {
+  ...formatAsResolverEntries(
+    import.meta.glob('./templates/**/*.{gjs,gts,js,ts}', { eager: true }),
+  ),
+  ...formatAsResolverEntries(
+    import.meta.glob('./services/**/*.{js,ts}', { eager: true }),
+  ),
+  ...formatAsResolverEntries(
+    import.meta.glob('./routes/**/*.{js,ts}', { eager: true }),
+  ),
+  [`${appName}/router`]: Router,
+}
+
+export const registry = {
+  ...resolverRegistry,
+  //[`${appName}/services/page-title`]: PageTitleService,
+}

--- a/packages/create-vite/template-ember-ts/src/router.ts
+++ b/packages/create-vite/template-ember-ts/src/router.ts
@@ -1,0 +1,9 @@
+import EmberRouter from '@ember/routing/router'
+import config from '#config'
+
+export default class Router extends EmberRouter {
+  location = config.locationType
+  rootURL = config.rootURL
+}
+
+Router.map(function () {})

--- a/packages/create-vite/template-ember-ts/src/styles/app.css
+++ b/packages/create-vite/template-ember-ts/src/styles/app.css
@@ -1,0 +1,5 @@
+/* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
+
+legend {
+  font-style: italic;
+}

--- a/packages/create-vite/template-ember-ts/src/templates/application.gjs
+++ b/packages/create-vite/template-ember-ts/src/templates/application.gjs
@@ -1,0 +1,6 @@
+<template>
+  <fieldset><legend>app/templates/application.gjs</legend>
+
+  {{outlet}}
+  </fieldset>
+</template>

--- a/packages/create-vite/template-ember-ts/tsconfig.json
+++ b/packages/create-vite/template-ember-ts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@ember/app-tsconfig",
+  "glint": {
+    "environment": ["ember-template-imports"]
+  },
+  "compilerOptions": {
+    "types": ["vite/client", "@embroider/core/virtual", "ember-source/types", "@glint/ember-tsc/types"]
+  }
+}

--- a/packages/create-vite/template-ember-ts/tsconfig.json
+++ b/packages/create-vite/template-ember-ts/tsconfig.json
@@ -4,6 +4,11 @@
     "environment": ["ember-template-imports"]
   },
   "compilerOptions": {
-    "types": ["vite/client", "@embroider/core/virtual", "ember-source/types", "@glint/ember-tsc/types"]
+    "types": [
+      "vite/client",
+      "@embroider/core/virtual",
+      "ember-source/types",
+      "@glint/ember-tsc/types"
+    ]
   }
 }

--- a/packages/create-vite/template-ember-ts/vite.config.mjs
+++ b/packages/create-vite/template-ember-ts/vite.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import { extensions, ember } from '@embroider/vite'
+import { babel } from '@rollup/plugin-babel'
+
+export default defineConfig({
+  plugins: [
+    ember(),
+    babel({
+      babelHelpers: 'runtime',
+      extensions,
+    }),
+  ],
+})

--- a/packages/create-vite/template-ember/_gitignore
+++ b/packages/create-vite/template-ember/_gitignore
@@ -1,0 +1,26 @@
+# compiled output
+/dist/
+
+# dependencies
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/connect.lock
+/.eslintcache
+/coverage/
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/npm-shrinkwrap.json.ember-try
+/package.json.ember-try
+/package-lock.json.ember-try
+/yarn.lock.ember-try
+
+# broccoli-debug
+/DEBUG/

--- a/packages/create-vite/template-ember/babel.config.cjs
+++ b/packages/create-vite/template-ember/babel.config.cjs
@@ -1,0 +1,37 @@
+const { buildMacros } = require('@embroider/macros/babel')
+
+const macros = buildMacros()
+
+module.exports = {
+  plugins: [
+    [
+      'babel-plugin-ember-template-compilation',
+      {
+        compilerPath: 'ember-source/dist/ember-template-compiler.js',
+        enableLegacyModules: ['ember-cli-htmlbars'],
+        transforms: [...macros.templateMacros],
+      },
+    ],
+    [
+      'module:decorator-transforms',
+      {
+        runtime: {
+          import: require.resolve('decorator-transforms/runtime-esm'),
+        },
+      },
+    ],
+    [
+      '@babel/plugin-transform-runtime',
+      {
+        absoluteRuntime: __dirname,
+        useESModules: true,
+        regenerator: false,
+      },
+    ],
+    ...macros.babelMacros,
+  ],
+
+  generatorOpts: {
+    compact: false,
+  },
+}

--- a/packages/create-vite/template-ember/index.html
+++ b/packages/create-vite/template-ember/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Vite Ember Starter</title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <link rel="stylesheet" href="./src/styles/app.css" />
+  </head>
+
+  <body>
+    <script type="module">
+      import Application from './src/app'
+      import environment from './src/config'
+
+      Application.create(environment.APP)
+    </script>
+  </body>
+</html>

--- a/packages/create-vite/template-ember/package.json
+++ b/packages/create-vite/template-ember/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "vite-ember-starter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#src/*": "./src/*",
+    "#config": "./src/config.js",
+    "#components/*": "./src/components/*"
+  },
+  "exports": {
+    "./tests/*": "./tests/*",
+    "./*": "./src/*"
+  },
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.19.3",
+    "@babel/plugin-transform-runtime": "^7.25.4",
+    "@babel/runtime": "^7.25.6",
+    "@embroider/core": "^4.0.1",
+    "@embroider/macros": "^1.17.1'",
+    "@embroider/vite": "^1.0.2",
+    "@glimmer/component": "^2.0.0",
+    "@rollup/plugin-babel": "^5.3.1",
+    "babel-plugin-ember-template-compilation": "^2.3.0",
+    "decorator-transforms": "^2.0.0",
+    "ember-modifier": "^4.1.0",
+    "ember-resolver": "^13.1.0",
+    "ember-source": "^6.3.0",
+    "vite": "^6.2.0"
+  },
+  "engines": {
+    "node": ">= 18"
+  },
+  "ember": {
+    "edition": "octane"
+  }
+}

--- a/packages/create-vite/template-ember/src/app.js
+++ b/packages/create-vite/template-ember/src/app.js
@@ -1,0 +1,10 @@
+import Application from '@ember/application'
+import Resolver from 'ember-resolver'
+import config from '#config'
+
+import { registry } from './registry.js'
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix
+  Resolver = Resolver.withModules(registry)
+}

--- a/packages/create-vite/template-ember/src/config.js
+++ b/packages/create-vite/template-ember/src/config.js
@@ -1,0 +1,12 @@
+const ENV = {
+  modulePrefix: 'vite-ember-starter',
+  environment: import.meta.env.DEV ? 'development' : 'production',
+  rootURL: '/',
+  locationType: 'history',
+  APP: {
+    // Here you can pass flags/options to your application instance
+    // when it is created
+  },
+}
+
+export default ENV

--- a/packages/create-vite/template-ember/src/registry.js
+++ b/packages/create-vite/template-ember/src/registry.js
@@ -1,0 +1,37 @@
+import Router from './router.js'
+//import PageTitleService from 'ember-page-title/services/page-title'
+import config from './config.js'
+
+const appName = config.modulePrefix
+
+function formatAsResolverEntries(imports) {
+  return Object.fromEntries(
+    Object.entries(imports).map(([k, v]) => [
+      k.replace(/\.g?(j|t)s$/, '').replace(/^\.\//, `${appName}/`),
+      v,
+    ]),
+  )
+}
+
+/**
+ * A global registry is needed until:
+ * - Services can be referenced via import paths (rather than strings)
+ * - we design a new routing system
+ */
+const resolverRegistry = {
+  ...formatAsResolverEntries(
+    import.meta.glob('./templates/**/*.{gjs,gts,js,ts}', { eager: true }),
+  ),
+  ...formatAsResolverEntries(
+    import.meta.glob('./services/**/*.{js,ts}', { eager: true }),
+  ),
+  ...formatAsResolverEntries(
+    import.meta.glob('./routes/**/*.{js,ts}', { eager: true }),
+  ),
+  [`${appName}/router`]: Router,
+}
+
+export const registry = {
+  ...resolverRegistry,
+  //[`${appName}/services/page-title`]: PageTitleService,
+}

--- a/packages/create-vite/template-ember/src/router.js
+++ b/packages/create-vite/template-ember/src/router.js
@@ -1,0 +1,9 @@
+import EmberRouter from '@ember/routing/router'
+import config from '#config'
+
+export default class Router extends EmberRouter {
+  location = config.locationType
+  rootURL = config.rootURL
+}
+
+Router.map(function () {})

--- a/packages/create-vite/template-ember/src/styles/app.css
+++ b/packages/create-vite/template-ember/src/styles/app.css
@@ -1,0 +1,5 @@
+/* Ember supports plain CSS out of the box. More info: https://cli.emberjs.com/release/advanced-use/stylesheets/ */
+
+legend {
+  font-style: italic;
+}

--- a/packages/create-vite/template-ember/src/templates/application.gjs
+++ b/packages/create-vite/template-ember/src/templates/application.gjs
@@ -1,0 +1,6 @@
+<template>
+  <fieldset><legend>app/templates/application.gjs</legend>
+
+  {{outlet}}
+  </fieldset>
+</template>

--- a/packages/create-vite/template-ember/vite.config.mjs
+++ b/packages/create-vite/template-ember/vite.config.mjs
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite'
+import { extensions, ember } from '@embroider/vite'
+import { babel } from '@rollup/plugin-babel'
+
+export default defineConfig({
+  plugins: [
+    ember(),
+    babel({
+      babelHelpers: 'runtime',
+      extensions,
+    }),
+  ],
+})


### PR DESCRIPTION
Current Blockers for "Ready for Review":


All things on the ember side:

- [x] make more minimal - (we have plans for a new "resolver")
- [x] Bug in our project generation - is not dropping in to interactive mode with the custom blueprint option -- this is fixed either by fixing the bug, or changing the default blueprint -- we should probably fix the bug tho lol
- [x] The currently specified blueprint is very out of date compared to what we want, and we should update it
  - implementation in progress over here: https://github.com/ember-cli/ember-app-blueprint
  - we also have a library blueprint: https://github.com/ember-cli/ember-addon-blueprint/ -- may add this as another "external tool" option
- [x] stable release of build deps 
- [x] stable release of ember-source
- [x] migrate away from `@tsconfig/ember` to `@ember/app-tsconfig`
- [x] stable release of ts/volar support

-------------------------------

### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR adds Ember (and Ember + TS) to the list of starter templates.

<details><summary>Some key differences from the other starter templates atm</summary>

- we use babel (for now)
- we have a custom build macros plugin (via babel) because `import.meta.ENV.*` isn't a standard (maybe one day soon? 🤞 ) -- we don't want macros-code to change between packaging systems (webpack, vite, our old legacy thing, etc)

</details>

<details><summary>Some key differences from a more normal ember-generated project</summary>

- no linting / formatting is configured (aligns with the other starter templates)
- no testing is configured
- some default libraries are removed
- we're using a `src` folder instead of `app` folder

</details>

To generate a more normal ember project, folks should use this option:
![image](https://github.com/user-attachments/assets/da6c93cf-d1e8-4537-9b4c-1f58931c4241)



<details><summary>old notes, no longer relevant</summary>

These notes are no longer relevant, because I've made the ember-vite templates as minimal as they currently can be, which more aligns with the other vite templates.

With the option to create a production-ready app by deferring to ember-ecosystem project generation, we can regain some of this:

- a small README is present
- we have a watchman config for ignoring the output directory (an assumption due to the prevalence of macos in JS Dev, and how you kinda have to use watchman to dev on a mac)
- some additional runtime dependencies are present, because we use separate packages as a means of showing folks how to do certain things with our low-level apis (they also provide very common utilities that folks use) -- there are tradeoffs to this that we're discussing right now -- mainly to address feelings of import fatigue 
- a test framework is pre-configured / wired up, as testing is fundamental to all ember development, and _at the moment_, we don't have compatibility with _every test framework_ out there, so there isn't really a choice to be made with regards to testing.
- we have a deprecation system for communicating progress of the framework


Here is our official "v2 app" blueprint / template: https://github.com/embroider-build/app-blueprint

which is notably different from the minimal template PR'd here:
https://github.com/embroider-build/embroider/pull/2301 (this is what this PR to vite is using) 

If testing is desired to be removed, we can delete:
- `tests/`
- deps:
  - ember-cli
  - ember-qunit
  - qunit
  - qunit-dom
  - @ember/test-helpers

My Todos

- [x] Add ember-template-ts 
- [x] Add the deprecation system boilerplate

</details>



---------------------

PR Checklist

- [x] Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- [x] Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- [x] Update the corresponding documentation if needed.
- [x] Include relevant tests that fail without this PR but pass with it.

