### PR TITLE
fix: "Cannot read properties of undefined (reading 'get')" in ModuleLoader triggered by CSS import

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -597,7 +597,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
       }
 
       const inlined = inlineRE.test(id)
-      const modules = cssModulesCache.get(config)!.get(id)
+      const modules = cssModulesCache.get(config)?.get(id)
 
       // #6984, #7552
       // `foo.module.css` => modulesCode


### PR DESCRIPTION
### Description

We are using Vite's `loadConfigFromFile` (runner mode) to load a TS file. We are aware that this is not 100% as intended, but it works fine and we do it at our own risk.
This TS file also loads a CSS file, which breaks the runner mode. A simple change, which I think makes sense anyway, fixes the problem.

To reproduce I created this StackBlitz: https://stackblitz.com/edit/vitejs-vite-yl98c3fh?file=package.json

You can `pnpm load-with-css` to see the problem:

```sh
❯ pnpm load-with-css

> vite-css-load-config-from-file@0.0.0 load-with-css /home/projects/vitejs-vite-yl98c3fh
> node load.js config-with-css.ts

failed to load config from /home/projects/vitejs-vite-yl98c3fh/config-with-css.ts
Error [TypeError]: Cannot read properties of undefined (reading 'get')
    at async ModuleLoader.import (https://vitejsviteyl98c3fh-vchr.w-credentialless-staticblitz.com/builtins.8cb5228f.js:154:2688)
    at async loadESM (https://vitejsviteyl98c3fh-vchr.w-credentialless-staticblitz.com/builtins.8cb5228f.js:184:541)
    at async handleMainPromise (https://vitejsviteyl98c3fh-vchr.w-credentialless-staticblitz.com/builtins.8cb5228f.js:165:296) {
  plugin: 'vite:css-post',
  id: '/home/projects/vitejs-vite-yl98c3fh/style.css',
```

I understand that you probably don't want to support the use case we have here and that it may break in the future, but I think the resulting fix still makes sense without all this context.