### PR TITLE
feat(types): type hints for hmr events

### DIFF
--- a/docs/guide/api-hmr.md
+++ b/docs/guide/api-hmr.md
@@ -10,7 +10,10 @@ Vite exposes its manual HMR API via the special `import.meta.hot` object:
 
 ```ts twoslash
 import type { ModuleNamespace } from 'vite/types/hot.d.ts'
-import type { InferCustomEventPayload } from 'vite/types/customEvent.d.ts'
+import type {
+  CustomEventName,
+  InferCustomEventPayload,
+} from 'vite/types/customEvent.d.ts'
 
 // ---cut---
 interface ImportMeta {
@@ -32,15 +35,18 @@ interface ViteHotContext {
   prune(cb: (data: any) => void): void
   invalidate(message?: string): void
 
-  on<T extends string>(
+  on<T extends CustomEventName>(
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
   ): void
-  off<T extends string>(
+  off<T extends CustomEventName>(
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
   ): void
-  send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void
+  send<T extends CustomEventName>(
+    event: T,
+    data?: InferCustomEventPayload<T>,
+  ): void
 }
 ```
 

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -33,9 +33,12 @@ export interface InvalidatePayload {
 }
 
 /**
- * provides types for built-in Vite events
+ * provides types for payloads of built-in Vite events
  */
 export type InferCustomEventPayload<T extends string> =
   T extends keyof CustomEventMap ? CustomEventMap[T] : any
 
+/**
+ * provides types for names of built-in Vite events
+ */
 export type CustomEventName = keyof CustomEventMap | (string & {})

--- a/packages/vite/types/customEvent.d.ts
+++ b/packages/vite/types/customEvent.d.ts
@@ -37,3 +37,5 @@ export interface InvalidatePayload {
  */
 export type InferCustomEventPayload<T extends string> =
   T extends keyof CustomEventMap ? CustomEventMap[T] : any
+
+export type CustomEventName = keyof CustomEventMap | (string & {})

--- a/packages/vite/types/hot.d.ts
+++ b/packages/vite/types/hot.d.ts
@@ -1,4 +1,4 @@
-import type { InferCustomEventPayload } from './customEvent'
+import type { CustomEventName, InferCustomEventPayload } from './customEvent'
 
 export type ModuleNamespace = Record<string, any> & {
   [Symbol.toStringTag]: 'Module'
@@ -24,13 +24,16 @@ export interface ViteHotContext {
   prune(cb: (data: any) => void): void
   invalidate(message?: string): void
 
-  on<T extends string>(
+  on<T extends CustomEventName>(
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
   ): void
-  off<T extends string>(
+  off<T extends CustomEventName>(
     event: T,
     cb: (payload: InferCustomEventPayload<T>) => void,
   ): void
-  send<T extends string>(event: T, data?: InferCustomEventPayload<T>): void
+  send<T extends CustomEventName>(
+    event: T,
+    data?: InferCustomEventPayload<T>,
+  ): void
 }


### PR DESCRIPTION
### Description

This adds type hints for hmr event names (`hot.on`, `hot.off`, `hot.send`). 
These are pretty much only for QOL as types aren't enforced, to still allow untyped custom events by vite plugins.
