### PR TITLE
docs: clarify `build.manifest` / `build.ssrManifest` option values

### DIFF
--- a/docs/config/build-options.md
+++ b/docs/config/build-options.md
@@ -191,7 +191,9 @@ export default defineConfig({
 - **Default:** `false`
 - **Related:** [Backend Integration](/guide/backend-integration)
 
-When set to `true`, the build will also generate a `.vite/manifest.json` file that contains a mapping of non-hashed asset filenames to their hashed versions, which can then be used by a server framework to render the correct asset links. When the value is a string, it will be used as the manifest file name.
+Whether to generate a manifest file that contains a mapping of non-hashed asset filenames to their hashed versions, which can then be used by a server framework to render the correct asset links.
+
+When the value is a string, it will be used as the manifest file path relative to `build.outDir`. When set to `true`, the path would be `.vite/manifest.json`.
 
 ## build.ssrManifest
 
@@ -199,7 +201,9 @@ When set to `true`, the build will also generate a `.vite/manifest.json` file th
 - **Default:** `false`
 - **Related:** [Server-Side Rendering](/guide/ssr)
 
-When set to `true`, the build will also generate an SSR manifest for determining style links and asset preload directives in production. When the value is a string, it will be used as the manifest file name.
+Whether to generate a SSR manifest file for determining style links and asset preload directives in production.
+
+When the value is a string, it will be used as the manifest file path relative to `build.outDir`. When set to `true`, the path would be `.vite/ssr-manifest.json`.
 
 ## build.ssr
 


### PR DESCRIPTION
### Description

Clarified the following facts:

- the string value of `build.manifest` is a relative path from `build.outDir`
- the string value of `build.ssrManifest` is a relative path from `build.outDir`
- the `true` value of `build.ssrManifest` will output the SSR manifest to `./.vite/ssr-manifest.json`

Also separated the description of the option itself and the values to two paragraphs.

close #19575

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
