### PR TITLE
refactor: remove `isBuild` check from preAliasPlugin

### DIFF
--- a/packages/vite/src/node/external.ts
+++ b/packages/vite/src/node/external.ts
@@ -32,24 +32,6 @@ export function shouldExternalize(
   return isExternal(id, importer)
 }
 
-const isConfiguredAsExternalCache = new WeakMap<
-  Environment,
-  (id: string, importer?: string) => boolean
->()
-
-export function isConfiguredAsExternal(
-  environment: Environment,
-  id: string,
-  importer?: string,
-): boolean {
-  let isExternal = isConfiguredAsExternalCache.get(environment)
-  if (!isExternal) {
-    isExternal = createIsConfiguredAsExternal(environment)
-    isConfiguredAsExternalCache.set(environment, isExternal)
-  }
-  return isExternal(id, importer)
-}
-
 export function createIsConfiguredAsExternal(
   environment: PartialEnvironment,
 ): (id: string, importer?: string) => boolean {

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -7,7 +7,6 @@ import type {
   ResolvedConfig,
 } from '..'
 import type { Plugin } from '../plugin'
-import { isConfiguredAsExternal } from '../external'
 import {
   bareImportRE,
   isInNodeModules,
@@ -22,7 +21,6 @@ import { tryOptimizedResolve } from './resolve'
  */
 export function preAliasPlugin(config: ResolvedConfig): Plugin {
   const findPatterns = getAliasPatterns(config.resolve.alias)
-  const isBuild = config.command === 'build'
   return {
     name: 'vite:pre-alias',
     async resolveId(id, importer, options) {
@@ -65,11 +63,6 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
               (isInNodeModules(resolvedId) ||
                 optimizeDeps.include?.includes(id)) &&
               isOptimizable(resolvedId, optimizeDeps) &&
-              !(
-                isBuild &&
-                ssr &&
-                isConfiguredAsExternal(environment, id, importer)
-              ) &&
               (!ssr || optimizeAliasReplacementForSSR(resolvedId, optimizeDeps))
             ) {
               // aliased dep has not yet been optimized


### PR DESCRIPTION
### Description

Since dep optimizer for build is removed (#15184), this `isBuild` is always `false` when `depsOptimizer` value exists.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
