### PR TITLE
refactor: use `applyToEnvironment` in internal plugins

### DIFF
--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -44,10 +44,13 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
 
   return {
     name: 'vite:asset-import-meta-url',
+
+    applyToEnvironment(environment) {
+      return environment.config.consumer === 'client'
+    },
+
     async transform(code, id) {
-      const { environment } = this
       if (
-        environment.config.consumer === 'client' &&
         id !== preloadHelperId &&
         id !== CLIENT_ENTRY &&
         code.includes('new URL') &&
@@ -121,7 +124,7 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
               tryIndex: false,
               preferRelative: true,
             })
-            file = await assetResolver(environment, url, id)
+            file = await assetResolver(this.environment, url, id)
             file ??=
               url[0] === '/'
                 ? slash(path.join(publicDir, url))

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -1,7 +1,6 @@
 import aliasPlugin, { type ResolverFunction } from '@rollup/plugin-alias'
 import type { ObjectHook } from 'rollup'
 import type { PluginHookUtils, ResolvedConfig } from '../config'
-import { isDepOptimizationDisabled } from '../optimizer'
 import type { HookHandler, Plugin, PluginWithRequiredHook } from '../plugin'
 import { watchPackageDataPlugin } from '../packages'
 import { jsonPlugin } from './json'
@@ -36,17 +35,12 @@ export async function resolvePlugins(
     ? await (await import('../build')).resolveBuildPlugins(config)
     : { pre: [], post: [] }
   const { modulePreload } = config.build
-  const depOptimizationEnabled =
-    !isBuild &&
-    Object.values(config.environments).some(
-      (environment) => !isDepOptimizationDisabled(environment.optimizeDeps),
-    )
 
   return [
-    depOptimizationEnabled ? optimizedDepsPlugin() : null,
+    !isBuild ? optimizedDepsPlugin() : null,
     isBuild ? metadataPlugin() : null,
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
-    preAliasPlugin(config),
+    !isBuild ? preAliasPlugin(config) : null,
     aliasPlugin({
       entries: config.resolve.alias,
       customResolver: viteAliasCustomResolver,

--- a/packages/vite/src/node/plugins/optimizedDeps.ts
+++ b/packages/vite/src/node/plugins/optimizedDeps.ts
@@ -8,7 +8,10 @@ import {
   ERR_OPTIMIZE_DEPS_PROCESSING_ERROR,
 } from '../constants'
 import { createDebugger } from '../utils'
-import { optimizedDepInfoFromFile } from '../optimizer'
+import {
+  isDepOptimizationDisabled,
+  optimizedDepInfoFromFile,
+} from '../optimizer'
 import { cleanUrl } from '../../shared/utils'
 import { ERR_OUTDATED_OPTIMIZED_DEP } from '../../shared/constants'
 
@@ -17,6 +20,10 @@ const debug = createDebugger('vite:optimize-deps')
 export function optimizedDepsPlugin(): Plugin {
   return {
     name: 'vite:optimized-deps',
+
+    applyToEnvironment(environment) {
+      return !isDepOptimizationDisabled(environment.config.optimizeDeps)
+    },
 
     resolveId(id) {
       const environment = this.environment as DevEnvironment

--- a/packages/vite/src/node/plugins/preAlias.ts
+++ b/packages/vite/src/node/plugins/preAlias.ts
@@ -4,6 +4,7 @@ import type {
   Alias,
   AliasOptions,
   DepOptimizationOptions,
+  DevEnvironment,
   ResolvedConfig,
 } from '..'
 import type { Plugin } from '../plugin'
@@ -14,6 +15,7 @@ import {
   moduleListContains,
 } from '../utils'
 import { cleanUrl, withTrailingSlash } from '../../shared/utils'
+import { isDepOptimizationDisabled } from '../optimizer'
 import { tryOptimizedResolve } from './resolve'
 
 /**
@@ -23,11 +25,13 @@ export function preAliasPlugin(config: ResolvedConfig): Plugin {
   const findPatterns = getAliasPatterns(config.resolve.alias)
   return {
     name: 'vite:pre-alias',
+    applyToEnvironment(environment) {
+      return !isDepOptimizationDisabled(environment.config.optimizeDeps)
+    },
     async resolveId(id, importer, options) {
-      const { environment } = this
+      const environment = this.environment as DevEnvironment
       const ssr = environment.config.consumer === 'server'
-      const depsOptimizer =
-        environment.mode === 'dev' ? environment.depsOptimizer : undefined
+      const depsOptimizer = environment.depsOptimizer
       if (
         importer &&
         depsOptimizer &&

--- a/packages/vite/src/node/plugins/workerImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/workerImportMetaUrl.ts
@@ -208,6 +208,10 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   return {
     name: 'vite:worker-import-meta-url',
 
+    applyToEnvironment(environment) {
+      return environment.config.consumer === 'client'
+    },
+
     shouldTransformCachedModule({ code }) {
       if (isBuild && config.build.watch && isIncludeWorkerImportMetaUrl(code)) {
         return true
@@ -215,10 +219,7 @@ export function workerImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
     },
 
     async transform(code, id) {
-      if (
-        this.environment.config.consumer === 'client' &&
-        isIncludeWorkerImportMetaUrl(code)
-      ) {
+      if (isIncludeWorkerImportMetaUrl(code)) {
         let s: MagicString | undefined
         const cleanString = stripLiteral(code)
         const workerImportMetaUrlRE =


### PR DESCRIPTION
### Description

~~Built on top of #19586~~

So that we can skip some plugins when not needed

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
