### PR TITLE
fix(css): inline css correctly for double quote use strict

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -951,7 +951,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               injectionPoint =
                 code.indexOf(doubleQuoteUseStruct) + doubleQuoteUseStruct.length
             } else {
-              throw new Error('Not found injection point for inlined CSS')
+              throw new Error('Injection point for inlined CSS not found')
             }
             s ||= new MagicString(code)
             s.appendRight(injectionPoint, injectCode)

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -939,17 +939,17 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               `document.head.appendChild(${style});`
             let injectionPoint
             const wrapIdx = code.indexOf('System.register')
-            const singleQuoteUseStruct = `'use strict';`
-            const doubleQuoteUseStruct = `"use strict";`
+            const singleQuoteUseStrict = `'use strict';`
+            const doubleQuoteUseStrict = `"use strict";`
             if (wrapIdx >= 0) {
               const executeFnStart = code.indexOf('execute:', wrapIdx)
               injectionPoint = code.indexOf('{', executeFnStart) + 1
-            } else if (code.includes(singleQuoteUseStruct)) {
+            } else if (code.includes(singleQuoteUseStrict)) {
               injectionPoint =
-                code.indexOf(singleQuoteUseStruct) + singleQuoteUseStruct.length
-            } else if (code.includes(doubleQuoteUseStruct)) {
+                code.indexOf(singleQuoteUseStrict) + singleQuoteUseStrict.length
+            } else if (code.includes(doubleQuoteUseStrict)) {
               injectionPoint =
-                code.indexOf(doubleQuoteUseStruct) + doubleQuoteUseStruct.length
+                code.indexOf(doubleQuoteUseStrict) + doubleQuoteUseStrict.length
             } else {
               throw new Error('Injection point for inlined CSS not found')
             }

--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -939,12 +939,19 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
               `document.head.appendChild(${style});`
             let injectionPoint
             const wrapIdx = code.indexOf('System.register')
+            const singleQuoteUseStruct = `'use strict';`
+            const doubleQuoteUseStruct = `"use strict";`
             if (wrapIdx >= 0) {
               const executeFnStart = code.indexOf('execute:', wrapIdx)
               injectionPoint = code.indexOf('{', executeFnStart) + 1
+            } else if (code.includes(singleQuoteUseStruct)) {
+              injectionPoint =
+                code.indexOf(singleQuoteUseStruct) + singleQuoteUseStruct.length
+            } else if (code.includes(doubleQuoteUseStruct)) {
+              injectionPoint =
+                code.indexOf(doubleQuoteUseStruct) + doubleQuoteUseStruct.length
             } else {
-              const insertMark = "'use strict';"
-              injectionPoint = code.indexOf(insertMark) + insertMark.length
+              throw new Error('Not found injection point for inlined CSS')
             }
             s ||= new MagicString(code)
             s.appendRight(injectionPoint, injectCode)


### PR DESCRIPTION
### Description

The original code assumed that `use strict` is written with single quotes. This is true for common cases as rollup outputs `use strict` with single quotes. But plugins before `vite:css-post` plugin might change them to double quotes, and in those cases, this code did not work.

Ported from https://github.com/vitejs/rolldown-vite/pull/79 (rolldown outputs `use strict` with double quotes so without this change it doesn't work; ported now as this would also fix issues not related to rolldown)

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
