### PR TITLE
fix: set `perEnvironmentStartEndDuringDev: true` for `runnerImport` to fix css import

### DIFF
--- a/packages/vite/src/node/__tests__/fixtures/runner-import/css-import-dep.css
+++ b/packages/vite/src/node/__tests__/fixtures/runner-import/css-import-dep.css
@@ -1,0 +1,3 @@
+body {
+  color: orange;
+}

--- a/packages/vite/src/node/__tests__/fixtures/runner-import/css-import.js
+++ b/packages/vite/src/node/__tests__/fixtures/runner-import/css-import.js
@@ -1,0 +1,2 @@
+import './css-import-dep.css'
+export default 'ok'

--- a/packages/vite/src/node/__tests__/runnerImport.spec.ts
+++ b/packages/vite/src/node/__tests__/runnerImport.spec.ts
@@ -70,4 +70,9 @@ describe('importing files using inlined environment', () => {
     // const dep = await module.default();
     // expect(dep.default).toMatchInlineSnapshot(`"ok"`)
   })
+
+  test('css import', async () => {
+    const { module } = await runnerImport<any>(fixture('css-import.js'))
+    expect(module.default).toMatchInlineSnapshot(`"ok"`)
+  })
 })

--- a/packages/vite/src/node/ssr/runnerImport.ts
+++ b/packages/vite/src/node/ssr/runnerImport.ts
@@ -39,6 +39,9 @@ export async function runnerImport<T>(
           },
         },
       },
+      server: {
+        perEnvironmentStartEndDuringDev: true,
+      },
     } satisfies InlineConfig),
     'serve',
   )


### PR DESCRIPTION
### Description

Related
- https://github.com/vitejs/vite/pull/19577
- https://github.com/vitejs/vite/issues/19606

Currently `buildStart` of internal css plugin is not called and that's causing a cryptic error on css import as reported https://github.com/vitejs/vite/pull/19577.