### PR TITLE
docs(troubleshooting): mention devcontainers as culprit for hanging requests

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -111,6 +111,9 @@ For Ubuntu Linux, you may need to add the line `* - nofile 65536` to the file `/
 
 Note that these settings persist but a **restart is required**.
 
+Alternatively, if the server is running inside a VS Code devcontainer, the request may appear to be stalled. To fix this issue, see
+[Dev Containers / VS Code Port Forwarding](#dev-containers-vs-code-port-forwarding).
+
 ### Network requests stop loading
 
 When using a self-signed SSL certificate, Chrome ignores all caching directives and reloads the content. Vite relies on these caching directives.


### PR DESCRIPTION
I'd like to link to the devcontainer section from the stalled network requests section because that is what it appears to be in the case of devcontainers, and the sections in between do not look related to hanging network requests which caused me to give up on these docs on the first pass.