### PR TITLE
chore: extend commit hash correctly when ambigious with a non-commit object

### DIFF
--- a/packages/vite/CHANGELOG.md
+++ b/packages/vite/CHANGELOG.md
@@ -13,7 +13,7 @@
 * test: convert config playground to unit tests (#19568) ([c0e68da](https://github.com/vitejs/vite/commit/c0e68da4774f3487e9ba0c4d4d2c5e76bdc890ea)), closes [#19568](https://github.com/vitejs/vite/issues/19568)
 * test: convert resolve-config playground to unit tests (#19567) ([db5fb48](https://github.com/vitejs/vite/commit/db5fb48f5d4c1ee411e59c1e9b70d62fdb9d53d2)), closes [#19567](https://github.com/vitejs/vite/issues/19567)
 * perf: flush compile cache after 10s (#19537) ([6c8a5a2](https://github.com/vitejs/vite/commit/6c8a5a27e645a182f5b03a4ed6aa726eab85993f)), closes [#19537](https://github.com/vitejs/vite/issues/19537)
-* chore(css): move environment destructuring after condition check (#19492) ([c9eda23](https://github.com/vitejs/vite/commit/c9eda23)), closes [#19492](https://github.com/vitejs/vite/issues/19492)
+* chore(css): move environment destructuring after condition check (#19492) ([c9eda23](https://github.com/vitejs/vite/commit/c9eda2348c244d591d23f131c6ddf262b256cbf0)), closes [#19492](https://github.com/vitejs/vite/issues/19492)
 * chore(html): remove unnecessary value check (#19491) ([797959f](https://github.com/vitejs/vite/commit/797959f01da583b85a0be1dc89f762fd01d138db)), closes [#19491](https://github.com/vitejs/vite/issues/19491)
 
 

--- a/scripts/extendCommitHash.ts
+++ b/scripts/extendCommitHash.ts
@@ -11,7 +11,9 @@ export default function extendCommitHash(path: string): void {
   while ((match = matchHashReg.exec(content))) {
     const shortHash = match[1]
     try {
-      const longHash = execSync(`git rev-parse ${shortHash}`).toString().trim()
+      const longHash = execSync(`git rev-parse "${shortHash}^{commit}"`)
+        .toString()
+        .trim()
       content = content.replace(`${base}${shortHash}`, `${base}${longHash}`)
     } catch {}
   }


### PR DESCRIPTION
### Description

I got the following error when releasing 6.2.1.
```
error: short object ID c9eda23 is ambiguous
hint: The candidates are:
hint:   c9eda2348 commit 2025-02-27 - chore(css): move environment destructuring after condition check (#19492)
hint:   c9eda234f blob
fatal: ambiguous argument 'c9eda23': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
This PR would avoid that error from happening when the ambiguousness is coming from commit and non-commit objects like in this case. The same error would still happen if there's a ambiguousness coming from multiple commits, but I'm not sure how to fix that one.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
