### PR TITLE
fix(ssr): use optional chaining to prevent "undefined is not an object" happening in `ssrRewriteStacktrace`

### DIFF
--- a/packages/vite/src/node/ssr/ssrStacktrace.ts
+++ b/packages/vite/src/node/ssr/ssrStacktrace.ts
@@ -52,7 +52,7 @@ export function ssrRewriteStacktrace(
             return input
           }
 
-          const trimmedVarName = varName.trim()
+          const trimmedVarName = varName?.trim()
           const sourceFile = path.resolve(path.dirname(id), pos.source)
           // stacktrace's column is 1-indexed, but sourcemap's one is 0-indexed
           const source = `${sourceFile}:${pos.line}:${pos.column + 1}`


### PR DESCRIPTION
### Description

This PR handles a case where `varName` passed from a RegExp match on stacktrace lines is `undefined` and causes `ssrRewriteStacktrace` to fail on `varName.trim()`.

This bug was encounted in the Vite dev server running with Bun via the command `bunx --bun vite`.

I have a [reproduction](https://github.com/saintnoodle/vite-ssr-repro) which demonstrates the error in a simple manner. There is also a patch for Vite on the branch "fix-patch" which demonstrates the fixed behaviour.

I'm not the first to encounter this according to this [issue](https://github.com/oven-sh/bun/issues/17730) over at Bun.

### Explaination

Upon inspecting the stack traces and comparing them between Node and Bun, the first line of the stack trace tends to contain "eval", which means the function safely accesses `varName.trim()` and continues to completion. However, in Bun, `varName` is `undefined` which causes the function to fail when it tries to access `.trim()` where it doesn't exist.

If it weren't for modules outside of the module graph being skipped after `moduleGraph.getModuleById()`, is `undefined` failure would be common as anonymous entries in the stacktrace usually occur.

The existance of `if (!trimmedVarName ...` indicates to me that this was expected, but `trimmedVarName` can't be `undefined` because of the lack of optional chaining since the function fails if the value is not a string before `undefined` can be assigned.

#### Bun stacktrace:
```
Error: Anonymous Error
    at C:/Users/{username}/Projects/vite-ssr-repro/app/routes/anonymous-error.tsx:7:10
    at loader (C:/Users/{username}/Projects/vite-ssr-repro/app/routes/anonymous-error.tsx:8:4)
    at C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:9174:21
    at callRouteHandler (C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:9173:32)
    at C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:9287:24
    at C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:9263:43
    at C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:3893:90
    at C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:3891:38
    at runHandler (C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:3896:42)
    at C:\Users\{username}\Projects\vite-ssr-repro\node_modules\react-router\dist\development\index.js:3943:21
```

#### Node stacktrace:
```
Error: Anonymous Error
    at eval (C:/Users/{username}/Projects/vite-ssr-node/app/routes/anonymous-error.tsx:7:11)
    at loader (C:/Users/{username}/Projects/vite-ssr-node/app/routes/anonymous-error.tsx:8:5)
    at callRouteHandler (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:9026:22)
    at commonRoute.loader (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:9139:25)
    at actualHandler (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3734:14)
    at file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3745:91
    at runHandler (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3750:7)
    at callLoaderOrAction (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3795:22)
    at Object.resolve (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3690:27)
    at file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3565:62
    at Array.map (<anonymous>)
    at defaultDataStrategy (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3565:49)
    at callDataStrategyImpl (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3705:23)
    at callDataStrategy (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3117:25)
    at loadRouteData (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:3084:25)
    at queryImpl (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:2900:26)
    at Object.query (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:2764:24)
    at handleDocumentRequest (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:9758:40)
    at requestHandler (file:///C:/Users/{username}/Projects/vite-ssr-node/node_modules/react-router/dist/development/chunk-K6CSEXPM.mjs:9684:24)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at nodeHandler (C:\Users\{username}\Projects\vite-ssr-node\node_modules\@react-router\dev\dist\vite.js:2932:30)
    at C:\Users\{username}\Projects\vite-ssr-node\node_modules\@react-router\dev\dist\vite.js:2938:17
```