### PR TITLE
fix: make glob pattern supports nested paths

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/assetImportMetaUrl.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/assetImportMetaUrl.spec.ts
@@ -23,11 +23,19 @@ async function createAssetImportMetaurlPluginTransform() {
 describe('assetImportMetaUrlPlugin', async () => {
   const transform = await createAssetImportMetaurlPluginTransform()
 
+  test('no file extension specified', async () => {
+    expect(
+      await transform('new URL(`./foo/${filePath}`, import.meta.url)'),
+    ).toMatchInlineSnapshot(
+      `"new URL((import.meta.glob("./foo/**", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${filePath}\`], import.meta.url)"`,
+    )
+  })
+
   test('variable between /', async () => {
     expect(
       await transform('new URL(`./foo/${dir}/index.js`, import.meta.url)'),
     ).toMatchInlineSnapshot(
-      `"new URL((import.meta.glob("./foo/*/index.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}/index.js\`], import.meta.url)"`,
+      `"new URL((import.meta.glob("./foo/**/index.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}/index.js\`], import.meta.url)"`,
     )
   })
 
@@ -35,7 +43,7 @@ describe('assetImportMetaUrlPlugin', async () => {
     expect(
       await transform('new URL(`./foo/${dir}.js`, import.meta.url)'),
     ).toMatchInlineSnapshot(
-      `"new URL((import.meta.glob("./foo/*.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}.js\`], import.meta.url)"`,
+      `"new URL((import.meta.glob("./foo/**/*.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}.js\`], import.meta.url)"`,
     )
   })
 
@@ -43,7 +51,7 @@ describe('assetImportMetaUrlPlugin', async () => {
     expect(
       await transform('new URL(`./foo/${dir}${file}.js`, import.meta.url)'),
     ).toMatchInlineSnapshot(
-      `"new URL((import.meta.glob("./foo/*.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}\${file}.js\`], import.meta.url)"`,
+      `"new URL((import.meta.glob("./foo/**/*.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}\${file}.js\`], import.meta.url)"`,
     )
   })
 
@@ -53,7 +61,7 @@ describe('assetImportMetaUrlPlugin', async () => {
         'new URL(`./foo/${dir}${dir2}/index.js`, import.meta.url)',
       ),
     ).toMatchInlineSnapshot(
-      `"new URL((import.meta.glob("./foo/*/index.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}\${dir2}/index.js\`], import.meta.url)"`,
+      `"new URL((import.meta.glob("./foo/**/index.js", {"eager":true,"import":"default","query":"?url"}))[\`./foo/\${dir}\${dir2}/index.js\`], import.meta.url)"`,
     )
   })
 

--- a/packages/vite/src/node/plugins/assetImportMetaUrl.ts
+++ b/packages/vite/src/node/plugins/assetImportMetaUrl.ts
@@ -169,21 +169,35 @@ export function assetImportMetaUrlPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
+const extRE = /^\.[a-zA-Z0-9]+$/
 function buildGlobPattern(ast: any) {
   let pattern = ''
-  let lastIsGlob = false
+  let hasGlob = false
   for (let i = 0; i < ast.quasis.length; i++) {
     const str = ast.quasis[i].value.raw
-    if (str) {
-      pattern += str
-      lastIsGlob = false
+    if (!str) {
+      continue
     }
 
-    if (ast.expressions[i] && !lastIsGlob) {
-      pattern += '*'
-      lastIsGlob = true
+    const isExt = extRE.test(str)
+
+    if (isExt) {
+      const endsWithStar = pattern.endsWith('*')
+      if (endsWithStar && hasGlob) {
+        pattern += '/*'
+      } else if (!endsWithStar) {
+        pattern += '*'
+      }
+    }
+
+    pattern += str
+
+    if (!hasGlob && !isExt) {
+      pattern += '**'
+      hasGlob = true
     }
   }
+
   return pattern
 }
 


### PR DESCRIPTION
### Description

closes: #19605

This fix supports matching nested paths by adding `/**` in the path.

I think it would be better to convert it like this.

before:
```text
./foo/${filePath}   =>   ./foo/*
./foo/${dir}/index.js   =>   ./foo/*/index.js
./foo/${dir}.js   =>   ./foo/*.js
./foo/${dir}${file}.js   =>   ./foo/*.js
${file}.js   =>   *.js
```

after:

```text
./foo/${filePath}   =>   ./foo/**
./foo/${dir}/index.js   =>   ./foo/**/index.js
./foo/${dir}.js   =>   ./foo/**/*.js
./foo/${dir}${file}.js   =>   ./foo/**/*.js
${file}.js   =>   *.js
```

### The execution result is as follows.

Before
```js
import micromatch from "micromatch";

const globs = ["/foo/*", "/foo/*.js", "/foo/*/foo.js"];
const paths = ["/foo/foo.js", "/foo/dir/foo.js"];

for (const glob of globs) {
  const matcher = micromatch.matcher(glob);
  const result = paths.map((p) => [p, matcher(p)]);

  console.log(`# ${glob}`);
  for (const res of result) {
    console.log(`- ${res[0]}: ${res[1]}`);
  }
  console.log();
}

```

```text
# /foo/*
- /foo/foo.js: true
- /foo/dir/foo.js: false

# /foo/*.js
- /foo/foo.js: true
- /foo/dir/foo.js: false

# /foo/*/foo.js
- /foo/foo.js: false
- /foo/dir/foo.js: true
```

```js
import micromatch from "micromatch";

const globs = ["/foo/**", "/foo/**/*.js", "/foo/**/foo.js"];
const paths = ["/foo/foo.js", "/foo/dir/foo.js"];

for (const glob of globs) {
  const matcher = micromatch.matcher(glob);
  const result = paths.map((p) => [p, matcher(p)]);

  console.log(`# ${glob}`);
  for (const res of result) {
    console.log(`- ${res[0]}: ${res[1]}`);
  }
  console.log();
}
```

```text
# /foo/**
- /foo/foo.js: true
- /foo/dir/foo.js: true

# /foo/**/*.js
- /foo/foo.js: true
- /foo/dir/foo.js: true

# /foo/**/foo.js
- /foo/foo.js: true
- /foo/dir/foo.js: true
```