### PR TITLE
fix: await client buildStart on top level buildStart

### DIFF
--- a/packages/vite/src/node/server/pluginContainer.ts
+++ b/packages/vite/src/node/server/pluginContainer.ts
@@ -1084,19 +1084,18 @@ class PluginContainer {
   // buildStart is called per environment for a plugin with the perEnvironmentStartEndDuring dev flag
 
   async buildStart(_options?: InputOptions): Promise<void> {
-    ;(this.environments.client as DevEnvironment).pluginContainer.buildStart(
-      _options,
-    )
+    return (
+      this.environments.client as DevEnvironment
+    ).pluginContainer.buildStart(_options)
   }
 
   async watchChange(
     id: string,
     change: { event: 'create' | 'update' | 'delete' },
   ): Promise<void> {
-    ;(this.environments.client as DevEnvironment).pluginContainer.watchChange(
-      id,
-      change,
-    )
+    return (
+      this.environments.client as DevEnvironment
+    ).pluginContainer.watchChange(id, change)
   }
 
   async resolveId(

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -331,20 +331,20 @@ test('buildStart before transform', async () => {
           fn('buildStart:out')
         },
         resolveId(source) {
-          expect(fn).toHaveBeenCalledWith('buildStart:out')
           if (source === 'virtual:test') {
+            fn('resolveId')
             return '\0' + source
           }
         },
         load(id) {
-          expect(fn).toHaveBeenCalledWith('buildStart:out')
           if (id === '\0virtual:test') {
+            fn('load')
             return `export default 'ok'`
           }
         },
         transform(code, id) {
-          expect(fn).toHaveBeenCalledWith('buildStart:out')
           if (id === '\0virtual:test') {
+            fn('transform')
             return code
           }
         },
@@ -356,4 +356,26 @@ test('buildStart before transform', async () => {
 
   const mod = await server.ssrLoadModule('virtual:test')
   expect(mod.default).toBe('ok')
+  expect(fn.mock.calls).toMatchInlineSnapshot(`
+    [
+      [
+        "buildStart:in",
+      ],
+      [
+        "buildStart:out",
+      ],
+      [
+        "resolveId",
+      ],
+      [
+        "resolveId",
+      ],
+      [
+        "load",
+      ],
+      [
+        "transform",
+      ],
+    ]
+  `)
 })

--- a/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
+++ b/packages/vite/src/node/ssr/__tests__/ssrLoadModule.spec.ts
@@ -315,3 +315,45 @@ test('named exports overwrite export all', async () => {
     }
   `)
 })
+
+test('buildStart before transform', async () => {
+  const fn = vi.fn()
+  const server = await createServer({
+    configFile: false,
+    root,
+    logLevel: 'error',
+    plugins: [
+      {
+        name: 'test-plugin',
+        async buildStart() {
+          fn('buildStart:in')
+          await new Promise((r) => setTimeout(r, 200))
+          fn('buildStart:out')
+        },
+        resolveId(source) {
+          expect(fn).toHaveBeenCalledWith('buildStart:out')
+          if (source === 'virtual:test') {
+            return '\0' + source
+          }
+        },
+        load(id) {
+          expect(fn).toHaveBeenCalledWith('buildStart:out')
+          if (id === '\0virtual:test') {
+            return `export default 'ok'`
+          }
+        },
+        transform(code, id) {
+          expect(fn).toHaveBeenCalledWith('buildStart:out')
+          if (id === '\0virtual:test') {
+            return code
+          }
+        },
+      },
+    ],
+  })
+  onTestFinished(() => server.close())
+  await server.pluginContainer.buildStart({})
+
+  const mod = await server.ssrLoadModule('virtual:test')
+  expect(mod.default).toBe('ok')
+})


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19607

It turns out Vite-node CLI skipping `buildStart` doesn't cause any issue since Vite-node always load `/@vite/env` in client environment before anything starts, which ensures `buildStart` is executed properly. So we don't need to hurry vite-node side fix https://github.com/vitest-dev/vitest/pull/7652. Once this is released, I'll probably update vite-node side to check vite version and try to skip explicit `buildStart` on certain version. (Or maybe we don't need such check since users should be fine to just bump Vite.)