### PR TITLE
fix(preview): use preview https config, not server

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -137,7 +137,7 @@ export async function preview(
     )
   }
 
-  const httpsOptions = await resolveHttpsConfig(config.server.https)
+  const httpsOptions = await resolveHttpsConfig(config.preview.https)
   const app = connect() as Connect.Server
   const httpServer = await resolveHttpServer(config.preview, app, httpsOptions)
   setClientErrorHandler(httpServer, config.logger)


### PR DESCRIPTION
### Description

Our company uses vite for our web dashboard. When running locally using `vite` we have https on, however, we have a part of our CI/CD pipeline that uses `vite preview` and requires https to be off. This CI/CD process recently started failing when we upgraded vite and it appears to be because the `vite preview` server was returning no data.

We narrowed the problem down to the [6.1.0](https://github.com/vitejs/vite/releases/tag/v6.1.0) release. We believe that the problem commit is this: https://github.com/vitejs/vite/commit/a5e306f2fc34fc70d543028c319367ff9b232ea0#diff-35ba301b85014a4bfaa9cad2d8e7eafa41c4e8c2ddd5c193182241d9a1542082. In that commit we changed the https config for the preview server to use the server's https config. I assume that this was done unintentionally so this commit changes it back.