### PR TITLE
fix(ci): remove changed files action after security incident

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,33 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changed:
-    name: Get changed files
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.changed-files.outputs.only_changed == 'true' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # Assume PRs are less than 50 commits
-          fetch-depth: 50
-
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
-        with:
-          files: |
-            docs/**
-            .github/**
-            !.github/workflows/ci.yml
-            packages/create-vite/template**
-            **.md
-
   test:
-    needs: changed
-    if: needs.changed.outputs.should_skip != 'true'
     timeout-minutes: 20
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
### Description

see https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/

the repo of the action isn't accessible as of creating this PR.


This is a regression as it runs tests on PRs that wouldn't need them and we should look into using an alternative way of achieving skip for non-code PRs but security first.