### PR TITLE
fix(optimizer): fix incorrect picomatch usage in filter()

### DIFF
--- a/packages/vite/src/node/optimizer/resolve.ts
+++ b/packages/vite/src/node/optimizer/resolve.ts
@@ -136,8 +136,9 @@ export function expandGlobIds(id: string, config: ResolvedConfig): string[] {
       }
     }
 
+    const isMatch = picomatch(pattern)
     const matched = possibleExportPaths
-      .filter(picomatch(pattern))
+      .filter((p) => isMatch(p))
       .map((match) => path.posix.join(pkgName, match))
     matched.unshift(pkgName)
     return matched


### PR DESCRIPTION
## Issue Description

In the Vite optimizer module, the current implementation directly uses the matcher function returned by `picomatch(pattern)` as a callback for `filter()`:

```js
const matched = possibleExportPaths
  .filter(picomatch(pattern))
  .map((match) => path.posix.join(pkgName, match))
```

This causes a subtle but critical issue: the matcher function returned by `picomatch` accepts two parameters:
1. The path string to match
2. A boolean option indicating whether to return an object (instead of a boolean)

As shown in [the picomatch source code](https://github.com/micromatch/picomatch/blob/bf6a33bd3db990edfbfd20b3b160eed926cd07dd/lib/picomatch.js#L65C9-L65C16), the matcher function checks the second parameter to determine whether to return detailed match information (an object) or just a boolean result:

```js
const matcher = (input, returnObject = false) => {
  // ...
}
```

When used in `Array.prototype.filter()`, JavaScript automatically passes three arguments to the callback function: the current element, index, and the array itself. This results in the array index being incorrectly passed to the matcher function as the second parameter, causing the matcher to return objects rather than booleans, which ultimately filters out all paths and causes optimizer resolution errors.

## Solution

By first creating the matcher function and then correctly calling it in an arrow function, we ensure only one parameter is passed:

```js
const isMatch = picomatch(pattern)
const matched = possibleExportPaths
  .filter(p => isMatch(p))
  .map((match) => path.posix.join(pkgName, match))
```

This ensures the matcher function always returns boolean values, making the filtering operation work as expected and fixing the optimizer's resolution issues.

## Test Results

After this fix, the optimizer module correctly resolves and filters paths, solving the issue where all paths were incorrectly filtered out.