### PR TITLE
docs: `server.https` option is always an options object

### DIFF
--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -60,7 +60,7 @@ Set to `true` to exit if port is already in use, instead of automatically trying
 - **Type:** `https.ServerOptions`
 - **Default:** [`server.https`](./server-options#server-https)
 
-Enable TLS + HTTP/2. Note this downgrades to TLS only when the [`server.proxy` option](./server-options#server-proxy) is also used.
+Enable TLS + HTTP/2.
 
 See [`server.https`](./server-options#server-https) for more details.
 

--- a/docs/config/preview-options.md
+++ b/docs/config/preview-options.md
@@ -62,7 +62,7 @@ Set to `true` to exit if port is already in use, instead of automatically trying
 
 Enable TLS + HTTP/2. Note this downgrades to TLS only when the [`server.proxy` option](./server-options#server-proxy) is also used.
 
-The value can also be an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
+See [`server.https`](./server-options#server-https) for more details.
 
 ## preview.open
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -92,7 +92,7 @@ Set to `true` to exit if port is already in use, instead of automatically trying
 
 Enable TLS + HTTP/2. Note this downgrades to TLS only when the [`server.proxy` option](#server-proxy) is also used.
 
-The value can also be an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
+The value is an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
 
 A valid certificate is needed. For a basic setup, you can add [@vitejs/plugin-basic-ssl](https://github.com/vitejs/vite-plugin-basic-ssl) to the project plugins, which will automatically create and cache a self-signed certificate. But we recommend creating your own certificates.
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -92,7 +92,7 @@ Set to `true` to exit if port is already in use, instead of automatically trying
 
 Enable TLS + HTTP/2. The value is an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
 
-Setting the sufficient value for TLS would also enable HTTP/2, unless the [`server.proxy` option](#server-proxy) is also used.
+Note that this downgrades to TLS only when the [`server.proxy` option](#server-proxy) is also used.
 
 A valid certificate is needed. For a basic setup, you can add [@vitejs/plugin-basic-ssl](https://github.com/vitejs/vite-plugin-basic-ssl) to the project plugins, which will automatically create and cache a self-signed certificate. But we recommend creating your own certificates.
 

--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -90,9 +90,9 @@ Set to `true` to exit if port is already in use, instead of automatically trying
 
 - **Type:** `https.ServerOptions`
 
-Enable TLS + HTTP/2. Note this downgrades to TLS only when the [`server.proxy` option](#server-proxy) is also used.
+Enable TLS + HTTP/2. The value is an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
 
-The value is an [options object](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener) passed to `https.createServer()`.
+Setting the sufficient value for TLS would also enable HTTP/2, unless the [`server.proxy` option](#server-proxy) is also used.
 
 A valid certificate is needed. For a basic setup, you can add [@vitejs/plugin-basic-ssl](https://github.com/vitejs/vite-plugin-basic-ssl) to the project plugins, which will automatically create and cache a self-signed certificate. But we recommend creating your own certificates.
 


### PR DESCRIPTION
### Description

close #19647

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
