### PR TITLE
ci: pin commit for actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,11 @@
       "depTypeList": ["peerDependencies"],
       "enabled": false,
     },
+    {
+      "matchDepTypes": ["action"],
+      "excludePackagePrefixes": ["actions/"],
+      "pinDigests": true,
+    },
   ],
   "ignoreDeps": [
     // manually bumping

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,7 @@
     },
     {
       "matchDepTypes": ["action"],
-      "excludePackagePrefixes": ["actions/"],
+      "excludePackagePrefixes": ["actions/", "github/"],
       "pinDigests": true,
     },
   ],


### PR DESCRIPTION
### Description

This config would make renovate to pin actions for non-official ones (the ones not under https://github.com/actions).

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
