### PR TITLE
docs: update to viteconf 2025

### DIFF
--- a/docs/.vitepress/theme/components/AsideSponsors.vue
+++ b/docs/.vitepress/theme/components/AsideSponsors.vue
@@ -21,14 +21,14 @@ const sponsors = computed(() => {
 <template>
   <a
     class="viteconf"
-    href="https://viteconf.org/24/replay?utm=vite-sidebar"
+    href="https://viteconf.amsterdam/?utm=vite-sidebar"
     target="_blank"
   >
     <img width="22" height="22" src="/viteconf.svg" alt="ViteConf Logo" />
     <span>
       <p class="extra-info">Building Together</p>
-      <p class="heading">ViteConf 2024</p>
-      <p class="extra-info">Watch the replay!</p>
+      <p class="heading">ViteConf 2025</p>
+      <p class="extra-info">First time in-person!</p>
     </span>
   </a>
   <VPDocAsideSponsors v-if="data" :data="sponsors" />

--- a/docs/.vitepress/theme/components/AsideSponsors.vue
+++ b/docs/.vitepress/theme/components/AsideSponsors.vue
@@ -21,7 +21,7 @@ const sponsors = computed(() => {
 <template>
   <a
     class="viteconf"
-    href="https://viteconf.amsterdam/?utm=vite-sidebar"
+    href="https://viteconf.org/?utm=vite-sidebar"
     target="_blank"
   >
     <img width="22" height="22" src="/viteconf.svg" alt="ViteConf Logo" />

--- a/docs/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
+++ b/docs/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
@@ -5,14 +5,14 @@ import HeroDiagram from './HeroDiagram.vue'
 <template>
   <div class="hero">
     <div class="container">
-      <!-- ViteConf Replay Button -->
+      <!-- ViteConf 2025 Button -->
       <a
-        href="https://viteconf.org/24/replay?utm=vite"
+        href="https://viteconf.amsterdam?utm=vite"
         class="hero__pill"
         target="_blank"
       >
         <img src="/viteconf.svg" alt="Viteconf logo" width="20" height="20" />
-        <span>ViteConf 2024 Talks</span>
+        <span>ViteConf 2025</span>
       </a>
 
       <!-- Heading -->

--- a/docs/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
+++ b/docs/.vitepress/theme/components/landing/1. hero-section/HeroSection.vue
@@ -7,7 +7,7 @@ import HeroDiagram from './HeroDiagram.vue'
     <div class="container">
       <!-- ViteConf 2025 Button -->
       <a
-        href="https://viteconf.amsterdam?utm=vite"
+        href="https://viteconf.org/?utm=vite"
         class="hero__pill"
         target="_blank"
       >


### PR DESCRIPTION
### Description

Given that the 2024 replay link is also going straight to the in-person ViteConf page, I thought updating occurrences to indicate the 2025 in-person edition could make sense 😋 