### PR TITLE
fix(css): scoped css order with non-scoped css

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -10,6 +10,7 @@ import type {
   OutputAsset,
   OutputChunk,
   RenderedChunk,
+  RenderedModule,
   RollupError,
   SourceMapInput,
 } from 'rollup'
@@ -440,69 +441,12 @@ export function cssPlugin(config: ResolvedConfig): Plugin {
   }
 }
 
-const createStyleContentMap = () => {
-  const contents = new Map<string, string>() // css id -> css content
-  const scopedIds = new Set<string>() // ids of css that are scoped
-  const relations = new Map<
-    /* the id of the target for which css is scoped to */ string,
-    Array<{
-      /** css id */ id: string
-      /** export name */ exp: string | undefined
-    }>
-  >()
-
-  return {
-    putContent(
-      id: string,
-      content: string,
-      scopeTo: CustomPluginOptionsVite['cssScopeTo'] | undefined,
-    ) {
-      contents.set(id, content)
-      if (scopeTo) {
-        const [scopedId, exp] = scopeTo
-        if (!relations.has(scopedId)) {
-          relations.set(scopedId, [])
-        }
-        relations.get(scopedId)!.push({ id, exp })
-        scopedIds.add(id)
-      }
-    },
-    hasContentOfNonScoped(id: string) {
-      return !scopedIds.has(id) && contents.has(id)
-    },
-    getContentOfNonScoped(id: string) {
-      if (scopedIds.has(id)) return
-      return contents.get(id)
-    },
-    hasContentsScopedTo(id: string) {
-      return (relations.get(id) ?? [])?.length > 0
-    },
-    getContentsScopedTo(id: string, importedIds: readonly string[]) {
-      const values = (relations.get(id) ?? []).map(
-        ({ id, exp }) =>
-          [
-            id,
-            {
-              content: contents.get(id) ?? '',
-              exp,
-            },
-          ] as const,
-      )
-      const styleIdToValue = new Map(values)
-      // get a sorted output by import order to make output deterministic
-      return importedIds
-        .filter((id) => styleIdToValue.has(id))
-        .map((id) => styleIdToValue.get(id)!)
-    },
-  }
-}
-
 /**
  * Plugin applied after user plugins
  */
 export function cssPostPlugin(config: ResolvedConfig): Plugin {
   // styles initialization in buildStart causes a styling loss in watch
-  const styles = createStyleContentMap()
+  const styles = new Map<string, string>()
   // queue to emit css serially to guarantee the files are emitted in a deterministic order
   let codeSplitEmitQueue = createSerialPromiseQueue<string>()
   const urlEmitQueue = createSerialPromiseQueue<unknown>()
@@ -646,19 +590,9 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
       // build CSS handling ----------------------------------------------------
 
-      const cssScopeTo =
-        // NOTE: `this.getModuleInfo` can be undefined when the plugin is called directly
-        //       adding `?.` temporary to avoid unocss from breaking
-        // TODO: remove `?.` after `this.getModuleInfo` in Vite 7
-        (
-          this.getModuleInfo?.(id)?.meta?.vite as
-            | CustomPluginOptionsVite
-            | undefined
-        )?.cssScopeTo
-
       // record css
       if (!inlined) {
-        styles.putContent(id, css, cssScopeTo)
+        styles.set(id, css)
       }
 
       let code: string
@@ -680,40 +614,48 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         map: { mappings: '' },
         // avoid the css module from being tree-shaken so that we can retrieve
         // it in renderChunk()
-        moduleSideEffects:
-          modulesCode || inlined || cssScopeTo ? false : 'no-treeshake',
+        moduleSideEffects: modulesCode || inlined ? false : 'no-treeshake',
       }
     },
 
-    async renderChunk(code, chunk, opts) {
+    async renderChunk(code, chunk, opts, meta) {
       let chunkCSS = ''
+      const renderedModules = Object.fromEntries(
+        Object.values(meta.chunks).flatMap((chunk) =>
+          Object.entries(chunk.modules),
+        ),
+      )
       // the chunk is empty if it's a dynamic entry chunk that only contains a CSS import
       const isJsChunkEmpty = code === '' && !chunk.isEntry
       let isPureCssChunk = chunk.exports.length === 0
       const ids = Object.keys(chunk.modules)
       for (const id of ids) {
-        if (styles.hasContentOfNonScoped(id)) {
+        if (styles.has(id)) {
           // ?transform-only is used for ?url and shouldn't be included in normal CSS chunks
-          if (!transformOnlyRE.test(id)) {
-            chunkCSS += styles.getContentOfNonScoped(id)
-            // a css module contains JS, so it makes this not a pure css chunk
-            if (cssModuleRE.test(id)) {
-              isPureCssChunk = false
-            }
+          if (transformOnlyRE.test(id)) {
+            continue
           }
-        } else if (styles.hasContentsScopedTo(id)) {
-          const renderedExports = chunk.modules[id]!.renderedExports
-          const importedIds = this.getModuleInfo(id)?.importedIds ?? []
-          // If this module has scoped styles, check for the rendered exports
-          // and include the corresponding CSS.
-          for (const { exp, content } of styles.getContentsScopedTo(
-            id,
-            importedIds,
-          )) {
-            if (exp === undefined || renderedExports.includes(exp)) {
-              chunkCSS += content
-            }
+
+          // If this CSS is scoped to its importers exports, check if those importers exports
+          // are rendered in the chunks. If they are not, we can skip bundling this CSS.
+          const cssScopeTo = (
+            this.getModuleInfo(id)?.meta?.vite as
+              | CustomPluginOptionsVite
+              | undefined
+          )?.cssScopeTo
+          if (
+            cssScopeTo &&
+            !isCssScopeToRendered(cssScopeTo, renderedModules)
+          ) {
+            continue
           }
+
+          // a css module contains JS, so it makes this not a pure css chunk
+          if (cssModuleRE.test(id)) {
+            isPureCssChunk = false
+          }
+
+          chunkCSS += styles.get(id)
         } else if (!isJsChunkEmpty) {
           // if the module does not have a style, then it's not a pure css chunk.
           // this is true because in the `transform` hook above, only modules
@@ -808,13 +750,13 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
             path.basename(originalFileName),
             '.css',
           )
-          if (!styles.hasContentOfNonScoped(id)) {
+          if (!styles.has(id)) {
             throw new Error(
               `css content for ${JSON.stringify(id)} was not found`,
             )
           }
 
-          let cssContent = styles.getContentOfNonScoped(id)!
+          let cssContent = styles.get(id)!
 
           cssContent = resolveAssetUrlsInCss(cssContent, cssAssetName)
 
@@ -1179,6 +1121,17 @@ export function cssAnalysisPlugin(config: ResolvedConfig): Plugin {
       }
     },
   }
+}
+
+function isCssScopeToRendered(
+  cssScopeTo: Exclude<CustomPluginOptionsVite['cssScopeTo'], undefined>,
+  renderedModules: Record<string, RenderedModule | undefined>,
+) {
+  const [importerId, exp] = cssScopeTo
+  const importer = renderedModules[importerId]
+  return (
+    importer && (exp === undefined || importer.renderedExports.includes(exp))
+  )
 }
 
 /**

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -5,6 +5,7 @@ import {
   editFile,
   findAssetFile,
   getBg,
+  getBgColor,
   getColor,
   isBuild,
   page,
@@ -504,6 +505,12 @@ test.runIf(isBuild)('Scoped CSS via cssScopeTo should be treeshaken', () => {
   const css = findAssetFile(/\.css$/, undefined, undefined, true)
   expect(css).not.toMatch(/\btreeshake-scoped-b\b/)
   expect(css).not.toMatch(/\btreeshake-scoped-c\b/)
+})
+
+test('Scoped CSS should have a correct order', async () => {
+  await page.goto(viteTestUrl + '/treeshake-scoped/')
+  expect(await getColor('.treeshake-scoped-order')).toBe('red')
+  expect(await getBgColor('.treeshake-scoped-order')).toBe('blue')
 })
 
 test.runIf(isBuild)(

--- a/playground/css/__tests__/css.spec.ts
+++ b/playground/css/__tests__/css.spec.ts
@@ -512,17 +512,3 @@ test('Scoped CSS should have a correct order', async () => {
   expect(await getColor('.treeshake-scoped-order')).toBe('red')
   expect(await getBgColor('.treeshake-scoped-order')).toBe('blue')
 })
-
-test.runIf(isBuild)(
-  'Scoped CSS via cssScopeTo should be bundled separately',
-  () => {
-    const scopedIndexCss = findAssetFile(/treeshakeScoped-[-\w]{8}\.css$/)
-    expect(scopedIndexCss).toContain('treeshake-scoped-barrel-a')
-    expect(scopedIndexCss).not.toContain('treeshake-scoped-barrel-b')
-    const scopedAnotherCss = findAssetFile(
-      /treeshakeScopedAnother-[-\w]{8}\.css$/,
-    )
-    expect(scopedAnotherCss).toContain('treeshake-scoped-barrel-b')
-    expect(scopedAnotherCss).not.toContain('treeshake-scoped-barrel-a')
-  },
-)

--- a/playground/css/treeshake-scoped/another.html
+++ b/playground/css/treeshake-scoped/another.html
@@ -1,7 +1,0 @@
-<h1>treeshake-scoped (another)</h1>
-<p class="scoped-another">Imported scoped CSS</p>
-
-<script type="module">
-  import { b } from './barrel/index.js'
-  document.querySelector('.scoped-another').classList.add(b())
-</script>

--- a/playground/css/treeshake-scoped/barrel/a-scoped.css
+++ b/playground/css/treeshake-scoped/barrel/a-scoped.css
@@ -1,4 +1,0 @@
-.treeshake-scoped-barrel-a {
-  text-decoration-line: underline;
-  text-decoration-color: red;
-}

--- a/playground/css/treeshake-scoped/barrel/a.js
+++ b/playground/css/treeshake-scoped/barrel/a.js
@@ -1,5 +1,0 @@
-import './a-scoped.css'
-
-export function a() {
-  return 'treeshake-scoped-barrel-a'
-}

--- a/playground/css/treeshake-scoped/barrel/b-scoped.css
+++ b/playground/css/treeshake-scoped/barrel/b-scoped.css
@@ -1,4 +1,0 @@
-.treeshake-scoped-barrel-b {
-  text-decoration-line: underline;
-  text-decoration-color: red;
-}

--- a/playground/css/treeshake-scoped/barrel/b.js
+++ b/playground/css/treeshake-scoped/barrel/b.js
@@ -1,5 +1,0 @@
-import './b-scoped.css'
-
-export function b() {
-  return 'treeshake-scoped-barrel-b'
-}

--- a/playground/css/treeshake-scoped/barrel/index.js
+++ b/playground/css/treeshake-scoped/barrel/index.js
@@ -1,2 +1,0 @@
-export * from './a'
-export * from './b'

--- a/playground/css/treeshake-scoped/index.html
+++ b/playground/css/treeshake-scoped/index.html
@@ -6,8 +6,7 @@
 
 <script type="module">
   import { d } from './index.js'
-  import { a } from './barrel/index.js'
   import order from './order/a.js'
-  document.querySelector('.scoped-index').classList.add(d(), a())
+  document.querySelector('.scoped-index').classList.add(d())
   document.querySelector('.treeshake-scoped-order').classList.add(order())
 </script>

--- a/playground/css/treeshake-scoped/index.html
+++ b/playground/css/treeshake-scoped/index.html
@@ -1,8 +1,13 @@
 <h1>treeshake-scoped</h1>
 <p class="scoped-index">Imported scoped CSS</p>
+<p class="treeshake-scoped-order">
+  scoped CSS order (this should be red text with blue background)
+</p>
 
 <script type="module">
   import { d } from './index.js'
   import { a } from './barrel/index.js'
+  import order from './order/a.js'
   document.querySelector('.scoped-index').classList.add(d(), a())
+  document.querySelector('.treeshake-scoped-order').classList.add(order())
 </script>

--- a/playground/css/treeshake-scoped/order/a-scoped.css
+++ b/playground/css/treeshake-scoped/order/a-scoped.css
@@ -1,0 +1,4 @@
+.treeshake-scoped-order {
+  color: red;
+  background: red;
+}

--- a/playground/css/treeshake-scoped/order/a.js
+++ b/playground/css/treeshake-scoped/order/a.js
@@ -1,0 +1,7 @@
+import './before.css'
+import './a-scoped.css'
+import './after.css'
+
+export default function a() {
+  return 'treeshake-scoped-order-a'
+}

--- a/playground/css/treeshake-scoped/order/after.css
+++ b/playground/css/treeshake-scoped/order/after.css
@@ -1,0 +1,4 @@
+.treeshake-scoped-order {
+  color: red;
+  background: blue;
+}

--- a/playground/css/treeshake-scoped/order/before.css
+++ b/playground/css/treeshake-scoped/order/before.css
@@ -1,0 +1,3 @@
+.treeshake-scoped-order {
+  color: blue;
+}

--- a/playground/css/vite.config.js
+++ b/playground/css/vite.config.js
@@ -46,10 +46,6 @@ export default defineConfig({
           __dirname,
           './treeshake-scoped/index.html',
         ),
-        treeshakeScopedAnother: path.resolve(
-          __dirname,
-          './treeshake-scoped/another.html',
-        ),
       },
       output: {
         manualChunks(id) {

--- a/playground/test-utils.ts
+++ b/playground/test-utils.ts
@@ -126,7 +126,10 @@ export async function getBgColor(
   el: string | ElementHandle | Locator,
 ): Promise<string> {
   el = await toEl(el)
-  return el.evaluate((el) => getComputedStyle(el as Element).backgroundColor)
+  const rgb = await el.evaluate(
+    (el) => getComputedStyle(el as Element).backgroundColor,
+  )
+  return hexToNameMap[rgbToHex(rgb)] ?? rgb
 }
 
 export function readFile(filename: string): string {


### PR DESCRIPTION
### Description

This PR changes the implementation of `cssScopeTo` support to the one proposed in #16058 from #19418.
The implementation in #19418 has a upside of a better chunking behavior, but had a downside of not preserving the style order when a single module has both scoped and non-scoped styles.

refs https://discord.com/channels/804011606160703521/804439875226173480/1349606289252028418
refs https://github.com/withastro/astro/pull/13420

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
