### PR TITLE
feat(config): improve bad character warning

### DIFF
--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -64,15 +64,6 @@ While it may work using [`--experimental-require-module`](https://nodejs.org/doc
 - adding `"type": "module"` to the nearest `package.json`
 - renaming `vite.config.js`/`vite.config.ts` to `vite.config.mjs`/`vite.config.mts`
 
-### `failed to load config from '/path/to/config*/vite.config.js'`
-
-> failed to load config from '/path/to/config\*/vite.config.js'
-> error when starting dev server:
-> Error: Build failed with 1 error:
-> error: Must use "outdir" when there are multiple input files
-
-The error above may occur if the path to your project folder contains `*`, which esbuild treats as a glob. You will need to rename your directory to remove the `*`.
-
 ## Dev Server
 
 ### Requests are stalled forever

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -361,7 +361,7 @@ describe('resolveConfig', () => {
     const logger = createLogger('info')
     logger.warn = (str) => {
       expect(str).to.include(
-        'Consider renaming the directory to remove the characters',
+        'Consider renaming the directory / file to remove the characters',
       )
     }
 

--- a/packages/vite/src/node/__tests__/config.spec.ts
+++ b/packages/vite/src/node/__tests__/config.spec.ts
@@ -355,7 +355,7 @@ describe('resolveConfig', () => {
     expect(results2.clearScreen).toBe(false)
   })
 
-  test('resolveConfig with root path including "#" and "?" should warn ', async () => {
+  test('resolveConfig with root path including "#" and "?" and "*" should warn ', async () => {
     expect.assertions(1)
 
     const logger = createLogger('info')
@@ -365,7 +365,7 @@ describe('resolveConfig', () => {
       )
     }
 
-    await resolveConfig({ root: './inc?ud#s', customLogger: logger }, 'build')
+    await resolveConfig({ root: './inc?ud#s*', customLogger: logger }, 'build')
   })
 })
 

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -862,7 +862,11 @@ export type ResolveFn = (
  * Check and warn if `path` includes characters that don't work well in Vite,
  * such as `#` and `?` and `*`.
  */
-function checkBadCharactersInPath(path: string, logger: Logger): void {
+function checkBadCharactersInPath(
+  name: string,
+  path: string,
+  logger: Logger,
+): void {
   const badChars = []
 
   if (path.includes('#')) {
@@ -881,9 +885,9 @@ function checkBadCharactersInPath(path: string, logger: Logger): void {
 
     logger.warn(
       colors.yellow(
-        `The project root contains the ${charString} ${inflectedChars} (${colors.cyan(
+        `${name} contains the ${charString} ${inflectedChars} (${colors.cyan(
           path,
-        )}), which may not work when running Vite. Consider renaming the directory to remove the characters.`,
+        )}), which may not work when running Vite. Consider renaming the directory / file to remove the characters.`,
       ),
     )
   }
@@ -1114,7 +1118,7 @@ export async function resolveConfig(
     config.root ? path.resolve(config.root) : process.cwd(),
   )
 
-  checkBadCharactersInPath(resolvedRoot, logger)
+  checkBadCharactersInPath('The project root', resolvedRoot, logger)
 
   const configEnvironmentsClient = config.environments!.client!
   configEnvironmentsClient.dev ??= {}
@@ -1779,12 +1783,11 @@ export async function loadConfigFromFile(
       dependencies,
     }
   } catch (e) {
-    createLogger(logLevel, { customLogger }).error(
-      colors.red(`failed to load config from ${resolvedPath}`),
-      {
-        error: e,
-      },
-    )
+    const logger = createLogger(logLevel, { customLogger })
+    checkBadCharactersInPath('The config path', resolvedPath, logger)
+    logger.error(colors.red(`failed to load config from ${resolvedPath}`), {
+      error: e,
+    })
     throw e
   }
 }

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -860,7 +860,7 @@ export type ResolveFn = (
 
 /**
  * Check and warn if `path` includes characters that don't work well in Vite,
- * such as `#` and `?`.
+ * such as `#` and `?` and `*`.
  */
 function checkBadCharactersInPath(path: string, logger: Logger): void {
   const badChars = []
@@ -870,6 +870,9 @@ function checkBadCharactersInPath(path: string, logger: Logger): void {
   }
   if (path.includes('?')) {
     badChars.push('?')
+  }
+  if (path.includes('*')) {
+    badChars.push('*')
   }
 
   if (badChars.length > 0) {


### PR DESCRIPTION
### Description

- treat `*` as bad characters included in #15761 for #17976
- run bad characters check if the config failed to load for #17457 and #17976
- remove troubleshooting entry which was for #17976 as we now have a better error message

close #17457
refs #15761
refs #19377

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
