### PR TITLE
fix: add back `.mts` to default `resolve.extensions`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -651,7 +651,7 @@ export const configDefaults = Object.freeze({
     // mainFields
     // conditions
     externalConditions: ['node'],
-    extensions: ['.mjs', '.js', '.ts', '.jsx', '.tsx', '.json'],
+    extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json'],
     dedupe: [],
     /** @experimental */
     noExternal: [],


### PR DESCRIPTION
### Description

`.mts` was removed from the default during https://github.com/vitejs/vite/pull/18550. Though tsc doesn't currently allow this as we discovered in https://github.com/vitejs/vite/issues/18500 and https://github.com/microsoft/TypeScript/issues/60409, I don't think this breaking change was intended for Vite 6.