### PR TITLE
perf: only bundle node version `debug`

### DIFF
--- a/packages/vite/rollup.config.ts
+++ b/packages/vite/rollup.config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import alias from '@rollup/plugin-alias'
 import nodeResolve from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import json from '@rollup/plugin-json'
@@ -82,6 +83,12 @@ function createSharedNodePlugins({
   esbuildOptions?: esbuildOptions
 }): Plugin[] {
   return [
+    alias({
+      entries: {
+        // we can always use node version (the default entry point has browser support)
+        debug: 'debug/src/node.js',
+      },
+    }),
     nodeResolve({ preferBuiltins: true }),
     esbuild({
       tsconfig: path.resolve(__dirname, 'src/node/tsconfig.json'),


### PR DESCRIPTION
### Description

`debug` contains code for both browsers and node. The default entrypoint detects the runtime and uses the corresponding file.
In our case, we know that we only run on node, and the browser code is not needed.

I set alias to `debug` to resolve to the file that will be used for node.

This PR reduces the compressed package size for 6kB. Not big, but I think the change is simple enough.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
