### PR TITLE
feat(legacy): add 'assumptions' option

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -563,6 +563,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
         compact: !!config.build.minify,
         sourceMaps,
         inputSourceMap: undefined,
+        assumptions,
         presets: [
           // forcing our plugin to run before preset-env by wrapping it in a
           // preset so we can catch the injected import statements...
@@ -577,9 +578,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           ],
           [
             (await import('@babel/preset-env')).default,
-            createBabelPresetEnvOptions(targets, assumptions, {
-              needPolyfills,
-            }),
+            createBabelPresetEnvOptions(targets, { needPolyfills }),
           ],
         ],
       })
@@ -754,10 +753,11 @@ export async function detectPolyfills(
     babelrc: false,
     configFile: false,
     compact: false,
+    assumptions,
     presets: [
       [
         (await import('@babel/preset-env')).default,
-        createBabelPresetEnvOptions(targets, assumptions, {}),
+        createBabelPresetEnvOptions(targets, {}),
       ],
     ],
   })
@@ -776,7 +776,6 @@ export async function detectPolyfills(
 
 function createBabelPresetEnvOptions(
   targets: any,
-  assumptions: Record<string, boolean>,
   { needPolyfills = true }: { needPolyfills?: boolean },
 ) {
   return {
@@ -793,7 +792,6 @@ function createBabelPresetEnvOptions(
       : undefined,
     shippedProposals: true,
     ignoreBrowserslistConfig: true,
-    assumptions,
   }
 }
 

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -745,7 +745,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
 export async function detectPolyfills(
   code: string,
   targets: any,
-  assumptions: Record<string, boolean> = {},
+  assumptions: Record<string, boolean>,
   list: Set<string>,
 ): Promise<void> {
   const babel = await loadBabel()
@@ -776,7 +776,7 @@ export async function detectPolyfills(
 
 function createBabelPresetEnvOptions(
   targets: any,
-  assumptions: Record<string, boolean> = {},
+  assumptions: Record<string, boolean>,
   { needPolyfills = true }: { needPolyfills?: boolean },
 ) {
   return {

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -493,7 +493,12 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           genModern
         ) {
           // analyze and record modern polyfills
-          await detectPolyfills(raw, modernTargets, assumptions, polyfillsDiscovered.modern)
+          await detectPolyfills(
+            raw,
+            modernTargets,
+            assumptions,
+            polyfillsDiscovered.modern,
+          )
         }
 
         const ms = new MagicString(raw)
@@ -572,7 +577,9 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
           ],
           [
             (await import('@babel/preset-env')).default,
-            createBabelPresetEnvOptions(targets, assumptions, { needPolyfills }),
+            createBabelPresetEnvOptions(targets, assumptions, {
+              needPolyfills,
+            }),
           ],
         ],
       })
@@ -738,7 +745,7 @@ function viteLegacyPlugin(options: Options = {}): Plugin[] {
 export async function detectPolyfills(
   code: string,
   targets: any,
-  assumptions: { [key: string]: boolean } = {},
+  assumptions: Record<string, boolean> = {},
   list: Set<string>,
 ): Promise<void> {
   const babel = await loadBabel()
@@ -769,7 +776,7 @@ export async function detectPolyfills(
 
 function createBabelPresetEnvOptions(
   targets: any,
-  assumptions: { [key: string]: boolean } = {},
+  assumptions: Record<string, boolean> = {},
   { needPolyfills = true }: { needPolyfills?: boolean },
 ) {
   return {

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -29,4 +29,10 @@ export interface Options {
    * default: true
    */
   renderModernChunks?: boolean
+  /**
+   * default: {}
+   */
+  assumptions?: {
+    [key: string]: boolean
+  }
 }

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -30,6 +30,8 @@ export interface Options {
    */
   renderModernChunks?: boolean
   /**
+   * @see https://babeljs.io/docs/assumptions
+   *
    * default: {}
    */
   assumptions?: Record<string, boolean>

--- a/packages/plugin-legacy/src/types.ts
+++ b/packages/plugin-legacy/src/types.ts
@@ -32,7 +32,5 @@ export interface Options {
   /**
    * default: {}
    */
-  assumptions?: {
-    [key: string]: boolean
-  }
+  assumptions?: Record<string, boolean>
 }


### PR DESCRIPTION
This updates and reopens https://github.com/vitejs/vite/pull/10887 which fixes https://github.com/vitejs/vite/issues/6965.

It does by adding a new plugin-legacy option: `assumptions`, which will be passed directly to `@babel/preset-env` options to configure [compiler assumptions](https://babeljs.io/docs/assumptions).