### PR TITLE
feat(create-vite): update "react" and "react-ts" templates to use extends in eslint config

### DIFF
--- a/packages/create-vite/template-react-ts/README.md
+++ b/packages/create-vite/template-react-ts/README.md
@@ -39,16 +39,19 @@ import reactX from 'eslint-plugin-react-x'
 import reactDom from 'eslint-plugin-react-dom'
 
 export default tseslint.config({
-  plugins: {
-    // Add the react-x and react-dom plugins
-    'react-x': reactX,
-    'react-dom': reactDom,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
+  extends: [
+    // other configs...
+    // Enable lint rules for React
+    reactX.configs['recommended-typescript'],
+    // Enable lint rules for React DOM
+    reactDom.configs.recommended,
+  ],
+  languageOptions: {
+    // other options...
+    parserOptions: {
+      project: ['./tsconfig.node.json', './tsconfig.app.json'],
+      tsconfigRootDir: import.meta.dirname,
+    },
   },
 })
 ```

--- a/packages/create-vite/template-react/eslint.config.js
+++ b/packages/create-vite/template-react/eslint.config.js
@@ -2,11 +2,13 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import { defineConfig } from 'eslint/config'
 
-export default [
+export default defineConfig([
   { ignores: ['dist'] },
   {
     files: ['**/*.{js,jsx}'],
+    extends: [js.configs.recommended],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
@@ -21,7 +23,6 @@ export default [
       'react-refresh': reactRefresh,
     },
     rules: {
-      ...js.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
       'react-refresh/only-export-components': [
@@ -30,4 +31,4 @@ export default [
       ],
     },
   },
-]
+])


### PR DESCRIPTION
### Description

Previous discussion: https://github.com/vitejs/vite/pull/19524, https://github.com/vitejs/vite/issues/19594 

ESLint has now officially [reintroduced `extends`](https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/#bringing-back-extends). This PR updates the example configurations in `template-react` and `template-react-ts` to use `extends` to simplify ESLint configuration.

closes #19594

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
