### PR TITLE
refactor(modulePreloadPolyfill): move polyfill code to own file

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/__snapshots__/modulePreloadPolyfill.spec.ts.snap
+++ b/packages/vite/src/node/__tests__/plugins/modulePreloadPolyfill/__snapshots__/modulePreloadPolyfill.spec.ts.snap
@@ -6,12 +6,14 @@ exports[`load > doesn't load modulepreload polyfill when format is cjs 1`] = `
 `;
 
 exports[`load > loads modulepreload polyfill 1`] = `
-"(function polyfill() {
+"(function modulePreloadPolyfill() {
   const relList = document.createElement("link").relList;
   if (relList && relList.supports && relList.supports("modulepreload")) {
     return;
   }
-  for (const link of document.querySelectorAll('link[rel="modulepreload"]')) {
+  for (const link of Array.from(
+    document.querySelectorAll('link[rel="modulepreload"]')
+  )) {
     processPreload(link);
   }
   new MutationObserver((mutations) => {

--- a/packages/vite/src/node/plugins/modulePreloadPolyfill/index.ts
+++ b/packages/vite/src/node/plugins/modulePreloadPolyfill/index.ts
@@ -1,0 +1,39 @@
+import type { ResolvedConfig } from '../..'
+import type { Plugin } from '../../plugin'
+import { isModernFlag } from '../importAnalysisBuild'
+import { modulePreloadPolyfill } from './modulePreloadPolyfill'
+
+export const modulePreloadPolyfillId = 'vite/modulepreload-polyfill'
+const resolvedModulePreloadPolyfillId = '\0' + modulePreloadPolyfillId + '.js'
+
+export function modulePreloadPolyfillPlugin(config: ResolvedConfig): Plugin {
+  let polyfillString: string | undefined
+
+  return {
+    name: 'vite:modulepreload-polyfill',
+    resolveId: {
+      handler(id) {
+        if (id === modulePreloadPolyfillId) {
+          return resolvedModulePreloadPolyfillId
+        }
+      },
+    },
+    load: {
+      handler(id) {
+        if (id === resolvedModulePreloadPolyfillId) {
+          // `isModernFlag` is only available during build since it is resolved by `vite:build-import-analysis`
+          if (
+            config.command !== 'build' ||
+            this.environment.config.consumer !== 'client'
+          ) {
+            return ''
+          }
+          if (!polyfillString) {
+            polyfillString = `${isModernFlag}&&(${modulePreloadPolyfill.toString()}());`
+          }
+          return { code: polyfillString, moduleSideEffects: true }
+        }
+      },
+    },
+  }
+}


### PR DESCRIPTION
This is a refactor I encountered when working on a separate bug.

This PR refactors the module preload polyfill plugin by separating browser-specific code into its own file. The previous implementation used `any` types, which reduced type safety.

By moving the polyfill to a dedicated file with appropriate DOM type declarations, the code is now more stable and maintainable. This surfaced the following type error which I fixed:
```
Type 'NodeListOf<Element>' must have a '[Symbol.iterator]()' method that returns an iterator.ts(2488)
```