### PR TITLE
docs: make redirects permanent

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,9 +1,9 @@
 # temporary, we'll flip this around some day
 https://vitejs.dev/* https://vite.dev/:splat 301!
 
-/guide/api-vite-runtime /guide/api-environment 302
-/guide/api-vite-runtime.html /guide/api-environment 302
-/guide/api-vite-environment /guide/api-environment 302
-/guide/api-vite-environment.html /guide/api-environment 302
-/guide/comparisons /guide/why#how-vite-relates-to-other-unbundled-build-tools 302
-/guide/comparisons.html /guide/why#how-vite-relates-to-other-unbundled-build-tools 302
+/guide/api-vite-runtime /guide/api-environment 301
+/guide/api-vite-runtime.html /guide/api-environment 301
+/guide/api-vite-environment /guide/api-environment 301
+/guide/api-vite-environment.html /guide/api-environment 301
+/guide/comparisons /guide/why#how-vite-relates-to-other-unbundled-build-tools 301
+/guide/comparisons.html /guide/why#how-vite-relates-to-other-unbundled-build-tools 301


### PR DESCRIPTION
As the pages in the `_redirects` file have moved permanently to a new place (as far as I know), I've adapted the status code [so crawlers know as well](https://developers.google.com/search/docs/crawling-indexing/301-redirects)