### PR TITLE
docs: add rolldown guide short link

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -7,4 +7,4 @@ https://vitejs.dev/* https://vite.dev/:splat 301!
 /guide/api-vite-environment.html /guide/api-environment 302
 /guide/comparisons /guide/why#how-vite-relates-to-other-unbundled-build-tools 302
 /guide/comparisons.html /guide/why#how-vite-relates-to-other-unbundled-build-tools 302
-/rolldown /guide/rolldown
+/rolldown /guide/rolldown 301

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -7,3 +7,4 @@ https://vitejs.dev/* https://vite.dev/:splat 301!
 /guide/api-vite-environment.html /guide/api-environment 302
 /guide/comparisons /guide/why#how-vite-relates-to-other-unbundled-build-tools 302
 /guide/comparisons.html /guide/why#how-vite-relates-to-other-unbundled-build-tools 302
+/rolldown /guide/rolldown


### PR DESCRIPTION
This short URL should make it easier to share [the Rolldown guide](https://github.com/vitejs/vite/pull/19680) in blog posts/videos/podcasts and similar.