### PR TITLE
feat: support for multiple additional hosts via env

### DIFF
--- a/docs/config/server-options.md
+++ b/docs/config/server-options.md
@@ -70,7 +70,7 @@ Setting `server.allowedHosts` to `true` allows any website to send requests to y
 :::
 
 ::: details Configure via environment variable
-You can set the environment variable `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` to add an additional allowed host.
+You can use the environment variable `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` to add one or multiple additional allowed hosts, seperated by comma.
 :::
 
 ## server.port

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -1166,8 +1166,10 @@ export function resolveServerOptions(
     process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS &&
     Array.isArray(server.allowedHosts)
   ) {
-    const additionalHost = process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
-    server.allowedHosts = [...server.allowedHosts, additionalHost]
+    const additionalHosts = process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS
+      .split(',')
+      .map((i) => i.replace(/^https?:\/\//, ''))
+    server.allowedHosts = [...server.allowedHosts, ...additionalHosts]
   }
 
   return server


### PR DESCRIPTION
### Description

Updates the code from #19325 to allow multiple hosts in the `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` environment variable, and trims the `http` or `https` in case it is an FQDN. (e.g. `https://example.com`)

May be better to use the [URL API](https://developer.mozilla.org/en-US/docs/Web/API/URL) to extract the hostname instead, please let me know if this is preferred! ("The 'URL.canParse' is still an experimental feature and is not supported until Node.js 19.9.0.")
