### PR TITLE
feat: add vite-plugin-checker to template

### DIFF
--- a/packages/create-vite/template-react-ts/package.json
+++ b/packages/create-vite/template-react-ts/package.json
@@ -24,6 +24,7 @@
     "globals": "^16.0.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^6.2.2"
+    "vite": "^6.2.2",
+    "vite-plugin-checker": "^0.9.1"
   }
 }

--- a/packages/create-vite/template-react-ts/src/App.tsx
+++ b/packages/create-vite/template-react-ts/src/App.tsx
@@ -24,6 +24,10 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
+        <p>
+          Uncomment <code>vite-plugin-checker</code> codes in{' '}
+          <code>vite.config.ts</code> to enable error overlay.
+        </p>
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more

--- a/packages/create-vite/template-react-ts/vite.config.ts
+++ b/packages/create-vite/template-react-ts/vite.config.ts
@@ -1,7 +1,19 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+// import checker from 'vite-plugin-checker';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    // checker({
+    //   typescript: {
+    //     tsconfigPath: './tsconfig.app.json',
+    //   },
+    //   eslint: {
+    //     lintCommand: 'lint',
+    //     useFlatConfig: true,
+    //   }
+    // }),
+    react(),
+  ],
 })


### PR DESCRIPTION
### Description

This PR adds `vite-plugin-checker` to `template-react-ts`.

I find it annoying that, in `dev` mode, type check or lint check is not run by default, causes those dev-errors not being shown on terminal nor browser. One can discover a similar discussion https://github.com/vitejs/vite/discussions/18543 being opened in few months ago, but people there does not really eloborate more on how to properly integrate type checking intto build process.

This is kinda frustrating, considering that many other build tool or framework by default can already gracefully display runtime type error or lint warning in terminal or browser overlay, for at least a few years. (CRA, nextjs, gatsby, and more...)

And then I find out this section in the doc, https://vite.dev/guide/features.html#transpile-only, which finally hint me to `vite-plugin-checker`. I do believe for beginners' sake, this should be brought into template itself, instead of being briefly mentioned in a few sentences in the documentation.

### Further code change

I am making a minimal change, by introducing `vite-plugin-checker` logic as commented code in `template-react-ts/vite.config.ts`. Another possible way I can think of is introducing another whole new template folder and add / modify CLI setup accordingly. I guess it is up to PR reviewers to tell which one shall be the way to go.

For simplicity I am only changing `template-react-ts` code. Since every template has lint script, IMO it actually make sense to promote this plugin usage into all other templates.

---

Hope this PR bring awareness to the issue I raised. Would be nice to have reviewers to have a word on it.
