### PR TITLE
perf(css): avoid constructing `renderedModules`

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -639,10 +639,19 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
 
     async renderChunk(code, chunk, opts, meta) {
       let chunkCSS = ''
-      const renderedModules = Object.fromEntries(
-        Object.values(meta.chunks).flatMap((chunk) =>
-          Object.entries(chunk.modules),
-        ),
+      const renderedModules = new Proxy(
+        {} as Record<string, RenderedModule | undefined>,
+        {
+          get(_target, p) {
+            for (const name in meta.chunks) {
+              const modules = meta.chunks[name].modules
+              const module = modules[p as string]
+              if (module) {
+                return module
+              }
+            }
+          },
+        },
       )
       // the chunk is empty if it's a dynamic entry chunk that only contains a CSS import
       const isJsChunkEmpty = code === '' && !chunk.isEntry


### PR DESCRIPTION
### Description

The previous code collected all modules to an object for each chunk. It is inefficient because only some modules are actually accessed, especially when the project is large. It somehow does not cause performance problems with normal Vite, but it was degrading performance with Rolldown-Vite.
This makes the code to avoid creating the big object.

refs #19678

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
