### PR TITLE
test: fix flaky hmr-ssr circular import test fail

### DIFF
--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -853,7 +853,7 @@ if (!isBuild) {
     )
     // it throws a same error as browser case,
     // but it doesn't auto reload and it calls `hot.accept(nextExports)` with `nextExports = undefined`
-    await untilUpdated(() => el(), '')
+    await untilUpdated(() => el(), /^$/)
 
     // test reloading manually for now
     runner.evaluatedModules.clear()

--- a/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
+++ b/playground/hmr-ssr/__tests__/hmr-ssr.spec.ts
@@ -856,7 +856,8 @@ if (!isBuild) {
     await untilUpdated(() => el(), '')
 
     // test reloading manually for now
-    server.moduleGraph.invalidateAll() // TODO: why is `runner.clearCache()` not enough?
+    runner.evaluatedModules.clear()
+    server.moduleGraph.invalidateAll()
     await runner.import('/self-accept-within-circular/index')
     await untilUpdated(() => el(), 'cc')
   })


### PR DESCRIPTION
### Description

This might fix https://github.com/vitejs/vite/actions/runs/14258157884/job/39964456146#step:12:200

I just referenced https://github.com/vitejs/vite/blob/2fa149580118a6b7988593dea9e2bf2ee679506c/packages/vite/src/node/ssr/runtime/__tests__/server-source-maps.spec.ts#L55-L56
I've not traced what's happening yet.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
