### PR TITLE
fix: unbundle `fdir` to fix `commonjsOptions.dynamicRequireTargets`

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -1056,21 +1056,6 @@ Repository: git://github.com/primus/eventemitter3.git
 
 ---------------------------------------
 
-## fdir
-License: MIT
-By: thecodrr
-Repository: git+https://github.com/thecodrr/fdir.git
-
-> Copyright 2023 Abdullah Atta
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------
-
 ## finalhandler
 License: MIT
 By: Douglas Christopher Wilson

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -86,6 +86,7 @@
   "//": "READ CONTRIBUTING.md to understand what to put under deps vs. devDeps!",
   "dependencies": {
     "esbuild": "^0.25.0",
+    "fdir": "^6.4.3",
     "picomatch": "^4.0.2",
     "postcss": "^8.5.3",
     "rollup": "^4.34.9",

--- a/playground/external/vite.config.js
+++ b/playground/external/vite.config.js
@@ -32,6 +32,7 @@ export default defineConfig({
     },
     commonjsOptions: {
       esmExternals: ['vue', 'slash5'],
+      dynamicRequireTargets: ['test-no-op-fdir-glob'],
     },
   },
   plugins: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       esbuild:
         specifier: ^0.25.0
         version: 0.25.0
+      fdir:
+        specifier: ^6.4.3
+        version: 6.4.3(picomatch@4.0.2)
       picomatch:
         specifier: ^4.0.2
         version: 4.0.2


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19727

`vite` bundles `fdir` transitively through `@rollup/plugin-commonjs`. `fdir` is cjs only and it uses `require.resolve("picomatch")`, but that's broken when bundled as esm.

I think rollup leaving `require.resolve` might be a bug (we should have `createRequire` banner?), but considering the story from https://github.com/vitejs/vite/pull/19487, we should avoid duplicating `fdir`, so I chose it unbundle though it's a bit weird since it's transitive dep.

Alternative is to unbundle `@rollup/plugin-commonjs`, but I think that would also cause more duplicate bundled/unbunled transitive dep (e.g. `@rollup/pluginutils`), so I didn't go with that for now.