### PR TITLE
fix(hmr): run HMR handler sequentially

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -5,6 +5,7 @@ import {
   createWebSocketModuleRunnerTransport,
   normalizeModuleRunnerTransport,
 } from '../shared/moduleRunnerTransport'
+import { createHMRHandler } from '../shared/hmrHandler'
 import { ErrorOverlay, overlayId } from './overlay'
 import '@vite/env'
 
@@ -165,7 +166,7 @@ const hmrClient = new HMRClient(
     return await importPromise
   },
 )
-transport.connect!(handleMessage)
+transport.connect!(createHMRHandler(handleMessage))
 
 async function handleMessage(payload: HotPayload) {
   switch (payload.type) {

--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -1,6 +1,5 @@
 import type { ErrorPayload, HotPayload } from 'types/hmrPayload'
 import type { ViteHotContext } from 'types/hot'
-import type { InferCustomEventPayload } from 'types/customEvent'
 import { HMRClient, HMRContext } from '../shared/hmr'
 import {
   createWebSocketModuleRunnerTransport,
@@ -174,7 +173,7 @@ async function handleMessage(payload: HotPayload) {
       console.debug(`[vite] connected.`)
       break
     case 'update':
-      notifyListeners('vite:beforeUpdate', payload)
+      await hmrClient.notifyListeners('vite:beforeUpdate', payload)
       if (hasDocument) {
         // if this is the first update and there's already an error overlay, it
         // means the page opened with existing server compile error and the whole
@@ -238,10 +237,10 @@ async function handleMessage(payload: HotPayload) {
           })
         }),
       )
-      notifyListeners('vite:afterUpdate', payload)
+      await hmrClient.notifyListeners('vite:afterUpdate', payload)
       break
     case 'custom': {
-      notifyListeners(payload.event, payload.data)
+      await hmrClient.notifyListeners(payload.event, payload.data)
       if (payload.event === 'vite:ws:disconnect') {
         if (hasDocument && !willUnload) {
           console.log(`[vite] server connection lost. Polling for restart...`)
@@ -255,7 +254,7 @@ async function handleMessage(payload: HotPayload) {
       break
     }
     case 'full-reload':
-      notifyListeners('vite:beforeFullReload', payload)
+      await hmrClient.notifyListeners('vite:beforeFullReload', payload)
       if (hasDocument) {
         if (payload.path && payload.path.endsWith('.html')) {
           // if html file is edited, only reload the page if the browser is
@@ -276,11 +275,11 @@ async function handleMessage(payload: HotPayload) {
       }
       break
     case 'prune':
-      notifyListeners('vite:beforePrune', payload)
+      await hmrClient.notifyListeners('vite:beforePrune', payload)
       await hmrClient.prunePaths(payload.paths)
       break
     case 'error': {
-      notifyListeners('vite:error', payload)
+      await hmrClient.notifyListeners('vite:error', payload)
       if (hasDocument) {
         const err = payload.err
         if (enableOverlay) {
@@ -300,14 +299,6 @@ async function handleMessage(payload: HotPayload) {
       return check
     }
   }
-}
-
-function notifyListeners<T extends string>(
-  event: T,
-  data: InferCustomEventPayload<T>,
-): void
-function notifyListeners(event: string, data: any): void {
-  hmrClient.notifyListeners(event, data)
 }
 
 const enableOverlay = __HMR_ENABLE_OVERLAY__

--- a/packages/vite/src/module-runner/hmrHandler.ts
+++ b/packages/vite/src/module-runner/hmrHandler.ts
@@ -1,133 +1,87 @@
 import type { HotPayload } from 'types/hmrPayload'
 import { slash, unwrapId } from '../shared/utils'
 import { ERR_OUTDATED_OPTIMIZED_DEP } from '../shared/constants'
+import { createHMRHandler } from '../shared/hmrHandler'
 import type { ModuleRunner } from './runner'
 
-// updates to HMR should go one after another. It is possible to trigger another update during the invalidation for example.
-export function createHMRHandler(
+export function createHMRHandlerForRunner(
   runner: ModuleRunner,
 ): (payload: HotPayload) => Promise<void> {
-  const queue = new Queue()
-  return (payload) => queue.enqueue(() => handleHotPayload(runner, payload))
-}
+  return createHMRHandler(async (payload) => {
+    const hmrClient = runner.hmrClient
+    if (!hmrClient || runner.isClosed()) return
+    switch (payload.type) {
+      case 'connected':
+        hmrClient.logger.debug(`connected.`)
+        break
+      case 'update':
+        await hmrClient.notifyListeners('vite:beforeUpdate', payload)
+        await Promise.all(
+          payload.updates.map(async (update): Promise<void> => {
+            if (update.type === 'js-update') {
+              // runner always caches modules by their full path without /@id/ prefix
+              update.acceptedPath = unwrapId(update.acceptedPath)
+              update.path = unwrapId(update.path)
+              return hmrClient.queueUpdate(update)
+            }
 
-export async function handleHotPayload(
-  runner: ModuleRunner,
-  payload: HotPayload,
-): Promise<void> {
-  const hmrClient = runner.hmrClient
-  if (!hmrClient || runner.isClosed()) return
-  switch (payload.type) {
-    case 'connected':
-      hmrClient.logger.debug(`connected.`)
-      break
-    case 'update':
-      await hmrClient.notifyListeners('vite:beforeUpdate', payload)
-      await Promise.all(
-        payload.updates.map(async (update): Promise<void> => {
-          if (update.type === 'js-update') {
-            // runner always caches modules by their full path without /@id/ prefix
-            update.acceptedPath = unwrapId(update.acceptedPath)
-            update.path = unwrapId(update.path)
-            return hmrClient.queueUpdate(update)
-          }
-
-          hmrClient.logger.error('css hmr is not supported in runner mode.')
-        }),
-      )
-      await hmrClient.notifyListeners('vite:afterUpdate', payload)
-      break
-    case 'custom': {
-      await hmrClient.notifyListeners(payload.event, payload.data)
-      break
-    }
-    case 'full-reload': {
-      const { triggeredBy } = payload
-      const clearEntrypointUrls = triggeredBy
-        ? getModulesEntrypoints(
-            runner,
-            getModulesByFile(runner, slash(triggeredBy)),
-          )
-        : findAllEntrypoints(runner)
-
-      if (!clearEntrypointUrls.size) break
-
-      hmrClient.logger.debug(`program reload`)
-      await hmrClient.notifyListeners('vite:beforeFullReload', payload)
-      runner.evaluatedModules.clear()
-
-      for (const url of clearEntrypointUrls) {
-        try {
-          await runner.import(url)
-        } catch (err) {
-          if (err.code !== ERR_OUTDATED_OPTIMIZED_DEP) {
-            hmrClient.logger.error(
-              `An error happened during full reload\n${err.message}\n${err.stack}`,
+            hmrClient.logger.error('css hmr is not supported in runner mode.')
+          }),
+        )
+        await hmrClient.notifyListeners('vite:afterUpdate', payload)
+        break
+      case 'custom': {
+        await hmrClient.notifyListeners(payload.event, payload.data)
+        break
+      }
+      case 'full-reload': {
+        const { triggeredBy } = payload
+        const clearEntrypointUrls = triggeredBy
+          ? getModulesEntrypoints(
+              runner,
+              getModulesByFile(runner, slash(triggeredBy)),
             )
+          : findAllEntrypoints(runner)
+
+        if (!clearEntrypointUrls.size) break
+
+        hmrClient.logger.debug(`program reload`)
+        await hmrClient.notifyListeners('vite:beforeFullReload', payload)
+        runner.evaluatedModules.clear()
+
+        for (const url of clearEntrypointUrls) {
+          try {
+            await runner.import(url)
+          } catch (err) {
+            if (err.code !== ERR_OUTDATED_OPTIMIZED_DEP) {
+              hmrClient.logger.error(
+                `An error happened during full reload\n${err.message}\n${err.stack}`,
+              )
+            }
           }
         }
+        break
       }
-      break
+      case 'prune':
+        await hmrClient.notifyListeners('vite:beforePrune', payload)
+        await hmrClient.prunePaths(payload.paths)
+        break
+      case 'error': {
+        await hmrClient.notifyListeners('vite:error', payload)
+        const err = payload.err
+        hmrClient.logger.error(
+          `Internal Server Error\n${err.message}\n${err.stack}`,
+        )
+        break
+      }
+      case 'ping': // noop
+        break
+      default: {
+        const check: never = payload
+        return check
+      }
     }
-    case 'prune':
-      await hmrClient.notifyListeners('vite:beforePrune', payload)
-      await hmrClient.prunePaths(payload.paths)
-      break
-    case 'error': {
-      await hmrClient.notifyListeners('vite:error', payload)
-      const err = payload.err
-      hmrClient.logger.error(
-        `Internal Server Error\n${err.message}\n${err.stack}`,
-      )
-      break
-    }
-    case 'ping': // noop
-      break
-    default: {
-      const check: never = payload
-      return check
-    }
-  }
-}
-
-class Queue {
-  private queue: {
-    promise: () => Promise<void>
-    resolve: (value?: unknown) => void
-    reject: (err?: unknown) => void
-  }[] = []
-  private pending = false
-
-  enqueue(promise: () => Promise<void>) {
-    return new Promise<any>((resolve, reject) => {
-      this.queue.push({
-        promise,
-        resolve,
-        reject,
-      })
-      this.dequeue()
-    })
-  }
-
-  dequeue() {
-    if (this.pending) {
-      return false
-    }
-    const item = this.queue.shift()
-    if (!item) {
-      return false
-    }
-    this.pending = true
-    item
-      .promise()
-      .then(item.resolve)
-      .catch(item.reject)
-      .finally(() => {
-        this.pending = false
-        this.dequeue()
-      })
-    return true
-  }
+  })
 }
 
 function getModulesByFile(runner: ModuleRunner, file: string): string[] {

--- a/packages/vite/src/module-runner/runner.ts
+++ b/packages/vite/src/module-runner/runner.ts
@@ -30,7 +30,7 @@ import {
   ssrModuleExportsKey,
 } from './constants'
 import { hmrLogger, silentConsole } from './hmrLogger'
-import { createHMRHandler } from './hmrHandler'
+import { createHMRHandlerForRunner } from './hmrHandler'
 import { enableSourceMapSupport } from './sourcemap/index'
 import { ESModulesEvaluator } from './esmEvaluator'
 
@@ -83,7 +83,7 @@ export class ModuleRunner {
           'HMR is not supported by this runner transport, but `hmr` option was set to true',
         )
       }
-      this.transport.connect(createHMRHandler(this))
+      this.transport.connect(createHMRHandlerForRunner(this))
     } else {
       this.transport.connect?.()
     }

--- a/packages/vite/src/shared/hmrHandler.ts
+++ b/packages/vite/src/shared/hmrHandler.ts
@@ -1,0 +1,49 @@
+import type { HotPayload } from 'types/hmrPayload'
+
+// updates to HMR should go one after another. It is possible to trigger another update during the invalidation for example.
+export function createHMRHandler(
+  handler: (payload: HotPayload) => Promise<void>,
+): (payload: HotPayload) => Promise<void> {
+  const queue = new Queue()
+  return (payload) => queue.enqueue(() => handler(payload))
+}
+
+class Queue {
+  private queue: {
+    promise: () => Promise<void>
+    resolve: (value?: unknown) => void
+    reject: (err?: unknown) => void
+  }[] = []
+  private pending = false
+
+  enqueue(promise: () => Promise<void>): Promise<void> {
+    return new Promise<any>((resolve, reject) => {
+      this.queue.push({
+        promise,
+        resolve,
+        reject,
+      })
+      this.dequeue()
+    })
+  }
+
+  dequeue(): boolean {
+    if (this.pending) {
+      return false
+    }
+    const item = this.queue.shift()
+    if (!item) {
+      return false
+    }
+    this.pending = true
+    item
+      .promise()
+      .then(item.resolve)
+      .catch(item.reject)
+      .finally(() => {
+        this.pending = false
+        this.dequeue()
+      })
+    return true
+  }
+}


### PR DESCRIPTION
### Description

This PR aims to fix the following flaky fail:

>  FAIL  playground/hmr/__tests__/hmr.spec.ts > invalidate works with multiple tabs
> AssertionError: expected '>>> vite:beforeUpdate -- update' to match '>>> vite:invalidate -- /invalidation/…'
> Expected: ">>> vite:invalidate -- /invalidation/child.js"
> Received: ">>> vite:beforeUpdate -- update"
> https://github.com/vitejs/vite/actions/runs/13994683432/job/39186785003#step:12:214

This fail was happening because multiple HMR event was processed concurrently.
This PR makes the HMR event handler to run sequentially. This makes the HMR behavior in browsers more aligned with the module runner.

I tested this locally with the following test:
```ts
  test.only('invalidate works with multiple tabs', async () => {
    const pages: Page[] = []
    try {
      for (let i = 0; i < 10; i++) {
        const p = await browser.newPage()
        await p.goto(viteTestUrl)
        pages.push(p)
      }

      for (let i = 0; i < 30; i++) {
        browserLogs.length = 0
        console.log('update!')

        const el = await page.$('.invalidation-parent')
        await untilBrowserLogAfter(
          () =>
            editFile('invalidation/child.js', (code) =>
              code.replace('child', 'child updated'),
            ),
          [
            '>>> vite:beforeUpdate -- update',
            '>>> vite:invalidate -- /invalidation/child.js',
            '[vite] invalidate /invalidation/child.js',
            '[vite] hot updated: /invalidation/child.js',
            '>>> vite:afterUpdate -- update',
            // if invalidate dedupe doesn't work correctly, this beforeUpdate will be called twice
            '>>> vite:beforeUpdate -- update',
            '(invalidation) parent is executing',
            '[vite] hot updated: /invalidation/parent.js',
            '>>> vite:afterUpdate -- update',
          ],
          true,
        )
        await untilUpdated(() => el.textContent(), 'child updated')
        console.log('update done!')
        await new Promise((r) => setTimeout(r, 10))
        editFile('invalidation/child.js', (code) =>
          code.replace('child updated', 'child'),
        )
        await untilUpdated(() => el.textContent(), /^child$/)
        await new Promise((r) => setTimeout(r, 30))
      }
    } finally {
      await Promise.all(pages.map((p) => p.close()))
    }
  })
```

refs https://github.com/vitejs/vite/pull/16307

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
