### PR TITLE
fix: addWatchFile doesn't work if base is specified (fixes #19792)

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -321,6 +321,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         url: string,
         pos: number,
         forceSkipImportAnalysis: boolean = false,
+        withBaseUrl: boolean = true,
       ): Promise<[string, string | null]> => {
         url = stripBase(url, base)
 
@@ -423,7 +424,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
 
         // prepend base
-        if (!ssr) url = joinUrlSegments(base, url)
+        if (!ssr && withBaseUrl) url = joinUrlSegments(base, url)
 
         return [url, resolved.id]
       }
@@ -804,7 +805,8 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         if (pluginImports) {
           ;(
             await Promise.all(
-              [...pluginImports].map((id) => normalizeUrl(id, 0, true)),
+              // importedUrls doesn't include base url
+              [...pluginImports].map((id) => normalizeUrl(id, 0, true, false)),
             )
           ).forEach(([url]) => importedUrls.add(url))
         }

--- a/packages/vite/src/node/plugins/importAnalysis.ts
+++ b/packages/vite/src/node/plugins/importAnalysis.ts
@@ -321,7 +321,6 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         url: string,
         pos: number,
         forceSkipImportAnalysis: boolean = false,
-        withBaseUrl: boolean = true,
       ): Promise<[string, string | null]> => {
         url = stripBase(url, base)
 
@@ -424,7 +423,7 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         }
 
         // prepend base
-        if (!ssr && withBaseUrl) url = joinUrlSegments(base, url)
+        if (!ssr) url = joinUrlSegments(base, url)
 
         return [url, resolved.id]
       }
@@ -805,10 +804,9 @@ export function importAnalysisPlugin(config: ResolvedConfig): Plugin {
         if (pluginImports) {
           ;(
             await Promise.all(
-              // importedUrls doesn't include base url
-              [...pluginImports].map((id) => normalizeUrl(id, 0, true, false)),
+              [...pluginImports].map((id) => normalizeUrl(id, 0, true)),
             )
-          ).forEach(([url]) => importedUrls.add(url))
+          ).forEach(([url]) => importedUrls.add(stripBase(url, base)))
         }
         // HMR transforms are no-ops in SSR, so an `accept` call will
         // never be injected. Avoid updating the `isSelfAccepting`

--- a/playground/transform-plugin/__tests__/base/transform-plugin.spec.ts
+++ b/playground/transform-plugin/__tests__/base/transform-plugin.spec.ts
@@ -1,0 +1,3 @@
+import { tests } from '../tests'
+
+tests()

--- a/playground/transform-plugin/__tests__/tests.ts
+++ b/playground/transform-plugin/__tests__/tests.ts
@@ -1,0 +1,15 @@
+import { expect, test } from 'vitest'
+import { editFile, isBuild, page, untilUpdated } from '~utils'
+
+export const tests = () => {
+  test('should re-run transform when dependencies are edited', async () => {
+    expect(await page.textContent('#transform-count')).toBe('1')
+
+    if (isBuild) return
+    editFile('plugin-dep.js', (str) => str)
+    await untilUpdated(() => page.textContent('#transform-count'), '2')
+
+    editFile('plugin-dep-load.js', (str) => str)
+    await untilUpdated(() => page.textContent('#transform-count'), '3')
+  })
+}

--- a/playground/transform-plugin/__tests__/transform-plugin.spec.ts
+++ b/playground/transform-plugin/__tests__/transform-plugin.spec.ts
@@ -1,13 +1,3 @@
-import { expect, test } from 'vitest'
-import { editFile, isBuild, page, untilUpdated } from '~utils'
+import { tests } from './tests'
 
-test('should re-run transform when dependencies are edited', async () => {
-  expect(await page.textContent('#transform-count')).toBe('1')
-
-  if (isBuild) return
-  editFile('plugin-dep.js', (str) => str)
-  await untilUpdated(() => page.textContent('#transform-count'), '2')
-
-  editFile('plugin-dep-load.js', (str) => str)
-  await untilUpdated(() => page.textContent('#transform-count'), '3')
-})
+tests()

--- a/playground/transform-plugin/vite.config-base.js
+++ b/playground/transform-plugin/vite.config-base.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import baseConfig from './vite.config.js'
+
+export default defineConfig({
+  ...baseConfig,
+  base: '/vite/',
+})


### PR DESCRIPTION
### Description

Fixes #19792 

URLs used in `updateModuleInfo` are relative to base url but normalizeUrl will prepend base url unconditionally.
This PR changes to not prepend base url if it's for pluginImports

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
