### PR TITLE
fix(types): remove the `keepProcessEnv` from the `DefaultEnvironmentOptions` type

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -292,7 +292,7 @@ export type ResolvedEnvironmentOptions = {
 
 export type DefaultEnvironmentOptions = Omit<
   EnvironmentOptions,
-  'consumer' | 'resolve'
+  'consumer' | 'resolve' | 'keepProcessEnv'
 > & {
   resolve?: AllResolveOptions
 }


### PR DESCRIPTION
the changes here remove the `keepProcessEnv` field from the `DefaultEnvironmentOptions` type, which incorrectly includes it giving the impression that it at the  top level vite configuration object (however doing it there doesn't have any effect and the field needs to be applied to specific environments)

cc. @sapphi-red