### PR TITLE
fix: avoid using `Promise.allSettled` in preload function

### DIFF
--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -95,6 +95,25 @@ function preload(
     // in that case fallback to getAttribute
     const cspNonce = cspNonceMeta?.nonce || cspNonceMeta?.getAttribute('nonce')
 
+    if (!Promise.allSettled) {
+      const rejectHandler: (reason: unknown) => {
+        status: 'rejected'
+        reason: unknown
+      } = (reason: unknown) => ({ status: 'rejected', reason })
+
+      const resolveHandler: (value: unknown) => {
+        status: 'fulfilled'
+        value: unknown
+      } = (value: unknown) => ({ status: 'fulfilled', value })
+
+      Promise.allSettled = function <T>(promises: Array<T | PromiseLike<T>>) {
+        const convertedPromises = promises.map((p) =>
+          Promise.resolve(p).then(resolveHandler, rejectHandler),
+        )
+        return Promise.all(convertedPromises)
+      }
+    }
+
     promise = Promise.allSettled(
       deps.map((dep) => {
         // @ts-expect-error assetsURL is declared before preload.toString()

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -95,7 +95,7 @@ function preload(
     // in that case fallback to getAttribute
     const cspNonce = cspNonceMeta?.nonce || cspNonceMeta?.getAttribute('nonce')
 
-    function allSettled<T>(promises: Array<T | PromiseLike<T>>)  {
+    function allSettled<T>(promises: Array<T | PromiseLike<T>>) {
       const rejectHandler: (reason: unknown) => {
         status: 'rejected'
         reason: unknown

--- a/packages/vite/src/node/plugins/importAnalysisBuild.ts
+++ b/packages/vite/src/node/plugins/importAnalysisBuild.ts
@@ -95,7 +95,7 @@ function preload(
     // in that case fallback to getAttribute
     const cspNonce = cspNonceMeta?.nonce || cspNonceMeta?.getAttribute('nonce')
 
-    if (!Promise.allSettled) {
+    function allSettled<T>(promises: Array<T | PromiseLike<T>>)  {
       const rejectHandler: (reason: unknown) => {
         status: 'rejected'
         reason: unknown
@@ -106,15 +106,13 @@ function preload(
         value: unknown
       } = (value: unknown) => ({ status: 'fulfilled', value })
 
-      Promise.allSettled = function <T>(promises: Array<T | PromiseLike<T>>) {
-        const convertedPromises = promises.map((p) =>
-          Promise.resolve(p).then(resolveHandler, rejectHandler),
-        )
-        return Promise.all(convertedPromises)
-      }
+      const convertedPromises = promises.map((p) =>
+        Promise.resolve(p).then(resolveHandler, rejectHandler),
+      )
+      return Promise.all(convertedPromises)
     }
 
-    promise = Promise.allSettled(
+    promise = allSettled(
       deps.map((dep) => {
         // @ts-expect-error assetsURL is declared before preload.toString()
         dep = assetsURL(dep, importerUrl)

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -143,7 +143,7 @@ describe.runIf(isBuild)('build tests', () => {
       {
         "debugId": "00000000-0000-0000-0000-000000000000",
         "ignoreList": [],
-        "mappings": ";+8BAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
+        "mappings": ";0pCAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -143,7 +143,7 @@ describe.runIf(isBuild)('build tests', () => {
       {
         "debugId": "00000000-0000-0000-0000-000000000000",
         "ignoreList": [],
-        "mappings": ";0pCAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
+        "mappings": ";8lCAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],

--- a/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
+++ b/playground/js-sourcemap/__tests__/js-sourcemap.spec.ts
@@ -143,7 +143,7 @@ describe.runIf(isBuild)('build tests', () => {
       {
         "debugId": "00000000-0000-0000-0000-000000000000",
         "ignoreList": [],
-        "mappings": ";8lCAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
+        "mappings": ";4kCAAA,OAAO,2BAAuB,0BAE9B,QAAQ,IAAI,uBAAuB",
         "sources": [
           "../../after-preload-dynamic.js",
         ],


### PR DESCRIPTION
### Description

Add polyfill of Promise.allSettled. In some legacy browser.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
