### PR TITLE
fix: correct the behavior when multiple transform filter options are specified

### DIFF
--- a/packages/vite/src/node/__tests__/plugins/pluginFilter.spec.ts
+++ b/packages/vite/src/node/__tests__/plugins/pluginFilter.spec.ts
@@ -2,8 +2,6 @@ import util from 'node:util'
 import path from 'node:path'
 import { describe, expect, test } from 'vitest'
 import {
-  FALLBACK_FALSE,
-  FALLBACK_TRUE,
   createCodeFilter,
   createFilterForTransform,
   createIdFilter,
@@ -16,37 +14,37 @@ describe('createIdFilter', () => {
       inputFilter: 'foo.js',
       cases: [
         { id: 'foo.js', expected: true },
-        { id: 'foo.ts', expected: FALLBACK_FALSE },
-        { id: '\0foo.js', expected: FALLBACK_FALSE },
-        { id: '\0' + path.resolve('foo.js'), expected: FALLBACK_FALSE },
+        { id: 'foo.ts', expected: false },
+        { id: '\0foo.js', expected: false },
+        { id: '\0' + path.resolve('foo.js'), expected: false },
       ],
     },
     {
       inputFilter: ['foo.js'],
       cases: [
         { id: 'foo.js', expected: true },
-        { id: 'foo.ts', expected: FALLBACK_FALSE },
+        { id: 'foo.ts', expected: false },
       ],
     },
     {
       inputFilter: { include: 'foo.js' },
       cases: [
         { id: 'foo.js', expected: true },
-        { id: 'foo.ts', expected: FALLBACK_FALSE },
+        { id: 'foo.ts', expected: false },
       ],
     },
     {
       inputFilter: { include: '*.js' },
       cases: [
         { id: 'foo.js', expected: true },
-        { id: 'foo.ts', expected: FALLBACK_FALSE },
+        { id: 'foo.ts', expected: false },
       ],
     },
     {
       inputFilter: { include: /\.js$/ },
       cases: [
         { id: 'foo.js', expected: true },
-        { id: 'foo.ts', expected: FALLBACK_FALSE },
+        { id: 'foo.ts', expected: false },
       ],
     },
     {
@@ -56,42 +54,42 @@ describe('createIdFilter', () => {
         ...(process.platform === 'win32'
           ? [{ id: 'a\\foo.js', expected: true }]
           : []),
-        { id: 'a_foo.js', expected: FALLBACK_FALSE },
+        { id: 'a_foo.js', expected: false },
       ],
     },
     {
       inputFilter: { include: [/\.js$/] },
       cases: [
         { id: 'foo.js', expected: true },
-        { id: 'foo.ts', expected: FALLBACK_FALSE },
+        { id: 'foo.ts', expected: false },
       ],
     },
     {
       inputFilter: { exclude: 'foo.js' },
       cases: [
         { id: 'foo.js', expected: false },
-        { id: 'foo.ts', expected: FALLBACK_TRUE },
+        { id: 'foo.ts', expected: true },
       ],
     },
     {
       inputFilter: { exclude: '*.js' },
       cases: [
         { id: 'foo.js', expected: false },
-        { id: 'foo.ts', expected: FALLBACK_TRUE },
+        { id: 'foo.ts', expected: true },
       ],
     },
     {
       inputFilter: { exclude: /\.js$/ },
       cases: [
         { id: 'foo.js', expected: false },
-        { id: 'foo.ts', expected: FALLBACK_TRUE },
+        { id: 'foo.ts', expected: true },
       ],
     },
     {
       inputFilter: { exclude: [/\.js$/] },
       cases: [
         { id: 'foo.js', expected: false },
-        { id: 'foo.ts', expected: FALLBACK_TRUE },
+        { id: 'foo.ts', expected: true },
       ],
     },
     {
@@ -99,7 +97,7 @@ describe('createIdFilter', () => {
       cases: [
         { id: 'foo.js', expected: true },
         { id: 'bar.js', expected: false },
-        { id: 'baz.js', expected: FALLBACK_FALSE },
+        { id: 'baz.js', expected: false },
       ],
     },
     {
@@ -140,56 +138,56 @@ describe('createCodeFilter', () => {
       inputFilter: 'import.meta',
       cases: [
         { code: 'import.meta', expected: true },
-        { code: 'import_meta', expected: FALLBACK_FALSE },
+        { code: 'import_meta', expected: false },
       ],
     },
     {
       inputFilter: ['import.meta'],
       cases: [
         { code: 'import.meta', expected: true },
-        { code: 'import_meta', expected: FALLBACK_FALSE },
+        { code: 'import_meta', expected: false },
       ],
     },
     {
       inputFilter: { include: 'import.meta' },
       cases: [
         { code: 'import.meta', expected: true },
-        { code: 'import_meta', expected: FALLBACK_FALSE },
+        { code: 'import_meta', expected: false },
       ],
     },
     {
       inputFilter: { include: /import\.\w+/ },
       cases: [
         { code: 'import.meta', expected: true },
-        { code: 'import_meta', expected: FALLBACK_FALSE },
+        { code: 'import_meta', expected: false },
       ],
     },
     {
       inputFilter: { include: [/import\.\w+/] },
       cases: [
         { code: 'import.meta', expected: true },
-        { code: 'import_meta', expected: FALLBACK_FALSE },
+        { code: 'import_meta', expected: false },
       ],
     },
     {
       inputFilter: { exclude: 'import.meta' },
       cases: [
         { code: 'import.meta', expected: false },
-        { code: 'import_meta', expected: FALLBACK_TRUE },
+        { code: 'import_meta', expected: true },
       ],
     },
     {
       inputFilter: { exclude: /import\.\w+/ },
       cases: [
         { code: 'import.meta', expected: false },
-        { code: 'import_meta', expected: FALLBACK_TRUE },
+        { code: 'import_meta', expected: true },
       ],
     },
     {
       inputFilter: { exclude: [/import\.\w+/] },
       cases: [
         { code: 'import.meta', expected: false },
-        { code: 'import_meta', expected: FALLBACK_TRUE },
+        { code: 'import_meta', expected: true },
       ],
     },
     {
@@ -197,7 +195,7 @@ describe('createCodeFilter', () => {
       cases: [
         { code: 'import.meta', expected: true },
         { code: 'import_meta', expected: false },
-        { code: 'importmeta', expected: FALLBACK_FALSE },
+        { code: 'importmeta', expected: false },
       ],
     },
     {
@@ -259,7 +257,30 @@ describe('createFilterForTransform', () => {
         { id: 'foo.js', code: 'import.meta', expected: false },
         { id: 'foo.js', code: 'import_meta', expected: false },
         { id: 'foo.ts', code: 'import.meta', expected: true },
-        { id: 'foo.ts', code: 'import_meta', expected: true },
+        { id: 'foo.ts', code: 'import_meta', expected: false },
+      ],
+    },
+    {
+      inputFilter: [
+        { include: 'a*', exclude: '*b' },
+        { include: 'a', exclude: 'b' },
+      ],
+      cases: [
+        { id: 'ab', code: '', expected: false },
+        { id: 'a', code: 'b', expected: false },
+        { id: 'a', code: '', expected: false },
+        { id: 'c', code: 'a', expected: false },
+        { id: 'a', code: 'a', expected: true },
+      ],
+    },
+    {
+      inputFilter: [{ include: 'a*', exclude: '*b' }, { exclude: 'b' }],
+      cases: [
+        { id: 'ab', code: '', expected: false },
+        { id: 'a', code: 'b', expected: false },
+        { id: 'a', code: '', expected: true },
+        { id: 'c', code: 'a', expected: false },
+        { id: 'a', code: 'a', expected: true },
       ],
     },
   ]

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -23,7 +23,7 @@ import { metadataPlugin } from './metadata'
 import { dynamicImportVarsPlugin } from './dynamicImportVars'
 import { importGlobPlugin } from './importMetaGlob'
 import {
-  type PluginFilterWithFallback,
+  type PluginFilter,
   type TransformHookFilter,
   createFilterForTransform,
   createIdFilter,
@@ -165,8 +165,8 @@ export function getHookHandler<T extends ObjectHook<Function>>(
 }
 
 type FilterForPluginValue = {
-  resolveId?: PluginFilterWithFallback | undefined
-  load?: PluginFilterWithFallback | undefined
+  resolveId?: PluginFilter | undefined
+  load?: PluginFilter | undefined
   transform?: TransformHookFilter | undefined
 }
 const filterForPlugin = new WeakMap<Plugin, FilterForPluginValue>()
@@ -184,7 +184,7 @@ export function getCachedFilterForPlugin<
     filterForPlugin.set(plugin, filters)
   }
 
-  let filter: PluginFilterWithFallback | TransformHookFilter | undefined
+  let filter: PluginFilter | TransformHookFilter | undefined
   switch (hookName) {
     case 'resolveId': {
       const rawFilter =


### PR DESCRIPTION
### Description

When multiple filter options were specified for a transform hook, the hook ran when either of it matched.
For example, the following filter matched for modules that whose id is `foo` or whose code contains `a`.
```js
{
  filter: { id: ['foo'], code: 'a' }
}
```
This is not useful.
This PR fixes that behavior. After this PR, the filter above only matches if the module id is `foo` **and** the code contains `a`.
The previous behavior (that is probably rarely needed) can be achieved by using multiple plugins:
```js
const filters = [{ id: ['foo'] }, { code: 'a' }]
const plugins = filters.map(filter => ({ name: 'plugin', transform: { filter, handler() { /* process the module */ } } }))
```

refs https://github.com/rolldown/rolldown/pull/4059

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
