### PR TITLE
docs(rolldown): add further insights

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -110,7 +110,7 @@ The `rolldown-vite` package is a temporary solution to gather feedback and stabi
 
 We encourage you to try out `rolldown-vite` and contribute to its development through feedback and issue reports.
 
-In the future, we will also introduce a "Full Bundle Mode" for Vite, which will server bundled files in production _and development mode_.
+In the future, we will also introduce a "Full Bundle Mode" for Vite, which will serve bundled files in production _and development mode_.
 
 ### Why introducing a Full Bundle Mode?
 

--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -76,6 +76,16 @@ After adding these overrides, reinstall your dependencies and start your develop
 
 While Rolldown aims to be a drop-in replacement for Rollup, there are features that are still being implemented and minor intentional behavior differences. For a comprehensive list, please refer to [this GitHub PR](https://github.com/vitejs/rolldown-vite/pull/84#issue-2903144667) which is regularly updated.
 
+### Option Validation Errors
+
+Rolldown throws an error when unknown or invalid options are passed. Because some options available in Rollup are not supported by Rolldown, you may encounter errors based on the options you or the meta framework you use set. Below, you can find an an example of such an error message:
+
+> Error: Failed validate input options.
+>
+> - For the "preserveEntrySignatures". Invalid key: Expected never but received "preserveEntrySignatures".
+
+If you don't pass the option in yourself, this must be fixed by the utilized framework. You can suppress this error in the meantime by setting the `ROLLDOWN_OPTIONS_VALIDATION=loose` environment variable.
+
 ## Enabling Native Plugins
 
 Thanks to Rolldown and OXC, various internal Vite plugins, such as the alias or resolve plugin, have been converted to Rust. At the time of writing, using these plugins is not enabled by default, as their behavior may differ from the JavaScript versions.
@@ -177,15 +187,12 @@ If you have `vite` as a dependency (not a peer dependency), the `rolldownVersion
 
 ### Ignoring option validation in Rolldown
 
-Rolldown throws an error when unknown or invalid options are passed. Because some options available in Rollup are not supported by Rolldown, you may encounter errors. Below, you can find an an example of such an error message:
+As [mentioned above](#option-validation-errors), Rolldown throws an error when unknown or invalid options are passed.
 
-> Error: Failed validate input options.
->
-> - For the "preserveEntrySignatures". Invalid key: Expected never but received "preserveEntrySignatures".
+This can be fixed by conditionally passing the option by checking whether it's running with `rolldown-vite` as [shown above](#detecting-rolldown-vite).
 
-This can be fixed by conditionally passing the option by checking whether it's running with `rolldown-vite` as shown above.
-
-If you would like to suppress this error for now, you can set the `ROLLDOWN_OPTIONS_VALIDATION=loose` environment variable. However, keep in mind that you will **eventually need to stop passing the options not supported by Rolldown**.
+Suppressing the error by setting the `ROLLDOWN_OPTIONS_VALIDATION=loose` environment variable also works in this case.
+However, keep in mind that you will **eventually need to stop passing the options not supported by Rolldown**.
 
 ### `transformWithEsbuild` requires `esbuild` to be installed separately
 

--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -119,6 +119,8 @@ With the Rolldown integration, we have an opportunity to unify the development a
 - Reduced network overhead on page refreshes
 - Maintained efficient HMR on top of ESM output
 
+When the Full Bundle Mode is introduced, it will be an opt-in feature at first. Similar to the Rolldown integration, we are aiming to make it the default after gathering feedback and ensuring stability.
+
 ## Plugin / Framework authors guide
 
 ::: tip

--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -88,7 +88,7 @@ If you don't pass the option in yourself, this must be fixed by the utilized fra
 
 ## Enabling Native Plugins
 
-Thanks to Rolldown and OXC, various internal Vite plugins, such as the alias or resolve plugin, have been converted to Rust. At the time of writing, using these plugins is not enabled by default, as their behavior may differ from the JavaScript versions.
+Thanks to Rolldown and Oxc, various internal Vite plugins, such as the alias or resolve plugin, have been converted to Rust. At the time of writing, using these plugins is not enabled by default, as their behavior may differ from the JavaScript versions.
 
 To test them, you can set the `experimental.enableNativePlugin` option to `true` in your Vite config.
 

--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -120,7 +120,7 @@ However, as projects scale in size and complexity, two main challenges have emer
 
 1. **Development/Production inconsistency**: The unbundled JavaScript served in development versus the bundled production build creates different runtime behaviors. This can lead to issues that only manifest in production, making debugging more difficult.
 
-2. **Performance degradation on page refresh**: When running the development server for large applications, a hard page refresh can trigger hundreds or even thousands of network requests as each module is loaded individually. While this is somewhat mitigated by HTTP/2 multiplexing, it still creates overhead that impacts startup performance, especially on slower networks or devices.
+2. **Performance degradation during development**: The unbundled approach results in each module being fetched separately, which creates a large number of network requests. While this has _no impact in production_, it causes significant overhead during dev server startup and when refreshing the page in development. The impact is especially noticeable in large applications where hundreds or even thousands of separate requests must be processed. These bottlenecks become even more severe when developers use network proxy, resulting in slower refresh times and degraded developer experience.
 
 With the Rolldown integration, we have an opportunity to unify the development and production experiences while maintaining Vite's signature performance. A Full Bundle Mode would allow serving bundled files not only in production but also during development, combining the best of both worlds:
 


### PR DESCRIPTION
This PR adds more info regarding the Rolldown integration, such as:

* Emphasis regarding additional features / beyond "what rollup & esbuild offer"
* Native Plugins
* Future Plans with Full Bundle Mode
* Boundary for readers to ensure that the plugin author section can be skipped for normal users
* Plugin authors should ideally not need conditional branching to differ between vite/rolldown-powered vite
* Restructured Option Validation Chapter as users might need to know about that too (example: When using meta frameworks or Vitepress)
* Smaller corrections