### PR TITLE
fix(preview): use host url to open browser

### DIFF
--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -276,7 +276,14 @@ export async function preview(
   )
 
   if (options.open) {
-    const url = server.resolvedUrls.local[0] ?? server.resolvedUrls.network[0]
+    const host = options.host
+    const url =
+      typeof host === 'string'
+        ? [
+            ...(server.resolvedUrls?.local ?? []),
+            ...(server.resolvedUrls?.network ?? []),
+          ].find((url) => url.includes(host))
+        : (server.resolvedUrls.local[0] ?? server.resolvedUrls.network[0])
     if (url) {
       const path =
         typeof options.open === 'string' ? new URL(options.open, url).href : url

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -25,6 +25,7 @@ import { indexHtmlMiddleware } from './server/middlewares/indexHtml'
 import { notFoundMiddleware } from './server/middlewares/notFound'
 import { proxyMiddleware } from './server/middlewares/proxy'
 import {
+  getServerUrlByHost,
   resolveHostname,
   resolveServerUrls,
   setupSIGTERMListener,
@@ -276,14 +277,7 @@ export async function preview(
   )
 
   if (options.open) {
-    const host = options.host
-    const url =
-      typeof host === 'string'
-        ? [
-            ...(server.resolvedUrls?.local ?? []),
-            ...(server.resolvedUrls?.network ?? []),
-          ].find((url) => url.includes(host))
-        : (server.resolvedUrls.local[0] ?? server.resolvedUrls.network[0])
+    const url = getServerUrlByHost(server, options.host)
     if (url) {
       const path =
         typeof options.open === 'string' ? new URL(options.open, url).href : url

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -26,6 +26,7 @@ import type { InlineConfig, ResolvedConfig } from '../config'
 import { resolveConfig } from '../config'
 import {
   diffDnsOrderChange,
+  getServerUrlByHost,
   isInNodeModules,
   isObject,
   isParentDirectory,
@@ -659,15 +660,7 @@ export async function _createServer(
     },
     openBrowser() {
       const options = server.config.server
-      const host = options.host
-      let url: string | undefined
-      if (typeof host === 'string') {
-        url = [
-          ...(server.resolvedUrls?.local ?? []),
-          ...(server.resolvedUrls?.network ?? []),
-        ].find((url) => url.includes(host))
-      }
-      url ??= server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+      const url = getServerUrlByHost(server, options.host)
       if (url) {
         const path =
           typeof options.open === 'string'

--- a/packages/vite/src/node/utils.ts
+++ b/packages/vite/src/node/utils.ts
@@ -1656,3 +1656,17 @@ export const teardownSIGTERMListener = (
     }
   }
 }
+
+export function getServerUrlByHost(
+  server: PreviewServer | ViteDevServer,
+  host: CommonServerOptions['host'],
+): string | undefined {
+  if (typeof host !== 'string') {
+    return server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+  }
+
+  return [
+    ...(server.resolvedUrls?.local ?? []),
+    ...(server.resolvedUrls?.network ?? []),
+  ].find((url) => url.includes(host))
+}


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

When you use `@vitejs/plugin-basic-ssl` or `vite-plugin-mkcert`, and run `vite preview --open --host foobar.com`, it will open `https://localhost:5173/` instead of `https://foobar.com`.

> This bug occurs since version 6.1.0

Related: https://github.com/vitejs/vite/pull/19414

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
