### PR TITLE
test: fix flaky transform-plugin playground test

### DIFF
--- a/playground/transform-plugin/__tests__/base/transform-plugin.spec.ts
+++ b/playground/transform-plugin/__tests__/base/transform-plugin.spec.ts
@@ -1,3 +1,4 @@
+// NOTE: a separate directory from `playground/transform-plugin` is created by playground/vitestGlobalSetup.ts
 import { tests } from '../tests'
 
 tests()

--- a/playground/vitestGlobalSetup.ts
+++ b/playground/vitestGlobalSetup.ts
@@ -45,6 +45,7 @@ export async function setup({ provide }: TestProject): Promise<void> {
   for (const [original, variants] of [
     ['css', ['sass-legacy', 'sass-modern', 'lightningcss']],
     ['css-sourcemap', ['sass-legacy', 'sass-modern']],
+    ['transform-plugin', ['base']],
   ] as const) {
     for (const variant of variants) {
       await fs.cp(


### PR DESCRIPTION
### Description

The transform-plugin playground test got flaky after #19794 because the variants edits the same file in parallel.

- https://github.com/vitejs/vite/actions/runs/14395089694/job/40369259850#step:13:142
- https://github.com/vitejs/vite/actions/runs/14394751920/job/40368361238#step:13:147

refs #19794

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
