### PR TITLE
docs: bump node version to LTS

### DIFF
--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -128,7 +128,7 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
 2. Create a file called `.gitlab-ci.yml` in the root of your project with the content below. This will build and deploy your site whenever you make changes to your content:
 
    ```yaml [.gitlab-ci.yml]
-   image: node:16.5.0
+   image: node:lts
    pages:
      stage: deploy
      cache:

--- a/docs/guide/static-deploy.md
+++ b/docs/guide/static-deploy.md
@@ -99,7 +99,7 @@ Now the `preview` command will launch the server at `http://localhost:8080`.
          - name: Set up Node
            uses: actions/setup-node@v4
            with:
-             node-version: 20
+             node-version: lts/*
              cache: 'npm'
          - name: Install dependencies
            run: npm ci


### PR DESCRIPTION
Since node is stable in 22, I think in the example we can give LTS. 

personally I am not sure if we can give `image: node:lts` in for gitlab image or not. But i think we can give this way also.
