### PR TITLE
fix(legacy): ensure `isLegacyBundle` checks all entry chunks for legacy suffix

### DIFF
--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -932,14 +932,12 @@ function isLegacyBundle(
   options: NormalizedOutputOptions,
 ) {
   if (options.format === 'system') {
-    const entryChunk = Object.values(bundle).find(
+    return Object.values(bundle).every(
       (output) =>
         output.type === 'chunk' &&
         output.isEntry &&
         output.fileName.includes('-legacy'),
     )
-
-    return !!entryChunk
   }
 
   return false

--- a/packages/plugin-legacy/src/index.ts
+++ b/packages/plugin-legacy/src/index.ts
@@ -933,10 +933,13 @@ function isLegacyBundle(
 ) {
   if (options.format === 'system') {
     const entryChunk = Object.values(bundle).find(
-      (output) => output.type === 'chunk' && output.isEntry,
+      (output) =>
+        output.type === 'chunk' &&
+        output.isEntry &&
+        output.fileName.includes('-legacy'),
     )
 
-    return !!entryChunk && entryChunk.fileName.includes('-legacy')
+    return !!entryChunk
   }
 
   return false


### PR DESCRIPTION
fix(plugin-legacy): ensure isLegacyBundle checks all entry chunks for legacy suffix

The previous implementation of `isLegacyBundle` found the first entry chunk and then checked if it had a '-legacy' suffix. This could lead to incorrect detection in multi-entry scenarios.

For example:
If a bundle contains:
1. An entry chunk with filename "other.js" (without "-legacy")
2. And another entry chunk with filename "main-legacy.js" (with "-legacy")

The original implementation would return `false` because it would find "other.js" first and check if it includes "-legacy", which it doesn't.

With this fix, the function directly searches for any entry chunk that has the "-legacy" suffix, correctly identifying bundles with any legacy entry chunks.

This ensures proper asset handling in the `generateBundle` hook, especially for multi-entry builds where some entries might be legacy and others modern.