### PR TITLE
fix(create-vite): adding an interactive flag to force interactivity

### DIFF
--- a/packages/create-vite/src/index.ts
+++ b/packages/create-vite/src/index.ts
@@ -148,7 +148,7 @@ const FRAMEWORKS: Framework[] = [
         display: 'TanStack Router ↗',
         color: cyan,
         customCommand:
-          'npm create -- tsrouter-app@latest TARGET_DIR --framework react',
+          'npm create -- tsrouter-app@latest TARGET_DIR --framework react --interactive',
       },
     ],
   },
@@ -235,7 +235,7 @@ const FRAMEWORKS: Framework[] = [
         display: 'TanStack Router ↗',
         color: cyan,
         customCommand:
-          'npm create -- tsrouter-app@latest TARGET_DIR --framework solid',
+          'npm create -- tsrouter-app@latest TARGET_DIR --framework solid --interactive',
       },
     ],
   },


### PR DESCRIPTION
### Description

Adding an `--interactive` flag to the `create-tsrouter-app` invocation to force it to prompt for additional features.