### PR TITLE
fix: backward compat for internal plugin `transform` calls

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -512,7 +512,7 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
     return cssBundleName
   }
 
-  return {
+  const plugin = {
     name: 'vite:css-post',
 
     renderStart() {
@@ -1080,7 +1080,14 @@ export function cssPostPlugin(config: ResolvedConfig): Plugin {
         }
       }
     },
-  }
+  } satisfies Plugin
+
+  // backward compat
+  const handler = plugin.transform.handler
+  ;(plugin as any).transform = handler
+  ;(plugin as any).transform.handler = handler
+
+  return plugin
 }
 
 export function cssAnalysisPlugin(config: ResolvedConfig): Plugin {

--- a/packages/vite/src/node/plugins/json.ts
+++ b/packages/vite/src/node/plugins/json.ts
@@ -41,7 +41,7 @@ export function jsonPlugin(
   options: Required<JsonOptions>,
   isBuild: boolean,
 ): Plugin {
-  return {
+  const plugin = {
     name: 'vite:json',
 
     transform: {
@@ -119,7 +119,14 @@ export function jsonPlugin(
         }
       },
     },
-  }
+  } satisfies Plugin
+
+  // backward compat
+  const handler = plugin.transform.handler
+  ;(plugin as any).transform = handler
+  ;(plugin as any).transform.handler = handler
+
+  return plugin
 }
 
 function serializeValue(value: unknown): string {


### PR DESCRIPTION
### Description

- Closes https://github.com/vitejs/vite/issues/19873

Adding a similar backward compat as https://github.com/vitejs/vite/pull/19586#discussion_r1982805459 for `vite:css-post` (unocss https://github.com/unocss/unocss/issues/4597) and `vite:json` (unplugin-vue-i18n https://github.com/intlify/bundle-tools/issues/483).

---

I verified the repro in https://github.com/intlify/bundle-tools/issues/483 is fixed https://stackblitz.com/edit/vitejs-vite-cddhcqn4?file=package.json