### PR TITLE
feat: allow passing down resolved config to vite's `createServer`

### DIFF
--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -632,6 +632,7 @@ export interface ResolvedConfig
       safeModulePaths: Set<string>
       /** @internal */
       additionalAllowedHosts: string[]
+      /** @internal */
       [SYMBOL_RESOLVED_CONFIG]: true
     } & PluginHookUtils
   > {}

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1034,6 +1034,16 @@ function resolveDepOptimizationOptions(
   )
 }
 
+export function isResolvedConfig(
+  inlineConfig: InlineConfig | ResolvedConfig,
+): inlineConfig is ResolvedConfig {
+  // assume that internal methods cannot be provided in inline config
+  return (
+    'fsDenyGlob' in inlineConfig &&
+    typeof inlineConfig.fsDenyGlob === 'function'
+  )
+}
+
 export async function resolveConfig(
   inlineConfig: InlineConfig,
   command: 'build' | 'serve',

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -1040,7 +1040,6 @@ function resolveDepOptimizationOptions(
 export function isResolvedConfig(
   inlineConfig: InlineConfig | ResolvedConfig,
 ): inlineConfig is ResolvedConfig {
-  // assume that internal methods cannot be provided in inline config
   return (
     SYMBOL_RESOLVED_CONFIG in inlineConfig &&
     inlineConfig[SYMBOL_RESOLVED_CONFIG]

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -106,6 +106,7 @@ import { getAdditionalAllowedHosts } from './server/middlewares/hostCheck'
 
 const debug = createDebugger('vite:config', { depth: 10 })
 const promisifiedRealpath = promisify(fs.realpath)
+const SYMBOL_RESOLVED_CONFIG = Symbol('vite:resolved-config')
 
 export interface ConfigEnv {
   /**
@@ -631,6 +632,7 @@ export interface ResolvedConfig
       safeModulePaths: Set<string>
       /** @internal */
       additionalAllowedHosts: string[]
+      [SYMBOL_RESOLVED_CONFIG]: true
     } & PluginHookUtils
   > {}
 
@@ -1039,8 +1041,8 @@ export function isResolvedConfig(
 ): inlineConfig is ResolvedConfig {
   // assume that internal methods cannot be provided in inline config
   return (
-    'fsDenyGlob' in inlineConfig &&
-    typeof inlineConfig.fsDenyGlob === 'function'
+    SYMBOL_RESOLVED_CONFIG in inlineConfig &&
+    inlineConfig[SYMBOL_RESOLVED_CONFIG]
   )
 }
 
@@ -1562,6 +1564,7 @@ export async function resolveConfig(
     ),
     safeModulePaths: new Set<string>(),
     additionalAllowedHosts: getAdditionalAllowedHosts(server, preview),
+    [SYMBOL_RESOLVED_CONFIG]: true,
   }
   resolved = {
     ...config,

--- a/packages/vite/src/node/preview.ts
+++ b/packages/vite/src/node/preview.ts
@@ -35,7 +35,7 @@ import {
 import { printServerUrls } from './logger'
 import { bindCLIShortcuts } from './shortcuts'
 import type { BindCLIShortcutsOptions } from './shortcuts'
-import { isResolvedConfig, resolveConfig } from './config'
+import { resolveConfig } from './config'
 import type { InlineConfig, ResolvedConfig } from './config'
 import { DEFAULT_PREVIEW_PORT } from './constants'
 import type { RequiredExceptFor } from './typeUtils'
@@ -112,23 +112,15 @@ export type PreviewServerHook = (
  * Starts the Vite server in preview mode, to simulate a production deployment
  */
 export async function preview(
-  inlineConfig: InlineConfig | ResolvedConfig = {},
+  inlineConfig: InlineConfig = {},
 ): Promise<PreviewServer> {
-  const config = isResolvedConfig(inlineConfig)
-    ? inlineConfig
-    : await resolveConfig(
-        inlineConfig,
-        'serve',
-        'production',
-        'production',
-        true,
-      )
-
-  if (config.command !== 'serve') {
-    throw new Error(
-      `Config was resolved for a "build", expected a "serve" command.`,
-    )
-  }
+  const config = await resolveConfig(
+    inlineConfig,
+    'serve',
+    'production',
+    'production',
+    true,
+  )
 
   const clientOutDir = config.environments.client.build.outDir
   const distDir = path.resolve(config.root, clientOutDir)

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -101,6 +101,8 @@ import type { DevEnvironment } from './environment'
 import { hostCheckMiddleware } from './middlewares/hostCheck'
 import { rejectInvalidRequestMiddleware } from './middlewares/rejectInvalidRequest'
 
+const usedConfigs = new WeakSet<ResolvedConfig>()
+
 export interface ServerOptions extends CommonServerOptions {
   /**
    * Configure HMR-specific options (port, host, path & protocol)
@@ -443,11 +445,17 @@ export async function _createServer(
     ? inlineConfig
     : await resolveConfig(inlineConfig, 'serve')
 
+  if (usedConfigs.has(config)) {
+    throw new Error(`There is already a server associated with the config.`)
+  }
+
   if (config.command !== 'serve') {
     throw new Error(
       `Config was resolved for a "build", expected a "serve" command.`,
     )
   }
+
+  usedConfigs.add(config)
 
   const initPublicFilesPromise = initPublicFiles(config)
 

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -443,6 +443,12 @@ export async function _createServer(
     ? inlineConfig
     : await resolveConfig(inlineConfig, 'serve')
 
+  if (config.command !== 'serve') {
+    throw new Error(
+      `Config was resolved for a "build", expected a "serve" command.`,
+    )
+  }
+
   const initPublicFilesPromise = initPublicFiles(config)
 
   const { root, server: serverConfig } = config

--- a/packages/vite/src/node/server/index.ts
+++ b/packages/vite/src/node/server/index.ts
@@ -23,7 +23,7 @@ import {
   setClientErrorHandler,
 } from '../http'
 import type { InlineConfig, ResolvedConfig } from '../config'
-import { resolveConfig } from '../config'
+import { isResolvedConfig, resolveConfig } from '../config'
 import {
   diffDnsOrderChange,
   getServerUrlByHost,
@@ -427,19 +427,21 @@ export interface ResolvedServerUrls {
 }
 
 export function createServer(
-  inlineConfig: InlineConfig = {},
+  inlineConfig: InlineConfig | ResolvedConfig = {},
 ): Promise<ViteDevServer> {
   return _createServer(inlineConfig, { listen: true })
 }
 
 export async function _createServer(
-  inlineConfig: InlineConfig = {},
+  inlineConfig: InlineConfig | ResolvedConfig = {},
   options: {
     listen: boolean
     previousEnvironments?: Record<string, DevEnvironment>
   },
 ): Promise<ViteDevServer> {
-  const config = await resolveConfig(inlineConfig, 'serve')
+  const config = isResolvedConfig(inlineConfig)
+    ? inlineConfig
+    : await resolveConfig(inlineConfig, 'serve')
 
   const initPublicFilesPromise = initPublicFiles(config)
 


### PR DESCRIPTION
### Description

Vitest has to resolve everything during the plugin's `config` phase to respect user configuration. This is fine if there is only one config, but when the `workspace` is involved, the config resolution becomes a mess. If we could resolve every config first and _then_ create servers, it would make the config resolution phase much simpler.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
