### PR TITLE
feat: add default value for LogOptions to createLogger

### DIFF
--- a/packages/vite/src/node/logger.ts
+++ b/packages/vite/src/node/logger.ts
@@ -51,6 +51,7 @@ export interface LoggerOptions {
   allowClearScreen?: boolean
   customLogger?: Logger
   console?: Console
+  defaultLogOptions?: LogOptions
 }
 
 // Only initialize the timeFormatter when the timestamp option is used, and
@@ -78,6 +79,7 @@ export function createLogger(
     prefix = '[vite]',
     allowClearScreen = true,
     console = globalThis.console,
+    defaultLogOptions = {},
   } = options
   const thresh = LogLevels[level]
   const canClearScreen =
@@ -85,6 +87,7 @@ export function createLogger(
   const clear = canClearScreen ? clearScreen : () => {}
 
   function format(type: LogType, msg: string, options: LogErrorOptions = {}) {
+    options = Object.assign(defaultLogOptions, options)
     if (options.timestamp) {
       let tag = ''
       if (type === 'info') {


### PR DESCRIPTION
### Description

Add an option to define a default value for LogOptions when creating a Logger. This can be used e.g. to create a Logger that per default prints out a timestamp without having to specify every time:
```js
let logger = createLogger("info", {defaultLogOptions: {timestamp: true}})
logger.info("Hello World!")
// 5:47:54 PM [vite] Hello World!
```
