### PR TITLE
fix: avoid missing source warnings for `react-refresh`

### DIFF
--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -13,6 +13,8 @@ const debug = createDebugger('vite:sourcemap', {
 // Virtual modules should be prefixed with a null byte to avoid a
 // false positive "missing source" warning. We also check for certain
 // prefixes used for special handling in esbuildDepPlugin.
+// vite-plugin-react isn't following the leading \0 virtual module convention.
+// We'll remove this as soon we're able to fix the react plugins.
 const virtualSourceRE = /^(?:dep:|browser-external:|virtual:)|\0|^\/@react-refresh/
 
 interface SourceMapLike {

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -15,7 +15,8 @@ const debug = createDebugger('vite:sourcemap', {
 // prefixes used for special handling in esbuildDepPlugin.
 // vite-plugin-react isn't following the leading \0 virtual module convention.
 // We'll remove this as soon we're able to fix the react plugins.
-const virtualSourceRE = /^(?:dep:|browser-external:|virtual:)|\0|^\/@react-refresh/
+const virtualSourceRE = 
+  /^(?:dep:|browser-external:|virtual:)|\0|^\/@react-refresh/
 
 interface SourceMapLike {
   sources: string[]

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -15,7 +15,7 @@ const debug = createDebugger('vite:sourcemap', {
 // prefixes used for special handling in esbuildDepPlugin.
 // vite-plugin-react isn't following the leading \0 virtual module convention.
 // We'll remove this as soon we're able to fix the react plugins.
-const virtualSourceRE = 
+const virtualSourceRE =
   /^(?:dep:|browser-external:|virtual:)|\0|^\/@react-refresh/
 
 interface SourceMapLike {

--- a/packages/vite/src/node/server/sourcemap.ts
+++ b/packages/vite/src/node/server/sourcemap.ts
@@ -13,7 +13,7 @@ const debug = createDebugger('vite:sourcemap', {
 // Virtual modules should be prefixed with a null byte to avoid a
 // false positive "missing source" warning. We also check for certain
 // prefixes used for special handling in esbuildDepPlugin.
-const virtualSourceRE = /^(?:dep:|browser-external:|virtual:)|\0/
+const virtualSourceRE = /^(?:dep:|browser-external:|virtual:)|\0|^\/@react-refresh/
 
 interface SourceMapLike {
   sources: string[]


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

This PR marks `/@react-refresh` as a virtual module to avoid false positive "missing source" warnings.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
