### PR TITLE
feat(build): provide names for asset entrypoints

### DIFF
--- a/packages/vite/src/node/plugins/manifest.ts
+++ b/packages/vite/src/node/plugins/manifest.ts
@@ -21,6 +21,7 @@ export interface ManifestChunk {
   assets?: string[]
   isEntry?: boolean
   name?: string
+  names?: string[]
   isDynamicEntry?: boolean
   imports?: string[]
   dynamicImports?: string[]
@@ -127,7 +128,10 @@ export function manifestPlugin(): Plugin {
           file: asset.fileName,
           src,
         }
-        if (isEntry) manifestChunk.isEntry = true
+        if (isEntry) {
+          manifestChunk.isEntry = true
+          manifestChunk.names = asset.names
+        }
         return manifestChunk
       }
 

--- a/playground/backend-integration/__tests__/backend-integration.spec.ts
+++ b/playground/backend-integration/__tests__/backend-integration.spec.ts
@@ -75,6 +75,7 @@ describe.runIf(isBuild)('build', () => {
     expect(dirFooAssetEntry).not.toBeUndefined() // '\\' should not be used even on windows
     // use the entry name
     expect(dirFooAssetEntry.file).toMatch('assets/bar-')
+    expect(dirFooAssetEntry.names).toStrictEqual(['bar.css'])
     expect(iconEntrypointEntry?.file).not.toBeUndefined()
     expect(waterContainerEntry?.file).not.toBeUndefined()
   })


### PR DESCRIPTION
### Description

Add `names` field to asset entrypoints in manifest.

This allows you to map back your asset-only entrypoints to corresponding files in the bundle. This was not possible previously because asset entrypoints only had `file`, `src` and `isEntry` files, none of which included information about entrypoint name.