### PR TITLE
docs(rolldown): make clear changes should be applied in `package.json`

### DIFF
--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -37,7 +37,8 @@ The rolldown-powered version of Vite is currently available as a separate packag
 ```json
 {
   "dependencies": {
-    "vite": "npm:rolldown-vite@latest"
+    "vite": "^6.0.0" // [!code --]
+    "vite": "npm:rolldown-vite@latest" // [!code ++]
   }
 }
 ```

--- a/docs/guide/rolldown.md
+++ b/docs/guide/rolldown.md
@@ -32,7 +32,7 @@ For additional insights on the motivations behind Rolldown, see the [reasons why
 
 ## How to Try Rolldown
 
-The rolldown-powered version of Vite is currently available as a separate package called `rolldown-vite`. If you have `vite` as a direct dependency, you can alias the `vite` package to `rolldown-vite` in your project, which should result in a drop-in replacement.
+The rolldown-powered version of Vite is currently available as a separate package called `rolldown-vite`. If you have `vite` as a direct dependency, you can alias the `vite` package to `rolldown-vite` in your project's `package.json`, which should result in a drop-in replacement.
 
 ```json
 {
@@ -42,7 +42,7 @@ The rolldown-powered version of Vite is currently available as a separate packag
 }
 ```
 
-If you use a Vitepress or a meta framework that has Vite as peer dependency, you have to override the `vite` dependency in your package manager:
+If you use a Vitepress or a meta framework that has Vite as peer dependency, you have to override the `vite` dependency in your `package.json`, which works slightly different depending on your package manager:
 
 :::code-group
 


### PR DESCRIPTION
Simple wording change to make sure readers are aware that changes go into the `package.json` + a nice diff for normal aliasing.