### PR TITLE
fix(worker): update plugin to be backward compatible

### DIFF
--- a/packages/vite/src/node/plugins/worker.ts
+++ b/packages/vite/src/node/plugins/worker.ts
@@ -247,7 +247,7 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
   const isBuild = config.command === 'build'
   const isWorker = config.isWorker
 
-  return {
+  const plugin = {
     name: 'vite:worker',
 
     buildStart() {
@@ -494,7 +494,14 @@ export function webWorkerPlugin(config: ResolvedConfig): Plugin {
       })
       workerMap.assets.clear()
     },
-  }
+  } satisfies Plugin
+
+  // backward compat
+  const handler = plugin.transform.handler
+  ;(plugin as any).transform = handler
+  ;(plugin as any).transform.handler = handler
+
+  return plugin
 }
 
 function isSameContent(a: string | Uint8Array, b: string | Uint8Array) {


### PR DESCRIPTION
### Description

This PR fixes backward compatibility for plugin `vite:worker`
~~Current doc (https://rollupjs.org/plugin-development/#transform) still not updated to mention new `plugin.transform.handler` structure and there are plugins expecting other plugins to always have `plugin.transform` as function (the handler)~~

The pattern in this PR already exists in a few other plugins:
https://github.com/vitejs/vite/blob/v6.3.2/packages/vite/src/node/plugins/json.ts#L124
https://github.com/vitejs/vite/blob/v6.3.2/packages/vite/src/node/plugins/css.ts#L447

I encounter error after updating vite to 6.3 and originally reported in
https://github.com/ElMassimo/vite-plugin-erb/issues/5

Update 1: Current doc is updated, also https://github.com/ElMassimo/vite-plugin-erb/issues/5 might already be fixed by plugin update