### PR TITLE
fix(css): resolve relative imports in sass properly on Windows

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -1207,6 +1207,8 @@ export function getEmptyChunkReplacer(
     )
 }
 
+const fileURLWithWindowsDriveRE = /^file:\/\/\/[a-zA-Z]:\//
+
 interface CSSAtImportResolvers {
   css: ResolveIdFn
   sass: ResolveIdFn
@@ -1245,7 +1247,9 @@ function createCSSResolvers(config: ResolvedConfig): CSSAtImportResolvers {
             args[1] = fileURLToPath(args[1], {
               windows:
                 // file:///foo cannot be converted to path with windows mode
-                isWindows && args[1].startsWith('file:///') ? false : undefined,
+                isWindows && !fileURLWithWindowsDriveRE.test(args[1])
+                  ? false
+                  : undefined,
             })
           }
           return resolver(...args)


### PR DESCRIPTION
### Description

`fileURLToPath('file:///C:/foo.js', { windows: false })` returns `/C:/foo.js`. Even with this output, it still worked because the internal resolve plugin supports that format (`/C:/foo.js`) as well.
https://github.com/vitejs/vite/blob/16a73c05d35daa34117a173784895546212db5f4/packages/vite/src/node/plugins/resolve.ts#L262-L274

But the expected result here for this input is `C:/foo.js`, and this PR fixes the condition to use `windows` option.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
